### PR TITLE
Allow server to introduce new fields without breaking old clients

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -39,7 +39,7 @@ def _get_request_message(request_message, flask_request=request):
         # result.
         query_string = re.sub('%5B%5D', '%5B0%5D', flask_request.query_string.decode("utf-8"))
         request_dict = parser.parse(query_string, normalized=True)
-        ParseDict(request_dict, request_message)
+        ParseDict(request_dict, request_message, ignore_unknown_fields=True)
         return request_message
 
     request_json = flask_request.get_json(force=True, silent=True)
@@ -54,7 +54,7 @@ def _get_request_message(request_message, flask_request=request):
     # If request doesn't have json body then assume it's empty.
     if request_json is None:
         request_json = {}
-    ParseDict(request_json, request_message)
+    ParseDict(request_json, request_message, ignore_unknown_fields=True)
     return request_message
 
 

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -76,7 +76,7 @@ class RestStore(AbstractStore):
         if 'error_code' in js_dict:
             raise RestException(js_dict)
 
-        ParseDict(js_dict=js_dict, message=response_proto)
+        ParseDict(js_dict=js_dict, message=response_proto, ignore_unknown_fields=True)
         return response_proto
 
     def list_experiments(self, include_deleted=False, only_deleted=False):

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -35,6 +35,7 @@ def test_can_parse_get_json_with_unknown_fields():
     msg = _get_request_message(CreateExperiment(), flask_request=request)
     assert msg.name == "hello"
 
+
 # Previous versions of the client sent a doubly string encoded JSON blob,
 # so this test ensures continued compliance with such clients.
 def test_can_parse_json_string():

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -19,6 +19,22 @@ def test_can_parse_json():
     assert msg.name == "hello"
 
 
+def test_can_parse_post_json_with_unknown_fields():
+    request = mock.MagicMock()
+    request.method = "POST"
+    request.get_json = mock.MagicMock()
+    request.get_json.return_value = {"name": "hello", "WHAT IS THIS FIELD EVEN": "DOING"}
+    msg = _get_request_message(CreateExperiment(), flask_request=request)
+    assert msg.name == "hello"
+
+
+def test_can_parse_get_json_with_unknown_fields():
+    request = mock.MagicMock()
+    request.method = "GET"
+    request.query_string = b"name=hello&superDuperUnknown=field"
+    msg = _get_request_message(CreateExperiment(), flask_request=request)
+    assert msg.name == "hello"
+
 # Previous versions of the client sent a doubly string encoded JSON blob,
 # so this test ensures continued compliance with such clients.
 def test_can_parse_json_string():

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -4,7 +4,6 @@ import six
 import unittest
 
 from mlflow.store.rest_store import RestStore, RestException
-from mlflow.entities import Experiment
 
 
 class TestRestStore(unittest.TestCase):

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -29,12 +29,10 @@ class TestRestStore(unittest.TestCase):
 
     @mock.patch('requests.request')
     def test_failed_http_request(self, request):
-        def mock_request(**_):
-            response = mock.MagicMock
-            response.status_code = 404
-            response.text = '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "No experiment"}'
-            return response
-        request.side_effect = mock_request
+        response = mock.MagicMock
+        response.status_code = 404
+        response.text = '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "No experiment"}'
+        request.return_value = response
 
         store = RestStore({'hostname': 'https://hello'})
         with self.assertRaises(RestException) as cm:
@@ -50,13 +48,11 @@ class TestRestStore(unittest.TestCase):
             "OMG_WHAT_IS_THIS_FIELD": "Hooly cow",
         }
 
-        def mock_request(**_):
-            response = mock.MagicMock
-            response.status_code = 200
-            experiments = {"experiments": [experiment_json]}
-            response.text = json.dumps(experiments)
-            return response
-        request.side_effect = mock_request
+        response = mock.MagicMock
+        response.status_code = 200
+        experiments = {"experiments": [experiment_json]}
+        response.text = json.dumps(experiments)
+        request.return_value = response
 
         store = RestStore({'hostname': 'https://hello'})
         experiments = store.list_experiments()


### PR DESCRIPTION
Currently, if the tracking server introduces a new field to a proto, older clients will be unable to deserialize the response. We can set `ignore_unknown_fields` and test this case appropriately.

All three new tests fail if I remove the associated `ignore_unknown_fields` call.