### PR TITLE
Fix bug in TensorFlow PyFunc model loader

### DIFF
--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -46,30 +46,18 @@ class _TFWrapper(object):
             sig_def = tf.contrib.saved_model.get_signature_def_by_key(meta_graph_def, 
                                                                       self._signature_def_key)
 
-            # Determining input tensors.
-            feed_mapping = {}
-            feed_names = []
-            for sigdef_key, tnsr_info in sig_def.inputs.items():
-                tnsr_name = tnsr_info.name
-                feed_mapping[sigdef_key] = tnsr_name
-                feed_names.append(tnsr_name)
-
             # Determining output tensors.
-            fetch_mapping = {}
-            fetch_names = []
-            for sigdef_key, tnsr_info in sig_def.outputs.items():
-                tnsr_name = tnsr_info.name
-                fetch_mapping[sigdef_key] = tnsr_name
-                fetch_names.append(tnsr_name)
+            fetch_mapping = {sigdef_key: graph.get_tensor_by_name(tnsr_info.name)
+                             for sigdef_key, tnsr_info in sig_def.outputs.items()}
 
-            fetches = [graph.get_tensor_by_name(t_name) for t_name in fetch_names]
-
-            feed_dict = {}
-            for col in feed_mapping:
-                tnsr_name = feed_mapping[col]
-                feed_dict[graph.get_tensor_by_name(tnsr_name)] = df[col].values
-            data = sess.run(fetches, feed_dict=feed_dict)
-            return pandas.DataFrame(data=data[0])
+            # Build the feed dict, mapping input tensors to DataFrame column values.
+            # We assume that input arguments to the signature def correspond to DataFrame column
+            # names
+            feed_dict = {graph.get_tensor_by_name(tnsr_info.name): df[sigdef_input].values
+                        for sigdef_input, tnsr_info in sig_def.inputs.items()}
+            raw_preds = sess.run(fetch_mapping, feed_dict=feed_dict)
+            pred_dict = {fetch_name: values.tolist() for fetch_name, values in raw_preds.items()}
+            return pandas.DataFrame(data=pred_dict)
 
 
 def log_saved_model(saved_model_dir, signature_def_key, artifact_path):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -56,7 +56,7 @@ class _TFWrapper(object):
             feed_dict = {graph.get_tensor_by_name(tnsr_info.name): df[sigdef_input].values
                         for sigdef_input, tnsr_info in sig_def.inputs.items()}
             raw_preds = sess.run(fetch_mapping, feed_dict=feed_dict)
-            pred_dict = {fetch_name: values.tolist() for fetch_name, values in raw_preds.items()}
+            pred_dict = {fetch_name: list(values) for fetch_name, values in raw_preds.items()}
             return pandas.DataFrame(data=pred_dict)
 
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -47,8 +47,8 @@ class _TFWrapper(object):
                                                                       self._signature_def_key)
 
             # Determining output tensors.
-            fetch_mapping = {sigdef_key: graph.get_tensor_by_name(tnsr_info.name)
-                             for sigdef_key, tnsr_info in sig_def.outputs.items()}
+            fetch_mapping = {sigdef_output: graph.get_tensor_by_name(tnsr_info.name)
+                             for sigdef_output, tnsr_info in sig_def.outputs.items()}
 
             # Build the feed dict, mapping input tensors to DataFrame column values.
             # We assume that input arguments to the signature def correspond to DataFrame column

--- a/tests/mlflow/tensorflow/test_tensorflow_model_export.py
+++ b/tests/mlflow/tensorflow/test_tensorflow_model_export.py
@@ -5,15 +5,13 @@ import os
 import pandas
 import unittest
 
-import numpy as np
 import pandas as pd
 import sklearn.datasets as datasets
-import shutil
+import tensorflow as tf
 
 from mlflow import tensorflow, pyfunc
 from mlflow import tracking
 from mlflow.utils.file_utils import TempDir
-import tensorflow as tf
 
 
 class TestModelExport(unittest.TestCase):

--- a/tests/mlflow/tensorflow/test_tensorflow_model_export.py
+++ b/tests/mlflow/tensorflow/test_tensorflow_model_export.py
@@ -6,13 +6,14 @@ import pandas
 import unittest
 
 import numpy as np
-import tensorflow as tf
+import pandas as pd
 import sklearn.datasets as datasets
 import shutil
 
 from mlflow import tensorflow, pyfunc
 from mlflow import tracking
 from mlflow.utils.file_utils import TempDir
+import tensorflow as tf
 
 
 class TestModelExport(unittest.TestCase):
@@ -35,8 +36,8 @@ class TestModelExport(unittest.TestCase):
         # Loading the saved TensorFlow model as a pyfunc.
         x = pyfunc.load_pyfunc(saved_estimator_path)
         # Predicting on the dataset using the pyfunc.
-        xpred = x.predict(df)
-        return [row for _, row in xpred.iterrows()]
+        return x.predict(df)
+
 
     def test_log_saved_model(self):
         # This tests model logging capabilities on the sklearn.iris dataset.
@@ -45,7 +46,6 @@ class TestModelExport(unittest.TestCase):
             X = iris.data[:, :2]  # we only take the first two features.
             y = iris.target
             trainingFeatures = {}
-            feature_names = iris.feature_names[:2]
             for i in range(0, 2):
                 # TensorFlow is fickle about feature names, so we remove offending characters
                 iris.feature_names[i] = iris.feature_names[i].replace(" ", "")
@@ -58,16 +58,20 @@ class TestModelExport(unittest.TestCase):
             for col in iris.feature_names[:2]:
                 tf_feat_cols.append(tf.feature_column.numeric_column(col))
             # Creating input training function.
-            input_train = tf.estimator.inputs.numpy_input_fn(trainingFeatures, 
-                                                                        y, 
-                                                                        shuffle=False, 
-                                                                        batch_size=1)
-            # Creating Deep Neural Network Regressor. 
-            estimator = tf.estimator.DNNRegressor(feature_columns=tf_feat_cols, 
-                                                    hidden_units=[1])
+            input_train = tf.estimator.inputs.numpy_input_fn(trainingFeatures,
+                                                             y,
+                                                             shuffle=False,
+                                                             batch_size=1)
+            # Creating Deep Neural Network Regressor.
+            estimator = tf.estimator.DNNRegressor(feature_columns=tf_feat_cols,
+                                                  hidden_units=[1])
             # Training and creating expected predictions on training dataset.
-            estimator.train(input_train, steps=100)
-            estimator_preds = estimator.predict(input_train)
+            estimator.train(input_train, steps=10)
+            # Saving the estimator's prediction on the training data; assume the DNNRegressor
+            # produces a single output column named 'predictions'
+            pred_col = "predictions"
+            estimator_preds = [s[pred_col] for s in estimator.predict(input_train)]
+            estimator_preds_df = pd.DataFrame({pred_col: estimator_preds})
             # Setting the logging such that it is in the temp folder and deleted after the test.
             old_tracking_dir = tracking.get_tracking_uri()
             tracking_dir = os.path.abspath(tmp.path("mlruns"))
@@ -78,13 +82,11 @@ class TestModelExport(unittest.TestCase):
                 feature_spec = {}
                 for name in feature_names:
                     feature_spec[name] = tf.placeholder("float", name=name, shape=[150])
-
-                saved = [s['predictions'] for s in estimator_preds]
-
-                results = self.helper(feature_spec, tmp, estimator, pandas.DataFrame(data=X, columns=feature_names))
+                pyfunc_preds_df = self.helper(feature_spec, tmp, estimator,
+                                              pandas.DataFrame(data=X, columns=feature_names))
 
                 # Asserting that the loaded model predictions are as expected.
-                np.testing.assert_array_equal(saved, results)
+                assert estimator_preds_df.equals(pyfunc_preds_df)
             finally:
                 # Restoring the old logging location.
                 tracking.end_run()
@@ -147,9 +149,12 @@ class TestModelExport(unittest.TestCase):
                 hidden_units=[20, 20], feature_columns=feature_columns)
 
             # Training the estimator.
-            estimator.train(input_fn=input_train, steps=100)
-            # Saving the estimator's prediction on the training data.
-            estimator_preds = estimator.predict(input_train)
+            estimator.train(input_fn=input_train, steps=10)
+            # Saving the estimator's prediction on the training data; assume the DNNRegressor
+            # produces a single output column named 'predictions'
+            pred_col = "predictions"
+            estimator_preds = [s[pred_col] for s in estimator.predict(input_train)]
+            estimator_preds_df = pd.DataFrame({pred_col: estimator_preds})
             # Setting the logging such that it is in the temp folder and deleted after the test.
             old_tracking_dir = tracking.get_tracking_uri()
             tracking_dir = os.path.abspath(tmp.path("mlruns"))
@@ -168,13 +173,11 @@ class TestModelExport(unittest.TestCase):
                                                             name="highway-mpg", 
                                                             shape=[None])
 
-                saved = [s['predictions'] for s in estimator_preds]
-
-                results = self.helper(feature_spec, tmp, estimator, df)
-
-                # Asserting that the loaded model predictions are as expected.
-                # TensorFlow is known to have precision errors, hence the almost_equal.
-                np.testing.assert_array_almost_equal(saved, results, decimal = 2)
+                pyfunc_preds_df = self.helper(feature_spec, tmp, estimator, df)
+                # Asserting that the loaded model predictions are as expected. Allow for some
+                # imprecision as this is expected with TensorFlow.
+                pandas.testing.assert_frame_equal(
+                    pyfunc_preds_df, estimator_preds_df, check_less_precise=6)
             finally:
                 # Restoring the old logging location.
                 tracking.end_run()


### PR DESCRIPTION
Currently, TensorFlow model import contains a bug where the loaded PyFunc predicts a DataFrame containing a single unnamed column (i.e. we assume the tf.estimator has a single output and don't preserve that output's name). This PR:
* Fixes the issue by passing a dictionary as the `fetches` argument to `sess.run`
* Updates tests to check that the PyFunc model's predict returns a DataFrame with the correct column names