### PR TITLE
Make GCS Artifact a pluggable dependency

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -223,13 +223,25 @@ For the clients and server to access the artifact location, you should configure
 provider credentials as normal. For example, for S3, you can set the ``AWS_ACCESS_KEY_ID``
 and ``AWS_SECRET_ACCESS_KEY`` environment variables, use an IAM role, or configure a default
 profile in ``~/.aws/credentials``. See `Set up AWS Credentials and Region for Development <https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/setup-credentials.html>`_ for more info.
-To utilize Google Cloud Storage you can set the artifact-root to ``gs://<storage_bucket>``, and you will need to provide auth as per
-the documentation for `Authentication <https://google-cloud.readthedocs.io/en/latest/core/auth.html>`_.
 
 Warning: If you do not specify a ``--default-artifact-root``, nor do you specify an artifact URI when creating
 the experiment (e.g., ``mlflow experiments create --artifact-root s3://<my-bucket>``), then the artifact root
 will be a path inside the File Store. Typically this is not an appropriate location, as the client and
 server will probably be referring to different physical locations (i.e., the same path on different disks).
+
+Additional Storage Backends
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In addition to the S3 and local-filesystem Artifact Stores, MLflow includes support for the
+following storage backends:
+
+
+Google Cloud Storage
+~~~~~~~~~~~~~~~~~~~~
+You can specify a GCS bucket for artifact storage by launching your server with ``--artifact-root``
+set to ``gs://<storage_bucket>``. Note that you'll need to install the GCS Python client
+(via ``pip install google-cloud-storage``) on the client and tracking server. You should also
+configure credentials for accessing the GCS bucket on the client and server as described
+`here <https://google-cloud.readthedocs.io/en/latest/core/auth.html>`_.
 
 
 Networking

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -5,7 +5,6 @@ from distutils import dir_util
 import os
 
 import boto3
-from google.cloud import storage as gcs_storage
 
 from mlflow.utils.file_utils import (mkdir, exists, list_all, get_relative_path,
                                      get_file_info, build_path, TempDir)
@@ -195,9 +194,12 @@ class GCSArtifactRepository(ArtifactRepository):
     """Stores artifacts on Google Cloud Storage.
        Assumes the google credentials are available in the environment,
        see https://google-cloud.readthedocs.io/en/latest/core/auth.html """
-
-    def __init__(self, artifact_uri, client=gcs_storage):
-        self.gcs = client
+    def __init__(self, artifact_uri, client=None):
+        if client:
+            self.gcs = client
+        else:
+            from google.cloud import storage as gcs_storage
+            self.gcs = gcs_storage
         super(GCSArtifactRepository, self).__init__(artifact_uri)
 
     @staticmethod

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
         'gitpython>=2.1.0',
         'pyyaml',
         'boto3',
-        'google-cloud-storage',
         'querystring_parser',
     ],
     entry_points='''

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -1,4 +1,6 @@
 # Test reqs
+google-cloud-storage
+h2o
 mock==2.0.0
 moto
 prospector[with_pyroma]==0.12.7
@@ -11,4 +13,3 @@ pytest-cov
 rstcheck==3.2
 scipy
 tensorflow
-h2o


### PR DESCRIPTION
Update GCS support to follow the pattern of existing third-party integrations (don't make GCS a required dependency of MLflow in setup.py & instead allow users to install GCS support if they'd like)