### PR TITLE
Recommend a simpler command to get version

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 - **Have I written custom code (as opposed to using a stock example script provided in MLflow)**:
 - **OS Platform and Distribution (e.g., Linux Ubuntu 16.04)**:
 - **MLflow installed from (source or binary)**: 
-- **MLflow version (run ``python -c "from mlflow import version; print(version.version)"``)**:
+- **MLflow version (run ``mlflow --version``)**:
 - **Python version**: 
 - **npm version (if running the dev UI):
 - **Exact command to reproduce**:

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 - **Have I written custom code (as opposed to using a stock example script provided in MLflow)**:
 - **OS Platform and Distribution (e.g., Linux Ubuntu 16.04)**:
 - **MLflow installed from (source or binary)**: 
-- **MLflow version (run ``python -c "from mlflow import version; print(version.VERSION)"``)**:
+- **MLflow version (run ``python -c "from mlflow import version; print(version.version)"``)**:
 - **Python version**: 
 - **npm version (if running the dev UI):
 - **Exact command to reproduce**:


### PR DESCRIPTION
As of MLFlow 0.1.0, the provided command (python -c "from mlflow import version; print(version.VERSION)") returns an AttributeError; the relevant attribute is `version.version`, not `version.VERSION`