### PR TITLE
Serve the sklearn models on 0.0.0.0 for use from within docker containers

### DIFF
--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -96,4 +96,4 @@ def serve_model(model_path, run_id=None, port=None):
         result = json.dumps({"predictions": predictions.tolist()})
         return flask.Response(status=200, response=result + "\n", mimetype='application/json')
 
-    app.run(port=port)
+    app.run("0.0.0.0", port=port)


### PR DESCRIPTION
Same change as #16.