### PR TITLE
Use Bearer auth for authenticating with tokens

### DIFF
--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -37,7 +37,7 @@ def _dbfs_download(output_path, endpoint, http_request_kwargs):
 
 def _dbfs_is_dir(dbfs_path, http_request_kwargs):
     response = http_request(endpoint=GET_STATUS_ENDPOINT, method='GET',
-                            req_body_json={'path': dbfs_path}, **http_request_kwargs)
+                            json={'path': dbfs_path}, **http_request_kwargs)
     json_response = json.loads(response.text)
     try:
         return json_response['is_dir']

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -41,16 +41,17 @@ def get_databricks_http_request_kwargs_or_fail(profile=None):
     if not hostname:
         _fail_malformed_databricks_auth(profile)
 
-    basic_auth_str = None
+    auth_str = None
     if config.username is not None and config.password is not None:
         basic_auth_str = ("%s:%s" % (config.username, config.password)).encode("utf-8")
+        auth_str = "Basic " + base64.standard_b64encode(basic_auth_str).decode("utf-8")
     elif config.token:
-        basic_auth_str = ("token:%s" % config.token).encode("utf-8")
-    if not basic_auth_str:
+        auth_str = "Bearer %s" % config.token
+    else:
         _fail_malformed_databricks_auth(profile)
 
     headers = {
-        "Authorization": "Basic " + base64.standard_b64encode(basic_auth_str).decode("utf-8")
+        "Authorization": auth_str,
     }
 
     verify = True

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -14,7 +14,7 @@ def test_databricks_params_token(get_config):
     assert params == {
         'hostname': 'host',
         'headers': {
-            'Authorization': 'Basic dG9rZW46bXl0b2tlbg=='
+            'Authorization': 'Bearer mytoken'
         },
         'verify': True,
     }


### PR DESCRIPTION
We use Basic auth with `token:$token` when authenticating to the Databricks REST API. This doesn't work in certain situations which require `Bearer $token` auth instead -- fortunately, the latter is a strict superset of the former, so we can just switch to that.

The [Databricks CLI](https://github.com/databricks/databricks-cli/blob/7fa40457453f8b1ddfd7e2d186540a1bb8518f7a/databricks_cli/sdk/api_client.py#L79) uses this pattern as well.