### PR TITLE
Add helper method get_experiment_by_name to MLFlowService

### DIFF
--- a/mlflow/tracking/service.py
+++ b/mlflow/tracking/service.py
@@ -71,6 +71,10 @@ class MLflowService(object):
         """:return: :py:class:`mlflow.entities.Experiment`"""
         return self.store.get_experiment(experiment_id)
 
+    def get_experiment_by_name(self, name):
+        """:return: :py:class:`mlflow.entities.Experiment`"""
+        return self.store.get_experiment_by_name(name)
+
     def create_experiment(self, name, artifact_location=None):
         """Creates an experiment.
 


### PR DESCRIPTION
A minor proposition to add to MLFlowService class a helper method to get experiment by name. Therefore, user can call directly
```
get_service().get_experiment_by_name(task_name)
```
instead of 
```
get_service().store.get_experiment_by_name(task_name)
```
What do you think about this feature ?
Thanks
