### PR TITLE
Fix static prefix validation

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -149,10 +149,11 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
     Conforms to the callback interface of click documented at
     http://click.pocoo.org/5/options/#callbacks-for-validation.
     """
-    if not value.startswith("/"):
-        raise UsageError("--static-prefix must begin with a '/'.")
-    if value.endswith("/"):
-        raise UsageError("--static-prefix should not end with a '/'.")
+    if value is not None:
+        if not value.startswith("/"):
+            raise UsageError("--static-prefix must begin with a '/'.")
+        if value.endswith("/"):
+            raise UsageError("--static-prefix should not end with a '/'.")
     return value
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,9 @@ from mlflow.cli import server
 
 def test_server_static_prefix_validation():
     with mock.patch("mlflow.cli._run_server") as run_server_mock:
+        CliRunner().invoke(server)
+        run_server_mock.assert_called_once()
+    with mock.patch("mlflow.cli._run_server") as run_server_mock:
         CliRunner().invoke(server, ["--static-prefix", "/mlflow"])
         run_server_mock.assert_called_once()
     with mock.patch("mlflow.cli._run_server") as run_server_mock:


### PR DESCRIPTION
This PR fixes #209. 

When we use default `--static-prefix` option, the CLI skips any validation  and use `None` as the static prefix.