### PR TITLE
Make DbfsArtifactRepo throw exceptions when artifacts are not logged correctly.

### DIFF
--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -81,7 +81,14 @@ class DbfsArtifactRepository(ArtifactRepository):
         else:
             http_endpoint = self._get_dbfs_endpoint(os.path.basename(local_file))
         with open(local_file, 'rb') as f:
-            http_request(endpoint=http_endpoint, method='POST', data=f, **self.http_request_kwargs)
+            response = http_request(endpoint=http_endpoint, method='POST', data=f,
+                                    allow_redirects=False, **self.http_request_kwargs)
+            if response.status_code == 409:
+                raise MlflowException('File already exists at {} and can\'t be overwritten.'
+                                      .format(http_endpoint))
+            elif response.status_code != 200:
+                raise MlflowException('log_artifact to "{}" returned a non-200 status code.'
+                                      .format(http_endpoint))
 
     def log_artifacts(self, local_dir, artifact_path=None):
         if artifact_path:
@@ -96,8 +103,14 @@ class DbfsArtifactRepository(ArtifactRepository):
             for name in filenames:
                 endpoint = build_path(dir_http_endpoint, name)
                 with open(build_path(dirpath, name), 'rb') as f:
-                    http_request(endpoint=endpoint, method='POST', data=f,
-                                 **self.http_request_kwargs)
+                    response = http_request(endpoint=endpoint, method='POST', data=f,
+                                            allow_redirects=False, **self.http_request_kwargs)
+                if response.status_code == 409:
+                    raise MlflowException('File already exists at {} and can\'t be overwritten.'
+                                          .format(endpoint))
+                elif response.status_code != 200:
+                    raise MlflowException('log_artifacts to "{}" returned a non-200 status code.'
+                                          .format(endpoint))
 
     def list_artifacts(self, path=None):
         if path:

--- a/tests/store/test_dbfs_artifact_repo.py
+++ b/tests/store/test_dbfs_artifact_repo.py
@@ -80,7 +80,7 @@ class TestDbfsArtifactRepository(object):
     def test_log_artifact_error(self, dbfs_artifact_repo, test_file):
         with mock.patch('mlflow.store.dbfs_artifact_repo.http_request') as http_request_mock:
             http_request_mock.return_value = Mock(status_code=409)
-            with pytest.raises(MlflowException) as e:
+            with pytest.raises(MlflowException):
                 dbfs_artifact_repo.log_artifact(test_file.strpath)
 
     @pytest.mark.parametrize("artifact_path", [
@@ -112,8 +112,8 @@ class TestDbfsArtifactRepository(object):
     def test_log_artifacts_error(self, dbfs_artifact_repo, test_dir):
         with mock.patch('mlflow.store.dbfs_artifact_repo.http_request') as http_request_mock:
             http_request_mock.return_value = Mock(status_code=409)
-            with pytest.raises(MlflowException) as e:
-                dbfs_artifact_repo.log_artifacts(test_dir)
+            with pytest.raises(MlflowException):
+                dbfs_artifact_repo.log_artifacts(test_dir.strpath)
 
     @pytest.mark.parametrize("artifact_path,expected_endpoints", [
         ('a', {'/dbfs/test/a/subdir/test.txt', '/dbfs/test/a/test.txt'}),

--- a/tests/store/test_dbfs_artifact_repo.py
+++ b/tests/store/test_dbfs_artifact_repo.py
@@ -67,6 +67,7 @@ class TestDbfsArtifactRepository(object):
             def my_http_request(**kwargs):
                 endpoints.append(kwargs['endpoint'])
                 data.append(kwargs['data'].read())
+                return Mock(status_code=200)
             http_request_mock.side_effect = my_http_request
             dbfs_artifact_repo.log_artifact(test_file.strpath, artifact_path)
             assert endpoints == [expected_endpoint]
@@ -75,6 +76,12 @@ class TestDbfsArtifactRepository(object):
     def test_log_artifact_empty(self, dbfs_artifact_repo, test_file):
         with pytest.raises(IllegalArtifactPathError):
             dbfs_artifact_repo.log_artifact(test_file.strpath, '')
+
+    def test_log_artifact_error(self, dbfs_artifact_repo, test_file):
+        with mock.patch('mlflow.store.dbfs_artifact_repo.http_request') as http_request_mock:
+            http_request_mock.return_value = Mock(status_code=409)
+            with pytest.raises(MlflowException) as e:
+                dbfs_artifact_repo.log_artifact(test_file.strpath)
 
     @pytest.mark.parametrize("artifact_path", [
         None,
@@ -89,6 +96,7 @@ class TestDbfsArtifactRepository(object):
             def my_http_request(**kwargs):
                 endpoints.append(kwargs['endpoint'])
                 data.append(kwargs['data'].read())
+                return Mock(status_code=200)
             http_request_mock.side_effect = my_http_request
             dbfs_artifact_repo.log_artifacts(test_dir.strpath, artifact_path)
             basename = test_dir.basename
@@ -100,6 +108,12 @@ class TestDbfsArtifactRepository(object):
                 TEST_FILE_2_CONTENT,
                 TEST_FILE_3_CONTENT,
             }
+
+    def test_log_artifacts_error(self, dbfs_artifact_repo, test_dir):
+        with mock.patch('mlflow.store.dbfs_artifact_repo.http_request') as http_request_mock:
+            http_request_mock.return_value = Mock(status_code=409)
+            with pytest.raises(MlflowException) as e:
+                dbfs_artifact_repo.log_artifacts(test_dir)
 
     @pytest.mark.parametrize("artifact_path,expected_endpoints", [
         ('a', {'/dbfs/test/a/subdir/test.txt', '/dbfs/test/a/test.txt'}),
@@ -113,6 +127,7 @@ class TestDbfsArtifactRepository(object):
 
             def my_http_request(**kwargs):
                 endpoints.append(kwargs['endpoint'])
+                return Mock(status_code=200)
             http_request_mock.side_effect = my_http_request
             dbfs_artifact_repo.log_artifacts(test_dir.strpath, artifact_path)
             assert set(endpoints) == expected_endpoints


### PR DESCRIPTION
See above, previously we silently continue when a user's log_artifact call fails with a bad HTTP status code.

We must make sure we don't allow_redirects because otherwise a POST to `/dbfs` can possibly redirect to the login page if the DBFS streaming upload feature is not enabled.