### PR TITLE
Install library version mlflow<=VERSION when running remote projects

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -178,8 +178,6 @@ def _run_shell_command_job(project_uri, command, env_vars, cluster_spec):
              Databricks Runs Get API (https://docs.databricks.com/api/latest/jobs.html#runs-get).
     """
     # Make jobs API request to launch run.
-    # NB: We use <= on the version specifier to allow running projects on pre-release
-    # versions, where we will select the most up-to-date mlflow version available.
     req_body_json = {
         'run_name': 'MLflow Run for %s' % project_uri,
         'new_cluster': cluster_spec,
@@ -187,6 +185,8 @@ def _run_shell_command_job(project_uri, command, env_vars, cluster_spec):
             'command': command,
             "env_vars": env_vars
         },
+        # NB: We use <= on the version specifier to allow running projects on pre-release
+        # versions, where we will select the most up-to-date mlflow version available.
         "libraries": [{"pypi": {"package": "mlflow<=%s" % VERSION}}]
     }
     run_submit_res = _jobs_runs_submit(req_body_json)

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -178,6 +178,8 @@ def _run_shell_command_job(project_uri, command, env_vars, cluster_spec):
              Databricks Runs Get API (https://docs.databricks.com/api/latest/jobs.html#runs-get).
     """
     # Make jobs API request to launch run.
+    # NB: We use <= on the version specifier to allow running projects on pre-release
+    # versions, where we will select the most up-to-date mlflow version available.
     req_body_json = {
         'run_name': 'MLflow Run for %s' % project_uri,
         'new_cluster': cluster_spec,
@@ -185,7 +187,7 @@ def _run_shell_command_job(project_uri, command, env_vars, cluster_spec):
             'command': command,
             "env_vars": env_vars
         },
-        "libraries": [{"pypi": {"package": "mlflow==%s" % VERSION}}]
+        "libraries": [{"pypi": {"package": "mlflow<=%s" % VERSION}}]
     }
     run_submit_res = _jobs_runs_submit(req_body_json)
     databricks_run_id = run_submit_res["run_id"]


### PR DESCRIPTION
There are three states in which the mlflow projects code may be run:
1. On a release branch (e.g., VERSION=0.5.1).
2. On a dev pre-release branch (e.g., VERSION=0.5.2.dev0)
3. On a release candidate (e.g., VERSION=0.5.2, but 0.5.2 is not yet published to PyPI [everywhere]).

Currently, I can use `mlflow run -m databricks` only in situation 1. In situations 2 & 3, PyPI does not know about my VERSION. Changing the indicator from `mlflow==VERSION` to `mlflow<=VERSION` makes all three cases work, although 2 & 3 will run the *last* release instead of the local release. Since this version is only used to boostrap the mlflow run, this should be unlikely to cause problems, and it seems unlikely that there is a better solution for these cases.