### PR TITLE
Two small UI fixes

### DIFF
--- a/mlflow/server/js/src/components/ArtifactView.css
+++ b/mlflow/server/js/src/components/ArtifactView.css
@@ -23,6 +23,10 @@ div.artifact-view {
   width: 400px;
 }
 
+.artifact-left li {
+  white-space: nowrap;
+}
+
 .artifact-right {
   width: 100%;
 }

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -83,7 +83,7 @@ class RunView extends Component {
   render() {
     const { run, experiment, params, tags, latestMetrics, getMetricPagePath } = this.props;
     const startTime = run.getStartTime() ? Utils.formatTimestamp(run.getStartTime()) : '(unknown)';
-    const duration = run.getStartTime() && run.getEndTime() ? run.getEndTime() - run.getStartTime() : '(unknown)';
+    const duration = run.getStartTime() && run.getEndTime() ? run.getEndTime() - run.getStartTime() : null;
     const experimentId = experiment.getExperimentId();
     const tableStyles = {
       table: {
@@ -149,10 +149,13 @@ class RunView extends Component {
             <span className="metadata-header">User: </span>
             <span className="metadata-info">{run.getUserId()}</span>
           </div>
-          <div className="run-info">
-            <span className="metadata-header">Duration: </span>
-            <span className="metadata-info">{Utils.formatDuration(duration)}</span>
-          </div>
+          {duration !== null ?
+            <div className="run-info">
+              <span className="metadata-header">Duration: </span>
+              <span className="metadata-info">{Utils.formatDuration(duration)}</span>
+            </div>
+            : null
+          }
         </div>
         {runCommand ?
           <div className="RunView-info">


### PR DESCRIPTION
1) Add `white-space: nowrap` to items in the file browser to avoid the ugly behavior below for long artifact names:
![screen shot 2018-07-28 at 4 38 51 pm](https://user-images.githubusercontent.com/228859/43379566-fdc37812-9381-11e8-9d35-c109c0a60107.png)

2) Hide a run's duration when its end time is not set, instead of showing "NaN" or "unknown" as before (the previous behavior showed NaN, although an earlier version showed unknown, but neither is super useful).