### PR TITLE
Make JS dev server work with non-localhost backends.

### DIFF
--- a/mlflow/server/js/config-overrides.js
+++ b/mlflow/server/js/config-overrides.js
@@ -1,0 +1,62 @@
+const url = require('url');
+const path = require('path');
+const fs = require('fs');
+
+// copied from 'react-dev-utils/WebpackDevServerUtils'
+function mayProxy(pathname) {
+  const maybePublicPath = path.resolve("public", pathname.slice(1));
+  return !fs.existsSync(maybePublicPath);
+}
+
+/**
+ * For 303's we need to rewrite the location to have host of `localhost`.
+ */
+function rewriteRedirect(proxyRes, req) {
+  if (proxyRes.headers['location'] && proxyRes.statusCode === 303) {
+    var u = url.parse(proxyRes.headers['location']);
+    u.host = req.headers['host'];
+    proxyRes.headers['location'] = u.format();
+  }
+}
+
+/**
+ * In Databricks, we send a cookie with a CSRF token and set the path of the cookie as "/mlflow".
+ * We need to rewrite the path to "/" for the dev index.html/bundle.js to use the CSRF token.
+ */
+function rewriteCookies(proxyRes) {
+  if (proxyRes.headers['set-cookie'] !== undefined) {
+    const newCookies = [];
+    proxyRes.headers['set-cookie'].forEach((c) => {
+      newCookies.push(c.replace('Path=/mlflow', 'Path=/'))
+    });
+    proxyRes.headers['set-cookie'] = newCookies;
+  }
+}
+
+module.exports = {
+  devServer: function(configFunction) {
+    return function(proxy, allowedHost) {
+      const config = configFunction(proxy, allowedHost);
+      const proxyTarget = process.env.MLFLOW_PROXY;
+      if (proxyTarget) {
+        config.hot = true;
+        config.https = true;
+        config.proxy = [{
+          context: function(pathname) {
+            return mayProxy(pathname);
+          },
+          target: proxyTarget,
+          secure: false,
+          changeOrigin: true,
+          ws: true,
+          xfwd: true,
+          onProxyRes: (proxyRes, req) => {
+            rewriteRedirect(proxyRes, req);
+            rewriteCookies(proxyRes);
+          },
+        }];
+      }
+      return config;
+    };
+  }
+}

--- a/mlflow/server/js/package-lock.json
+++ b/mlflow/server/js/package-lock.json
@@ -9010,6 +9010,16 @@
         "prop-types": "15.6.1"
       }
     },
+    "react-app-rewired": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/react-app-rewired/-/react-app-rewired-1.5.2.tgz",
+      "integrity": "sha512-/cbaFBaSYvCcj2BnolCh2Cx0J8QwFECg5RssXFPckhdzC9iEb5BKJGqt71ZTOF35gv6ebo4CPKJR4nZajzW4Sw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "dotenv": "4.0.0"
+      }
+    },
     "react-bootstrap": {
       "version": "0.32.1",
       "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.32.1.tgz",

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -28,13 +28,12 @@
     "dateformat": "3.0.3"
   },
   "scripts": {
-    "start": "react-scripts start",
-    "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
+    "start": "react-app-rewired start",
+    "build": "react-app-rewired build",
+    "test": "react-app-rewired test --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "react-scripts run lint"
   },
-  "proxy": "http://localhost:5000",
   "homepage": "static-files",
   "jest": {
     "collectCoverageFrom": [
@@ -45,5 +44,9 @@
     "coverageReporters": [
       "lcov"
     ]
+  },
+  "proxy": "http://localhost:5000",
+  "devDependencies": {
+    "react-app-rewired": "^1.5.2"
   }
 }


### PR DESCRIPTION
In my JS development, I'd like to be able to target the dev server against non-localhost servers. To do this we can set the env var, `MLFLOW_PROXY` to the host which will serve the proxied API requests. By default it is still proxied to `http://localhost:5000`.