### PR TITLE
rearrange package installation to ensure correct version of GitPython

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,9 @@ install:
   - source activate test-environment
   - python --version
   - pip install --upgrade pip
-  - pip install .
   - pip install -r dev-requirements.txt -q
   - pip install -r test-requirements.txt -q
+  - pip install .
   - export MLFLOW_HOME=$(pwd)
   # Remove boto config present in Travis VMs (https://github.com/travis-ci/travis-ci/issues/7940)
   - sudo rm -f /etc/boto.cfg


### PR DESCRIPTION
in `.travis.yml`, the current sequence of package installations is
```
  - pip install .
  - pip install -r dev-requirements.txt -q
  - pip install -r test-requirements.txt -q
```
mlflow requires `GitPython` greater than 2.1.0, so the 2.1.11. version was installed when `pip install .` ran. But then `pypi-publisher` package requires `GitPython` version 0.3.6. So when `pip install -r dev-requirements.txt -q` ran, the 2.1.11 version of `GitPython` was uninstalled and replaced with 0.3.6 version. Output from this pip command
```
  Found existing installation: GitPython 2.1.11
    Uninstalling GitPython-2.1.11:
      Successfully uninstalled GitPython-2.1.11
Successfully installed Pygments-2.2.0 alabaster-0.7.11 argh-0.26.2 babel-2.6.0 codecov-2.0.15 coverage-4.5.1 gitdb-0.6.4 gitpython-0.3.6 imagesize-1.0.0 livereload-2.5.2 nose-1.3.7 packaging-17.1 pathtools-0.1.2 port-for-0.3.1 pyparsing-2.2.0 pypi-publisher-0.0.4 smmap-0.9.0 snowballstemmer-1.2.1 sphinx-1.7.6 sphinx-autobuild-0.7.1 sphinx-rtd-theme-0.4.1 sphinxcontrib-websupport-1.1.0 tornado-5.1 watchdog-0.8.3
```
This causes problems when a new test from #294 uses `GitPython`.

This PR rearranges the package installation to make sure the version of `GitPython` is what mlflow requires.