### PR TITLE
Launch Databricks project runs asynchronously via the CLI, clean up error messages 

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -107,7 +107,7 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
             git_password=git_password,
             use_conda=(not no_conda),
             storage_dir=storage_dir,
-            block=mode == "local",
+            block=mode == "local" or mode is None,
             run_id=run_id,
         )
     except projects.ExecutionException as e:

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -15,6 +15,7 @@ import mlflow.sagemaker.cli
 
 from mlflow.entities.experiment import Experiment
 from mlflow.utils.process import ShellCommandException
+from mlflow.utils.logging_utils import eprint
 from mlflow.utils import cli_args
 from mlflow.server import _run_server
 from mlflow import tracking
@@ -73,7 +74,7 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
     """
     Run an MLflow project from the given URI.
 
-    Blocks till the run completes.
+    For local runs, blocks the run completes. Otherwise, runs the project asynchronously.
 
     If running locally (the default), the URI can be either a Git repository URI or a local path.
     If running on Databricks, the URI must be a Git repository.
@@ -106,12 +107,11 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
             git_password=git_password,
             use_conda=(not no_conda),
             storage_dir=storage_dir,
-            block=True,
+            block=mode == "local",
             run_id=run_id,
         )
-    except projects.ExecutionException:
-        import traceback
-        traceback.print_exc(file=sys.stderr)
+    except projects.ExecutionException as e:
+        eprint(e)
         sys.exit(1)
 
 

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -111,7 +111,7 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
             run_id=run_id,
         )
     except projects.ExecutionException as e:
-        eprint(e)
+        eprint("=== %s ===" % e)
         sys.exit(1)
 
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -137,7 +137,7 @@ def _wait_for(submitted_run_obj):
             _maybe_set_run_terminated(active_run, "FINISHED")
         else:
             _maybe_set_run_terminated(active_run, "FAILED")
-            raise ExecutionException("=== Run (ID '%s') failed ===" % run_id)
+            raise ExecutionException("Run (ID '%s') failed" % run_id)
     except KeyboardInterrupt:
         eprint("=== Run (ID '%s') interrupted, cancelling run ===" % run_id)
         submitted_run_obj.cancel()

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -139,7 +139,7 @@ def _wait_for(submitted_run_obj):
             _maybe_set_run_terminated(active_run, "FAILED")
             raise ExecutionException("=== Run (ID '%s') failed ===" % run_id)
     except KeyboardInterrupt:
-        eprint("=== Run (ID '%s') === interrupted, cancelling run ===" % run_id)
+        eprint("=== Run (ID '%s') interrupted, cancelling run ===" % run_id)
         submitted_run_obj.cancel()
         _maybe_set_run_terminated(active_run, "FAILED")
         raise

--- a/tests/utils/test_exception.py
+++ b/tests/utils/test_exception.py
@@ -1,0 +1,6 @@
+from mlflow.utils.exception import ExecutionException
+
+
+def test_execution_exception_string_repr():
+    exc = ExecutionException("Uh oh")
+    assert str(exc) == "Uh oh"


### PR DESCRIPTION
Update databricks runs to run in non-blocking mode when launched via the CLI and print only the exception error message (rather than a full stacktrace) on failed runs launched from the CLI