### PR TITLE
Fix mlflow server with newest client

### DIFF
--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -10,20 +10,20 @@ def test_get_endpoints():
 
 
 def test_can_parse_json():
-	request = mock.MagicMock()
-	request.query_string = ""
-	request.get_json = mock.MagicMock()
-	request.get_json.return_value = {"name": "hello"}
-	msg = _get_request_message(CreateExperiment(), flask_request=request)
-	assert msg.name == "hello"
+    request = mock.MagicMock()
+    request.query_string = ""
+    request.get_json = mock.MagicMock()
+    request.get_json.return_value = {"name": "hello"}
+    msg = _get_request_message(CreateExperiment(), flask_request=request)
+    assert msg.name == "hello"
 
 
 # Previous versions of the client sent a doubly string encoded JSON blob,
 # so this test ensures continued compliance with such clients.
 def test_can_parse_json_string():
-	request = mock.MagicMock()
-	request.query_string = ""
-	request.get_json = mock.MagicMock()
-	request.get_json.return_value = '{"name": "hello2"}'
-	msg = _get_request_message(CreateExperiment(), flask_request=request)
-	assert msg.name == "hello2"
+    request = mock.MagicMock()
+    request.query_string = ""
+    request.get_json = mock.MagicMock()
+    request.get_json.return_value = '{"name": "hello2"}'
+    msg = _get_request_message(CreateExperiment(), flask_request=request)
+    assert msg.name == "hello2"

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -28,4 +28,3 @@ def test_can_parse_json_string():
     request.get_json.return_value = '{"name": "hello2"}'
     msg = _get_request_message(CreateExperiment(), flask_request=request)
     assert msg.name == "hello2"
-

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -3,6 +3,7 @@ import mock
 from mlflow.server.handlers import get_endpoints, _create_experiment, _get_request_message
 from mlflow.protos.service_pb2 import CreateExperiment
 
+
 def test_get_endpoints():
     endpoints = get_endpoints()
     create_experiment_endpoint = [e for e in endpoints if e[1] == _create_experiment]
@@ -27,3 +28,4 @@ def test_can_parse_json_string():
     request.get_json.return_value = '{"name": "hello2"}'
     msg = _get_request_message(CreateExperiment(), flask_request=request)
     assert msg.name == "hello2"
+

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -1,7 +1,29 @@
-from mlflow.server.handlers import get_endpoints, _create_experiment
+import mock
 
+from mlflow.server.handlers import get_endpoints, _create_experiment, _get_request_message
+from mlflow.protos.service_pb2 import CreateExperiment
 
 def test_get_endpoints():
     endpoints = get_endpoints()
     create_experiment_endpoint = [e for e in endpoints if e[1] == _create_experiment]
     assert len(create_experiment_endpoint) == 2
+
+
+def test_can_parse_json():
+	request = mock.MagicMock()
+	request.query_string = ""
+	request.get_json = mock.MagicMock()
+	request.get_json.return_value = {"name": "hello"}
+	msg = _get_request_message(CreateExperiment(), flask_request=request)
+	assert msg.name == "hello"
+
+
+# Previous versions of the client sent a doubly string encoded JSON blob,
+# so this test ensures continued compliance with such clients.
+def test_can_parse_json_string():
+	request = mock.MagicMock()
+	request.query_string = ""
+	request.get_json = mock.MagicMock()
+	request.get_json.return_value = '{"name": "hello2"}'
+	msg = _get_request_message(CreateExperiment(), flask_request=request)
+	assert msg.name == "hello2"

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -2,7 +2,6 @@
 import mock
 import pytest
 
-from databricks_cli.configure import provider
 from databricks_cli.configure.provider import DatabricksConfig
 from mlflow.utils import rest_utils
 

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -7,13 +7,6 @@ from databricks_cli.configure.provider import DatabricksConfig
 from mlflow.utils import rest_utils
 
 
-def _mock_profile(expected_profile, config):
-    def mock_get_config_for_profile(profile):
-        assert profile == expected_profile
-        return config
-    provider.get_config_for_profile = mock_get_config_for_profile
-
-
 @mock.patch('databricks_cli.configure.provider.get_config_for_profile')
 def test_databricks_params_token(get_config_for_profile):
     get_config_for_profile.return_value = \


### PR DESCRIPTION
[This commit](https://github.com/mlflow/mlflow/commit/017cb08b1f75ae1bbbfdd9f202bb023e08b0a76f#diff-0c033907303d1beb526d1a168a366cc4R68) accidentally broke the interaction between the client & server for the rest store. Unfortunately, we don't have any unit or integration test coverage between the client and server interactions, so this is not super surprising.

This PR fixes the support (client no longer doubly-serializes the JSON as a string), while allowing support for the old version, to preserve server-side backwards-compatibility.