### PR TITLE
Replace MLFLOW_CONDA with MLFLOW_CONDA_HOME

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -29,8 +29,9 @@ Dependencies
     Libraries needed to run the project. MLflow currently uses the
     `Conda <https://conda.io/docs>`_ package manager, which supports both Python packages and native
     libraries (for example, CuDNN or Intel MKL), to specify dependencies. MLflow will use the
-    conda executable given by the ``MLFLOW_CONDA`` environment variable if specified, and
-    default to running "conda" otherwise.
+    conda installation given by the ``MLFLOW_CONDA_HOME`` environment variable if specified
+    (e.g. running conda commands by invoking "$MLFLOW_CONDA_HOME/bin/conda"), and default to
+    running "conda" otherwise.
 
 Entry Points
     Commands that can be executed within the project, and information about their

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -172,13 +172,18 @@ def test_run_async(tracking_uri_mock):  # pylint: disable=unused-argument
 
 
 @pytest.mark.parametrize(
-    "mock_env,expected",
-    [({}, "conda"), ({mlflow.projects.MLFLOW_CONDA: "/some/dir/conda"}, "/some/dir/conda")]
+    "mock_env,expected_conda,expected_activate",
+    [
+        ({}, "conda", "activate"),
+        ({mlflow.projects.MLFLOW_CONDA_HOME: "/some/dir/"}, "/some/dir/bin/conda",
+         "/some/dir/bin/activate")
+     ]
 )
-def test_conda_path(mock_env, expected):
-    """Verify that we correctly determine the path to a conda executable"""
+def test_conda_path(mock_env, expected_conda, expected_activate):
+    """Verify that we correctly determine the path to conda executables"""
     with mock.patch.dict("os.environ", mock_env):
-        assert mlflow.projects._conda_executable() == expected
+        assert mlflow.projects._get_conda_bin_executable("conda") == expected_conda
+        assert mlflow.projects._get_conda_bin_executable("activate") == expected_activate
 
 
 def test_cancel_run(tracking_uri_mock):  # pylint: disable=unused-argument


### PR DESCRIPTION
In this PR we replace the `MLFLOW_CONDA` environment variable (path to conda executable) with an `MLFLOW_CONDA_HOME` environment variable (path to conda installation directory), to enable  access to conda-related executables besides `conda` (e.g. "activate").

The directory structure of a conda installation is loosely guaranteed [here](https://conda.io/docs/user-guide/concepts.html#conda-directory-structure) - empirically all Miniconda installations I've seen follow this directory structure.