### PR TITLE
Bump mlflow version to 0.5.2.dev0

### DIFF
--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,4 +1,4 @@
 # Copyright 2018 Databricks, Inc.
 
 
-VERSION = '0.5.1'
+VERSION = '0.5.2.dev0'


### PR DESCRIPTION
This allows wheels and such built from this version not to look like the already-released version, 0.5.1.