### PR TITLE
Fix metric values going out of order on x axis

### DIFF
--- a/mlflow/server/js/src/components/MetricView.js
+++ b/mlflow/server/js/src/components/MetricView.js
@@ -92,7 +92,6 @@ const mapStateToProps = (state, ownProps) => {
       metrics[i][runUuid] = entries[i].value;
     }
   });
-  console.log("metrics", metrics);
   return {
     metrics,
     title: <span>{metricKey}</span>,

--- a/mlflow/server/js/src/components/MetricView.js
+++ b/mlflow/server/js/src/components/MetricView.js
@@ -82,7 +82,7 @@ const mapStateToProps = (state, ownProps) => {
   runUuids.forEach(runUuid => {
     maxLength = Math.max(maxLength, getMetricsByKey(runUuid, metricKey, state).length)
   });
-  let metrics = new Array(maxLength);
+  const metrics = new Array(maxLength);
   for (let i = 0; i < metrics.length; i++) {
     metrics[i] = {index: i};
   }


### PR DESCRIPTION
This fixes #45, which happens because the JavaScript sorting code we had for combining metrics would sometimes reorder them based on the order of fields in some objects (especially when metrics had the same timestamp). Also related to #123.