### PR TITLE
Fix bug with fetching projects from SSH URIs

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,19 @@
 def pytest_addoption(parser):
     parser.addoption('--large', action='store_true', dest="large",
                      default=False, help="Run tests decorated with 'large' annotation")
+    parser.addoption("--requires-ssh", action='store_true', dest="requires_ssh",
+                     default=False, help="Run tests decorated with 'requires_ssh' annotation. "
+                                         "These tests require keys to be configured locally "
+                                         "for SSH authentication.")
 
 
 def pytest_configure(config):
+    # Override the markexpr argument to pytest
+    # See https://docs.pytest.org/en/latest/example/markers.html for more details
+    markexpr = []
     if not config.option.large:
-        setattr(config.option, 'markexpr', 'not large')
+        markexpr.append('not large')
+    if not config.option.requires_ssh:
+        markexpr.append('not requires_ssh')
+    if len(markexpr) > 0:
+        setattr(config.option, 'markexpr', " and ".join(markexpr))

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -12,6 +12,7 @@ import tempfile
 
 from six.moves import urllib
 
+import mlflow.data
 from mlflow.projects.submitted_run import LocalSubmittedRun
 from mlflow.projects._project_spec import Project
 from mlflow.entities.run_status import RunStatus
@@ -176,13 +177,20 @@ def _get_storage_dir(storage_dir):
 
 
 def _expand_uri(uri):
-    if _GIT_URI_REGEX.match(uri):
+    if _is_git_uri(uri):
         return uri
     return os.path.abspath(uri)
 
 
-def _is_local_path(uri):
-    return urllib.parse.urlparse(uri).scheme == ''
+def _is_git_uri(uri):
+    return _GIT_URI_REGEX.match(uri) is not None
+
+
+def _should_use_temp_dir(parsed_uri):
+    """
+    Returns True if we should fetch the project at the passed-in URI into a temporary directory.
+    """
+    return _is_git_uri(parsed_uri) or mlflow.data.is_uri(parsed_uri)
 
 
 def _fetch_project(uri, force_tempdir, version=None, git_username=None, git_password=None):
@@ -193,12 +201,12 @@ def _fetch_project(uri, force_tempdir, version=None, git_username=None, git_pass
                           path of local projects (i.e. perform a no-op for local projects).
     """
     parsed_uri, subdirectory = _parse_subdirectory(uri)
-    use_temp_dst_dir = force_tempdir or not _is_local_path(uri)
-    dst_dir = tempfile.mkdtemp() if use_temp_dst_dir else urllib.parse.urlparse(uri).path
+    use_temp_dst_dir = force_tempdir or _should_use_temp_dir(uri)
+    dst_dir = tempfile.mkdtemp() if use_temp_dst_dir else parsed_uri
     if use_temp_dst_dir:
         eprint("=== Fetching project from %s into %s ===" % (uri, dst_dir))
     # Download a project to the target `dst_dir` from a Git URI or local path.
-    if _GIT_URI_REGEX.match(uri):
+    if _GIT_URI_REGEX.match(parsed_uri):
         # Use Git to clone the project
         _fetch_git_repo(parsed_uri, version, dst_dir, git_username, git_password)
     else:

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -180,6 +180,7 @@ def _expand_uri(uri):
 
 
 def _is_local_uri(uri):
+    """Returns True if the passed-in URI should be interpreted as a path on the local filesystem."""
     return not _GIT_URI_REGEX.match(uri)
 
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -12,7 +12,6 @@ import tempfile
 
 from six.moves import urllib
 
-import mlflow.data
 from mlflow.projects.submitted_run import LocalSubmittedRun
 from mlflow.projects._project_spec import Project
 from mlflow.entities.run_status import RunStatus
@@ -177,20 +176,9 @@ def _get_storage_dir(storage_dir):
 
 
 def _expand_uri(uri):
-    if _is_git_uri(uri):
+    if _GIT_URI_REGEX.match(uri):
         return uri
     return os.path.abspath(uri)
-
-
-def _is_git_uri(uri):
-    return _GIT_URI_REGEX.match(uri) is not None
-
-
-def _should_use_temp_dir(parsed_uri):
-    """
-    Returns True if we should fetch the project at the passed-in URI into a temporary directory.
-    """
-    return _is_git_uri(parsed_uri) or mlflow.data.is_uri(parsed_uri)
 
 
 def _fetch_project(uri, force_tempdir, version=None, git_username=None, git_password=None):
@@ -201,7 +189,7 @@ def _fetch_project(uri, force_tempdir, version=None, git_username=None, git_pass
                           path of local projects (i.e. perform a no-op for local projects).
     """
     parsed_uri, subdirectory = _parse_subdirectory(uri)
-    use_temp_dst_dir = force_tempdir or _should_use_temp_dir(uri)
+    use_temp_dst_dir = force_tempdir or _GIT_URI_REGEX.match(parsed_uri)
     dst_dir = tempfile.mkdtemp() if use_temp_dst_dir else parsed_uri
     if use_temp_dst_dir:
         eprint("=== Fetching project from %s into %s ===" % (uri, dst_dir))

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -64,7 +64,6 @@ def test_fetch_project(local_git_repo, local_git_repo_uri):
     for force_tempdir, uri in [(None, TEST_PROJECT_DIR), (False, TEST_PROJECT_DIR)]:
         assert mlflow.projects._fetch_project(uri=uri, force_tempdir=force_tempdir) == \
                os.path.abspath(TEST_PROJECT_DIR)
-    assert mlflow.projects._should_use_temp_dir("git@localhost:%s.git" % local_git_repo)
 
 
 def test_fetch_project_validations(local_git_repo_uri):

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -59,11 +59,12 @@ def test_fetch_project(local_git_repo, local_git_repo_uri):
     # Test that we correctly determine the dest directory to use when fetching a project.
     for force_tempdir, uri in [(True, TEST_PROJECT_DIR), (False, GIT_PROJECT_URI)]:
         dest_dir = mlflow.projects._fetch_project(uri=uri, force_tempdir=force_tempdir)
-        assert dest_dir != uri
+        assert os.path.commonprefix([dest_dir, tempfile.gettempdir()]) == tempfile.gettempdir()
         assert os.path.exists(dest_dir)
     for force_tempdir, uri in [(None, TEST_PROJECT_DIR), (False, TEST_PROJECT_DIR)]:
         assert mlflow.projects._fetch_project(uri=uri, force_tempdir=force_tempdir) == \
                os.path.abspath(TEST_PROJECT_DIR)
+    assert mlflow.projects._should_use_temp_dir("git@localhost:%s.git" % local_git_repo)
 
 
 def test_fetch_project_validations(local_git_repo_uri):

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -26,7 +26,7 @@ def test_run_git_https(tracking_uri_mock):  # pylint: disable=unused-argument
 
 @pytest.mark.large
 def test_run_git_ssh(tracking_uri_mock):  # pylint: disable=unused-argument
-    assert SSH_PROJECT_URI.startswith("https")
+    assert SSH_PROJECT_URI.startswith("git@")
     # Disable host-key checking so the test can run without prompting for approval
     with update_temp_env({"GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"}):
         invoke_cli_runner(cli.run, [SSH_PROJECT_URI, "-P", "alpha=0.5"])

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -1,7 +1,7 @@
 import pytest
 
 from mlflow import cli
-from tests.integration.utils import invoke_cli_runner, update_temp_env
+from tests.integration.utils import invoke_cli_runner
 from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_URI
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
@@ -25,9 +25,11 @@ def test_run_git_https(tracking_uri_mock):  # pylint: disable=unused-argument
 
 
 @pytest.mark.large
+@pytest.mark.requires_ssh
 def test_run_git_ssh(tracking_uri_mock):  # pylint: disable=unused-argument
+    # Note: this test requires SSH authentication to GitHub, and so is disabled in Travis, where SSH
+    # keys are unavailable. However it should be run locally whenever logic related to running
+    # Git projects is modified.
     assert SSH_PROJECT_URI.startswith("git@")
-    # Disable host-key checking so the test can run without prompting for approval
-    with update_temp_env({"GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"}):
-        invoke_cli_runner(cli.run, [SSH_PROJECT_URI, "-P", "alpha=0.5"])
-        invoke_cli_runner(cli.run, [SSH_PROJECT_URI, "-P", "alpha=0.5"])
+    invoke_cli_runner(cli.run, [SSH_PROJECT_URI, "-P", "alpha=0.5"])
+    invoke_cli_runner(cli.run, [SSH_PROJECT_URI, "-P", "alpha=0.5"])

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -19,12 +19,14 @@ def test_run_local(tracking_uri_mock):  # pylint: disable=unused-argument
 def test_run_git_https(tracking_uri_mock):  # pylint: disable=unused-argument
     # Invoke command twice to ensure we set Git state in an isolated manner (e.g. don't attempt to
     # create a git repo in the same directory twice, etc)
+    assert GIT_PROJECT_URI.startswith("https")
     invoke_cli_runner(cli.run, [GIT_PROJECT_URI, "-P", "alpha=0.5"])
     invoke_cli_runner(cli.run, [GIT_PROJECT_URI, "-P", "alpha=0.5"])
 
 
 @pytest.mark.large
 def test_run_git_ssh(tracking_uri_mock):  # pylint: disable=unused-argument
+    assert SSH_PROJECT_URI.startswith("https")
     # Disable host-key checking so the test can run without prompting for approval
     with update_temp_env({"GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"}):
         invoke_cli_runner(cli.run, [SSH_PROJECT_URI, "-P", "alpha=0.5"])

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -1,7 +1,7 @@
 import pytest
 
 from mlflow import cli
-from tests.integration.utils import invoke_cli_runner
+from tests.integration.utils import invoke_cli_runner, update_temp_env
 from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_URI
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
@@ -25,5 +25,7 @@ def test_run_git_https(tracking_uri_mock):  # pylint: disable=unused-argument
 
 @pytest.mark.large
 def test_run_git_ssh(tracking_uri_mock):  # pylint: disable=unused-argument
-    invoke_cli_runner(cli.run, [SSH_PROJECT_URI, "-P", "alpha=0.5"])
-    invoke_cli_runner(cli.run, [SSH_PROJECT_URI, "-P", "alpha=0.5"])
+    # Disable host-key checking so the test can run without prompting for approval
+    with update_temp_env({"GIT_SSH_COMMAND": "ssh -o StrictHostKeyChecking=no"}):
+        invoke_cli_runner(cli.run, [SSH_PROJECT_URI, "-P", "alpha=0.5"])
+        invoke_cli_runner(cli.run, [SSH_PROJECT_URI, "-P", "alpha=0.5"])

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -1,25 +1,29 @@
 import pytest
 
-import mlflow
 from mlflow import cli
-from mlflow.utils.file_utils import TempDir
-from tests.integration.utils import invoke_cli_runner, update_temp_env
-from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI
+from tests.integration.utils import invoke_cli_runner
+from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_URI
+from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 
 @pytest.mark.large
-def test_run_local():
-    with TempDir() as tmp:
-        with update_temp_env({mlflow.tracking._TRACKING_URI_ENV_VAR: tmp.path()}):
-            excitement_arg = 2
-            name = "friend"
-            invoke_cli_runner(cli.run, [TEST_PROJECT_DIR, "-e", "greeter", "-P",
-                                        "greeting=hi", "-P", "name=%s" % name,
-                                        "-P", "excitement=%s" % excitement_arg])
+def test_run_local(tracking_uri_mock):  # pylint: disable=unused-argument
+    excitement_arg = 2
+    name = "friend"
+    invoke_cli_runner(cli.run, [TEST_PROJECT_DIR, "-e", "greeter", "-P",
+                                "greeting=hi", "-P", "name=%s" % name,
+                                "-P", "excitement=%s" % excitement_arg])
 
 
 @pytest.mark.large
-def test_run_git():
-    with TempDir() as tmp:
-        with update_temp_env({mlflow.tracking._TRACKING_URI_ENV_VAR: tmp.path()}):
-            invoke_cli_runner(cli.run, [GIT_PROJECT_URI, "--no-conda", "-P", "alpha=0.5"])
+def test_run_git_https(tracking_uri_mock):  # pylint: disable=unused-argument
+    # Invoke command twice to ensure we set Git state in an isolated manner (e.g. don't attempt to
+    # create a git repo in the same directory twice, etc)
+    invoke_cli_runner(cli.run, [GIT_PROJECT_URI, "-P", "alpha=0.5"])
+    invoke_cli_runner(cli.run, [GIT_PROJECT_URI, "-P", "alpha=0.5"])
+
+
+@pytest.mark.large
+def test_run_git_ssh(tracking_uri_mock):  # pylint: disable=unused-argument
+    invoke_cli_runner(cli.run, [SSH_PROJECT_URI, "-P", "alpha=0.5"])
+    invoke_cli_runner(cli.run, [SSH_PROJECT_URI, "-P", "alpha=0.5"])

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -12,6 +12,7 @@ from mlflow.projects import Project
 TEST_DIR = "tests"
 TEST_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_project")
 GIT_PROJECT_URI = "https://github.com/mlflow/mlflow-example"
+SSH_PROJECT_URI = "git@github.com:mlflow/mlflow-example.git"
 
 
 def load_project():


### PR DESCRIPTION
Fixes a bug introduced in #215 where we'd fetch project URIs of the form `"git@github.com:/some/path"` into a local directory with name `"git@github.com:/some/path"` instead of into a temporary directory, and adds a regression test.