### PR TITLE
 Clarify that the artifact root passed to mlflow server is just the default

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -202,7 +202,7 @@ An example configuration for a server is as follows:
 
     mlflow server \
         --file-store /mnt/persistent-disk \
-        --artifact-root s3://my-mlflow-bucket/ \
+        --default-artifact-root s3://my-mlflow-bucket/ \
         --host 0.0.0.0
 
 Storage
@@ -210,8 +210,8 @@ Storage
 There are two properties related to how data is stored:
 
 * ``--file-store`` a persistent (non-ephemeral) disk where the server stores run and experiment information.
-* ``--artifact-root`` a location suitable for large data (such as an S3 bucket or shared NFS file system)
-  where clients log their artifact output (for example, models). If
+* ``--default-artifact-root`` a location suitable for large data (such as an S3 bucket or shared NFS file system)
+  where clients log their artifact output (for example, models) for newly created experiments. If
   you do not provide this option, clients write artifacts to *their* local directories,
   which the server won't serve.
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -227,7 +227,7 @@ To utilize Google Cloud Storage you can set the artifact-root to ``gs://<storage
 the documentation for `Authentication <https://google-cloud.readthedocs.io/en/latest/core/auth.html>`_.
 
 Warning: If you do not specify a ``--default-artifact-root``, nor do you specify an artifact URI when creating
-the experiemnt (e.g., ``mlflow experiments create --artifact-root s3://<my-bucket>``), then the artifact root
+the experiment (e.g., ``mlflow experiments create --artifact-root s3://<my-bucket>``), then the artifact root
 will be a path inside the File Store. Typically this is not an appropriate location, as the client and
 server will probably be referring to different physical locations (i.e., the same path on different disks).
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -215,9 +215,9 @@ running in a server, make sure that this points to a persistent (i.e., non-ephem
 
 The **Artifact Store** is a location suitable for large data (such as an S3 bucket or shared NFS file system)
 where clients log their artifact output (for example, models). The Artifact Store is actually a property
-of an Experiment, but the ``--default-artifact-root`` flag is used to specify what artifact root URI will
-be provided for newly-created experiments that do not have an override. Note that once an experiment
-is created, the ``--default-artifact-root` will no longer have an effect on it.
+of an Experiment, but the ``--default-artifact-root`` flag is used to set the artifact root URI for
+newly-created experments that do not specify one. Note that once an experiment is created,
+the ``--default-artifact-root`` is no longer relevant to it.
 
 For the clients and server to access the artifact location, you should configure your cloud
 provider credentials as normal. For example, for S3, you can set the ``AWS_ACCESS_KEY_ID``

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -209,11 +209,15 @@ Storage
 ^^^^^^^
 There are two properties related to how data is stored:
 
-* ``--file-store`` a persistent (non-ephemeral) disk where the server stores run and experiment information.
-* ``--default-artifact-root`` a location suitable for large data (such as an S3 bucket or shared NFS file system)
-  where clients log their artifact output (for example, models) for newly created experiments. If
-  you do not provide this option, clients write artifacts to *their* local directories,
-  which the server won't serve.
+The **File Store** (exposed via ``--file-store``) is where the server will store run and experiment metadata.
+It defaults to the local ./mlruns directory (same as when running ``mlflow run`` locally), but when
+running in a server, make sure that this points to a persistent (i.e., non-ephemeral) file system location.
+
+The **Artifact Store** is a location suitable for large data (such as an S3 bucket or shared NFS file system)
+where clients log their artifact output (for example, models). The Artifact Store is actually a property
+of an Experiment, but the ``--default-artifact-root`` flag is used to specify what artifact root URI will
+be provided for newly-created experiments that do not have an override. Note that once an experiment
+is created, the ``--default-artifact-root` will no longer have an effect on it.
 
 For the clients and server to access the artifact location, you should configure your cloud
 provider credentials as normal. For example, for S3, you can set the ``AWS_ACCESS_KEY_ID``
@@ -221,6 +225,11 @@ and ``AWS_SECRET_ACCESS_KEY`` environment variables, use an IAM role, or configu
 profile in ``~/.aws/credentials``. See `Set up AWS Credentials and Region for Development <https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/setup-credentials.html>`_ for more info.
 To utilize Google Cloud Storage you can set the artifact-root to ``gs://<storage_bucket>``, and you will need to provide auth as per
 the documentation for `Authentication <https://google-cloud.readthedocs.io/en/latest/core/auth.html>`_.
+
+Warning: If you do not specify a ``--default-artifact-root``, nor do you specify an artifact URI when creating
+the experiemnt (e..g, ``mlflow experiments create --artifact-root s3://<my-bucket>``), then the artifact root
+will be a path inside the File Store. Typically this is not an appropriate location, as the client and
+server will probably be referring to different physical locations (i.e., the same path on different disks).
 
 
 Networking

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -227,7 +227,7 @@ To utilize Google Cloud Storage you can set the artifact-root to ``gs://<storage
 the documentation for `Authentication <https://google-cloud.readthedocs.io/en/latest/core/auth.html>`_.
 
 Warning: If you do not specify a ``--default-artifact-root``, nor do you specify an artifact URI when creating
-the experiemnt (e..g, ``mlflow experiments create --artifact-root s3://<my-bucket>``), then the artifact root
+the experiemnt (e.g., ``mlflow experiments create --artifact-root s3://<my-bucket>``), then the artifact root
 will be a path inside the File Store. Typically this is not an appropriate location, as the client and
 server will probably be referring to different physical locations (i.e., the same path on different disks).
 

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -141,8 +141,10 @@ def ui(file_store, host, port):
 @click.option("--file-store", metavar="PATH", default=None,
               help="The root of the backing file store for experiment and run data "
                    "(default: ./mlruns).")
-@click.option("--artifact-root", metavar="URI", default=None,
-              help="Local or S3 URI to store artifacts in (default: inside file store).")
+@click.option("--default-artifact-root", metavar="URI", default=None,
+              help="Local or S3 URI to store artifacts in, for newly created experiments. "
+                   "Note that this flag does not impact already-created experiments. "
+                   "Default: inside file store.")
 @click.option("--host", "-h", metavar="HOST", default="127.0.0.1",
               help="The network address to listen on (default: 127.0.0.1). "
                    "Use 0.0.0.0 to bind to all addresses if you want to access the tracking "
@@ -151,7 +153,7 @@ def ui(file_store, host, port):
               help="The port to listen on (default: 5000).")
 @click.option("--workers", "-w", default=4,
               help="Number of gunicorn worker processes to handle requests (default: 4).")
-def server(file_store, artifact_root, host, port, workers):
+def server(file_store, default_artifact_root, host, port, workers):
     """
     Run the MLflow tracking server.
 
@@ -160,7 +162,7 @@ def server(file_store, artifact_root, host, port, workers):
     pass --host 0.0.0.0 to listen on all network interfaces (or a specific interface address).
     """
     try:
-        mlflow.server._run_server(file_store, artifact_root, host, port, workers)
+        mlflow.server._run_server(file_store, default_artifact_root, host, port, workers)
     except ShellCommandException:
         print("Running the mlflow server failed. Please see the logs above for details.",
               file=sys.stderr)

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -36,13 +36,13 @@ def serve(path):  # pylint: disable=unused-argument
     return send_from_directory(STATIC_DIR, 'index.html')
 
 
-def _run_server(file_store_path, artifact_root, host, port, workers):
+def _run_server(file_store_path, default_artifact_root, host, port, workers):
     """Run the MLflow server, wrapping it in gunicorn"""
     env_map = {}
     if file_store_path:
         env_map[FILE_STORE_ENV_VAR] = file_store_path
-    if artifact_root:
-        env_map[ARTIFACT_ROOT_ENV_VAR] = artifact_root
+    if default_artifact_root:
+        env_map[ARTIFACT_ROOT_ENV_VAR] = default_artifact_root
     bind_address = "%s:%s" % (host, port)
     exec_cmd(["gunicorn", "-b", bind_address, "-w", "%s" % workers, "mlflow.server:app"],
              env=env_map, stream_output=True)

--- a/tests/mlflow/spark/test_spark_model_export.py
+++ b/tests/mlflow/spark/test_spark_model_export.py
@@ -17,7 +17,7 @@ from mlflow import tracking
 from mlflow.utils.environment import _mlflow_conda_env
 from tests.helper_functions import score_model_in_sagemaker_docker_container
 
-
+@pytest.mark.large
 def test_model_export(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["pyspark=={}".format(pyspark_version)])
@@ -52,6 +52,7 @@ def test_model_export(tmpdir):
     assert preds1 == preds3
 
 
+@pytest.mark.large
 def test_model_log(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
     _mlflow_conda_env(conda_env, additional_pip_deps=["pyspark=={}".format(pyspark_version)])

--- a/tests/mlflow/spark/test_spark_model_export.py
+++ b/tests/mlflow/spark/test_spark_model_export.py
@@ -17,6 +17,7 @@ from mlflow import tracking
 from mlflow.utils.environment import _mlflow_conda_env
 from tests.helper_functions import score_model_in_sagemaker_docker_container
 
+
 @pytest.mark.large
 def test_model_export(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")


### PR DESCRIPTION
This PR renames the "--artifact-root" parameter to "--default-artifact-root." This is to help avoid confusion when changing the artifact root passed to the server after already creating an experiment.

Hopefully this would prevent issues like #158 and #163, which are unintuitive to debug.