### PR TITLE
Small tracking UI improvements

### DIFF
--- a/mlflow/server/js/src/Routes.js
+++ b/mlflow/server/js/src/Routes.js
@@ -8,13 +8,21 @@ class Routes {
     return `/experiments/${experimentId}/runs/${runUuid}`;
   }
   static runPageRoute = "/experiments/:experimentId/runs/:runUuid";
-  static getMetricPageRoute(runUuids, metricKey) {
-    return `/metric/${metricKey}?runs=${JSON.stringify(runUuids)}`;
+  static getMetricPageRoute(runUuids, metricKey, experimentId) {
+    let route = `/metric/${metricKey}?runs=${JSON.stringify(runUuids)}`;
+    if (experimentId !== undefined) {
+      route += `&experiment=${experimentId}`;
+    }
+    return route;
   }
   static metricPageRoute = "/metric/:metricKey";
 
-  static getCompareRunPageRoute(runUuids) {
-    return `/compare-runs?runs=${JSON.stringify(runUuids)}`
+  static getCompareRunPageRoute(runUuids, experimentId) {
+    let route = `/compare-runs?runs=${JSON.stringify(runUuids)}`;
+    if (experimentId !== undefined) {
+      route += `&experiment=${experimentId}`;
+    }
+    return route;
   }
   static compareRunPageRoute = "/compare-runs"
 }

--- a/mlflow/server/js/src/Routes.js
+++ b/mlflow/server/js/src/Routes.js
@@ -1,29 +1,28 @@
 class Routes {
   static rootRoute = "/";
+
   static getExperimentPageRoute(experimentId) {
     return `/experiments/${experimentId}`;
   }
+
   static experimentPageRoute = "/experiments/:experimentId";
+
   static getRunPageRoute(experimentId, runUuid) {
     return `/experiments/${experimentId}/runs/${runUuid}`;
   }
+
   static runPageRoute = "/experiments/:experimentId/runs/:runUuid";
+
   static getMetricPageRoute(runUuids, metricKey, experimentId) {
-    let route = `/metric/${metricKey}?runs=${JSON.stringify(runUuids)}`;
-    if (experimentId !== undefined) {
-      route += `&experiment=${experimentId}`;
-    }
-    return route;
+    return `/metric/${metricKey}?runs=${JSON.stringify(runUuids)}&experiment=${experimentId}`;
   }
+
   static metricPageRoute = "/metric/:metricKey";
 
   static getCompareRunPageRoute(runUuids, experimentId) {
-    let route = `/compare-runs?runs=${JSON.stringify(runUuids)}`;
-    if (experimentId !== undefined) {
-      route += `&experiment=${experimentId}`;
-    }
-    return route;
+    return `/compare-runs?runs=${JSON.stringify(runUuids)}&experiment=${experimentId}`;
   }
+
   static compareRunPageRoute = "/compare-runs"
 }
 

--- a/mlflow/server/js/src/components/App.css
+++ b/mlflow/server/js/src/components/App.css
@@ -107,6 +107,10 @@ h1 {
   color: #333;
 }
 
+h1 a, h1 a:hover, h1 a:active, h1 a:visited {
+  color: #333;
+}
+
 h2 {
   font-size: 18px;
   font-weight: normal;
@@ -148,4 +152,10 @@ table th {
   background-color: #fafafa;
   color: #888888;
   font-weight: 500;
+}
+
+.breadcrumb-chevron {
+  font-size: 75%;
+  margin-left: 10px;
+  margin-right: 8px;
 }

--- a/mlflow/server/js/src/components/BreadcrumbTitle.js
+++ b/mlflow/server/js/src/components/BreadcrumbTitle.js
@@ -1,7 +1,7 @@
-import React, {Component} from "react";
+import React, { Component } from "react";
 import PropTypes from "prop-types";
-import {Experiment} from "../sdk/MlflowMessages";
-import {Link} from 'react-router-dom';
+import { Experiment } from "../sdk/MlflowMessages";
+import { Link } from 'react-router-dom';
 import Routes from "../Routes";
 
 /**

--- a/mlflow/server/js/src/components/BreadcrumbTitle.js
+++ b/mlflow/server/js/src/components/BreadcrumbTitle.js
@@ -1,0 +1,48 @@
+import React, {Component} from "react";
+import PropTypes from "prop-types";
+import {Experiment} from "../sdk/MlflowMessages";
+import {Link} from 'react-router-dom';
+import Routes from "../Routes";
+
+/**
+ * A title component that creates a <h1> with breadcrumbs pointing to an experiment and optionally
+ * a run or a run comparison page.
+ */
+export default class BreadcrumbTitle extends Component {
+  static propTypes = {
+    experiment: PropTypes.instanceOf(Experiment).isRequired,
+    runUuids: PropTypes.arrayOf(String), // Optional because not all pages are nested under runs
+    title: PropTypes.any.isRequired,
+  };
+
+  render() {
+    const {experiment, runUuids, title} = this.props;
+    const experimentId = experiment.getExperimentId();
+    const experimentLink = (
+      <Link to={Routes.getExperimentPageRoute(experimentId)}>
+        {experiment.getName()}
+      </Link>
+    );
+    let runsLink = null;
+    if (runUuids) {
+      runsLink = (runUuids.length === 1 ?
+        <Link to={Routes.getRunPageRoute(experimentId, runUuids[0])} key="link">
+          Run {runUuids[0]}
+        </Link>
+        :
+        <Link to={Routes.getCompareRunPageRoute(runUuids, experimentId)} key="link">
+          Comparing {runUuids.length} Runs
+        </Link>
+      );
+    }
+    let chevron = <i className="fas fa-chevron-right breadcrumb-chevron" key="chevron"/>;
+    return (
+      <h1>
+        {experimentLink}
+        {chevron}
+        { runsLink ? [runsLink, chevron] : [] }
+        {title}
+      </h1>
+    );
+  }
+}

--- a/mlflow/server/js/src/components/CompareRunPage.js
+++ b/mlflow/server/js/src/components/CompareRunPage.js
@@ -2,17 +2,23 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import qs from 'qs';
 import { connect } from 'react-redux';
-import { getRunApi, getUUID } from '../Actions';
+import {getExperimentApi, getRunApi, getUUID} from '../Actions';
 import RequestStateWrapper from './RequestStateWrapper';
 import CompareRunView from './CompareRunView';
 
 class CompareRunPage extends Component {
   static propTypes = {
+    experimentId: PropTypes.number, // Optional in case we allow comparison across experiments later
     runUuids: PropTypes.arrayOf(String).isRequired,
   };
 
   componentWillMount() {
     this.requestIds = [];
+    if (this.props.experimentId !== null) {
+      const experimentRequestId = getUUID();
+      this.props.dispatch(getExperimentApi(this.props.experimentId, experimentRequestId));
+      this.requestIds.push(experimentRequestId);
+    }
     this.props.runUuids.forEach((runUuid) => {
       const requestId = getUUID();
       this.requestIds.push(requestId);
@@ -23,7 +29,7 @@ class CompareRunPage extends Component {
   render() {
     return (
       <RequestStateWrapper requestIds={this.requestIds}>
-        <CompareRunView runUuids={this.props.runUuids}/>
+        <CompareRunView runUuids={this.props.runUuids} experimentId={this.props.experimentId}/>
       </RequestStateWrapper>
     );
   }
@@ -33,7 +39,11 @@ const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps;
   const searchValues = qs.parse(location.search);
   const runUuids = JSON.parse(searchValues["?runs"]);
-  return { runUuids };
+  let experimentId = null;
+  if (searchValues.hasOwnProperty("experiment")) {
+    experimentId = parseInt(searchValues["experiment"], 10);
+  }
+  return { experimentId, runUuids };
 };
 
 export default connect(mapStateToProps)(CompareRunPage);

--- a/mlflow/server/js/src/components/CompareRunPage.js
+++ b/mlflow/server/js/src/components/CompareRunPage.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import qs from 'qs';
 import { connect } from 'react-redux';
-import {getExperimentApi, getRunApi, getUUID} from '../Actions';
+import { getExperimentApi, getRunApi, getUUID } from '../Actions';
 import RequestStateWrapper from './RequestStateWrapper';
 import CompareRunView from './CompareRunView';
 

--- a/mlflow/server/js/src/components/CompareRunPage.js
+++ b/mlflow/server/js/src/components/CompareRunPage.js
@@ -8,17 +8,15 @@ import CompareRunView from './CompareRunView';
 
 class CompareRunPage extends Component {
   static propTypes = {
-    experimentId: PropTypes.number, // Optional in case we allow comparison across experiments later
+    experimentId: PropTypes.number.isRequired,
     runUuids: PropTypes.arrayOf(String).isRequired,
   };
 
   componentWillMount() {
     this.requestIds = [];
-    if (this.props.experimentId !== null) {
-      const experimentRequestId = getUUID();
-      this.props.dispatch(getExperimentApi(this.props.experimentId, experimentRequestId));
-      this.requestIds.push(experimentRequestId);
-    }
+    const experimentRequestId = getUUID();
+    this.props.dispatch(getExperimentApi(this.props.experimentId, experimentRequestId));
+    this.requestIds.push(experimentRequestId);
     this.props.runUuids.forEach((runUuid) => {
       const requestId = getUUID();
       this.requestIds.push(requestId);
@@ -39,10 +37,7 @@ const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps;
   const searchValues = qs.parse(location.search);
   const runUuids = JSON.parse(searchValues["?runs"]);
-  let experimentId = null;
-  if (searchValues.hasOwnProperty("experiment")) {
-    experimentId = parseInt(searchValues["experiment"], 10);
-  }
+  const experimentId = parseInt(searchValues["experiment"], 10);
   return { experimentId, runUuids };
 };
 

--- a/mlflow/server/js/src/components/CompareRunScatter.css
+++ b/mlflow/server/js/src/components/CompareRunScatter.css
@@ -1,11 +1,16 @@
 .scatter-tooltip {
   width: 300px;
-  font-size: 90%;
+}
+
+.scatter-tooltip h3 {
+  font-size: 105%;
+  color: #888;
 }
 
 .scatter-tooltip h4 {
-  font-size: 110%;
-  margin: 4px 0 0 0;
+  font-size: 105%;
+  color: #888;
+  margin: 0;
 }
 
 .scatter-tooltip ul {
@@ -16,8 +21,8 @@
 .scatter-tooltip ul li {
   display: block;
   margin: 0;
-  padding: 0 0 0 16px;
-  text-indent: -13px;
+  padding: 0 0 0 0;
+  text-indent: 0;
 }
 
 .scatter-tooltip ul li .value {

--- a/mlflow/server/js/src/components/CompareRunScatter.js
+++ b/mlflow/server/js/src/components/CompareRunScatter.js
@@ -6,7 +6,16 @@ import './CompareRunView.css';
 import { RunInfo } from '../sdk/MlflowMessages';
 import Utils from '../utils/Utils';
 import { getLatestMetrics } from '../reducers/MetricReducer';
-import {ScatterChart, Scatter, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Label} from 'recharts';
+import {
+  ScatterChart,
+  Scatter,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  Label,
+} from 'recharts';
 import './CompareRunScatter.css';
 
 class CompareRunScatter extends Component {
@@ -18,6 +27,8 @@ class CompareRunScatter extends Component {
 
   constructor(props) {
     super(props);
+
+    this.renderTooltip = this.renderTooltip.bind(this);
 
     this.metricKeys = CompareRunScatter.getKeys(this.props.metricLists);
     this.paramKeys = CompareRunScatter.getKeys(this.props.paramLists);
@@ -126,15 +137,17 @@ class CompareRunScatter extends Component {
                 <YAxis type="number" dataKey='y' name='y'>
                   {this.renderAxisLabel('y')}
                 </YAxis>
-                <CartesianGrid />
-                <Tooltip 
+                <CartesianGrid/>
+                <Tooltip
                   isAnimationActive={false}
                   cursor={{strokeDasharray: '3 3'}}
-                  content={this.renderTooltip.bind(this)}/>
+                  content={this.renderTooltip}
+                />
                 <Scatter
                   data={scatterData}
-                  fill='#8884d8'
-                  isAnimationActive={false} />
+                  fill='#AE76A6'
+                  isAnimationActive={false}
+                />
               </ScatterChart>
             </ResponsiveContainer>
           </div>

--- a/mlflow/server/js/src/components/CompareRunView.css
+++ b/mlflow/server/js/src/components/CompareRunView.css
@@ -12,7 +12,7 @@
 
 .run-metadata-label {
   display: inline-block;
-  width: 500px;
+  width: 250px;
   font-size: 16px;
   color: #888;
 }
@@ -27,3 +27,4 @@
   padding-left: 8px;
   font-size: 16px;
 }
+

--- a/mlflow/server/js/src/components/CompareRunView.js
+++ b/mlflow/server/js/src/components/CompareRunView.js
@@ -149,7 +149,7 @@ class Private {
       const runUuidsWithMetric = Object.keys(mergedMetrics[metricKey]);
       const curRow = [];
       curRow.push(
-        <Link to={Routes.getMetricPageRoute(runUuidsWithMetric, metricKey, experimentId)} title="View chart">
+        <Link to={Routes.getMetricPageRoute(runUuidsWithMetric, metricKey, experimentId)} title="Plot chart">
           {metricKey}
           <i className="fas fa-chart-line" style={{paddingLeft: "6px"}}/>
         </Link>

--- a/mlflow/server/js/src/components/CompareRunView.js
+++ b/mlflow/server/js/src/components/CompareRunView.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import {getExperiment, getParams, getRunInfo} from '../reducers/Reducers';
+import { getExperiment, getParams, getRunInfo } from '../reducers/Reducers';
 import { connect } from 'react-redux';
 import './CompareRunView.css';
-import {Experiment, RunInfo} from '../sdk/MlflowMessages';
+import { Experiment, RunInfo } from '../sdk/MlflowMessages';
 import HtmlTableView from './HtmlTableView';
 import CompareRunScatter from './CompareRunScatter';
 import Routes from '../Routes';

--- a/mlflow/server/js/src/components/CompareRunView.js
+++ b/mlflow/server/js/src/components/CompareRunView.js
@@ -10,12 +10,11 @@ import Routes from '../Routes';
 import { Link } from 'react-router-dom';
 import Utils from '../utils/Utils';
 import { getLatestMetrics } from '../reducers/MetricReducer';
+import BreadcrumbTitle from "./BreadcrumbTitle";
 
 class CompareRunView extends Component {
   static propTypes = {
-    // This prop is optional in case we allow comparing runs across experiments in the future
-    experiment: PropTypes.instanceOf(Experiment),
-    // Other props are required
+    experiment: PropTypes.instanceOf(Experiment).isRequired,
     runInfos: PropTypes.arrayOf(RunInfo).isRequired,
     metricLists: PropTypes.arrayOf(Array).isRequired,
     paramLists: PropTypes.arrayOf(Array).isRequired,
@@ -41,19 +40,14 @@ class CompareRunView extends Component {
       },
     };
 
-    let experiment = this.props.experiment;
-    let experimentId = experiment ? experiment.getExperimentId() : undefined;
+    const experiment = this.props.experiment;
+    const experimentId = experiment.getExperimentId();
     return (
       <div className="CompareRunView">
-        {experiment ?
-            <h1>
-              <Link to={Routes.getExperimentPageRoute(experiment.getExperimentId())}>{experiment.getName()}</Link>
-              <i className="fas fa-chevron-right breadcrumb-chevron"></i>
-              Comparing {this.props.runInfos.length} Runs
-            </h1>
-          :
-            <h1>Comparing {this.props.runInfos.length} Runs</h1>
-        }
+        <BreadcrumbTitle
+          experiment={experiment}
+          title={"Comparing " + this.props.runInfos.length + " Runs"}
+        />
         <div className="run-metadata-container">
           <div className="run-metadata-label">Run ID:</div>
           <div className="run-metadata-row">
@@ -99,7 +93,7 @@ const mapStateToProps = (state, ownProps) => {
   const metricLists = [];
   const paramLists = [];
   const { experimentId, runUuids } = ownProps;
-  const experiment = experimentId !== null ? getExperiment(experimentId, state) : null;
+  const experiment = getExperiment(experimentId, state);
   runUuids.forEach((runUuid) => {
     runInfos.push(getRunInfo(runUuid, state));
     metricLists.push(Object.values(getLatestMetrics(runUuid, state)));
@@ -155,8 +149,9 @@ class Private {
       const runUuidsWithMetric = Object.keys(mergedMetrics[metricKey]);
       const curRow = [];
       curRow.push(
-        <Link to={Routes.getMetricPageRoute(runUuidsWithMetric, metricKey, experimentId)}>
+        <Link to={Routes.getMetricPageRoute(runUuidsWithMetric, metricKey, experimentId)} title="View chart">
           {metricKey}
+          <i className="fas fa-chart-line" style={{paddingLeft: "6px"}}/>
         </Link>
       );
       runInfos.forEach((r) => {

--- a/mlflow/server/js/src/components/ExperimentListView.css
+++ b/mlflow/server/js/src/components/ExperimentListView.css
@@ -45,4 +45,5 @@
   height: 24px;
   text-align: center;
   margin-left: 68px;
+  cursor: pointer;
 }

--- a/mlflow/server/js/src/components/ExperimentListView.js
+++ b/mlflow/server/js/src/components/ExperimentListView.js
@@ -38,7 +38,9 @@ class ExperimentListView extends Component {
         <div>
           <h1 className="experiments-header">Experiments</h1>
           <div className="collapser-container">
-            <i onClick={this.props.onClickListExperiments} className="collapser fa fa-chevron-left login-icon"/>
+            <i onClick={this.props.onClickListExperiments}
+               title="Hide experiment list"
+               className="collapser fa fa-chevron-left login-icon"/>
           </div>
           <div className="experiment-list-container" style={{ height: experimentListHeight }}>
             {this.props.experiments.map((e) => {

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -330,7 +330,8 @@ class ExperimentView extends Component {
 
   onCompare() {
     const runsSelectedList = Object.keys(this.state.runsSelected);
-    this.props.history.push(Routes.getCompareRunPageRoute(runsSelectedList));
+    this.props.history.push(Routes.getCompareRunPageRoute(
+      runsSelectedList, this.props.experiment.getExperimentId()));
   }
 
   onDownloadCsv() {
@@ -428,13 +429,13 @@ class ExperimentView extends Component {
       if (sortState.isMetric !== isMetric
         || sortState.isParam !== isParam
         || sortState.key !== key)
-        return "sortable"
+        return "sortable";
       return "sortable sorted " + (sortState.ascending?"asc":"desc");
-    }
+    };
     const getHeaderCell = (key, text) => {
       return <th key={"meta-"+key} className={"bottom-row " + sortedClassName(false, false, key)}
         onClick={() => onSortBy(false, false, key)}>{text}</th>
-    }
+    };
 
     const numParams = paramKeyList.length;
     const numMetrics = metricKeyList.length;

--- a/mlflow/server/js/src/components/HomePage.css
+++ b/mlflow/server/js/src/components/HomePage.css
@@ -32,5 +32,6 @@
   height: 24px;
   text-align: center;
   vertical-align: bottom;
+  cursor: pointer;
 }
 /* END css for when experiment list collapsed */

--- a/mlflow/server/js/src/components/HomePage.js
+++ b/mlflow/server/js/src/components/HomePage.js
@@ -56,7 +56,9 @@ class HomePage extends Component {
       return (
         <div>
           <div className="collapsed-expander-container">
-            <i onClick={this.onClickListExperiments} className="expander fa fa-chevron-right login-icon"/>
+            <i onClick={this.onClickListExperiments}
+               title="Show experiment list"
+               className="expander fa fa-chevron-right login-icon"/>
           </div>
           <div className="experiment-page-container">
             <ExperimentPage match={this.props.match}/>

--- a/mlflow/server/js/src/components/MetricPage.js
+++ b/mlflow/server/js/src/components/MetricPage.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import qs from 'qs';
-import { getMetricHistoryApi, getUUID } from '../Actions';
+import { getExperimentApi, getMetricHistoryApi, getRunApi, getUUID } from '../Actions';
 import RequestStateWrapper from './RequestStateWrapper';
 import NotFoundPage from './NotFoundPage';
 import MetricView from './MetricView';
@@ -15,6 +15,11 @@ class MetricPage extends Component {
 
   componentWillMount() {
     this.requestIds = [];
+    if (this.props.experimentId !== null) {
+      const experimentRequestId = getUUID();
+      this.props.dispatch(getExperimentApi(this.props.experimentId, experimentRequestId));
+      this.requestIds.push(experimentRequestId);
+    }
     this.props.runUuids.forEach((runUuid) => {
       const requestId = getUUID();
       this.requestIds.push(requestId);
@@ -25,7 +30,9 @@ class MetricPage extends Component {
   render() {
     let view;
     if (this.props.runUuids.length >= 1) {
-      view = <MetricView runUuids={this.props.runUuids} metricKey={this.props.metricKey}/>
+      view = <MetricView runUuids={this.props.runUuids}
+                         metricKey={this.props.metricKey}
+                         experimentId={this.props.experimentId}/>
     } else {
       view = <NotFoundPage/>
     }
@@ -41,10 +48,15 @@ const mapStateToProps = (state, ownProps) => {
   const { match, location } = ownProps;
   const searchValues = qs.parse(location.search);
   const runUuids = JSON.parse(searchValues["?runs"]);
+  let experimentId = null;
+  if (searchValues.hasOwnProperty("experiment")) {
+    experimentId = parseInt(searchValues["experiment"], 10);
+  }
   const { metricKey } = match.params;
   return {
     runUuids,
     metricKey,
+    experimentId,
   }
 };
 

--- a/mlflow/server/js/src/components/MetricPage.js
+++ b/mlflow/server/js/src/components/MetricPage.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import qs from 'qs';
-import { getExperimentApi, getMetricHistoryApi, getRunApi, getUUID } from '../Actions';
+import { getExperimentApi, getMetricHistoryApi, getUUID } from '../Actions';
 import RequestStateWrapper from './RequestStateWrapper';
 import NotFoundPage from './NotFoundPage';
 import MetricView from './MetricView';

--- a/mlflow/server/js/src/components/MetricView.css
+++ b/mlflow/server/js/src/components/MetricView.css
@@ -4,6 +4,3 @@ div.MetricView {
     max-height: 10%;
 }
 
-h1.MetricView-title {
-    padding-bottom: 16px;
-}

--- a/mlflow/server/js/src/components/MetricView.css
+++ b/mlflow/server/js/src/components/MetricView.css
@@ -3,3 +3,7 @@ div.MetricView {
     max-width: 1200px;
     max-height: 10%;
 }
+
+h1.MetricView-title {
+    padding-bottom: 16px;
+}

--- a/mlflow/server/js/src/components/MetricView.css
+++ b/mlflow/server/js/src/components/MetricView.css
@@ -4,3 +4,6 @@ div.MetricView {
     max-height: 10%;
 }
 
+div.MetricView h1 {
+    margin-bottom: 24px;
+}

--- a/mlflow/server/js/src/components/MetricView.js
+++ b/mlflow/server/js/src/components/MetricView.js
@@ -4,6 +4,11 @@ import { LineChart, BarChart, Bar, XAxis, Tooltip, CartesianGrid, Line, YAxis, R
 import { connect } from 'react-redux';
 import Utils from '../utils/Utils';
 import { getMetricsByKey } from '../reducers/MetricReducer';
+import './MetricView.css';
+import {Experiment} from "../sdk/MlflowMessages";
+import {getExperiment} from "../reducers/Reducers";
+import Routes from "../Routes";
+import {Link} from "react-router-dom";
 
 const COLORS = [
   "#993955",
@@ -16,69 +21,113 @@ const COLORS = [
 
 class MetricView extends Component {
   static propTypes = {
+    // Experiment is optional but we'll link back to an experiment if we have it
+    experiment: PropTypes.instanceOf(Experiment),
     title: PropTypes.element.isRequired,
     // Object with keys from Metric json and also
     metrics: PropTypes.arrayOf(Object).isRequired,
     runUuids: PropTypes.arrayOf(String).isRequired,
   };
 
-    render() {
-        if (this.props.metrics.length === 1) {
-            return (
-                <div className="MetricView">
-                    <h2 className="MetricView-title">{this.props.title} </h2>
-                    <ResponsiveContainer width="100%" aspect={1.55}>
-                        <BarChart
-                            data={this.props.metrics}
-                            margin={{top: 10, right: 10, left: 10, bottom: 10}}
-                        >
-                            <XAxis dataKey="index"/>
-                            <Tooltip isAnimationActive={false} labelStyle={{display: "none"}}/>
-                            <CartesianGrid strokeDasharray="3 3"/>
-                            <Legend verticalAlign="bottom"/>
-                            <YAxis/>
-                            {this.props.runUuids.map((uuid, idx) => (
-                                <Bar key={uuid}
-                                     dataKey={uuid}
-                                     isAnimationActive={false}
-                                     fill={COLORS[idx % COLORS.length]}/>
-                            ))}
-                        </BarChart>
-                    </ResponsiveContainer>
-                </div>
-            )
-        } else {
-            return (
-                <div className="MetricView">
-                    <h2 className="MetricView-title">{this.props.title} </h2>
-                    <ResponsiveContainer width="100%" aspect={1.55}>
-                        <LineChart
-                            data={Utils.convertTimestampToInt(this.props.metrics)}
-                            margin={{top: 10, right: 10, left: 10, bottom: 10}}
-                        >
-                            <XAxis dataKey="index" type="number"/>
-                            <Tooltip isAnimationActive={false} labelStyle={{display: "none"}}/>
-                            <CartesianGrid strokeDasharray="3 3"/>
-                            <Legend verticalAlign="bottom"/>
-                            <YAxis/>
-                            {this.props.runUuids.map((uuid, idx) => (
-                                <Line type="linear"
-                                      dataKey={uuid}
-                                      key={uuid}
-                                      isAnimationActive={false}
-                                      connectNulls
-                                      stroke={COLORS[idx % COLORS.length]}/>
-                            ))}
-                        </LineChart>
-                    </ResponsiveContainer>
-                </div>
-            )
-        }
+
+  getTitle() {
+    const experiment = this.props.experiment;
+    const runUuids = this.props.runUuids;
+    if (experiment) {
+      const experimentId = experiment.getExperimentId();
+      const experimentLink = (
+        <Link to={Routes.getExperimentPageRoute(experimentId)}>
+          {experiment.getName()}
+        </Link>
+      );
+      const runsLink = (runUuids.length === 1 ?
+          <Link to={Routes.getRunPageRoute(experimentId, runUuids[0])}>
+            Run {runUuids[0]}
+          </Link>
+        :
+          <Link to={Routes.getCompareRunPageRoute(runUuids, experimentId)}>
+            Comparing {runUuids.length} Runs
+          </Link>
+      );
+      return (
+        <h1 className="MetricView-title">
+          {experimentLink}
+          <i className="fas fa-chevron-right breadcrumb-chevron"></i>
+          {runsLink}
+          <i className="fas fa-chevron-right breadcrumb-chevron"></i>
+          {this.props.title}
+        </h1>
+      )
+    } else {
+      // Without an experiment ID, we can't link back to the run and compare pages;
+      // this might come up if we allow cross-run comparison and we'll have to design some
+      // other mechanism to go back in that case.
+      return (
+        <h1 className="MetricView-title">
+          {this.props.title}
+        </h1>
+      )
     }
+  }
+
+  render() {
+      if (this.props.metrics.length === 1) {
+          return (
+              <div className="MetricView">
+                  {this.getTitle()}
+                  <ResponsiveContainer width="100%" aspect={1.55}>
+                      <BarChart
+                          data={this.props.metrics}
+                          margin={{top: 10, right: 10, left: 10, bottom: 10}}
+                      >
+                          <XAxis dataKey="index"/>
+                          <Tooltip isAnimationActive={false} labelStyle={{display: "none"}}/>
+                          <CartesianGrid strokeDasharray="3 3"/>
+                          <Legend verticalAlign="bottom"/>
+                          <YAxis/>
+                          {this.props.runUuids.map((uuid, idx) => (
+                              <Bar dataKey={uuid}
+                                   key={uuid}
+                                   isAnimationActive={false}
+                                   fill={COLORS[idx % COLORS.length]}/>
+                          ))}
+                      </BarChart>
+                  </ResponsiveContainer>
+              </div>
+          )
+      } else {
+          return (
+              <div className="MetricView">
+                  {this.getTitle()}
+                  <ResponsiveContainer width="100%" aspect={1.55}>
+                      <LineChart
+                          data={Utils.convertTimestampToInt(this.props.metrics)}
+                          margin={{top: 10, right: 10, left: 10, bottom: 10}}
+                      >
+                          <XAxis dataKey="index" type="number"/>
+                          <Tooltip isAnimationActive={false} labelStyle={{display: "none"}}/>
+                          <CartesianGrid strokeDasharray="3 3"/>
+                          <Legend verticalAlign="bottom"/>
+                          <YAxis/>
+                          {this.props.runUuids.map((uuid, idx) => (
+                              <Line type="linear"
+                                    dataKey={uuid}
+                                    key={uuid}
+                                    isAnimationActive={false}
+                                    connectNulls
+                                    stroke={COLORS[idx % COLORS.length]}/>
+                          ))}
+                      </LineChart>
+                  </ResponsiveContainer>
+              </div>
+          )
+      }
+  }
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const { metricKey, runUuids } = ownProps;
+  const { metricKey, runUuids, experimentId } = ownProps;
+  const experiment = experimentId !== null ? getExperiment(experimentId, state) : null;
   let maxLength = 0;
   runUuids.forEach(runUuid => {
     maxLength = Math.max(maxLength, getMetricsByKey(runUuid, metricKey, state).length)
@@ -94,6 +143,7 @@ const mapStateToProps = (state, ownProps) => {
     }
   });
   return {
+    experiment,
     metrics,
     title: <span>{metricKey}</span>,
     runUuids: runUuids,

--- a/mlflow/server/js/src/components/MetricView.js
+++ b/mlflow/server/js/src/components/MetricView.js
@@ -5,8 +5,8 @@ import { connect } from 'react-redux';
 import Utils from '../utils/Utils';
 import { getMetricsByKey } from '../reducers/MetricReducer';
 import './MetricView.css';
-import {Experiment} from "../sdk/MlflowMessages";
-import {getExperiment} from "../reducers/Reducers";
+import { Experiment } from "../sdk/MlflowMessages";
+import { getExperiment } from "../reducers/Reducers";
 import BreadcrumbTitle from "./BreadcrumbTitle";
 
 const COLORS = [

--- a/mlflow/server/js/src/components/MetricView.js
+++ b/mlflow/server/js/src/components/MetricView.js
@@ -7,8 +7,7 @@ import { getMetricsByKey } from '../reducers/MetricReducer';
 import './MetricView.css';
 import {Experiment} from "../sdk/MlflowMessages";
 import {getExperiment} from "../reducers/Reducers";
-import Routes from "../Routes";
-import {Link} from "react-router-dom";
+import BreadcrumbTitle from "./BreadcrumbTitle";
 
 const COLORS = [
   "#993955",
@@ -21,107 +20,66 @@ const COLORS = [
 
 class MetricView extends Component {
   static propTypes = {
-    // Experiment is optional but we'll link back to an experiment if we have it
-    experiment: PropTypes.instanceOf(Experiment),
+    experiment: PropTypes.instanceOf(Experiment).isRequired,
     title: PropTypes.element.isRequired,
     // Object with keys from Metric json and also
     metrics: PropTypes.arrayOf(Object).isRequired,
     runUuids: PropTypes.arrayOf(String).isRequired,
   };
 
-
-  getTitle() {
-    const experiment = this.props.experiment;
-    const runUuids = this.props.runUuids;
-    if (experiment) {
-      const experimentId = experiment.getExperimentId();
-      const experimentLink = (
-        <Link to={Routes.getExperimentPageRoute(experimentId)}>
-          {experiment.getName()}
-        </Link>
-      );
-      const runsLink = (runUuids.length === 1 ?
-          <Link to={Routes.getRunPageRoute(experimentId, runUuids[0])}>
-            Run {runUuids[0]}
-          </Link>
-        :
-          <Link to={Routes.getCompareRunPageRoute(runUuids, experimentId)}>
-            Comparing {runUuids.length} Runs
-          </Link>
-      );
-      return (
-        <h1 className="MetricView-title">
-          {experimentLink}
-          <i className="fas fa-chevron-right breadcrumb-chevron"></i>
-          {runsLink}
-          <i className="fas fa-chevron-right breadcrumb-chevron"></i>
-          {this.props.title}
-        </h1>
-      )
-    } else {
-      // Without an experiment ID, we can't link back to the run and compare pages;
-      // this might come up if we allow cross-run comparison and we'll have to design some
-      // other mechanism to go back in that case.
-      return (
-        <h1 className="MetricView-title">
-          {this.props.title}
-        </h1>
-      )
-    }
-  }
-
   render() {
-      if (this.props.metrics.length === 1) {
-          return (
-              <div className="MetricView">
-                  {this.getTitle()}
-                  <ResponsiveContainer width="100%" aspect={1.55}>
-                      <BarChart
-                          data={this.props.metrics}
-                          margin={{top: 10, right: 10, left: 10, bottom: 10}}
-                      >
-                          <XAxis dataKey="index"/>
-                          <Tooltip isAnimationActive={false} labelStyle={{display: "none"}}/>
-                          <CartesianGrid strokeDasharray="3 3"/>
-                          <Legend verticalAlign="bottom"/>
-                          <YAxis/>
-                          {this.props.runUuids.map((uuid, idx) => (
-                              <Bar dataKey={uuid}
-                                   key={uuid}
-                                   isAnimationActive={false}
-                                   fill={COLORS[idx % COLORS.length]}/>
-                          ))}
-                      </BarChart>
-                  </ResponsiveContainer>
-              </div>
-          )
-      } else {
-          return (
-              <div className="MetricView">
-                  {this.getTitle()}
-                  <ResponsiveContainer width="100%" aspect={1.55}>
-                      <LineChart
-                          data={Utils.convertTimestampToInt(this.props.metrics)}
-                          margin={{top: 10, right: 10, left: 10, bottom: 10}}
-                      >
-                          <XAxis dataKey="index" type="number"/>
-                          <Tooltip isAnimationActive={false} labelStyle={{display: "none"}}/>
-                          <CartesianGrid strokeDasharray="3 3"/>
-                          <Legend verticalAlign="bottom"/>
-                          <YAxis/>
-                          {this.props.runUuids.map((uuid, idx) => (
-                              <Line type="linear"
-                                    dataKey={uuid}
-                                    key={uuid}
-                                    isAnimationActive={false}
-                                    connectNulls
-                                    stroke={COLORS[idx % COLORS.length]}/>
-                          ))}
-                      </LineChart>
-                  </ResponsiveContainer>
-              </div>
-          )
-      }
+    const { experiment, runUuids, title, metrics } = this.props;
+    if (metrics.length === 1) {
+      return (
+        <div className="MetricView">
+          <BreadcrumbTitle experiment={experiment} runUuids={runUuids} title={title}/>
+          <ResponsiveContainer width="100%" aspect={1.55}>
+            <BarChart
+              data={metrics}
+              margin={{top: 10, right: 10, left: 10, bottom: 10}}
+            >
+              <XAxis dataKey="index"/>
+              <Tooltip isAnimationActive={false} labelStyle={{display: "none"}}/>
+              <CartesianGrid strokeDasharray="3 3"/>
+              <Legend verticalAlign="bottom"/>
+              <YAxis/>
+              {runUuids.map((uuid, idx) => (
+                <Bar dataKey={uuid}
+                     key={uuid}
+                     isAnimationActive={false}
+                     fill={COLORS[idx % COLORS.length]}/>
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+      );
+    } else {
+      return (
+        <div className="MetricView">
+          <BreadcrumbTitle experiment={experiment} runUuids={runUuids} title={title}/>
+          <ResponsiveContainer width="100%" aspect={1.55}>
+            <LineChart
+              data={Utils.convertTimestampToInt(metrics)}
+              margin={{top: 10, right: 10, left: 10, bottom: 10}}
+            >
+              <XAxis dataKey="index" type="number"/>
+              <Tooltip isAnimationActive={false} labelStyle={{display: "none"}}/>
+              <CartesianGrid strokeDasharray="3 3"/>
+              <Legend verticalAlign="bottom"/>
+              <YAxis/>
+              {runUuids.map((uuid, idx) => (
+                <Line type="linear"
+                      dataKey={uuid}
+                      key={uuid}
+                      isAnimationActive={false}
+                      connectNulls
+                      stroke={COLORS[idx % COLORS.length]}/>
+              ))}
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      );
+    }
   }
 }
 

--- a/mlflow/server/js/src/components/RunPage.js
+++ b/mlflow/server/js/src/components/RunPage.js
@@ -10,6 +10,7 @@ class RunPage extends Component {
   static propTypes = {
     match: PropTypes.object.isRequired,
     runUuid: PropTypes.string.isRequired,
+    experimentId: PropTypes.number.isRequired,
   };
 
   state = {
@@ -34,7 +35,9 @@ class RunPage extends Component {
         >
           <RunView
             runUuid={this.props.runUuid}
-            getMetricPagePath={(key) => Routes.getMetricPageRoute([this.props.runUuid], key)}
+            getMetricPagePath={
+              (key) => Routes.getMetricPageRoute([this.props.runUuid], key, this.props.experimentId)
+            }
             experimentId={this.props.experimentId}
           />
         </RequestStateWrapper>

--- a/mlflow/server/js/src/components/RunPage.js
+++ b/mlflow/server/js/src/components/RunPage.js
@@ -48,7 +48,11 @@ class RunPage extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   const { match } = ownProps;
-  return { runUuid: match.params.runUuid, match, experimentId: match.params.experimentId };
+  return {
+    runUuid: match.params.runUuid,
+    match,
+    experimentId: parseInt(match.params.experimentId, 10)
+  };
 };
 
 export default connect(mapStateToProps)(RunPage);

--- a/mlflow/server/js/src/components/RunView.css
+++ b/mlflow/server/js/src/components/RunView.css
@@ -22,7 +22,7 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  border-bottom: solid 1px #e2e2e2;
+  padding-top: 16px;
 }
 
 .run-info {

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -241,7 +241,7 @@ const getMetricValues = (latestMetrics, getMetricPagePath) => {
   return Object.values(latestMetrics).sort().map((m) => {
     const key = m.key;
     return [
-      <Link to={getMetricPagePath(key)} title="View chart">
+      <Link to={getMetricPagePath(key)} title="Plot chart">
         {key}
         <i className="fas fa-chart-line" style={{paddingLeft: "6px"}}/>
       </Link>,

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -8,8 +8,8 @@ import { Link } from 'react-router-dom';
 import ArtifactPage from './ArtifactPage';
 import { getLatestMetrics } from '../reducers/MetricReducer';
 import { Experiment } from '../sdk/MlflowMessages';
-import Routes from '../Routes';
 import Utils from '../utils/Utils';
+import BreadcrumbTitle from "./BreadcrumbTitle";
 
 const PARAMATERS_KEY = 'parameters';
 const METRICS_KEY = 'metrics';
@@ -85,7 +85,6 @@ class RunView extends Component {
     const { run, experiment, params, tags, latestMetrics, getMetricPagePath } = this.props;
     const startTime = run.getStartTime() ? Utils.formatTimestamp(run.getStartTime()) : '(unknown)';
     const duration = run.getStartTime() && run.getEndTime() ? run.getEndTime() - run.getStartTime() : null;
-    const experimentId = experiment.getExperimentId();
     const tableStyles = {
       table: {
         width: 'auto',
@@ -115,11 +114,7 @@ class RunView extends Component {
     return (
       <div className="RunView">
         <div className="header-container">
-          <h1>
-            <Link to={Routes.getExperimentPageRoute(experimentId)}>{experiment.getName()}</Link>
-            <i className="fas fa-chevron-right breadcrumb-chevron"></i>
-            Run {run.getRunUuid()}
-          </h1>
+          <BreadcrumbTitle experiment={experiment} title={"Run " + run.getRunUuid()}/>
         </div>
         <div className="run-info-container">
           <div className="run-info">
@@ -245,7 +240,13 @@ const getTagValues = (tags) => {
 const getMetricValues = (latestMetrics, getMetricPagePath) => {
   return Object.values(latestMetrics).sort().map((m) => {
     const key = m.key;
-    return [<Link to={getMetricPagePath(key)}>{key}</Link>, Utils.formatMetric(m.value)]
+    return [
+      <Link to={getMetricPagePath(key)} title="View chart">
+        {key}
+        <i className="fas fa-chart-line" style={{paddingLeft: "6px"}}/>
+      </Link>,
+      Utils.formatMetric(m.value)
+    ]
   });
 };
 

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -115,17 +115,15 @@ class RunView extends Component {
     return (
       <div className="RunView">
         <div className="header-container">
-          <h1 className="run-uuid">Run {run.getRunUuid()}</h1>
+          <h1>
+            <Link to={Routes.getExperimentPageRoute(experimentId)}>{experiment.getName()}</Link>
+            <i className="fas fa-chevron-right breadcrumb-chevron"></i>
+            Run {run.getRunUuid()}
+          </h1>
         </div>
         <div className="run-info-container">
           <div className="run-info">
-            <span className="metadata-header">Experiment Name: </span>
-            <Link to={Routes.getExperimentPageRoute(experimentId)}>
-              <span className="metadata-info">{experiment.getName()}</span>
-            </Link>
-          </div>
-          <div className="run-info">
-            <span className="metadata-header">Start Time: </span>
+            <span className="metadata-header">Date: </span>
             <span className="metadata-info">{startTime}</span>
           </div>
           <div className="run-info">

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -159,7 +159,7 @@ class RunView extends Component {
         {runCommand ?
           <div className="RunView-info">
             <h2>Run Command</h2>
-            <textarea className="run-command text-area" readOnly={true}>{runCommand}</textarea>
+            <textarea className="run-command text-area" readOnly={true} value={runCommand}/>
           </div>
           : null
         }


### PR DESCRIPTION
This PR makes a few small fixes:

1) Got rid of NaNs shown on the Compare Runs page for run IDs that didn't have a specific metric.
2) Changed the collapse/expand button for opening the Experiments sidebar to have `cursor: pointer` so it looks like a clickable object.
3) Added a breadcrumb link back to each experiment on the Run, Compare Runs and Metrics pages (the "Default > ..." in the headings below):

![screen shot 2018-08-07 at 3 52 05 pm](https://user-images.githubusercontent.com/228859/43806814-63bbf14c-9a5a-11e8-960e-4a24eee1aefc.png)

![screen shot 2018-08-07 at 3 51 47 pm](https://user-images.githubusercontent.com/228859/43806820-66ddad70-9a5a-11e8-997a-4d39ffdb4503.png)

![screen shot 2018-08-07 at 6 52 16 pm](https://user-images.githubusercontent.com/228859/43811765-173593b4-9a73-11e8-9398-32a19dfee5ba.png)
