### PR TITLE
Add support for Databricks-backed RestStore

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -63,7 +63,7 @@ ran your program. You can then run ``mlflow ui`` to see the logged runs. Set the
 There are a different kinds of remote tracking URIs:
 
 - Local file path (specified as ``file:/my/local/dir``), where data is just directly stored locally.
-- HTTP server (specified as ``https://my-server:5000``), which is server hosting :ref:`your own tracking server <tracking_server>`.
+- HTTP server (specified as ``https://my-server:5000``), which is a server hosting :ref:`your own tracking server <tracking_server>`.
 - Databricks workspace (specified as ``databricks``, or a specific Databricks CLI profile as ``databricks://profileName``. For more information on configuring a Databricks CLI, see `here <https://github.com/databricks/databricks-cli>`_. This only works for workspaces for which the Databricks MLflow Tracking Server is enabled; please contact Databricks if interested.
 
 Logging Data to Runs

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -60,7 +60,11 @@ ran your program. You can then run ``mlflow ui`` to see the logged runs. Set the
 ``MLFLOW_TRACKING_URI`` environment variable to a server's URI or call
 :py:func:`mlflow.set_tracking_uri` to log runs remotely.
 
-You can also :ref:`run your own tracking server <tracking_server>` to record runs.
+There are a different kinds of remote tracking URIs:
+
+- Local file path (specified as ``file:/my/local/dir``), where data is just directly stored locally.
+- HTTP server (specified as ``https://my-server:5000``), which is server hosting :ref:`your own tracking server <tracking_server>`.
+- Databricks workspace (specified as ``databricks``, or a specific Databricks CLI profile as ``databricks://profileName``. For more information on configuring a Databricks CLI, see `here <https://github.com/databricks/databricks-cli>`_. This only works for workspaces for which the Databricks MLflow Tracking Server is enabled; please contact Databricks if interested.
 
 Logging Data to Runs
 --------------------

--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -19,7 +19,7 @@ def commands():
 @click.argument("experiment_name")
 def create(experiment_name):
     """
-    Creates a new experiment in FileStore backend.
+    Creates a new experiment in the configured tracking server.
     """
     store = _get_store()
     exp_id = store.create_experiment(experiment_name)
@@ -29,7 +29,7 @@ def create(experiment_name):
 @commands.command("list")
 def list_experiments():
     """
-    List all experiment in FileStore backend.
+    List all experiments in the configured tracking server.
     """
     store = _get_store()
     experiments = store.list_experiments()

--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -5,8 +5,8 @@ import os
 import click
 from tabulate import tabulate
 
-from mlflow.store import file_store as store
 from mlflow.data import is_uri
+from mlflow.tracking import _get_store
 
 
 @click.group("experiments")
@@ -16,31 +16,23 @@ def commands():
 
 
 @commands.command()
-@click.option("--file-store", default=None,
-              help="The root of the backing file store for experiment and run data "
-                   "(default: ./mlruns).")
-@click.option("--artifact-root", metavar="URI", default=None,
-              help="Local or S3 URI to store artifacts in (default: inside file store).")
 @click.argument("experiment_name")
-def create(file_store, artifact_root, experiment_name):
+def create(experiment_name):
     """
     Creates a new experiment in FileStore backend.
     """
-    fs = store.FileStore(file_store, artifact_root)
-    exp_id = fs.create_experiment(experiment_name)
+    store = _get_store()
+    exp_id = store.create_experiment(experiment_name)
     print("Created experiment '%s' with id %d" % (experiment_name, exp_id))
 
 
 @commands.command("list")
-@click.option("--file-store", default=None,
-              help="The root of the backing file store for experiment and run data "
-                   "(default: ./mlruns).")
-def list_experiments(file_store):
+def list_experiments():
     """
     List all experiment in FileStore backend.
     """
-    fs = store.FileStore(file_store)
-    experiments = fs.list_experiments()
+    store = _get_store()
+    experiments = store.list_experiments()
     table = [[exp.experiment_id, exp.name, exp.artifact_location if is_uri(exp.artifact_location)
               else os.path.abspath(exp.artifact_location)] for exp in experiments]
     print(tabulate(sorted(table), headers=["Experiment Id", "Name", "Artifact Location"]))

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -91,7 +91,7 @@ def _check_databricks_auth_available():
             "Could not find Databricks CLI on PATH. Please install and configure the Databricks "
             "CLI as described in https://github.com/databricks/databricks-cli")
     # Verify that we can get Databricks auth
-    rest_utils.get_databricks_http_request_params_or_fail()
+    rest_utils.get_databricks_http_request_kwargs_or_fail()
 
 
 def _upload_to_dbfs(src_path, dbfs_uri):

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -91,7 +91,7 @@ def _check_databricks_auth_available():
             "Could not find Databricks CLI on PATH. Please install and configure the Databricks "
             "CLI as described in https://github.com/databricks/databricks-cli")
     # Verify that we can get Databricks auth
-    rest_utils.get_databricks_hostname_and_auth()
+    rest_utils.get_databricks_http_request_params_or_fail()
 
 
 def _upload_to_dbfs(src_path, dbfs_uri):
@@ -198,18 +198,13 @@ def _create_databricks_run(tracking_uri, experiment_id, source_name, source_vers
     status or log metrics/params for the run.
     """
     if tracking.is_local_uri(tracking_uri):
-        # TODO: we'll actually use the Databricks deployment's tracking URI here in the future
         eprint("WARNING: MLflow tracking URI is set to a local URI (%s), so results from "
                "Databricks will not be logged permanently." % tracking_uri)
-        return None
-    else:
-        # Assume non-local tracking URIs are accessible from Databricks (won't work for e.g.
-        # localhost)
-        return tracking._create_run(experiment_id=experiment_id,
-                                    source_name=source_name,
-                                    source_version=source_version,
-                                    entry_point_name=entry_point_name,
-                                    source_type=SourceType.PROJECT)
+    return tracking._create_run(experiment_id=experiment_id,
+                                source_name=source_name,
+                                source_version=source_version,
+                                entry_point_name=entry_point_name,
+                                source_type=SourceType.PROJECT)
 
 
 def _parse_dbfs_uri_path(dbfs_uri):

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -45,7 +45,7 @@ class RestException(Exception):
         message = json['error_code']
         if 'message' in json:
             message = "%s: %s" % (message, json['message'])
-        super(Exception, self).__init__(message)
+        super(RestException, self).__init__(message)
         self.json = json
 
 

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -41,24 +41,18 @@ _METHOD_TO_INFO = _api_method_to_info()
 class RestStore(AbstractStore):
     """ Client for a remote tracking server accessed via REST API calls """
 
-    def __init__(self, hostname):
+    def __init__(self, http_request_params):
         super(RestStore, self).__init__()
-        self.hostname = hostname
-
-    def _get_headers(self):  # noqa
-        """ Returns header for REST API requests. Can be overridden in subclasses """
-        return None
-
-    def _get_auth(self):  # noqa
-        """ Returns auth for REST API requests. Can be overridden in subclasses """
-        return None
+        self.http_request_params = http_request_params
+        if not http_request_params['hostname']:
+            raise Exception('hostname must be provided to RestStore')
 
     def _call_endpoint(self, api, json_body):
         endpoint, method = _METHOD_TO_INFO[api]
         response_proto = api.Response()
         js_dict = http_request(hostname=self.hostname, endpoint=endpoint, method=method,
-                               auth=self._get_auth(), headers=self._get_headers(),
-                               req_body_json=json_body, params=None)
+                               auth=self.auth, headers=self.headers,
+                               req_body_json=json_body, params=None, **http_request_params)
         ParseDict(js_dict=js_dict, message=response_proto)
         return response_proto
 

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -1,3 +1,4 @@
+import json
 from google.protobuf.json_format import MessageToJson, ParseDict
 
 
@@ -37,7 +38,9 @@ def _api_method_to_info():
 
 _METHOD_TO_INFO = _api_method_to_info()
 
+
 class RestException(Exception):
+    """Exception thrown on 400-level errors from the REST API"""
     def __init__(self, json):
         message = json['error_code']
         if 'message' in json:
@@ -58,6 +61,9 @@ class RestStore(AbstractStore):
     def _call_endpoint(self, api, json_body):
         endpoint, method = _METHOD_TO_INFO[api]
         response_proto = api.Response()
+        # Convert json string to json dictionary, to pass to requests
+        if json_body:
+            json_body = json.loads(json_body)
         js_dict = http_request(endpoint=endpoint, method=method,
                                req_body_json=json_body, params=None, **self.http_request_params)
 

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -50,12 +50,16 @@ class RestException(Exception):
 
 
 class RestStore(AbstractStore):
-    """ Client for a remote tracking server accessed via REST API calls """
+    """
+    Client for a remote tracking server accessed via REST API calls
+    :param http_request_kwargs arguments to add to rest_utils.http_request for all requests.
+                               'hostname' is required.
+    """
 
-    def __init__(self, http_request_params):
+    def __init__(self, http_request_kwargs):
         super(RestStore, self).__init__()
-        self.http_request_params = http_request_params
-        if not http_request_params['hostname']:
+        self.http_request_kwargs = http_request_kwargs
+        if not http_request_kwargs['hostname']:
             raise Exception('hostname must be provided to RestStore')
 
     def _call_endpoint(self, api, json_body):
@@ -65,7 +69,7 @@ class RestStore(AbstractStore):
         if json_body:
             json_body = json.loads(json_body)
         js_dict = http_request(endpoint=endpoint, method=method,
-                               req_body_json=json_body, params=None, **self.http_request_params)
+                               req_body_json=json_body, params=None, **self.http_request_kwargs)
 
         if 'error_code' in js_dict:
             raise RestException(js_dict)

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -16,7 +16,7 @@ from mlflow.entities.source_type import SourceType
 from mlflow.store.file_store import FileStore
 from mlflow.store.rest_store import RestStore
 from mlflow.store.artifact_repo import ArtifactRepository
-from mlflow.utils import env
+from mlflow.utils import env, rest_utils
 
 
 _RUN_ID_ENV_VAR = "MLFLOW_RUN_ID"
@@ -88,8 +88,7 @@ def _get_rest_store(store_uri):
 
 
 def _get_databricks_rest_store(store_uri):
-    parsed_uri = urllib.parse.urlparse(uri)
-    scheme = urllib.parse.urlparse(uri).scheme
+    parsed_uri = urllib.parse.urlparse(store_uri)
 
     profile = None
     if parsed_uri.scheme == 'databricks':
@@ -104,12 +103,12 @@ def _get_store():
     if store_uri is None:
         return FileStore()
     # Pattern-match on the URI
+    if _is_databricks_uri(store_uri):
+        return _get_databricks_rest_store(store_uri)
     if is_local_uri(store_uri):
         return _get_file_store(store_uri)
     if _is_http_uri(store_uri):
         return _get_rest_store(store_uri)
-    if _is_databricks_uri(store_uri):
-        return _get_databricks_rest_store(store_uri)
 
     raise Exception("Tracking URI must be a local filesystem URI of the form '%s...' or a "
                     "remote URI of the form '%s...'. Please update the tracking URI via "

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -42,6 +42,14 @@ def set_tracking_uri(uri):
     """
     Sets the tracking server URI to the passed-in value. Note that this does not affect the
     currently active run (if one exists), but will take effect for any successive runs.
+
+    The provided URI may be one of three types:
+
+    - An empty string, or a local file path, prefixed with file:/. Data will be stored
+      locally at the provided file (or ./mlruns if empty).
+    - An HTTP URI like https://my-tracking-server:5000.
+    - A Databricks workspace, provided as just the string "databricks" or, to use a specific
+      Databricks profile (per the Databricks CLI), "databricks://profileName".
     """
     global _tracking_uri
     _tracking_uri = uri

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -93,8 +93,8 @@ def _get_databricks_rest_store(store_uri):
     profile = None
     if parsed_uri.scheme == 'databricks':
         profile = parsed_uri.hostname
-    http_request_params = rest_utils.get_databricks_http_request_params_or_fail(profile)
-    return RestStore(http_request_params)
+    http_request_kwargs = rest_utils.get_databricks_http_request_kwargs_or_fail(profile)
+    return RestStore(http_request_kwargs)
 
 
 def _get_store():

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -38,7 +38,7 @@ def get_databricks_http_request_params_or_fail(profile=None):
     elif config.token:
         basic_auth_str = ("token:%s" % config.token).encode("utf-8")
     if not basic_auth_str:
-        fail_malformed_databricks_auth(profile)
+        _fail_malformed_databricks_auth(profile)
 
     headers = {
         "Authorization": "Basic " + base64.standard_b64encode(basic_auth_str).decode("utf-8")

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -14,7 +14,7 @@ def _fail_malformed_databricks_auth(profile):
                     "https://github.com/databricks/databricks-cli." % profile)
 
 
-def get_databricks_http_request_params_or_fail(profile=None):
+def get_databricks_http_request_kwargs_or_fail(profile=None):
     """
     Reads in configuration necessary to make HTTP requests to a Databricks server. This
     uses the Databricks CLI's ConfigProvider interface to load the DatabricksConfig object.
@@ -57,7 +57,7 @@ def get_databricks_http_request_params_or_fail(profile=None):
 
 def databricks_api_request(endpoint, method, req_body_json=None, params=None):
     final_endpoint = "/api/2.0/%s" % endpoint
-    request_params = get_databricks_http_request_params_or_fail()
+    request_params = get_databricks_http_request_kwargs_or_fail()
     return http_request(endpoint=final_endpoint, method=method, req_body_json=req_body_json,
                         params=params, **request_params)
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -16,11 +16,11 @@ def _fail_malformed_databricks_auth(profile):
 def get_databricks_http_request_params_or_fail(profile=None):
     if not profile:
         profile = provider.DEFAULT_SECTION
-    config = provider._fail_malformed_databricks_auth(profile)
+    config = provider.get_config_for_profile(profile)
 
     hostname = config.host
     if not hostname:
-        fail_malformed_databricks_auth(profile)
+        _fail_malformed_databricks_auth(profile)
 
     basic_auth_str = None
     if config.username is not None and config.password is not None:
@@ -52,7 +52,7 @@ def databricks_api_request(endpoint, method, req_body_json=None, params=None):
                         params=params, **request_params)
 
 
-def http_request(hostname, endpoint, method, auth, headers, req_body_json, params,
+def http_request(hostname, endpoint, method, headers=None, req_body_json=None, params=None,
                  secure_verify=True, retries=3, retry_interval=3):
     """
     Makes an HTTP request with the specified method to the specified hostname/endpoint. Retries
@@ -60,7 +60,6 @@ def http_request(hostname, endpoint, method, auth, headers, req_body_json, param
     `retry_interval` seconds between successive retries. Parses the API response (assumed to be
     JSON) into a Python object and returns it.
 
-    :param auth: Auth tuple for Basic/Digest/Custom HTTP Auth
     :param headers: Request headers to use when making the HTTP request
     :param req_body_json: Dictionary containing the request body
     :param params: Query parameters for the request
@@ -69,7 +68,7 @@ def http_request(hostname, endpoint, method, auth, headers, req_body_json, param
     url = "%s%s" % (hostname, endpoint)
     for i in range(retries):
         response = requests.request(method=method, url=url, headers=headers, verify=secure_verify,
-                                    params=params, json=req_body_json, auth=auth)
+                                    params=params, json=req_body_json)
         if response.status_code >= 200 and response.status_code < 500:
             return json.loads(response.text)
         else:

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -7,41 +7,53 @@ import requests
 
 from mlflow.utils.logging_utils import eprint
 
-
-def get_databricks_hostname_and_auth():
-    """
-    Reads the hostname & auth token to use for running on Databricks from the config file created
-    by the Databricks CLI. Returns a tuple of (hostname, auth, token) to use when making API
-    requests.
-    """
-    profile = provider.DEFAULT_SECTION
-    config = provider.get_config_for_profile(profile)
-    if config.username is not None and config.password is not None:
-        return config.host, (config.username, config.password), config.token
-    if config.token:
-        return config.host, None, config.token
+def _fail_malformed_databricks_auth(profile):
     raise Exception("Got malformed Databricks CLI profile '%s'. Please make sure the Databricks "
-                    "CLI is properly configured as described at "
-                    "https://github.com/databricks/databricks-cli." % profile)
+                "CLI is properly configured as described at "
+                "https://github.com/databricks/databricks-cli." % profile)
+
+
+def get_databricks_http_request_params_or_fail(profile=None):
+    if not profile:
+        profile = provider.DEFAULT_SECTION
+    config = provider._fail_malformed_databricks_auth(profile)
+
+    hostname = config.host
+    if not hostname:
+        fail_malformed_databricks_auth(profile)
+
+    basic_auth_str = None
+    if config.username is not None and config.password is not None:
+        basic_auth_str = ("%s:%s" % (config.username, config.password)).encode("utf-8")
+    elif config.token:
+        basic_auth_str = ("token:%s" % token).encode("utf-8")
+    if not basic_auth_str:
+        fail_malformed_databricks_auth(profile)
+
+    headers = {
+        "Authorization": "Basic " + base64.standard_b64encode(basic_auth_str).decode("utf-8")
+    }
+
+    secure_verify = True
+    if hasattr(config, 'insecure'):
+        secure_verify = False
+
+    return {
+        'hostname': hostname,
+        'headers': headers,
+        'secure_verify': secure_verify,
+    }
 
 
 def databricks_api_request(endpoint, method, req_body_json=None, params=None):
-    hostname, auth, token = get_databricks_hostname_and_auth()
     final_endpoint = "/api/2.0/%s" % endpoint
-    if token is not None:
-        token_bytes = ("token:%s" % token).encode("utf-8")
-        headers = {
-            "Authorization": "Basic " + base64.standard_b64encode(token_bytes).decode("utf-8")
-        }
-    else:
-        headers = None
-    # TODO: Remove `verify=False`, currently need it to run against dev shards.
-    return http_request(hostname=hostname, endpoint=final_endpoint, method=method, auth=auth,
-                        headers=headers, req_body_json=req_body_json, params=params)
+    request_params = get_databricks_http_request_params_or_fail()
+    return http_request(endpoint=final_endpoint, method=method, req_body_json=req_body_json,
+                        params=params, **request_params)
 
 
 def http_request(hostname, endpoint, method, auth, headers, req_body_json, params,
-                 retries=3, retry_interval=3):
+                 secure_verify=True, retries=3, retry_interval=3):
     """
     Makes an HTTP request with the specified method to the specified hostname/endpoint. Retries
     up to `retries` times if a request fails with a server error (e.g. error code 500), waiting
@@ -56,7 +68,7 @@ def http_request(hostname, endpoint, method, auth, headers, req_body_json, param
     """
     url = "%s%s" % (hostname, endpoint)
     for i in range(retries):
-        response = requests.request(method=method, url=url, headers=headers, verify=False,
+        response = requests.request(method=method, url=url, headers=headers, verify=secure_verify,
                                     params=params, json=req_body_json, auth=auth)
         if response.status_code >= 200 and response.status_code < 500:
             return json.loads(response.text)

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -1,0 +1,43 @@
+import mock
+import unittest
+
+from mlflow.store.rest_store import RestStore, RestException
+
+
+class TestRestStore(unittest.TestCase):
+    @mock.patch('requests.request')
+    def test_successful_http_request(self, request):
+        def mock_request(**kwargs):
+            # Filter out None arguments
+            kwargs = dict((k, v) for k, v in kwargs.iteritems() if v is not None)
+            assert kwargs == {
+                'method': 'GET',
+                'url': 'https://hello/api/2.0/preview/mlflow/experiments/list',
+                'verify': True,
+            }
+            response = mock.MagicMock
+            response.status_code = 200
+            response.text = '{"experiments": [{"name": "Exp!"}]}'
+            return response
+        request.side_effect = mock_request
+
+        store = RestStore({'hostname': 'https://hello'})
+        experiments = store.list_experiments()
+        assert experiments[0].name == "Exp!"
+
+    @mock.patch('requests.request')
+    def test_failed_http_request(self, request):
+        def mock_request(**_):
+            response = mock.MagicMock
+            response.status_code = 404
+            response.text = '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "No experiment"}'
+            return response
+        request.side_effect = mock_request
+
+        store = RestStore({'hostname': 'https://hello'})
+        with self.assertRaises(RestException) as cm:
+            store.list_experiments()
+        self.assertEqual(cm.exception.message, "RESOURCE_DOES_NOT_EXIST: No experiment")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -1,4 +1,5 @@
 import mock
+import six
 import unittest
 
 from mlflow.store.rest_store import RestStore, RestException
@@ -9,7 +10,7 @@ class TestRestStore(unittest.TestCase):
     def test_successful_http_request(self, request):
         def mock_request(**kwargs):
             # Filter out None arguments
-            kwargs = dict((k, v) for k, v in kwargs.iteritems() if v is not None)
+            kwargs = dict((k, v) for k, v in six.iteritems(kwargs) if v is not None)
             assert kwargs == {
                 'method': 'GET',
                 'url': 'https://hello/api/2.0/preview/mlflow/experiments/list',
@@ -37,7 +38,7 @@ class TestRestStore(unittest.TestCase):
         store = RestStore({'hostname': 'https://hello'})
         with self.assertRaises(RestException) as cm:
             store.list_experiments()
-        self.assertEqual(cm.exception.message, "RESOURCE_DOES_NOT_EXIST: No experiment")
+        self.assertIn("RESOURCE_DOES_NOT_EXIST: No experiment", str(cm.exception))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 import mock
 import pytest
-import requests
 
 from databricks_cli.configure import provider
 from databricks_cli.configure.provider import DatabricksConfig

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+import mock
+import pytest
+import requests
+
+from databricks_cli.configure import provider
+from databricks_cli.configure.provider import DatabricksConfig
+from mlflow.utils import rest_utils
+
+
+def _mock_profile(expected_profile, config):
+    def mock_get_config_for_profile(profile):
+        assert profile == expected_profile
+        return config
+    provider.get_config_for_profile = mock_get_config_for_profile
+
+
+def test_databricks_params_token():
+    _mock_profile("DEFAULT", DatabricksConfig("host", None, None, "mytoken", insecure=False))
+    params = rest_utils.get_databricks_http_request_params_or_fail()
+    assert params == {
+      'hostname': 'host',
+      'headers': {
+        'Authorization': 'Basic dG9rZW46bXl0b2tlbg=='
+      },
+      'secure_verify': True,
+    }
+
+
+def test_databricks_params_user_password():
+    _mock_profile("DEFAULT", DatabricksConfig("host", "user", "pass", None, insecure=False))
+    params = rest_utils.get_databricks_http_request_params_or_fail()
+    assert params == {
+      'hostname': 'host',
+      'headers': {
+        'Authorization': 'Basic dXNlcjpwYXNz'
+      },
+      'secure_verify': True,
+    }
+
+
+def test_databricks_params_no_verify():
+    _mock_profile("DEFAULT", DatabricksConfig("host", "user", "pass", None, insecure=True))
+    params = rest_utils.get_databricks_http_request_params_or_fail()
+    assert params['secure_verify'] is False
+
+
+def test_databricks_params_custom_profile():
+    _mock_profile("profile", DatabricksConfig("host", "user", "pass", None, insecure=True))
+    params = rest_utils.get_databricks_http_request_params_or_fail("profile")
+    assert params['secure_verify'] is False
+
+
+def test_databricks_params_throws_errors():
+    _mock_profile("DEFAULT", DatabricksConfig("host", "user", "pass", None, insecure=False))
+
+    # No such profile
+    with pytest.raises(Exception):
+        rest_utils.get_databricks_http_request_params_or_fail("profile")
+
+    # No hostname
+    _mock_profile("DEFAULT", DatabricksConfig(None, "user", "pass", None, insecure=False))
+    with pytest.raises(Exception):
+        rest_utils.get_databricks_http_request_params_or_fail()
+
+    # No authentication
+    _mock_profile("DEFAULT", DatabricksConfig("host", None, None, None, insecure=False))
+    with pytest.raises(Exception):
+        rest_utils.get_databricks_http_request_params_or_fail()
+
+
+def test_databricks_http_request_integration():
+    """Confirms that the databricks http request params can in fact be used as an HTTP request"""
+    def confirm_requests(**kvargs):
+        assert kvargs == {
+            'method': 'PUT',
+            'url': 'host/api/2.0/clusters/list',
+            'headers': {
+                'Authorization': 'Basic dXNlcjpwYXNz'
+            },
+            'verify': True,
+            'params': 'x=y',
+            'json': {'a': 'b'}
+        }
+        response = mock.MagicMock()
+        response.status_code = 200
+        response.text = '{"OK": "woo"}'
+        return response
+    requests.request = confirm_requests
+    _mock_profile("DEFAULT", DatabricksConfig("host", "user", "pass", None, insecure=False))
+    response = rest_utils.databricks_api_request('clusters/list', 'PUT',
+                                                 req_body_json={'a': 'b'}, params='x=y')
+    assert response == {'OK': 'woo'}


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds support for an mlflow tracking URI which refers to a Databricks profile (per the Databricks CLI spec). The URI format proposed is the word "databricks" to refer to the default profile, or "databricks://profile-name" to refer to a different profile.

This PR also changes the interface of how we parse the Databricks CLI to be leak less information between the parsing of the config and the actual HTTP request part of the library. This was done is enable us to parse new configurations over time without having to update every intermediate user (e.g., `secure_verify`).

## How is this patch tested?

- [x] Unit tests - New test suite confirms that the config parsing works as expected, and can invoke the http_request method.
- [x] Manual tests - Tested against a Databricks API endpoint.
