### PR TITLE
Make UI experiment entry fully clickable

### DIFF
--- a/mlflow/server/js/src/components/ExperimentListView.css
+++ b/mlflow/server/js/src/components/ExperimentListView.css
@@ -5,7 +5,7 @@
 .experiment-list-container {
   overflow-y: scroll;
   overflow-x: hidden;
-  width: 236px;
+  width: 220px;
 }
 
 .active-experiment-list-item {
@@ -19,7 +19,6 @@
   white-space: nowrap;
   font-size: 16px;
   height: 40px;
-  width: 220px;
   line-height: 40px;
   padding-left: 12px;
 }

--- a/mlflow/server/js/src/components/ExperimentListView.js
+++ b/mlflow/server/js/src/components/ExperimentListView.js
@@ -41,18 +41,18 @@ class ExperimentListView extends Component {
                 className = `${className} active-experiment-list-item`
               }
               return (
-                <div
-                  className={className}
-                  key={e.getExperimentId()}
-                  title={e.getName()}
+                <Link
+                  style={{ textDecoration: 'none', color: 'unset' }}
+                  to={Routes.getExperimentPageRoute(e.getExperimentId())}
                 >
-                  <Link
-                    style={{ textDecoration: 'none', color: 'unset' }}
-                    to={Routes.getExperimentPageRoute(e.getExperimentId())}
+                  <div
+                    className={className}
+                    key={e.getExperimentId()}
+                    title={e.getName()}
                   >
                     {e.getName()}
-                  </Link>
-                </div>
+                  </div>
+                </Link>
               );
             })}
           </div>


### PR DESCRIPTION
Currently, only the experiment name is clickable in the experiment list:

<img width="274" alt="screen shot 2018-08-06 at 1 26 07 pm" src="https://user-images.githubusercontent.com/3478847/43739446-ecc8de70-997c-11e8-848a-7abb0383b850.png">

I find the UI more intuitive and easier to click if we make the entire div clickable by wrapping the `<div>` within the `<a>` tag as follows:

<img width="251" alt="screen shot 2018-08-06 at 1 27 25 pm" src="https://user-images.githubusercontent.com/3478847/43739482-1033dcca-997d-11e8-91dc-c8d27b178039.png">

This PR does not change the actual aesthetics:

<img width="1281" alt="screen shot 2018-08-06 at 1 35 18 pm" src="https://user-images.githubusercontent.com/3478847/43739634-96b8f5aa-997d-11e8-8e04-5744b629d268.png">
