### PR TITLE
Add defaults to SageMaker deploy() params: bucket, execution role arn

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -262,7 +262,6 @@ def _get_default_s3_bucket(region_name):
     # create bucket if it does not exist
     sess = boto3.Session()
     account_id = _get_account_id()
-    region_name = sess.region_name or "us-west-2"
     bucket_name = "{pfx}-{rn}-{aid}".format(pfx=DEFAULT_BUCKET_NAME_PREFIX, rn=region_name, aid=account_id)
     s3 = sess.client('s3')
     response = s3.list_buckets()

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -15,6 +15,8 @@ from mlflow.utils.file_utils import TempDir, _copy_project
 
 DEFAULT_IMAGE_NAME = "mlflow-pyfunc"
 
+IMAGE_NAME_ENV_VAR = "SAGEMAKER_DEPLOY_IMG_URL"
+
 DEFAULT_BUCKET_NAME_PREFIX = "mlflow-sagemaker"
 
 _DOCKERFILE_TEMPLATE = """
@@ -224,6 +226,10 @@ def _check_compatible(path):
 
 
 def _get_default_image_url():
+    env_img = os.environ.get(IMAGE_NAME_ENV_VAR)
+    if env_img:
+        return env_img
+
     ecr_client = boto3.client("ecr")
     repository_conf = ecr_client.describe_repositories(
         repositoryNames=[DEFAULT_IMAGE_NAME])['repositories'][0]

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -157,7 +157,7 @@ def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=No
     :param run_id: MLflow run id.
     :param image: name of the Docker image to be used. if not specified, uses a 
                   publicly-available pre-built image.
-    :param region_name: Name of the AWS region to deploy to. defaults to 
+    :param region_name: Name of the AWS region to deploy to.
     """
     if not image_url:
         image_url = _get_default_image_url()

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -22,7 +22,7 @@ def commands():
 @click.option("--execution-role-arn", "-e", default=None, help="SageMaker execution role")
 @click.option("--bucket", "-b", default=None, help="S3 bucket to store model artifacts")
 @cli_args.RUN_ID
-@click.option("--image_url", "-i", default=None, help="ECR URL for the Docker image")
+@click.option("--image-url", "-i", default=None, help="ECR URL for the Docker image")
 @click.option("--region-name", "-r", default="us-west-2", help="region name")
 def deploy(app_name, model_path, execution_role_arn, bucket, run_id, image_url, region_name):
     """

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -22,27 +22,27 @@ def commands():
 @click.option("--execution-role-arn", "-e", default=None, help="SageMaker execution role")
 @click.option("--bucket", "-b", default=None, help="S3 bucket to store model artifacts")
 @cli_args.RUN_ID
-@click.option("--container", "-c", default=None, help="container name")
+@click.option("--image_url", "-i", default=None, help="ECR URL for the Docker image")
 @click.option("--region-name", "-r", default="us-west-2", help="region name")
-def deploy(app_name, model_path, execution_role_arn, bucket, run_id, container, region_name):
+def deploy(app_name, model_path, execution_role_arn, bucket, run_id, image_url, region_name):
     """
-    Deploy model on Sagemaker. Current active AWS account needs to have correct permissions setup.
+    Deploy model on Sagemaker as a REST API endpoint. Current active AWS account needs to have correct permissions setup.
     """
     mlflow.sagemaker.deploy(app_name=app_name, model_path=model_path,
                             execution_role_arn=execution_role_arn, bucket=bucket, run_id=run_id,
-                            image=container, region_name=region_name)
+                            image_url=image_url, region_name=region_name)
 
 
 @commands.command("run-local")
 @cli_args.MODEL_PATH
 @cli_args.RUN_ID
 @click.option("--port", "-p", default=5000, help="Server port. [default: 5000]")
-@click.option("--container", "-c", default=IMAGE, help="container name")
-def run_local(model_path, run_id, port, container):
+@click.option("--image", "-i", default=IMAGE, help="Docker image name")
+def run_local(model_path, run_id, port, image):
     """
     Serve model locally running in a Sagemaker-compatible Docker container.
     """
-    mlflow.sagemaker.run_local(model_path=model_path, run_id=run_id, port=port, image=container)
+    mlflow.sagemaker.run_local(model_path=model_path, run_id=run_id, port=port, image=image)
 
 
 @commands.command("build-and-push-container")

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -19,11 +19,11 @@ def commands():
 @commands.command("deploy")
 @click.option("--app-name", "-a", help="Application name.", required=True)
 @cli_args.MODEL_PATH
-@click.option("--execution-role-arn", "-e", help="SageMaker execution role", required=True)
-@click.option("--bucket", "-b", help="S3 bucket to store model artifacts", required=True)
+@click.option("--execution-role-arn", "-e", default=None, help="SageMaker execution role")
+@click.option("--bucket", "-b", default=None, help="S3 bucket to store model artifacts")
 @cli_args.RUN_ID
-@click.option("--container", "-c", default="mlflow_sage", help="container name")
-@click.option("--region-name", default="us-west-2", help="region name")
+@click.option("--container", "-c", default=None, help="container name")
+@click.option("--region-name", "-r", default="us-west-2", help="region name")
 def deploy(app_name, model_path, execution_role_arn, bucket, run_id, container, region_name):
     """
     Deploy model on Sagemaker. Current active AWS account needs to have correct permissions setup.

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,3 +1,4 @@
 # Copyright 2018 Databricks, Inc.
 
 VERSION = '0.2.1' #  NOQA
+NEXT_VERSION = '0.2.2' #  NOQA

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,4 +1,3 @@
 # Copyright 2018 Databricks, Inc.
 
-VERSION = '0.2.1' #  NOQA
-NEXT_VERSION = '0.2.2' #  NOQA
+VERSION = '0.2.1'  # NOQA

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,3 +1,3 @@
 # Copyright 2018 Databricks, Inc.
 
-VERSION = '0.2.1'  # NOQA
+VERSION = '0.2.1' #  NOQA


### PR DESCRIPTION
This PR automates some of the parameters and steps for the SageMaker deploy functionality:
* Makes the S3 bucket parameter optional. Creates and uses a default S3 bucket if not specified. This behavior mirrors what SageMaker does. The default bucket cannot be used if the currently-assumed IAM role or AWS user does not have permissions to create the default S3 bucket. SageMakerFullAccess policy, recommended to be used for SageMaker actions by AWS SageMaker, grants this permission.
* Makes the sagemaker execution role arn parameter optional. Uses the currently-assumed role's ARN if left empty.

It also changes the cli parameter for the docker image from "--container" to "--image-url" so images from different AWS accounts, or different versions of the image can be used. This is a **breaking** change.

Tests (manual):
* unsupported region invokes ValueError
* local run
* deploy (function calls & CLI)
  * S3 - default, custom
  * sagemaker execution role arn - default, custom
  * image_url - default, custom

Note: SageMaker Endpoints get stuck in the "Creating" status sometimes, with the exact same settings that other times succeed. Haven't figured out what exactly the problem is yet (the only thing I can see right now is that for the ones failing the endpoint names are longer).  