### PR TITLE
Allow 'databricks' tracking uri for runs on Databricks

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -221,7 +221,7 @@ def _before_run_validations(tracking_uri, cluster_spec):
     if cluster_spec is None:
         raise ExecutionException("Cluster spec must be provided when launching MLflow project runs "
                                  "on Databricks.")
-    if tracking.is_local_uri(tracking_uri):
+    if not tracking._is_databricks_uri(tracking_uri) and tracking.is_local_uri(tracking_uri):
         raise ExecutionException(
             "When running on Databricks, the MLflow tracking URI must be set to a remote URI "
             "accessible to both the current client and code running on Databricks. Got local "

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -154,8 +154,9 @@ def test_run_databricks_validations(
             mlflow.projects.run(TEST_PROJECT_DIR, mode="databricks", block=True, cluster_spec=None)
         assert db_api_req_mock.call_count == 0
         db_api_req_mock.reset_mock()
-        # Test that validations pass with a good tracking URI
+        # Test that validations pass with good tracking URIs
         databricks._before_run_validations("http://", cluster_spec_mock)
+        databricks._before_run_validations("databricks", cluster_spec_mock)
 
 
 def test_run_databricks(


### PR DESCRIPTION
These are in fact accessible when running on Databricks! The updated unit test did not pass until the change was made.