### PR TITLE
Completely disable projects/test_databricks temporarily

### DIFF
--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -77,6 +77,7 @@ def run_databricks_project(cluster_spec_path, block=False):
         uri=GIT_PROJECT_URI, mode="databricks", cluster_spec=cluster_spec_path, block=block)
 
 
+@pytest.mark.skip(reason="flaky running in travis py2.7")
 def test_run_databricks(
         tmpdir, runs_cancel_mock, create_databricks_run_mock,  # pylint: disable=unused-argument
         runs_submit_mock, runs_get_mock, cluster_spec_mock):
@@ -91,6 +92,7 @@ def test_run_databricks(
         validate_exit_status(submitted_run.get_status(), expected_status)
 
 
+@pytest.mark.skip(reason="flaky running in travis py2.7")
 def test_run_databricks_cancel(
         tmpdir, create_databricks_run_mock,  # pylint: disable=unused-argument
         runs_submit_mock, runs_cancel_mock,  # pylint: disable=unused-argument


### PR DESCRIPTION
In preparation for the release, we want a non-flaky, green build. We have spent some time debugging `projects/test_databricks` as to why it's very flaky on Travis for Python 2.7, but have not yet come to a solid conclusion.

@smurching continues to debug this issue, but because we know this test passes locally (on Python 2.7), and the code itself works when run against non-mocked objects, we are disabling the test to unblock PRs unrelated to the `projects` API, including the release.