### PR TITLE
Update to databricks-cli 0.8.0

### DIFF
--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -28,9 +28,14 @@ def get_databricks_http_request_kwargs_or_fail(profile=None):
     :return: Dictionary with parameters that can be passed to http_request(). This will
              at least include the hostname and headers sufficient to authenticate to Databricks.
     """
-    if not profile:
-        profile = provider.DEFAULT_SECTION
-    config = provider.get_config_for_profile(profile)
+    if not hasattr(provider, 'get_config'):
+        eprint("Warning: support for databricks-cli<0.8.0 is deprecated and will be removed"
+               " in a future version.")
+        config = provider.get_config_for_profile(profile)
+    elif profile:
+        config = provider.ProfileConfigProvider(profile).get_config()
+    else:
+        config = provider.get_config()
 
     hostname = config.host
     if not hostname:

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     install_requires=[
         'awscli',
         'click>=6.7',
-        'databricks-cli',
+        'databricks-cli>=0.8.0',
         'requests>=2.17.3',
         'six>=1.10.0',
         'uuid',

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -154,8 +154,9 @@ def test_run_databricks_validations(
             mlflow.projects.run(TEST_PROJECT_DIR, mode="databricks", block=True, cluster_spec=None)
         assert db_api_req_mock.call_count == 0
         db_api_req_mock.reset_mock()
-        # Test that validations pass with a good tracking URI
+        # Test that validations pass with good tracking URIs
         databricks._before_run_validations("http://", cluster_spec_mock)
+        databricks._before_run_validations("databricks", cluster_spec_mock)
 
 
 def test_run_databricks(

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -6,9 +6,9 @@ from databricks_cli.configure.provider import DatabricksConfig
 from mlflow.utils import rest_utils
 
 
-@mock.patch('databricks_cli.configure.provider.get_config_for_profile')
-def test_databricks_params_token(get_config_for_profile):
-    get_config_for_profile.return_value = \
+@mock.patch('databricks_cli.configure.provider.get_config')
+def test_databricks_params_token(get_config):
+    get_config.return_value = \
         DatabricksConfig("host", None, None, "mytoken", insecure=False)
     params = rest_utils.get_databricks_http_request_kwargs_or_fail()
     assert params == {
@@ -18,12 +18,11 @@ def test_databricks_params_token(get_config_for_profile):
         },
         'verify': True,
     }
-    get_config_for_profile.assert_called_with("DEFAULT")
 
 
-@mock.patch('databricks_cli.configure.provider.get_config_for_profile')
-def test_databricks_params_user_password(get_config_for_profile):
-    get_config_for_profile.return_value = \
+@mock.patch('databricks_cli.configure.provider.get_config')
+def test_databricks_params_user_password(get_config):
+    get_config.return_value = \
         DatabricksConfig("host", "user", "pass", None, insecure=False)
     params = rest_utils.get_databricks_http_request_kwargs_or_fail()
     assert params == {
@@ -35,41 +34,47 @@ def test_databricks_params_user_password(get_config_for_profile):
     }
 
 
-@mock.patch('databricks_cli.configure.provider.get_config_for_profile')
-def test_databricks_params_no_verify(get_config_for_profile):
-    get_config_for_profile.return_value = \
+@mock.patch('databricks_cli.configure.provider.get_config')
+def test_databricks_params_no_verify(get_config):
+    get_config.return_value = \
         DatabricksConfig("host", "user", "pass", None, insecure=True)
     params = rest_utils.get_databricks_http_request_kwargs_or_fail()
     assert params['verify'] is False
 
 
-@mock.patch('databricks_cli.configure.provider.get_config_for_profile')
-def test_databricks_params_custom_profile(get_config_for_profile):
-    get_config_for_profile.return_value = \
+@mock.patch('databricks_cli.configure.provider.ProfileConfigProvider')
+def test_databricks_params_custom_profile(ProfileConfigProvider):
+    mock_provider = mock.MagicMock()
+    mock_provider.get_config.return_value = \
         DatabricksConfig("host", "user", "pass", None, insecure=True)
+    ProfileConfigProvider.return_value = mock_provider
     params = rest_utils.get_databricks_http_request_kwargs_or_fail("profile")
     assert params['verify'] is False
-    get_config_for_profile.assert_called_with("profile")
+    ProfileConfigProvider.assert_called_with("profile")
 
 
-@mock.patch('databricks_cli.configure.provider.get_config_for_profile')
-def test_databricks_params_throws_errors(get_config_for_profile):
+@mock.patch('databricks_cli.configure.provider.ProfileConfigProvider')
+def test_databricks_params_throws_errors(ProfileConfigProvider):
     # No hostname
-    get_config_for_profile.return_value = \
-        DatabricksConfig(None, "user", "pass", None, insecure=False)
+    mock_provider = mock.MagicMock()
+    mock_provider.get_config.return_value = \
+        DatabricksConfig(None, "user", "pass", None, insecure=True)
+    ProfileConfigProvider.return_value = mock_provider
     with pytest.raises(Exception):
         rest_utils.get_databricks_http_request_kwargs_or_fail()
 
     # No authentication
-    get_config_for_profile.return_value = \
-        DatabricksConfig("host", None, None, None, insecure=False)
+    mock_provider = mock.MagicMock()
+    mock_provider.get_config.return_value = \
+        DatabricksConfig("host", None, None, None, insecure=True)
+    ProfileConfigProvider.return_value = mock_provider
     with pytest.raises(Exception):
         rest_utils.get_databricks_http_request_kwargs_or_fail()
 
 
 @mock.patch('requests.request')
-@mock.patch('databricks_cli.configure.provider.get_config_for_profile')
-def test_databricks_http_request_integration(get_config_for_profile, request):
+@mock.patch('databricks_cli.configure.provider.get_config')
+def test_databricks_http_request_integration(get_config, request):
     """Confirms that the databricks http request params can in fact be used as an HTTP request"""
     def confirm_request_params(**kwargs):
         assert kwargs == {
@@ -86,7 +91,7 @@ def test_databricks_http_request_integration(get_config_for_profile, request):
         http_response.text = '{"OK": "woo"}'
         return http_response
     request.side_effect = confirm_request_params
-    get_config_for_profile.return_value = \
+    get_config.return_value = \
         DatabricksConfig("host", "user", "pass", None, insecure=False)
 
     response = rest_utils.databricks_api_request('clusters/list', 'PUT',


### PR DESCRIPTION
Upgrading to databricks-cli 0.8.0 allows us to use the new `ConfigProvider` interface to pull config information from environment variables or a user-supplied provider, when MLFLOW_TRACKING_URI is set to `databricks`.