### PR TITLE
Require gitpython>=2.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'scikit-learn',
         'python-dateutil',
         'protobuf>=3.6.0',
-        'gitpython',
+        'gitpython>=2.1.0',
         'pyyaml',
         'boto3',
         'querystring_parser',


### PR DESCRIPTION
In #90, we started importing `GitCommandNotFound`, which is a class added in [gitpython 2.1.0](https://github.com/gitpython-developers/GitPython/pull/519). Tested locally by downgrading my gitpython to this version, and the error does not show up.

Thanks @tomasatdatabricks 