### PR TITLE
[DATA-8085] Reverted adding no-conda to a test. Should work with conda now.

### DIFF
--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -17,7 +17,7 @@ def test_run_local():
         with update_temp_env({mlflow.tracking._TRACKING_URI_ENV_VAR: tmp.path()}):
             excitement_arg = 2
             res = invoke_cli_runner(cli.run, [TEST_PROJECT_DIR, "-e", "greeter", "-P",
-                                              "greeting=hi", "--no-conda", "-P", "name=friend",
+                                              "greeting=hi", "-P", "name=friend",
                                               "-P", "excitement=%s" % excitement_arg])
             _assert_succeeded(res.output)
 


### PR DESCRIPTION
The test used to fail with conda so --no-conda was added to it. It actually passes if we fix python version in the conda environment -> I've removed the --no-conda argument to increase test coverage.