### PR TITLE
Add missing mlflow.version import to sagemaker module

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -10,6 +10,7 @@ import uuid
 import base64
 import boto3
 import mlflow
+import mlflow.version
 from mlflow import pyfunc
 from mlflow.models import Model
 from mlflow.tracking import _get_model_log_dir


### PR DESCRIPTION
Fixes errors in `mlflow.sagemaker.<build_image/push_to_ecr/_get_default_image_url>()`.