### PR TITLE
Add S3 artifact repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,8 @@ install:
   - pip install .
   - pip install -r dev-requirements.txt
   - export MLFLOW_HOME=$(pwd)
-  - export BOTO_CONFIG=/dev/null
+  # Remove boto config present in Travis VMs
+  - sudo rm -f /etc/boto.cfg
 script:
   - pip list
   - which mlflow

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
   - pip install .
   - pip install -r dev-requirements.txt
   - export MLFLOW_HOME=$(pwd)
-  # Remove boto config present in Travis VMs
+  # Remove boto config present in Travis VMs (https://github.com/travis-ci/travis-ci/issues/7940)
   - sudo rm -f /etc/boto.cfg
 script:
   - pip list

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ install:
   - pip install .
   - pip install -r dev-requirements.txt
   - export MLFLOW_HOME=$(pwd)
+  - export BOTO_CONFIG=/dev/null
 script:
   - pip list
   - which mlflow

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -133,13 +133,15 @@ def ui(file_store, host, port):
     The UI will be visible at http://localhost:5000 by default.
     """
     # TODO: We eventually want to disable the write path in this version of the server.
-    mlflow.server._run_server(file_store, host, port, 1)
+    mlflow.server._run_server(file_store, file_store, host, port, 1)
 
 
 @cli.command()
 @click.option("--file-store", metavar="PATH", default=None,
               help="The root of the backing file store for experiment and run data "
                    "(default: ./mlruns).")
+@click.option("--artifact-root", metavar="URI", default=None,
+              help="Local or S3 URI to store artifacts in (default: inside file store).")
 @click.option("--host", "-h", metavar="HOST", default="127.0.0.1",
               help="The network address to listen on (default: 127.0.0.1). "
                    "Use 0.0.0.0 to bind to all addresses if you want to access the tracking "
@@ -148,7 +150,7 @@ def ui(file_store, host, port):
               help="The port to listen on (default: 5000).")
 @click.option("--workers", "-w", default=4,
               help="Number of gunicorn worker processes to handle requests (default: 4).")
-def server(file_store, host, port, workers):
+def server(file_store, artifact_root, host, port, workers):
     """
     Run the MLflow tracking server.
 
@@ -156,7 +158,7 @@ def server(file_store, host, port, workers):
     the local machine. To let the server accept connections from other machines, you will need to
     pass --host 0.0.0.0 to listen on all network interfaces (or a specific interface address).
     """
-    mlflow.server._run_server(file_store, host, port, workers)
+    mlflow.server._run_server(file_store, artifact_root, host, port, workers)
 
 
 cli.add_command(mlflow.sklearn.commands)

--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -10,7 +10,7 @@ from mlflow.store import file_store as store
 
 @click.group("experiments")
 def commands():
-    """Tracking APIs."""
+    """Manage experiments."""
     pass
 
 
@@ -18,25 +18,29 @@ def commands():
 @click.option("--file-store", default=None,
               help="The root of the backing file store for experiment and run data "
                    "(default: ./mlruns).")
+@click.option("--artifact-root", metavar="URI", default=None,
+              help="Local or S3 URI to store artifacts in (default: inside file store).")
 @click.argument("experiment_name")
-def create(file_store, experiment_name):
+def create(file_store, artifact_root, experiment_name):
     """
     Creates a new experiment in FileStore backend.
     """
-    fs = store.FileStore(file_store)
+    fs = store.FileStore(file_store, artifact_root)
     exp_id = fs.create_experiment(experiment_name)
-    print("Created experiment '%s' with id '%d'" % (experiment_name, exp_id))
+    print("Created experiment '%s' with id %d" % (experiment_name, exp_id))
 
 
 @commands.command("list")
 @click.option("--file-store", default=None,
               help="The root of the backing file store for experiment and run data "
                    "(default: ./mlruns).")
-def list_experiments(file_store):
+@click.option("--artifact-root", metavar="URI", default=None,
+              help="Local or S3 URI to store artifacts in (default: inside file store).")
+def list_experiments(file_store, artifact_root):
     """
     List all experiment in FileStore backend.
     """
-    fs = store.FileStore(file_store)
+    fs = store.FileStore(file_store, artifact_root)
     experiments = fs.list_experiments()
     table = [[exp.experiment_id, exp.name, os.path.abspath(exp.artifact_location)]
              for exp in experiments]

--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -34,13 +34,11 @@ def create(file_store, artifact_root, experiment_name):
 @click.option("--file-store", default=None,
               help="The root of the backing file store for experiment and run data "
                    "(default: ./mlruns).")
-@click.option("--artifact-root", metavar="URI", default=None,
-              help="Local or S3 URI to store artifacts in (default: inside file store).")
-def list_experiments(file_store, artifact_root):
+def list_experiments(file_store):
     """
     List all experiment in FileStore backend.
     """
-    fs = store.FileStore(file_store, artifact_root)
+    fs = store.FileStore(file_store)
     experiments = fs.list_experiments()
     table = [[exp.experiment_id, exp.name, os.path.abspath(exp.artifact_location)]
              for exp in experiments]

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -6,6 +6,7 @@ from mlflow.server import handlers
 from mlflow.utils.process import exec_cmd
 
 FILE_STORE_ENV_VAR = "MLFLOW_SERVER_FILE_STORE"
+ARTIFACT_ROOT_ENV_VAR = "MLFLOW_SERVER_ARTIFACT_ROOT"
 
 REL_STATIC_DIR = "js/build"
 app = Flask(__name__, static_folder=REL_STATIC_DIR)
@@ -35,11 +36,13 @@ def serve(path):  # pylint: disable=unused-argument
     return send_from_directory(STATIC_DIR, 'index.html')
 
 
-def _run_server(file_store_path, host, port, workers):
+def _run_server(file_store_path, artifact_root, host, port, workers):
     """Run the MLflow server, wrapping it in gunicorn"""
     env_map = {}
     if file_store_path:
         env_map[FILE_STORE_ENV_VAR] = file_store_path
+    if artifact_root:
+        env_map[ARTIFACT_ROOT_ENV_VAR] = artifact_root
     bind_address = "%s:%s" % (host, port)
     exec_cmd(["gunicorn", "-b", bind_address, "-w", "%s" % workers, "mlflow.server:app"],
              env=env_map, stream_output=True)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -173,13 +173,13 @@ def _list_artifacts():
     return response
 
 
-_TEXT_EXTENSIONS = ['txt', 'yaml', 'json', 'js', 'py', 'csv', 'MLmodel', 'MLproject']
+_TEXT_EXTENSIONS = ['txt', 'yaml', 'json', 'js', 'py', 'csv', 'md', 'rst', 'MLmodel', 'MLproject']
 
 
 def _get_artifact():
     request_message = _get_request_message(GetArtifact(), from_get=True)
     run = _get_store().get_run(request_message.run_uuid)
-    filename = os.path.abspath(_get_artifact_repo(run).download_artifact(request_message.path))
+    filename = os.path.abspath(_get_artifact_repo(run).download_artifacts(request_message.path))
     extension = os.path.splitext(filename)[-1].replace(".", "")
     if extension in _TEXT_EXTENSIONS:
         return send_file(filename, mimetype='text/plain')

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -22,11 +22,12 @@ _store = None
 
 
 def _get_store():
-    from mlflow.server import FILE_STORE_ENV_VAR
+    from mlflow.server import FILE_STORE_ENV_VAR, ARTIFACT_ROOT_ENV_VAR
     global _store
     if _store is None:
         store_dir = os.environ.get(FILE_STORE_ENV_VAR, os.path.abspath("mlruns"))
-        _store = FileStore(store_dir)
+        artifact_root = os.environ.get(ARTIFACT_ROOT_ENV_VAR, store_dir)
+        _store = FileStore(store_dir, artifact_root)
     return _store
 
 

--- a/mlflow/server/js/src/utils/FileUtils.js
+++ b/mlflow/server/js/src/utils/FileUtils.js
@@ -9,4 +9,5 @@ export const getExtension = (path) => {
 };
 
 export const IMAGE_EXTENSIONS = new Set(['jpg', 'bmp', 'jpeg', 'png', 'gif', 'svg']);
-export const TEXT_EXTENSIONS = new Set(['txt', 'py', 'js', 'yaml', 'json', 'csv', 'MLmodel', 'MLproject']);
+export const TEXT_EXTENSIONS = new Set(
+  ['txt', 'py', 'js', 'yaml', 'json', 'csv', 'md', 'rst', 'MLmodel', 'MLproject']);

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -136,7 +136,7 @@ class S3ArtifactRepository(ArtifactRepository):
             dest_path = build_path(dest_path, artifact_path)
         s3 = boto3.client('s3')
         local_dir = os.path.abspath(local_dir)
-        for (root, dirs, filenames) in os.walk(local_dir):
+        for (root, _, filenames) in os.walk(local_dir):
             upload_path = dest_path
             if root != local_dir:
                 rel_path = get_relative_path(local_dir, root)
@@ -167,22 +167,23 @@ class S3ArtifactRepository(ArtifactRepository):
                 infos.append(FileInfo(name, False, size))
         return sorted(infos, key=lambda f: f.path)
 
-    def download_artifacts(self, artifact_path, dest_dir=None):
-        if not dest_dir:
-            with TempDir(remove_on_exit=False) as tmp:
-                return self.download_artifacts(artifact_path, tmp.path())
+    def download_artifacts(self, artifact_path):
+        with TempDir(remove_on_exit=False) as tmp:
+            return self._download_artifacts_into(artifact_path, tmp.path())
+
+    def _download_artifacts_into(self, artifact_path, dest_dir):
+        """Private version of download_artifacts that takes a destination directory."""
+        basename = os.path.basename(artifact_path)
+        local_path = build_path(dest_dir, basename)
+        listing = self.list_artifacts(artifact_path)
+        if len(listing) > 0:
+            # Artifact_path is a directory, so make a directory for it and download everything
+            os.mkdir(local_path)
+            for file_info in listing:
+                self._download_artifacts_into(file_info.path, local_path)
         else:
-            basename = os.path.basename(artifact_path)
-            local_path = build_path(dest_dir, basename)
-            listing = self.list_artifacts(artifact_path)
-            if len(listing) > 0:
-                # Artifact_path is a directory, so make a directory for it and download everything
-                os.mkdir(local_path)
-                for file_info in listing:
-                    self.download_artifacts(file_info.path, local_path)
-            else:
-                (bucket, s3_path) = self.parse_s3_uri(self.artifact_uri)
-                s3_path = build_path(s3_path, artifact_path)
-                boto3.client('s3').download_file(bucket, s3_path, local_path)
-            return local_path
+            (bucket, s3_path) = self.parse_s3_uri(self.artifact_uri)
+            s3_path = build_path(s3_path, artifact_path)
+            boto3.client('s3').download_file(bucket, s3_path, local_path)
+        return local_path
 

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -49,7 +49,7 @@ class ArtifactRepository:
     def list_artifacts(self, path):
         """
         Return all the artifacts for this run_uuid directly under path.
-        :param path: relative source path that contain desired artifacts
+        :param path: Relative source path that contain desired artifacts
         :return: List of artifacts as FileInfo listed directly under path.
         """
         pass
@@ -57,11 +57,13 @@ class ArtifactRepository:
     @abstractmethod
     def download_artifacts(self, artifact_path):
         """
-        Download an artifact (either file or directory) to a local directory if applicable, and
-        return a local path for it.
-        :param path: relative source path to the desired artifact
+        Download an artifact file or directory to a local directory if applicable, and return a
+        local path for it.
+        :param path: Relative source path to the desired artifact
         :return: Full path desired artifact.
         """
+        # TODO: Probably need to add a more efficient method to stream just a single artifact
+        # without downloading it, or to get a pre-signed URL for cloud storage.
         pass
 
     @staticmethod
@@ -78,7 +80,7 @@ class ArtifactRepository:
 
 
 class LocalArtifactRepository(ArtifactRepository):
-    """Stores files in a local directory."""
+    """Stores artifacts as files in a local directory."""
 
     def log_artifact(self, local_file, artifact_path=None):
         artifact_dir = build_path(self.artifact_uri, artifact_path) \
@@ -107,7 +109,7 @@ class LocalArtifactRepository(ArtifactRepository):
 
 
 class S3ArtifactRepository(ArtifactRepository):
-    """Stores files on Amazon S3."""
+    """Stores artifacts on Amazon S3."""
 
     @staticmethod
     def parse_s3_uri(uri):
@@ -147,7 +149,6 @@ class S3ArtifactRepository(ArtifactRepository):
         dest_path = artifact_path
         if path:
             dest_path = build_path(dest_path, path)
-        print "list_artifacts %s %s %s" % (self.artifact_uri, dest_path, bucket)
         infos = []
         prefix = dest_path + "/"
         paginator = boto3.client('s3').get_paginator("list_objects_v2")

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -1,10 +1,14 @@
-
 from abc import abstractmethod, ABCMeta
 import shutil
-
+from six.moves import urllib
 from distutils import dir_util
-from mlflow.utils.file_utils import (mkdir, exists, list_all, get_relative_path, 
-                                     get_file_info, build_path)
+import os
+
+import boto3
+
+from mlflow.utils.file_utils import (mkdir, exists, list_all, get_relative_path,
+                                     get_file_info, build_path, TempDir)
+from mlflow.entities.file_info import FileInfo
 
 
 class ArtifactRepository:
@@ -51,20 +55,35 @@ class ArtifactRepository:
         pass
 
     @abstractmethod
-    def download_artifact(self, artifact_path):
+    def download_artifacts(self, artifact_path):
         """
+        Download an artifact (either file or directory) to a local directory if applicable, and
+        return a local path for it.
         :param path: relative source path to the desired artifact
         :return: Full path desired artifact.
         """
         pass
 
+    #@abstractmethod
+    #def open_artifact(self, artifact_path):
+    #    """
+    #    Open an artifact as a file-like object.
+    #    :param path: relative source path to the desired artifact
+    #    :return: Full path desired artifact.
+    #    """
+    #    pass
+
     @staticmethod
-    def from_artifact_uri(artfact_uri):
-        """Given an artifact URI for an Experiment Run (e.g., /local/file/path or s3://my/bucket),
+    def from_artifact_uri(artifact_uri):
+        """
+        Given an artifact URI for an Experiment Run (e.g., /local/file/path or s3://my/bucket),
         returns an ArtifactReposistory instance capable of logging and downloading artifacts
         on behalf of this URI.
         """
-        return LocalFileRepository(artfact_uri)
+        if artifact_uri.startswith("s3:/"):
+            return S3Repository(artifact_uri)
+        else:
+            return LocalFileRepository(artifact_uri)
 
 
 class LocalFileRepository(ArtifactRepository):
@@ -88,8 +107,99 @@ class LocalFileRepository(ArtifactRepository):
         artifact_dir = self.artifact_uri
         list_dir = build_path(artifact_dir, path) if path else artifact_dir
         artifact_files = list_all(list_dir, full_path=True)
-        return [get_file_info(f, get_relative_path(artifact_dir, f)) for f in artifact_files]
+        infos = [get_file_info(f, get_relative_path(artifact_dir, f)) for f in artifact_files]
+        return sorted(infos, key=lambda f: f.path)
 
-    def download_artifact(self, artifact_path):
-        """Since this is a local file store, we do not need to download the artifact."""
+    def download_artifacts(self, artifact_path):
+        """Since this is a local file store, just return the artifacts' local path."""
         return build_path(self.artifact_uri, artifact_path)
+
+    #def open_artifact(self, artifact_path):
+    #    """Since this is a local file store, just open the local file."""
+    #    return open(build_path(self.artifact_uri, artifact_path))
+
+
+class S3Repository(ArtifactRepository):
+    """Stores files on Amazon S3."""
+
+    @staticmethod
+    def parse_s3_uri(uri):
+        """Parse an S3 URI, returning (bucket, path)"""
+        parsed = urllib.parse.urlparse(uri)
+        if parsed.scheme != "s3":
+            raise Exception("Not an S3 URI: %s" % uri)
+        path = parsed.path
+        if path.startswith('/'):
+            path = path[1:]
+        return parsed.netloc, path
+
+    def log_artifact(self, local_file, artifact_path):
+        (bucket, dest_path) = S3Repository.parse_s3_uri(self.artifact_uri)
+        if artifact_path:
+            dest_path = build_path(dest_path, artifact_path)
+        dest_path = build_path(dest_path, os.path.basename(local_file))
+
+        boto3.client('s3').upload_file(local_file, bucket, dest_path)
+
+    def log_artifacts(self, local_dir, artifact_path):
+        (bucket, dest_path) = S3Repository.parse_s3_uri(self.artifact_uri)
+        if artifact_path:
+            dest_path = build_path(dest_path, artifact_path)
+        s3 = boto3.client('s3')
+        local_dir = os.path.abspath(local_dir)
+        for (root, dirs, filenames) in os.walk(local_dir):
+            upload_path = dest_path
+            if root != local_dir:
+                rel_path = get_relative_path(local_dir, root)
+                upload_path = build_path(dest_path, rel_path)
+            for f in filenames:
+                s3.upload_file(build_path(root, f), bucket, build_path(upload_path, f))
+
+    def list_artifacts(self, path=None):
+        (bucket, artifact_path) = S3Repository.parse_s3_uri(self.artifact_uri)
+        dest_path = artifact_path
+        if path:
+            dest_path = build_path(dest_path, path)
+        print "list_artifacts %s %s %s" % (self.artifact_uri, dest_path, bucket)
+        infos = []
+        prefix = dest_path + "/"
+        paginator = boto3.client('s3').get_paginator("list_objects_v2")
+        results = paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter='/')
+        for result in results:
+            # Subdirectories will be listed as "common prefixes" due to the way we made the request
+            for obj in result.get("CommonPrefixes", []):
+                subdir = obj.get("Prefix")[len(artifact_path)+1:]
+                if subdir.endswith("/"):
+                    subdir = subdir[:-1]
+                infos.append(FileInfo(subdir, True, None))
+            # Objects listed directly will be files
+            for obj in result.get('Contents', []):
+                name = obj.get("Key")[len(artifact_path)+1:]
+                size = int(obj.get('Size'))
+                infos.append(FileInfo(name, False, size))
+        return sorted(infos, key=lambda f: f.path)
+
+    def download_artifacts(self, artifact_path, dest_dir=None):
+        if not dest_dir:
+            with TempDir(remove_on_exit=False) as tmp:
+                return self.download_artifacts(artifact_path, tmp.path())
+        else:
+            basename = os.path.basename(artifact_path)
+            local_path = build_path(dest_dir, basename)
+            listing = self.list_artifacts(artifact_path)
+            if len(listing) > 0:
+                # Artifact_path is a directory, so make a directory for it and download everything
+                os.mkdir(local_path)
+                for file_info in listing:
+                    self.download_artifacts(file_info.path, local_path)
+            else:
+                (bucket, s3_path) = S3Repository.parse_s3_uri(self.artifact_uri)
+                s3_path = build_path(s3_path, artifact_path)
+                boto3.client('s3').download_file(bucket, s3_path, local_path)
+            return local_path
+
+    #def open_artifact(self, artifact_path):
+    #    (bucket, dest_path) = S3Repository.parse_s3_uri(self.artifact_uri)
+    #    dest_path = build_path(dest_path, artifact_path)
+    #    obj = boto3.resource('s3').Object(bucket, dest_path)
+    #    return obj.get()["Body"]

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -64,15 +64,6 @@ class ArtifactRepository:
         """
         pass
 
-    #@abstractmethod
-    #def open_artifact(self, artifact_path):
-    #    """
-    #    Open an artifact as a file-like object.
-    #    :param path: relative source path to the desired artifact
-    #    :return: Full path desired artifact.
-    #    """
-    #    pass
-
     @staticmethod
     def from_artifact_uri(artifact_uri):
         """
@@ -113,10 +104,6 @@ class LocalFileRepository(ArtifactRepository):
     def download_artifacts(self, artifact_path):
         """Since this is a local file store, just return the artifacts' local path."""
         return build_path(self.artifact_uri, artifact_path)
-
-    #def open_artifact(self, artifact_path):
-    #    """Since this is a local file store, just open the local file."""
-    #    return open(build_path(self.artifact_uri, artifact_path))
 
 
 class S3Repository(ArtifactRepository):
@@ -198,8 +185,3 @@ class S3Repository(ArtifactRepository):
                 boto3.client('s3').download_file(bucket, s3_path, local_path)
             return local_path
 
-    #def open_artifact(self, artifact_path):
-    #    (bucket, dest_path) = S3Repository.parse_s3_uri(self.artifact_uri)
-    #    dest_path = build_path(dest_path, artifact_path)
-    #    obj = boto3.resource('s3').Object(bucket, dest_path)
-    #    return obj.get()["Body"]

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -68,8 +68,11 @@ class FileStore(AbstractStore):
                           param_name)
 
     def _get_artifact_dir(self, experiment_id, run_uuid):
-        artifacts_dir = build_path(self._get_run_dir(experiment_id, run_uuid),
+        artifacts_dir = build_path(self.get_experiment(experiment_id).artifact_location,
+                                   run_uuid,
                                    FileStore.ARTIFACTS_FOLDER_NAME)
+        #artifacts_dir = build_path(self._get_run_dir(experiment_id, run_uuid),
+        #                           FileStore.ARTIFACTS_FOLDER_NAME)
         return artifacts_dir
 
     def list_experiments(self):
@@ -78,9 +81,9 @@ class FileStore(AbstractStore):
 
     def _create_experiment_with_id(self, name, experiment_id):
         self._check_root_dir()
-        location = mkdir(self.root_directory, str(experiment_id))
-        experiment = Experiment(experiment_id, name, location)
-        write_yaml(location, FileStore.META_DATA_FILE_NAME, dict(experiment))
+        exp_location = mkdir(self.root_directory, str(experiment_id))
+        experiment = Experiment(experiment_id, name, exp_location)
+        write_yaml(exp_location, FileStore.META_DATA_FILE_NAME, dict(experiment))
         return experiment_id
 
     def create_experiment(self, name):
@@ -160,7 +163,7 @@ class FileStore(AbstractStore):
         write_yaml(run_dir, FileStore.META_DATA_FILE_NAME, dict(run_info))
         mkdir(run_dir, FileStore.METRICS_FOLDER_NAME)
         mkdir(run_dir, FileStore.PARAMS_FOLDER_NAME)
-        mkdir(run_dir, FileStore.ARTIFACTS_FOLDER_NAME)
+        #mkdir(run_dir, FileStore.ARTIFACTS_FOLDER_NAME)
         return Run(run_info=run_info, run_data=None)
 
     def get_run(self, run_uuid):

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -32,10 +32,13 @@ class FileStore(AbstractStore):
     PARAMS_FOLDER_NAME = "params"
     META_DATA_FILE_NAME = "meta.yaml"
 
-    def __init__(self, root_directory=None, artifact_root_dir=None):
+    def __init__(self, root_directory=None, artifact_root_uri=None):
+        """
+        Create a new FileStore with the given root directory and a given default artifact root URI.
+        """
         super(FileStore, self).__init__()
         self.root_directory = root_directory or _default_root_dir()
-        self.artifact_root_dir = artifact_root_dir or self.root_directory
+        self.artifact_root_uri = artifact_root_uri or self.root_directory
         # Create root directory if needed
         if not exists(self.root_directory):
             mkdir(self.root_directory)
@@ -79,9 +82,10 @@ class FileStore(AbstractStore):
 
     def _create_experiment_with_id(self, name, experiment_id):
         self._check_root_dir()
-        location = mkdir(self.root_directory, str(experiment_id))
-        experiment = Experiment(experiment_id, name, location)
-        write_yaml(location, FileStore.META_DATA_FILE_NAME, dict(experiment))
+        meta_dir = mkdir(self.root_directory, str(experiment_id))
+        artifact_uri = build_path(self.artifact_root_uri, str(experiment_id))
+        experiment = Experiment(experiment_id, name, artifact_uri)
+        write_yaml(meta_dir, FileStore.META_DATA_FILE_NAME, dict(experiment))
         return experiment_id
 
     def create_experiment(self, name):

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -71,8 +71,6 @@ class FileStore(AbstractStore):
         artifacts_dir = build_path(self.get_experiment(experiment_id).artifact_location,
                                    run_uuid,
                                    FileStore.ARTIFACTS_FOLDER_NAME)
-        #artifacts_dir = build_path(self._get_run_dir(experiment_id, run_uuid),
-        #                           FileStore.ARTIFACTS_FOLDER_NAME)
         return artifacts_dir
 
     def list_experiments(self):
@@ -81,9 +79,9 @@ class FileStore(AbstractStore):
 
     def _create_experiment_with_id(self, name, experiment_id):
         self._check_root_dir()
-        exp_location = mkdir(self.root_directory, str(experiment_id))
-        experiment = Experiment(experiment_id, name, exp_location)
-        write_yaml(exp_location, FileStore.META_DATA_FILE_NAME, dict(experiment))
+        location = mkdir(self.root_directory, str(experiment_id))
+        experiment = Experiment(experiment_id, name, location)
+        write_yaml(location, FileStore.META_DATA_FILE_NAME, dict(experiment))
         return experiment_id
 
     def create_experiment(self, name):
@@ -163,7 +161,7 @@ class FileStore(AbstractStore):
         write_yaml(run_dir, FileStore.META_DATA_FILE_NAME, dict(run_info))
         mkdir(run_dir, FileStore.METRICS_FOLDER_NAME)
         mkdir(run_dir, FileStore.PARAMS_FOLDER_NAME)
-        #mkdir(run_dir, FileStore.ARTIFACTS_FOLDER_NAME)
+        mkdir(run_dir, FileStore.ARTIFACTS_FOLDER_NAME)
         return Run(run_info=run_info, run_data=None)
 
     def get_run(self, run_uuid):

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -341,7 +341,7 @@ def _get_model_log_dir(model_name, run_id):
         artifact_repo = ArtifactRepository.from_artifact_uri(run.info.artifact_uri)
     else:
         artifact_repo = _get_legacy_artifact_repo(_get_store(), run.info)
-    return artifact_repo.download_artifact(model_name)
+    return artifact_repo.download_artifacts(model_name)
 
 
 def _get_legacy_artifact_repo(file_store, run_info):

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -130,10 +130,10 @@ class ActiveRun(object):
     def log_param(self, param):
         self.store.log_param(self.run_info.run_uuid, param)
 
-    def log_artifact(self, local_path, artifact_path):
+    def log_artifact(self, local_path, artifact_path=None):
         self.artifact_repo.log_artifact(local_path, artifact_path)
 
-    def log_artifacts(self, local_dir, artifact_path):
+    def log_artifacts(self, local_dir, artifact_path=None):
         self.artifact_repo.log_artifacts(local_dir, artifact_path)
 
     def get_artifact_uri(self):

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -250,18 +250,6 @@ class TestFileStore(unittest.TestCase):
                     self.assertEqual(param.key, param_name)
                     self.assertEqual(param.value, param_value)
 
-    def test_list_artifacts(self):
-        fs = FileStore(self.test_root)
-        # replace with test with code is implemented
-        with self.assertRaises(Exception):
-            self.assertIsNotNone(fs.list_artifacts("random uuid", "some relative path"))
-
-    def test_get_artifact(self):
-        fs = FileStore(self.test_root)
-        # replace with test with code is implemented
-        with self.assertRaises(Exception):
-            self.assertIsNotNone(fs.get_artifact("random uuid", "some relative path"))
-
     def test_search_runs(self):
         # replace with test with code is implemented
         fs = FileStore(self.test_root)

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -1,0 +1,60 @@
+import os
+import shutil
+import unittest
+
+from mlflow.store.artifact_repo import ArtifactRepository, LocalArtifactRepository
+from mlflow.utils.file_utils import TempDir
+from tests.helper_functions import random_int
+
+
+class TestLocalArtifactRepo(unittest.TestCase):
+    ROOT_LOCATION = "/tmp"
+
+    def setUp(self):
+        self._create_root(TestLocalArtifactRepo.ROOT_LOCATION)
+
+    def _create_root(self, root):
+        self.test_root = os.path.abspath(os.path.join(root, "test_local_repo_%d" % random_int()))
+        os.mkdir(self.test_root)
+
+    def test_basic_functions(self):
+        repo = ArtifactRepository.from_artifact_uri(self.test_root)
+        self.assertIsInstance(repo, LocalArtifactRepository)
+        self.assertListEqual(repo.list_artifacts(), [])
+        with self.assertRaises(Exception):
+            open(repo.download_artifacts("test.txt")).read()
+
+        with TempDir() as tmp:
+            # Create and log a test.txt file directly
+            with open(tmp.path("test.txt"), "w") as f:
+                f.write("Hello world!")
+            repo.log_artifact(tmp.path("test.txt"))
+            text = open(repo.download_artifacts("test.txt")).read()
+            self.assertEqual(text, "Hello world!")
+            # Check that it actually got written in the expected place
+            text = open(os.path.join(self.test_root, "test.txt")).read()
+            self.assertEqual(text, "Hello world!")
+
+            # Create a subdirectory for log_artifacts
+            os.mkdir(tmp.path("subdir"))
+            os.mkdir(tmp.path("subdir", "nested"))
+            with open(tmp.path("subdir", "a.txt"), "w") as f:
+                f.write("A")
+            with open(tmp.path("subdir", "b.txt"), "w") as f:
+                f.write("B")
+            with open(tmp.path("subdir", "nested", "c.txt"), "w") as f:
+                f.write("C")
+            repo.log_artifacts(tmp.path("subdir"))
+            text = open(repo.download_artifacts("a.txt")).read()
+            self.assertEqual(text, "A")
+            text = open(repo.download_artifacts("b.txt")).read()
+            self.assertEqual(text, "B")
+            text = open(repo.download_artifacts("nested/c.txt")).read()
+            self.assertEqual(text, "C")
+            paths = sorted([f.path for f in repo.list_artifacts()])
+            self.assertListEqual(paths, ["a.txt", "b.txt", "nested", "test.txt"])
+            paths = sorted([f.path for f in repo.list_artifacts("nested")])
+            self.assertListEqual(paths, ["nested/c.txt"])
+
+    def tearDown(self):
+        shutil.rmtree(self.test_root, ignore_errors=True)

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -42,8 +42,19 @@ class TestLocalArtifactRepo(unittest.TestCase):
             self.assertEqual(text, "B")
             text = open(repo.download_artifacts("nested/c.txt")).read()
             self.assertEqual(text, "C")
-            paths = sorted([f.path for f in repo.list_artifacts()])
-            self.assertListEqual(paths, ["a.txt", "b.txt", "nested", "test.txt"])
-            paths = sorted([f.path for f in repo.list_artifacts("nested")])
-            self.assertListEqual(paths, ["nested/c.txt"])
+            infos = sorted([(f.path, f.is_dir, f.file_size) for f in repo.list_artifacts()])
+            self.assertListEqual(infos, [
+                ("a.txt", False, 1),
+                ("b.txt", False, 1),
+                ("nested", True, None),
+                ("test.txt", False, 12)
+            ])
+            infos = sorted([(f.path, f.is_dir, f.file_size) for f in repo.list_artifacts("nested")])
+            self.assertListEqual(infos, [("nested/c.txt", False, 1)])
+
+            # Download a subdirectory
+            downloaded_dir = repo.download_artifacts("nested")
+            self.assertEqual(os.path.basename(downloaded_dir), "nested")
+            text = open(os.path.join(downloaded_dir, "c.txt")).read()
+            self.assertEqual(text, "C")
 

--- a/tests/store/test_s3_artifact_repo.py
+++ b/tests/store/test_s3_artifact_repo.py
@@ -1,0 +1,55 @@
+import os
+import unittest
+
+import boto3
+from moto import mock_s3
+
+from mlflow.store.artifact_repo import ArtifactRepository, S3ArtifactRepository
+from mlflow.utils.file_utils import TempDir
+from tests.helper_functions import random_int
+
+
+class TestS3ArtifactRepo(unittest.TestCase):
+    @mock_s3
+    def test_basic_functions(self):
+        s3 = boto3.client("s3")
+        s3.create_bucket(Bucket="test_bucket")
+
+        repo = ArtifactRepository.from_artifact_uri("s3://test_bucket/some/path")
+        self.assertIsInstance(repo, S3ArtifactRepository)
+        self.assertListEqual(repo.list_artifacts(), [])
+        with self.assertRaises(Exception):
+            open(repo.download_artifacts("test.txt")).read()
+
+        with TempDir() as tmp:
+            # Create and log a test.txt file directly
+            with open(tmp.path("test.txt"), "w") as f:
+                f.write("Hello world!")
+            repo.log_artifact(tmp.path("test.txt"))
+            text = open(repo.download_artifacts("test.txt")).read()
+            self.assertEqual(text, "Hello world!")
+            # Check that it actually made it to S3
+            obj = s3.get_object(Bucket="test_bucket", Key="some/path/test.txt")
+            text = obj["Body"].read().decode('utf-8')
+            self.assertEqual(text, "Hello world!")
+
+            # Create a subdirectory for log_artifacts
+            os.mkdir(tmp.path("subdir"))
+            os.mkdir(tmp.path("subdir", "nested"))
+            with open(tmp.path("subdir", "a.txt"), "w") as f:
+                f.write("A")
+            with open(tmp.path("subdir", "b.txt"), "w") as f:
+                f.write("B")
+            with open(tmp.path("subdir", "nested", "c.txt"), "w") as f:
+                f.write("C")
+            repo.log_artifacts(tmp.path("subdir"))
+            text = open(repo.download_artifacts("a.txt")).read()
+            self.assertEqual(text, "A")
+            text = open(repo.download_artifacts("b.txt")).read()
+            self.assertEqual(text, "B")
+            text = open(repo.download_artifacts("nested/c.txt")).read()
+            self.assertEqual(text, "C")
+            paths = sorted([f.path for f in repo.list_artifacts()])
+            self.assertListEqual(paths, ["a.txt", "b.txt", "nested", "test.txt"])
+            paths = sorted([f.path for f in repo.list_artifacts("nested")])
+            self.assertListEqual(paths, ["nested/c.txt"])

--- a/tests/store/test_s3_artifact_repo.py
+++ b/tests/store/test_s3_artifact_repo.py
@@ -12,16 +12,16 @@ from tests.helper_functions import random_int
 class TestS3ArtifactRepo(unittest.TestCase):
     @mock_s3
     def test_basic_functions(self):
-        s3 = boto3.client("s3")
-        s3.create_bucket(Bucket="test_bucket")
-
-        repo = ArtifactRepository.from_artifact_uri("s3://test_bucket/some/path")
-        self.assertIsInstance(repo, S3ArtifactRepository)
-        self.assertListEqual(repo.list_artifacts(), [])
-        with self.assertRaises(Exception):
-            open(repo.download_artifacts("test.txt")).read()
-
         with TempDir() as tmp:
+            s3 = boto3.client("s3")
+            s3.create_bucket(Bucket="test_bucket")
+
+            repo = ArtifactRepository.from_artifact_uri("s3://test_bucket/some/path")
+            self.assertIsInstance(repo, S3ArtifactRepository)
+            self.assertListEqual(repo.list_artifacts(), [])
+            with self.assertRaises(Exception):
+                open(repo.download_artifacts("test.txt")).read()
+
             # Create and log a test.txt file directly
             with open(tmp.path("test.txt"), "w") as f:
                 f.write("Hello world!")

--- a/tests/store/test_s3_artifact_repo.py
+++ b/tests/store/test_s3_artifact_repo.py
@@ -50,7 +50,18 @@ class TestS3ArtifactRepo(unittest.TestCase):
             self.assertEqual(text, "B")
             text = open(repo.download_artifacts("nested/c.txt")).read()
             self.assertEqual(text, "C")
-            paths = sorted([f.path for f in repo.list_artifacts()])
-            self.assertListEqual(paths, ["a.txt", "b.txt", "nested", "test.txt"])
-            paths = sorted([f.path for f in repo.list_artifacts("nested")])
-            self.assertListEqual(paths, ["nested/c.txt"])
+            infos = sorted([(f.path, f.is_dir, f.file_size) for f in repo.list_artifacts()])
+            self.assertListEqual(infos, [
+                ("a.txt", False, 1),
+                ("b.txt", False, 1),
+                ("nested", True, None),
+                ("test.txt", False, 12)
+            ])
+            infos = sorted([(f.path, f.is_dir, f.file_size) for f in repo.list_artifacts("nested")])
+            self.assertListEqual(infos, [("nested/c.txt", False, 1)])
+
+            # Download a subdirectory
+            downloaded_dir = repo.download_artifacts("nested")
+            self.assertEqual(os.path.basename(downloaded_dir), "nested")
+            text = open(os.path.join(downloaded_dir, "c.txt")).read()
+            self.assertEqual(text, "C")

--- a/tests/store/test_s3_artifact_repo.py
+++ b/tests/store/test_s3_artifact_repo.py
@@ -13,7 +13,7 @@ class TestS3ArtifactRepo(unittest.TestCase):
     @mock_s3
     def test_basic_functions(self):
         with TempDir() as tmp:
-            # Create a mock bucket in S3
+            # Create a mock S3 bucket in moto
             s3 = boto3.client("s3")
             s3.create_bucket(Bucket="test_bucket")
 

--- a/tests/store/test_s3_artifact_repo.py
+++ b/tests/store/test_s3_artifact_repo.py
@@ -13,6 +13,7 @@ class TestS3ArtifactRepo(unittest.TestCase):
     @mock_s3
     def test_basic_functions(self):
         with TempDir() as tmp:
+            # Create a mock bucket in S3
             s3 = boto3.client("s3")
             s3.create_bucket(Bucket="test_bucket")
 

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -1,5 +1,6 @@
 # Test reqs
 mock==2.0.0
+moto
 prospector[with_pyroma]==0.12.7
 pyarrow
 pylint==1.8.2


### PR DESCRIPTION
Also adds an `--artifact-root` option to `mlflow server` and the experiment commands to allow setting the default artifact root for new experiments when launching a server.