### PR TITLE
Tag SageMaker docker image upload with current mlflow version

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -13,7 +13,7 @@ from mlflow.tracking import _get_model_log_dir
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.file_utils import TempDir, _copy_project
 
-DEFAULT_IMAGE_NAME = "mlflow_sage"
+DEFAULT_IMAGE_NAME = "mlflow-pyfunc"
 
 _DOCKERFILE_TEMPLATE = """
 # Build an image that can serve pyfunc model in SageMaker
@@ -102,10 +102,10 @@ def build_image(name=DEFAULT_IMAGE_NAME, mlflow_home=None):
             eprint(x, end='')
 
 
-_full_template = "{account}.dkr.ecr.{region}.amazonaws.com/{image}:latest"
+_full_template = "{account}.dkr.ecr.{region}.amazonaws.com/{image}:{version}"
 
 
-def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
+def push_image_to_ecr(image=DEFAULT_IMAGE_NAME, version="latest"):
     """
     Push local Docker image to ECR.
 
@@ -119,7 +119,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
     account = caller_id['Account']
     my_session = boto3.session.Session()
     region = my_session.region_name or "us-west-2"
-    fullname = _full_template.format(account=account, region=region, image=image)
+    fullname = _full_template.format(account=account, region=region, image=image, version=version)
     ecr_client = boto3.client('ecr')
     if not ecr_client.describe_repositories(repositoryNames=[image])['repositories']:
         ecr_client.create_repository(repositoryName=image)

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -105,7 +105,7 @@ def build_image(name=DEFAULT_IMAGE_NAME, mlflow_home=None):
 _full_template = "{account}.dkr.ecr.{region}.amazonaws.com/{image}:{version}"
 
 
-def push_image_to_ecr(image=DEFAULT_IMAGE_NAME, version="latest"):
+def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
     """
     Push local Docker image to ECR.
 
@@ -119,7 +119,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME, version="latest"):
     account = caller_id['Account']
     my_session = boto3.session.Session()
     region = my_session.region_name or "us-west-2"
-    fullname = _full_template.format(account=account, region=region, image=image, version=version)
+    fullname = _full_template.format(account=account, region=region, image=image, version=mlflow.version.VERSION)
     eprint("Pushing docker image {image} to {repo}".format(image=image, repo=fullname))
     ecr_client = boto3.client('ecr')
     if not ecr_client.describe_repositories(repositoryNames=[image])['repositories']:

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -120,6 +120,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME, version="latest"):
     my_session = boto3.session.Session()
     region = my_session.region_name or "us-west-2"
     fullname = _full_template.format(account=account, region=region, image=image, version=version)
+    print("Pushing docker image {image} to {repo}".format(image=image, repo=fullname))
     ecr_client = boto3.client('ecr')
     if not ecr_client.describe_repositories(repositoryNames=[image])['repositories']:
         ecr_client.create_repository(repositoryName=image)

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -120,7 +120,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME, version="latest"):
     my_session = boto3.session.Session()
     region = my_session.region_name or "us-west-2"
     fullname = _full_template.format(account=account, region=region, image=image, version=version)
-    print("Pushing docker image {image} to {repo}".format(image=image, repo=fullname))
+    eprint("Pushing docker image {image} to {repo}".format(image=image, repo=fullname))
     ecr_client = boto3.client('ecr')
     if not ecr_client.describe_repositories(repositoryNames=[image])['repositories']:
         ecr_client.create_repository(repositoryName=image)

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -49,9 +49,9 @@ def run_local(model_path, run_id, port, container):
 @click.option("--build/--no-build", default=True, help="Build the container if set.")
 @click.option("--push/--no-push", default=True, help="Push the container to amazon ecr if set.")
 @click.option("--container", "-c", default=IMAGE, help="image name")
-@click.option("--version", "-v", default="latest", help="version to tag image with")
+@click.option("--version", "-v", default="latest", help="version to tag the image with")
 @cli_args.MLFLOW_HOME
-def build_and_push_container(build, push, container, mlflow_home, version, account):
+def build_and_push_container(build, push, container, version, mlflow_home):
     """
     Build new MLflow Sagemaker image, assign it given name and push to ECR.
 

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -49,8 +49,9 @@ def run_local(model_path, run_id, port, container):
 @click.option("--build/--no-build", default=True, help="Build the container if set.")
 @click.option("--push/--no-push", default=True, help="Push the container to amazon ecr if set.")
 @click.option("--container", "-c", default=IMAGE, help="image name")
+@click.option("--version", "-v", default="latest", help="version to tag image with")
 @cli_args.MLFLOW_HOME
-def build_and_push_container(build, push, container, mlflow_home):
+def build_and_push_container(build, push, container, mlflow_home, version, account):
     """
     Build new MLflow Sagemaker image, assign it given name and push to ECR.
 
@@ -65,4 +66,4 @@ def build_and_push_container(build, push, container, mlflow_home):
                                      mlflow_home=os.path.abspath(mlflow_home) if mlflow_home
                                      else None)
     if push:
-        mlflow.sagemaker.push_image_to_ecr(container)
+        mlflow.sagemaker.push_image_to_ecr(container, version)

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -49,9 +49,8 @@ def run_local(model_path, run_id, port, container):
 @click.option("--build/--no-build", default=True, help="Build the container if set.")
 @click.option("--push/--no-push", default=True, help="Push the container to amazon ecr if set.")
 @click.option("--container", "-c", default=IMAGE, help="image name")
-@click.option("--version", "-v", default="latest", help="version to tag the image with")
 @cli_args.MLFLOW_HOME
-def build_and_push_container(build, push, container, version, mlflow_home):
+def build_and_push_container(build, push, container, mlflow_home):
     """
     Build new MLflow Sagemaker image, assign it given name and push to ECR.
 
@@ -66,4 +65,4 @@ def build_and_push_container(build, push, container, version, mlflow_home):
                                      mlflow_home=os.path.abspath(mlflow_home) if mlflow_home
                                      else None)
     if push:
-        mlflow.sagemaker.push_image_to_ecr(container, version)
+        mlflow.sagemaker.push_image_to_ecr(container)


### PR DESCRIPTION
The SageMaker deployment docker image should be tagged with the mlflow version used so one can track the correct image to use in `deploy()`. This PR uses the current mlflow version to tag the ECR image instead of "latest" for SageMaker docker image upload.

To test (which should mirror the release process):
1. Set `mlflow.version.VERSION` to the next version (e.g. 0.2.2 for the current state).
2. Run `mlflow sagemaker build-and-push-container -c mlflow-pyfunc --mlflow_home <path_to_mlflow_git_checkout>`
3. Check image was uploaded, tagged with the correct version, by running `aws ecr describe-images --repository-name mlflow-pyfunc` and examining the field `"imageTags"` (should be "0.2.2" given the command in 1).