### PR TITLE
Log Databricks notebook information as tags

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -13,6 +13,8 @@ import time
 
 from mlflow.entities import Experiment, Run, SourceType
 from mlflow.utils import env
+from mlflow.utils.databricks_utils import is_in_databricks_notebook, get_notebook_id, \
+    get_notebook_path, get_webapp_url
 from mlflow.utils.validation import _validate_run_id
 from mlflow.tracking.service import get_service
 
@@ -20,6 +22,9 @@ from mlflow.tracking.service import get_service
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"
 _RUN_ID_ENV_VAR = "MLFLOW_RUN_ID"
 _active_run = None
+_TAG_DATABRICKS_NOTEBOOK_ID = "DATABRICKS_NOTEBOOK_ID"
+_TAG_DATABRICKS_NOTEBOOK_PATH = "DATABRICKS_NOTEBOOK_PATH"
+_TAG_DATABRICKS_WEBAPP_URL = "DATABRICKS_WEBAPP_URL"
 
 
 class ActiveRun(Run):  # pylint: disable=W0223
@@ -73,13 +78,33 @@ def start_run(run_uuid=None, experiment_id=None, source_name=None, source_versio
         active_run_obj = get_service().get_run(existing_run_uuid)
     else:
         exp_id_for_run = experiment_id or _get_experiment_id()
-        active_run_obj = get_service().create_run(
-            experiment_id=exp_id_for_run,
-            run_name=run_name,
-            source_name=source_name or _get_source_name(),
-            source_version=source_version or _get_source_version(),
-            entry_point_name=entry_point_name,
-            source_type=source_type or _get_source_type())
+        if is_in_databricks_notebook():
+            databricks_tags = {}
+            notebook_id = get_notebook_id()
+            notebook_path = get_notebook_path()
+            webapp_url = get_webapp_url()
+            if notebook_id is not None:
+                databricks_tags[_TAG_DATABRICKS_NOTEBOOK_ID] = notebook_id
+            if notebook_path is not None:
+                databricks_tags[_TAG_DATABRICKS_NOTEBOOK_PATH] = notebook_path
+            if webapp_url is not None:
+                databricks_tags[_TAG_DATABRICKS_WEBAPP_URL] = webapp_url
+            active_run_obj = get_service().create_run(
+                experiment_id=exp_id_for_run,
+                run_name=run_name,
+                source_name=notebook_path,
+                source_version=source_version or _get_source_version(),
+                entry_point_name=entry_point_name,
+                source_type=SourceType.NOTEBOOK,
+                tags=databricks_tags)
+        else:
+            active_run_obj = get_service().create_run(
+                experiment_id=exp_id_for_run,
+                run_name=run_name,
+                source_name=source_name or _get_source_name(),
+                source_version=source_version or _get_source_version(),
+                entry_point_name=entry_point_name,
+                source_type=source_type or _get_source_type())
     _active_run = ActiveRun(active_run_obj)
     return _active_run
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -22,9 +22,9 @@ from mlflow.tracking.service import get_service
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"
 _RUN_ID_ENV_VAR = "MLFLOW_RUN_ID"
 _active_run = None
-_TAG_DATABRICKS_NOTEBOOK_ID = "DATABRICKS_NOTEBOOK_ID"
-_TAG_DATABRICKS_NOTEBOOK_PATH = "DATABRICKS_NOTEBOOK_PATH"
-_TAG_DATABRICKS_WEBAPP_URL = "DATABRICKS_WEBAPP_URL"
+_TAG_MLFLOW_DATABRICKS_NOTEBOOK_ID = "mlflow.databricks.notebookID"
+_TAG_MLFLOW_DATABRICKS_NOTEBOOK_PATH = "mlflow.databricks.notebookPath"
+_TAG_MLFLOW_DATABRICKS_WEBAPP_URL = "mlflow.databricks.webappURL"
 
 
 class ActiveRun(Run):  # pylint: disable=W0223
@@ -84,11 +84,11 @@ def start_run(run_uuid=None, experiment_id=None, source_name=None, source_versio
             notebook_path = get_notebook_path()
             webapp_url = get_webapp_url()
             if notebook_id is not None:
-                databricks_tags[_TAG_DATABRICKS_NOTEBOOK_ID] = notebook_id
+                databricks_tags[_TAG_MLFLOW_DATABRICKS_NOTEBOOK_ID] = notebook_id
             if notebook_path is not None:
-                databricks_tags[_TAG_DATABRICKS_NOTEBOOK_PATH] = notebook_path
+                databricks_tags[_TAG_MLFLOW_DATABRICKS_NOTEBOOK_PATH] = notebook_path
             if webapp_url is not None:
-                databricks_tags[_TAG_DATABRICKS_WEBAPP_URL] = webapp_url
+                databricks_tags[_TAG_MLFLOW_DATABRICKS_WEBAPP_URL] = webapp_url
             active_run_obj = get_service().create_run(
                 experiment_id=exp_id_for_run,
                 run_name=run_name,

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1,0 +1,52 @@
+def _get_dbutils():
+    try:
+        import IPython
+        ip_shell = IPython.get_ipython()
+        if ip_shell is None:
+            raise _NoDbutilsError
+        return ip_shell.ns_table["user_global"]["dbutils"]
+    except ImportError:
+        raise _NoDbutilsError
+    except KeyError:
+        raise _NoDbutilsError
+
+
+class _NoDbutilsError(Exception):
+    pass
+
+
+def _get_extra_context(context_key):
+    dbutils = _get_dbutils()
+    java_dbutils = dbutils.notebook.entry_point.getDbutils()
+    return java_dbutils.notebook().getContext().extraContext().get(context_key).get()
+
+
+def is_in_databricks_notebook():
+    try:
+        return _get_extra_context("aclPathOfAclRoot").startswith('/workspace')
+    except Exception:
+        return False
+
+
+def get_notebook_id():
+    try:
+        acl_path = _get_extra_context("aclPathOfAclRoot")
+        if acl_path.startswith('/workspace'):
+            return acl_path.split('/')[-1]
+        return None
+    except Exception:
+        return None
+
+
+def get_notebook_path():
+    try:
+        return _get_extra_context("notebook_path")
+    except Exception:
+        return None
+
+
+def get_webapp_url():
+    try:
+        return _get_extra_context("api_url")
+    except Exception:
+        return None

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -24,29 +24,23 @@ def _get_extra_context(context_key):
 def is_in_databricks_notebook():
     try:
         return _get_extra_context("aclPathOfAclRoot").startswith('/workspace')
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         return False
 
 
 def get_notebook_id():
-    try:
-        acl_path = _get_extra_context("aclPathOfAclRoot")
-        if acl_path.startswith('/workspace'):
-            return acl_path.split('/')[-1]
-        return None
-    except Exception:
-        return None
+    """Should only be called if is_in_databricks_notebook is true"""
+    acl_path = _get_extra_context("aclPathOfAclRoot")
+    if acl_path.startswith('/workspace'):
+        return acl_path.split('/')[-1]
+    return None
 
 
 def get_notebook_path():
-    try:
-        return _get_extra_context("notebook_path")
-    except Exception:
-        return None
+    """Should only be called if is_in_databricks_notebook is true"""
+    return _get_extra_context("notebook_path")
 
 
 def get_webapp_url():
-    try:
-        return _get_extra_context("api_url")
-    except Exception:
-        return None
+    """Should only be called if is_in_databricks_notebook is true"""
+    return _get_extra_context("api_url")

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -7,6 +7,3 @@ def test_no_throw():
     None.
     """
     assert not databricks_utils.is_in_databricks_notebook()
-    assert databricks_utils.get_notebook_id() is None
-    assert databricks_utils.get_notebook_path() is None
-    assert databricks_utils.get_webapp_url() is None

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -1,0 +1,12 @@
+from mlflow.utils import databricks_utils
+
+
+def test_no_throw():
+    """
+    Outside of Databricks the databricks_utils methods should never throw and should only return
+    None.
+    """
+    assert not databricks_utils.is_in_databricks_notebook()
+    assert databricks_utils.get_notebook_id() is None
+    assert databricks_utils.get_notebook_path() is None
+    assert databricks_utils.get_webapp_url() is None


### PR DESCRIPTION
When running as a Databricks notebook, MLflow should take a best effort to log the following

- notebook ID
- notebook path
- webapp url