### PR TITLE
Improve string representations of entities

### DIFF
--- a/mlflow/entities/_mlflow_object.py
+++ b/mlflow/entities/_mlflow_object.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+import pprint
 
 
 class _MLflowObject(object):
@@ -20,3 +21,37 @@ class _MLflowObject(object):
     @classmethod
     def from_dictionary(cls, the_dict):
         return cls(**the_dict)
+
+    def __repr__(self):
+        return serialize(self)
+
+
+def serialize(obj):
+    return _MLflowObjectPrinter().serialize(obj)
+
+
+def get_classname(obj):
+    return obj.__module__ + "." + obj.__class__.__qualname__
+
+
+class _MLflowObjectPrinter(object):
+    _MAX_LIST_LEN = 2
+
+    def __init__(self):
+        super(_MLflowObjectPrinter, self).__init__()
+        self.printer = pprint.PrettyPrinter()
+
+    def serialize(self, obj):
+        if isinstance(obj, _MLflowObject):
+            return "<%s: %s>" % (get_classname(obj), self.serialize_entity(obj))
+        # Handle nested lists inside MLflow entities (e.g. lists of metrics/params)
+        if isinstance(obj, list):
+            res = [serialize(elem) for elem in obj[:self._MAX_LIST_LEN]]
+            if len(obj) > self._MAX_LIST_LEN:
+                res.append("...")
+            return "[%s]" % ", ".join(res)
+        return self.printer.pformat(obj)
+
+    def serialize_entity(self, entity):
+        return ", ".join(["%s=%s" % (self.serialize(key), self.serialize(value))
+                          for key, value in sorted(dict(entity).items())])

--- a/mlflow/entities/_mlflow_object.py
+++ b/mlflow/entities/_mlflow_object.py
@@ -23,15 +23,15 @@ class _MLflowObject(object):
         return cls(**the_dict)
 
     def __repr__(self):
-        return serialize(self)
+        return to_string(self)
 
 
-def serialize(obj):
-    return _MLflowObjectPrinter().serialize(obj)
+def to_string(obj):
+    return _MLflowObjectPrinter().to_string(obj)
 
 
 def get_classname(obj):
-    return obj.__module__ + "." + obj.__class__.__qualname__
+    return type(obj).__name__
 
 
 class _MLflowObjectPrinter(object):
@@ -41,17 +41,16 @@ class _MLflowObjectPrinter(object):
         super(_MLflowObjectPrinter, self).__init__()
         self.printer = pprint.PrettyPrinter()
 
-    def serialize(self, obj):
+    def to_string(self, obj):
         if isinstance(obj, _MLflowObject):
-            return "<%s: %s>" % (get_classname(obj), self.serialize_entity(obj))
+            return "<%s: %s>" % (get_classname(obj), self._entity_to_string(obj))
         # Handle nested lists inside MLflow entities (e.g. lists of metrics/params)
         if isinstance(obj, list):
-            res = [serialize(elem) for elem in obj[:self._MAX_LIST_LEN]]
+            res = [self.to_string(elem) for elem in obj[:self._MAX_LIST_LEN]]
             if len(obj) > self._MAX_LIST_LEN:
                 res.append("...")
             return "[%s]" % ", ".join(res)
         return self.printer.pformat(obj)
 
-    def serialize_entity(self, entity):
-        return ", ".join(["%s=%s" % (self.serialize(key), self.serialize(value))
-                          for key, value in sorted(dict(entity).items())])
+    def _entity_to_string(self, entity):
+        return ", ".join(["%s=%s" % (key, self.to_string(value)) for key, value in entity])

--- a/mlflow/entities/run.py
+++ b/mlflow/entities/run.py
@@ -47,12 +47,7 @@ class Run(_MLflowObject):
     def to_dictionary(self):
         return {"info": dict(self.info), "data": dict(self.data)}
 
-    def __iter__(self):
-        the_dict = self.to_dictionary()
-        for k in the_dict:
-            yield k, the_dict[k]
 
     @classmethod
     def _properties(cls):
-        # This method should never get called since __iter__ from base class has been overridden.
-        raise NotImplementedError
+        return ["info", "data"]

--- a/mlflow/entities/run.py
+++ b/mlflow/entities/run.py
@@ -47,7 +47,6 @@ class Run(_MLflowObject):
     def to_dictionary(self):
         return {"info": dict(self.info), "data": dict(self.data)}
 
-
     @classmethod
     def _properties(cls):
         return ["info", "data"]

--- a/tests/entities/test_experiment.py
+++ b/tests/entities/test_experiment.py
@@ -30,5 +30,4 @@ class TestExperiment(unittest.TestCase):
 
     def test_string_repr(self):
         exp = Experiment(experiment_id=0, name="myname", artifact_location="hi")
-        assert str(exp) == """<mlflow.entities.experiment.Experiment 'artifact_location'='hi', 'experiment_id'=0, 'name'='myname'>"""
-
+        assert str(exp) == "<Experiment: experiment_id=0, name='myname', artifact_location='hi'>"

--- a/tests/entities/test_experiment.py
+++ b/tests/entities/test_experiment.py
@@ -27,3 +27,8 @@ class TestExperiment(unittest.TestCase):
 
         exp3 = Experiment.from_dictionary(as_dict)
         self._check(exp3, exp_id, name, location)
+
+    def test_string_repr(self):
+        exp = Experiment(experiment_id=0, name="myname", artifact_location="hi")
+        assert str(exp) == """<mlflow.entities.experiment.Experiment 'artifact_location'='hi', 'experiment_id'=0, 'name'='myname'>"""
+

--- a/tests/entities/test_run.py
+++ b/tests/entities/test_run.py
@@ -1,4 +1,4 @@
-from mlflow.entities import Run, Metric, Param, RunData, RunTag, SourceType, RunStatus, RunInfo
+from mlflow.entities import Run, Metric, RunData, SourceType, RunStatus, RunInfo
 from tests.entities.test_run_data import TestRunData
 from tests.entities.test_run_info import TestRunInfo
 
@@ -55,12 +55,10 @@ class TestRun(TestRunInfo, TestRunData):
         metrics = [Metric("key", i, 0) for i in range(5)]
         run_data = RunData(metrics=metrics, params=[], tags=[])
         run1 = Run(run_info, run_data)
-        expected = "<mlflow.entities.run.Run: 'data'=<mlflow.entities.run_data.RunData: " \
-                   "'metrics'=[<mlflow.entities.metric.Metric: 'key'='key', 'timestamp'=0, " \
-                   "'value'=0>, <mlflow.entities.metric.Metric: 'key'='key', 'timestamp'=0, " \
-                   "'value'=1>, ...], 'params'=[], 'tags'=[]>, " \
-                   "'info'=<mlflow.entities.run_info.RunInfo: 'artifact_uri'=None, 'end_time'=1, " \
-                   "'entry_point_name'='entry-point-name', 'experiment_id'=0, 'name'='name', " \
-                   "'run_uuid'='hi', 'source_name'='source-name', 'source_type'=3, " \
-                   "'source_version'='version', 'start_time'=0, 'status'=4, 'user_id'='user-id'>>"
+        expected = "<Run: info=<RunInfo: run_uuid='hi', experiment_id=0, name='name', " \
+                   "source_type=3, source_name='source-name', " \
+                   "entry_point_name='entry-point-name', user_id='user-id', status=4, " \
+                   "start_time=0, end_time=1, source_version='version', artifact_uri=None>, " \
+                   "data=<RunData: metrics=[<Metric: key='key', value=0, timestamp=0>, " \
+                   "<Metric: key='key', value=1, timestamp=0>, ...], params=[], tags=[]>>"
         assert str(run1) == expected

--- a/tests/entities/test_run.py
+++ b/tests/entities/test_run.py
@@ -1,4 +1,4 @@
-from mlflow.entities import Run
+from mlflow.entities import Run, Metric, Param, RunData, RunTag, SourceType, RunStatus, RunInfo
 from tests.entities.test_run_data import TestRunData
 from tests.entities.test_run_info import TestRunInfo
 
@@ -37,7 +37,7 @@ class TestRun(TestRunInfo, TestRunData):
                    "data": {"metrics": metrics,
                             "params": params,
                             "tags": tags}}
-        self.assertEqual(dict(run1), as_dict)
+        self.assertEqual(run1.to_dictionary(), as_dict)
 
         # proto = run1.to_proto()
         # run2 = Run.from_proto(proto)
@@ -45,3 +45,22 @@ class TestRun(TestRunInfo, TestRunData):
 
         run3 = Run.from_dictionary(as_dict)
         self._check_run(run3, run_info, run_data)
+
+    def test_string_repr(self):
+        run_info = RunInfo(
+            run_uuid="hi", experiment_id=0, name="name", source_type=SourceType.PROJECT,
+            source_name="source-name", entry_point_name="entry-point-name",
+            user_id="user-id", status=RunStatus.FAILED, start_time=0, end_time=1,
+            source_version="version")
+        metrics = [Metric("key", i, 0) for i in range(5)]
+        run_data = RunData(metrics=metrics, params=[], tags=[])
+        run1 = Run(run_info, run_data)
+        expected = "<mlflow.entities.run.Run: 'data'=<mlflow.entities.run_data.RunData: " \
+                   "'metrics'=[<mlflow.entities.metric.Metric: 'key'='key', 'timestamp'=0, " \
+                   "'value'=0>, <mlflow.entities.metric.Metric: 'key'='key', 'timestamp'=0, " \
+                   "'value'=1>, ...], 'params'=[], 'tags'=[]>, " \
+                   "'info'=<mlflow.entities.run_info.RunInfo: 'artifact_uri'=None, 'end_time'=1, " \
+                   "'entry_point_name'='entry-point-name', 'experiment_id'=0, 'name'='name', " \
+                   "'run_uuid'='hi', 'source_name'='source-name', 'source_type'=3, " \
+                   "'source_version'='version', 'start_time'=0, 'status'=4, 'user_id'='user-id'>>"
+        assert str(run1) == expected


### PR DESCRIPTION
Currently, MLflow entities use default Python string serialization, resulting in hard-to-interpret output like:

```
>>> from  mlflow.tracking import get_service
>>> service = get_service()
>>> experiments = service.list_experiments()
[<mlflow.entities.experiment.Experiment at 0x7f93a8902a90>]
```

This PR improves entities' string representations to include a listing of their fields (and recursive serialization of lists of entities, e.g. lists of metrics/params within a run). The above now results in:

```
>>> from  mlflow.tracking import get_service
>>> service = get_service()
>>> experiments = service.list_experiments()
[<mlflow.entities.experiment.Experiment: 'artifact_location'='/Users/sid/code/mlflow/mlruns/0', 'experiment_id'=0, 'name'='Default'>]
```

Runs now appear as:
```
>>> r = service.get_run(run_id)
>>> r
<mlflow.entities.run.Run: 'data'=<mlflow.entities.run_data.RunData: 'metrics'=[<mlflow.entities.metric.Metric: 'key'='random_int', 'timestamp'=1534987517, 'value'=75.0>, <mlflow.entities.metric.Metric: 'key'='foo', 'timestamp'=1534987517, 'value'=7.0>], 'params'=[<mlflow.entities.param.Param: 'key'='param1', 'value'='5'>], 'tags'=[]>, 'info'=<mlflow.entities.run_info.RunInfo: 'artifact_uri'='/Users/sid/code/mlflow/mlruns/0/145d84e1b29c4fe9a3b191f27e63a79f/artifacts', 'end_time'=1534987517756, 'entry_point_name'='', 'experiment_id'=0, 'name'='Run 6', 'run_uuid'='145d84e1b29c4fe9a3b191f27e63a79f', 'source_name'='example/advanced/test_remote_server.py', 'source_type'=4, 'source_version'='e375c52679ab74b3f6e864d6bcab0118125e31e4', 'start_time'=1534987517633, 'status'=3, 'user_id'='sid'>>
```

Feedback is welcome - run serialization is still somewhat unwieldy due to the number of fields in a run.