### PR TITLE
Fix docs path relativism after docs theme change

### DIFF
--- a/docs/theme/mlflow/body_postscripts.html
+++ b/docs/theme/mlflow/body_postscripts.html
@@ -14,12 +14,14 @@
   {%- endfor %}
 {% endif %}
 
-<script type="text/javascript" src="/_static/js/clipboard.min.js"></script>
-<script type="text/javascript" src="/_static/js/jquery.waypoints.min.js"></script>
+<script type="text/javascript" src="{{ pathto('_static/js/clipboard.min.js', 1) }}"></script>
+<script type="text/javascript" src="{{ pathto('_static/js/jquery.waypoints.min.js', 1) }}"></script>
 
 {# RTD hosts this file, so just load on non RTD builds #}
 {% if not READTHEDOCS %}
-  <script type="text/javascript" src="{{ pathto('/_static/js/custom.js', 1) }}"></script>
+  {# I'm sorry, I don't know how to use sphinx to inject this into the static JS. #}
+  <script type="text/javascript">var CLIPPY_SVG_PATH = "{{ pathto('_static/clippy.svg', 1) }}";</script>
+  <script type="text/javascript" src="{{ pathto('_static/js/custom.js', 1) }}"></script>
 {% endif %}
 
 {# STICKY NAVIGATION #}

--- a/docs/theme/mlflow/header.html
+++ b/docs/theme/mlflow/header.html
@@ -1,6 +1,6 @@
 <ul>
   <li class="menu-toggle">
     <i data-toggle="wy-nav-top" class="wy-nav-top-menu-button db-icon db-icon-menu pull-left"></i>
-      <a href="{{ pathto(master_doc) }}" class="wy-nav-top-logo"><img src="{{ pathto('/_static/MLflow-logo-final-black.png', 1) }}" alt="MLFlow" /></a>
+      <a href="{{ pathto(master_doc) }}" class="wy-nav-top-logo"><img src="{{ pathto('_static/MLflow-logo-final-black.png', 1) }}" alt="MLFlow" /></a>
   </li>
 </ul>

--- a/docs/theme/mlflow/layout.html
+++ b/docs/theme/mlflow/layout.html
@@ -29,7 +29,7 @@
   {% endif %}
   {# FAVICON #}
   {% if favicon %}
-    <link rel="shortcut icon" href="{{ pathto('/_static/' + favicon, 1) }}"/>
+    <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
     {% endif %}
 
     {% if s %}
@@ -58,7 +58,7 @@
   {# OPENSEARCH #}
   {% if not embedded %}
     {% if use_opensearch %}
-      <link rel="search" type="application/opensearchdescription+xml" title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}" href="{{ pathto('/_static/opensearch.xml', 1) }}"/>
+      <link rel="search" type="application/opensearchdescription+xml" title="{% trans docstitle=docstitle|e %}Search within {{ docstitle }}{% endtrans %}" href="{{ pathto('_static/opensearch.xml', 1) }}"/>
     {% endif %}
 
   {% endif %}
@@ -66,12 +66,12 @@
   {# RTD hosts this file, so just load on non RTD builds #}
   {% if not READTHEDOCS %}
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600" rel="stylesheet">
-    <link rel="stylesheet" href="{{ pathto('/_static/css/theme.css', 1) }}" type="text/css" />
-    <link rel="stylesheet" href="{{ pathto('/_static/css/custom.css', 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto('_static/css/theme.css', 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto('_static/css/custom.css', 1) }}" type="text/css" />
     {% if target_cloud == 'azure' %}
-      <link rel="stylesheet" href="{{ pathto('/_static/css/custom-azure.css', 1) }}" type="text/css" />
+      <link rel="stylesheet" href="{{ pathto('_static/css/custom-azure.css', 1) }}" type="text/css" />
     {% endif %}
-    <link rel="stylesheet" href="{{ pathto('/_static/css/algolia.css', 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto('_static/css/algolia.css', 1) }}" type="text/css" />
     
   {% endif %}
 
@@ -104,7 +104,7 @@
   {%- block extrahead %} {% endblock %}
 
   {# Keep modernizr in head - http://modernizr.com/docs/#installing #}
-  <script src="{{ pathto('/_static/js/modernizr.min.js', 1) }}"></script>
+  <script src="{{ pathto('_static/js/modernizr.min.js', 1) }}"></script>
 
 </head>
 
@@ -154,16 +154,18 @@
   </script>
 
   {%- for scriptfile in script_files %}
-  <script type="text/javascript" src="/{{ pathto(scriptfile, 1) }}"></script>
+  <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
   {%- endfor %}
   {% endif %}
 
-  <script type="text/javascript" src="/_static/js/clipboard.min.js"></script>
-  <script type="text/javascript" src="/_static/js/jquery.waypoints.min.js"></script>
+  <script type="text/javascript" src="{{ pathto('_static/js/clipboard.min.js', 1) }}"></script>
+  <script type="text/javascript" src="{{ pathto('_static/js/jquery.waypoints.min.js', 1) }}"></script>
 
   {# RTD hosts this file, so just load on non RTD builds #}
   {% if not READTHEDOCS %}
-  <script type="text/javascript" src="{{ pathto('/_static/js/custom.js', 1) }}"></script>
+  {# I'm sorry, I don't know how to use sphinx to inject this into the static JS. #}
+  <script type="text/javascript">var CLIPPY_SVG_PATH = "{{ pathto('_static/clippy.svg', 1) }}";</script>
+  <script type="text/javascript" src="{{ pathto('_static/js/custom.js', 1) }}"></script>
   {% endif %}
 
   {# STICKY NAVIGATION #}
@@ -188,7 +190,7 @@
       };
     </script>
     <div id="algolia-wrapper"></div>
-    <script src="{{ pathto('/_static/js/tether.min.js', 1) }}"></script>
+    <script src="{{ pathto('_static/js/tether.min.js', 1) }}"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js"></script>
   {% endif %}
 </body>

--- a/docs/theme/mlflow/layout_old.html
+++ b/docs/theme/mlflow/layout_old.html
@@ -52,7 +52,7 @@
           {%- block sidebarlogo %}
           {%- if logo %}
             <p class="logo"><a href="{{ pathto(master_doc) }}">
-              <img class="logo" src="{{ pathto('/_static/' + logo, 1) }}" alt="Logo"/>
+              <img class="logo" src="{{ pathto('_static/' + logo, 1) }}" alt="Logo"/>
             </a></p>
           {%- endif %}
           {%- endblock %}

--- a/docs/theme/mlflow/side_nav.html
+++ b/docs/theme/mlflow/side_nav.html
@@ -21,7 +21,7 @@
 
   <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
     {% if not (logo and theme_logo_only) %}
-      <a href="{{ pathto(master_doc) }}" class="main-navigation-home"><img src="{{ pathto('/_static/icons/nav-home.svg', 1) }}"> {{ project }}</a>
+      <a href="{{ pathto(master_doc) }}" class="main-navigation-home"><img src="{{ pathto('_static/icons/nav-home.svg', 1) }}"> {{ project }}</a>
     {% endif %}
 
     {% block menu %}

--- a/docs/theme/mlflow/static/css/custom.css
+++ b/docs/theme/mlflow/static/css/custom.css
@@ -808,7 +808,7 @@ text-transform: capitalize;
   background-color: #1CB1C2;
 }
 .admonition.note .admonition-title:before {
-  background-image: url("/_static/icons/note-icon.svg");
+  background-image: url("../icons/note-icon.svg");
   font-size: .9em;
 }
 
@@ -819,7 +819,7 @@ text-transform: capitalize;
   background-color: #C5CD18;
 }
 .admonition.tip .admonition-title:before {
-  background-image: url("/_static/icons/tip-icon.svg");
+  background-image: url("../icons/tip-icon.svg");
   font-size: .9em;
 }
 
@@ -830,7 +830,7 @@ text-transform: capitalize;
   background-color: #F1582C;
 }
 .admonition.warning .admonition-title:before {
-  background-image: url("/_static/icons/warning-icon.svg");
+  background-image: url("../icons/warning-icon.svg");
   font-size: .9em;
 }
 
@@ -841,7 +841,7 @@ text-transform: capitalize;
   background-color: #F0B37E;
 }
 .admonition.important .admonition-title:before {
-  background-image: url("/_static/icons/important-icon.svg");
+  background-image: url("../icons/important-icon.svg");
   font-size: .9em;
 }
 

--- a/docs/theme/mlflow/static/js/custom.js
+++ b/docs/theme/mlflow/static/js/custom.js
@@ -203,7 +203,7 @@ $('.code').map(function(i, val) {
         return languages.indexOf(className) != -1;
     });
 
-    var clippyStrStart = '<div class="clippy"><img src="/_static/clippy.svg" alt="Copy to clipboard">';
+    var clippyStrStart = '<div class="clippy"><img src="' + CLIPPY_SVG_PATH + '" alt="Copy to clipboard">';
     var clippyStrEnd = '</div>';
     var copyStr = '<span>Copy</span>';
     var langStr = lang;

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -18,6 +18,7 @@ Pyfunc model format is defined as a directory structure containing all required 
 configuration:
 
 ./dst-path/
+
     ./MLmodel - config
     <code> - any code packaged with the model (specified in the conf file, see below)
     <data> - any data packaged with the model (specified in the conf file, see below)
@@ -26,50 +27,47 @@ configuration:
 It must contain MLmodel file in its root with "python_function" format with the following
 parameters:
 
-   - loader_module [required]:
+- loader_module [required]:
          Python module that can load the model. Expected as module identifier
-          e.g. ``mlflow.sklearn``, it will be imported via importlib.import_module.
+         e.g. ``mlflow.sklearn``, it will be imported via importlib.import_module.
          The imported module must contain function with the following signature:
 
               load_pyfunc(path: string) -> <pyfunc model>
 
          The path argument is specified by the data parameter and may refer to a file or directory.
 
-   - code [optional]:
+- code [optional]:
         relative path to a directory containing the code packaged with this model.
         All files and directories inside this directory are added to the python path
         prior to importing the model loader.
 
-   - data [optional]:
+- data [optional]:
          relative path to a file or directory containing model data.
          the path is passed to the model loader.
 
-   - env [optional]:
+- env [optional]:
          relative path to an exported conda environment. If present this environment
          should be activated prior to running the model.
 
 Example:
 
-```
->tree example/sklearn_iris/mlruns/run1/outputs/linear-lr
-├── MLmodel
-├── code
-│   ├── sklearn_iris.py
-│  
-├── data
-│   └── model.pkl
-└── mlflow_env.yml
+.. code:: shell
 
->cat example/sklearn_iris/mlruns/run1/outputs/linear-lr/MLmodel
-python_function:
-  code: code
-  data: data/model.pkl
-  env: mlflow_env.yml
-  main: sklearn_iris
+  >tree example/sklearn_iris/mlruns/run1/outputs/linear-lr
+  ├── MLmodel
+  ├── code
+  │   ├── sklearn_iris.py
+  │  
+  ├── data
+  │   └── model.pkl
+  └── mlflow_env.yml
 
-```
-Todo:
-* Get default conda_env of the project.
+  >cat example/sklearn_iris/mlruns/run1/outputs/linear-lr/MLmodel
+  python_function:
+    code: code
+    data: data/model.pkl
+    env: mlflow_env.yml
+    main: sklearn_iris
 """
 
 import importlib

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -142,7 +142,7 @@ def deploy(app_name, model_path, execution_role_arn, bucket, run_id=None,
 
     :param app_name: Name of the deployed app.
     :param path: Path to the model.
-    Either local if no run_id or MLflow-relative if run_id is specified)
+                Either local if no run_id or MLflow-relative if run_id is specified)
     :param execution_role_arn: Amazon execution role with sagemaker rights
     :param bucket: S3 bucket where model artifacts are gonna be stored
     :param run_id: MLflow run id.


### PR DESCRIPTION
After the algolia theme change, all resource paths were made absolute to the root, which doesn't work when we try to export them to the mlflow.org website, where they are under `/docs/`.

These ones are the only still-absolute paths I can find:

```
$ grep -r /_static/ build/html  | grep -v '\.\./'
build/html/_static/websupport.js:    commentImage: '/static/_static/comment.png',
build/html/_static/websupport.js:    closeCommentImage: '/static/_static/comment-close.png',
build/html/_static/websupport.js:    loadingImage: '/static/_static/ajax-loader.gif',
build/html/_static/websupport.js:    commentBrightImage: '/static/_static/comment-bright.png',
build/html/_static/websupport.js:    upArrow: '/static/_static/up.png',
build/html/_static/websupport.js:    downArrow: '/static/_static/down.png',
build/html/_static/websupport.js:    upArrowPressed: '/static/_static/up-pressed.png',
build/html/_static/websupport.js:    downArrowPressed: '/static/_static/down-pressed.png',
```

Browsing through the website locally seems to generally work; I'm not sure those files are actually used anywhere.