### PR TITLE
Have flask listen on all interfaces so that the UI works insider Docker

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -129,7 +129,7 @@ def ui(file_store_path):
     Run the MLflow tracking UI. The UI is served at http://localhost:5000.
     """
     server.handlers.store = FileStore(file_store_path)
-    server.app.run()
+    server.app.run("0.0.0.0")
 
 
 cli.add_command(mlflow.sklearn.commands)


### PR DESCRIPTION
I wasn't able to get the UI to run from within a docker container (either installing from source or from the pip version).  Eventually I tracked it down to flask not listening on all interfaces.  This fixes that.