### PR TITLE
Fix Spark UDF when running in an actual cluster

### DIFF
--- a/mlflow/pyfunc/spark_model_cache.py
+++ b/mlflow/pyfunc/spark_model_cache.py
@@ -50,8 +50,8 @@ class SparkModelCache(object):
         # BUG: Despite the documentation of SparkContext.addFile() and SparkFiles.get() in Scala
         # and Python, it turns out that we actually need to use the basename as the input to
         # SparkFiles.get(), as opposed to the (absolute) path.
-        relative_archive_path = os.path.basename(archive_path)
-        local_path = SparkFiles.get(relative_archive_path)
+        archive_path_basename = os.path.basename(archive_path)
+        local_path = SparkFiles.get(archive_path_basename)
         temp_dir = tempfile.mkdtemp()
         zip_ref = zipfile.ZipFile(local_path, 'r')
         zip_ref.extractall(temp_dir)

--- a/mlflow/pyfunc/spark_model_cache.py
+++ b/mlflow/pyfunc/spark_model_cache.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import tempfile
 import zipfile
@@ -46,7 +47,11 @@ class SparkModelCache(object):
             SparkModelCache._cache_hits += 1
             return SparkModelCache._models[archive_path]
 
-        local_path = SparkFiles.get(archive_path)
+        # BUG: Despite the documentation of SparkContext.addFile() and SparkFiles.get() in Scala
+        # and Python, it turns out that we actually need to use the basename as the input to
+        # SparkFiles.get(), as opposed to the (absolute) path.
+        relative_archive_path = os.path.basename(archive_path)
+        local_path = SparkFiles.get(relative_archive_path)
         temp_dir = tempfile.mkdtemp()
         zip_ref = zipfile.ZipFile(local_path, 'r')
         zip_ref.extractall(temp_dir)


### PR DESCRIPTION
Despite the documentation in [SparkContext.addFiles](https://github.com/apache/spark/blob/6a97e8eb31da76fe5af912a6304c07b63735062f/core/src/main/scala/org/apache/spark/SparkContext.scala#L1500) and [SparkFiles.get](https://github.com/apache/spark/blob/6a97e8eb31da76fe5af912a6304c07b63735062f/core/src/main/scala/org/apache/spark/SparkFiles.scala#L30), it turns out that when the file is actually fetched into the "local root directory", we actually only use the [basename/filename part of the path](https://github.com/apache/spark/blob/6a97e8eb31da76fe5af912a6304c07b63735062f/core/src/main/scala/org/apache/spark/util/Utils.scala#L459). This subsequently implies that the input to SparkFiles.get should also be the basename, since it is straightforwardly appended to the root directory.

Unfortunately the unit test did not catch this because even though the executors were running in different processes in the test, they shared a root file system, so the absolute path worked because it's not going through SparkContext.addFile.