### PR TITLE
Making metrics chart points connect on X axis in correct order

### DIFF
--- a/mlflow/server/js/src/components/MetricView.js
+++ b/mlflow/server/js/src/components/MetricView.js
@@ -88,7 +88,7 @@ const mapStateToProps = (state, ownProps) => {
   const mergedMetricsByIdx = Utils.mergeRuns(runUuids, metricsByIdxList);
 
   const metrics = [];
-  Object.keys(mergedMetricsByIdx).sort().forEach((idx) => {
+  Object.keys(mergedMetricsByIdx).forEach((idx) => {
     let metric = { index: parseInt(idx, 10) };
     runUuids.forEach((runUuid) => {
       metric[runUuid] = mergedMetricsByIdx[idx][runUuid] || null;


### PR DESCRIPTION
Issue: #45
It seems that sort  operation 
```
Object.keys(mergedMetricsByIdx).sort()
```
was performing sort on strings and thus mixing the order.  