### PR TITLE
Fix DBFS Artifactory log_artifacts

### DIFF
--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -94,7 +94,7 @@ class DbfsArtifactRepository(ArtifactRepository):
         if artifact_path:
             root_http_endpoint = self._get_dbfs_endpoint(artifact_path)
         else:
-            root_http_endpoint = self._get_dbfs_endpoint(os.path.basename(local_dir))
+            root_http_endpoint = self._get_dbfs_endpoint('')
         for (dirpath, _, filenames) in os.walk(local_dir):
             dir_http_endpoint = root_http_endpoint
             if dirpath != local_dir:

--- a/tests/store/test_dbfs_artifact_repo.py
+++ b/tests/store/test_dbfs_artifact_repo.py
@@ -99,10 +99,9 @@ class TestDbfsArtifactRepository(object):
                 return Mock(status_code=200)
             http_request_mock.side_effect = my_http_request
             dbfs_artifact_repo.log_artifacts(test_dir.strpath, artifact_path)
-            basename = test_dir.basename
             assert set(endpoints) == {
-                '/dbfs/test/%s/subdir/test.txt' % basename,
-                '/dbfs/test/%s/test.txt' % basename
+                '/dbfs/test/subdir/test.txt',
+                '/dbfs/test/test.txt'
             }
             assert set(data) == {
                 TEST_FILE_2_CONTENT,


### PR DESCRIPTION
Before `log_artifacts('images')` would create a directory called 'images' in the artifact root and upload all contents in it. Now we change it to upload the contents at the artifact root. This matches the local artifact repo.