### PR TITLE
Pin old boto3 version in test-requirements.txt

### DIFF
--- a/mlflow/store/s3_artifact_repo.py
+++ b/mlflow/store/s3_artifact_repo.py
@@ -3,6 +3,7 @@ import os
 import boto3
 from six.moves import urllib
 
+from mlflow import data
 from mlflow.entities import FileInfo
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import build_path, get_relative_path, TempDir
@@ -23,7 +24,7 @@ class S3ArtifactRepository(ArtifactRepository):
         return parsed.netloc, path
 
     def log_artifact(self, local_file, artifact_path=None):
-        (bucket, dest_path) = self.parse_s3_uri(self.artifact_uri)
+        (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)
         if artifact_path:
             dest_path = build_path(dest_path, artifact_path)
         dest_path = build_path(dest_path, os.path.basename(local_file))
@@ -31,7 +32,7 @@ class S3ArtifactRepository(ArtifactRepository):
         boto3.client('s3').upload_file(local_file, bucket, dest_path)
 
     def log_artifacts(self, local_dir, artifact_path=None):
-        (bucket, dest_path) = self.parse_s3_uri(self.artifact_uri)
+        (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)
         if artifact_path:
             dest_path = build_path(dest_path, artifact_path)
         s3 = boto3.client('s3')
@@ -45,7 +46,7 @@ class S3ArtifactRepository(ArtifactRepository):
                 s3.upload_file(build_path(root, f), bucket, build_path(upload_path, f))
 
     def list_artifacts(self, path=None):
-        (bucket, artifact_path) = self.parse_s3_uri(self.artifact_uri)
+        (bucket, artifact_path) = data.parse_s3_uri(self.artifact_uri)
         dest_path = artifact_path
         if path:
             dest_path = build_path(dest_path, path)
@@ -82,7 +83,7 @@ class S3ArtifactRepository(ArtifactRepository):
             for file_info in listing:
                 self._download_artifacts_into(file_info.path, local_path)
         else:
-            (bucket, s3_path) = self.parse_s3_uri(self.artifact_uri)
+            (bucket, s3_path) = data.parse_s3_uri(self.artifact_uri)
             s3_path = build_path(s3_path, artifact_path)
             boto3.client('s3').download_file(bucket, s3_path, local_path)
         return local_path

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     package_data={"mlflow": js_files + sagmaker_server_files},
     install_requires=[
-        'awscli',
         'click>=6.7',
         'databricks-cli>=0.8.0',
         'requests>=2.17.3',

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@
 azure-storage
 google-cloud-storage
 h2o
+boto3==1.7.84
 mock==2.0.0
 moto
 prospector[with_pyroma]==0.12.7

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,7 @@
 azure-storage
 google-cloud-storage
 h2o
+# TODO: don't pin boto version once https://github.com/spulec/moto/issues/1793 is addressed
 boto3==1.7.84
 mock==2.0.0
 moto


### PR DESCRIPTION
As described in https://github.com/spulec/moto/issues/1793, moto doesn't seem to be properly mocking S3 calls with boto3 1.8 releases, so this PR pins the version of boto3 in test-requirements.txt to the latest 1.7 boto3 release

Also: this PR removes the `awscli` dependency, which transitively depends on a botocore version (1.11) that causes the s3 artifact store tests to fail.