### PR TITLE
Fix DBFS artifactory logging binary files

### DIFF
--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -20,7 +20,7 @@ class DownloadException(Exception):
 
 def _fetch_dbfs(uri, local_path):
     print("=== Downloading DBFS file %s to local path %s ===" % (uri, os.path.abspath(local_path)))
-    process.exec_cmd(cmd=["databricks", "fs", "cp", "--overwrite", uri, local_path])
+    process.exec_cmd(cmd=["databricks", "fs", "cp", "-r", uri, local_path])
 
 
 def _fetch_s3(uri, local_path):

--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -95,7 +95,7 @@ class DbfsArtifactRepository(ArtifactRepository):
                 dir_http_endpoint = build_path(root_http_endpoint, rel_path)
             for name in filenames:
                 endpoint = build_path(dir_http_endpoint, name)
-                with open(build_path(dirpath, name), 'r') as f:
+                with open(build_path(dirpath, name), 'rb') as f:
                     http_request(endpoint=endpoint, method='POST', data=f,
                                  **self.http_request_kwargs)
 

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -222,7 +222,7 @@ class RestStore(AbstractStore):
         """
         search_expressions_protos = [expr.to_proto() for expr in search_expressions]
         req_body = _message_to_json(SearchRuns(experiment_ids=experiment_ids,
-                                               search_expressions=search_expressions_protos))
+                                               anded_expressions=search_expressions_protos))
         response_proto = self._call_endpoint(SearchRuns, req_body)
         return [Run.from_proto(proto_run) for proto_run in response_proto.runs]
 

--- a/tests/store/test_dbfs_artifact_repo.py
+++ b/tests/store/test_dbfs_artifact_repo.py
@@ -13,9 +13,9 @@ from mlflow.store.dbfs_artifact_repo import DbfsArtifactRepository
 def dbfs_artifact_repo():
     return DbfsArtifactRepository('dbfs:/test/', {})
 
-TEST_FILE_1_CONTENT = "Hello 🍆🍔"
-TEST_FILE_2_CONTENT = "World 🍆🍔🍆"
-TEST_FILE_3_CONTENT = "¡🍆🍆🍔🍆🍆!"
+TEST_FILE_1_CONTENT = bytes("Hello 🍆🍔")
+TEST_FILE_2_CONTENT = bytes("World 🍆🍔🍆")
+TEST_FILE_3_CONTENT = bytes("¡🍆🍆🍔🍆🍆!")
 
 
 @pytest.fixture()

--- a/tests/store/test_dbfs_artifact_repo.py
+++ b/tests/store/test_dbfs_artifact_repo.py
@@ -13,9 +13,9 @@ from mlflow.store.dbfs_artifact_repo import DbfsArtifactRepository
 def dbfs_artifact_repo():
     return DbfsArtifactRepository('dbfs:/test/', {})
 
-TEST_FILE_1_CONTENT = bytes("Hello 🍆🍔", "utf-8")
-TEST_FILE_2_CONTENT = bytes("World 🍆🍔🍆", "utf-8")
-TEST_FILE_3_CONTENT = bytes("¡🍆🍆🍔🍆🍆!", "utf-8")
+TEST_FILE_1_CONTENT = u"Hello 🍆🍔".encode("utf-8")
+TEST_FILE_2_CONTENT = u"World 🍆🍔🍆".encode("utf-8")
+TEST_FILE_3_CONTENT = u"¡🍆🍆🍔🍆🍆!".encode("utf-8")
 
 
 @pytest.fixture()

--- a/tests/store/test_dbfs_artifact_repo.py
+++ b/tests/store/test_dbfs_artifact_repo.py
@@ -13,9 +13,9 @@ from mlflow.store.dbfs_artifact_repo import DbfsArtifactRepository
 def dbfs_artifact_repo():
     return DbfsArtifactRepository('dbfs:/test/', {})
 
-TEST_FILE_1_CONTENT = bytes("Hello 🍆🍔")
-TEST_FILE_2_CONTENT = bytes("World 🍆🍔🍆")
-TEST_FILE_3_CONTENT = bytes("¡🍆🍆🍔🍆🍆!")
+TEST_FILE_1_CONTENT = bytes("Hello 🍆🍔", "utf-8")
+TEST_FILE_2_CONTENT = bytes("World 🍆🍔🍆", "utf-8")
+TEST_FILE_3_CONTENT = bytes("¡🍆🍆🍔🍆🍆!", "utf-8")
 
 
 @pytest.fixture()


### PR DESCRIPTION
Turns out we forgot the 'b' when opening DBFS files locally. Fixing this was trivial, but adding a test a bit less so!