### PR TITLE
Add missing files (.dockerignore, .travis.yml)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+mlruns
+outputs
+__pycache__
+.*
+~*
+*.swp
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Mlflow
 mlruns/
+outputs/
 
 # Mac
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+sudo: true
+language: python
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.6
+      env: TOXENV=py36
+install:
+  - pip install --upgrade pip
+  - pip install .
+  - pip install -r dev-requirements.txt
+script:
+  - pip list
+  - tox


### PR DESCRIPTION
Adds additional config files to the repo:
* .dockerignore for files ignored during docker image builds
* .travis.yml for CI
* Updates .gitignore to ignore the outputs/ directory generated by the `example/quickstart/test.py` script
