### PR TITLE
Include python version in example conda.yaml

### DIFF
--- a/example/tutorial/conda.yaml
+++ b/example/tutorial/conda.yaml
@@ -2,6 +2,7 @@ name: tutorial
 channels:
   - defaults
 dependencies:
+  - python=3.6
   - numpy=1.14.3
   - pandas=0.22.0
   - scikit-learn=0.19.1


### PR DESCRIPTION
We should probably require this in all conda.yamls, but this at least makes the example reproducible independent of miniconda version (2 or 3).