### PR TITLE
Propagate Databricks tracking URI correctly to Databricks project runs

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -235,8 +235,6 @@ def _before_run_validations(tracking_uri, cluster_spec):
 
 def _get_tracking_uri_for_run():
     if not tracking.utils.is_tracking_uri_set():
-        eprint("No tracking URI was specified, defaulting to using tracking URI 'databricks' for "
-               "Databricks project execution.")
         return "databricks"
     uri = tracking.get_tracking_uri()
     if uri.startswith("databricks"):

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -234,6 +234,10 @@ def _before_run_validations(tracking_uri, cluster_spec):
 
 
 def _get_tracking_uri_for_run():
+    if not tracking.utils.is_tracking_uri_set():
+        eprint("No tracking URI was specified, defaulting to using tracking URI 'databricks' for "
+               "Databricks project execution.")
+        return "databricks"
     uri = tracking.get_tracking_uri()
     if uri.startswith("databricks"):
         return "databricks"

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -233,12 +233,19 @@ def _before_run_validations(tracking_uri, cluster_spec):
             "tracking URI %s." % tracking_uri)
 
 
+def _get_tracking_uri_for_run():
+    uri = tracking.get_tracking_uri()
+    if uri.startswith("databricks"):
+        return "databricks"
+    return uri
+
+
 def run_databricks(remote_run, uri, entry_point, work_dir, parameters, experiment_id, cluster_spec):
     """
     Runs the project at the specified URI on Databricks, returning a `SubmittedRun` that can be
     used to query the run's status or wait for the resulting Databricks Job run to terminate.
     """
-    tracking_uri = tracking.get_tracking_uri()
+    tracking_uri = _get_tracking_uri_for_run()
     _before_run_validations(tracking_uri, cluster_spec)
 
     dbfs_fuse_uri = _upload_project_to_dbfs(work_dir, experiment_id)

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -18,6 +18,13 @@ _REMOTE_URI_PREFIX = "http://"
 _tracking_uri = None
 
 
+def is_tracking_uri_set():
+    """Returns True if the tracking URI has been set, False otherwise."""
+    if _tracking_uri or env.get_env(_TRACKING_URI_ENV_VAR):
+        return True
+    return False
+
+
 def set_tracking_uri(uri):
     """
     Set the tracking server URI to the passed-in value. This does not affect the

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -205,3 +205,14 @@ def test_fetch_and_clean_project(tmpdir):
     for fetched_dir in [fetched0, fetched1]:
         with open(os.path.join(fetched_dir, "MLproject")) as handle:
             assert handle.read() == "Hello"
+
+
+def test_get_tracking_uri_for_run():
+    with mock.patch.dict(os.environ, {}):
+        mlflow.set_tracking_uri(None)
+        assert databricks._get_tracking_uri_for_run() == "databricks"
+        mlflow.set_tracking_uri("some-uri")
+        assert databricks._get_tracking_uri_for_run() == "some-uri"
+    mlflow.set_tracking_uri(None)
+    with mock.patch.dict(os.environ, {mlflow.tracking._TRACKING_URI_ENV_VAR: "some-uri"}):
+        assert mlflow.tracking.utils.get_tracking_uri() == "some-uri"

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -211,8 +211,10 @@ def test_get_tracking_uri_for_run():
     with mock.patch.dict(os.environ, {}):
         mlflow.set_tracking_uri(None)
         assert databricks._get_tracking_uri_for_run() == "databricks"
-        mlflow.set_tracking_uri("some-uri")
-        assert databricks._get_tracking_uri_for_run() == "some-uri"
+        mlflow.set_tracking_uri("http://some-uri")
+        assert databricks._get_tracking_uri_for_run() == "http://some-uri"
+        mlflow.set_tracking_uri("databricks://profile")
+        assert databricks._get_tracking_uri_for_run() == "databricks"
     mlflow.set_tracking_uri(None)
-    with mock.patch.dict(os.environ, {mlflow.tracking._TRACKING_URI_ENV_VAR: "some-uri"}):
-        assert mlflow.tracking.utils.get_tracking_uri() == "some-uri"
+    with mock.patch.dict(os.environ, {mlflow.tracking._TRACKING_URI_ENV_VAR: "http://some-uri"}):
+        assert mlflow.tracking.utils.get_tracking_uri() == "http://some-uri"


### PR DESCRIPTION
* If a databricks://profile tracking URI is specified for a databricks project run, set tracking URI to 'databricks' in the shell job. 
* If no tracking URI is specified, set tracking uri to "databricks" in the shell job
* Otherwise, retain the old behavior: if an HTTP tracking URI is specified, propagate that to the shell job, and if a local tracking URI is specified, raise an exception
