### PR TITLE
Remove direct invocations of Databricks CLI during Databricks project execution

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -57,13 +57,14 @@ def _get_databricks_run_cmd(dbfs_fuse_tar_uri, run_id, entry_point, parameters):
     container_tar_path = os.path.abspath(os.path.join(DB_TARFILE_BASE,
                                                       os.path.basename(dbfs_fuse_tar_uri)))
     project_dir = os.path.join(DB_PROJECTS_BASE, tar_hash)
-    mlflow_run_arr = list(map(shlex_quote, ["mlflow", "run", project_dir,
-                                            "--entry-point", entry_point]))
-    if run_id:
-        mlflow_run_arr.extend(["--run-id", run_id])
-    if parameters:
-        for key, value in parameters.items():
-            mlflow_run_arr.extend(["-P", "%s=%s" % (key, value)])
+    # mlflow_run_arr = list(map(shlex_quote, ["mlflow", "run", project_dir,
+    #                                         "--entry-point", entry_point]))
+    mlflow_run_arr = ["databricks", "clusters", "list"]
+    # if run_id:
+    #     mlflow_run_arr.extend(["--run-id", run_id])
+    # if parameters:
+    #     for key, value in parameters.items():
+    #         mlflow_run_arr.extend(["-P", "%s=%s" % (key, value)])
     mlflow_run_cmd = " ".join(mlflow_run_arr)
     shell_command = textwrap.dedent("""
     export PATH=$DB_HOME/conda/bin:$DB_HOME/python/bin:$PATH &&

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -87,6 +87,10 @@ def _get_databricks_run_cmd(dbfs_fuse_tar_uri, run_id, entry_point, parameters):
 
 
 def _check_databricks_auth_available():
+    """
+    Verifies that information for making API requests to Databricks is available to MLflow, raising
+    an exception if not.
+    """
     rest_utils.get_databricks_http_request_kwargs_or_fail()
 
 

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -87,13 +87,6 @@ def _get_databricks_run_cmd(dbfs_fuse_tar_uri, run_id, entry_point, parameters):
 
 
 def _check_databricks_auth_available():
-    try:
-        process.exec_cmd(["databricks", "--version"])
-    except process.ShellCommandException:
-        raise ExecutionException(
-            "Could not find Databricks CLI on PATH. Please install and configure the Databricks "
-            "CLI as described in https://github.com/databricks/databricks-cli")
-    # Verify that we can get Databricks auth
     rest_utils.get_databricks_http_request_kwargs_or_fail()
 
 

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -14,7 +14,7 @@ from mlflow.entities.source_type import SourceType
 
 from mlflow.projects import _fetch_project, _expand_uri, _project_spec
 from mlflow.projects.submitted_run import SubmittedRun
-from mlflow.utils import rest_utils, file_utils, process
+from mlflow.utils import rest_utils, file_utils
 from mlflow.utils.exception import ExecutionException
 from mlflow.utils.logging_utils import eprint
 from mlflow import tracking

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -138,7 +138,7 @@ def _upload_project_to_dbfs(project_dir, experiment_id):
             tarfile_hash = hashlib.sha256(tarred_project.read()).hexdigest()
         # TODO: Get subdirectory for experiment from the tracking server
         dbfs_fuse_uri = os.path.join("/dbfs", DBFS_EXPERIMENT_DIR_BASE, str(experiment_id),
-                                "projects-code", "%s.tar.gz" % tarfile_hash)
+                                     "projects-code", "%s.tar.gz" % tarfile_hash)
         if not _dbfs_path_exists(dbfs_fuse_uri):
             _upload_to_dbfs(temp_tar_filename, dbfs_fuse_uri)
             eprint("=== Finished uploading project to %s ===" % dbfs_fuse_uri)

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -57,14 +57,13 @@ def _get_databricks_run_cmd(dbfs_fuse_tar_uri, run_id, entry_point, parameters):
     container_tar_path = os.path.abspath(os.path.join(DB_TARFILE_BASE,
                                                       os.path.basename(dbfs_fuse_tar_uri)))
     project_dir = os.path.join(DB_PROJECTS_BASE, tar_hash)
-    # mlflow_run_arr = list(map(shlex_quote, ["mlflow", "run", project_dir,
-    #                                         "--entry-point", entry_point]))
-    mlflow_run_arr = ["databricks", "clusters", "list"]
-    # if run_id:
-    #     mlflow_run_arr.extend(["--run-id", run_id])
-    # if parameters:
-    #     for key, value in parameters.items():
-    #         mlflow_run_arr.extend(["-P", "%s=%s" % (key, value)])
+    mlflow_run_arr = list(map(shlex_quote, ["mlflow", "run", project_dir,
+                                            "--entry-point", entry_point]))
+    if run_id:
+        mlflow_run_arr.extend(["--run-id", run_id])
+    if parameters:
+        for key, value in parameters.items():
+            mlflow_run_arr.extend(["-P", "%s=%s" % (key, value)])
     mlflow_run_cmd = " ".join(mlflow_run_arr)
     shell_command = textwrap.dedent("""
     export PATH=$DB_HOME/conda/bin:$DB_HOME/python/bin:$PATH &&

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -53,7 +53,7 @@ def dbfs_root_mock(tmpdir):
 @pytest.fixture()
 def upload_to_dbfs_mock(dbfs_root_mock):
     def upload_mock_fn(src_path, dbfs_uri):
-        mock_dbfs_dst = os.path.join(dbfs_root_mock, dbfs_uri.split("dbfs:/")[1])
+        mock_dbfs_dst = os.path.join(dbfs_root_mock, dbfs_uri.split("/dbfs/")[1])
         os.makedirs(os.path.dirname(mock_dbfs_dst))
         shutil.copy(src_path, mock_dbfs_dst)
 
@@ -109,7 +109,7 @@ def test_upload_project_to_dbfs(
     dbfs_uri = databricks._upload_project_to_dbfs(
         project_dir=TEST_PROJECT_DIR, experiment_id=0)
     # Get expected tar
-    local_tar_path = os.path.join(dbfs_root_mock, dbfs_uri.split("dbfs:/")[1])
+    local_tar_path = os.path.join(dbfs_root_mock, dbfs_uri.split("/dbfs/")[1])
     expected_tar_path = str(tmpdir.join("expected.tar.gz"))
     file_utils.make_tarfile(
         output_filename=expected_tar_path, source_dir=TEST_PROJECT_DIR,


### PR DESCRIPTION
This PR removes explicit invocations of Databricks CLI (which require the CLI to be on the PATH instead of just importable by Python) in favor of making Databricks API requests. This simplifies launching projects runs on Databricks from a notebook (i.e. calling `mlflow.projects.run(mode="databricks")` from a notebook)