### PR TITLE
Allow metric and parameter names to contain slashes

### DIFF
--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -101,6 +101,16 @@ def mkdir(root, name=None):  # noqa
         raise e
 
 
+def make_containing_dirs(path):
+    """
+    Create the base directory for a given file path if it does not exist; also creates parent
+    directories.
+    """
+    dir_name = os.path.dirname(path)
+    if not os.path.exists(dir_name):
+        os.makedirs(dir_name)
+
+
 def write_yaml(root, file_name, data, overwrite=False):
     """
     Write dictionary data in yaml format.

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -98,10 +98,11 @@ def test_log_metric():
             mlflow.log_metric("name_1", 25)
             mlflow.log_metric("name_2", -3)
             mlflow.log_metric("name_1", 30)
+            mlflow.log_metric("nested/nested/name", 40)
         finished_run = active_run.store.get_run(run_uuid)
         # Validate metrics
-        assert len(finished_run.data.metrics) == 2
-        expected_pairs = {"name_1": 30, "name_2": -3}
+        assert len(finished_run.data.metrics) == 3
+        expected_pairs = {"name_1": 30, "name_2": -3, "nested/nested/name": 40}
         for metric in finished_run.data.metrics:
             assert expected_pairs[metric.key] == metric.value
 
@@ -126,10 +127,11 @@ def test_log_param():
             mlflow.log_param("name_1", "a")
             mlflow.log_param("name_2", "b")
             mlflow.log_param("name_1", "c")
+            mlflow.log_param("nested/nested/name", 5)
         finished_run = active_run.store.get_run(run_uuid)
         # Validate params
-        assert len(finished_run.data.params) == 2
-        expected_pairs = {"name_1": "c", "name_2": "b"}
+        assert len(finished_run.data.params) == 3
+        expected_pairs = {"name_1": "c", "name_2": "b", "nested/nested/name": "5"}
         for param in finished_run.data.params:
             assert expected_pairs[param.key] == param.value
 


### PR DESCRIPTION
This is useful for organizing them hierarchically as in TensorBoard, and having the same name for metrics in both cases (for example if we want to automatically report stuff to both).