### PR TITLE
Fix for Incompatible file structure returned by GCSArtifactRepository (#172)

### DIFF
--- a/tests/store/test_gcs_artifact_repo.py
+++ b/tests/store/test_gcs_artifact_repo.py
@@ -55,10 +55,10 @@ def test_list_artifacts(gcs_mock):
 
     artifacts = repo.list_artifacts()
     assert artifacts[0].path == dir_name
-    assert artifacts[0].is_dir == True
-    assert artifacts[0].file_size == None
+    assert artifacts[0].is_dir is True
+    assert artifacts[0].file_size is None
     assert artifacts[1].path == file_name
-    assert artifacts[1].is_dir == False
+    assert artifacts[1].is_dir is False
     assert artifacts[1].file_size == obj_mock.size
 
 

--- a/tests/store/test_gcs_artifact_repo.py
+++ b/tests/store/test_gcs_artifact_repo.py
@@ -36,6 +36,8 @@ def test_list_artifacts(gcs_mock):
     dest_path = "/some/path/"
     repo = GCSArtifactRepository("gs://test_bucket" + dest_path, gcs_mock)
 
+    # mocking a single blob returned by bucket.list_blobs iterator
+    # https://googlecloudplatform.github.io/google-cloud-python/latest/storage/buckets.html#google.cloud.storage.bucket.Bucket.list_blobs
     dir_mock = mock.Mock()
     dir_name = "0_subpath"
     dir_mock.configure_mock(prefixes=(dest_path + dir_name + "/",))

--- a/tests/store/test_gcs_artifact_repo.py
+++ b/tests/store/test_gcs_artifact_repo.py
@@ -27,23 +27,37 @@ def test_artifact_uri_factory():
 
 def test_list_artifacts_empty(gcs_mock):
     repo = GCSArtifactRepository("gs://test_bucket/some/path", gcs_mock)
-    gcs_mock.Client.return_value.get_bucket.return_value\
-        .list_blobs.return_value = []
+    gcs_mock.Client.return_value.get_bucket.return_value \
+        .list_blobs.return_value = mock.MagicMock()
     assert repo.list_artifacts() == []
 
 
 def test_list_artifacts(gcs_mock):
-    repo = GCSArtifactRepository("gs://test_bucket/some/path", gcs_mock)
-    mockobj = mock.Mock()
-    mockobj.configure_mock(
-            name='/some/path/mockeryname',
-            f='/mockeryname',
-            size=1,
-    )
+    dest_path = "/some/path/"
+    repo = GCSArtifactRepository("gs://test_bucket" + dest_path, gcs_mock)
+
+    dir_mock = mock.Mock()
+    dir_name = "0_subpath"
+    dir_mock.configure_mock(prefixes=(dest_path + dir_name + "/",))
+
+    obj_mock = mock.Mock()
+    file_name = '1_file'
+    obj_mock.configure_mock(name=dest_path + file_name, size=1)
+
+    mock_results = mock.MagicMock()
+    mock_results.configure_mock(pages=[dir_mock])
+    mock_results.__iter__.return_value = [obj_mock]
+
     gcs_mock.Client.return_value.get_bucket.return_value\
-        .list_blobs.return_value = [mockobj]
-    assert repo.list_artifacts()[0].path == mockobj.f
-    assert repo.list_artifacts()[0].file_size == mockobj.size
+        .list_blobs.return_value = mock_results
+
+    artifacts = repo.list_artifacts()
+    assert artifacts[0].path == dir_name
+    assert artifacts[0].is_dir == True
+    assert artifacts[0].file_size == None
+    assert artifacts[1].path == file_name
+    assert artifacts[1].is_dir == False
+    assert artifacts[1].file_size == obj_mock.size
 
 
 def test_log_artifact(gcs_mock, tmpdir):


### PR DESCRIPTION
Ensures that the GCSArtifactRepository returns the same file structure as the LocalArtifactRepository. This fixes (#172)