### PR TITLE
Subprocess.Popen returns text not bytes

### DIFF
--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -28,14 +28,15 @@ def exec_cmd(cmd, throw_on_error=True, env=None, stream_output=False, cwd=None, 
         cmd_env.update(env)
 
     if stream_output:
-        child = subprocess.Popen(cmd, env=cmd_env, cwd=cwd, **kwargs)
+        child = subprocess.Popen(cmd, env=cmd_env, cwd=cwd, universal_newlines=True, **kwargs)
         exit_code = child.wait()
         if throw_on_error and exit_code is not 0:
             raise ShellCommandException("Non-zero exitcode: %s" % (exit_code))
         return exit_code
     else:
         child = subprocess.Popen(
-            cmd, env=cmd_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=cwd, **kwargs)
+            cmd, env=cmd_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            cwd=cwd, universal_newlines=True, **kwargs)
         (stdout, stderr) = child.communicate()
         exit_code = child.wait()
         if throw_on_error and exit_code is not 0:


### PR DESCRIPTION
related issue https://github.com/databricks/mlflow/issues/8

This PR modifies calls to subprocess.Popen so they return text, not bytes. This makes mlflow compatible with python3.5.3. 

Checked tests and linted.