### PR TITLE
Use git_username, git_password arguments when running projects locally.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ install:
   - pip install .
   - pip install -r dev-requirements.txt
 script:
+  - git --version
+  - whoami
   - pip list
   - which mlflow
   - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,6 @@ install:
   - pip install .
   - pip install -r dev-requirements.txt
 script:
-  - git --version
-  - whoami
   - pip list
   - which mlflow
   - tox

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -67,9 +67,9 @@ def _encode(string_val):
 # NOTE: github recommends using tokens as environment vars
 # see https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
 @click.option("--git-username", metavar="USERNAME", envvar="MLFLOW_GIT_USERNAME",
-              help="Username for HTTP(S) Git authentication. Only used when running on Databricks.")
+              help="Username for HTTP(S) Git authentication.")
 @click.option("--git-password", metavar="PASSWORD", envvar="MLFLOW_GIT_PASSWORD",
-              help="Password for HTTP(S) Git authentication. Only used when running on Databricks.")
+              help="Password for HTTP(S) Git authentication.")
 @click.option("--no-conda", is_flag=True,
               help="If specified, will assume that MLflow is running within a Conda environment "
                    "with the necessary dependencies for the current project instead of attempting "

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -64,8 +64,6 @@ def _encode(string_val):
                    "Databricks. See "
                    "https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster for "
                    "more info. Note that MLflow runs are currently launched against a new cluster.")
-# NOTE: github recommends using tokens as environment vars
-# see https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
 @click.option("--git-username", metavar="USERNAME", envvar="MLFLOW_GIT_USERNAME",
               help="Username for HTTP(S) Git authentication.")
 @click.option("--git-password", metavar="PASSWORD", envvar="MLFLOW_GIT_PASSWORD",

--- a/mlflow/projects.py
+++ b/mlflow/projects.py
@@ -354,10 +354,11 @@ def _fetch_git_repo(uri, version, dst_dir, git_username, git_password):
     if not (all(arg is not None for arg in git_args) or all(arg is None for arg in git_args)):
         raise ExecutionException("Either both or neither of git_username and git_password must be "
                                  "specified.")
-    git_credentials = "url=%s\nusername=%s\npassword=%s" % (uri, git_username, git_password)
-    repo.git.config("--local", "credential.helper", "cache")
-    process.exec_cmd(cmd=["git", "credential-cache", "store"], cwd=dst_dir,
-                     cmd_stdin=git_credentials)
+    if git_username:
+        git_credentials = "url=%s\nusername=%s\npassword=%s" % (uri, git_username, git_password)
+        repo.git.config("--local", "credential.helper", "cache")
+        process.exec_cmd(cmd=["git", "credential-cache", "store"], cwd=dst_dir,
+                         cmd_stdin=git_credentials)
     origin.fetch()
     if version is not None:
         repo.git.checkout(version)

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -6,7 +6,8 @@ class ShellCommandException(Exception):
     pass
 
 
-def exec_cmd(cmd, throw_on_error=True, env=None, stream_output=False, cwd=None, **kwargs):
+def exec_cmd(cmd, throw_on_error=True, env=None, stream_output=False, cwd=None, stdin=None,
+             **kwargs):
     """
     Runs a command as a child process.
 
@@ -37,7 +38,7 @@ def exec_cmd(cmd, throw_on_error=True, env=None, stream_output=False, cwd=None, 
         child = subprocess.Popen(
             cmd, env=cmd_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
             cwd=cwd, universal_newlines=True, **kwargs)
-        (stdout, stderr) = child.communicate()
+        (stdout, stderr) = child.communicate(stdin)
         exit_code = child.wait()
         if throw_on_error and exit_code is not 0:
             raise ShellCommandException("Non-zero exit code: %s\n\nSTDOUT:\n%s\n\nSTDERR:%s" %

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -6,7 +6,7 @@ class ShellCommandException(Exception):
     pass
 
 
-def exec_cmd(cmd, throw_on_error=True, env=None, stream_output=False, cwd=None, stdin=None,
+def exec_cmd(cmd, throw_on_error=True, env=None, stream_output=False, cwd=None, cmd_stdin=None,
              **kwargs):
     """
     Runs a command as a child process.
@@ -19,6 +19,7 @@ def exec_cmd(cmd, throw_on_error=True, env=None, stream_output=False, cwd=None, 
     cwd -- working directory for child process
     stream_output -- if true, does not capture standard output and error; if false, captures these
       streams and returns them
+    cmd_stdin -- if specified, passes the specified string as stdin to the child process.
 
     Note on the return value: If stream_output is true, then only the exit code is returned. If
     stream_output is false, then a tuple of the exit code, standard output and standard error is
@@ -29,16 +30,18 @@ def exec_cmd(cmd, throw_on_error=True, env=None, stream_output=False, cwd=None, 
         cmd_env.update(env)
 
     if stream_output:
-        child = subprocess.Popen(cmd, env=cmd_env, cwd=cwd, universal_newlines=True, **kwargs)
+        child = subprocess.Popen(cmd, env=cmd_env, cwd=cwd, universal_newlines=True,
+                                 stdin=subprocess.PIPE, **kwargs)
+        child.communicate(cmd_stdin)
         exit_code = child.wait()
         if throw_on_error and exit_code is not 0:
             raise ShellCommandException("Non-zero exitcode: %s" % (exit_code))
         return exit_code
     else:
         child = subprocess.Popen(
-            cmd, env=cmd_env, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            cmd, env=cmd_env, stdout=subprocess.PIPE, stdin=subprocess.PIPE, stderr=subprocess.PIPE,
             cwd=cwd, universal_newlines=True, **kwargs)
-        (stdout, stderr) = child.communicate(stdin)
+        (stdout, stderr) = child.communicate(cmd_stdin)
         exit_code = child.wait()
         if throw_on_error and exit_code is not 0:
             raise ShellCommandException("Non-zero exit code: %s\n\nSTDOUT:\n%s\n\nSTDERR:%s" %

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -39,7 +39,6 @@ def test_fetch_project():
                                                git_password=password)
 
 
-
 def test_run_mode():
     """ Verify that we pick the right run helper given an execution mode """
     with TempDir() as tmp, mock.patch("mlflow.tracking.get_tracking_uri") as get_tracking_uri_mock:

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -30,6 +30,14 @@ def test_fetch_project():
         with pytest.raises(ExecutionException):
             mlflow.projects._fetch_project(uri=TEST_PROJECT_DIR, version="some-version",
                                            dst_dir=dst_dir, git_username=None, git_password=None)
+    # Passing only one of git_username, git_password results in an error
+    for username, password in [(None, "hi"), ("hi", None)]:
+        with TempDir() as dst_dir:
+            with pytest.raises(ExecutionException):
+                mlflow.projects._fetch_project(uri=TEST_PROJECT_DIR, version="some-version",
+                                               dst_dir=dst_dir, git_username=username,
+                                               git_password=password)
+
 
 
 def test_run_mode():

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -18,7 +18,8 @@ def test_fetch_project():
     """ Test fetching a project to be run locally. """
     with TempDir() as tmp:
         dst_dir = tmp.path()
-        mlflow.projects._fetch_project(uri=TEST_PROJECT_DIR, version=None, dst_dir=dst_dir)
+        mlflow.projects._fetch_project(uri=TEST_PROJECT_DIR, version=None, dst_dir=dst_dir,
+                                       git_username=None, git_password=None)
         dir_comparison = filecmp.dircmp(TEST_PROJECT_DIR, dst_dir)
         assert len(dir_comparison.left_only) == 0
         assert len(dir_comparison.right_only) == 0
@@ -28,7 +29,7 @@ def test_fetch_project():
     with TempDir() as dst_dir:
         with pytest.raises(ExecutionException):
             mlflow.projects._fetch_project(uri=TEST_PROJECT_DIR, version="some-version",
-                                           dst_dir=dst_dir)
+                                           dst_dir=dst_dir, git_username=None, git_password=None)
 
 
 def test_run_mode():


### PR DESCRIPTION
Allow users to pass `git_username` and `git_password` arguments to `mlflow run` when running locally, storing the credentials in-memory using the [cache credential helper](https://git-scm.com/docs/gitcredentials#gitcredentials-cache) and using them to fetch the project.