### PR TITLE
Point users to logs when running 'mlflow ui' fails

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -14,6 +14,7 @@ import mlflow.sagemaker.cli
 import mlflow.server
 
 from mlflow.entities.experiment import Experiment
+from mlflow.utils.process import ShellCommandException
 from mlflow import tracking
 
 
@@ -128,7 +129,12 @@ def ui(file_store, host, port):
     The UI will be visible at http://localhost:5000 by default.
     """
     # TODO: We eventually want to disable the write path in this version of the server.
-    mlflow.server._run_server(file_store, file_store, host, port, 1)
+    try:
+        mlflow.server._run_server(file_store, file_store, host, port, 1)
+    except ShellCommandException:
+        print("Running the mlflow server failed. Please see the logs above for details.",
+              file=sys.stderr)
+        sys.exit(1)
 
 
 @cli.command()
@@ -153,7 +159,12 @@ def server(file_store, artifact_root, host, port, workers):
     the local machine. To let the server accept connections from other machines, you will need to
     pass --host 0.0.0.0 to listen on all network interfaces (or a specific interface address).
     """
-    mlflow.server._run_server(file_store, artifact_root, host, port, workers)
+    try:
+        mlflow.server._run_server(file_store, artifact_root, host, port, workers)
+    except ShellCommandException:
+        print("Running the mlflow server failed. Please see the logs above for details.",
+              file=sys.stderr)
+        sys.exit(1)
 
 
 cli.add_command(mlflow.sklearn.commands)


### PR DESCRIPTION
The change attempts to address #91 by pointing users to the logs of
trying to start the mlflow server instead of printing an exception
that does not explain the cause for failure and is slightly noisy.

Here are the logs when the server is run and the desired port is being used by another process:

**Before change**
```
(env) Michaels-MacBook-Pro:mlflow mhuston$ mlflow ui
[2018-07-08 16:36:08 -0700] [17612] [INFO] Starting gunicorn 19.9.0
[2018-07-08 16:36:08 -0700] [17612] [ERROR] Connection in use: ('127.0.0.1', 5000)
[2018-07-08 16:36:08 -0700] [17612] [ERROR] Retrying in 1 second.
[2018-07-08 16:36:09 -0700] [17612] [ERROR] Connection in use: ('127.0.0.1', 5000)
[2018-07-08 16:36:09 -0700] [17612] [ERROR] Retrying in 1 second.
[2018-07-08 16:36:10 -0700] [17612] [ERROR] Connection in use: ('127.0.0.1', 5000)
[2018-07-08 16:36:10 -0700] [17612] [ERROR] Retrying in 1 second.
[2018-07-08 16:36:11 -0700] [17612] [ERROR] Connection in use: ('127.0.0.1', 5000)
[2018-07-08 16:36:11 -0700] [17612] [ERROR] Retrying in 1 second.
[2018-07-08 16:36:12 -0700] [17612] [ERROR] Connection in use: ('127.0.0.1', 5000)
[2018-07-08 16:36:12 -0700] [17612] [ERROR] Retrying in 1 second.
[2018-07-08 16:36:13 -0700] [17612] [ERROR] Can't connect to ('127.0.0.1', 5000)
Traceback (most recent call last):
  File "/Users/mhuston/Code/mlflow/env/bin/mlflow", line 11, in <module>
    load_entry_point('mlflow', 'console_scripts', 'mlflow')()
  File "/Users/mhuston/Code/mlflow/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/mhuston/Code/mlflow/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/mhuston/Code/mlflow/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/mhuston/Code/mlflow/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/mhuston/Code/mlflow/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/mhuston/Code/mlflow/mlflow/cli.py", line 131, in ui
    mlflow.server._run_server(file_store, file_store, host, port, 1)
  File "/Users/mhuston/Code/mlflow/mlflow/server/__init__.py", line 48, in _run_server
    env=env_map, stream_output=True)
  File "/Users/mhuston/Code/mlflow/mlflow/utils/process.py", line 38, in exec_cmd
    raise ShellCommandException("Non-zero exitcode: %s" % (exit_code))
mlflow.utils.process.ShellCommandException: Non-zero exitcode: 1
```

**After change**
```
(env) Michaels-MacBook-Pro:mlflow mhuston$ mlflow ui
[2018-07-08 18:17:31 -0700] [20335] [INFO] Starting gunicorn 19.9.0
[2018-07-08 18:17:31 -0700] [20335] [ERROR] Connection in use: ('127.0.0.1', 5000)
[2018-07-08 18:17:31 -0700] [20335] [ERROR] Retrying in 1 second.
[2018-07-08 18:17:32 -0700] [20335] [ERROR] Connection in use: ('127.0.0.1', 5000)
[2018-07-08 18:17:32 -0700] [20335] [ERROR] Retrying in 1 second.
[2018-07-08 18:17:33 -0700] [20335] [ERROR] Connection in use: ('127.0.0.1', 5000)
[2018-07-08 18:17:33 -0700] [20335] [ERROR] Retrying in 1 second.
[2018-07-08 18:17:34 -0700] [20335] [ERROR] Connection in use: ('127.0.0.1', 5000)
[2018-07-08 18:17:34 -0700] [20335] [ERROR] Retrying in 1 second.
[2018-07-08 18:17:35 -0700] [20335] [ERROR] Connection in use: ('127.0.0.1', 5000)
[2018-07-08 18:17:35 -0700] [20335] [ERROR] Retrying in 1 second.
[2018-07-08 18:17:36 -0700] [20335] [ERROR] Can't connect to ('127.0.0.1', 5000)
Running the mlflow server failed. Please see the logs above for details.
```