### PR TITLE
Attempt to fix hanging projects CLI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,11 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   # Useful for debugging any issues with conda
   - conda info -a
+  # Install virtualenv inside conda env
+  - conda install virtualenv
   - pip install --upgrade pip
   - pip install .
   - pip install -r dev-requirements.txt
-  - pip install -r tox-requirements.txt
   - export MLFLOW_HOME=$(pwd)
   # Remove boto config present in Travis VMs (https://github.com/travis-ci/travis-ci/issues/7940)
   - sudo rm -f /etc/boto.cfg
@@ -43,10 +44,7 @@ script:
   - pip list
   - which mlflow
   - echo $MLFLOW_HOME
-  # Run Python tests & linter
-  - pytest tests --cov=mlflow --verbose --large
-  - ./lint.sh
-  # Run JS tests
+  - tox
   - cd mlflow/server/js
   - npm i
   - npm test -- --coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - which mlflow
   - echo $MLFLOW_HOME
   # Run Python tests & linter
-  - pytest tests --cov=mlflow --verbose --large --capture=no
+  - pytest tests --cov=mlflow --verbose --large
   - ./lint.sh
   # Run JS tests
   - cd mlflow/server/js

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,10 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   # Useful for debugging any issues with conda
   - conda info -a
-  # Install virtualenv inside conda env
-  - conda install virtualenv
   - pip install --upgrade pip
   - pip install .
   - pip install -r dev-requirements.txt
+  - pip install -r tox-requirements.txt
   - export MLFLOW_HOME=$(pwd)
   # Remove boto config present in Travis VMs (https://github.com/travis-ci/travis-ci/issues/7940)
   - sudo rm -f /etc/boto.cfg
@@ -44,7 +43,10 @@ script:
   - pip list
   - which mlflow
   - echo $MLFLOW_HOME
-  - tox
+  # Run Python tests & linter
+  - pytest tests --cov=mlflow --verbose --large --capture=no
+  - ./lint.sh
+  # Run JS tests
   - cd mlflow/server/js
   - npm i
   - npm test -- --coverage

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -17,7 +17,7 @@ def test_run_local():
         with update_temp_env({mlflow.tracking._TRACKING_URI_ENV_VAR: tmp.path()}):
             excitement_arg = 2
             res = invoke_cli_runner(cli.run, [TEST_PROJECT_DIR, "-e", "greeter", "-P",
-                                              "greeting=hi", "-P", "name=friend",
+                                              "greeting=hi", "--no-conda", "-P", "name=friend",
                                               "-P", "excitement=%s" % excitement_arg])
             _assert_succeeded(res.output)
 
@@ -26,6 +26,6 @@ def test_run_local():
 def test_run_git():
     with TempDir() as tmp:
         with update_temp_env({mlflow.tracking._TRACKING_URI_ENV_VAR: tmp.path()}):
-            res = invoke_cli_runner(cli.run, [GIT_PROJECT_URI, "-P", "alpha=0.5"])
+            res = invoke_cli_runner(cli.run, [GIT_PROJECT_URI, "--no-conda", "-P", "alpha=0.5"])
             assert "python train.py 0.5 0.1" in res.output
             _assert_succeeded(res.output)


### PR DESCRIPTION
As @tomasatdatabricks found in #72, some of the projects CLI tests have been hanging/failing when installing conda dependencies. This PR works around the issue for now by passing `--no-conda` to our CLI tests (i.e. not testing conda installation).

See https://travis-ci.org/databricks/mlflow/jobs/398457095 for an example of test failure on conda package installation.