### PR TITLE
Update metric and parameter filters to let users control column order

### DIFF
--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -5,7 +5,7 @@ import { getExperimentApi, getUUID, searchRunsApi } from '../Actions';
 import { connect } from 'react-redux';
 import ExperimentView from './ExperimentView';
 import RequestStateWrapper from './RequestStateWrapper';
-import KeyFilter from "../utils/KeyFilter";
+import KeyFilter from '../utils/KeyFilter';
 
 
 class ExperimentPage extends Component {
@@ -19,8 +19,8 @@ class ExperimentPage extends Component {
   };
 
   state = {
-    paramKeyFilterSet: new KeyFilter(),
-    metricKeyFilterSet: new KeyFilter(),
+    paramKeyFilter: new KeyFilter(),
+    metricKeyFilter: new KeyFilter(),
     getExperimentRequestId: getUUID(),
     searchRunsRequestId: getUUID(),
     searchInput: '',
@@ -29,10 +29,9 @@ class ExperimentPage extends Component {
 
   static getDerivedStateFromProps(props, state) {
     if (props.experimentId !== state.lastExperimentId) {
-      console.log(`different ${props.experimentId} ${state.lastExperimentId}`);
       const newState = {
-        paramKeyFilterSet: new KeyFilter(),
-        metricKeyFilterSet: new KeyFilter(),
+        paramKeyFilter: new KeyFilter(),
+        metricKeyFilter: new KeyFilter(),
         getExperimentRequestId: getUUID(),
         searchRunsRequestId: getUUID(),
         searchInput: '',

--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -5,6 +5,7 @@ import { getExperimentApi, getUUID, searchRunsApi } from '../Actions';
 import { connect } from 'react-redux';
 import ExperimentView from './ExperimentView';
 import RequestStateWrapper from './RequestStateWrapper';
+import KeyFilter from "../utils/KeyFilter";
 
 
 class ExperimentPage extends Component {
@@ -18,8 +19,8 @@ class ExperimentPage extends Component {
   };
 
   state = {
-    paramKeyFilterSet: new Set(),
-    metricKeyFilterSet: new Set(),
+    paramKeyFilterSet: new KeyFilter(),
+    metricKeyFilterSet: new KeyFilter(),
     getExperimentRequestId: getUUID(),
     searchRunsRequestId: getUUID(),
     searchInput: '',
@@ -30,8 +31,8 @@ class ExperimentPage extends Component {
     if (props.experimentId !== state.lastExperimentId) {
       console.log(`different ${props.experimentId} ${state.lastExperimentId}`);
       const newState = {
-        paramKeyFilterSet: new Set(),
-        metricKeyFilterSet: new Set(),
+        paramKeyFilterSet: new KeyFilter(),
+        metricKeyFilterSet: new KeyFilter(),
         getExperimentRequestId: getUUID(),
         searchRunsRequestId: getUUID(),
         searchInput: '',
@@ -43,8 +44,8 @@ class ExperimentPage extends Component {
     }
   }
 
-  onSearch(paramKeyFilterSet, metricKeyFilterSet, andedExpressions, searchInput) {
-    this.setState({paramKeyFilterSet, metricKeyFilterSet, searchInput});
+  onSearch(paramKeyFilter, metricKeyFilter, andedExpressions, searchInput) {
+    this.setState({paramKeyFilter, metricKeyFilter, searchInput});
     const searchRunsRequestId = this.props.dispatchSearchRuns(this.props.experimentId,
       andedExpressions);
     this.setState({ searchRunsRequestId });
@@ -55,8 +56,8 @@ class ExperimentPage extends Component {
       <div className="ExperimentPage">
         <RequestStateWrapper requestIds={this.getRequestIds()}>
           <ExperimentView
-            paramKeyFilterSet={this.state.paramKeyFilterSet}
-            metricKeyFilterSet={this.state.metricKeyFilterSet}
+            paramKeyFilter={this.state.paramKeyFilter}
+            metricKeyFilter={this.state.metricKeyFilter}
             experimentId={this.props.experimentId}
             searchRunsRequestId={this.state.searchRunsRequestId}
             onSearch={this.onSearch}

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -12,6 +12,7 @@ import { Experiment, RunInfo } from '../sdk/MlflowMessages';
 import { SearchUtils } from '../utils/SearchUtils';
 import { saveAs } from 'file-saver';
 import { getLatestMetrics } from '../reducers/MetricReducer';
+import KeyFilter from "../utils/KeyFilter";
 import Utils from "../utils/Utils";
 
 class ExperimentView extends Component {
@@ -31,20 +32,29 @@ class ExperimentView extends Component {
     onSearch: PropTypes.func.isRequired,
     runInfos: PropTypes.arrayOf(RunInfo).isRequired,
     experiment: PropTypes.instanceOf(Experiment).isRequired,
+
+    // List of all parameter keys available in the runs we're viewing
     paramKeyList: PropTypes.arrayOf(String).isRequired,
+    // List of all metric keys available in the runs we're viewing
     metricKeyList: PropTypes.arrayOf(String).isRequired,
-    // List of list of params.
+
+    // List of list of params in all the visible runs
     paramsList: PropTypes.arrayOf(Array).isRequired,
-    // List of list of metrics.
+    // List of list of metrics in all the visible runs
     metricsList: PropTypes.arrayOf(Array).isRequired,
 
-    // Set of paramKeys to include
-    paramKeyFilterSet: PropTypes.instanceOf(Set).isRequired,
-    // Set of metricKeys to include
-    metricKeyFilterSet: PropTypes.instanceOf(Set).isRequired,
+    // Input to the paramKeyFilter field
+    paramKeyFilter: PropTypes.instanceOf(KeyFilter).isRequired,
+    // Input to the paramKeyFilter field
+    metricKeyFilter: PropTypes.instanceOf(KeyFilter).isRequired,
 
-    // The initial searchInput.
+    // The initial searchInput
     searchInput: PropTypes.string.required,
+  };
+
+  static defaultProps = {
+    paramKeyFilter: new KeyFilter(),
+    metricKeyFilter: new KeyFilter()
   };
 
   state = {
@@ -56,9 +66,9 @@ class ExperimentView extends Component {
   };
 
   static getDerivedStateFromProps(nextProps, prevState) {
-    const { searchInput, paramKeyFilterSet, metricKeyFilterSet } = nextProps;
-    const paramKeyFilterInput = Array.from(paramKeyFilterSet.values()).join(", ");
-    const metricKeyFilterInput = Array.from(metricKeyFilterSet.values()).join(", ");
+    const { searchInput, paramKeyFilter, metricKeyFilter } = nextProps;
+    const paramKeyFilterInput = paramKeyFilter.getFilterString();
+    const metricKeyFilterInput = metricKeyFilter.getFilterString();
     return {
       ...prevState,
       searchInput,
@@ -69,32 +79,32 @@ class ExperimentView extends Component {
 
   render() {
     const { experiment_id, name, artifact_location } = this.props.experiment;
-    const {
+    let {
       runInfos,
       paramKeyList,
       metricKeyList,
       paramsList,
       metricsList,
-      paramKeyFilterSet,
-      metricKeyFilterSet
+      paramKeyFilter,
+      metricKeyFilter
     } = this.props;
-    const columns = Private.getColumnHeaders(
-        paramKeyList,
-        metricKeyList,
-        paramKeyFilterSet,
-        metricKeyFilterSet);
-    const metricRanges = Private.computeMetricRanges(metricsList);
+
+    // Apply the parameter and metric key filters to just pass the filtered, sorted lists
+    // of parameter and metric names around later
+    paramKeyList = paramKeyFilter.apply(paramKeyList);
+    metricKeyList = metricKeyFilter.apply(metricKeyList);
+
+    const columns = ExperimentView.getColumnHeaders(paramKeyList, metricKeyList);
+    const metricRanges = ExperimentView.computeMetricRanges(metricsList);
     const rows = [...Array(runInfos.length).keys()].map((idx) => ({
         key: runInfos[idx].run_uuid,
-        contents: Private.runInfoToRow(
+        contents: ExperimentView.runInfoToRow(
           runInfos[idx],
           this.onCheckbox,
           paramKeyList,
           metricKeyList,
           paramsList[idx],
           metricsList[idx],
-          paramKeyFilterSet,
-          metricKeyFilterSet,
           metricRanges)
       })
     );
@@ -180,8 +190,12 @@ class ExperimentView extends Component {
             <tbody>
             <tr>
               <th className="top-row" scope="colgroup" colSpan="5"></th>
-              <th className="top-row left-border" scope="colgroup" colSpan={Private.getNumParams(paramKeyList, paramKeyFilterSet)}>Parameters</th>
-              <th className="top-row left-border" scope="colgroup" colSpan={Private.getNumMetrics(metricKeyList, metricKeyFilterSet)}>Metrics</th>
+              <th className="top-row left-border" scope="colgroup"
+                  colSpan={paramKeyList.length}>Parameters
+              </th>
+              <th className="top-row left-border" scope="colgroup"
+                  colSpan={metricKeyList.length}>Metrics
+              </th>
             </tr>
             <tr>
               {columns}
@@ -224,35 +238,21 @@ class ExperimentView extends Component {
   onSearch(e) {
     e.preventDefault();
     const { paramKeyFilterInput, metricKeyFilterInput, searchInput } = this.state;
-    const paramKeyFilterSet = new Set();
-    const metricKeyFilterSet = new Set();
-    if (paramKeyFilterInput !== '') {
-      paramKeyFilterInput.split(',').forEach((key) => {
-        if (key.trim() !== "") {
-          paramKeyFilterSet.add(key.trim());
-        }
-      });
-    }
-    if (metricKeyFilterInput !== '') {
-      metricKeyFilterInput.split(',').forEach((key) => {
-        if (key.trim() !== "") {
-          metricKeyFilterSet.add(key.trim());
-        }
-      });
-    }
+    const paramKeyFilter = new KeyFilter(paramKeyFilterInput);
+    const metricKeyFilter = new KeyFilter(metricKeyFilterInput);
     try {
       const andedExpressions = SearchUtils.parseSearchInput(searchInput);
-      this.props.onSearch(paramKeyFilterSet, metricKeyFilterSet, andedExpressions, searchInput);
+      this.props.onSearch(paramKeyFilter, metricKeyFilter, andedExpressions, searchInput);
     } catch(e) {
       this.setState({ searchErrorMessage: e.errorMessage });
     }
   }
 
   onClear() {
-    const paramKeyFilterSet = new Set();
-    const metricKeyFilterSet = new Set();
+    const paramKeyFilter = new KeyFilter();
+    const metricKeyFilter = new KeyFilter();
     const andedExpressions = [];
-    this.props.onSearch(paramKeyFilterSet, metricKeyFilterSet, andedExpressions, "");
+    this.props.onSearch(paramKeyFilter, metricKeyFilter, andedExpressions, "");
   }
 
   onCompare() {
@@ -261,62 +261,19 @@ class ExperimentView extends Component {
   }
 
   onDownloadCsv() {
-    const csv = Private.runInfosToCsv(
+    const csv = ExperimentView.runInfosToCsv(
       this.props.runInfos,
-      this.props.paramKeyList,
-      this.props.metricKeyList,
+      this.props.paramKeyFilter.apply(this.props.paramKeyList),
+      this.props.metricKeyFilter.apply(this.props.metricKeyList),
       this.props.paramsList,
-      this.props.metricsList,
-      this.props.paramKeyFilterSet,
-      this.props.metricKeyFilterSet);
+      this.props.metricsList);
     const blob = new Blob([csv], { type: 'application/csv;charset=utf-8' });
     saveAs(blob, "runs.csv");
   }
-}
 
-const mapStateToProps = (state, ownProps) => {
-  const { searchRunsRequestId } = ownProps;
-  const searchRunApi = getApis([searchRunsRequestId], state)[0];
-  // The runUuids we should serve.
-  let runUuids;
-  if (searchRunApi.data.runs) {
-    runUuids = new Set(searchRunApi.data.runs.map((r) => r.info.run_uuid));
-  } else {
-    runUuids = new Set();
-  }
-  const runInfos = getRunInfos(state).filter((rInfo) =>
-    runUuids.has(rInfo.getRunUuid())
-  );
-  const experiment = getExperiment(ownProps.experimentId, state);
-  const metricKeysSet = new Set();
-  const paramKeysSet = new Set();
-  const metricsList = runInfos.map((runInfo) => {
-    const metrics = Object.values(getLatestMetrics(runInfo.getRunUuid(), state));
-    metrics.forEach((metric) => {
-      metricKeysSet.add(metric.key);
-    });
-    return metrics
-  });
-  const paramsList = runInfos.map((runInfo) => {
-    const params = Object.values(getParams(runInfo.getRunUuid(), state));
-    params.forEach((param) => {
-      paramKeysSet.add(param.key);
-    });
-    return params;
-  });
-  return {
-    runInfos,
-    experiment,
-    metricKeyList: Array.from(metricKeysSet.values()).sort(),
-    paramKeyList: Array.from(paramKeysSet.values()).sort(),
-    metricsList,
-    paramsList,
-  };
-};
-
-export default withRouter(connect(mapStateToProps)(ExperimentView));
-
-class Private {
+  /**
+   * Generate a row for a specific run, extracting the params and metrics in the given lists.
+   */
   static runInfoToRow(
     runInfo,
     onCheckbox,
@@ -324,13 +281,10 @@ class Private {
     metricKeyList,
     params,
     metrics,
-    paramKeyFilterSet,
-    metricKeyFilterSet,
     metricRanges) {
 
-    const numParams = Private.getNumParams(paramKeyList, paramKeyFilterSet);
-    const numMetrics = Private.getNumMetrics(metricKeyList, metricKeyFilterSet);
-
+    const numParams = paramKeyList.length;
+    const numMetrics = metricKeyList.length;
     const row = [
       <td><input type="checkbox" onClick={() => onCheckbox(runInfo.run_uuid)}/></td>,
       <td>
@@ -343,21 +297,19 @@ class Private {
       <td>{Utils.renderVersion(runInfo)}</td>,
     ];
 
-    const paramsMap = Private.toParamsMap(params);
-    const metricsMap = Private.toMetricsMap(metrics);
+    const paramsMap = ExperimentView.toParamsMap(params);
+    const metricsMap = ExperimentView.toMetricsMap(metrics);
 
     let firstParam = true;
     paramKeyList.forEach((paramKey) => {
-      if (Private.shouldIncludeKey(paramKey, paramKeyFilterSet)) {
-        const className = firstParam ? "left-border": undefined;
-        firstParam = false;
-        if (paramsMap[paramKey]) {
-          row.push(<td className={className}>
-            {paramsMap[paramKey].getValue()}
-          </td>);
-        } else {
-          row.push(<td className={className}/>);
-        }
+      const className = firstParam ? "left-border": undefined;
+      firstParam = false;
+      if (paramsMap[paramKey]) {
+        row.push(<td className={className}>
+          {paramsMap[paramKey].getValue()}
+        </td>);
+      } else {
+        row.push(<td className={className}/>);
       }
     });
     if (numParams === 0) {
@@ -366,30 +318,28 @@ class Private {
 
     let firstMetric = true;
     metricKeyList.forEach((metricKey) => {
-      if (Private.shouldIncludeKey(metricKey, metricKeyFilterSet)) {
-        const className = firstMetric ? "left-border": undefined;
-        firstMetric = false;
-        if (metricsMap[metricKey]) {
-          const metric = metricsMap[metricKey].getValue();
-          const range = metricRanges[metricKey];
-          let fraction = 1.0;
-          if (range.max > range.min) {
-            fraction = (metric - range.min) / (range.max - range.min);
-          }
-          const percent = (fraction * 100) + "%";
-          row.push(
-            <td className={className}>
-              <div className="metric-filler-bg">
-                <div className="metric-filler-fg" style={{width: percent}}/>
-                <div className="metric-text">
-                  {Utils.formatMetric(metric)}
-                </div>
-              </div>
-            </td>
-          );
-        } else {
-          row.push(<td className={className}/>);
+      const className = firstMetric ? "left-border": undefined;
+      firstMetric = false;
+      if (metricsMap[metricKey]) {
+        const metric = metricsMap[metricKey].getValue();
+        const range = metricRanges[metricKey];
+        let fraction = 1.0;
+        if (range.max > range.min) {
+          fraction = (metric - range.min) / (range.max - range.min);
         }
+        const percent = (fraction * 100) + "%";
+        row.push(
+          <td className={className}>
+            <div className="metric-filler-bg">
+              <div className="metric-filler-fg" style={{width: percent}}/>
+              <div className="metric-text">
+                {Utils.formatMetric(metric)}
+              </div>
+            </div>
+          </td>
+        );
+      } else {
+        row.push(<td className={className}/>);
       }
     });
     if (numMetrics === 0) {
@@ -398,9 +348,9 @@ class Private {
     return row;
   }
 
-  static getColumnHeaders(paramKeyList, metricKeyList, paramKeyFilterSet, metricKeyFilterSet) {
-    const numParams = Private.getNumParams(paramKeyList, paramKeyFilterSet);
-    const numMetrics = Private.getNumMetrics(metricKeyList, metricKeyFilterSet);
+  static getColumnHeaders(paramKeyList, metricKeyList) {
+    const numParams = paramKeyList.length;
+    const numMetrics = metricKeyList.length;
     const columns = [
       <th className="bottom-row"/>,  // TODO: checkbox for select-all
       <th className="bottom-row">Date</th>,
@@ -410,11 +360,9 @@ class Private {
     ];
     let firstParam = true;
     paramKeyList.forEach((paramKey) => {
-      if (Private.shouldIncludeKey(paramKey, paramKeyFilterSet)) {
-        const className = "bottom-row" + (firstParam ? " left-border" : "");
-        firstParam = false;
-        columns.push(<th className={className}>{paramKey}</th>);
-      }
+      const className = "bottom-row" + (firstParam ? " left-border" : "");
+      firstParam = false;
+      columns.push(<th className={className}>{paramKey}</th>);
     });
     if (numParams === 0) {
       columns.push(<th className="bottom-row left-border">(n/a)</th>);
@@ -422,11 +370,9 @@ class Private {
 
     let firstMetric = true;
     metricKeyList.forEach((metricKey) => {
-      if (Private.shouldIncludeKey(metricKey, metricKeyFilterSet)) {
-        const className = "bottom-row" + (firstMetric ? " left-border" : "");
-        firstMetric = false;
-        columns.push(<th className={className}>{metricKey}</th>);
-      }
+      const className = "bottom-row" + (firstMetric ? " left-border" : "");
+      firstMetric = false;
+      columns.push(<th className={className}>{metricKey}</th>);
     });
     if (numMetrics === 0) {
       columns.push(<th className="bottom-row left-border">(n/a)</th>);
@@ -476,22 +422,6 @@ class Private {
     return ret;
   }
 
-  static getNumMetrics(metricKeyList, metricKeyFilterSet) {
-    return metricKeyList.filter((metricKey) =>
-      Private.shouldIncludeKey(metricKey, metricKeyFilterSet)
-    ).length;
-  }
-
-  static getNumParams(paramKeyList, paramKeyFilterSet) {
-    return paramKeyList.filter((paramKey) =>
-      Private.shouldIncludeKey(paramKey, paramKeyFilterSet)
-    ).length;
-  }
-
-  static shouldIncludeKey(key, filterSet) {
-    return filterSet.size === 0 || filterSet.has(key);
-  }
-
   /**
    * Format a string for insertion into a CSV file.
    */
@@ -516,7 +446,7 @@ class Private {
     let i;
 
     for (i = 0; i < columns.length; i++) {
-      csv += Private.csvEscape(columns[i]);
+      csv += ExperimentView.csvEscape(columns[i]);
       if (i < columns.length - 1) {
         csv += ',';
       }
@@ -525,7 +455,7 @@ class Private {
 
     for (i = 0; i < data.length; i++) {
       for (let j = 0; j < data[i].length; j++) {
-        csv += Private.csvEscape(data[i][j]);
+        csv += ExperimentView.csvEscape(data[i][j]);
         if (j < data[i].length - 1) {
           csv += ',';
         }
@@ -537,16 +467,15 @@ class Private {
   };
 
   /**
-   * Convert an array of run infos to a CSV string.
+   * Convert an array of run infos to a CSV string, extracting the params and metrics in the
+   * provided lists.
    */
   static runInfosToCsv(
     runInfos,
     paramKeyList,
     metricKeyList,
     paramsList,
-    metricsList,
-    paramKeyFilterSet,
-    metricKeyFilterSet) {
+    metricsList) {
 
     const columns = [
       "Run ID",
@@ -556,17 +485,11 @@ class Private {
       "User",
       "Status",
     ];
-
     paramKeyList.forEach(paramKey => {
-      if (Private.shouldIncludeKey(paramKey, paramKeyFilterSet)) {
-        columns.push(paramKey);
-      }
+      columns.push(paramKey);
     });
-
     metricKeyList.forEach(metricKey => {
-      if (Private.shouldIncludeKey(metricKey, metricKeyFilterSet)) {
-        columns.push(metricKey);
-      }
+      columns.push(metricKey);
     });
 
     const data = runInfos.map((runInfo, index) => {
@@ -578,29 +501,67 @@ class Private {
         runInfo.user_id,
         runInfo.status,
       ];
-      const paramsMap = Private.toParamsMap(paramsList[index]);
-      const metricsMap = Private.toMetricsMap(metricsList[index]);
+      const paramsMap = ExperimentView.toParamsMap(paramsList[index]);
+      const metricsMap = ExperimentView.toMetricsMap(metricsList[index]);
       paramKeyList.forEach((paramKey) => {
-        if (Private.shouldIncludeKey(paramKey, paramKeyFilterSet)) {
-          if (paramsMap[paramKey]) {
-            row.push(paramsMap[paramKey].getValue());
-          } else {
-            row.push("");
-          }
+        if (paramsMap[paramKey]) {
+          row.push(paramsMap[paramKey].getValue());
+        } else {
+          row.push("");
         }
       });
       metricKeyList.forEach((metricKey) => {
-        if (Private.shouldIncludeKey(metricKey, metricKeyFilterSet)) {
-          if (metricsMap[metricKey]) {
-            row.push(metricsMap[metricKey].getValue());
-          } else {
-            row.push("");
-          }
+        if (metricsMap[metricKey]) {
+          row.push(metricsMap[metricKey].getValue());
+        } else {
+          row.push("");
         }
       });
       return row;
     });
 
-    return Private.tableToCsv(columns, data)
+    return ExperimentView.tableToCsv(columns, data)
   }
 }
+
+const mapStateToProps = (state, ownProps) => {
+  const { searchRunsRequestId } = ownProps;
+  const searchRunApi = getApis([searchRunsRequestId], state)[0];
+  // The runUuids we should serve.
+  let runUuids;
+  if (searchRunApi.data.runs) {
+    runUuids = new Set(searchRunApi.data.runs.map((r) => r.info.run_uuid));
+  } else {
+    runUuids = new Set();
+  }
+  const runInfos = getRunInfos(state).filter((rInfo) =>
+    runUuids.has(rInfo.getRunUuid())
+  );
+  const experiment = getExperiment(ownProps.experimentId, state);
+  const metricKeysSet = new Set();
+  const paramKeysSet = new Set();
+  const metricsList = runInfos.map((runInfo) => {
+    const metrics = Object.values(getLatestMetrics(runInfo.getRunUuid(), state));
+    metrics.forEach((metric) => {
+      metricKeysSet.add(metric.key);
+    });
+    return metrics
+  });
+  const paramsList = runInfos.map((runInfo) => {
+    const params = Object.values(getParams(runInfo.getRunUuid(), state));
+    params.forEach((param) => {
+      paramKeysSet.add(param.key);
+    });
+    return params;
+  });
+  return {
+    runInfos,
+    experiment,
+    metricKeyList: Array.from(metricKeysSet.values()).sort(),
+    paramKeyList: Array.from(paramKeysSet.values()).sort(),
+    metricsList,
+    paramsList,
+  };
+};
+
+export default withRouter(connect(mapStateToProps)(ExperimentView));

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -12,8 +12,8 @@ import { Experiment, RunInfo } from '../sdk/MlflowMessages';
 import { SearchUtils } from '../utils/SearchUtils';
 import { saveAs } from 'file-saver';
 import { getLatestMetrics } from '../reducers/MetricReducer';
-import KeyFilter from "../utils/KeyFilter";
-import Utils from "../utils/Utils";
+import KeyFilter from '../utils/KeyFilter';
+import Utils from '../utils/Utils';
 
 class ExperimentView extends Component {
   constructor(props) {
@@ -52,11 +52,6 @@ class ExperimentView extends Component {
     searchInput: PropTypes.string.required,
   };
 
-  static defaultProps = {
-    paramKeyFilter: new KeyFilter(),
-    metricKeyFilter: new KeyFilter()
-  };
-
   state = {
     runsSelected: {},
     paramKeyFilterInput: '',
@@ -79,20 +74,18 @@ class ExperimentView extends Component {
 
   render() {
     const { experiment_id, name, artifact_location } = this.props.experiment;
-    let {
+    const {
       runInfos,
-      paramKeyList,
-      metricKeyList,
       paramsList,
       metricsList,
       paramKeyFilter,
       metricKeyFilter
     } = this.props;
 
-    // Apply the parameter and metric key filters to just pass the filtered, sorted lists
+    // Apply our parameter and metric key filters to just pass the filtered, sorted lists
     // of parameter and metric names around later
-    paramKeyList = paramKeyFilter.apply(paramKeyList);
-    metricKeyList = metricKeyFilter.apply(metricKeyList);
+    const paramKeyList = paramKeyFilter.apply(this.props.paramKeyList);
+    const metricKeyList = metricKeyFilter.apply(this.props.metricKeyList);
 
     const columns = ExperimentView.getColumnHeaders(paramKeyList, metricKeyList);
     const metricRanges = ExperimentView.computeMetricRanges(metricsList);

--- a/mlflow/server/js/src/utils/KeyFilter.js
+++ b/mlflow/server/js/src/utils/KeyFilter.js
@@ -5,6 +5,8 @@
  * might want to switch to a more sophisticated filtering language in the future, such as allowing
  * a list of wildcard expressions. In any case, the apply method applies the filter to a list of
  * keys and returns the passing ones in the order we want to display them.
+ *
+ * NOTE: This class should stay immutable because it's part of some React components' state.
  */
 export default class KeyFilter {
   constructor(filterString) {

--- a/mlflow/server/js/src/utils/KeyFilter.js
+++ b/mlflow/server/js/src/utils/KeyFilter.js
@@ -1,0 +1,43 @@
+/**
+ * A parsed filter used to represent both the parameter and metric key filters in the UI.
+ * We currently represent each filter as a list of keys to include, in the order the user wants to
+ * display them, and with the empty list meaning "include all keys in sorted order". However, we
+ * might want to switch to a more sophisticated filtering language in the future, such as allowing
+ * a list of wildcard expressions. In any case, the apply method applies the filter to a list of
+ * keys and returns the passing ones in the order we want to display them.
+ */
+export default class KeyFilter {
+  constructor(filterString) {
+    this.filterString = filterString || "";
+    this.keyList = [];
+    this.filterString.split(',').forEach(key => {
+      if (key.trim() !== "") {
+        this.keyList.push(key.trim());
+      }
+    });
+  }
+
+  /** Return the filter string originally provided by the user. */
+  getFilterString() {
+    return this.filterString;
+  }
+
+  /**
+   * Apply the filter to an array of keys, returning a new array with the keys that pass the filter
+   * in the order the user wants them displayed.
+   */
+  apply(inputKeys) {
+    if (this.keyList.length === 0) {
+      return inputKeys.slice().sort();  // Just return them in sorted order
+    } else {
+      const inputKeysAsSet = new Set(inputKeys);
+      const outputKeys = [];
+      this.keyList.forEach(key => {
+        if (inputKeysAsSet.has(key)) {
+          outputKeys.push(key);
+        }
+      });
+      return outputKeys;
+    }
+  }
+}

--- a/mlflow/server/js/src/utils/KeyFilter.test.js
+++ b/mlflow/server/js/src/utils/KeyFilter.test.js
@@ -1,0 +1,35 @@
+import KeyFilter from './KeyFilter'
+
+test("basic filter", () => {
+  const filter = new KeyFilter("b, a");
+  expect(filter.apply(["d", "a", "b", "c"])).toEqual(["b", "a"]);
+  expect(filter.apply(["d", "a", "c"])).toEqual(["a"]);
+  expect(filter.apply(["b"])).toEqual(["b"]);
+  expect(filter.apply(["c", "d"])).toEqual([]);
+});
+
+test("no filter", () => {
+  // This filter should just return the input keys in sorted order
+  const filter = new KeyFilter("");
+  expect(filter.apply(["d", "a", "b", "c"])).toEqual(["a", "b", "c", "d"]);
+  expect(filter.apply(["d", "a", "c"])).toEqual(["a", "c", "d"]);
+  expect(filter.apply([])).toEqual([]);
+});
+
+test("no constructor argument given", () => {
+  const filter = new KeyFilter();
+  expect(filter.apply(["d", "a", "b", "c"])).toEqual(["a", "b", "c", "d"]);
+  expect(filter.apply(["d", "a", "c"])).toEqual(["a", "c", "d"]);
+  expect(filter.apply([])).toEqual([]);
+});
+
+test("spaces and empty strings in parsing", () => {
+  expect(new KeyFilter("").keyList).toEqual([]);
+  expect(new KeyFilter(" ").keyList).toEqual([]);
+  expect(new KeyFilter(" , \t,").keyList).toEqual([]);
+  expect(new KeyFilter("a").keyList).toEqual(["a"]);
+  expect(new KeyFilter("   a \t").keyList).toEqual(["a"]);
+  expect(new KeyFilter("b, a").keyList).toEqual(["b", "a"]);
+  expect(new KeyFilter(" b,  , a ").keyList).toEqual(["b", "a"]);
+});
+

--- a/mlflow/server/js/src/utils/Utils.test.js
+++ b/mlflow/server/js/src/utils/Utils.test.js
@@ -1,83 +1,83 @@
 import Utils from './Utils'
 
 test("formatMetric", () => {
-  expect(Utils.formatMetric(0)).toBe("0");
-  expect(Utils.formatMetric(0.5)).toBe("0.5");
-  expect(Utils.formatMetric(0.001)).toBe("0.001");
+  expect(Utils.formatMetric(0)).toEqual("0");
+  expect(Utils.formatMetric(0.5)).toEqual("0.5");
+  expect(Utils.formatMetric(0.001)).toEqual("0.001");
 
-  expect(Utils.formatMetric(0.12345)).toBe("0.123");
-  expect(Utils.formatMetric(0.12355)).toBe("0.124");
-  expect(Utils.formatMetric(-0.12345)).toBe("-0.123");
-  expect(Utils.formatMetric(-0.12355)).toBe("-0.124");
+  expect(Utils.formatMetric(0.12345)).toEqual("0.123");
+  expect(Utils.formatMetric(0.12355)).toEqual("0.124");
+  expect(Utils.formatMetric(-0.12345)).toEqual("-0.123");
+  expect(Utils.formatMetric(-0.12355)).toEqual("-0.124");
 
-  expect(Utils.formatMetric(1.12345)).toBe("1.123");
-  expect(Utils.formatMetric(1.12355)).toBe("1.124");
-  expect(Utils.formatMetric(-1.12345)).toBe("-1.123");
-  expect(Utils.formatMetric(-1.12355)).toBe("-1.124");
+  expect(Utils.formatMetric(1.12345)).toEqual("1.123");
+  expect(Utils.formatMetric(1.12355)).toEqual("1.124");
+  expect(Utils.formatMetric(-1.12345)).toEqual("-1.123");
+  expect(Utils.formatMetric(-1.12355)).toEqual("-1.124");
 
-  expect(Utils.formatMetric(12.12345)).toBe("12.12");
-  expect(Utils.formatMetric(12.12555)).toBe("12.13");
-  expect(Utils.formatMetric(-12.12345)).toBe("-12.12");
-  expect(Utils.formatMetric(-12.12555)).toBe("-12.13");
+  expect(Utils.formatMetric(12.12345)).toEqual("12.12");
+  expect(Utils.formatMetric(12.12555)).toEqual("12.13");
+  expect(Utils.formatMetric(-12.12345)).toEqual("-12.12");
+  expect(Utils.formatMetric(-12.12555)).toEqual("-12.13");
 
-  expect(Utils.formatMetric(123.12345)).toBe("123.1");
-  expect(Utils.formatMetric(123.15555)).toBe("123.2");
-  expect(Utils.formatMetric(-123.12345)).toBe("-123.1");
-  expect(Utils.formatMetric(-123.15555)).toBe("-123.2");
+  expect(Utils.formatMetric(123.12345)).toEqual("123.1");
+  expect(Utils.formatMetric(123.15555)).toEqual("123.2");
+  expect(Utils.formatMetric(-123.12345)).toEqual("-123.1");
+  expect(Utils.formatMetric(-123.15555)).toEqual("-123.2");
 
-  expect(Utils.formatMetric(1234.12345)).toBe("1234.1");
-  expect(Utils.formatMetric(1234.15555)).toBe("1234.2");
-  expect(Utils.formatMetric(-1234.12345)).toBe("-1234.1");
-  expect(Utils.formatMetric(-1234.15555)).toBe("-1234.2");
+  expect(Utils.formatMetric(1234.12345)).toEqual("1234.1");
+  expect(Utils.formatMetric(1234.15555)).toEqual("1234.2");
+  expect(Utils.formatMetric(-1234.12345)).toEqual("-1234.1");
+  expect(Utils.formatMetric(-1234.15555)).toEqual("-1234.2");
 
-  expect(Utils.formatMetric(1e30)).toBe("1e+30");
+  expect(Utils.formatMetric(1e30)).toEqual("1e+30");
 });
 
 test("formatDuration", () => {
-  expect(Utils.formatDuration(0)).toBe("0ms");
-  expect(Utils.formatDuration(50)).toBe("50ms");
-  expect(Utils.formatDuration(499)).toBe("499ms");
-  expect(Utils.formatDuration(500)).toBe("0.5s");
-  expect(Utils.formatDuration(900)).toBe("0.9s");
-  expect(Utils.formatDuration(999)).toBe("1.0s");
-  expect(Utils.formatDuration(1000)).toBe("1.0s");
-  expect(Utils.formatDuration(1500)).toBe("1.5s");
-  expect(Utils.formatDuration(2000)).toBe("2.0s");
-  expect(Utils.formatDuration(59 * 1000)).toBe("59.0s");
-  expect(Utils.formatDuration(60 * 1000)).toBe("1.0min");
-  expect(Utils.formatDuration(90 * 1000)).toBe("1.5min");
-  expect(Utils.formatDuration(120 * 1000)).toBe("2.0min");
-  expect(Utils.formatDuration(59 * 60 * 1000)).toBe("59.0min");
-  expect(Utils.formatDuration(60 * 60 * 1000)).toBe("1.0h");
-  expect(Utils.formatDuration(90 * 60 * 1000)).toBe("1.5h");
-  expect(Utils.formatDuration(23 * 60 * 60 * 1000)).toBe("23.0h");
-  expect(Utils.formatDuration(24 * 60 * 60 * 1000)).toBe("1.0d");
-  expect(Utils.formatDuration(36 * 60 * 60 * 1000)).toBe("1.5d");
-  expect(Utils.formatDuration(48 * 60 * 60 * 1000)).toBe("2.0d");
-  expect(Utils.formatDuration(480 * 60 * 60 * 1000)).toBe("20.0d");
+  expect(Utils.formatDuration(0)).toEqual("0ms");
+  expect(Utils.formatDuration(50)).toEqual("50ms");
+  expect(Utils.formatDuration(499)).toEqual("499ms");
+  expect(Utils.formatDuration(500)).toEqual("0.5s");
+  expect(Utils.formatDuration(900)).toEqual("0.9s");
+  expect(Utils.formatDuration(999)).toEqual("1.0s");
+  expect(Utils.formatDuration(1000)).toEqual("1.0s");
+  expect(Utils.formatDuration(1500)).toEqual("1.5s");
+  expect(Utils.formatDuration(2000)).toEqual("2.0s");
+  expect(Utils.formatDuration(59 * 1000)).toEqual("59.0s");
+  expect(Utils.formatDuration(60 * 1000)).toEqual("1.0min");
+  expect(Utils.formatDuration(90 * 1000)).toEqual("1.5min");
+  expect(Utils.formatDuration(120 * 1000)).toEqual("2.0min");
+  expect(Utils.formatDuration(59 * 60 * 1000)).toEqual("59.0min");
+  expect(Utils.formatDuration(60 * 60 * 1000)).toEqual("1.0h");
+  expect(Utils.formatDuration(90 * 60 * 1000)).toEqual("1.5h");
+  expect(Utils.formatDuration(23 * 60 * 60 * 1000)).toEqual("23.0h");
+  expect(Utils.formatDuration(24 * 60 * 60 * 1000)).toEqual("1.0d");
+  expect(Utils.formatDuration(36 * 60 * 60 * 1000)).toEqual("1.5d");
+  expect(Utils.formatDuration(48 * 60 * 60 * 1000)).toEqual("2.0d");
+  expect(Utils.formatDuration(480 * 60 * 60 * 1000)).toEqual("20.0d");
 });
 
 test("formatUser", () => {
-  expect(Utils.formatUser("bob")).toBe("bob");
-  expect(Utils.formatUser("bob.mcbob")).toBe("bob.mcbob");
-  expect(Utils.formatUser("bob@example.com")).toBe("bob");
+  expect(Utils.formatUser("bob")).toEqual("bob");
+  expect(Utils.formatUser("bob.mcbob")).toEqual("bob.mcbob");
+  expect(Utils.formatUser("bob@example.com")).toEqual("bob");
 });
 
 test("baseName", () => {
-  expect(Utils.baseName("foo")).toBe("foo");
-  expect(Utils.baseName("foo/bar/baz")).toBe("baz");
-  expect(Utils.baseName("/foo/bar/baz")).toBe("baz");
-  expect(Utils.baseName("file:///foo/bar/baz")).toBe("baz");
+  expect(Utils.baseName("foo")).toEqual("foo");
+  expect(Utils.baseName("foo/bar/baz")).toEqual("baz");
+  expect(Utils.baseName("/foo/bar/baz")).toEqual("baz");
+  expect(Utils.baseName("file:///foo/bar/baz")).toEqual("baz");
 });
 
 test("dropExtension", () => {
-  expect(Utils.dropExtension("foo")).toBe("foo");
-  expect(Utils.dropExtension("foo.xyz")).toBe("foo");
-  expect(Utils.dropExtension("foo.xyz.zyx")).toBe("foo.xyz");
-  expect(Utils.dropExtension("foo/bar/baz.xyz")).toBe("foo/bar/baz");
-  expect(Utils.dropExtension(".foo/.bar/baz.xyz")).toBe(".foo/.bar/baz");
-  expect(Utils.dropExtension(".foo")).toBe(".foo");
-  expect(Utils.dropExtension(".foo.bar")).toBe(".foo");
-  expect(Utils.dropExtension("/.foo")).toBe("/.foo");
-  expect(Utils.dropExtension(".foo/.bar/.xyz")).toBe(".foo/.bar/.xyz");
+  expect(Utils.dropExtension("foo")).toEqual("foo");
+  expect(Utils.dropExtension("foo.xyz")).toEqual("foo");
+  expect(Utils.dropExtension("foo.xyz.zyx")).toEqual("foo.xyz");
+  expect(Utils.dropExtension("foo/bar/baz.xyz")).toEqual("foo/bar/baz");
+  expect(Utils.dropExtension(".foo/.bar/baz.xyz")).toEqual(".foo/.bar/baz");
+  expect(Utils.dropExtension(".foo")).toEqual(".foo");
+  expect(Utils.dropExtension(".foo.bar")).toEqual(".foo");
+  expect(Utils.dropExtension("/.foo")).toEqual("/.foo");
+  expect(Utils.dropExtension(".foo/.bar/.xyz")).toEqual(".foo/.bar/.xyz");
 });


### PR DESCRIPTION
This also adds a KeyFilter class to represent filters, and cleans up the code in ExperimentView a bit to use this and to eliminate the separate Private class.

This addresses part of #105, though we'd still like to make filters saveable.