### PR TITLE
FileStore implementation for delete and restore experiments

### DIFF
--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -17,8 +17,11 @@ class AbstractStore:
         pass
 
     @abstractmethod
-    def list_experiments(self):
+    def list_experiments(self, include_deleted, only_deleted):
         """
+
+        :param include_deleted: Response list to also includes experiments marked for deletion.
+        :param only_deleted: Response list to only include experiments that are marked for deletion.
         :return: a list of all known Experiment objects
         """
         pass
@@ -36,12 +39,32 @@ class AbstractStore:
         pass
 
     @abstractmethod
-    def get_experiment(self, experiment_id):
+    def get_experiment(self, experiment_id, include_deleted, only_deleted):
         """
         Fetches the experiment from the backend store.
 
         :param experiment_id: Integer id for the experiment
+        :param include_deleted: Response list to also includes experiments marked for deletion.
+        :param only_deleted: Response list to only include experiments that are marked for deletion.
         :return: A single Experiment object if it exists, otherwise raises an Exception.
+        """
+        pass
+
+    @abstractmethod
+    def delete_experiment(self, experiment_id):
+        """
+        Deletes the experiment from the backend store.
+
+        :param experiment_id: Integer id for the experiment
+        """
+        pass
+
+    @abstractmethod
+    def restore_experiment(self, experiment_id):
+        """
+        Restore deleted experiment.
+
+        :param experiment_id: Integer id for the experiment
         """
         pass
 

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -112,10 +112,10 @@ class RestStore(AbstractStore):
         return Experiment.from_proto(response_proto.experiment)
 
     def delete_experiment(self, experiment_id):
-        raise NotImplementedError()
+        pass
 
     def restore_experiment(self, experiment_id):
-        raise NotImplementedError()
+        pass
 
     def get_run(self, run_uuid):
         """

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -1,4 +1,5 @@
 import json
+
 from google.protobuf.json_format import MessageToJson, ParseDict
 
 
@@ -78,7 +79,7 @@ class RestStore(AbstractStore):
         ParseDict(js_dict=js_dict, message=response_proto)
         return response_proto
 
-    def list_experiments(self):
+    def list_experiments(self, include_deleted=False, only_deleted=False):
         """
         :return: a list of all known Experiment objects
         """
@@ -99,7 +100,7 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(CreateExperiment, req_body)
         return response_proto.experiment_id
 
-    def get_experiment(self, experiment_id):
+    def get_experiment(self, experiment_id, include_deleted=False, only_deleted=False):
         """
         Fetches the experiment from the backend store.
 
@@ -109,6 +110,12 @@ class RestStore(AbstractStore):
         req_body = _message_to_json(GetExperiment(experiment_id=experiment_id))
         response_proto = self._call_endpoint(GetExperiment, req_body)
         return Experiment.from_proto(response_proto.experiment)
+
+    def delete_experiment(self, experiment_id):
+        raise NotImplementedError()
+
+    def restore_experiment(self, experiment_id):
+        raise NotImplementedError()
 
     def get_run(self, run_uuid):
         """

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -231,6 +231,10 @@ def get_relative_path(root_path, target_path):
     return os.path.relpath(target_path, common_prefix)
 
 
+def mv(target, new_parent):
+    shutil.move(target, new_parent)
+
+
 def write_to(filename, data):
     with open(filename, "w") as handle:
         handle.write(data)


### PR DESCRIPTION
- new `delete_experiment` and `restore_experiment` methods for Abstract-, Rest-, and FileStore
- updated `get_experiment`, `list_experiment` methods to work with trash folder
- tests 