### PR TITLE
Update quickstart & tutorial to use `mlflow/examples` as the working directory

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,6 +42,12 @@ Start it with::
 
     mlflow ui
 
+**Note:** Running ``mlflow ui`` from within a clone of MLflow is not recommended - doing so will
+run the dev UI from source (using your clone of MLflow, which may not contain the static assets
+needed to serve the UI). We recommend running the UI from a different working directory.
+Alternatively, see instructions for running the dev UI in the
+`contributor guide <CONTRIBUTING.rst>`_.
+
 
 Running a Project from a URI
 ----------------------------

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,7 @@ Running a Sample App With the Tracking API
 ------------------------------------------
 The programs in ``example`` use the MLflow Tracking API. For instance, run::
 
+
     python example/quickstart/test.py
 
 This program will use `MLflow Tracking API <https://mlflow.org/docs/latest/tracking.html>`_,
@@ -43,10 +44,9 @@ Start it with::
     mlflow ui
 
 **Note:** Running ``mlflow ui`` from within a clone of MLflow is not recommended - doing so will
-run the dev UI from source (using your clone of MLflow, which may not contain the static assets
-needed to serve the UI). We recommend running the UI from a different working directory.
-Alternatively, see instructions for running the dev UI in the
-`contributor guide <CONTRIBUTING.rst>`_.
+run the dev UI from source. We recommend running the UI from a different working directory, using the
+``--file-store`` option to specify which log directory to run against. Alternatively, see instructions
+for running the dev UI in the `contributor guide <CONTRIBUTING.rst>`_.
 
 
 Running a Project from a URI

--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,6 @@ Running a Sample App With the Tracking API
 ------------------------------------------
 The programs in ``example`` use the MLflow Tracking API. For instance, run::
 
-
     python example/quickstart/test.py
 
 This program will use `MLflow Tracking API <https://mlflow.org/docs/latest/tracking.html>`_,

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -21,10 +21,15 @@ You install MLflow by running:
 At this point we recommend you follow the :doc:`tutorial` for a walk-through on how you
 can leverage MLflow in your daily workflow.
 
-.. note::
 
-    The quickstart below should be run from within the `examples` subdirectory of a clone of MLflow
-    (clone via ``git clone https://github.com/mlflow/mlflow``).
+Downloading the Quickstart
+--------------------------
+Download the quickstart code by cloning MLflow via ``git clone https://github.com/mlflow/mlflow``,
+and cd into the ``example`` subdirectory of the repository. We'll use this working directory for
+running the quickstart.
+
+We avoid running directly from our clone of MLflow as doing so would cause the tutorial to
+use MLflow from source, rather than your PyPi installation of MLflow.
 
 
 Using the Tracking API
@@ -84,11 +89,11 @@ either a local directory or a GitHub URI:
 
 .. code:: bash
 
-    mlflow run example/tutorial -P alpha=0.5
+    mlflow run tutorial -P alpha=0.5
 
     mlflow run git@github.com:mlflow/mlflow-example.git -P alpha=5
 
-There's a sample project in ``example/tutorial``, including a ``MLproject`` file that
+There's a sample project in ``tutorial``, including a ``MLproject`` file that
 specifies its dependencies. All projects that run also log their Tracking API data in the local
 ``mlruns`` directory (or on your tracking server if you've configured one), so you should be able
 to see these runs using ``mlflow ui``.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -21,12 +21,18 @@ You install MLflow by running:
 At this point we recommend you follow the :doc:`tutorial` for a walk-through on how you
 can leverage MLflow in your daily workflow.
 
+.. note::
+
+    The quickstart below should be run from within the `examples` subdirectory of a clone of MLflow
+    (clone via ``git clone https://github.com/mlflow/mlflow``).
+
+
 Using the Tracking API
 ----------------------
 
 The :doc:`MLflow Tracking API<tracking/>` lets you log metrics and artifacts (files) from your data
 science code and see a history of your runs. You can try it out by writing a simple Python script
-as follows (this example is also included in ``example/quickstart/test.py``):
+as follows (this example is also included in ``quickstart/test.py``):
 
 .. code:: python
 
@@ -106,11 +112,11 @@ containers or commercial serving platforms.
 
 To illustrate this functionality, the ``mlflow.sklearn`` package can log scikit-learn models as
 MLflow artifacts and then load them again for serving. There is an example training application in
-``example/quickstart/test_sklearn.py`` that you can run as follows:
+``quickstart/test_sklearn.py`` that you can run as follows:
 
 .. code:: bash
 
-    python example/quickstart/test_sklearn.py
+    python quickstart/test_sklearn.py
 
 When you run the example, it outputs an MLflow run ID for that experiment. If you look at
 ``mlflow ui``, you will also see that the run saved a ``model`` folder containing an ``MLmodel``
@@ -140,7 +146,7 @@ which returns::
 
 .. note::
 
-    The ``example/quickstart/test_sklearn.py`` script must be run with the same Python version as
+    The ``quickstart/test_sklearn.py`` script must be run with the same Python version as
     the version of Python that runs ``mlflow sklearn serve``. If they are not the same version,
     the stacktrace below may appear::
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -20,12 +20,13 @@ is from UCI's `machine learning repository <http://archive.ics.uci.edu/ml/datase
 
 What You'll Need
 ----------------
-This tutorial uses MLflow, `conda <https://conda.io/docs/user-guide/install/index.html#>`_, and the tutorial code located at
-``example/tutorial`` in the MLflow repository. To download the tutorial code, run:
+To run this tutorial, you'll need to:
 
-.. code::
+ - Install MLflow (via ``pip install mlflow``)
+ - Install `conda <https://conda.io/docs/user-guide/install/index.html#>`_
+ - Download the tutorial code located at ``example/tutorial`` in the MLflow repository
+   (via ``git clone https://github.com/mlflow/mlflow``)
 
-    git clone https://github.com/mlflow/mlflow
 
 Training the Model
 ------------------

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -24,13 +24,14 @@ To run this tutorial, you'll need to:
 
  - Install MLflow (via ``pip install mlflow``)
  - Install `conda <https://conda.io/docs/user-guide/install/index.html#>`_
- - Download the tutorial code located at ``example/tutorial`` in the MLflow repository
-   (via ``git clone https://github.com/mlflow/mlflow``)
+ - Download the MLflow repository (via ``git clone https://github.com/mlflow/mlflow``)
+ - `cd` into the ``examples`` directory within your clone of MLflow - we'll use this working
+   directory for running the tutorial.
 
 
 Training the Model
 ------------------
-First, train a linear regression model that takes two hyperparameters: ``alpha`` and ``l1_ratio``. The code is located at ``example/tutorial/train.py`` and is reproduced below.
+First, train a linear regression model that takes two hyperparameters: ``alpha`` and ``l1_ratio``. The code is located at ``tutorial/train.py`` and is reproduced below.
 
 .. code:: python
 
@@ -93,18 +94,18 @@ You can run the example with default hyperparameters as follows:
 
 .. code:: bash
 
-    python example/tutorial/train.py
+    python tutorial/train.py
 
 Try out some other values for ``alpha`` and ``l1_ratio`` by passing them as arguments to ``train.py``:
 
 .. code:: bash
 
-    python example/tutorial/train.py <alpha> <l1_ratio>
+    python tutorial/train.py <alpha> <l1_ratio>
 
 Each time you run the example, MLflow logs information about your experiment runs in the directory ``mlruns``.
 
 .. note::
-    If you would like to use the Jupyter notebook version of ``train.py``, try out the tutorial notebook at ``example/tutorial/train.py/train.ipynb``.
+    If you would like to use the Jupyter notebook version of ``train.py``, try out the tutorial notebook at ``tutorial/train.py/train.ipynb``.
 
 Comparing the Models
 --------------------
@@ -125,13 +126,13 @@ you can download this table as a CSV and use your favorite data munging software
 Packaging the Training Code
 ---------------------------
 Now that you have your training code, you can package it so that other data scientists can easily reuse the model, or so that you can run the training remotely, for example on Databricks. You do this by using :doc:`projects` conventions to specify the
-dependencies and entry points to your code. The ``example/tutorial/MLproject`` file specifies that the project has the dependencies located in a
+dependencies and entry points to your code. The ``tutorial/MLproject`` file specifies that the project has the dependencies located in a
 `Conda environment file <https://conda.io/docs/user-guide/tasks/manage-environments.html#creating-an-environment-file-manually>`_
 called ``conda.yaml`` and has one entry point that takes two parameters: ``alpha`` and ``l1_ratio``.
 
 .. code:: yaml
 
-    # example/tutorial/MLproject
+    # tutorial/MLproject
 
     name: tutorial
 
@@ -149,7 +150,7 @@ The Conda file lists the dependencies:
 
 .. code:: yaml
 
-    # example/tutorial/conda.yaml
+    # tutorial/conda.yaml
 
     name: tutorial
     channels:
@@ -161,7 +162,7 @@ The Conda file lists the dependencies:
       - pip:
         - mlflow
 
-To run this project, invoke ``mlflow run example/tutorial -P alpha=0.42``. After running
+To run this project, invoke ``mlflow run tutorial -P alpha=0.42``. After running
 this command, MLflow will run your training code in a new Conda environment with the dependencies
 specified in ``conda.yaml``.
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -18,15 +18,19 @@ is from UCI's `machine learning repository <http://archive.ics.uci.edu/ml/datase
   :local:
   :depth: 1
 
+.. _what-youll-need
+
 What You'll Need
 ----------------
 To run this tutorial, you'll need to:
 
  - Install MLflow (via ``pip install mlflow``)
  - Install `conda <https://conda.io/docs/user-guide/install/index.html#>`_
- - Download the MLflow repository (via ``git clone https://github.com/mlflow/mlflow``)
+ - Clone (download) the MLflow repository via ``git clone https://github.com/mlflow/mlflow``
  - `cd` into the ``examples`` directory within your clone of MLflow - we'll use this working
-   directory for running the tutorial.
+   directory for running the tutorial. We avoid running directly from our clone of MLflow as doing
+   so would cause the tutorial to use MLflow from source, rather than your PyPi installation of
+   MLflow.
 
 
 Training the Model


### PR DESCRIPTION
Addresses some of the issues discussed in https://github.com/mlflow/mlflow/issues/108 and https://github.com/mlflow/mlflow/issues/101 (running `mlflow ui` from the root project directory inadvertently runs the dev UI) by:
* Updating tutorial & quickstart documentation to run code / the UI from within the `examples` directory
* Adding a note to the README recommending against running the UI from within a checkout of MLflow

Alternatively, we could move the quickstart & tutorial to a separate repo a la [TensorFlow](https://github.com/tensorflow/models/tree/master/samples/core/tutorials)