### PR TITLE
Add host commandline argument for UI and sklearn server

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -125,7 +125,7 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
               help="The root of the backing file store for experiment and run data. Defaults to %s."
                    % file_store._default_root_dir())
 @click.option("--host", default="127.0.0.1",
-              help="The networking interface on which the UI server listens. Defaults to 127.0.0.1.")
+              help="The networking interface on which the UI server listens. Defaults to 127.0.0.1.  Use 0.0.0.0 for docker.")
 def ui(file_store_path, host):
     """
     Run the MLflow tracking UI. The UI is served at http://localhost:5000.

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -125,7 +125,9 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
               help="The root of the backing file store for experiment and run data. Defaults to %s."
                    % file_store._default_root_dir())
 @click.option("--host", default="127.0.0.1",
-              help="The networking interface on which the UI server listens. Defaults to 127.0.0.1.  Use 0.0.0.0 for docker.")
+              help="The networking interface on which the UI server listens. Defaults to "
+                   "127.0.0.1.  Use 0.0.0.0 to bind to all addresses, which is useful for running "
+                   "inside of docker.")
 def ui(file_store_path, host):
     """
     Run the MLflow tracking UI. The UI is served at http://localhost:5000.

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -124,12 +124,14 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
 @click.option("--file-store-path", default=None,
               help="The root of the backing file store for experiment and run data. Defaults to %s."
                    % file_store._default_root_dir())
-def ui(file_store_path):
+@click.option("--host", default="127.0.0.1",
+              help="The networking interface on which the UI server listens. Defaults to 127.0.0.1.")
+def ui(file_store_path, host):
     """
     Run the MLflow tracking UI. The UI is served at http://localhost:5000.
     """
     server.handlers.store = FileStore(file_store_path)
-    server.app.run("0.0.0.0")
+    server.app.run(host)
 
 
 cli.add_command(mlflow.sklearn.commands)

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -76,7 +76,9 @@ def commands():
 @click.argument("model_path")
 @click.option("--run_id", "-r", metavar="RUN_ID", help="Run ID to look for the model in.")
 @click.option("--port", "-p", default=5000, help="Server port. [default: 5000]")
-def serve_model(model_path, run_id=None, port=None):
+@click.option("--host", default="127.0.0.1",
+              help="The networking interface on which the UI server listens. Defaults to 127.0.0.1.  Use 0.0.0.0 for docker.")
+def serve_model(model_path, run_id=None, port=None, host="127.0.0.1"):
     """
     Serve a SciKit-Learn model saved with MLflow.
 
@@ -96,4 +98,4 @@ def serve_model(model_path, run_id=None, port=None):
         result = json.dumps({"predictions": predictions.tolist()})
         return flask.Response(status=200, response=result + "\n", mimetype='application/json')
 
-    app.run(port=port)
+    app.run(host, port=port)

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -77,7 +77,9 @@ def commands():
 @click.option("--run_id", "-r", metavar="RUN_ID", help="Run ID to look for the model in.")
 @click.option("--port", "-p", default=5000, help="Server port. [default: 5000]")
 @click.option("--host", default="127.0.0.1",
-              help="The networking interface on which the UI server listens. Defaults to 127.0.0.1.  Use 0.0.0.0 for docker.")
+              help="The networking interface on which the prediction server listens. Defaults to "
+                   "127.0.0.1.  Use 0.0.0.0 to bind to all addresses, which is useful for running "
+                   "inside of docker.")
 def serve_model(model_path, run_id=None, port=None, host="127.0.0.1"):
     """
     Serve a SciKit-Learn model saved with MLflow.


### PR DESCRIPTION
The UI and the model server run on 127.0.0.1 by default, but this doesn't work from within a docker container.  This PR introduces a `-host` commandline flag so that you can pass in `0.0.0.0` to listen on all interfaces.

To verify that this works, you can do the following:

```
git clone https://github.com/databricks/mlflow.git
cd mlflow
docker build -t mlfow .
docker run -it -p 5000:5000 mlflow
```

Then from within the container:

```
mlflow ui
```
And go to http://127.0.0.1:5000 and notice that you don't see the UI.  Then from within the container instead do:

```
mlflow ui --host=0.0.0.0
```

and visit http://0.0.0.0:5000

To see the model serving stuff, go into the container and do

```
python example/quickstart/test_sklearn.py
```

and note the model id.  Then do

```
mlflow sklearn serve -r <MODEL_ID> model
```

and from a separate terminal try (but fail) to get a prediction:

```
curl -d '[{"x": 1}, {"x": -1}]' -H 'Content-Type: application/json'  -X POST localhost:5000/invocations
```

Instead try

```
 mlflow sklearn serve -r 03947ea706cd474aa4d2395db7d9d6ff --host=0.0.0.0 model
```

```
curl -d '[{"x": 1}, {"x": -1}]' -H 'Content-Type: application/json'  -X POST 0.0.0.0:5000/invocations
```