### PR TITLE
printing traceback

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -112,7 +112,7 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
             storage_dir=storage_dir,
             block=True,
         )
-    except projects.ExecutionException as e:
+    except projects.ExecutionException:
         import traceback
         traceback.print_exc(file=sys.stderr)
         sys.exit(1)

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -113,7 +113,8 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
             block=True,
         )
     except projects.ExecutionException as e:
-        print(e.message, file=sys.stderr)
+        import traceback
+        traceback.print_exc(file=sys.stderr)
         sys.exit(1)
 
 


### PR DESCRIPTION
The print stmt accesses the `message` attribute of `ExecutionException` which doesn't exist. Resulting in two exceptions being thrown. 
This small PR prints the full traceback of the execption