### PR TITLE
Remove tox from dev-requirements and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ pip-delete-this-directory.txt
 
 # Unit test / coverage reports
 htmlcov/
-.tox/
 .coverage
 .coverage.*
 .cache
@@ -54,7 +53,6 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
-.tox
 
 # Sphinx documentation
 docs/_build/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,3 @@
-tox==2.9.1
-
 # Dev/Deployment
 sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
Followup to 6e996d719726f9c42879f4790fee65602e6c6221: remove tox from
dev-requirements since it is no longer used in development workflow