### PR TITLE
Link to MLflow nightly snapshot wheels

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,8 @@ Install MLflow from PyPi via ``pip install mlflow``
 
 MLflow requires ``conda`` to be on the ``PATH`` for the projects feature.
 
+Nightly snapshots of MLflow master are also available `here <https://mlflow-snapshots.s3-us-west-2.amazonaws.com/>`_.
+
 Documentation
 -------------
 Official documentation for MLflow can be found at https://mlflow.org/docs/latest/index.html.


### PR DESCRIPTION
We are now publishing nightly MLflow wheels to the [mlflow-snapshots](https://mlflow-snapshots.s3-us-west-2.amazonaws.com/) S3 bucket. Listing the root directory will show the available keys, and you can download them by going to a URL like

https://mlflow-snapshots.s3-us-west-2.amazonaws.com/mlflow-0.5.0-py2.py3-none-any-122532a.whl

We include the git hash of the commit in the release (i.e., 122532a). These snapshots are deleted from the bucket automatically after 14 days.