### PR TITLE
fixing GCS issue with nested directories

### DIFF
--- a/mlflow/store/gcs_artifact_repo.py
+++ b/mlflow/store/gcs_artifact_repo.py
@@ -69,7 +69,7 @@ class GCSArtifactRepository(ArtifactRepository):
 
         bkt = self.gcs.Client().get_bucket(bucket)
 
-        infos = self._list_folders(bkt, prefix)
+        infos = self._list_folders(bkt, prefix, artifact_path)
 
         results = bkt.list_blobs(prefix=prefix, delimiter="/")
         for result in results:
@@ -78,13 +78,13 @@ class GCSArtifactRepository(ArtifactRepository):
 
         return sorted(infos, key=lambda f: f.path)
 
-    def _list_folders(self, bkt, prefix):
+    def _list_folders(self, bkt, prefix, artifact_path):
         results = bkt.list_blobs(prefix=prefix, delimiter="/")
         dir_paths = set()
         for page in results.pages:
             dir_paths.update(page.prefixes)
 
-        return [FileInfo(path[len(prefix):-1], True, None)for path in dir_paths]
+        return [FileInfo(path[len(artifact_path)+1:-1], True, None)for path in dir_paths]
 
     def download_artifacts(self, artifact_path):
         with TempDir(remove_on_exit=False) as tmp:

--- a/tests/store/test_gcs_artifact_repo.py
+++ b/tests/store/test_gcs_artifact_repo.py
@@ -33,26 +33,65 @@ def test_list_artifacts_empty(gcs_mock):
     assert repo.list_artifacts() == []
 
 
-def test_list_artifacts_with_subdir(gcs_mock):
-    dest_path = "/experiment_id/run_id/"
-    repo = GCSArtifactRepository("gs://test_bucket" + dest_path, gcs_mock)
+def test_list_artifacts(gcs_mock):
+    artifact_root_path = "/experiment_id/run_id/"
+    repo = GCSArtifactRepository("gs://test_bucket" + artifact_root_path, gcs_mock)
 
     # mocked bucket/blob structure
-    # gs://test_bucket/experiment_id/run_id/model
-    #  | model.pb
-    #  | variables
+    # gs://test_bucket/experiment_id/run_id/
+    #  |- file
+    #  |- model
+    #     |- model.pb
 
     # mocking a single blob returned by bucket.list_blobs iterator
     # https://googlecloudplatform.github.io/google-cloud-python/latest/storage/buckets.html#google.cloud.storage.bucket.Bucket.list_blobs
-    dir_name = "model"
 
+    # list artifacts at artifact root level
     obj_mock = mock.Mock()
-    file_name = dir_name + "/" + 'model.pb'
-    obj_mock.configure_mock(name=dest_path + file_name, size=1)
+    file_path = 'file'
+    obj_mock.configure_mock(name=artifact_root_path + file_path, size=1)
+
+    dir_mock = mock.Mock()
+    dir_name = "model"
+    dir_mock.configure_mock(prefixes=(artifact_root_path + dir_name + "/",))
+
+    mock_results = mock.MagicMock()
+    mock_results.configure_mock(pages=[dir_mock])
+    mock_results.__iter__.return_value = [obj_mock]
+
+    gcs_mock.Client.return_value.get_bucket.return_value\
+        .list_blobs.return_value = mock_results
+
+    artifacts = repo.list_artifacts(path=None)
+
+    assert len(artifacts) == 2
+    assert artifacts[0].path == file_path
+    assert artifacts[0].is_dir is False
+    assert artifacts[0].file_size == obj_mock.size
+    assert artifacts[1].path == dir_name
+    assert artifacts[1].is_dir is True
+    assert artifacts[1].file_size is None
+
+
+def test_list_artifacts_with_subdir(gcs_mock):
+    artifact_root_path = "/experiment_id/run_id/"
+    repo = GCSArtifactRepository("gs://test_bucket" + artifact_root_path, gcs_mock)
+
+    # mocked bucket/blob structure
+    # gs://test_bucket/experiment_id/run_id/
+    #  |- model
+    #     |- model.pb
+    #     |- variables
+
+    # list artifacts at sub directory level
+    dir_name = "model"
+    obj_mock = mock.Mock()
+    file_path = dir_name + "/" + 'model.pb'
+    obj_mock.configure_mock(name=artifact_root_path + file_path, size=1)
 
     subdir_mock = mock.Mock()
     subdir_name = dir_name + "/" + 'variables'
-    subdir_mock.configure_mock(prefixes=(dest_path + subdir_name + "/",))
+    subdir_mock.configure_mock(prefixes=(artifact_root_path + subdir_name + "/",))
 
     mock_results = mock.MagicMock()
     mock_results.configure_mock(pages=[subdir_mock])
@@ -61,8 +100,9 @@ def test_list_artifacts_with_subdir(gcs_mock):
     gcs_mock.Client.return_value.get_bucket.return_value\
         .list_blobs.return_value = mock_results
 
-    artifacts = repo.list_artifacts(dir_name)
-    assert artifacts[0].path == file_name
+    artifacts = repo.list_artifacts(path=dir_name)
+    assert len(artifacts) == 2
+    assert artifacts[0].path == file_path
     assert artifacts[0].is_dir is False
     assert artifacts[0].file_size == obj_mock.size
     assert artifacts[1].path == subdir_name

--- a/tests/store/test_gcs_artifact_repo.py
+++ b/tests/store/test_gcs_artifact_repo.py
@@ -33,34 +33,41 @@ def test_list_artifacts_empty(gcs_mock):
     assert repo.list_artifacts() == []
 
 
-def test_list_artifacts(gcs_mock):
-    dest_path = "/some/path/"
+def test_list_artifacts_with_subdir(gcs_mock):
+    dest_path = "/experiment_id/run_id/"
     repo = GCSArtifactRepository("gs://test_bucket" + dest_path, gcs_mock)
+
+    # mocked bucket/blob structure
+    # gs://test_bucket/experiment_id/run_id/model
+    #  | model.pb
+    #  | variables
 
     # mocking a single blob returned by bucket.list_blobs iterator
     # https://googlecloudplatform.github.io/google-cloud-python/latest/storage/buckets.html#google.cloud.storage.bucket.Bucket.list_blobs
-    dir_mock = mock.Mock()
-    dir_name = "0_subpath"
-    dir_mock.configure_mock(prefixes=(dest_path + dir_name + "/",))
+    dir_name = "model"
 
     obj_mock = mock.Mock()
-    file_name = '1_file'
+    file_name = dir_name + "/" + 'model.pb'
     obj_mock.configure_mock(name=dest_path + file_name, size=1)
 
+    subdir_mock = mock.Mock()
+    subdir_name = dir_name + "/" + 'variables'
+    subdir_mock.configure_mock(prefixes=(dest_path + subdir_name + "/",))
+
     mock_results = mock.MagicMock()
-    mock_results.configure_mock(pages=[dir_mock])
+    mock_results.configure_mock(pages=[subdir_mock])
     mock_results.__iter__.return_value = [obj_mock]
 
     gcs_mock.Client.return_value.get_bucket.return_value\
         .list_blobs.return_value = mock_results
 
-    artifacts = repo.list_artifacts()
-    assert artifacts[0].path == dir_name
-    assert artifacts[0].is_dir is True
-    assert artifacts[0].file_size is None
-    assert artifacts[1].path == file_name
-    assert artifacts[1].is_dir is False
-    assert artifacts[1].file_size == obj_mock.size
+    artifacts = repo.list_artifacts(dir_name)
+    assert artifacts[0].path == file_name
+    assert artifacts[0].is_dir is False
+    assert artifacts[0].file_size == obj_mock.size
+    assert artifacts[1].path == subdir_name
+    assert artifacts[1].is_dir is True
+    assert artifacts[1].file_size is None
 
 
 def test_log_artifact(gcs_mock, tmpdir):


### PR DESCRIPTION
This fixes the issue (#219) when files are stored in nested directories on  GCS.
The implementation was incorrectly returning a path relative to the `prefix` instead of the `artifact_path`. This was no problem as long the files were on the root level where `prefix` == `artifact_path`.

I adapted the unit test to test cases where the files and subfolders are not stored on the root folder.