### PR TITLE
Experiment API fixes

### DIFF
--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -85,6 +85,8 @@ class FileStore(AbstractStore):
 
     def create_experiment(self, name):
         self._check_root_dir()
+        if name is None or name == "":
+            raise Exception("Invalid experiment name '%s'" % name)
         experiment = self.get_experiment_by_name(name)
         if experiment is not None:
             raise Exception("Experiment '%s' already exists." % experiment.name)

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -162,7 +162,7 @@ def list_experiments():
 
 def create_experiment(experiment_name):
     """
-    Creates an experiment with the specified name and returns its id.
+    Creates an experiment with the specified name and returns its ID.
     """
     if experiment_name is None or experiment_name == "":
         raise Exception("Invalid experiment name '%s'" % experiment_name)

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -153,11 +153,19 @@ class ActiveRun(object):
         return exc_type is None
 
 
-def create_experiment(experiment_name=None):
+def list_experiments():
     """
-    Creates an experiment with the specified name (or a random UUID name if no name is specified)
-    and returns its id.
+    Returns a list of all experiments
     """
+    return _get_store().list_experiments()
+
+
+def create_experiment(experiment_name):
+    """
+    Creates an experiment with the specified name and returns its id.
+    """
+    if experiment_name is None or experiment_name == "":
+        raise Exception("Invalid experiment name '%s'" % experiment_name)
     return _get_store().create_experiment(experiment_name)
 
 

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -143,6 +143,13 @@ class TestFileStore(unittest.TestCase):
 
     def test_create_experiment(self):
         fs = FileStore(self.test_root)
+
+        # Error cases
+        with self.assertRaises(Exception):
+            fs.create_experiment(None)
+        with self.assertRaises(Exception):
+            fs.create_experiment("")
+
         next_id = max(self.experiments) + 1
         name = random_str(25)  # since existing experiments are 10 chars long
         created_id = fs.create_experiment(name)


### PR DESCRIPTION
- `mlflow.list_experiments()` tracking api
- enforce non-null non-empty name requirement for `create_experiment` api