### PR TITLE
Add get_or_create_experiment to tracking api

### DIFF
--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -169,6 +169,19 @@ def create_experiment(experiment_name):
     return _get_store().create_experiment(experiment_name)
 
 
+def get_or_create_experiment(experiment_name):
+    """
+    Finds an existing experiment or creates it if it does not exist. Always returns the experiment ID.
+    """
+    if experiment_name is None or experiment_name == "":
+        raise Exception("Invalid experiment name '%s'" % experiment_name)
+    experiment = _get_store().get_experiment_by_name(experiment_name)
+    if experiment is not None:
+        return experiment.experiment_id
+    return _get_store().create_experiment(experiment_name)
+
+
+
 def _get_main_file():
     if len(sys.argv) > 0:
         return sys.argv[0]
@@ -295,7 +308,7 @@ def log_param(key, value):
     Logs the passed-in parameter under the current run, creating a run if necessary.
     :param key: Parameter name (string)
     :param value: Parameter value (string)
-    """  
+    """
     _get_or_start_run().log_param(Param(key, str(value)))
 
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -38,6 +38,28 @@ def test_create_experiment():
         exp_id = tracking.create_experiment("Some random experiment name %d" % random.randint(1, 1e6))
         assert exp_id is not None
 
+def test_get_or_create_experiment():
+    with pytest.raises(TypeError):
+        tracking.get_or_create_experiment()
+
+    with pytest.raises(Exception):
+        tracking.get_or_create_experiment(None)
+
+    with pytest.raises(Exception):
+        tracking.get_or_create_experiment("")
+
+    with temp_directory() as tmp_dir, mock.patch("mlflow.tracking._get_store") as get_store_mock:
+        get_store_mock.return_value = FileStore(tmp_dir)
+        exp_id = tracking.get_or_create_experiment("Non-existent experiment %d" % random.randint(1, 1e6))
+        assert exp_id is not None
+
+    with temp_directory() as tmp_dir, mock.patch("mlflow.tracking._get_store") as get_store_mock:
+        get_store_mock.return_value = FileStore(tmp_dir)
+        experiment_name = "Experiment %d" % random.randint(1, 1e6)
+        exp_id_first_time = tracking.get_or_create_experiment(experiment_name)
+        assert exp_id_first_time is not None
+        exp_id_second_time = tracking.get_or_create_experiment(experiment_name)
+        assert exp_id_first_time == exp_id_second_time
 
 def test_start_run_context_manager():
     with temp_directory() as tmp_dir, mock.patch("mlflow.tracking._get_store") as get_store_mock:


### PR DESCRIPTION
I find this new method particularly useful when running the same experiment multiple times e.g. when running a python notebook. A concrete example of how I'm using the tracking API can be found at: https://github.com/Cs4r/digit-recognizer-mlflow/blob/master/MNIST%20data.ipynb