### PR TITLE
Remove "uuid" from dependency list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
         'databricks-cli>=0.8.0',
         'requests>=2.17.3',
         'six>=1.10.0',
-        'uuid',
         'gunicorn',
         'Flask',
         'numpy',


### PR DESCRIPTION
"uuid" is in the standard library, and has been for a while. Including it in "setup.py" pulls in an old version that is incompatible with python3

This is an attempt to fix #330 