### PR TITLE
Add SetTag API & move tags to RunData

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -37,6 +37,7 @@ import mlflow.tracking.fluent
 ActiveRun = mlflow.tracking.fluent.ActiveRun
 log_param = mlflow.tracking.fluent.log_param
 log_metric = mlflow.tracking.fluent.log_metric
+set_tag = mlflow.tracking.fluent.set_tag
 log_artifacts = mlflow.tracking.fluent.log_artifacts
 log_artifact = mlflow.tracking.fluent.log_artifact
 active_run = mlflow.tracking.fluent.active_run
@@ -51,6 +52,6 @@ create_experiment = mlflow.tracking.fluent.create_experiment
 run = projects.run
 
 
-__all__ = ["ActiveRun", "log_param", "log_metric", "log_artifacts", "log_artifact", "active_run",
-           "start_run", "end_run", "get_artifact_uri", "set_tracking_uri", "create_experiment",
-           "run"]
+__all__ = ["ActiveRun", "log_param", "log_metric", "set_tag", "log_artifacts", "log_artifact",
+           "active_run", "start_run", "end_run", "get_artifact_uri", "set_tracking_uri",
+           "create_experiment", "run"]

--- a/mlflow/entities/run_data.py
+++ b/mlflow/entities/run_data.py
@@ -1,6 +1,7 @@
 from mlflow.entities._mlflow_object import _MLflowObject
 from mlflow.entities.metric import Metric
 from mlflow.entities.param import Param
+from mlflow.entities.run_tag import RunTag
 from mlflow.protos.service_pb2 import RunData as ProtoRunData
 
 
@@ -8,25 +9,34 @@ class RunData(_MLflowObject):
     """
     Class exposing run data (metrics and parameters).
     """
-    def __init__(self, metrics=None, params=None):
+    def __init__(self, metrics=None, params=None, tags=None):
         self._metrics = []
         self._params = []
+        self._tags = []
         if metrics is not None:
             for m in metrics:
                 self._add_metric(m)
         if params is not None:
             for p in params:
                 self._add_param(p)
+        if tags is not None:
+            for t in tags:
+                self._add_tag(t)
 
     @property
     def metrics(self):
-        """List of :py:class:`mlflow.entities.metric.Metric` for the current run."""
+        """List of :py:class:`mlflow.entities.Metric` for the current run."""
         return self._metrics
 
     @property
     def params(self):
-        """List of :py:class:`mlflow.entities.param.Param` for the current run."""
+        """List of :py:class:`mlflow.entities.Param` for the current run."""
         return self._params
+
+    @property
+    def tags(self):
+        """List of :py:class:`mlflow.entities.RunTag` for the current run."""
+        return self._tags
 
     def _add_metric(self, metric):
         self._metrics.append(metric)
@@ -34,20 +44,26 @@ class RunData(_MLflowObject):
     def _add_param(self, param):
         self._params.append(param)
 
+    def _add_tag(self, tag):
+        self._tags.append(tag)
+
     def to_proto(self):
         run_data = ProtoRunData()
         run_data.metrics.extend([m.to_proto() for m in self.metrics])
         run_data.params.extend([p.to_proto() for p in self.params])
+        run_data.tags.extend([t.to_proto() for t in self.tags])
         return run_data
 
     @classmethod
     def from_proto(cls, proto):
         run_data = cls()
-        # iterate proto and add metrics and params
+        # iterate proto and add metrics, params, and tags
         for proto_metric in proto.metrics:
             run_data._add_metric(Metric.from_proto(proto_metric))
         for proto_param in proto.params:
             run_data._add_param(Param.from_proto(proto_param))
+        for proto_tag in proto.tags:
+            run_data._add_tag(RunTag.from_proto(proto_tag))
 
         return run_data
 
@@ -58,9 +74,11 @@ class RunData(_MLflowObject):
             run_data._add_metric(p)
         for p in the_dict.get("params", []):
             run_data._add_param(p)
+        for t in the_dict.get("tags", []):
+            run_data._add_tag(t)
         return run_data
 
     @classmethod
     def _properties(cls):
         # TODO: Hard coding this list of props for now. There has to be a clearer way...
-        return ["metrics", "params"]
+        return ["metrics", "params", "tags"]

--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -1,5 +1,4 @@
 from mlflow.entities._mlflow_object import _MLflowObject
-from mlflow.entities.run_tag import RunTag
 
 from mlflow.protos.service_pb2 import RunInfo as ProtoRunInfo
 

--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -7,7 +7,7 @@ from mlflow.protos.service_pb2 import RunInfo as ProtoRunInfo
 class RunInfo(_MLflowObject):
     """ Class containing metadata for a run. """
     def __init__(self, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
-                 user_id, status, start_time, end_time, source_version, tags, artifact_uri=None):
+                 user_id, status, start_time, end_time, source_version, artifact_uri=None):
         if run_uuid is None:
             raise Exception("run_uuid cannot be None")
         if experiment_id is None:
@@ -35,7 +35,6 @@ class RunInfo(_MLflowObject):
         self._start_time = start_time
         self._end_time = end_time
         self._source_version = source_version
-        self._tags = tags
         self._artifact_uri = artifact_uri
 
     def __eq__(self, other):
@@ -117,11 +116,6 @@ class RunInfo(_MLflowObject):
         return self._source_version
 
     @property
-    def tags(self):
-        """List of :py:class:`mlflow.entities.run_tag.RunTag` for the run."""
-        return self._tags
-
-    @property
     def artifact_uri(self):
         """String: root artifact URI of the run."""
         return self._artifact_uri
@@ -142,24 +136,24 @@ class RunInfo(_MLflowObject):
             proto.end_time = self.end_time
         if self.source_version:
             proto.source_version = self.source_version
-        proto.tags.extend([tag.to_proto() for tag in self.tags])
         if self.artifact_uri:
             proto.artifact_uri = self.artifact_uri
         return proto
 
     @classmethod
     def from_proto(cls, proto):
-        tags = [RunTag.from_proto(proto_tag) for proto_tag in proto.tags]
         return cls(proto.run_uuid, proto.experiment_id, proto.name, proto.source_type,
                    proto.source_name, proto.entry_point_name, proto.user_id, proto.status,
-                   proto.start_time, proto.end_time, proto.source_version, tags,
+                   proto.start_time, proto.end_time, proto.source_version,
                    proto.artifact_uri)
 
     @classmethod
     def from_dictionary(cls, the_dict):
-        info = cls(**the_dict)
-        # We must manually deserialize tags into proto tags
-        info._tags = the_dict.get("tags", [])
+        dict_copy = the_dict.copy()
+        # 'tags' was moved from RunInfo to RunData, so we must remove it from the serialzed copy.
+        if 'tags' in dict_copy:
+            del dict_copy['tags']
+        info = cls(**dict_copy)
         return info
 
     @classmethod
@@ -167,4 +161,4 @@ class RunInfo(_MLflowObject):
         # TODO: Hard coding this list of props for now. There has to be a clearer way...
         return ["run_uuid", "experiment_id", "name", "source_type", "source_name",
                 "entry_point_name", "user_id", "status", "start_time", "end_time",
-                "source_version", "tags", "artifact_uri"]
+                "source_version", "artifact_uri"]

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -103,9 +103,9 @@ service MlflowService {
     };
   }
 
- // Log a param used for this run. Examples are hyperparameters used for ML model training, or
- // constant dates and values used in an ETL pipeline. A param is a key-value pair (string key,
- // string value). A param may only be logged once for a given run.
+  // Log a param used for this run. Examples are hyperparameters used for ML model training, or
+  // constant dates and values used in an ETL pipeline. A param is a key-value pair (string key,
+  // string value). A param may only be logged once for a given run.
   rpc logParam(LogParam) returns (LogParam.Response) {
     option (rpc) = {
       endpoints: [{
@@ -119,6 +119,20 @@ service MlflowService {
     };
   }
 
+  // Sets a tag on this run. Tags are metadata of a run which can be updated during and after
+  // a run completes.
+  rpc setTag(SetTag) returns (SetTag.Response) {
+    option (rpc) = {
+      endpoints: [{
+        method: "POST",
+        path: "/preview/mlflow/runs/set-tag"
+        since { major: 2, minor: 0 },
+      }],
+
+      visibility: PUBLIC,
+      rpc_doc_title: "Set Tag",
+    };
+  }
 
   // Get metadata, params, tags, and metrics for run. Only the last logged value for each metric is
   // returned.
@@ -284,6 +298,9 @@ message RunData {
   repeated Metric metrics = 1;
 
   repeated Param params = 2;
+
+  // Additional metadata key-value pairs.
+  repeated RunTag tags = 3;
 }
 
 // Tag for a run.
@@ -326,9 +343,6 @@ message RunInfo {
 
   // Name of the entry point for the run.
   optional string entry_point_name = 11;
-
-  // Additional metadata key-value pairs.
-  repeated RunTag tags = 12;
 
   // URI of the directory where artifacts should be uploaded.
   // This can be a local path (starting with "/"), or a distributed file system (DFS)
@@ -471,10 +485,26 @@ message LogParam {
   // ID of the run under which to log the param.
   optional string run_uuid = 1 [(validate_required) = true];
 
-  // Name of the param.
+  // Name of the param. Maximum size is 255 bytes.
   optional string key = 2 [(validate_required) = true];
 
-  // String value of the param being logged.
+  // String value of the param being logged. Maximum size if 500 bytes.
+  optional string value = 3 [(validate_required) = true];
+
+  message Response {
+  }
+}
+
+message SetTag {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // ID of the run under which to log the param.
+  optional string run_uuid = 1 [(validate_required) = true];
+
+  // Name of the tag. Maximum size is 255 bytes.
+  optional string key = 2 [(validate_required) = true];
+
+  // String value of the tag being logged. Maximum size if 500 bytes.
   optional string value = 3 [(validate_required) = true];
 
   message Response {

--- a/mlflow/protos/service_pb2.py
+++ b/mlflow/protos/service_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\037com.databricks.api.proto.mlflow\220\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"7\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"I\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xbe\x02\n\x07RunInfo\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\x03\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x16\n\x0esource_version\x18\n \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x0b \x01(\t\x12\x1c\n\x04tags\x18\x0c \x03(\x0b\x32\x0e.mlflow.RunTag\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\"L\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"s\n\x0fListExperiments\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1aQ\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12\x1d\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x02\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x10\n\x08run_name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x06 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x16\n\x0esource_version\x18\x08 \x01(\t\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb4\x01\n\tUpdateRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9d\x01\n\tLogMetric\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\x02\x42\x04\x88\xb5\x18\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x83\x01\n\x08LogParam\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"s\n\x06GetRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\tGetMetric\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a*\n\x08Response\x12\x1e\n\x06metric\x18\x01 \x01(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x97\x01\n\x08GetParam\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nparam_name\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a,\n\x08Response\x12 \n\tparameter\x18\x01 \x01(\x0b\x32\r.mlflow.Param:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8a\x01\n\x10SearchExpression\x12\x30\n\x06metric\x18\x01 \x01(\x0b\x32\x1e.mlflow.MetricSearchExpressionH\x00\x12\x36\n\tparameter\x18\x02 \x01(\x0b\x32!.mlflow.ParameterSearchExpressionH\x00\x42\x0c\n\nexpression\"U\n\x16MetricSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05\x66loat\x18\x02 \x01(\x0b\x32\x13.mlflow.FloatClauseH\x00\x42\x08\n\x06\x63lause\"Z\n\x19ParameterSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x06string\x18\x02 \x01(\x0b\x32\x14.mlflow.StringClauseH\x00\x42\x08\n\x06\x63lause\"1\n\x0cStringClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x0b\x46loatClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02\"\xad\x01\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\x03\x12\x33\n\x11\x61nded_expressions\x18\x02 \x03(\x0b\x32\x18.mlflow.SearchExpression\x1a%\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9b\x01\n\rListArtifacts\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"\x9e\x01\n\x10GetMetricHistory\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\xfa\r\n\rMlflowService\x12\x9c\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"K\x82\xb5\x18G\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\x95\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"G\x82\xb5\x18\x43\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\x8c\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"D\x82\xb5\x18@\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12y\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"=\x82\xb5\x18\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12y\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"=\x82\xb5\x18\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12}\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"A\x82\xb5\x18=\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12|\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"C\x82\xb5\x18?\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12i\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"6\x82\xb5\x18\x32\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12x\n\tgetMetric\x12\x11.mlflow.GetMetric\x1a\x1a.mlflow.GetMetric.Response\"<\x82\xb5\x18\x38\n(\n\x03GET\x12\x1b/preview/mlflow/metrics/get\x1a\x04\x08\x02\x10\x00\x10\x01*\nGet Metric\x12s\n\x08getParam\x12\x10.mlflow.GetParam\x1a\x19.mlflow.GetParam.Response\":\x82\xb5\x18\x36\n\'\n\x03GET\x12\x1a/preview/mlflow/params/get\x1a\x04\x08\x02\x10\x00\x10\x01*\tGet Param\x12\xa7\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"h\x82\xb5\x18\x64\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\x8b\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"C\x82\xb5\x18?\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\x9d\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"L\x82\xb5\x18H\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric HistoryB)\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"7\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xa0\x02\n\x07RunInfo\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\x03\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x16\n\x0esource_version\x18\n \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x0b \x01(\t\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\"L\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"s\n\x0fListExperiments\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1aQ\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12\x1d\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x02\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x10\n\x08run_name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x06 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x16\n\x0esource_version\x18\x08 \x01(\t\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb4\x01\n\tUpdateRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9d\x01\n\tLogMetric\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\x02\x42\x04\x88\xb5\x18\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x83\x01\n\x08LogParam\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x81\x01\n\x06SetTag\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"s\n\x06GetRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\tGetMetric\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a*\n\x08Response\x12\x1e\n\x06metric\x18\x01 \x01(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x97\x01\n\x08GetParam\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nparam_name\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a,\n\x08Response\x12 \n\tparameter\x18\x01 \x01(\x0b\x32\r.mlflow.Param:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8a\x01\n\x10SearchExpression\x12\x30\n\x06metric\x18\x01 \x01(\x0b\x32\x1e.mlflow.MetricSearchExpressionH\x00\x12\x36\n\tparameter\x18\x02 \x01(\x0b\x32!.mlflow.ParameterSearchExpressionH\x00\x42\x0c\n\nexpression\"U\n\x16MetricSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05\x66loat\x18\x02 \x01(\x0b\x32\x13.mlflow.FloatClauseH\x00\x42\x08\n\x06\x63lause\"Z\n\x19ParameterSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x06string\x18\x02 \x01(\x0b\x32\x14.mlflow.StringClauseH\x00\x42\x08\n\x06\x63lause\"1\n\x0cStringClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x0b\x46loatClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02\"\xad\x01\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\x03\x12\x33\n\x11\x61nded_expressions\x18\x02 \x03(\x0b\x32\x18.mlflow.SearchExpression\x1a%\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9b\x01\n\rListArtifacts\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"\x9e\x01\n\x10GetMetricHistory\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\xea\x0e\n\rMlflowService\x12\x9c\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"K\x82\xb5\x18G\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\x95\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"G\x82\xb5\x18\x43\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\x8c\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"D\x82\xb5\x18@\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12y\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"=\x82\xb5\x18\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12y\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"=\x82\xb5\x18\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12}\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"A\x82\xb5\x18=\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12|\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"C\x82\xb5\x18?\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12n\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\";\x82\xb5\x18\x37\n*\n\x04POST\x12\x1c/preview/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12i\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"6\x82\xb5\x18\x32\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12x\n\tgetMetric\x12\x11.mlflow.GetMetric\x1a\x1a.mlflow.GetMetric.Response\"<\x82\xb5\x18\x38\n(\n\x03GET\x12\x1b/preview/mlflow/metrics/get\x1a\x04\x08\x02\x10\x00\x10\x01*\nGet Metric\x12s\n\x08getParam\x12\x10.mlflow.GetParam\x1a\x19.mlflow.GetParam.Response\":\x82\xb5\x18\x36\n\'\n\x03GET\x12\x1a/preview/mlflow/params/get\x1a\x04\x08\x02\x10\x00\x10\x01*\tGet Param\x12\xa7\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"h\x82\xb5\x18\x64\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\x8b\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"C\x82\xb5\x18?\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\x9d\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"L\x82\xb5\x18H\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric HistoryB)\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -57,8 +57,8 @@ _SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3376,
-  serialized_end=3449,
+  serialized_start=3508,
+  serialized_end=3581,
 )
 _sym_db.RegisterEnumDescriptor(_SOURCETYPE)
 
@@ -92,8 +92,8 @@ _RUNSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=3451,
-  serialized_end=3528,
+  serialized_start=3583,
+  serialized_end=3660,
 )
 _sym_db.RegisterEnumDescriptor(_RUNSTATUS)
 
@@ -253,6 +253,13 @@ _RUNDATA = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='tags', full_name='mlflow.RunData.tags', index=2,
+      number=3, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -266,7 +273,7 @@ _RUNDATA = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=229,
-  serialized_end=302,
+  serialized_end=332,
 )
 
 
@@ -303,8 +310,8 @@ _RUNTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=304,
-  serialized_end=340,
+  serialized_start=334,
+  serialized_end=370,
 )
 
 
@@ -393,14 +400,7 @@ _RUNINFO = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='tags', full_name='mlflow.RunInfo.tags', index=11,
-      number=12, type=11, cpp_type=10, label=3,
-      has_default_value=False, default_value=[],
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='artifact_uri', full_name='mlflow.RunInfo.artifact_uri', index=12,
+      name='artifact_uri', full_name='mlflow.RunInfo.artifact_uri', index=11,
       number=13, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -418,7 +418,7 @@ _RUNINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=343,
+  serialized_start=373,
   serialized_end=661,
 )
 
@@ -993,6 +993,74 @@ _LOGPARAM = _descriptor.Descriptor(
 )
 
 
+_SETTAG_RESPONSE = _descriptor.Descriptor(
+  name='Response',
+  full_name='mlflow.SetTag.Response',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto2',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=809,
+  serialized_end=819,
+)
+
+_SETTAG = _descriptor.Descriptor(
+  name='SetTag',
+  full_name='mlflow.SetTag',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='run_uuid', full_name='mlflow.SetTag.run_uuid', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='key', full_name='mlflow.SetTag.key', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='mlflow.SetTag.value', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_SETTAG_RESPONSE, ],
+  enum_types=[
+  ],
+  serialized_options=_b('\342?(\n&com.databricks.rpc.RPC[$this.Response]'),
+  is_extendable=False,
+  syntax='proto2',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1976,
+  serialized_end=2105,
+)
+
+
 _GETRUN_RESPONSE = _descriptor.Descriptor(
   name='Response',
   full_name='mlflow.GetRun.Response',
@@ -1049,8 +1117,8 @@ _GETRUN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1975,
-  serialized_end=2090,
+  serialized_start=2107,
+  serialized_end=2222,
 )
 
 
@@ -1080,8 +1148,8 @@ _GETMETRIC_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2156,
-  serialized_end=2198,
+  serialized_start=2288,
+  serialized_end=2330,
 )
 
 _GETMETRIC = _descriptor.Descriptor(
@@ -1117,8 +1185,8 @@ _GETMETRIC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2093,
-  serialized_end=2243,
+  serialized_start=2225,
+  serialized_end=2375,
 )
 
 
@@ -1148,8 +1216,8 @@ _GETPARAM_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2308,
-  serialized_end=2352,
+  serialized_start=2440,
+  serialized_end=2484,
 )
 
 _GETPARAM = _descriptor.Descriptor(
@@ -1185,8 +1253,8 @@ _GETPARAM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2246,
-  serialized_end=2397,
+  serialized_start=2378,
+  serialized_end=2529,
 )
 
 
@@ -1226,8 +1294,8 @@ _SEARCHEXPRESSION = _descriptor.Descriptor(
       name='expression', full_name='mlflow.SearchExpression.expression',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2400,
-  serialized_end=2538,
+  serialized_start=2532,
+  serialized_end=2670,
 )
 
 
@@ -1267,8 +1335,8 @@ _METRICSEARCHEXPRESSION = _descriptor.Descriptor(
       name='clause', full_name='mlflow.MetricSearchExpression.clause',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2540,
-  serialized_end=2625,
+  serialized_start=2672,
+  serialized_end=2757,
 )
 
 
@@ -1308,8 +1376,8 @@ _PARAMETERSEARCHEXPRESSION = _descriptor.Descriptor(
       name='clause', full_name='mlflow.ParameterSearchExpression.clause',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2627,
-  serialized_end=2717,
+  serialized_start=2759,
+  serialized_end=2849,
 )
 
 
@@ -1346,8 +1414,8 @@ _STRINGCLAUSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2719,
-  serialized_end=2768,
+  serialized_start=2851,
+  serialized_end=2900,
 )
 
 
@@ -1384,8 +1452,8 @@ _FLOATCLAUSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2770,
-  serialized_end=2818,
+  serialized_start=2902,
+  serialized_end=2950,
 )
 
 
@@ -1415,8 +1483,8 @@ _SEARCHRUNS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2912,
-  serialized_end=2949,
+  serialized_start=3044,
+  serialized_end=3081,
 )
 
 _SEARCHRUNS = _descriptor.Descriptor(
@@ -1452,8 +1520,8 @@ _SEARCHRUNS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2821,
-  serialized_end=2994,
+  serialized_start=2953,
+  serialized_end=3126,
 )
 
 
@@ -1490,8 +1558,8 @@ _LISTARTIFACTS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3046,
-  serialized_end=3107,
+  serialized_start=3178,
+  serialized_end=3239,
 )
 
 _LISTARTIFACTS = _descriptor.Descriptor(
@@ -1527,8 +1595,8 @@ _LISTARTIFACTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2997,
-  serialized_end=3152,
+  serialized_start=3129,
+  serialized_end=3284,
 )
 
 
@@ -1572,8 +1640,8 @@ _FILEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3154,
-  serialized_end=3213,
+  serialized_start=3286,
+  serialized_end=3345,
 )
 
 
@@ -1603,8 +1671,8 @@ _GETMETRICHISTORY_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3286,
-  serialized_end=3329,
+  serialized_start=3418,
+  serialized_end=3461,
 )
 
 _GETMETRICHISTORY = _descriptor.Descriptor(
@@ -1640,17 +1708,17 @@ _GETMETRICHISTORY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3216,
-  serialized_end=3374,
+  serialized_start=3348,
+  serialized_end=3506,
 )
 
 _RUN.fields_by_name['info'].message_type = _RUNINFO
 _RUN.fields_by_name['data'].message_type = _RUNDATA
 _RUNDATA.fields_by_name['metrics'].message_type = _METRIC
 _RUNDATA.fields_by_name['params'].message_type = _PARAM
+_RUNDATA.fields_by_name['tags'].message_type = _RUNTAG
 _RUNINFO.fields_by_name['source_type'].enum_type = _SOURCETYPE
 _RUNINFO.fields_by_name['status'].enum_type = _RUNSTATUS
-_RUNINFO.fields_by_name['tags'].message_type = _RUNTAG
 _CREATEEXPERIMENT_RESPONSE.containing_type = _CREATEEXPERIMENT
 _LISTEXPERIMENTS_RESPONSE.fields_by_name['experiments'].message_type = _EXPERIMENT
 _LISTEXPERIMENTS_RESPONSE.containing_type = _LISTEXPERIMENTS
@@ -1666,6 +1734,7 @@ _UPDATERUN_RESPONSE.containing_type = _UPDATERUN
 _UPDATERUN.fields_by_name['status'].enum_type = _RUNSTATUS
 _LOGMETRIC_RESPONSE.containing_type = _LOGMETRIC
 _LOGPARAM_RESPONSE.containing_type = _LOGPARAM
+_SETTAG_RESPONSE.containing_type = _SETTAG
 _GETRUN_RESPONSE.fields_by_name['run'].message_type = _RUN
 _GETRUN_RESPONSE.containing_type = _GETRUN
 _GETMETRIC_RESPONSE.fields_by_name['metric'].message_type = _METRIC
@@ -1709,6 +1778,7 @@ DESCRIPTOR.message_types_by_name['CreateRun'] = _CREATERUN
 DESCRIPTOR.message_types_by_name['UpdateRun'] = _UPDATERUN
 DESCRIPTOR.message_types_by_name['LogMetric'] = _LOGMETRIC
 DESCRIPTOR.message_types_by_name['LogParam'] = _LOGPARAM
+DESCRIPTOR.message_types_by_name['SetTag'] = _SETTAG
 DESCRIPTOR.message_types_by_name['GetRun'] = _GETRUN
 DESCRIPTOR.message_types_by_name['GetMetric'] = _GETMETRIC
 DESCRIPTOR.message_types_by_name['GetParam'] = _GETPARAM
@@ -1879,6 +1949,21 @@ LogParam = _reflection.GeneratedProtocolMessageType('LogParam', (_message.Messag
 _sym_db.RegisterMessage(LogParam)
 _sym_db.RegisterMessage(LogParam.Response)
 
+SetTag = _reflection.GeneratedProtocolMessageType('SetTag', (_message.Message,), dict(
+
+  Response = _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), dict(
+    DESCRIPTOR = _SETTAG_RESPONSE,
+    __module__ = 'service_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.SetTag.Response)
+    ))
+  ,
+  DESCRIPTOR = _SETTAG,
+  __module__ = 'service_pb2'
+  # @@protoc_insertion_point(class_scope:mlflow.SetTag)
+  ))
+_sym_db.RegisterMessage(SetTag)
+_sym_db.RegisterMessage(SetTag.Response)
+
 GetRun = _reflection.GeneratedProtocolMessageType('GetRun', (_message.Message,), dict(
 
   Response = _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), dict(
@@ -2030,6 +2115,10 @@ _LOGPARAM.fields_by_name['run_uuid']._options = None
 _LOGPARAM.fields_by_name['key']._options = None
 _LOGPARAM.fields_by_name['value']._options = None
 _LOGPARAM._options = None
+_SETTAG.fields_by_name['run_uuid']._options = None
+_SETTAG.fields_by_name['key']._options = None
+_SETTAG.fields_by_name['value']._options = None
+_SETTAG._options = None
 _GETRUN.fields_by_name['run_uuid']._options = None
 _GETRUN._options = None
 _GETMETRIC.fields_by_name['run_uuid']._options = None
@@ -2050,8 +2139,8 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=3531,
-  serialized_end=5317,
+  serialized_start=3663,
+  serialized_end=5561,
   methods=[
   _descriptor.MethodDescriptor(
     name='createExperiment',
@@ -2117,9 +2206,18 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     serialized_options=_b('\202\265\030?\n0\n\004POST\022\"/preview/mlflow/runs/log-parameter\032\004\010\002\020\000\020\001*\tLog Param'),
   ),
   _descriptor.MethodDescriptor(
+    name='setTag',
+    full_name='mlflow.MlflowService.setTag',
+    index=7,
+    containing_service=None,
+    input_type=_SETTAG,
+    output_type=_SETTAG_RESPONSE,
+    serialized_options=_b('\202\265\0307\n*\n\004POST\022\034/preview/mlflow/runs/set-tag\032\004\010\002\020\000\020\001*\007Set Tag'),
+  ),
+  _descriptor.MethodDescriptor(
     name='getRun',
     full_name='mlflow.MlflowService.getRun',
-    index=7,
+    index=8,
     containing_service=None,
     input_type=_GETRUN,
     output_type=_GETRUN_RESPONSE,
@@ -2128,7 +2226,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='getMetric',
     full_name='mlflow.MlflowService.getMetric',
-    index=8,
+    index=9,
     containing_service=None,
     input_type=_GETMETRIC,
     output_type=_GETMETRIC_RESPONSE,
@@ -2137,7 +2235,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='getParam',
     full_name='mlflow.MlflowService.getParam',
-    index=9,
+    index=10,
     containing_service=None,
     input_type=_GETPARAM,
     output_type=_GETPARAM_RESPONSE,
@@ -2146,7 +2244,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='searchRuns',
     full_name='mlflow.MlflowService.searchRuns',
-    index=10,
+    index=11,
     containing_service=None,
     input_type=_SEARCHRUNS,
     output_type=_SEARCHRUNS_RESPONSE,
@@ -2155,7 +2253,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='listArtifacts',
     full_name='mlflow.MlflowService.listArtifacts',
-    index=11,
+    index=12,
     containing_service=None,
     input_type=_LISTARTIFACTS,
     output_type=_LISTARTIFACTS_RESPONSE,
@@ -2164,7 +2262,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='getMetricHistory',
     full_name='mlflow.MlflowService.getMetricHistory',
-    index=12,
+    index=13,
     containing_service=None,
     input_type=_GETMETRICHISTORY,
     output_type=_GETMETRICHISTORY_RESPONSE,

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -12,7 +12,7 @@ from mlflow.entities import Metric, Param, RunTag
 from mlflow.protos import databricks_pb2
 from mlflow.protos.service_pb2 import CreateExperiment, MlflowService, GetExperiment, \
     GetRun, SearchRuns, ListArtifacts, GetMetricHistory, CreateRun, \
-    UpdateRun, LogMetric, LogParam, ListExperiments, GetMetric, GetParam
+    UpdateRun, LogMetric, LogParam, SetTag, ListExperiments, GetMetric, GetParam
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.store.file_store import FileStore
 
@@ -167,6 +167,16 @@ def _log_param():
     return response
 
 
+def _set_tag():
+    request_message = _get_request_message(SetTag())
+    tag = RunTag(request_message.key, request_message.value)
+    _get_store().set_tag(request_message.run_uuid, tag)
+    response_message = SetTag.Response()
+    response = Response(mimetype='application/json')
+    response.set_data(_message_to_json(response_message))
+    return response
+
+
 def _get_run():
     request_message = _get_request_message(GetRun())
     response_message = GetRun.Response()
@@ -286,6 +296,7 @@ HANDLERS = {
     UpdateRun: _update_run,
     LogParam: _log_param,
     LogMetric: _log_metric,
+    SetTag: _set_tag,
     GetRun: _get_run,
     SearchRuns: _search_runs,
     ListArtifacts: _list_artifacts,

--- a/mlflow/server/js/src/reducers/Reducers.js
+++ b/mlflow/server/js/src/reducers/Reducers.js
@@ -158,7 +158,7 @@ const tagsByRunUuid = (state = {}, action) => {
   switch (action.type) {
     case fulfilled(GET_RUN_API): {
       const runInfo = RunInfo.fromJs(action.payload.run.info);
-      return amendTagsByRunUuid(state, action.payload.run.info.tags, runInfo.getRunUuid());
+      return amendTagsByRunUuid(state, action.payload.run.data.tags, runInfo.getRunUuid());
     }
     case fulfilled(SEARCH_RUNS_API): {
       const runs = action.payload.runs;
@@ -167,7 +167,7 @@ const tagsByRunUuid = (state = {}, action) => {
         runs.forEach((rJson) => {
           const run = Run.fromJs(rJson);
           newState = amendTagsByRunUuid(
-              newState, rJson.info.tags, run.getInfo().getRunUuid());
+              newState, rJson.data.tags, run.getInfo().getRunUuid());
         });
       }
       return newState;

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -114,6 +114,14 @@ class AbstractStore:
         """
         pass
 
+    def set_tag(self, run_uuid, tag):
+        """
+        Sets a tag for the specified run
+        :param run_uuid: String id for the run
+        :param tag: RunTag instance to set
+        """
+        pass
+
     @abstractmethod
     def get_metric(self, run_uuid, metric_key):
         """

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -10,8 +10,8 @@ from mlflow.entities import Experiment, Run, RunInfo, Param, Metric
 from mlflow.utils.rest_utils import http_request
 
 from mlflow.protos.service_pb2 import CreateExperiment, MlflowService, GetExperiment, \
-    GetRun, SearchRuns, ListExperiments, GetMetricHistory, LogMetric, LogParam, UpdateRun,\
-    CreateRun, GetMetric, GetParam
+    GetRun, SearchRuns, ListExperiments, GetMetricHistory, LogMetric, LogParam, SetTag, \
+    UpdateRun, CreateRun, GetMetric, GetParam
 
 from mlflow.protos import databricks_pb2
 
@@ -172,6 +172,15 @@ class RestStore(AbstractStore):
         """
         req_body = _message_to_json(LogParam(run_uuid=run_uuid, key=param.key, value=param.value))
         self._call_endpoint(LogParam, req_body)
+
+    def set_tag(self, run_uuid, tag):
+        """
+        Sets a tag for the specified run
+        :param run_uuid: String id for the run
+        :param tag: RunTag instance to log
+        """
+        req_body = _message_to_json(SetTag(run_uuid=run_uuid, key=tag.key, value=tag.value))
+        self._call_endpoint(SetTag, req_body)
 
     def get_metric(self, run_uuid, metric_key):
         """

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -110,6 +110,17 @@ def log_param(key, value):
     get_service().log_param(run_id, key, value)
 
 
+def set_tag(key, value):
+    """
+    Sets the passed-in tag under the current run, creating a run if necessary.
+
+    :param key: Tag name (string)
+    :param value: Tag value (string, but will be string-ified if not)
+    """
+    run_id = _get_or_start_run().info.run_uuid
+    get_service().set_tag(run_id, key, value)
+
+
 def log_metric(key, value):
     """
     Log the passed-in metric under the current run, creating a run if necessary.

--- a/mlflow/tracking/service.py
+++ b/mlflow/tracking/service.py
@@ -8,7 +8,8 @@ import os
 import time
 from six import iteritems
 
-from mlflow.utils.validation import _validate_metric_name, _validate_param_name, _validate_run_id
+from mlflow.utils.validation import _validate_metric_name, _validate_param_name, \
+                                    _validate_tag_name, _validate_run_id
 from mlflow.entities import Param, Metric, RunStatus, RunTag
 from mlflow.tracking.utils import _get_store
 from mlflow.store.artifact_repo import ArtifactRepository
@@ -96,6 +97,12 @@ class MLflowService(object):
         _validate_param_name(key)
         param = Param(key, str(value))
         self.store.log_param(run_id, param)
+
+    def set_tag(self, run_id, key, value):
+        """Sets a tag on the given run id. Value will be converted to a string."""
+        _validate_tag_name(key)
+        tag = RunTag(key, str(value))
+        self.store.set_tag(run_id, tag)
 
     def log_artifact(self, artifact_uri, local_path, artifact_path=None):
         """Writes a local file to the remote artifact_uri.

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -43,6 +43,15 @@ def _validate_param_name(name):
         raise Exception("Invalid parameter name: '%s'. %s" % (name, _bad_path_message(name)))
 
 
+def _validate_tag_name(name):
+    """Check that `name` is a valid tag name and raise an exception if it isn't."""
+    # Reuse param & metric check.
+    if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
+        raise Exception("Invalid tag name: '%s'. %s" % (name, _BAD_CHARACTERS_MESSAGE))
+    if _path_not_unique(name):
+        raise Exception("Invalid tag name: '%s'. %s" % (name, _bad_path_message(name)))
+
+
 def _validate_run_id(run_id):
     """Check that `run_id` is a valid run ID and raise an exception if it isn't."""
     if _RUN_ID_REGEX.match(run_id) is None:

--- a/tests/entities/test_run.py
+++ b/tests/entities/test_run.py
@@ -8,13 +8,13 @@ class TestRun(TestRunInfo, TestRunData):
         TestRunInfo._check(self, run.info, ri.run_uuid, ri.experiment_id, ri.name,
                            ri.source_type, ri.source_name, ri.entry_point_name,
                            ri.user_id, ri.status, ri.start_time, ri.end_time, ri.source_version,
-                           ri.tags, ri.artifact_uri)
-        TestRunData._check(self, run.data, rd.metrics, rd.params)
+                           ri.artifact_uri)
+        TestRunData._check(self, run.data, rd.metrics, rd.params, rd.tags)
 
     def test_creation_and_hydration(self):
-        run_data, metrics, params = TestRunData._create()
+        run_data, metrics, params, tags = TestRunData._create()
         (run_info, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
-         user_id, status, start_time, end_time, source_version, tags,
+         user_id, status, start_time, end_time, source_version,
          artifact_uri) = TestRunInfo._create()
 
         run1 = Run(run_info, run_data)
@@ -32,11 +32,11 @@ class TestRun(TestRunInfo, TestRunData):
                             "start_time": start_time,
                             "end_time": end_time,
                             "source_version": source_version,
-                            "tags": tags,
                             "artifact_uri": artifact_uri,
                             },
                    "data": {"metrics": metrics,
-                            "params": params}}
+                            "params": params,
+                            "tags": tags}}
         self.assertEqual(dict(run1), as_dict)
 
         # proto = run1.to_proto()

--- a/tests/entities/test_run_data.py
+++ b/tests/entities/test_run_data.py
@@ -1,7 +1,7 @@
 import time
 import unittest
 
-from mlflow.entities import Metric, Param, RunData
+from mlflow.entities import Metric, Param, RunData, RunTag
 from tests.helper_functions import random_str, random_int
 
 
@@ -16,9 +16,14 @@ class TestRunData(unittest.TestCase):
         self.assertEqual(set([p.key for p in params_1]), set([p.key for p in params_2]))
         self.assertEqual(set([p.value for p in params_1]), set([p.value for p in params_2]))
 
-    def _check(self, rd, metrics, params):
+    def _check_tags(self, tags_1, tags_2):
+        self.assertEqual(set([t.key for t in tags_1]), set([t.key for t in tags_2]))
+        self.assertEqual(set([t.value for t in tags_2]), set([t.value for t in tags_2]))
+
+    def _check(self, rd, metrics, params, tags):
         self._check_metrics(rd.metrics, metrics)
         self._check_params(rd.params, params)
+        self._check_tags(rd.tags, tags)
 
     @staticmethod
     def _create():
@@ -26,23 +31,26 @@ class TestRunData(unittest.TestCase):
                           int(time.time() + random_int(-1e4, 1e4)))
                    for _ in range(100)]
         params = [Param(random_str(10), random_str(random_int(10, 35))) for _ in range(10)]  # noqa
+        tags = [RunTag(random_str(10), random_str(random_int(10, 35))) for _ in range(10)]  # noqa
         rd = RunData()
         for p in params:
             rd._add_param(p)
         for m in metrics:
             rd._add_metric(m)
-        return rd, metrics, params
+        for t in tags:
+            rd._add_tag(t)
+        return rd, metrics, params, tags
 
     def test_creation_and_hydration(self):
-        rd1, metrics, params = self._create()
-        self._check(rd1, metrics, params)
+        rd1, metrics, params, tags = self._create()
+        self._check(rd1, metrics, params, tags)
 
-        as_dict = {"metrics": metrics, "params": params}
+        as_dict = {"metrics": metrics, "params": params, "tags": tags}
         self.assertEqual(dict(rd1), as_dict)
 
         proto = rd1.to_proto()
         rd2 = RunData.from_proto(proto)
-        self._check(rd2, metrics, params)
+        self._check(rd2, metrics, params, tags)
 
         rd3 = RunData.from_dictionary(as_dict)
-        self._check(rd3, metrics, params)
+        self._check(rd3, metrics, params, tags)

--- a/tests/entities/test_run_info.py
+++ b/tests/entities/test_run_info.py
@@ -8,7 +8,7 @@ from tests.helper_functions import random_str, random_int
 class TestRunInfo(unittest.TestCase):
     def _check(self, ri, run_uuid, experiment_id, name, source_type, source_name,
                entry_point_name, user_id, status, start_time, end_time, source_version,
-               tags, artifact_uri):
+               artifact_uri):
         self.assertEqual(ri.run_uuid, run_uuid)
         self.assertEqual(ri.experiment_id, experiment_id)
         self.assertEqual(ri.name, name)
@@ -20,7 +20,6 @@ class TestRunInfo(unittest.TestCase):
         self.assertEqual(ri.start_time, start_time)
         self.assertEqual(ri.end_time, end_time)
         self.assertEqual(ri.source_version, source_version)
-        self.assertSequenceEqual(ri.tags, tags)
         self.assertEqual(ri.artifact_uri, artifact_uri)
 
     @staticmethod
@@ -36,22 +35,20 @@ class TestRunInfo(unittest.TestCase):
         start_time = random_int(1, 10)
         end_time = start_time + random_int(1, 10)
         source_version = random_str(random_int(10, 40))
-        tags = [RunTag(key=random_str(random_int(1, 5)), value=random_str(random_int(1, 5)))
-                for _ in range(2)]
         artifact_uri = random_str(random_int(10, 40))
         ri = RunInfo(run_uuid=run_uuid, experiment_id=experiment_id, name=name,
                      source_type=source_type, source_name=source_name,
                      entry_point_name=entry_point_name, user_id=user_id,
                      status=status, start_time=start_time, end_time=end_time,
-                     source_version=source_version, tags=tags, artifact_uri=artifact_uri)
+                     source_version=source_version, artifact_uri=artifact_uri)
         return (ri, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
-                user_id, status, start_time, end_time, source_version, tags, artifact_uri)
+                user_id, status, start_time, end_time, source_version, artifact_uri)
 
     def test_creation_and_hydration(self):
         (ri1, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
-         user_id, status, start_time, end_time, source_version, tags, artifact_uri) = self._create()
+         user_id, status, start_time, end_time, source_version, artifact_uri) = self._create()
         self._check(ri1, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
-                    user_id, status, start_time, end_time, source_version, tags, artifact_uri)
+                    user_id, status, start_time, end_time, source_version, artifact_uri)
         as_dict = {
             "run_uuid": run_uuid,
             "experiment_id": experiment_id,
@@ -64,7 +61,6 @@ class TestRunInfo(unittest.TestCase):
             "start_time": start_time,
             "end_time": end_time,
             "source_version": source_version,
-            "tags": tags,
             "artifact_uri": artifact_uri,
         }
         self.assertEqual(dict(ri1), as_dict)
@@ -72,7 +68,7 @@ class TestRunInfo(unittest.TestCase):
         proto = ri1.to_proto()
         ri2 = RunInfo.from_proto(proto)
         self._check(ri2, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
-                    user_id, status, start_time, end_time, source_version, tags, artifact_uri)
+                    user_id, status, start_time, end_time, source_version, artifact_uri)
         ri3 = RunInfo.from_dictionary(as_dict)
         self._check(ri3, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
-                    user_id, status, start_time, end_time, source_version, tags, artifact_uri)
+                    user_id, status, start_time, end_time, source_version, artifact_uri)

--- a/tests/entities/test_run_info.py
+++ b/tests/entities/test_run_info.py
@@ -1,7 +1,7 @@
 import unittest
 import uuid
 
-from mlflow.entities import RunInfo, RunTag
+from mlflow.entities import RunInfo
 from tests.helper_functions import random_str, random_int
 
 

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -203,6 +203,7 @@ class TestFileStore(unittest.TestCase):
                 run_info = self.run_data[run_uuid]
                 run_info.pop("metrics")
                 run_info.pop("params")
+                run_info.pop("tags")
                 self.assertEqual(run_info, dict(run.info))
 
     def test_list_run_infos(self):
@@ -214,6 +215,7 @@ class TestFileStore(unittest.TestCase):
                 dict_run_info = self.run_data[run_uuid]
                 dict_run_info.pop("metrics")
                 dict_run_info.pop("params")
+                dict_run_info.pop("tags")
                 self.assertEqual(dict_run_info, dict(run_info))
 
     def test_get_metric(self):
@@ -303,7 +305,7 @@ class TestFileStore(unittest.TestCase):
         fs = FileStore(self.test_root)
         run_uuid = self.exp_data[0]["runs"][0]
         fs.set_tag(run_uuid, RunTag(WEIRD_TAG_NAME, "Muhahaha!"))
-        tag = fs.get_run(run_uuid).tags[0]
+        tag = fs.get_run(run_uuid).data.tags[0]
         assert tag.key == WEIRD_TAG_NAME
         assert tag.value == "Muhahaha!"
 
@@ -312,15 +314,16 @@ class TestFileStore(unittest.TestCase):
         run_uuid = self.exp_data[0]["runs"][0]
         fs.set_tag(run_uuid, RunTag("tag0", "value0"))
         fs.set_tag(run_uuid, RunTag("tag1", "value1"))
-        tags = fs.get_run(run_uuid).tags
-        assert set(tags) == set(
-            RunTag("tag0", "value0"),
-            RunTag("tag1", "value1"),
-        )
+        tags = [(t.key, t.value) for t in fs.get_run(run_uuid).data.tags]
+        assert set(tags) == {
+            ("tag0", "value0"),
+            ("tag1", "value1"),
+        }
 
         # Can overwrite tags.
         fs.set_tag(run_uuid, RunTag("tag0", "value2"))
-        assert set(tags) == set(
-            RunTag("tag0", "value2"),
-            RunTag("tag1", "value1"),
-        )
+        tags = [(t.key, t.value) for t in fs.get_run(run_uuid).data.tags]
+        assert set(tags) == {
+            ("tag0", "value2"),
+            ("tag1", "value1"),
+        }

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -5,7 +5,7 @@ import uuid
 
 import time
 
-from mlflow.entities import Experiment, Metric, Param
+from mlflow.entities import Experiment, Metric, Param, RunTag
 from mlflow.store.file_store import FileStore
 from mlflow.utils.file_utils import write_yaml
 from tests.helper_functions import random_int, random_str
@@ -297,3 +297,30 @@ class TestFileStore(unittest.TestCase):
         assert metric.key == WEIRD_METRIC_NAME
         assert metric.value == 10
         assert metric.timestamp == 1234
+
+    def test_weird_tag_names(self):
+        WEIRD_TAG_NAME = "this is/a weird/but valid tag"
+        fs = FileStore(self.test_root)
+        run_uuid = self.exp_data[0]["runs"][0]
+        fs.set_tag(run_uuid, RunTag(WEIRD_TAG_NAME, "Muhahaha!"))
+        tag = fs.get_run(run_uuid).tags[0]
+        assert tag.key == WEIRD_TAG_NAME
+        assert tag.value == "Muhahaha!"
+
+    def test_set_tags(self):
+        fs = FileStore(self.test_root)
+        run_uuid = self.exp_data[0]["runs"][0]
+        fs.set_tag(run_uuid, RunTag("tag0", "value0"))
+        fs.set_tag(run_uuid, RunTag("tag1", "value1"))
+        tags = fs.get_run(run_uuid).tags
+        assert set(tags) == set(
+            RunTag("tag0", "value0"),
+            RunTag("tag1", "value1"),
+        )
+
+        # Can overwrite tags.
+        fs.set_tag(run_uuid, RunTag("tag0", "value2"))
+        assert set(tags) == set(
+            RunTag("tag0", "value2"),
+            RunTag("tag1", "value1"),
+        )

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -1,6 +1,7 @@
 import pytest
 
-from mlflow.utils.validation import _validate_metric_name, _validate_param_name, _validate_run_id
+from mlflow.utils.validation import _validate_metric_name, _validate_param_name, \
+                                    _validate_tag_name, _validate_run_id
 
 GOOD_METRIC_OR_PARAM_NAMES = [
     "a", "Ab-5_", "a/b/c", "a.b.c", ".a", "b.", "a..a/._./o_O/.e.", "a b/c d",
@@ -24,6 +25,14 @@ def test_validate_param_name():
     for bad_name in BAD_METRIC_OR_PARAM_NAMES:
         with pytest.raises(Exception, match="Invalid parameter name"):
             _validate_param_name(bad_name)
+
+
+def test_validate_tag_name():
+    for good_name in GOOD_METRIC_OR_PARAM_NAMES:
+        _validate_tag_name(good_name)
+    for bad_name in BAD_METRIC_OR_PARAM_NAMES:
+        with pytest.raises(Exception, match="Invalid tag name"):
+            _validate_tag_name(bad_name)
 
 
 def test_validate_run_id():


### PR DESCRIPTION
Tags are intended to store metadata about the context in which a run has executed. Unlike parameters, these do not necessarily change the result. Examples of potential tags are things like cluster on which the run was executing, notes about a run, a parent run id (or child run ids), etc.

Currently, tags are unused, and can only be set on run creation. Since tags may be large and varied, we change them to follow the RunData paradigm.

## How is this patch tested?

- [x] Unit tests
- [x] Manually - logged to a local file store, to a REST store running locally based on a different directory. Made sure that we could deserialize and write to old file stores, and display on the UI before and after.