### PR TITLE
Propagate run ID, experiment ID, tracking URI env vars to blocking MLflow runs

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -68,7 +68,7 @@ def _run(uri, entry_point="main", version=None, parameters=None, experiment_id=N
         if block:
             command = _get_entry_point_command(
                 work_dir, entry_point, use_conda, parameters, storage_dir)
-            return _run_entry_point(command, work_dir, run_id=active_run.run_info.run_uuid)
+            return _run_entry_point(command, work_dir, exp_id, run_id=active_run.run_info.run_uuid)
         # Otherwise, invoke `mlflow run` in a subprocess
         return _invoke_mlflow_run_subprocess(
             work_dir=work_dir, entry_point=entry_point, parameters=parameters, experiment_id=exp_id,
@@ -317,7 +317,7 @@ def _get_entry_point_command(project_dir, entry_point, use_conda, parameters, st
     return " && ".join(commands)
 
 
-def _run_entry_point(command, work_dir, run_id):
+def _run_entry_point(command, work_dir, experiment_id, run_id):
     """
     Runs an entry point command in a subprocess, returning a SubmittedRun that can be used to
     query the run's status.
@@ -325,8 +325,10 @@ def _run_entry_point(command, work_dir, run_id):
     :param work_dir: Working directory in which to run the command
     :param run_id: MLflow run ID associated with the entry point execution.
     """
+    env = os.environ.copy()
+    env.update(_get_env_map(run_id, experiment_id))
     eprint("=== Running command '%s' in run with ID '%s' === " % (command, run_id))
-    process = subprocess.Popen(["bash", "-c", command], close_fds=True, cwd=work_dir)
+    process = subprocess.Popen(["bash", "-c", command], close_fds=True, cwd=work_dir, env=env)
     return LocalSubmittedRun(run_id, process)
 
 
@@ -375,6 +377,16 @@ def _create_run(uri, experiment_id, work_dir, entry_point, parameters):
     return active_run
 
 
+def _get_env_map(run_id, experiment_id):
+    # Add the run id into a magic environment variable that the subprocess will read,
+    # causing it to reuse the run.
+    return {
+        tracking._RUN_ID_ENV_VAR: run_id,
+        tracking._TRACKING_URI_ENV_VAR: tracking.get_tracking_uri(),
+        tracking._EXPERIMENT_ID_ENV_VAR: str(experiment_id),
+    }
+
+
 def _invoke_mlflow_run_subprocess(
         work_dir, entry_point, parameters, experiment_id, use_conda, storage_dir, run_id):
     """
@@ -382,15 +394,8 @@ def _invoke_mlflow_run_subprocess(
     a SubmittedRun that can be used to query run status.
     """
     eprint("=== Asynchronously launching MLflow run with ID %s ===" % run_id)
-    # Add the run id into a magic environment variable that the subprocess will read,
-    # causing it to reuse the run.
-    env_map = {
-        tracking._RUN_ID_ENV_VAR: run_id,
-        tracking._TRACKING_URI_ENV_VAR: tracking.get_tracking_uri(),
-        tracking._EXPERIMENT_ID_ENV_VAR: str(experiment_id),
-    }
     mlflow_run_arr = _build_mlflow_run_cmd(
         uri=work_dir, entry_point=entry_point, storage_dir=storage_dir, use_conda=use_conda,
         run_id=run_id, parameters=parameters)
-    mlflow_run_subprocess = _run_mlflow_run_cmd(mlflow_run_arr, env_map)
+    mlflow_run_subprocess = _run_mlflow_run_cmd(mlflow_run_arr, _get_env_map(run_id, experiment_id))
     return LocalSubmittedRun(run_id, mlflow_run_subprocess)

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -149,6 +149,7 @@ def test_run(tmpdir, tracking_uri_mock, use_start_run):  # pylint: disable=unuse
     for param in run.data.params:
         assert param.value == expected_params[param.key]
     expected_metrics = {"some_key": 3}
+    assert len(run.data.metrics) == len(expected_metrics)
     for metric in run.data.metrics:
         assert metric.value == expected_metrics[metric.key]
 


### PR DESCRIPTION
As part of #193, we updated the `projects.run()` API to directly invoke entry point commands in a subprocess when `block=True` was passed. However, we didn't propagate run/experiment/tracking URI information to the entry point command subprocess (one symptom of this: running the projects tests in master will generate an `mlruns` folder in tests/resources/example_project).

This PR properly sets environment variables containing the run ID, experiment ID, etc in the entry point subprocesses for blocking runs. It also strengthens the blocking-run unit test to catch the original bug.