### PR TITLE
Avoid requiring git on PATH for running server

### DIFF
--- a/mlflow/projects.py
+++ b/mlflow/projects.py
@@ -8,7 +8,6 @@ import shutil
 import tempfile
 
 from distutils import dir_util
-import git
 
 from six.moves import shlex_quote
 from databricks_cli.configure import provider
@@ -349,6 +348,9 @@ def _fetch_git_repo(uri, version, dst_dir, git_username, git_password):
     assumes authentication parameters are specified by the environment, e.g. by a Git credential
     helper.
     """
+    # We defer importing git until the last moment, because the import requires that the git
+    # executable is availble on the PATH, so we only want to fail if we actually need it.
+    import git
     repo = git.Repo.init(dst_dir)
     origin = repo.create_remote("origin", uri)
     git_args = [git_username, git_password]

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -6,7 +6,6 @@ import os
 import sys
 import time
 
-from git import Repo, InvalidGitRepositoryError
 from six.moves import urllib
 
 from mlflow.entities.experiment import Experiment
@@ -353,6 +352,12 @@ def _get_legacy_artifact_repo(file_store, run_info):
 
 
 def _get_git_commit(path):
+    try:
+        from git import Repo, InvalidGitRepositoryError
+    except ImportError, e:
+        print("Notice: failed to import git (the git executable is probably not on your PATH),"
+              " so git sha will not be available. Error: %s" % e, file=sys.stderr)
+        return None 
     try:
         if os.path.isfile(path):
             path = os.path.dirname(path)

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -354,7 +354,7 @@ def _get_legacy_artifact_repo(file_store, run_info):
 def _get_git_commit(path):
     try:
         from git import Repo, InvalidGitRepositoryError, GitCommandNotFound
-    except ImportError, e:
+    except ImportError as e:
         print("Notice: failed to import git (the git executable is probably not on your PATH),"
               " so git sha will not be available. Error: %s" % e, file=sys.stderr)
         return None 

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -353,7 +353,7 @@ def _get_legacy_artifact_repo(file_store, run_info):
 
 def _get_git_commit(path):
     try:
-        from git import Repo, InvalidGitRepositoryError
+        from git import Repo, InvalidGitRepositoryError, GitCommandNotFound
     except ImportError, e:
         print("Notice: failed to import git (the git executable is probably not on your PATH),"
               " so git sha will not be available. Error: %s" % e, file=sys.stderr)
@@ -364,5 +364,5 @@ def _get_git_commit(path):
         repo = Repo(path, search_parent_directories=True)
         commit = repo.head.commit.hexsha
         return commit
-    except (InvalidGitRepositoryError, ValueError):
+    except (InvalidGitRepositoryError, GitCommandNotFound, ValueError):
         return None


### PR DESCRIPTION
Currently when starting an `mlflow server` on a new, empty host or container, we require `git` to be installed on the PATH. This doesn't make sense, since the server doesn't fundamentally need git.

This PR causes the git loading to be lazy, activated only when we run a repo from git or attempt to get the local commit sha. For the sake of usability, I additionally propose that we only print a warning when git is not available when using mlflow from a directory as opposed to crashing.

Example error today:

```
$ mlflow server
Traceback (most recent call last):
  File "/usr/bin/mlflow", line 7, in <module>
    from mlflow.cli import cli
  File "/usr/lib/python2.7/site-packages/mlflow/__init__.py", line 8, in <module>
    import mlflow.projects as projects  # noqa
  File "/usr/lib/python2.7/site-packages/mlflow/projects.py", line 11, in <module>
    import git
  File "/usr/lib64/python2.7/site-packages/git/__init__.py", line 82, in <module>
    refresh()
  File "/usr/lib64/python2.7/site-packages/git/__init__.py", line 73, in refresh
    if not Git.refresh(path=path):
  File "/usr/lib64/python2.7/site-packages/git/cmd.py", line 290, in refresh
    raise ImportError(err)
ImportError: Bad git executable.
The git executable must be specified in one of the following ways:
    - be included in your $PATH
    - be set via $GIT_PYTHON_GIT_EXECUTABLE
    - explicitly set via git.refresh()

All git commands will error until this is rectified.

This initial warning can be silenced or aggravated in the future by setting the
$GIT_PYTHON_REFRESH environment variable. Use one of the following values:
    - quiet|q|silence|s|none|n|0: for no warning or exception
    - warn|w|warning|1: for a printed warning
    - error|e|raise|r|2: for a raised exception

Example:
    export GIT_PYTHON_REFRESH=quiet
```

After this change, `mlflow server` works if git is not installed. If I try running `mlflow run` on a local repo, I get:

```
$ python example/tutorial/train.py 0.1
Notice: failed to import git (the git executable is probably not on your PATH), so git sha will not be available. Error: Bad git executable.
The git executable must be specified in one of the following ways:
    - be included in your $PATH
    - be set via $GIT_PYTHON_GIT_EXECUTABLE
    - explicitly set via git.refresh()

All git commands will error until this is rectified.

This initial warning can be silenced or aggravated in the future by setting the
$GIT_PYTHON_REFRESH environment variable. Use one of the following values:
    - quiet|q|silence|s|none|n|0: for no warning or exception
    - warn|w|warning|1: for a printed warning
    - error|e|raise|r|2: for a raised exception

Example:
    export GIT_PYTHON_REFRESH=quiet
Elasticnet model (alpha=0.100000, l1_ratio=0.500000):
  RMSE: 0.7845017946547458
  MAE: 0.6150949836730213
  R2: 0.2051086790093516
```

If I set `GIT_PYTHON_REFRESH=quiet`, then the error is completely eliminated.