### PR TITLE
Add artifact location to create-experiment, add POST /runs/search

### DIFF
--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -17,12 +17,18 @@ def commands():
 
 @commands.command()
 @click.argument("experiment_name")
-def create(experiment_name):
+@click.option("--artifact-location", "-l",
+              help="Base location for runs to store artifact results. Artifacts will be stored "
+                   "at $artifact_location/$run_id/artifacts. See "
+                   "https://mlflow.org/docs/latest/tracking.html#where-runs-get-recorded for "
+                   "more info on the properties of artifact location. "
+                   "If no location is provided, the tracking server will pick a default.")
+def create(experiment_name, artifact_location):
     """
     Creates a new experiment in the configured tracking server.
     """
     store = _get_store()
-    exp_id = store.create_experiment(experiment_name)
+    exp_id = store.create_experiment(experiment_name, artifact_location)
     print("Created experiment '%s' with id %d" % (experiment_name, exp_id))
 
 

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -150,6 +150,10 @@ service MlflowService {
   rpc searchRuns (SearchRuns) returns (SearchRuns.Response) {
     option (rpc) = {
       endpoints: [{
+        method: "POST",
+        path: "/preview/mlflow/runs/search"
+        since { major: 2, minor: 0 },
+      }, {
         method: "GET",
         path: "/preview/mlflow/runs/search"
         since { major: 2, minor: 0 },
@@ -197,7 +201,6 @@ service MlflowService {
   }
 }
 
-
 // Descrption of the source that generated a run
 enum SourceType {
   // Within Databricks Notebook environment.
@@ -234,13 +237,13 @@ enum RunStatus {
   KILLED = 5;
 }
 
-// Metric associated with a run with string key and double value
+// Metric associated with a run with string key and float value
 message Metric {
   // Key identifying this metric
   optional string key = 1;
 
   // Value associated with this metric
-  optional double value = 2;
+  optional float value = 2;
 
   // The timestamp at which this metric was recorded
   optional int64 timestamp = 3;
@@ -313,7 +316,7 @@ message RunInfo {
   // URI of the directory where artifacts should be uploaded.
   // This can be a local path (starting with "/"), or a distributed file system (DFS)
   // path, like s3://bucket/directory or dbfs:/my/directory.
-  // If not set, the local "./mlruns" directory will be chosen.
+  // If not set, by default system will log artifacts to local "./mlruns" directory.
   optional string artifact_uri = 13;
 }
 
@@ -335,6 +338,10 @@ message CreateExperiment {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
   optional string name = 1 [(validate_required) = true];
+
+  // Location where all artifacts for this experiment are stored.
+  // If not provided, the remote server will select an appropriate default.
+  optional string artifact_location = 2;
 
   message Response {
     optional int64 experiment_id = 1;
@@ -412,7 +419,7 @@ message LogMetric {
 
   optional string key = 2 [(validate_required) = true];
 
-  optional double value = 3 [(validate_required) = true];
+  optional float value = 3 [(validate_required) = true];
 
   optional int64 timestamp = 4 [(validate_required) = true];
 
@@ -505,7 +512,7 @@ message FloatClause {
   // OneOf (">", ">=", "==", "!=", "<=", "<")
   optional string comparator = 1;
 
-  optional double value = 2;
+  optional float value = 2;
 }
 
 message SearchRuns {

--- a/mlflow/protos/service_pb2.py
+++ b/mlflow/protos/service_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\037com.databricks.api.proto.mlflow\220\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"7\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"I\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xbe\x02\n\x07RunInfo\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\x03\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x16\n\x0esource_version\x18\n \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x0b \x01(\t\x12\x1c\n\x04tags\x18\x0c \x03(\x0b\x32\x0e.mlflow.RunTag\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\"L\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\"v\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"s\n\x0fListExperiments\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1aQ\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12\x1d\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x02\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x10\n\x08run_name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x06 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x16\n\x0esource_version\x18\x08 \x01(\t\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb4\x01\n\tUpdateRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9d\x01\n\tLogMetric\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\x88\xb5\x18\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x83\x01\n\x08LogParam\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"s\n\x06GetRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\tGetMetric\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a*\n\x08Response\x12\x1e\n\x06metric\x18\x01 \x01(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x97\x01\n\x08GetParam\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nparam_name\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a,\n\x08Response\x12 \n\tparameter\x18\x01 \x01(\x0b\x32\r.mlflow.Param:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8a\x01\n\x10SearchExpression\x12\x30\n\x06metric\x18\x01 \x01(\x0b\x32\x1e.mlflow.MetricSearchExpressionH\x00\x12\x36\n\tparameter\x18\x02 \x01(\x0b\x32!.mlflow.ParameterSearchExpressionH\x00\x42\x0c\n\nexpression\"U\n\x16MetricSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05\x66loat\x18\x02 \x01(\x0b\x32\x13.mlflow.FloatClauseH\x00\x42\x08\n\x06\x63lause\"Z\n\x19ParameterSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x06string\x18\x02 \x01(\x0b\x32\x14.mlflow.StringClauseH\x00\x42\x08\n\x06\x63lause\"1\n\x0cStringClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x0b\x46loatClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\"\xad\x01\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\x03\x12\x33\n\x11\x61nded_expressions\x18\x02 \x03(\x0b\x32\x18.mlflow.SearchExpression\x1a%\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9b\x01\n\rListArtifacts\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"f\n\x0bGetArtifact\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9e\x01\n\x10GetMetricHistory\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\x8d\r\n\rMlflowService\x12\x89\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"8\x82\xb5\x18\x34\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01\x12\x83\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"5\x82\xb5\x18\x31\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01\x12|\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"4\x82\xb5\x18\x30\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01\x12m\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"1\x82\xb5\x18-\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01\x12m\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"1\x82\xb5\x18-\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01\x12q\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"5\x82\xb5\x18\x31\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01\x12q\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"8\x82\xb5\x18\x34\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01\x12`\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"-\x82\xb5\x18)\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01\x12l\n\tgetMetric\x12\x11.mlflow.GetMetric\x1a\x1a.mlflow.GetMetric.Response\"0\x82\xb5\x18,\n(\n\x03GET\x12\x1b/preview/mlflow/metrics/get\x1a\x04\x08\x02\x10\x00\x10\x01\x12h\n\x08getParam\x12\x10.mlflow.GetParam\x1a\x19.mlflow.GetParam.Response\"/\x82\xb5\x18+\n\'\n\x03GET\x12\x1a/preview/mlflow/params/get\x1a\x04\x08\x02\x10\x00\x10\x01\x12o\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"0\x82\xb5\x18,\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01\x12{\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"3\x82\xb5\x18/\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01\x12t\n\x0bgetArtifact\x12\x13.mlflow.GetArtifact\x1a\x1c.mlflow.GetArtifact.Response\"2\x82\xb5\x18.\n*\n\x03GET\x12\x1d/preview/mlflow/artifacts/get\x1a\x04\x08\x02\x10\x00\x10\x01\x12\x89\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"8\x82\xb5\x18\x34\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01\x42)\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"7\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"I\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xbe\x02\n\x07RunInfo\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\x03\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x16\n\x0esource_version\x18\n \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x0b \x01(\t\x12\x1c\n\x04tags\x18\x0c \x03(\x0b\x32\x0e.mlflow.RunTag\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\"L\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"s\n\x0fListExperiments\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1aQ\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12\x1d\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x02\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x10\n\x08run_name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x06 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x16\n\x0esource_version\x18\x08 \x01(\t\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb4\x01\n\tUpdateRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9d\x01\n\tLogMetric\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\x02\x42\x04\x88\xb5\x18\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x83\x01\n\x08LogParam\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"s\n\x06GetRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\tGetMetric\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a*\n\x08Response\x12\x1e\n\x06metric\x18\x01 \x01(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x97\x01\n\x08GetParam\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nparam_name\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a,\n\x08Response\x12 \n\tparameter\x18\x01 \x01(\x0b\x32\r.mlflow.Param:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8a\x01\n\x10SearchExpression\x12\x30\n\x06metric\x18\x01 \x01(\x0b\x32\x1e.mlflow.MetricSearchExpressionH\x00\x12\x36\n\tparameter\x18\x02 \x01(\x0b\x32!.mlflow.ParameterSearchExpressionH\x00\x42\x0c\n\nexpression\"U\n\x16MetricSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05\x66loat\x18\x02 \x01(\x0b\x32\x13.mlflow.FloatClauseH\x00\x42\x08\n\x06\x63lause\"Z\n\x19ParameterSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x06string\x18\x02 \x01(\x0b\x32\x14.mlflow.StringClauseH\x00\x42\x08\n\x06\x63lause\"1\n\x0cStringClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x0b\x46loatClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02\"\xad\x01\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\x03\x12\x33\n\x11\x61nded_expressions\x18\x02 \x03(\x0b\x32\x18.mlflow.SearchExpression\x1a%\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9b\x01\n\rListArtifacts\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"f\n\x0bGetArtifact\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9e\x01\n\x10GetMetricHistory\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\xb9\r\n\rMlflowService\x12\x89\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"8\x82\xb5\x18\x34\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01\x12\x83\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"5\x82\xb5\x18\x31\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01\x12|\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"4\x82\xb5\x18\x30\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01\x12m\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"1\x82\xb5\x18-\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01\x12m\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"1\x82\xb5\x18-\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01\x12q\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"5\x82\xb5\x18\x31\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01\x12q\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"8\x82\xb5\x18\x34\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01\x12`\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"-\x82\xb5\x18)\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01\x12l\n\tgetMetric\x12\x11.mlflow.GetMetric\x1a\x1a.mlflow.GetMetric.Response\"0\x82\xb5\x18,\n(\n\x03GET\x12\x1b/preview/mlflow/metrics/get\x1a\x04\x08\x02\x10\x00\x10\x01\x12h\n\x08getParam\x12\x10.mlflow.GetParam\x1a\x19.mlflow.GetParam.Response\"/\x82\xb5\x18+\n\'\n\x03GET\x12\x1a/preview/mlflow/params/get\x1a\x04\x08\x02\x10\x00\x10\x01\x12\x9a\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"[\x82\xb5\x18W\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01\x12{\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"3\x82\xb5\x18/\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01\x12t\n\x0bgetArtifact\x12\x13.mlflow.GetArtifact\x1a\x1c.mlflow.GetArtifact.Response\"2\x82\xb5\x18.\n*\n\x03GET\x12\x1d/preview/mlflow/artifacts/get\x1a\x04\x08\x02\x10\x00\x10\x01\x12\x89\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"8\x82\xb5\x18\x34\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01\x42)\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -57,8 +57,8 @@ _SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3452,
-  serialized_end=3525,
+  serialized_start=3480,
+  serialized_end=3553,
 )
 _sym_db.RegisterEnumDescriptor(_SOURCETYPE)
 
@@ -92,8 +92,8 @@ _RUNSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3527,
-  serialized_end=3604,
+  serialized_start=3555,
+  serialized_end=3632,
 )
 _sym_db.RegisterEnumDescriptor(_RUNSTATUS)
 
@@ -127,7 +127,7 @@ _METRIC = _descriptor.Descriptor(
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='mlflow.Metric.value', index=1,
-      number=2, type=1, cpp_type=5, label=1,
+      number=2, type=2, cpp_type=6, label=1,
       has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -494,8 +494,8 @@ _CREATEEXPERIMENT_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=781,
-  serialized_end=814,
+  serialized_start=809,
+  serialized_end=842,
 )
 
 _CREATEEXPERIMENT = _descriptor.Descriptor(
@@ -512,6 +512,13 @@ _CREATEEXPERIMENT = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='artifact_location', full_name='mlflow.CreateExperiment.artifact_location', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -524,8 +531,8 @@ _CREATEEXPERIMENT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=741,
-  serialized_end=859,
+  serialized_start=742,
+  serialized_end=887,
 )
 
 
@@ -555,8 +562,8 @@ _LISTEXPERIMENTS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=880,
-  serialized_end=931,
+  serialized_start=908,
+  serialized_end=959,
 )
 
 _LISTEXPERIMENTS = _descriptor.Descriptor(
@@ -578,8 +585,8 @@ _LISTEXPERIMENTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=861,
-  serialized_end=976,
+  serialized_start=889,
+  serialized_end=1004,
 )
 
 
@@ -616,8 +623,8 @@ _GETEXPERIMENT_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1025,
-  serialized_end=1106,
+  serialized_start=1053,
+  serialized_end=1134,
 )
 
 _GETEXPERIMENT = _descriptor.Descriptor(
@@ -646,8 +653,8 @@ _GETEXPERIMENT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=979,
-  serialized_end=1151,
+  serialized_start=1007,
+  serialized_end=1179,
 )
 
 
@@ -677,8 +684,8 @@ _CREATERUN_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1387,
-  serialized_end=1423,
+  serialized_start=1415,
+  serialized_end=1451,
 )
 
 _CREATERUN = _descriptor.Descriptor(
@@ -763,8 +770,8 @@ _CREATERUN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1154,
-  serialized_end=1468,
+  serialized_start=1182,
+  serialized_end=1496,
 )
 
 
@@ -794,8 +801,8 @@ _UPDATERUN_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1561,
-  serialized_end=1606,
+  serialized_start=1589,
+  serialized_end=1634,
 )
 
 _UPDATERUN = _descriptor.Descriptor(
@@ -838,8 +845,8 @@ _UPDATERUN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1471,
-  serialized_end=1651,
+  serialized_start=1499,
+  serialized_end=1679,
 )
 
 
@@ -862,8 +869,8 @@ _LOGMETRIC_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=781,
-  serialized_end=791,
+  serialized_start=809,
+  serialized_end=819,
 )
 
 _LOGMETRIC = _descriptor.Descriptor(
@@ -889,7 +896,7 @@ _LOGMETRIC = _descriptor.Descriptor(
       serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='mlflow.LogMetric.value', index=2,
-      number=3, type=1, cpp_type=5, label=1,
+      number=3, type=2, cpp_type=6, label=1,
       has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -913,8 +920,8 @@ _LOGMETRIC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1654,
-  serialized_end=1811,
+  serialized_start=1682,
+  serialized_end=1839,
 )
 
 
@@ -937,8 +944,8 @@ _LOGPARAM_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=781,
-  serialized_end=791,
+  serialized_start=809,
+  serialized_end=819,
 )
 
 _LOGPARAM = _descriptor.Descriptor(
@@ -981,8 +988,8 @@ _LOGPARAM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1814,
-  serialized_end=1945,
+  serialized_start=1842,
+  serialized_end=1973,
 )
 
 
@@ -1012,8 +1019,8 @@ _GETRUN_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1387,
-  serialized_end=1423,
+  serialized_start=1415,
+  serialized_end=1451,
 )
 
 _GETRUN = _descriptor.Descriptor(
@@ -1042,8 +1049,8 @@ _GETRUN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1947,
-  serialized_end=2062,
+  serialized_start=1975,
+  serialized_end=2090,
 )
 
 
@@ -1073,8 +1080,8 @@ _GETMETRIC_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2128,
-  serialized_end=2170,
+  serialized_start=2156,
+  serialized_end=2198,
 )
 
 _GETMETRIC = _descriptor.Descriptor(
@@ -1110,8 +1117,8 @@ _GETMETRIC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2065,
-  serialized_end=2215,
+  serialized_start=2093,
+  serialized_end=2243,
 )
 
 
@@ -1141,8 +1148,8 @@ _GETPARAM_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2280,
-  serialized_end=2324,
+  serialized_start=2308,
+  serialized_end=2352,
 )
 
 _GETPARAM = _descriptor.Descriptor(
@@ -1178,8 +1185,8 @@ _GETPARAM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2218,
-  serialized_end=2369,
+  serialized_start=2246,
+  serialized_end=2397,
 )
 
 
@@ -1219,8 +1226,8 @@ _SEARCHEXPRESSION = _descriptor.Descriptor(
       name='expression', full_name='mlflow.SearchExpression.expression',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2372,
-  serialized_end=2510,
+  serialized_start=2400,
+  serialized_end=2538,
 )
 
 
@@ -1260,8 +1267,8 @@ _METRICSEARCHEXPRESSION = _descriptor.Descriptor(
       name='clause', full_name='mlflow.MetricSearchExpression.clause',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2512,
-  serialized_end=2597,
+  serialized_start=2540,
+  serialized_end=2625,
 )
 
 
@@ -1301,8 +1308,8 @@ _PARAMETERSEARCHEXPRESSION = _descriptor.Descriptor(
       name='clause', full_name='mlflow.ParameterSearchExpression.clause',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2599,
-  serialized_end=2689,
+  serialized_start=2627,
+  serialized_end=2717,
 )
 
 
@@ -1339,8 +1346,8 @@ _STRINGCLAUSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2691,
-  serialized_end=2740,
+  serialized_start=2719,
+  serialized_end=2768,
 )
 
 
@@ -1360,7 +1367,7 @@ _FLOATCLAUSE = _descriptor.Descriptor(
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='mlflow.FloatClause.value', index=1,
-      number=2, type=1, cpp_type=5, label=1,
+      number=2, type=2, cpp_type=6, label=1,
       has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -1377,8 +1384,8 @@ _FLOATCLAUSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2742,
-  serialized_end=2790,
+  serialized_start=2770,
+  serialized_end=2818,
 )
 
 
@@ -1408,8 +1415,8 @@ _SEARCHRUNS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2884,
-  serialized_end=2921,
+  serialized_start=2912,
+  serialized_end=2949,
 )
 
 _SEARCHRUNS = _descriptor.Descriptor(
@@ -1445,8 +1452,8 @@ _SEARCHRUNS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2793,
-  serialized_end=2966,
+  serialized_start=2821,
+  serialized_end=2994,
 )
 
 
@@ -1483,8 +1490,8 @@ _LISTARTIFACTS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3018,
-  serialized_end=3079,
+  serialized_start=3046,
+  serialized_end=3107,
 )
 
 _LISTARTIFACTS = _descriptor.Descriptor(
@@ -1520,8 +1527,8 @@ _LISTARTIFACTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2969,
-  serialized_end=3124,
+  serialized_start=2997,
+  serialized_end=3152,
 )
 
 
@@ -1565,8 +1572,8 @@ _FILEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3126,
-  serialized_end=3185,
+  serialized_start=3154,
+  serialized_end=3213,
 )
 
 
@@ -1589,8 +1596,8 @@ _GETARTIFACT_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=781,
-  serialized_end=791,
+  serialized_start=809,
+  serialized_end=819,
 )
 
 _GETARTIFACT = _descriptor.Descriptor(
@@ -1626,8 +1633,8 @@ _GETARTIFACT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3187,
-  serialized_end=3289,
+  serialized_start=3215,
+  serialized_end=3317,
 )
 
 
@@ -1657,8 +1664,8 @@ _GETMETRICHISTORY_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3362,
-  serialized_end=3405,
+  serialized_start=3390,
+  serialized_end=3433,
 )
 
 _GETMETRICHISTORY = _descriptor.Descriptor(
@@ -1694,8 +1701,8 @@ _GETMETRICHISTORY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3292,
-  serialized_end=3450,
+  serialized_start=3320,
+  serialized_end=3478,
 )
 
 _RUN.fields_by_name['info'].message_type = _RUNINFO
@@ -2122,8 +2129,8 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=3607,
-  serialized_end=5284,
+  serialized_start=3635,
+  serialized_end=5356,
   methods=[
   _descriptor.MethodDescriptor(
     name='createExperiment',
@@ -2222,7 +2229,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_SEARCHRUNS,
     output_type=_SEARCHRUNS_RESPONSE,
-    serialized_options=_b('\202\265\030,\n(\n\003GET\022\033/preview/mlflow/runs/search\032\004\010\002\020\000\020\001'),
+    serialized_options=_b('\202\265\030W\n)\n\004POST\022\033/preview/mlflow/runs/search\032\004\010\002\020\000\n(\n\003GET\022\033/preview/mlflow/runs/search\032\004\010\002\020\000\020\001'),
   ),
   _descriptor.MethodDescriptor(
     name='listArtifacts',

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -75,6 +75,7 @@ def _not_implemented():
 
 
 def _message_to_json(message):
+    # preserving_proto_field_name keeps the JSON-serialized form snake_case
     return MessageToJson(message, preserving_proto_field_name=True)
 
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -32,8 +32,8 @@ def _get_store():
     return _store
 
 
-def _get_request_message(request_message, from_get=False, flask_request=request):
-    if from_get and len(flask_request.query_string) > 0:
+def _get_request_message(request_message, flask_request=request):
+    if request.method == 'GET' and len(flask_request.query_string) > 0:
         # This is a hack to make arrays of length 1 work with the parser.
         # for example experiment_ids%5B%5D=0 should be parsed to {experiment_ids: [0]}
         # but it gets parsed to {experiment_ids: 0}
@@ -74,25 +74,30 @@ def _not_implemented():
     return response
 
 
+def _message_to_json(message):
+    return MessageToJson(message, preserving_proto_field_name=True)
+
+
 def _create_experiment():
     request_message = _get_request_message(CreateExperiment())
-    experiment_id = _get_store().create_experiment(request_message.name)
+    experiment_id = _get_store().create_experiment(request_message.name,
+                                                   request_message.artifact_location)
     response_message = CreateExperiment.Response()
     response_message.experiment_id = experiment_id
     response = Response(mimetype='application/json')
-    response.set_data(MessageToJson(response_message))
+    response.set_data(_message_to_json(response_message))
     return response
 
 
 def _get_experiment():
-    request_message = _get_request_message(GetExperiment(), from_get=True)
+    request_message = _get_request_message(GetExperiment())
     response_message = GetExperiment.Response()
     response_message.experiment.MergeFrom(_get_store().get_experiment(request_message.experiment_id)
                                           .to_proto())
     run_info_entities = _get_store().list_run_infos(request_message.experiment_id)
     response_message.runs.extend([r.to_proto() for r in run_info_entities])
     response = Response(mimetype='application/json')
-    response.set_data(MessageToJson(response_message, preserving_proto_field_name=True))
+    response.set_data(_message_to_json(response_message))
     return response
 
 
@@ -114,7 +119,7 @@ def _create_run():
     response_message = CreateRun.Response()
     response_message.run.MergeFrom(run.to_proto())
     response = Response(mimetype='application/json')
-    response.set_data(MessageToJson(response_message, preserving_proto_field_name=True))
+    response.set_data(_message_to_json(response_message))
     return response
 
 
@@ -124,7 +129,7 @@ def _update_run():
                                                 request_message.end_time)
     response_message = UpdateRun.Response(run_info=updated_info.to_proto())
     response = Response(mimetype='application/json')
-    response.set_data(MessageToJson(response_message, preserving_proto_field_name=True))
+    response.set_data(_message_to_json(response_message))
     return response
 
 
@@ -134,7 +139,7 @@ def _log_metric():
     _get_store().log_metric(request_message.run_uuid, metric)
     response_message = LogMetric.Response()
     response = Response(mimetype='application/json')
-    response.set_data(MessageToJson(response_message, preserving_proto_field_name=True))
+    response.set_data(_message_to_json(response_message))
     return response
 
 
@@ -144,32 +149,32 @@ def _log_param():
     _get_store().log_param(request_message.run_uuid, param)
     response_message = LogParam.Response()
     response = Response(mimetype='application/json')
-    response.set_data(MessageToJson(response_message, preserving_proto_field_name=True))
+    response.set_data(_message_to_json(response_message))
     return response
 
 
 def _get_run():
-    request_message = _get_request_message(GetRun(), from_get=True)
+    request_message = _get_request_message(GetRun())
     response_message = GetRun.Response()
     response_message.run.MergeFrom(_get_store().get_run(request_message.run_uuid).to_proto())
     response = Response(mimetype='application/json')
-    response.set_data(MessageToJson(response_message, preserving_proto_field_name=True))
+    response.set_data(_message_to_json(response_message))
     return response
 
 
 def _search_runs():
-    request_message = _get_request_message(SearchRuns(), from_get=True)
+    request_message = _get_request_message(SearchRuns())
     response_message = SearchRuns.Response()
     run_entities = _get_store().search_runs(request_message.experiment_ids,
                                             request_message.anded_expressions)
     response_message.runs.extend([r.to_proto() for r in run_entities])
     response = Response(mimetype='application/json')
-    response.set_data(MessageToJson(response_message, preserving_proto_field_name=True))
+    response.set_data(_message_to_json(response_message))
     return response
 
 
 def _list_artifacts():
-    request_message = _get_request_message(ListArtifacts(), from_get=True)
+    request_message = _get_request_message(ListArtifacts())
     response_message = ListArtifacts.Response()
     if request_message.HasField('path'):
         path = request_message.path
@@ -180,7 +185,7 @@ def _list_artifacts():
     response_message.files.extend([a.to_proto() for a in artifact_entities])
     response_message.root_uri = _get_artifact_repo(run).artifact_uri
     response = Response(mimetype='application/json')
-    response.set_data(MessageToJson(response_message, preserving_proto_field_name=True))
+    response.set_data(_message_to_json(response_message))
     return response
 
 
@@ -188,7 +193,7 @@ _TEXT_EXTENSIONS = ['txt', 'yaml', 'json', 'js', 'py', 'csv', 'md', 'rst', 'MLmo
 
 
 def _get_artifact():
-    request_message = _get_request_message(GetArtifact(), from_get=True)
+    request_message = _get_request_message(GetArtifact())
     run = _get_store().get_run(request_message.run_uuid)
     filename = os.path.abspath(_get_artifact_repo(run).download_artifacts(request_message.path))
     extension = os.path.splitext(filename)[-1].replace(".", "")
@@ -199,33 +204,33 @@ def _get_artifact():
 
 
 def _get_metric_history():
-    request_message = _get_request_message(GetMetricHistory(), from_get=True)
+    request_message = _get_request_message(GetMetricHistory())
     response_message = GetMetricHistory.Response()
     metric_entites = _get_store().get_metric_history(request_message.run_uuid,
                                                      request_message.metric_key)
     response_message.metrics.extend([m.to_proto() for m in metric_entites])
     response = Response(mimetype='application/json')
-    response.set_data(MessageToJson(response_message, preserving_proto_field_name=True))
+    response.set_data(_message_to_json(response_message))
     return response
 
 
 def _get_metric():
-    request_message = _get_request_message(GetMetric(), from_get=True)
+    request_message = _get_request_message(GetMetric())
     response_message = GetMetric.Response()
     metric = _get_store().get_metric(request_message.run_uuid, request_message.metric_key)
     response_message.metric.MergeFrom(metric.to_proto())
     response = Response(mimetype='application/json')
-    response.set_data(MessageToJson(response_message, preserving_proto_field_name=True))
+    response.set_data(_message_to_json(response_message))
     return response
 
 
 def _get_param():
-    request_message = _get_request_message(GetParam(), from_get=True)
+    request_message = _get_request_message(GetParam())
     response_message = GetParam.Response()
     parameter = _get_store().get_param(request_message.run_uuid, request_message.param_name)
     response_message.parameter.MergeFrom(parameter.to_proto())
     response = Response(mimetype='application/json')
-    response.set_data(MessageToJson(response_message, preserving_proto_field_name=True))
+    response.set_data(_message_to_json(response_message))
     return response
 
 
@@ -234,7 +239,7 @@ def _list_experiments():
     experiment_entities = _get_store().list_experiments()
     response_message.experiments.extend([e.to_proto() for e in experiment_entities])
     response = Response(mimetype='application/json')
-    response.set_data(MessageToJson(response_message, preserving_proto_field_name=True))
+    response.set_data(_message_to_json(response_message))
     return response
 
 

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -33,7 +33,7 @@ def _get_store():
 
 
 def _get_request_message(request_message, flask_request=request):
-    if request.method == 'GET' and len(flask_request.query_string) > 0:
+    if flask_request.method == 'GET' and len(flask_request.query_string) > 0:
         # This is a hack to make arrays of length 1 work with the parser.
         # for example experiment_ids%5B%5D=0 should be parsed to {experiment_ids: [0]}
         # but it gets parsed to {experiment_ids: 0}

--- a/mlflow/server/js/src/sdk/MlflowService.js
+++ b/mlflow/server/js/src/sdk/MlflowService.js
@@ -3,7 +3,7 @@
  *
  * @NOTE(dli) 12-21-2016
  *   This file is generated. For now, it is a snapshot of the proto services as of
- *   May 31, 2018 6:19:48 PM. We will update the generation pipeline to actually
+ *   Aug 1, 2018 3:42:41 PM. We will update the generation pipeline to actually
  *   place these generated objects in the correct location shortly.
  */
 
@@ -72,6 +72,74 @@ export class MlflowService {
   }
 
   /**
+   * @param {CreateRun} data: Immutable Record
+   * @param {function} success
+   * @param {function} error
+   * @return {Promise}
+   */
+  static createRun({ data, success, error }) {
+    return $.ajax('/ajax-api/2.0/preview/mlflow/runs/create', {
+      type: 'POST',
+      dataType: 'json',
+      data: JSON.stringify(data),
+      jsonp: false,
+      success: success,
+      error: error,
+    });
+  }
+
+  /**
+   * @param {UpdateRun} data: Immutable Record
+   * @param {function} success
+   * @param {function} error
+   * @return {Promise}
+   */
+  static updateRun({ data, success, error }) {
+    return $.ajax('/ajax-api/2.0/preview/mlflow/runs/update', {
+      type: 'POST',
+      dataType: 'json',
+      data: JSON.stringify(data),
+      jsonp: false,
+      success: success,
+      error: error,
+    });
+  }
+
+  /**
+   * @param {LogMetric} data: Immutable Record
+   * @param {function} success
+   * @param {function} error
+   * @return {Promise}
+   */
+  static logMetric({ data, success, error }) {
+    return $.ajax('/ajax-api/2.0/preview/mlflow/runs/log-metric', {
+      type: 'POST',
+      dataType: 'json',
+      data: JSON.stringify(data),
+      jsonp: false,
+      success: success,
+      error: error,
+    });
+  }
+
+  /**
+   * @param {LogParam} data: Immutable Record
+   * @param {function} success
+   * @param {function} error
+   * @return {Promise}
+   */
+  static logParam({ data, success, error }) {
+    return $.ajax('/ajax-api/2.0/preview/mlflow/runs/log-parameter', {
+      type: 'POST',
+      dataType: 'json',
+      data: JSON.stringify(data),
+      jsonp: false,
+      success: success,
+      error: error,
+    });
+  }
+
+  /**
    * @param {GetRun} data: Immutable Record
    * @param {function} success
    * @param {function} error
@@ -112,6 +180,26 @@ export class MlflowService {
   }
 
   /**
+   * @param {GetParam} data: Immutable Record
+   * @param {function} success
+   * @param {function} error
+   * @return {Promise}
+   */
+  static getParam({ data, success, error }) {
+    return $.ajax('/ajax-api/2.0/preview/mlflow/params/get', {
+      type: 'GET',
+      dataType: 'json',
+      converters: {
+        'text json': StrictJsonBigInt.parse,
+      },
+      data: data,
+      jsonp: false,
+      success: success,
+      error: error,
+    });
+  }
+
+  /**
    * @param {SearchRuns} data: Immutable Record
    * @param {function} success
    * @param {function} error
@@ -119,12 +207,9 @@ export class MlflowService {
    */
   static searchRuns({ data, success, error }) {
     return $.ajax('/ajax-api/2.0/preview/mlflow/runs/search', {
-      type: 'GET',
+      type: 'POST',
       dataType: 'json',
-      converters: {
-        'text json': StrictJsonBigInt.parse,
-      },
-      data: data,
+      data: JSON.stringify(data),
       jsonp: false,
       success: success,
       error: error,
@@ -191,4 +276,3 @@ export class MlflowService {
     });
   }
 }
-

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -24,12 +24,13 @@ class AbstractStore:
         pass
 
     @abstractmethod
-    def create_experiment(self, name):
+    def create_experiment(self, name, artifact_location):
         """
         Creates a new experiment.
         If an experiment with the given name already exists, throws exception.
 
         :param name: Desired name for an experiment
+        :param artifact_location: Base location for artifacts in runs. May be None.
         :return: experiment_id (integer) for the newly created experiment if successful, else None
         """
         pass

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -80,15 +80,15 @@ class FileStore(AbstractStore):
         self._check_root_dir()
         return [self.get_experiment(exp_id) for exp_id in list_subdirs(self.root_directory)]
 
-    def _create_experiment_with_id(self, name, experiment_id):
+    def _create_experiment_with_id(self, name, experiment_id, artifact_uri):
         self._check_root_dir()
         meta_dir = mkdir(self.root_directory, str(experiment_id))
-        artifact_uri = build_path(self.artifact_root_uri, str(experiment_id))
+        artifact_uri = artifact_uri or build_path(self.artifact_root_uri, str(experiment_id))
         experiment = Experiment(experiment_id, name, artifact_uri)
         write_yaml(meta_dir, FileStore.META_DATA_FILE_NAME, dict(experiment))
         return experiment_id
 
-    def create_experiment(self, name):
+    def create_experiment(self, name, artifact_location):
         self._check_root_dir()
         if name is None or name == "":
             raise Exception("Invalid experiment name '%s'" % name)
@@ -99,7 +99,7 @@ class FileStore(AbstractStore):
         # len(list_all(..)) would not work when experiments are deleted.
         experiments_ids = [e.experiment_id for e in self.list_experiments()]
         experiment_id = max(experiments_ids) + 1
-        return self._create_experiment_with_id(name, experiment_id)
+        return self._create_experiment_with_id(name, experiment_id, artifact_location)
 
     def _has_experiment(self, experiment_id):
         return len(find(self.root_directory, str(experiment_id), full_path=True)) > 0

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -45,7 +45,8 @@ class FileStore(AbstractStore):
         # Create default experiment if needed
         if not self._has_experiment(experiment_id=Experiment.DEFAULT_EXPERIMENT_ID):
             self._create_experiment_with_id(name="Default",
-                                            experiment_id=Experiment.DEFAULT_EXPERIMENT_ID)
+                                            experiment_id=Experiment.DEFAULT_EXPERIMENT_ID,
+                                            artifact_uri=None)
 
     def _check_root_dir(self):
         """
@@ -88,7 +89,7 @@ class FileStore(AbstractStore):
         write_yaml(meta_dir, FileStore.META_DATA_FILE_NAME, dict(experiment))
         return experiment_id
 
-    def create_experiment(self, name, artifact_location):
+    def create_experiment(self, name, artifact_location=None):
         self._check_root_dir()
         if name is None or name == "":
             raise Exception("Invalid experiment name '%s'" % name)

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -40,6 +40,7 @@ _METHOD_TO_INFO = _api_method_to_info()
 
 
 def _message_to_json(message):
+    # preserving_proto_field_name keeps the JSON-serialized form snake_case
     return MessageToJson(message, preserving_proto_field_name=True)
 
 

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -89,7 +89,7 @@ class RestStore(AbstractStore):
         return [Experiment.from_proto(experiment_proto)
                 for experiment_proto in response_proto.experiments]
 
-    def create_experiment(self, name, artifact_location):
+    def create_experiment(self, name, artifact_location=None):
         """
         Creates a new experiment.
         If an experiment with the given name already exists, throws exception.
@@ -127,7 +127,7 @@ class RestStore(AbstractStore):
     def update_run_info(self, run_uuid, run_status, end_time):
         """ Updates the metadata of the specified run. """
         req_body = _message_to_json(UpdateRun(run_uuid=run_uuid, status=run_status,
-                                           end_time=end_time))
+                                              end_time=end_time))
         response_proto = self._call_endpoint(UpdateRun, req_body)
         return RunInfo.from_proto(response_proto.run_info)
 
@@ -220,7 +220,7 @@ class RestStore(AbstractStore):
         """
         search_expressions_protos = [expr.to_proto() for expr in search_expressions]
         req_body = _message_to_json(SearchRuns(experiment_ids=experiment_ids,
-                                            search_expressions=search_expressions_protos))
+                                               search_expressions=search_expressions_protos))
         response_proto = self._call_endpoint(SearchRuns, req_body)
         return [Run.from_proto(proto_run) for proto_run in response_proto.runs]
 

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -184,13 +184,13 @@ def list_experiments():
     return _get_store().list_experiments()
 
 
-def create_experiment(experiment_name):
+def create_experiment(experiment_name, artifact_location=None):
     """
     Create an experiment with the specified name and return its ID.
     """
     if experiment_name is None or experiment_name == "":
         raise Exception("Invalid experiment name '%s'" % experiment_name)
-    return _get_store().create_experiment(experiment_name)
+    return _get_store().create_experiment(experiment_name, artifact_location)
 
 
 def _get_main_file():

--- a/tests/entities/test_metric.py
+++ b/tests/entities/test_metric.py
@@ -2,7 +2,7 @@ import time
 import unittest
 
 from mlflow.entities.metric import Metric
-from tests.helper_functions import random_str, random_int
+from tests.helper_functions import random_str
 
 
 class TestMetric(unittest.TestCase):

--- a/tests/entities/test_metric.py
+++ b/tests/entities/test_metric.py
@@ -13,7 +13,7 @@ class TestMetric(unittest.TestCase):
 
     def test_creation_and_hydration(self):
         key = random_str()
-        value = random_int()
+        value = 10000
         ts = int(time.time())
 
         metric = Metric(key, value, ts)

--- a/tests/entities/test_run_data.py
+++ b/tests/entities/test_run_data.py
@@ -24,7 +24,8 @@ class TestRunData(unittest.TestCase):
 
     @staticmethod
     def _create():
-        metrics = [Metric(random_str(10), random_int(), int(time.time() + random_int(-1e4, 1e4)))
+        metrics = [Metric(random_str(10), random_int(0, 1000),
+                          int(time.time() + random_int(-1e4, 1e4)))
                    for _ in range(100)]
         params = [Param(random_str(10), random_str(random_int(10, 35))) for _ in range(10)]  # noqa
         rd = RunData()

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -12,7 +12,7 @@ def test_get_endpoints():
 
 def test_can_parse_json():
     request = mock.MagicMock()
-    request.query_string = ""
+    request.method = "POST"
     request.get_json = mock.MagicMock()
     request.get_json.return_value = {"name": "hello"}
     msg = _get_request_message(CreateExperiment(), flask_request=request)
@@ -23,7 +23,7 @@ def test_can_parse_json():
 # so this test ensures continued compliance with such clients.
 def test_can_parse_json_string():
     request = mock.MagicMock()
-    request.query_string = ""
+    request.method = "POST"
     request.get_json = mock.MagicMock()
     request.get_json.return_value = '{"name": "hello2"}'
     msg = _get_request_message(CreateExperiment(), flask_request=request)


### PR DESCRIPTION
## What changes are proposed in this pull request?

I combined a few changes which require proto API changes into this pull request.

1. Artifact location can now be provided on experiment creation time, as part of `mlflow experiments create --artifact-location` or the REST API. This overrides the default in the REST store.
2. Added a POST endpoint for `/runs/search` to aid server/proxy implementations that have a hard time dealing with the `experiment_id[]=0` style of passing arrays through a GET request query string (such as the Databricks API frontend). The UI is changed to use this by default, but the server retains support for the GET API to retain backwards-compatibility.
3. Changed the JSON serialization used from mlflow client to server to use snake_case instead of camelCase. This is backwards- and forwards-compatible as the python protobuf deserialization pathway accepts either.