### PR TITLE
[Minor] Mark tests that rely on external resources as large

### DIFF
--- a/tests/mlflow/sagemaker/test_model_export.py
+++ b/tests/mlflow/sagemaker/test_model_export.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import os
 import pickle
+import pytest
 import requests
 from subprocess import Popen, PIPE, STDOUT
 import tempfile
@@ -54,6 +55,7 @@ class TestModelExport(unittest.TestCase):
         print("Building mlflow Docker image with MLFLOW_HOME =", mlflow_root)
         mlflow.sagemaker.build_image(mlflow_home=mlflow_root)
 
+    @pytest.mark.large
     def test_model_export(self):
         path_to_remove = None
         try:

--- a/tests/mlflow/sagemaker/test_model_export.py
+++ b/tests/mlflow/sagemaker/test_model_export.py
@@ -2,17 +2,12 @@ from __future__ import print_function
 
 import os
 import pickle
+import pytest
 import requests
 from subprocess import Popen, PIPE, STDOUT
 import tempfile
 import time
 import unittest
-
-try:
-    import pytest
-except ImportError:
-    # This file is also loaded inside the container, where we do not need pytest.
-    pass
 
 import sklearn.datasets as datasets
 import sklearn.linear_model as glm
@@ -31,6 +26,7 @@ def load_pyfunc(path):
         return pickle.load(f)
 
 
+# We include pytest since we load this self-same file within the container.
 CONDA_ENV = """
 name: mlflow-env
 channels:
@@ -38,6 +34,7 @@ channels:
   - defaults
 dependencies:
   - python={python_version}
+  - pytest
 
 """
 

--- a/tests/mlflow/sagemaker/test_model_export.py
+++ b/tests/mlflow/sagemaker/test_model_export.py
@@ -2,12 +2,17 @@ from __future__ import print_function
 
 import os
 import pickle
-import pytest
 import requests
 from subprocess import Popen, PIPE, STDOUT
 import tempfile
 import time
 import unittest
+
+try:
+    import pytest
+except ImportError:
+    # This file is also loaded inside the container, where we do not need pytest.
+    pass
 
 import sklearn.datasets as datasets
 import sklearn.linear_model as glm

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -1,3 +1,5 @@
+import pytest
+
 import mlflow
 from mlflow import cli
 from mlflow.utils.file_utils import TempDir
@@ -9,6 +11,7 @@ def _assert_succeeded(run_output):
     assert "=== Run succeeded ===" in run_output
 
 
+@pytest.mark.large
 def test_run_local():
     with TempDir() as tmp:
         with update_temp_env({mlflow.tracking._TRACKING_URI_ENV_VAR: tmp.path()}):
@@ -19,6 +22,7 @@ def test_run_local():
             _assert_succeeded(res.output)
 
 
+@pytest.mark.large
 def test_run_git():
     with TempDir() as tmp:
         with update_temp_env({mlflow.tracking._TRACKING_URI_ENV_VAR: tmp.path()}):

--- a/tests/store/test_s3_artifact_repo.py
+++ b/tests/store/test_s3_artifact_repo.py
@@ -14,6 +14,11 @@ class TestS3ArtifactRepo(unittest.TestCase):
     def test_basic_functions(self):
         with TempDir() as tmp:
             # Create a mock S3 bucket in moto
+            # Note that we must set these as environment variables in case users
+            # so that boto does not attempt to assume credentials from the ~/.aws/config
+            # or IAM role. moto does not correctly pass the arguments to boto3.client().
+            os.environ["AWS_ACCESS_KEY_ID"] = "a" 
+            os.environ["AWS_SECRET_ACCESS_KEY"] = "b" 
             s3 = boto3.client("s3")
             s3.create_bucket(Bucket="test_bucket")
 


### PR DESCRIPTION
The tests in `test_projects_cli.py` take a while to run (the local one takes ~10 seconds, and the other one relies on github). The test in `sagemaker/test_model_export.py` relies on Docker running.

I also fixed the S3 Artifactory test, which for weird reasons still tries to reach out to AWS to get credentials if your local `~/.aws/credentials` file contains an assume-role, and furthermore this fails because moto mocks out all outgoing AWS connections.

In total, `pytest` goes from ~60 seconds to 24 seconds on my machine. Note that you can run these test locally by using `pytest -k test_projects_cli --large`.