### PR TITLE
Experiment name

### DIFF
--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import os
 
 import uuid
@@ -85,6 +86,8 @@ class FileStore(AbstractStore):
 
     def create_experiment(self, name):
         self._check_root_dir()
+        if name is None:
+            name = "Experiment {}".format(datetime.now().isoformat())
         experiment = self.get_experiment_by_name(name)
         if experiment is not None:
             raise Exception("Experiment '%s' already exists." % experiment.name)

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -1,5 +1,6 @@
-from google.protobuf.json_format import MessageToJson, ParseDict
+from datetime import datetime
 
+from google.protobuf.json_format import MessageToJson, ParseDict
 
 from mlflow.store.abstract_store import AbstractStore
 
@@ -78,6 +79,8 @@ class RestStore(AbstractStore):
         :param name: Desired name for an experiment
         :return: experiment_id (integer) for the newly created experiment if successful, else None
         """
+        if name is None:
+            name = "Experiment {}".format(datetime.now().isoformat())
         req_body = MessageToJson(CreateExperiment(name=name))
         response_proto = self._call_endpoint(CreateExperiment, req_body)
         return response_proto.experiment_id

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -157,6 +157,12 @@ class TestFileStore(unittest.TestCase):
         exp2 = fs.get_experiment_by_name(name)
         self.assertEqual(exp2.experiment_id, created_id)
 
+        # test that experiment is given a name if not provided
+        experiment_id = fs.create_experiment(None)
+        exp3 = fs.get_experiment(experiment_id)
+        self.assertIsNotNone(exp3.name)
+        self.assertIsInstance(exp3.name, (str, bytes))
+
     def test_create_duplicate_experiments(self):
         fs = FileStore(self.test_root)
         for exp_id in self.experiments:


### PR DESCRIPTION
Calling `mlflow.create_experiment()` without passing a name does not generate a new unique name for the experiment but the docstring says a random UUID name will be generated (which it does not). If a name is not set for an experiment the UI throws a 500 and raises the following exception:
```
TypeError: None has type <class 'NoneType'>, but expected one of: (<class 'bytes'>, <class 'str'>)
```
This will now generate a human readable experiment name such as:
```
Experiment 2018-06-10T21:34:21.539164
```
which may be desirable over something like `uuid.uuid4().hex`. I had originally only worked with the FileStore then realized it would probably be an issue for the RestStore as well. Currently this creates a name within the store backends but maybe it would be more appropriate to create/assign the name in `tracking/__init__.py:create_experiment`. Open to discussion to hear what is preferred