### PR TITLE
Fix typo in name of environment variable used to indicate path to conda executable

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -27,7 +27,7 @@ from mlflow.utils.logging_utils import eprint
 _GIT_URI_REGEX = re.compile(r"^[^/]*:")
 # Environment variable indicating a path to a conda installation. MLflow will default to running
 # "conda" if unset
-MLFLOW_CONDA = "MLFLOW_MLFLOW_CONDA"
+MLFLOW_CONDA = "MLFLOW_CONDA"
 
 
 class ExecutionException(Exception):


### PR DESCRIPTION
Renames "MLFLOW_MLFLOW_CONDA" -> "MLFLOW_CONDA"