### PR TITLE
Update GitHub regex to match http(s):// URLs in addition to SSH URLs

### DIFF
--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -134,7 +134,7 @@ class RunView extends Component {
           {run.source_version ?
             <div className="run-info">
               <span className="metadata-header">Git Commit: </span>
-              <span className="metadata-info">{run.source_version.substring(0, 20)}</span>
+              <span className="metadata-info">{Utils.renderVersion(run)}</span>
             </div>
             : null
           }

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -96,7 +96,7 @@ class Utils {
       if (run.entry_point && run.entry_point !== "main") {
         res += ":" + run.entry_point;
       }
-      const GITHUB_RE = /[:@]github.com[:/]([^/.]+)\/([^/.]+)/;
+      const GITHUB_RE = /[@/]github.com[:/]([^/.\n]+)\/([^/.\n]+)/;
       const match = run.source_name.match(GITHUB_RE);
       if (match) {
         const url = "https://github.com/" + match[1] + "/" + match[2];
@@ -112,7 +112,7 @@ class Utils {
     if (run.source_version) {
       const shortVersion = run.source_version.substring(0, 6);
       if (run.source_type === "PROJECT") {
-        const GITHUB_RE = /[:@]github.com[:/]([^/.]+)\/([^/.]+)/;
+        const GITHUB_RE = /[@/]github.com[:/]([^/.\n]+)\/([^/.\n]+)/;
         const match = run.source_name.match(GITHUB_RE);
         if (match) {
           const url = "https://github.com/" + match[1] + "/" + match[2] + "/tree/" + run.source_version;

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -90,14 +90,17 @@ class Utils {
     return path.replace(/(.*[^/])\.[^/.]+$/, "$1")
   }
 
+  static getGitHubRegex() {
+    return /[@/]github.com[:/]([^/.\n]+)\/([^/.\n]+)/;
+  }
+
   static renderSource(run) {
     if (run.source_type === "PROJECT") {
       let res = Utils.dropExtension(Utils.baseName(run.source_name));
       if (run.entry_point && run.entry_point !== "main") {
         res += ":" + run.entry_point;
       }
-      const GITHUB_RE = /[@/]github.com[:/]([^/.\n]+)\/([^/.\n]+)/;
-      const match = run.source_name.match(GITHUB_RE);
+      const match = run.source_name.match(getGitHubRegex());
       if (match) {
         const url = "https://github.com/" + match[1] + "/" + match[2];
         res = <a href={url}>{res}</a>;
@@ -112,8 +115,7 @@ class Utils {
     if (run.source_version) {
       const shortVersion = run.source_version.substring(0, 6);
       if (run.source_type === "PROJECT") {
-        const GITHUB_RE = /[@/]github.com[:/]([^/.\n]+)\/([^/.\n]+)/;
-        const match = run.source_name.match(GITHUB_RE);
+        const match = run.source_name.match(getGitHubRegex());
         if (match) {
           const url = "https://github.com/" + match[1] + "/" + match[2] + "/tree/" + run.source_version;
           return <a href={url}>{shortVersion}</a>;

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -91,7 +91,7 @@ class Utils {
   }
 
   static getGitHubRegex() {
-    return /[@/]github.com[:/]([^/.\n]+)\/([^/.\n]+)/;
+    return /[@/]github.com[:/]([^/.]+)\/([^/.]+)/;
   }
 
   static renderSource(run) {
@@ -100,7 +100,7 @@ class Utils {
       if (run.entry_point && run.entry_point !== "main") {
         res += ":" + run.entry_point;
       }
-      const match = run.source_name.match(getGitHubRegex());
+      const match = run.source_name.match(Utils.getGitHubRegex());
       if (match) {
         const url = "https://github.com/" + match[1] + "/" + match[2];
         res = <a href={url}>{res}</a>;
@@ -115,7 +115,7 @@ class Utils {
     if (run.source_version) {
       const shortVersion = run.source_version.substring(0, 6);
       if (run.source_type === "PROJECT") {
-        const match = run.source_name.match(getGitHubRegex());
+        const match = run.source_name.match(Utils.getGitHubRegex());
         if (match) {
           const url = "https://github.com/" + match[1] + "/" + match[2] + "/tree/" + run.source_version;
           return <a href={url}>{shortVersion}</a>;

--- a/mlflow/server/js/src/utils/Utils.test.js
+++ b/mlflow/server/js/src/utils/Utils.test.js
@@ -81,3 +81,21 @@ test("dropExtension", () => {
   expect(Utils.dropExtension("/.foo")).toEqual("/.foo");
   expect(Utils.dropExtension(".foo/.bar/.xyz")).toEqual(".foo/.bar/.xyz");
 });
+
+test("gitHubRegexMatch", () => {
+  const gitHubRegex = Utils.getGitHubRegex();
+  const urlAndExpected = [
+    ["http://github.com/mlflow/mlflow-apps", ["/github.com/mlflow/mlflow-apps", "mlflow", "mlflow-apps"]],
+    ["https://github.com/mlflow/mlflow-apps", ["/github.com/mlflow/mlflow-apps", "mlflow", "mlflow-apps"]],
+    ["http://github.com/mlflow/mlflow-apps.git", ["/github.com/mlflow/mlflow-apps", "mlflow", "mlflow-apps"]],
+    ["https://github.com/mlflow/mlflow-apps.git", ["/github.com/mlflow/mlflow-apps", "mlflow", "mlflow-apps"]],
+    ["git@github.com:mlflow/mlflow-apps.git", ["/github.com/mlflow/mlflow-apps", "mlflow", "mlflow-apps"]],
+    ["https://some-other-site.com?q=github.com/mlflow/mlflow-apps.git", null],
+    ["ssh@some-server:mlflow/mlflow-apps.git", null],
+  ]
+  urlAndExpected.forEach(lst => {
+    const url = lst[0];
+    const match = url.match(gitHubRegex);
+    expect(match == lst[1]);
+  })
+})

--- a/mlflow/server/js/src/utils/Utils.test.js
+++ b/mlflow/server/js/src/utils/Utils.test.js
@@ -82,7 +82,7 @@ test("dropExtension", () => {
   expect(Utils.dropExtension(".foo/.bar/.xyz")).toEqual(".foo/.bar/.xyz");
 });
 
-test("gitHubRegexMatch", () => {
+test("getGitHubRegex", () => {
   const gitHubRegex = Utils.getGitHubRegex();
   const urlAndExpected = [
     ["http://github.com/mlflow/mlflow-apps", ["/github.com/mlflow/mlflow-apps", "mlflow", "mlflow-apps"]],


### PR DESCRIPTION
* Updates the regex used to identify GitHub repo URLs in the frontend to match HTTP(S) URLs, and adds a unit test verifying this behavior
* Also display a link to a specific GitHub version in the run view page