### PR TITLE
Add 'mlflow artifacts' CLI to list, download, and upload to artifact repos

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -19,6 +19,7 @@ from mlflow.utils.logging_utils import eprint
 from mlflow.utils import cli_args
 from mlflow.server import _run_server
 from mlflow import tracking
+import mlflow.store.cli
 
 
 @click.group()
@@ -194,6 +195,7 @@ cli.add_command(mlflow.pyfunc.cli.commands)
 cli.add_command(mlflow.sagemaker.cli.commands)
 cli.add_command(mlflow.azureml.cli.commands)
 cli.add_command(mlflow.experiments.commands)
+cli.add_command(mlflow.store.cli.commands)
 
 if __name__ == '__main__':
     cli()

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -5,7 +5,6 @@ import re
 import six
 
 from flask import Response, request, send_file
-from google.protobuf.json_format import MessageToJson, ParseDict
 from querystring_parser import parser
 
 from mlflow.entities import Metric, Param, RunTag
@@ -16,6 +15,7 @@ from mlflow.protos.service_pb2 import CreateExperiment, MlflowService, GetExperi
     DeleteExperiment, RestoreExperiment
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.store.file_store import FileStore
+from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 
 
 _store = None
@@ -40,7 +40,7 @@ def _get_request_message(request_message, flask_request=request):
         # result.
         query_string = re.sub('%5B%5D', '%5B0%5D', flask_request.query_string.decode("utf-8"))
         request_dict = parser.parse(query_string, normalized=True)
-        ParseDict(request_dict, request_message, ignore_unknown_fields=True)
+        parse_dict(request_dict, request_message)
         return request_message
 
     request_json = flask_request.get_json(force=True, silent=True)
@@ -55,7 +55,7 @@ def _get_request_message(request_message, flask_request=request):
     # If request doesn't have json body then assume it's empty.
     if request_json is None:
         request_json = {}
-    ParseDict(request_json, request_message, ignore_unknown_fields=True)
+    parse_dict(request_json, request_message)
     return request_message
 
 
@@ -88,11 +88,6 @@ def _not_implemented():
     return response
 
 
-def _message_to_json(message):
-    # preserving_proto_field_name keeps the JSON-serialized form snake_case
-    return MessageToJson(message, preserving_proto_field_name=True)
-
-
 def _create_experiment():
     request_message = _get_request_message(CreateExperiment())
     experiment_id = _get_store().create_experiment(request_message.name,
@@ -100,7 +95,7 @@ def _create_experiment():
     response_message = CreateExperiment.Response()
     response_message.experiment_id = experiment_id
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -112,7 +107,7 @@ def _get_experiment():
     run_info_entities = _get_store().list_run_infos(request_message.experiment_id)
     response_message.runs.extend([r.to_proto() for r in run_info_entities])
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -121,7 +116,7 @@ def _delete_experiment():
     _get_store().delete_experiment(request_message.experiment_id)
     response_message = DeleteExperiment.Response()
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -130,7 +125,7 @@ def _restore_experiment():
     _get_store().restore_experiment(request_message.experiment_id)
     response_message = RestoreExperiment.Response()
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -152,7 +147,7 @@ def _create_run():
     response_message = CreateRun.Response()
     response_message.run.MergeFrom(run.to_proto())
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -162,7 +157,7 @@ def _update_run():
                                                 request_message.end_time)
     response_message = UpdateRun.Response(run_info=updated_info.to_proto())
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -172,7 +167,7 @@ def _log_metric():
     _get_store().log_metric(request_message.run_uuid, metric)
     response_message = LogMetric.Response()
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -182,7 +177,7 @@ def _log_param():
     _get_store().log_param(request_message.run_uuid, param)
     response_message = LogParam.Response()
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -192,7 +187,7 @@ def _set_tag():
     _get_store().set_tag(request_message.run_uuid, tag)
     response_message = SetTag.Response()
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -201,7 +196,7 @@ def _get_run():
     response_message = GetRun.Response()
     response_message.run.MergeFrom(_get_store().get_run(request_message.run_uuid).to_proto())
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -212,7 +207,7 @@ def _search_runs():
                                             request_message.anded_expressions)
     response_message.runs.extend([r.to_proto() for r in run_entities])
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -228,7 +223,7 @@ def _list_artifacts():
     response_message.files.extend([a.to_proto() for a in artifact_entities])
     response_message.root_uri = _get_artifact_repo(run).artifact_uri
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -239,7 +234,7 @@ def _get_metric_history():
                                                      request_message.metric_key)
     response_message.metrics.extend([m.to_proto() for m in metric_entites])
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -249,7 +244,7 @@ def _get_metric():
     metric = _get_store().get_metric(request_message.run_uuid, request_message.metric_key)
     response_message.metric.MergeFrom(metric.to_proto())
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -259,7 +254,7 @@ def _get_param():
     parameter = _get_store().get_param(request_message.run_uuid, request_message.param_name)
     response_message.parameter.MergeFrom(parameter.to_proto())
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 
@@ -269,7 +264,7 @@ def _list_experiments():
     response_message = ListExperiments.Response()
     response_message.experiments.extend([e.to_proto() for e in experiment_entities])
     response = Response(mimetype='application/json')
-    response.set_data(_message_to_json(response_message))
+    response.set_data(message_to_json(response_message))
     return response
 
 

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -52,6 +52,7 @@ class ArtifactRepository:
         """
         Download an artifact file or directory to a local directory if applicable, and return a
         local path for it.
+        The caller is responsible for managing the lifecycle of the downloaded artifacts.
         :param path: Relative source path to the desired artifact
         :return: Full path desired artifact.
         """

--- a/mlflow/store/cli.py
+++ b/mlflow/store/cli.py
@@ -32,7 +32,7 @@ def log_artifact(local_file, run_id, artifact_path):
     artifact_uri = store.get_run(run_id).info.artifact_uri
     artifact_repo = ArtifactRepository.from_artifact_uri(artifact_uri, store)
     artifact_repo.log_artifact(local_file, artifact_path)
-    eprint("Logged artifact from local file '%s' to '%s'" % (local_file, artifact_path))
+    eprint("Logged artifact from local file %s to artifact_path=%s" % (local_file, artifact_path))
 
 
 @commands.command("log-artifacts",
@@ -55,7 +55,7 @@ def log_artifacts(local_dir, run_id, artifact_path):
     artifact_uri = store.get_run(run_id).info.artifact_uri
     artifact_repo = ArtifactRepository.from_artifact_uri(artifact_uri, store)
     artifact_repo.log_artifacts(local_dir, artifact_path)
-    eprint("Logged artifact from local file '%s' to '%s'" % (local_dir, artifact_path))
+    eprint("Logged artifact from local dir %s to artifact_path=%s" % (local_dir, artifact_path))
 
 
 @commands.command("list",

--- a/mlflow/store/cli.py
+++ b/mlflow/store/cli.py
@@ -1,0 +1,92 @@
+from mlflow.utils.logging_utils import eprint
+
+import json
+import os
+import tempfile
+
+import click
+
+from tabulate import tabulate
+
+from mlflow.data import is_uri
+from mlflow.entities import ViewType
+from mlflow.tracking import _get_store
+from mlflow.store.artifact_repo import ArtifactRepository
+from mlflow.utils.proto_json_utils import message_to_json
+
+
+@click.group("artifacts")
+def commands():
+    """Manage experiments."""
+    pass
+
+
+@commands.command("log-artifact")
+@click.option("--local-file", "-l", required=True,
+              help="Base location for runs to store artifact results. Artifacts will be stored ")
+@click.option("--run-id", "-r", required=True)
+@click.option("--artifact-path", "-a",
+              help="Base location for runs to store artifact results. Artifacts will be stored ")
+def log_artifact(local_file, run_id, artifact_path):
+    """
+    Creates a new experiment in the configured tracking server.
+    """
+    store = _get_store()
+    artifact_uri = store.get_run(run_id).info.artifact_uri
+    artifact_repo = ArtifactRepository.from_artifact_uri(artifact_uri, store)
+    artifact_repo.log_artifact(local_file, artifact_path)
+    eprint("Logged artifact from local file '%s' to '%s'" % (local_file, artifact_path))
+
+
+@commands.command("log-artifacts")
+@click.option("--local-dir", "-l", required=True,
+              help="Base location for runs to store artifact results. Artifacts will be stored ")
+@click.option("--run-id", "-r", required=True)
+@click.option("--artifact-path", "-a",
+              help="Base location for runs to store artifact results. Artifacts will be stored ")
+def log_artifacts(local_dir, run_id, artifact_path):
+    """
+    Creates a new experiment in the configured tracking server.
+    """
+    store = _get_store()
+    artifact_uri = store.get_run(run_id).info.artifact_uri
+    artifact_repo = ArtifactRepository.from_artifact_uri(artifact_uri, store)
+    artifact_repo.log_artifacts(local_dir, artifact_path)
+    eprint("Logged artifact from local file '%s' to '%s'" % (local_dir, artifact_path))
+
+
+@commands.command("list")
+@click.option("--run-id", "-r", required=True)
+@click.option("--artifact-path", "-a",
+              help="Base location for runs to store artifact results. Artifacts will be stored ")
+def list_artifacts(run_id, artifact_path):
+    """
+    Creates a new experiment in the configured tracking server.
+    """
+    artifact_path = artifact_path if artifact_path is not None else ""
+    store = _get_store()
+    artifact_uri = store.get_run(run_id).info.artifact_uri
+    artifact_repo = ArtifactRepository.from_artifact_uri(artifact_uri, store)
+    file_infos = artifact_repo.list_artifacts(artifact_path)
+    print(_file_infos_to_json(file_infos))
+
+
+def _file_infos_to_json(file_infos):
+  json_list = [message_to_json(file_info.to_proto()) for file_info in file_infos]
+  return "[" + ", ".join(json_list) + "]"
+
+
+@commands.command("download-artifacts")
+@click.option("--run-id", "-r", required=True)
+@click.option("--artifact-path", "-a",
+              help="Base location for runs to store artifact results. Artifacts will be stored ")
+def download_artifacts(run_id, artifact_path):
+    """
+    Creates a new experiment in the configured tracking server.
+    """
+    artifact_path = artifact_path if artifact_path is not None else ""
+    store = _get_store()
+    artifact_uri = store.get_run(run_id).info.artifact_uri
+    artifact_repo = ArtifactRepository.from_artifact_uri(artifact_uri, store)
+    artifact_location = artifact_repo.download_artifacts(artifact_path)
+    print(artifact_location)

--- a/mlflow/store/cli.py
+++ b/mlflow/store/cli.py
@@ -85,7 +85,7 @@ def _file_infos_to_json(file_infos):
               help="If specified, a path relative to the run's root directory to download")
 def download_artifacts(run_id, artifact_path):
     """
-    Download an artifact file or directory to a local directory. 
+    Download an artifact file or directory to a local directory.
     The output is the name of the file or directory on the local disk.
     """
     artifact_path = artifact_path if artifact_path is not None else ""

--- a/mlflow/store/cli.py
+++ b/mlflow/store/cli.py
@@ -13,10 +13,7 @@ def commands():
     pass
 
 
-@commands.command("log-artifact",
-                  help="Logs a local file as an artifact of a run, optionally within a " +
-                       "run-specific artifact path. Run artifacts can be organized into " +
-                       "directories, so you can place the artifact in a directory this way.")
+@commands.command("log-artifact")
 @click.option("--local-file", "-l", required=True,
               help="Local path to artifact to log")
 @click.option("--run-id", "-r", required=True,
@@ -26,7 +23,9 @@ def commands():
                    "run's artifact directory.")
 def log_artifact(local_file, run_id, artifact_path):
     """
-    Creates a new experiment in the configured tracking server.
+    Logs a local file as an artifact of a run, optionally within a run-specific
+    artifact path. Run artifacts can be organized into directories, so you can
+    place the artifact in a directory this way.
     """
     store = _get_store()
     artifact_uri = store.get_run(run_id).info.artifact_uri
@@ -35,11 +34,7 @@ def log_artifact(local_file, run_id, artifact_path):
     eprint("Logged artifact from local file %s to artifact_path=%s" % (local_file, artifact_path))
 
 
-@commands.command("log-artifacts",
-                  help="Logs the files within a local directory as an artifact " +
-                       "of a run, optionally within a run-specific artifact path. Run " +
-                       "artifacts can be organized into directories, so you can place the " +
-                       "artifact in a directory this way.")
+@commands.command("log-artifacts")
 @click.option("--local-dir", "-l", required=True,
               help="Directory of local artifacts to log")
 @click.option("--run-id", "-r", required=True,
@@ -49,7 +44,9 @@ def log_artifact(local_file, run_id, artifact_path):
                    "run's artifact directory.")
 def log_artifacts(local_dir, run_id, artifact_path):
     """
-    Creates a new experiment in the configured tracking server.
+    Logs the files within a local directory as an artifact of a run, optionally
+    within a run-specific artifact path. Run artifacts can be organized into
+    directories, so you can place the artifact in a directory this way.
     """
     store = _get_store()
     artifact_uri = store.get_run(run_id).info.artifact_uri
@@ -58,16 +55,15 @@ def log_artifacts(local_dir, run_id, artifact_path):
     eprint("Logged artifact from local dir %s to artifact_path=%s" % (local_dir, artifact_path))
 
 
-@commands.command("list",
-                  help="Return all the artifacts directly under run's root artifact " +
-                       "directory, or a sub-directory. The output is a JSON-formatted list.")
+@commands.command("list")
 @click.option("--run-id", "-r", required=True,
               help="Run ID to be listed")
 @click.option("--artifact-path", "-a",
               help="If specified, a path relative to the run's root directory to list.")
 def list_artifacts(run_id, artifact_path):
     """
-    Creates a new experiment in the configured tracking server.
+    Return all the artifacts directly under run's root artifact directory,
+    or a sub-directory. The output is a JSON-formatted list.
     """
     artifact_path = artifact_path if artifact_path is not None else ""
     store = _get_store()
@@ -82,16 +78,15 @@ def _file_infos_to_json(file_infos):
     return "[" + ", ".join(json_list) + "]"
 
 
-@commands.command("download-artifacts",
-                  help="Download an artifact file or directory to a local directory. " +
-                       "The output is the name of the file or directory on the local disk.")
+@commands.command("download")
 @click.option("--run-id", "-r", required=True,
               help="Run ID from which to download")
 @click.option("--artifact-path", "-a",
               help="If specified, a path relative to the run's root directory to download")
 def download_artifacts(run_id, artifact_path):
     """
-    Creates a new experiment in the configured tracking server.
+    Download an artifact file or directory to a local directory. 
+    The output is the name of the file or directory on the local disk.
     """
     artifact_path = artifact_path if artifact_path is not None else ""
     store = _get_store()

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -125,7 +125,7 @@ class RestStore(AbstractStore):
     def update_run_info(self, run_uuid, run_status, end_time):
         """ Updates the metadata of the specified run. """
         req_body = message_to_json(UpdateRun(run_uuid=run_uuid, status=run_status,
-                                              end_time=end_time))
+                                             end_time=end_time))
         response_proto = self._call_endpoint(UpdateRun, req_body)
         return RunInfo.from_proto(response_proto.run_info)
 
@@ -227,7 +227,7 @@ class RestStore(AbstractStore):
         """
         search_expressions_protos = [expr.to_proto() for expr in search_expressions]
         req_body = message_to_json(SearchRuns(experiment_ids=experiment_ids,
-                                               anded_expressions=search_expressions_protos))
+                                              anded_expressions=search_expressions_protos))
         response_proto = self._call_endpoint(SearchRuns, req_body)
         return [Run.from_proto(proto_run) for proto_run in response_proto.runs]
 

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -1,0 +1,9 @@
+from google.protobuf.json_format import MessageToJson, ParseDict
+
+def message_to_json(message):
+    """Converts a message to JSON, using snake_case for field names."""
+    return MessageToJson(message, preserving_proto_field_name=True)
+
+def parse_dict(js_dict, message):
+    """Parses a JSON dictionary into a message proto, ignoring unknown fields in the JOSN."""
+    ParseDict(js_dict=js_dict, message=message, ignore_unknown_fields=True)

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -1,8 +1,10 @@
 from google.protobuf.json_format import MessageToJson, ParseDict
 
+
 def message_to_json(message):
     """Converts a message to JSON, using snake_case for field names."""
     return MessageToJson(message, preserving_proto_field_name=True)
+
 
 def parse_dict(js_dict, message):
     """Parses a JSON dictionary into a message proto, ignoring unknown fields in the JOSN."""

--- a/tests/store/test_cli.py
+++ b/tests/store/test_cli.py
@@ -1,0 +1,22 @@
+from click.testing import CliRunner
+from mock import mock
+
+from mlflow.entities import FileInfo
+from mlflow.store.cli import _file_infos_to_json
+
+def test_file_info_to_json():
+  file_infos = [
+    FileInfo("/my/file", False, 123),
+    FileInfo("/my/dir", True, None),
+  ]
+  info_str = _file_infos_to_json(file_infos)
+  assert info_str == (
+    '[{\n' +
+    '  "path": "/my/file",\n' +
+    '  "is_dir": false,\n' +
+    '  "file_size": "123"\n' +
+    '}, {\n' +
+    '  "path": "/my/dir",\n' +
+    '  "is_dir": true\n' +
+    '}]'
+  )

--- a/tests/store/test_cli.py
+++ b/tests/store/test_cli.py
@@ -1,3 +1,5 @@
+import json
+
 from mlflow.entities import FileInfo
 from mlflow.store.cli import _file_infos_to_json
 
@@ -8,13 +10,11 @@ def test_file_info_to_json():
         FileInfo("/my/dir", True, None),
     ]
     info_str = _file_infos_to_json(file_infos)
-    assert info_str == (
-        '[{\n' +
-        '  "path": "/my/file",\n' +
-        '  "is_dir": false,\n' +
-        '  "file_size": "123"\n' +
-        '}, {\n' +
-        '  "path": "/my/dir",\n' +
-        '  "is_dir": true\n' +
-        '}]'
-    )
+    assert json.loads(info_str) == [{
+        "path": "/my/file",
+        "is_dir": False,
+        "file_size": "123",
+    }, {
+        "path": "/my/dir",
+        "is_dir": True,
+    }]

--- a/tests/store/test_cli.py
+++ b/tests/store/test_cli.py
@@ -1,22 +1,20 @@
-from click.testing import CliRunner
-from mock import mock
-
 from mlflow.entities import FileInfo
 from mlflow.store.cli import _file_infos_to_json
 
+
 def test_file_info_to_json():
-  file_infos = [
-    FileInfo("/my/file", False, 123),
-    FileInfo("/my/dir", True, None),
-  ]
-  info_str = _file_infos_to_json(file_infos)
-  assert info_str == (
-    '[{\n' +
-    '  "path": "/my/file",\n' +
-    '  "is_dir": false,\n' +
-    '  "file_size": "123"\n' +
-    '}, {\n' +
-    '  "path": "/my/dir",\n' +
-    '  "is_dir": true\n' +
-    '}]'
-  )
+    file_infos = [
+        FileInfo("/my/file", False, 123),
+        FileInfo("/my/dir", True, None),
+    ]
+    info_str = _file_infos_to_json(file_infos)
+    assert info_str == (
+        '[{\n' +
+        '  "path": "/my/file",\n' +
+        '  "is_dir": false,\n' +
+        '  "file_size": "123"\n' +
+        '}, {\n' +
+        '  "path": "/my/dir",\n' +
+        '  "is_dir": true\n' +
+        '}]'
+    )

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -1,17 +1,17 @@
+import json
+
 from mlflow.entities import Experiment
 from mlflow.protos.service_pb2 import Experiment as ProtoExperiment
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 
 
 def test_message_to_json():
-    json = message_to_json(Experiment(123, "name", "arty").to_proto())
-    assert json == (
-        '{\n' +
-        '  "experiment_id": "123",\n' +
-        '  "name": "name",\n' +
-        '  "artifact_location": "arty"\n' +
-        '}'
-    )
+    json_out = message_to_json(Experiment(123, "name", "arty").to_proto())
+    assert json.loads(json_out) == {
+        "experiment_id": "123",
+        "name": "name",
+        "artifact_location": "arty",
+    }
 
 
 def test_parse_dict():

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -2,21 +2,23 @@ from mlflow.entities import Experiment
 from mlflow.protos.service_pb2 import Experiment as ProtoExperiment
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 
+
 def test_message_to_json():
-  json = message_to_json(Experiment(123, "name", "arty").to_proto())
-  assert json == (
-    '{\n' +
-    '  "experiment_id": "123",\n' +
-    '  "name": "name",\n' +
-    '  "artifact_location": "arty"\n' +
-    '}'
-  )
+    json = message_to_json(Experiment(123, "name", "arty").to_proto())
+    assert json == (
+        '{\n' +
+        '  "experiment_id": "123",\n' +
+        '  "name": "name",\n' +
+        '  "artifact_location": "arty"\n' +
+        '}'
+    )
+
 
 def test_parse_dict():
-  in_json = {"experiment_id": "123", "name": "name", "unknown": "field"}
-  message = ProtoExperiment()
-  parse_dict(in_json, message)
-  experiment = Experiment.from_proto(message)
-  assert experiment.experiment_id == 123
-  assert experiment.name == 'name'
-  assert experiment.artifact_location == ''
+    in_json = {"experiment_id": "123", "name": "name", "unknown": "field"}
+    message = ProtoExperiment()
+    parse_dict(in_json, message)
+    experiment = Experiment.from_proto(message)
+    assert experiment.experiment_id == 123
+    assert experiment.name == 'name'
+    assert experiment.artifact_location == ''

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -1,0 +1,22 @@
+from mlflow.entities import Experiment
+from mlflow.protos.service_pb2 import Experiment as ProtoExperiment
+from mlflow.utils.proto_json_utils import message_to_json, parse_dict
+
+def test_message_to_json():
+  json = message_to_json(Experiment(123, "name", "arty").to_proto())
+  assert json == (
+    '{\n' +
+    '  "experiment_id": "123",\n' +
+    '  "name": "name",\n' +
+    '  "artifact_location": "arty"\n' +
+    '}'
+  )
+
+def test_parse_dict():
+  in_json = {"experiment_id": "123", "name": "name", "unknown": "field"}
+  message = ProtoExperiment()
+  parse_dict(in_json, message)
+  experiment = Experiment.from_proto(message)
+  assert experiment.experiment_id == 123
+  assert experiment.name == 'name'
+  assert experiment.artifact_location == ''


### PR DESCRIPTION
This PR introduces an `mlflow artifacts` CLI command. Example usage:

```sh
RUN_ID=someRunId
mlflow artifacts log-artifact --local-path /my/local/file --run-id $RUN_ID
mlflow artifacts log-artifacts --local-path /my/other/dir --run-id $RUN_ID --artifact-path foo

# See JSON output of "file" and "dir".
mlflow artifacts list --run-id $RUN_ID

# See JSON output dir's conents
mlflow artifacts list --run-id $RUN_ID -a dir

# Outputs a local directory containing both file & dir.
mlflow artifacts download-artifacts --run-id $RUN_ID

# Outputs a local file.
mlflow artifacts download-artifacts --run-id $RUN_ID -a file
```

The goal of this CLI is mainly to enable the other SDK languages (namely Java and R) to be able to access the wide range of Artifact Repositories available in Python. Currently, we support local files, S3, Azure Blob Storage, GCS, SFTP, and DBFS, and more are being added.

There are three main shortcomings to this interface:

1. The API requires having the `mlflow` CLI available to the Java/R clients.
2. Configuration necessary to find the Tracking Server needs to be passed/inherited from the Java/R client. This can be awkward for more complicated schemes of credential-sharing, but for the common case should work by just passing the `MLFLOW_TRACKING_URI` environment variable when forking `mlflow`.
3. This mechanism is inefficient; when downloading, always create tempdirs/tempfles and write the bytes there first, and then return a pointer to the files. Streaming would be somewhat more efficient, and loading the files into a Spark DataFrame would be dramatically so.

Due to these shortcomings, we assume that we will still need at least partial implementation of the more high-throughput artifact repositories within each language SDK, but can fallback onto this interface until necessary.