### PR TITLE
Fix escaping issue with "mlflow<=VERSION" installation in remote runs

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -178,9 +178,6 @@ def _run_shell_command_job(project_uri, command, env_vars, cluster_spec):
              Databricks Runs Get API (https://docs.databricks.com/api/latest/jobs.html#runs-get).
     """
     # Make jobs API request to launch run.
-    # NB: We use mlflow==VERSION unless we're in a dev version, in which case
-    # we use just 'mlflow' instead.
-    mlflow_package = "mlflow==%s" % VERSION if "dev" not in VERSION else "mlflow"
     req_body_json = {
         'run_name': 'MLflow Run for %s' % project_uri,
         'new_cluster': cluster_spec,

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -178,6 +178,9 @@ def _run_shell_command_job(project_uri, command, env_vars, cluster_spec):
              Databricks Runs Get API (https://docs.databricks.com/api/latest/jobs.html#runs-get).
     """
     # Make jobs API request to launch run.
+    # NB: We use mlflow==VERSION unless we're in a dev version, in which case
+    # we use just 'mlflow' instead.
+    mlflow_package = "mlflow==%s" % VERSION if "dev" not in VERSION else "mlflow"
     req_body_json = {
         'run_name': 'MLflow Run for %s' % project_uri,
         'new_cluster': cluster_spec,
@@ -185,9 +188,7 @@ def _run_shell_command_job(project_uri, command, env_vars, cluster_spec):
             'command': command,
             "env_vars": env_vars
         },
-        # NB: We use <= on the version specifier to allow running projects on pre-release
-        # versions, where we will select the most up-to-date mlflow version available.
-        "libraries": [{"pypi": {"package": "mlflow<=%s" % VERSION}}]
+        "libraries": [{"pypi": {"package": mlflow_package}}]
     }
     run_submit_res = _jobs_runs_submit(req_body_json)
     databricks_run_id = run_submit_res["run_id"]

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -188,7 +188,10 @@ def _run_shell_command_job(project_uri, command, env_vars, cluster_spec):
             'command': command,
             "env_vars": env_vars
         },
-        "libraries": [{"pypi": {"package": mlflow_package}}]
+        # NB: We use <= on the version specifier to allow running projects on pre-release
+        # versions, where we will select the most up-to-date mlflow version available.
+        # Also note, that we escape this so '<' is not treated as a shell pipe.
+        "libraries": [{"pypi": {"package": "'mlflow<=%s'" % VERSION}}]
     }
     run_submit_res = _jobs_runs_submit(req_body_json)
     databricks_run_id = run_submit_res["run_id"]


### PR DESCRIPTION
#383 didn't actually work, because there is a bug in Databricks which causes it to require quoting when using `>=` or `<=` specifications.

Apologies for not manually testing the previous PR, I thought it was too simple. I have manually tested both conditionals here, with a dev version and without (by fiddling with `mlflow/version.py`).