### PR TITLE
Fix typo caused by lack of space character

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -117,7 +117,7 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
                    "(default: ./mlruns).")
 @click.option("--host", "-h", metavar="HOST", default="127.0.0.1",
               help="The network address to listen on (default: 127.0.0.1). "
-                   "Use 0.0.0.0 to bind to all addresses if you want to access the UI from"
+                   "Use 0.0.0.0 to bind to all addresses if you want to access the UI from "
                    "other machines.")
 @click.option("--port", "-p", default=5000,
               help="The port to listen on (default: 5000).")


### PR DESCRIPTION
Fix typo of "fromother" to "from other".