### PR TITLE
Fix HtmlTableView bug that was hiding metric and param names on Run page

### DIFF
--- a/mlflow/server/js/src/components/HtmlTableView.js
+++ b/mlflow/server/js/src/components/HtmlTableView.js
@@ -30,13 +30,13 @@ class HtmlTableView extends Component {
           { this.props.values.map((vArray, index) => (
             <tr key={index} style={styles['tr']}>
               { vArray.map((v, idx) => {
-                let style;
-                if (idx === 0) {
-                  style = styles['td-first'] || styles['td'];
-                } else {
-                  style = styles['td'];
-                }
-                  return <td key={idx} style={style}>{isNaN(v) ? "" : v}</td>;
+                  let style;
+                  if (idx === 0) {
+                    style = styles['td-first'] || styles['td'];
+                  } else {
+                    style = styles['td'];
+                  }
+                  return <td key={idx} style={style}>{v}</td>;
                 }
               )}
             </tr>


### PR DESCRIPTION
The problem was assuming that HtmlTableView will only receive numbers as its contents in #256 .