### PR TITLE
Recognize "databricks" as not a local URI

### DIFF
--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -74,7 +74,7 @@ def get_tracking_uri():
 
 def is_local_uri(uri):
     scheme = urllib.parse.urlparse(uri).scheme
-    return scheme == '' or scheme == 'file'
+    return uri != 'databricks' and (scheme == '' or scheme == 'file')
 
 
 def _is_http_uri(uri):

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -171,3 +171,26 @@ def test_log_artifact():
             assert len(dir_comparison.right_only) == 0
             assert len(dir_comparison.diff_files) == 0
             assert len(dir_comparison.funny_files) == 0
+
+
+def test_uri_types():
+    assert tracking.is_local_uri("mlruns")
+    assert tracking.is_local_uri("./mlruns")
+    assert tracking.is_local_uri("file:///foo/mlruns")
+    assert not tracking.is_local_uri("https://whatever")
+    assert not tracking.is_local_uri("http://whatever")
+    assert not tracking.is_local_uri("databricks")
+    assert not tracking.is_local_uri("databricks:whatever")
+    assert not tracking.is_local_uri("databricks://whatever")
+
+    assert tracking._is_databricks_uri("databricks")
+    assert tracking._is_databricks_uri("databricks:whatever")
+    assert tracking._is_databricks_uri("databricks://whatever")
+    assert not tracking._is_databricks_uri("mlruns")
+    assert not tracking._is_databricks_uri("http://whatever")
+
+    assert tracking._is_http_uri("http://whatever")
+    assert tracking._is_http_uri("https://whatever")
+    assert not tracking._is_http_uri("file://whatever")
+    assert not tracking._is_http_uri("databricks://whatever")
+    assert not tracking._is_http_uri("mlruns")


### PR DESCRIPTION
This is needed to get project execution on Databricks to work properly with the latest code.