### PR TITLE
Fix bug with list artifacts UI.

### DIFF
--- a/mlflow/server/js/src/components/ArtifactView.css
+++ b/mlflow/server/js/src/components/ArtifactView.css
@@ -57,3 +57,11 @@ div.artifact-view {
   padding-top: 8px;
   color: #888888;
 }
+
+.loading-spinner {
+  height: 20px;
+  opacity: 0;
+  -webkit-animation: spin 3s linear infinite;
+  -moz-animation: spin 3s linear infinite;
+  animation: spin 3s linear infinite;
+}

--- a/mlflow/server/js/src/components/ArtifactView.js
+++ b/mlflow/server/js/src/components/ArtifactView.js
@@ -11,6 +11,7 @@ import { decorators, Treebeard } from 'react-treebeard';
 import bytes from 'bytes';
 import './ArtifactView.css';
 import ShowArtifactPage from './artifact-view-components/ShowArtifactPage';
+import spinner from '../static/mlflow-spinner.png';
 
 class ArtifactView extends Component {
   constructor(props) {
@@ -248,9 +249,6 @@ const TREEBEARD_STYLE = {
         listStyle: 'none',
         paddingLeft: '19px'
       },
-      loading: {
-        color: '#81e232'
-      }
     }
   }
 };
@@ -279,6 +277,15 @@ decorators.Header = ({style, node}) => {
 
         {node.name}
       </div>
+    </div>
+  );
+};
+
+decorators.Loading = (props) => {
+  return (
+    <div style={props.style}>
+      <img className="loading-spinner" src={spinner}/>
+      {' '}loading...
     </div>
   );
 };

--- a/mlflow/server/js/src/reducers/Reducers.js
+++ b/mlflow/server/js/src/reducers/Reducers.js
@@ -206,6 +206,7 @@ const artifactsByRunUuid = (state = {}, action) => {
       let artifactNode = state[runUuid] || new ArtifactNode(true);
       // Make deep copy.
       artifactNode = artifactNode.deepCopy();
+      console.log(artifactNode);
 
       const files = action.payload.files;
       // Do not coerce these out of JSON because we use JSON.parse(JSON.stringify

--- a/mlflow/server/js/src/reducers/Reducers.js
+++ b/mlflow/server/js/src/reducers/Reducers.js
@@ -206,7 +206,6 @@ const artifactsByRunUuid = (state = {}, action) => {
       let artifactNode = state[runUuid] || new ArtifactNode(true);
       // Make deep copy.
       artifactNode = artifactNode.deepCopy();
-      console.log(artifactNode);
 
       const files = action.payload.files;
       // Do not coerce these out of JSON because we use JSON.parse(JSON.stringify

--- a/mlflow/server/js/src/utils/ArtifactUtils.js
+++ b/mlflow/server/js/src/utils/ArtifactUtils.js
@@ -2,17 +2,21 @@ export class ArtifactNode {
   constructor(isRoot, fileInfo, children) {
     this.isRoot = isRoot;
     this.isLoaded = false;
+    // fileInfo should not be defined for the root node.
     this.fileInfo = fileInfo;
     // map of basename to ArtifactNode
     this.children = children;
   }
 
   deepCopy() {
-    let node = new ArtifactNode(this.isRoot, this.fileInfo, {});
+    let node = new ArtifactNode(this.isRoot, this.fileInfo, undefined);
+    node.isLoaded = this.isLoaded;
     if (this.children) {
+      const copiedChildren = {};
       Object.keys(this.children).forEach((name) => {
-        node.children[name] = this.children[name].deepCopy();
+        copiedChildren[name] = this.children[name].deepCopy();
       });
+      node.children = copiedChildren;
     }
     return node;
   }

--- a/mlflow/server/js/src/utils/ArtifactUtils.test.js
+++ b/mlflow/server/js/src/utils/ArtifactUtils.test.js
@@ -1,0 +1,18 @@
+import { ArtifactNode } from './ArtifactUtils';
+
+const getTestArtifactNode = () => {
+  const rootNode = new ArtifactNode(true, undefined);
+  rootNode.isLoaded = true;
+  const dir1 = new ArtifactNode(false, { path: "dir1", is_dir: true });
+  const file1 = new ArtifactNode(false, { path: "file1", is_dir: false, file_size: "159" });
+  rootNode.children = { dir1, file1, };
+  return rootNode;
+};
+
+test("deepCopy works properly", () => {
+  const rootNode = getTestArtifactNode();
+  const copiedNode = rootNode.deepCopy();
+  // Checks equality of all members.
+  expect(rootNode).toEqual(copiedNode);
+  expect(rootNode).not.toBe(copiedNode);
+});


### PR DESCRIPTION
In the artifacts UI, when we listed a new directory, the `deepCopy` function on an `ArtifactNode` fails to copy the `isLoaded` property. We should copy it so the UI doesn't get confused.

Also, the old `loading...` message had a hideous green color. This PR changes it.

Before: 
![screen shot 2018-08-13 at 3 02 16 pm](https://user-images.githubusercontent.com/4492809/44063970-b8e209d8-9f17-11e8-8b8a-8fa3b00cffbd.png)
After (with some spinning):
![screen shot 2018-08-13 at 2 52 57 pm](https://user-images.githubusercontent.com/4492809/44063968-b746f98a-9f17-11e8-820b-ccd4e4f81925.png)
