### PR TITLE
fix for unknown uid on untar package when running on azure databricks

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -74,7 +74,7 @@ def _get_databricks_run_cmd(dbfs_fuse_tar_uri, run_id, entry_point, parameters):
     # Extract project into a temporary directory. We don't extract directly into the desired
     # directory as tar extraction isn't guaranteed to be atomic
     cd $(mktemp -d) &&
-    tar -xzvf {container_tar_path} &&
+    tar --no-same-owner -xzvf {container_tar_path} &&
     # Atomically move the extracted project into the desired directory
     mv -T {tarfile_archive_name} {work_dir} &&
     {mlflow_run}


### PR DESCRIPTION
When starting a run on an azure databricks cluster, the un-tarring the uploaded package would use the uid/gid from the files. Added `--no-same-owner` to prevent that. Not sure if this is related to my specific environment, but seems like this should not hurt in the general case? 