### PR TITLE
Remove the duplicate gitpython req in setup.py

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -14,7 +14,7 @@ We recommend installing MLflow in its own virtualenv for development, as follows
     source env/bin/activate
     pip install -r dev-requirements.txt
     pip install -r tox-requirements.txt
-    pip install -e .
+    pip install -e .  # installs mlflow from current checkout
 
 
 ``npm`` is required to run the Javascript dev server.

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,6 @@ setup(
         'requests>=2.17.3',
         'six>=1.10.0',
         'uuid',
-        'gitpython',
         'gunicorn',
         'Flask',
         'numpy',


### PR DESCRIPTION
Because there is a `gitpython` entry before `gitpython=...` entry in setup.py, running `pip install -e .` does not install the required version of gitpython, which results in an unsuccessful installation of mlflow for development purposes. Removing the duplicate entry (that doesn't have the version number) fixes the issue. 