### PR TITLE
Update PATH to put conda python first (before Databricks python)

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -65,7 +65,7 @@ def _get_databricks_run_cmd(dbfs_fuse_tar_uri, run_id, entry_point, parameters):
             mlflow_run_arr.extend(["-P", "%s=%s" % (key, value)])
     mlflow_run_cmd = " ".join(mlflow_run_arr)
     shell_command = textwrap.dedent("""
-    export PATH=$PATH:$DB_HOME/python/bin:/$DB_HOME/conda/bin &&
+    export PATH=$DB_HOME/conda/bin:$DB_HOME/python/bin:$PATH &&
     mlflow --version &&
     # Make local directories in the container into which to copy/extract the tarred project
     mkdir -p {tarfile_base} {projects_base} &&


### PR DESCRIPTION
Fixes issue where Databricks Python was being used instead of conda Python in MLflow projects run on Databricks as Jobs.