### PR TITLE
Change MLflowService.list_runs to MLflowService.list_runs_infos

### DIFF
--- a/mlflow/tracking/service.py
+++ b/mlflow/tracking/service.py
@@ -9,7 +9,7 @@ import time
 from six import iteritems
 
 from mlflow.utils.validation import _validate_metric_name, _validate_param_name, _validate_run_id
-from mlflow.entities import Param, Metric, Run, RunStatus, RunTag
+from mlflow.entities import Param, Metric, RunStatus, RunTag
 from mlflow.tracking.utils import _get_store
 from mlflow.store.artifact_repo import ArtifactRepository
 

--- a/mlflow/tracking/service.py
+++ b/mlflow/tracking/service.py
@@ -58,10 +58,9 @@ class MLflowService(object):
             tags=[RunTag(key, value) for (key, value) in iteritems(tags)],
         )
 
-    def list_runs(self, experiment_id):
-        """:return: list of :py:class:`mlflow.entities.Run` (with only RunInfo filled)"""
-        run_infos = self.store.list_run_infos(experiment_id)
-        return [Run(run_info.run_uuid, run_info) for run_info in run_infos]
+    def list_runs_infos(self, experiment_id):
+        """:return: list of :py:class:`mlflow.entities.RunInfo`"""
+        return self.store.list_run_infos(experiment_id)
 
     def list_experiments(self):
         """:return: list of :py:class:`mlflow.entities.Experiment`"""


### PR DESCRIPTION
The first parameter to Run is run_info, not run_uuid. In this case, I made a backwards-incompatible change of `list_runs` to `list_run_infos` since the current API is a bit nonsensical (insofar as returning a partial Run) and doesn't match the REST API anyway.