### PR TITLE
Support compute specification when deploying SageMaker models

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -32,6 +32,9 @@ IMAGE_NAME_ENV_VAR = "SAGEMAKER_DEPLOY_IMG_URL"
 
 DEFAULT_BUCKET_NAME_PREFIX = "mlflow-sagemaker"
 
+DEFAULT_SAGEMAKER_INSTANCE_TYPE = "ml.m4.xlarge"
+DEFAULT_SAGEMAKER_INSTANCE_COUNT = 1
+
 _DOCKERFILE_TEMPLATE = """
 # Build an image that can serve pyfunc model in SageMaker
 FROM ubuntu:16.04
@@ -162,7 +165,8 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
 
 def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=None,
            image_url=None, region_name="us-west-2", mode=DEPLOYMENT_MODE_CREATE, archive=False, 
-           instance_type="ml.m4.xlarge", instance_count=1):
+           instance_type=DEFAULT_SAGEMAKER_INSTANCE_TYPE, 
+           instance_count=DEFAULT_SAGEMAKER_INSTANCE_COUNT):
     """
     Deploy model on SageMaker.
     Current active AWS account needs to have correct permissions setup.

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -207,8 +207,10 @@ def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=No
     :param archive: If True, any pre-existing SageMaker application resources that become inactive
                     (i.e. as a result of deploying in mlflow.sagemaker.DEPLOYMENT_MODE_REPLACE mode)
                     will be preserved. If False, these resources will be deleted.
-    :param instance_type: The type of EC2 instance on which to deploy the model.
-    :param instance_count: The number of EC2 instances on which to deploy the model.
+    :param instance_type: The type of SageMaker ML instance on which to deploy the model.
+                          For a list of supported instance types, see 
+                          https://aws.amazon.com/sagemaker/pricing/instance-types/.
+    :param instance_count: The number of SageMaker ML instances on which to deploy the model.
     """
     if mode not in DEPLOYMENT_MODES:
         raise ValueError("`mode` must be one of: {mds}".format(
@@ -426,8 +428,8 @@ def _deploy(role, image_url, app_name, model_s3_path, run_id, region_name, mode,
     :param archive: If True, any pre-existing SageMaker application resources that become inactive
                     (i.e. as a result of deploying in mlflow.sagemaker.DEPLOYMENT_MODE_REPLACE mode)
                     will be preserved. If False, these resources will be deleted.
-    :param instance_type: The type of EC2 instance on which to deploy the model.
-    :param instance_count: The number of EC2 instances on which to deploy the model.
+    :param instance_type: The type of SageMaker ML instance on which to deploy the model.
+    :param instance_count: The number of SageMaker ML instances on which to deploy the model.
     """
     sage_client = boto3.client('sagemaker', region_name=region_name)
     s3_client = boto3.client('s3', region_name=region_name)
@@ -510,8 +512,8 @@ def _create_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
     :param image_url: URL of the ECR-hosted docker image the model is being deployed into
     :param model_s3_path: s3 path where we stored the model artifacts
     :param run_id: RunId that generated this model
-    :param instance_type: The type of EC2 instance on which to deploy the model.
-    :param instance_count: The number of EC2 instances on which to deploy the model.
+    :param instance_type: The type of SageMaker ML instance on which to deploy the model.
+    :param instance_count: The number of SageMaker ML instances on which to deploy the model.
     :param role: SageMaker execution ARN role
     :param sage_client: A boto3 client for SageMaker
     """
@@ -562,8 +564,8 @@ def _update_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
     :param image_url: URL of the ECR-hosted docker image the model is being deployed into
     :param model_s3_path: s3 path where we stored the model artifacts
     :param run_id: RunId that generated this model
-    :param instance_type: The type of EC2 instance on which to deploy the model.
-    :param instance_count: The number of EC2 instances on which to deploy the model.
+    :param instance_type: The type of SageMaker ML instance on which to deploy the model.
+    :param instance_count: The number of SageMaker ML instances on which to deploy the model.
     :param mode: either mlflow.sagemaker.DEPLOYMENT_MODE_ADD or
                  mlflow.sagemaker.DEPLOYMENT_MODE_REPLACE.
     :param archive: If True, any pre-existing SageMaker application resources that become inactive

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -164,8 +164,8 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
 
 
 def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=None,
-           image_url=None, region_name="us-west-2", mode=DEPLOYMENT_MODE_CREATE, archive=False, 
-           instance_type=DEFAULT_SAGEMAKER_INSTANCE_TYPE, 
+           image_url=None, region_name="us-west-2", mode=DEPLOYMENT_MODE_CREATE, archive=False,
+           instance_type=DEFAULT_SAGEMAKER_INSTANCE_TYPE,
            instance_count=DEFAULT_SAGEMAKER_INSTANCE_COUNT):
     """
     Deploy model on SageMaker.
@@ -413,7 +413,7 @@ def _upload_s3(local_model_path, bucket, prefix):
             return '{}/{}/{}'.format(s3.meta.endpoint_url, bucket, key)
 
 
-def _deploy(role, image_url, app_name, model_s3_path, run_id, region_name, mode, archive, 
+def _deploy(role, image_url, app_name, model_s3_path, run_id, region_name, mode, archive,
             instance_type, instance_count):
     """
     Deploy model on sagemaker.
@@ -504,7 +504,7 @@ def _get_sagemaker_config_name(endpoint_name):
     return "{en}-config-{uid}".format(en=endpoint_name, uid=unique_id)
 
 
-def _create_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, instance_type, 
+def _create_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, instance_type,
                                instance_count, role, sage_client):
     """
     :param image_url: URL of the ECR-hosted docker image the model is being deployed into
@@ -528,12 +528,12 @@ def _create_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
     eprint("Created model with arn: %s" % model_response["ModelArn"])
 
     production_variant = {
-                            'VariantName': model_name,
-                            'ModelName': model_name,
-                            'InitialInstanceCount': instance_count,
-                            'InstanceType': instance_type,
-                            'InitialVariantWeight': 1,
-                         }
+        'VariantName': model_name,
+        'ModelName': model_name,
+        'InitialInstanceCount': instance_count,
+        'InstanceType': instance_type,
+        'InitialVariantWeight': 1,
+    }
     config_name = _get_sagemaker_config_name(endpoint_name)
     endpoint_config_response = sage_client.create_endpoint_config(
         EndpointConfigName=config_name,
@@ -556,7 +556,7 @@ def _create_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
     eprint("Created endpoint with arn: %s" % endpoint_response["EndpointArn"])
 
 
-def _update_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, instance_type, 
+def _update_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, instance_type,
                                instance_count, mode, archive, role, sage_client, s3_client):
     """
     :param image_url: URL of the ECR-hosted docker image the model is being deployed into

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -208,7 +208,7 @@ def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=No
                     (i.e. as a result of deploying in mlflow.sagemaker.DEPLOYMENT_MODE_REPLACE mode)
                     will be preserved. If False, these resources will be deleted.
     :param instance_type: The type of SageMaker ML instance on which to deploy the model.
-                          For a list of supported instance types, see 
+                          For a list of supported instance types, see
                           https://aws.amazon.com/sagemaker/pricing/instance-types/.
     :param instance_count: The number of SageMaker ML instances on which to deploy the model.
     """

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -207,8 +207,8 @@ def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=No
     :param archive: If True, any pre-existing SageMaker application resources that become inactive
                     (i.e. as a result of deploying in mlflow.sagemaker.DEPLOYMENT_MODE_REPLACE mode)
                     will be preserved. If False, these resources will be deleted.
-    :param instance_type: The type of Amazon EC2 instance on which to deploy the model. 
-    :param instance_count: The number of EC2 instances on which to deploy the model. 
+    :param instance_type: The type of Amazon EC2 instance on which to deploy the model.
+    :param instance_count: The number of EC2 instances on which to deploy the model.
     """
     if mode not in DEPLOYMENT_MODES:
         raise ValueError("`mode` must be one of: {mds}".format(
@@ -426,8 +426,8 @@ def _deploy(role, image_url, app_name, model_s3_path, run_id, region_name, mode,
     :param archive: If True, any pre-existing SageMaker application resources that become inactive
                     (i.e. as a result of deploying in mlflow.sagemaker.DEPLOYMENT_MODE_REPLACE mode)
                     will be preserved. If False, these resources will be deleted.
-    :param instance_type: The type of Amazon EC2 instance on which to deploy the model. 
-    :param instance_count: The number of EC2 instances on which to deploy the model. 
+    :param instance_type: The type of Amazon EC2 instance on which to deploy the model.
+    :param instance_count: The number of EC2 instances on which to deploy the model.
     """
     sage_client = boto3.client('sagemaker', region_name=region_name)
     s3_client = boto3.client('s3', region_name=region_name)
@@ -510,8 +510,8 @@ def _create_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
     :param image_url: URL of the ECR-hosted docker image the model is being deployed into
     :param model_s3_path: s3 path where we stored the model artifacts
     :param run_id: RunId that generated this model
-    :param instance_type: The type of Amazon EC2 instance on which to deploy the model. 
-    :param instance_count: The number of EC2 instances on which to deploy the model. 
+    :param instance_type: The type of Amazon EC2 instance on which to deploy the model.
+    :param instance_count: The number of EC2 instances on which to deploy the model.
     :param role: SageMaker execution ARN role
     :param sage_client: A boto3 client for SageMaker
     """
@@ -562,8 +562,8 @@ def _update_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
     :param image_url: URL of the ECR-hosted docker image the model is being deployed into
     :param model_s3_path: s3 path where we stored the model artifacts
     :param run_id: RunId that generated this model
-    :param instance_type: The type of Amazon EC2 instance on which to deploy the model. 
-    :param instance_count: The number of EC2 instances on which to deploy the model. 
+    :param instance_type: The type of Amazon EC2 instance on which to deploy the model.
+    :param instance_count: The number of EC2 instances on which to deploy the model.
     :param mode: either mlflow.sagemaker.DEPLOYMENT_MODE_ADD or
                  mlflow.sagemaker.DEPLOYMENT_MODE_REPLACE.
     :param archive: If True, any pre-existing SageMaker application resources that become inactive

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -207,7 +207,7 @@ def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=No
     :param archive: If True, any pre-existing SageMaker application resources that become inactive
                     (i.e. as a result of deploying in mlflow.sagemaker.DEPLOYMENT_MODE_REPLACE mode)
                     will be preserved. If False, these resources will be deleted.
-    :param instance_type: The type of Amazon EC2 instance on which to deploy the model.
+    :param instance_type: The type of EC2 instance on which to deploy the model.
     :param instance_count: The number of EC2 instances on which to deploy the model.
     """
     if mode not in DEPLOYMENT_MODES:
@@ -426,7 +426,7 @@ def _deploy(role, image_url, app_name, model_s3_path, run_id, region_name, mode,
     :param archive: If True, any pre-existing SageMaker application resources that become inactive
                     (i.e. as a result of deploying in mlflow.sagemaker.DEPLOYMENT_MODE_REPLACE mode)
                     will be preserved. If False, these resources will be deleted.
-    :param instance_type: The type of Amazon EC2 instance on which to deploy the model.
+    :param instance_type: The type of EC2 instance on which to deploy the model.
     :param instance_count: The number of EC2 instances on which to deploy the model.
     """
     sage_client = boto3.client('sagemaker', region_name=region_name)
@@ -510,7 +510,7 @@ def _create_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
     :param image_url: URL of the ECR-hosted docker image the model is being deployed into
     :param model_s3_path: s3 path where we stored the model artifacts
     :param run_id: RunId that generated this model
-    :param instance_type: The type of Amazon EC2 instance on which to deploy the model.
+    :param instance_type: The type of EC2 instance on which to deploy the model.
     :param instance_count: The number of EC2 instances on which to deploy the model.
     :param role: SageMaker execution ARN role
     :param sage_client: A boto3 client for SageMaker
@@ -562,7 +562,7 @@ def _update_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
     :param image_url: URL of the ECR-hosted docker image the model is being deployed into
     :param model_s3_path: s3 path where we stored the model artifacts
     :param run_id: RunId that generated this model
-    :param instance_type: The type of Amazon EC2 instance on which to deploy the model.
+    :param instance_type: The type of EC2 instance on which to deploy the model.
     :param instance_count: The number of EC2 instances on which to deploy the model.
     :param mode: either mlflow.sagemaker.DEPLOYMENT_MODE_ADD or
                  mlflow.sagemaker.DEPLOYMENT_MODE_REPLACE.

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -162,8 +162,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
 
 def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=None,
            image_url=None, region_name="us-west-2", mode=DEPLOYMENT_MODE_CREATE, archive=False, 
-           instance_type="ml.m4.xlarge", instance_count=1, autoscaling_policy=None, 
-           autoscaling_min_instances=1, autoscaling_max_instances=2):
+           instance_type="ml.m4.xlarge", instance_count=1):
     """
     Deploy model on SageMaker.
     Current active AWS account needs to have correct permissions setup.
@@ -206,19 +205,6 @@ def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=No
                     will be preserved. If False, these resources will be deleted.
     :param instance_type: The type of Amazon EC2 instance on which to deploy the model. 
     :param instance_count: The number of EC2 instances on which to deploy the model. 
-    :param autoscaling_policy: The EC2 resource `TargetTracking` autoscaling policy to use for the
-                               model, in dictionary format. If `None`, no autoscaling policy will 
-                               be used. For more information about autoscaling policies, see 
-                               https://docs.aws.amazon.com/sagemaker/latest/dg/
-                               endpoint-auto-scaling.html. For a `TargetTracking` autoscaling policy 
-                               format reference, see
-                               `Applying a Scaling Policy (Application Auto Scaling API)`
-                               (https://docs.aws.amazon.com/sagemaker/latest/dg/endpoint-
-                               auto-scaling-add-policy.html#endpoint-auto-scaling-add-code).
-    :param autoscaling_min_instances: The minimum number of EC2 instances on which to run the model.
-                                      This is only used if autoscaling_policy is not `None`.
-    :param autoscaling_max_instances: The maximum number of EC2 instances on which to run the model.
-                                      This is only used if autoscaling_policy is not `None`.
     """
     if mode not in DEPLOYMENT_MODES:
         raise ValueError("`mode` must be one of: {mds}".format(
@@ -251,10 +237,7 @@ def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=No
             mode=mode,
             archive=archive,
             instance_type=instance_type,
-            instance_count=instance_count,
-            autoscaling_policy=autoscaling_policy,
-            autoscaling_min_instances=autoscaling_min_instances,
-            autoscaling_max_instances=autoscaling_max_instances)
+            instance_count=instance_count)
 
 
 def delete(app_name, region_name="us-west-2", archive=False):
@@ -427,8 +410,7 @@ def _upload_s3(local_model_path, bucket, prefix):
 
 
 def _deploy(role, image_url, app_name, model_s3_path, run_id, region_name, mode, archive, 
-            instance_type, instance_count, autoscaling_policy, autoscaling_min_instances, 
-            autoscaling_max_instances):
+            instance_type, instance_count):
     """
     Deploy model on sagemaker.
     :param role: SageMaker execution ARN role
@@ -442,17 +424,9 @@ def _deploy(role, image_url, app_name, model_s3_path, run_id, region_name, mode,
                     will be preserved. If False, these resources will be deleted.
     :param instance_type: The type of Amazon EC2 instance on which to deploy the model. 
     :param instance_count: The number of EC2 instances on which to deploy the model. 
-    :param autoscaling_policy: The EC2 resource `TargetTracking` autoscaling policy to use for the
-                               model, in dictionary format. If `None`, no autoscaling policy will 
-                               be used.
-    :param autoscaling_min_instances: The minimum number of EC2 instances on which to run the model.
-                                      This is only used if autoscaling_policy is not `None`.
-    :param autoscaling_max_instances: The maximum number of EC2 instances on which to run the model.
-                                      This is only used if autoscaling_policy is not `None`.
     """
     sage_client = boto3.client('sagemaker', region_name=region_name)
     s3_client = boto3.client('s3', region_name=region_name)
-    as_client = boto3.client('application-autoscaling', region_name=region_name)
 
     endpoints_page = sage_client.list_endpoints(
         MaxResults=100, NameContains=app_name)
@@ -482,15 +456,11 @@ def _deploy(role, image_url, app_name, model_s3_path, run_id, region_name, mode,
                                           run_id=run_id,
                                           instance_type=instance_type,
                                           instance_count=instance_count,
-                                          autoscaling_policy=autoscaling_policy,
-                                          autoscaling_min_instances=autoscaling_min_instances,
-                                          autoscaling_max_instances=autoscaling_max_instances,
                                           mode=mode,
                                           archive=archive,
                                           role=role,
                                           sage_client=sage_client,
-                                          s3_client=s3_client,
-                                          as_client=as_client)
+                                          s3_client=s3_client)
     else:
         return _create_sagemaker_endpoint(endpoint_name=app_name,
                                           image_url=image_url,
@@ -498,12 +468,8 @@ def _deploy(role, image_url, app_name, model_s3_path, run_id, region_name, mode,
                                           run_id=run_id,
                                           instance_type=instance_type,
                                           instance_count=instance_count,
-                                          autoscaling_policy=autoscaling_policy,
-                                          autoscaling_min_instances=autoscaling_min_instances,
-                                          autoscaling_max_instances=autoscaling_max_instances,
                                           role=role,
-                                          sage_client=sage_client,
-                                          as_client=as_client)
+                                          sage_client=sage_client)
 
 
 def _get_sagemaker_resource_unique_id():
@@ -535,22 +501,15 @@ def _get_sagemaker_config_name(endpoint_name):
 
 
 def _create_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, instance_type, 
-                               instance_count, autoscaling_policy, autoscaling_min_instances, 
-                               autoscaling_max_instances, role, sage_client, as_client):
+                               instance_count, role, sage_client):
     """
     :param image_url: URL of the ECR-hosted docker image the model is being deployed into
     :param model_s3_path: s3 path where we stored the model artifacts
     :param run_id: RunId that generated this model
     :param instance_type: The type of Amazon EC2 instance on which to deploy the model. 
     :param instance_count: The number of EC2 instances on which to deploy the model. 
-    :param autoscaling_policy: The EC2 resource `TargetTracking` autoscaling policy to use for the
-                               model, in dictionary format. If `None`, no autoscaling policy will 
-                               be used.
-    :param autoscaling_min_instances: The minimum number of EC2 instances on which to run the model.
-    :param autoscaling_max_instances: The maximum number of EC2 instances on which to run the model.
     :param role: SageMaker execution ARN role
     :param sage_client: A boto3 client for SageMaker
-    :param as_client: A boto3 client for ApplicationAutoScaling 
     """
     eprint("Creating new endpoint with name: {en} ...".format(
         en=endpoint_name))
@@ -592,32 +551,15 @@ def _create_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
     )
     eprint("Created endpoint with arn: %s" % endpoint_response["EndpointArn"])
 
-    if autoscaling_policy is not None:
-        as_response = _apply_sagemaker_autoscaling_policy(endpoint_name=endpoint_name,
-                                                          production_variant=production_variant, 
-                                                          policy=autoscaling_policy,
-                                                          min_instances=autoscaling_min_instances,
-                                                          max_instances=autoscaling_max_instances,
-                                                          as_client=as_client)
-        eprint("Created and applied autoscaling policy with ARN: {arn}".format(
-            arn=as_response["PolicyArn"])) 
-
 
 def _update_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, instance_type, 
-                               instance_count, autoscaling_policy, autoscaling_min_instances, 
-                               autoscaling_max_instances, mode, archive, role, sage_client, 
-                               s3_client, as_client):
+                               instance_count, mode, archive, role, sage_client, s3_client):
     """
     :param image_url: URL of the ECR-hosted docker image the model is being deployed into
     :param model_s3_path: s3 path where we stored the model artifacts
     :param run_id: RunId that generated this model
     :param instance_type: The type of Amazon EC2 instance on which to deploy the model. 
     :param instance_count: The number of EC2 instances on which to deploy the model. 
-    :param autoscaling_policy: The EC2 resource `TargetTracking` autoscaling policy to use for the
-                               model, in dictionary format. If `None`, no autoscaling policy will 
-                               be used.
-    :param autoscaling_min_instances: The minimum number of EC2 instances on which to run the model.
-    :param autoscaling_max_instances: The maximum number of EC2 instances on which to run the model.
     :param mode: either mlflow.sagemaker.DEPLOYMENT_MODE_ADD or
                  mlflow.sagemaker.DEPLOYMENT_MODE_REPLACE.
     :param archive: If True, any pre-existing SageMaker application resources that become inactive
@@ -626,7 +568,6 @@ def _update_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
     :param role: SageMaker execution ARN role
     :param sage_client: A boto3 client for SageMaker
     :param s3_client: A boto3 client for S3
-    :param as_client: A boto3 client for ApplicationAutoScaling 
     """
     if mode not in [DEPLOYMENT_MODE_ADD, DEPLOYMENT_MODE_REPLACE]:
         msg = "Invalid mode `{md}` for deployment to a pre-existing application".format(
@@ -689,16 +630,6 @@ def _update_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
                                 EndpointConfigName=new_config_name)
     eprint("Updated endpoint with new configuration!")
 
-    if autoscaling_policy is not None:
-        as_response = _apply_sagemaker_autoscaling_policy(endpoint_name=endpoint_name,
-                                                          production_variant=production_variant, 
-                                                          autoscaling_policy=autoscaling_policy, 
-                                                          min_instances=autoscaling_min_instances,
-                                                          max_instances=autoscaling_max_instances,
-                                                          as_client=as_client)
-        eprint("Created and applied autoscaling policy with ARN: {arn}".format(
-            arn=as_response["PolicyArn"])) 
-
     # If applicable, clean up unused models and old configurations
     if not archive:
         eprint("Cleaning up unused resources...")
@@ -740,26 +671,6 @@ def _create_sagemaker_model(model_name, model_s3_path, run_id, image_url, execut
         Tags=[{'Key': 'run_id', 'Value': str(run_id)}, ],
     )
     return model_response
-
-
-def _apply_sagemaker_autoscaling_policy(endpoint_name, production_variant, policy, min_instances,
-                                        max_instances, as_client):
-    variant_name = production_variant["VariantName"]
-    policy_name = "{vn}-policy".format(vn=variant_name)
-    resource_id = "endpoint/{en}/variant/{vn}".format(en=endpoint_name, vn=variant_name)
-
-    as_client.register_scalable_target(ServiceNamespace="sagemaker",
-                                       ResourceId=resource_id,
-                                       MinCapacity=min_instances,
-                                       MaxCapacity=max_instances,
-                                       ScalableDimension="sagemaker:variant:DesiredInstanceCount")
-
-    return as_client.put_scaling_policy(PolicyName=policy_name,
-                                        ServiceNamespace="sagemaker",
-                                        ResourceId=resource_id,
-                                        ScalableDimension="sagemaker:variant:DesiredInstanceCount",
-                                        PolicyType="TargetTrackingScaling",
-                                        TargetTrackingScalingPolicyConfiguration=policy)
 
 
 def _delete_sagemaker_model(model_name, sage_client, s3_client):

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -33,8 +33,8 @@ def commands():
               " become inactive (i.e as the result of replacement) will be preserved")
 @click.option("--instance-type", "-t", default=mlflow.sagemaker.DEFAULT_SAGEMAKER_INSTANCE_TYPE,
               help="The type of SageMaker ML instance on which to deploy the model. For a list of"
-                    " supported instance types, see"
-                    " https://aws.amazon.com/sagemaker/pricing/instance-types/.")
+              " supported instance types, see"
+              " https://aws.amazon.com/sagemaker/pricing/instance-types/.")
 @click.option("--instance-count", "-c", default=mlflow.sagemaker.DEFAULT_SAGEMAKER_INSTANCE_COUNT,
               help="The number of SageMaker ML instances on which to deploy the model")
 def deploy(app_name, model_path, execution_role_arn, bucket, run_id, image_url, region_name, mode,

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -32,9 +32,11 @@ def commands():
 @click.option("--archive", "-ar", is_flag=True, help="If specified, any SageMaker resources that"
               " become inactive (i.e as the result of replacement) will be preserved")
 @click.option("--instance-type", "-t", default=mlflow.sagemaker.DEFAULT_SAGEMAKER_INSTANCE_TYPE,
-              help="The type of Amazon EC2 instance on which to deploy the model")
+              help="The type of SageMaker ML instance on which to deploy the model. For a list of
+                    supported instance types, see"
+                    " https://aws.amazon.com/sagemaker/pricing/instance-types/").
 @click.option("--instance-count", "-c", default=mlflow.sagemaker.DEFAULT_SAGEMAKER_INSTANCE_COUNT,
-              help="The number of EC2 instances on which to deploy the model")
+              help="The number of SageMaker ML instances on which to deploy the model")
 def deploy(app_name, model_path, execution_role_arn, bucket, run_id, image_url, region_name, mode,
            archive, instance_type, instance_count):
     """

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -44,7 +44,7 @@ def deploy(app_name, model_path, execution_role_arn, bucket, run_id, image_url, 
     mlflow.sagemaker.deploy(app_name=app_name, model_path=model_path,
                             execution_role_arn=execution_role_arn, bucket=bucket, run_id=run_id,
                             image_url=image_url, region_name=region_name, mode=mode,
-                            archive=archive, instance_type=instance_type, 
+                            archive=archive, instance_type=instance_type,
                             instance_count=instance_count)
 
 

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -31,8 +31,12 @@ def commands():
                   mds=", ".join(mlflow.sagemaker.DEPLOYMENT_MODES)))
 @click.option("--archive", "-ar", is_flag=True, help="If specified, any SageMaker resources that"
               " become inactive (i.e as the result of replacement) will be preserved")
+@click.option("--instance-type", "-t", default=mlflow.sagemaker.DEFAULT_SAGEMAKER_INSTANCE_TYPE,
+              help="The type of Amazon EC2 instance on which to deploy the model")
+@click.option("--instance-count", "-c", default=mlflow.sagemaker.DEFAULT_SAGEMAKER_INSTANCE_COUNT,
+              help="The number of EC2 instances on which to deploy the model")
 def deploy(app_name, model_path, execution_role_arn, bucket, run_id, image_url, region_name, mode,
-           archive):
+           archive, instance_type, instance_count):
     """
     Deploy model on Sagemaker as a REST API endpoint. Current active AWS account needs to have
     correct permissions setup.
@@ -40,7 +44,8 @@ def deploy(app_name, model_path, execution_role_arn, bucket, run_id, image_url, 
     mlflow.sagemaker.deploy(app_name=app_name, model_path=model_path,
                             execution_role_arn=execution_role_arn, bucket=bucket, run_id=run_id,
                             image_url=image_url, region_name=region_name, mode=mode,
-                            archive=archive)
+                            archive=archive, instance_type=instance_type, 
+                            instance_count=instance_count)
 
 
 @commands.command("delete")

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -32,9 +32,9 @@ def commands():
 @click.option("--archive", "-ar", is_flag=True, help="If specified, any SageMaker resources that"
               " become inactive (i.e as the result of replacement) will be preserved")
 @click.option("--instance-type", "-t", default=mlflow.sagemaker.DEFAULT_SAGEMAKER_INSTANCE_TYPE,
-              help="The type of SageMaker ML instance on which to deploy the model. For a list of
-                    supported instance types, see"
-                    " https://aws.amazon.com/sagemaker/pricing/instance-types/").
+              help="The type of SageMaker ML instance on which to deploy the model. For a list of"
+                    " supported instance types, see"
+                    " https://aws.amazon.com/sagemaker/pricing/instance-types/.")
 @click.option("--instance-count", "-c", default=mlflow.sagemaker.DEFAULT_SAGEMAKER_INSTANCE_COUNT,
               help="The number of SageMaker ML instances on which to deploy the model")
 def deploy(app_name, model_path, execution_role_arn, bucket, run_id, image_url, region_name, mode,


### PR DESCRIPTION
* This PR allows users to specify the type and quantity of SageMaker-compatible EC2 instances on which to deploy a model

**Test Strategy**

This PR is tested by manually evaluating the following cases via the Python API and CLI:

1. Deploy a model without specifying a non-default instance type or instance count. 
**Expected result**: The model should be deployed using the default instance type (`ml.m4.xlarge`) and instance count (`1`).

2. Deploy a model, specifying a non-default instance type. 
**Expected result**: The model should be deployed using the specified instance type and the default instance count (`1`).

3. Deploy a model, specifying a non-default instance count. 
**Expected result:** The model should be deployed using the default instance type (`ml.m4.xlarge`) and the specified instance count.

4. Deploy a model, specifying both a non-default instance type and a non-default instance count.
**Expected result**: The model should be deployed using the specified instance type and count.