### PR TITLE
Add a CLI-based fallback ArtifactRepository in Java

### DIFF
--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -45,6 +45,15 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+    <dependency>
+        <groupId>com.google.code.findbugs</groupId>
+        <artifactId>jsr305</artifactId>
+        <version>1.3.9</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -41,6 +41,10 @@
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java-util</artifactId>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+    </dependency>
   </dependencies>
 
   <build>
@@ -72,6 +76,7 @@
               <include>com.google.guava:guava</include>
               <include>com.google.code.gson:gson</include>
               <include>commons-codec:commons-codec</include>
+              <include>commons-io:commons-io</include>
               <include>commons-logging:commons-logging</include>
               <include>org.apache.httpcomponents:httpcore</include>
             </includes>

--- a/mlflow/java/client/src/main/java/org/mlflow/artifacts/ArtifactRepository.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/artifacts/ArtifactRepository.java
@@ -81,8 +81,8 @@ public interface ArtifactRepository {
 
   /**
    * Returns a local directory containing *all* artifacts within the run's artifact directory.
-   * This method is recursive, and so may be an expensive operation if the artifact directory
-   * is large.
+   * Note that this will download the entire directory path, and so may be expensive if
+   * the directory a lot of data.
    */
   File downloadArtifacts();
 
@@ -94,8 +94,9 @@ public interface ArtifactRepository {
    *   downloadArtifacts("model") // returns a local directory containing "file1" and "file2"
    *   downloadArtifacts("model/file1") // returns a local *file* with the contents of file1.
    *
-   * This method is recursive, and so may be an expensive operation if the given subdirectory
-   * is large.
+   * Note that this will download the entire subdirectory path, and so may be expensive if
+   * the subdirectory a lot of data.
+   *
    * @param artifactPath Artifact path relative to the run's root directory. Should NOT
    *                     start with a /.
    */

--- a/mlflow/java/client/src/main/java/org/mlflow/artifacts/ArtifactRepository.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/artifacts/ArtifactRepository.java
@@ -1,5 +1,6 @@
 package org.mlflow.artifacts;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.List;
 
@@ -31,9 +32,9 @@ public interface ArtifactRepository {
    *
    * @param localFile File to upload. Must exist, and must be a simple file (not a directory).
    * @param artifactPath Artifact path relative to the run's root directory. Should NOT
-   *                     start with a /. May be null.
+   *                     start with a /.
    */
-  void logArtifact(File localFile, String artifactPath);
+  void logArtifact(File localFile, @Nonnull String artifactPath);
 
   /**
    * Uploads all files within the given local director the run's root artifact directory.
@@ -58,9 +59,9 @@ public interface ArtifactRepository {
    *
    * @param localDir Directory to upload. Must exist, and must be a directory (not a simple file).
    * @param artifactPath Artifact path relative to the run's root directory. Should NOT
-   *                     start with a /. May be null.
+   *                     start with a /.
    */
-  void logArtifacts(File localDir, String artifactPath);
+  void logArtifacts(File localDir, @Nonnull String artifactPath);
 
   /**
    * Lists the artifacts immediately under the run's root artifact directory. This does not
@@ -74,9 +75,9 @@ public interface ArtifactRepository {
    * irectory. This does not recursively list; instead, it will return FileInfos with isDir=true
    * where further listing may be done.
    * @param artifactPath Artifact path relative to the run's root directory. Should NOT
-   *                     start with a /. May be null.
+   *                     start with a /.
    */
-  List<FileInfo> listArtifacts(String artifactPath);
+  List<FileInfo> listArtifacts(@Nonnull String artifactPath);
 
   /**
    * Returns a local directory containing *all* artifacts within the run's artifact directory.
@@ -96,7 +97,7 @@ public interface ArtifactRepository {
    * This method is recursive, and so may be an expensive operation if the given subdirectory
    * is large.
    * @param artifactPath Artifact path relative to the run's root directory. Should NOT
-   *                     start with a /. May be null.
+   *                     start with a /.
    */
-  File downloadArtifacts(String artifactPath);
+  File downloadArtifacts(@Nonnull String artifactPath);
 }

--- a/mlflow/java/client/src/main/java/org/mlflow/artifacts/ArtifactRepository.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/artifacts/ArtifactRepository.java
@@ -1,0 +1,102 @@
+package org.mlflow.artifacts;
+
+import java.io.File;
+import java.util.List;
+
+import org.mlflow.api.proto.Service.FileInfo;
+
+/**
+ * Allows logging, listing, and downloading artifacts against a remote Artifact Repository.
+ * This is used for storing potentially-large objects associated with MLflow runs.
+ */
+public interface ArtifactRepository {
+
+  /**
+   * Uploads the given local file to the run's root artifact directory. For example,
+   *
+   *  logArtifact("/my/localModel")
+   *  listArtifacts() // returns "localModel"
+   *
+   * @param localFile File to upload. Must exist, and must be a simple file (not a directory).
+   */
+  void logArtifact(File localFile);
+
+  /**
+   * Uploads the given local file to an artifactPath within the run's root directory. For example,
+   *
+   *   logArtifact("/my/localModel", "model")
+   *   listArtifacts("model") // returns "model/localModel"
+   *
+   * (i.e., the localModel file is now available in model/localModel).
+   *
+   * @param localFile File to upload. Must exist, and must be a simple file (not a directory).
+   * @param artifactPath Artifact path relative to the run's root directory. Should NOT
+   *                     start with a /. May be null.
+   */
+  void logArtifact(File localFile, String artifactPath);
+
+  /**
+   * Uploads all files within the given local director the run's root artifact directory.
+   * For example, if /my/local/dir/ contains two files "file1" and "file2", then
+   *
+   *  logArtifacts("/my/local/dir")
+   *  listArtifacts() // returns "file1" and "file2"
+   *
+   * @param localDir Directory to upload. Must exist, and must be a directory (not a simple file).
+   */
+  void logArtifacts(File localDir);
+
+
+  /**
+   * Uploads all files within the given local director an artifactPath within the run's root
+   * artifact directory. For example, if /my/local/dir/ contains two files "file1" and "file2", then
+   *
+   *  logArtifacts("/my/local/dir", "model")
+   *  listArtifacts("model") // returns "model/file1" and "model/file2"
+   *
+   * (i.e., the contents of the local directory are now available in model/).
+   *
+   * @param localDir Directory to upload. Must exist, and must be a directory (not a simple file).
+   * @param artifactPath Artifact path relative to the run's root directory. Should NOT
+   *                     start with a /. May be null.
+   */
+  void logArtifacts(File localDir, String artifactPath);
+
+  /**
+   * Lists the artifacts immediately under the run's root artifact directory. This does not
+   * recursively list; instead, it will return FileInfos with isDir=true where further
+   * listing may be done.
+   */
+  List<FileInfo> listArtifacts();
+
+  /**
+   * Lists the artifacts immediately under the given artifactPath within the run's root artifact
+   * irectory. This does not recursively list; instead, it will return FileInfos with isDir=true
+   * where further listing may be done.
+   * @param artifactPath Artifact path relative to the run's root directory. Should NOT
+   *                     start with a /. May be null.
+   */
+  List<FileInfo> listArtifacts(String artifactPath);
+
+  /**
+   * Returns a local directory containing *all* artifacts within the run's artifact directory.
+   * This method is recursive, and so may be an expensive operation if the artifact directory
+   * is large.
+   */
+  File downloadArtifacts();
+
+  /**
+   * Returns a local file or directory containing all artifacts within the given artifactPath
+   * within the run's root artifactDirectory. For example, if "model/file1" and "model/file2"
+   * exist within the artifact directory, then
+   *
+   *   downloadArtifacts("model") // returns a local directory containing "file1" and "file2"
+   *   downloadArtifacts("model/file1") // returns a local *file* with the contents of file1.
+   *
+   * This method is recursive, and so may be an expensive operation if the given subdirectory
+   * is large.
+   * @param artifactPath Artifact path relative to the run's root directory. Should NOT
+   *                     start with a /. May be null.
+   */
+  File downloadArtifacts(String artifactPath);
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/artifacts/CliBasedArtifactRepository.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/artifacts/CliBasedArtifactRepository.java
@@ -106,7 +106,7 @@ public class CliBasedArtifactRepository implements ArtifactRepository {
     checkMlflowAccessible();
     String tag = "download artifacts for " + getTargetIdentifier(artifactPath);
     List<String> command = appendRunIdArtifactPath(
-      Lists.newArrayList(mlflowExecutable, "artifacts", "download-artifacts"), runId, artifactPath);
+      Lists.newArrayList(mlflowExecutable, "artifacts", "download"), runId, artifactPath);
     String localPath = forkProcess(command, tag).trim();
     return new File(localPath);
   }

--- a/mlflow/java/client/src/main/java/org/mlflow/artifacts/CliBasedArtifactRepository.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/artifacts/CliBasedArtifactRepository.java
@@ -97,6 +97,7 @@ public class CliBasedArtifactRepository implements ArtifactRepository {
     forkProcess(command, tag);
   }
 
+  @Override
   public void logArtifacts(File localDir) {
     logArtifacts(localDir, null);
   }
@@ -111,6 +112,7 @@ public class CliBasedArtifactRepository implements ArtifactRepository {
     return new File(localPath);
   }
 
+  @Override
   public File downloadArtifacts() {
     return downloadArtifacts(null);
   }
@@ -125,6 +127,7 @@ public class CliBasedArtifactRepository implements ArtifactRepository {
     return parseFileInfos(jsonOutput);
   }
 
+  @Override
   public List<Service.FileInfo> listArtifacts() {
     return listArtifacts(null);
   }

--- a/mlflow/java/client/src/main/java/org/mlflow/artifacts/CliBasedArtifactRepository.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/artifacts/CliBasedArtifactRepository.java
@@ -1,0 +1,242 @@
+package org.mlflow.artifacts;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.common.collect.Lists;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+
+import org.mlflow.api.proto.Service;
+import org.mlflow.tracking.MlflowClientException;
+import org.mlflow.tracking.creds.MlflowHostCredsProvider;
+
+/**
+ * Shells out to the 'mlflow' command line utility to upload, download, and list artifacts. This
+ * is used as a fallback to implement any artifact repositories which are not natively supported
+ * within Java.
+ *
+ * We require that 'mlflow' is available in the system path.
+ */
+public class CliBasedArtifactRepository implements ArtifactRepository {
+  private static final Logger logger = Logger.getLogger(CliBasedArtifactRepository.class);
+
+  // Global check if we ever successfully loaded 'mlflow'. This allows us to print a more
+  // helpful error message if the executable is not in the path.
+  private static final AtomicBoolean mlflowSuccessfullyLoaded = new AtomicBoolean(false);
+
+  // Name of the mlflow CLI utility which can be exec'd directly.
+  private final String mlflowExecutable = "mlflow";
+
+  // Base directory of the artifactory, used to let the user know why this repository was chosen.
+  private final String artifactBaseDir;
+
+  // Run ID this repository is targeting.
+  private final String runId;
+
+  // Used to pass the MLFLOW_TRACKING_URI on to the mlflow process.
+  private final MlflowHostCredsProvider hostCredsProvider;
+
+  public CliBasedArtifactRepository(
+      String artifactBaseDir,
+      String runId,
+      MlflowHostCredsProvider hostCredsProvider) {
+    this.artifactBaseDir = artifactBaseDir;
+    this.runId = runId;
+    this.hostCredsProvider = hostCredsProvider;
+  }
+
+  @Override
+  public void logArtifact(File localFile, String artifactPath) {
+    checkMlflowAccessible();
+    if (!localFile.exists()) {
+      throw new MlflowClientException("Local file does not exist: " + localFile);
+    }
+    if (localFile.isDirectory()) {
+      throw new MlflowClientException("Local path points to a directory. Use logArtifacts" +
+        " instead: " + localFile);
+    }
+
+    List<String> baseCommand = Lists.newArrayList(
+      mlflowExecutable, "artifacts", "log-artifact", "--local-file", localFile.toString());
+    List<String> command = appendRunIdArtifactPath(baseCommand, runId, artifactPath);
+    String tag = "log file " + localFile + " to " + getTargetIdentifier(artifactPath);
+    forkProcess(command, tag);
+  }
+
+  @Override
+  public void logArtifact(File localFile) {
+    logArtifact(localFile, null);
+  }
+
+  @Override
+  public void logArtifacts(File localDir, String artifactPath) {
+    checkMlflowAccessible();
+    if (!localDir.exists()) {
+      throw new MlflowClientException("Local file does not exist: " + localDir);
+    }
+    if (localDir.isFile()) {
+      throw new MlflowClientException("Local path points to a file. Use logArtifact" +
+        " instead: " + localDir);
+    }
+
+    List<String> baseCommand = Lists.newArrayList(
+      mlflowExecutable, "artifacts", "log-artifacts", "--local-dir", localDir.toString());
+    List<String> command = appendRunIdArtifactPath(baseCommand, runId, artifactPath);
+    String tag = "log dir " + localDir + " to " + getTargetIdentifier(artifactPath);
+    forkProcess(command, tag);
+  }
+
+  public void logArtifacts(File localDir) {
+    logArtifacts(localDir, null);
+  }
+
+  @Override
+  public File downloadArtifacts(String artifactPath) {
+    checkMlflowAccessible();
+    String tag = "download artifacts for " + getTargetIdentifier(artifactPath);
+    List<String> command = appendRunIdArtifactPath(
+      Lists.newArrayList(mlflowExecutable, "artifacts", "download-artifacts"), runId, artifactPath);
+    String localPath = forkProcess(command, tag).trim();
+    return new File(localPath);
+  }
+
+  public File downloadArtifacts() {
+    return downloadArtifacts(null);
+  }
+
+  @Override
+  public List<Service.FileInfo> listArtifacts(String artifactPath) {
+    checkMlflowAccessible();
+    String tag = "list artifacts in " + getTargetIdentifier(artifactPath);
+    List<String> command = appendRunIdArtifactPath(
+      Lists.newArrayList(mlflowExecutable, "artifacts", "list"), runId, artifactPath);
+    String jsonOutput = forkProcess(command, tag);
+    return parseFileInfos(jsonOutput);
+  }
+
+  public List<Service.FileInfo> listArtifacts() {
+    return listArtifacts(null);
+  }
+
+  /** Parses a list of JSON FileInfos, as returned by 'mlflow artifacts list'. */
+  private List<Service.FileInfo> parseFileInfos(String json) {
+    // The protobuf deserializer doesn't allow us to directly deserialize a list, so we
+    // deserialize a list-of-dictionaries, and then reserialize each dictionary to pass it to
+    // the protobuf deserializer.
+    Gson gson = new Gson();
+    Type type = new TypeToken<List<Map<String, Object>>>(){}.getType();
+    List<Map<String, Object>> listOfDicts = gson.fromJson(json, type);
+    List<Service.FileInfo> fileInfos = new ArrayList<>();
+    for (Map<String, Object> dict: listOfDicts) {
+      String fileInfoJson = gson.toJson(dict);
+      try {
+        Service.FileInfo.Builder builder = Service.FileInfo.newBuilder();
+        JsonFormat.parser().merge(fileInfoJson, builder);
+        fileInfos.add(builder.build());
+      } catch (InvalidProtocolBufferException e) {
+        throw new MlflowClientException("Failed to deserialize JSON into FileInfo: " + json, e);
+      }
+    }
+    return fileInfos;
+  }
+
+  /**
+   * Checks whether the 'mlflow' executable is available, and throws a nice error if not.
+   * If this method has ever run successfully before (in the entire JVM), we will not rerun it.
+   */
+  private void checkMlflowAccessible() {
+    if (mlflowSuccessfullyLoaded.get()) {
+      return;
+    }
+
+    try {
+      String tag = "get mlflow version";
+      String mlflowVersion = forkProcess(Lists.newArrayList(mlflowExecutable, "--version"), tag);
+      logger.info("Found local mlflow executable with version=" + mlflowVersion);
+      mlflowSuccessfullyLoaded.set(true);
+    } catch (MlflowClientException e) {
+      String errorMessage = String.format("Failed to exec process %s, needed to access artifacts " +
+          "within the non-Java-native artifact store at '%s'. Please make sure mlflow is " +
+          "available on your local system path (e.g.," + "from 'pip install mlflow')",
+        mlflowExecutable, artifactBaseDir);
+      throw new MlflowClientException(errorMessage, e);
+    }
+  }
+
+  /**
+   * Forks the given mlflow command and awaits for its successful completion.
+   *
+   * @param command Command used to fork the process.
+   * @param tag User-facing tag which will be used to identify what we were trying to do
+   *            in the case of a failure.
+   * @return raw stdout of the process, decoded as a utf-8 string
+   * @throws MlflowClientException if the process exits with a non-zero exit code, or anything
+   *                               else goes wrong.
+   */
+  private String forkProcess(List<String> command, String tag) {
+    String stdout;
+    Process process = null;
+    try {
+      ProcessBuilder pb = new ProcessBuilder(command);
+      // TODO(aaron) Figure out a way to pass the other fields of the host-creds.
+      pb.environment().put("MLFLOW_TRACKING_URI", hostCredsProvider.getHostCreds().getHost());
+      process = pb.start();
+      stdout = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
+      int exitValue = process.waitFor();
+      if (exitValue != 0) {
+        throw new MlflowClientException("Failed to " + tag + ". Error: " +
+          getErrorBestEffort(process));
+      }
+    } catch (IOException | InterruptedException e) {
+      throw new MlflowClientException("Failed to fork mlflow process to " + tag +
+        ". Process stderr: " + getErrorBestEffort(process), e);
+    }
+    return stdout;
+  }
+
+  /** Does our best to get the process's stderr, or returns a dummy return value. */
+  private String getErrorBestEffort(Process process) {
+    if (process == null) {
+      return "<process not started>";
+    }
+    try {
+      return IOUtils.toString(process.getErrorStream(), StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      return "<error unknown>";
+    }
+  }
+
+  /** Appends --run-id $runId and --artifact-path $artifactPath, omitting artifactPath if null. */
+  private List<String> appendRunIdArtifactPath(
+    List<String> baseCommand,
+    String runId,
+    String artifactPath) {
+    baseCommand.add("--run-id");
+    baseCommand.add(runId);
+    if (artifactPath != null) {
+      baseCommand.add("--artifact-path");
+      baseCommand.add(artifactPath);
+    }
+    return baseCommand;
+  }
+
+  /** Returns user-facing identifier "runId=abc, artifactId=/foo", omitting artifactPath if null. */
+  private String getTargetIdentifier(String artifactPath) {
+    String identifier = "runId=" + runId;
+    if (artifactPath != null) {
+      return identifier + ", artifactPath=" + artifactPath;
+    }
+    return identifier;
+  }
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -16,10 +16,11 @@ import java.util.stream.Collectors;
  * Client to an MLflow Tracking Sever.
  */
 public class MlflowClient {
-  private static long DEFAULT_EXPERIMENT_ID = 0;
+  private static final long DEFAULT_EXPERIMENT_ID = 0;
 
   private final MlflowProtobufMapper mapper = new MlflowProtobufMapper();
   private final MlflowHttpCaller httpCaller;
+  private final MlflowHostCredsProvider hostCredsProvider;
 
   /** Returns a default client based on the MLFLOW_TRACKING_URI environment variable. */
   public MlflowClient() {
@@ -36,7 +37,8 @@ public class MlflowClient {
    * {@link #MlflowClient()} ()} or {@link #MlflowClient(String)} if possible.
    */
   public MlflowClient(MlflowHostCredsProvider hostCredsProvider) {
-    httpCaller = new MlflowHttpCaller(hostCredsProvider);
+    this.hostCredsProvider = hostCredsProvider;
+    this.httpCaller = new MlflowHttpCaller(hostCredsProvider);
   }
 
   /** Returns the run associated with the id. */
@@ -165,6 +167,14 @@ public class MlflowClient {
    */
   public String doPost(String path, String json) {
     return httpCaller.post(path, json);
+  }
+
+  /**
+   * Returns the HostCredsProvider backing this MlflowClient.
+   * Intended for internal usage, and may be removed in future versions.
+   */
+  public MlflowHostCredsProvider getInternalHostCredsProvider() {
+    return hostCredsProvider;
   }
 
   private URIBuilder newURIBuilder(String base) {

--- a/mlflow/java/client/src/test/java/org/mlflow/artifacts/CliBasedArtifactRepositorySuite.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/artifacts/CliBasedArtifactRepositorySuite.java
@@ -1,0 +1,142 @@
+package org.mlflow.artifacts;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import org.apache.commons.io.FileUtils;
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import org.mlflow.api.proto.Service.FileInfo;
+import org.mlflow.api.proto.Service.RunInfo;
+import org.mlflow.tracking.MlflowClient;
+import org.mlflow.tracking.TestClientProvider;
+
+public class CliBasedArtifactRepositorySuite {
+  private static final Logger logger = Logger.getLogger(CliBasedArtifactRepositorySuite.class);
+
+  private final TestClientProvider testClientProvider = new TestClientProvider();
+
+  private MlflowClient client;
+
+  @BeforeSuite
+  public void beforeAll() throws IOException {
+    client = testClientProvider.initializeClientAndServer();
+  }
+
+  @AfterSuite
+  public void afterAll() throws InterruptedException {
+    testClientProvider.cleanupClientAndServer();
+  }
+
+  private CliBasedArtifactRepository newRepo() {
+    RunInfo runInfo = client.createRun();
+    logger.info("Created run with id=" + runInfo.getRunUuid() + " and artifactUri=" +
+      runInfo.getArtifactUri());
+    return new CliBasedArtifactRepository(runInfo.getArtifactUri(), runInfo.getRunUuid(),
+      client.getInternalHostCredsProvider());
+  }
+
+  @Test
+  public void testLogAndDownloadArtifact() throws IOException {
+    // Tests the logArtifact and downloadArtifacts APIs when targeting a single file.
+    ArtifactRepository repo = newRepo();
+    Path tempFile = Files.createTempFile(getClass().getSimpleName(), ".txt");
+    FileUtils.writeStringToFile(tempFile.toFile(), "Hello, World!", StandardCharsets.UTF_8);
+    repo.logArtifact(tempFile.toFile());
+    Path returnFile = repo.downloadArtifacts(tempFile.getFileName().toString()).toPath();
+    Assert.assertEquals(readFile(returnFile), "Hello, World!");
+  }
+
+  @Test
+  public void testLogListAndDownloadArtifacts() throws IOException {
+    // Tests the logArtifacts, list, downloadArtifacts APIs when targeting a set of files.
+    ArtifactRepository repo = newRepo();
+    Path tempDir = Files.createTempDirectory(getClass().getSimpleName());
+    FileUtils.writeStringToFile(tempDir.resolve("a").toFile(), "A", StandardCharsets.UTF_8);
+    FileUtils.writeStringToFile(tempDir.resolve("b").toFile(), "B", StandardCharsets.UTF_8);
+    repo.logArtifacts(tempDir.toFile());
+    Set<FileInfo> fileInfos = Sets.newHashSet(repo.listArtifacts());
+    Assert.assertEquals(fileInfos, Sets.newHashSet(fileInfo("a", 1), fileInfo("b", 1)));
+    Path returnDir = repo.downloadArtifacts().toPath();
+    Assert.assertEquals(readFile(returnDir.resolve("a")), "A");
+    Assert.assertEquals(readFile(returnDir.resolve("b")), "B");
+  }
+
+  @Test
+  public void testEverything() throws IOException {
+    // This is a comprehensive integration test which tests all 8 APIs exposed by ArtifactRepository
+    // on a mix of files, directories, and subdirectories.
+    ArtifactRepository repo = newRepo();
+
+    // Create a temporary directory with /childFile and /childDir/granchild as files.
+    Path tempDir = Files.createTempDirectory(getClass().getSimpleName());
+    Path childFile = tempDir.resolve("childFile");
+    String childContents = "File contents!";
+    FileUtils.writeStringToFile(childFile.toFile(), childContents, StandardCharsets.UTF_8);
+    Path childDir = tempDir.resolve("childDir");
+    Path grandchildFile = childDir.resolve("grandchild");
+    String grandchildContents = "Baby content!";
+    childDir.toFile().mkdir();
+    FileUtils.writeStringToFile(grandchildFile.toFile(), grandchildContents, StandardCharsets.UTF_8);
+
+    // Log artifacts such that we expect:
+    //   childFile
+    //   grandchild
+    //   subpath/childFile
+    //   subpath/subberpath/grandchild
+    repo.logArtifact(childFile.toFile());
+    repo.logArtifacts(childDir.toFile());
+    repo.logArtifact(childFile.toFile(), "subpath");
+    repo.logArtifacts(childDir.toFile(), "subpath/subberpath");
+
+    // List at the root, we should see childFile, grandchild, and subpath/.
+    List<FileInfo> fileInfos = repo.listArtifacts();
+    Set<FileInfo> expectedFileInfos = Sets.newHashSet(
+      fileInfo("childFile", childContents.length()),
+      fileInfo("grandchild", grandchildContents.length()),
+      dirInfo("subpath")
+    );
+    Assert.assertEquals(Sets.newHashSet(fileInfos), expectedFileInfos);
+
+    // List within subpath/, we should see childFile and subberpath.
+    List<FileInfo> subpathFileInfos = repo.listArtifacts("subpath");
+    Set<FileInfo> expectedSubpathFileInfos = Sets.newHashSet(
+      fileInfo("subpath/childFile", childContents.length()),
+      dirInfo("subpath/subberpath")
+    );
+    Assert.assertEquals(Sets.newHashSet(subpathFileInfos), expectedSubpathFileInfos);
+
+    // Download everything, and confirm that we have the four expected files.
+    Path allArtifacts = repo.downloadArtifacts().toPath();
+    Assert.assertEquals(childContents, readFile(allArtifacts.resolve("childFile")));
+    Assert.assertEquals(childContents, readFile(allArtifacts.resolve("subpath/childFile")));
+    Assert.assertEquals(grandchildContents, readFile(allArtifacts.resolve("grandchild")));
+    Assert.assertEquals(grandchildContents,
+      readFile(allArtifacts.resolve("subpath/subberpath/grandchild")));
+
+    // Download subpath/subberpath, and confirm that we have just the grandchild.
+    Path subberpathArtifacts = repo.downloadArtifacts("subpath/subberpath").toPath();
+    Assert.assertEquals(grandchildContents, readFile(subberpathArtifacts.resolve("grandchild")));
+    Assert.assertEquals(subberpathArtifacts.toFile().list(), new String[] {"grandchild"});
+  }
+
+  private String readFile(Path path) throws IOException {
+    return FileUtils.readFileToString(path.toFile(), StandardCharsets.UTF_8);
+  }
+
+  private FileInfo fileInfo(String path, int fileSize) {
+    return FileInfo.newBuilder().setPath(path).setFileSize(fileSize).setIsDir(false).build();
+  }
+  private FileInfo dirInfo(String path) {
+    return FileInfo.newBuilder().setPath(path).setIsDir(true).build();
+  }
+}

--- a/mlflow/java/client/src/test/java/org/mlflow/artifacts/CliBasedArtifactRepositoryTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/artifacts/CliBasedArtifactRepositoryTest.java
@@ -54,7 +54,6 @@ public class CliBasedArtifactRepositoryTest {
     repo.logArtifact(tempFile.toFile());
     Path returnFile = repo.downloadArtifacts(tempFile.getFileName().toString()).toPath();
     Assert.assertEquals(readFile(returnFile), "Hello, World!");
-    throw new RuntimeException();
   }
 
   @Test

--- a/mlflow/java/client/src/test/java/org/mlflow/artifacts/CliBasedArtifactRepositoryTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/artifacts/CliBasedArtifactRepositoryTest.java
@@ -20,8 +20,8 @@ import org.mlflow.api.proto.Service.RunInfo;
 import org.mlflow.tracking.MlflowClient;
 import org.mlflow.tracking.TestClientProvider;
 
-public class CliBasedArtifactRepositorySuite {
-  private static final Logger logger = Logger.getLogger(CliBasedArtifactRepositorySuite.class);
+public class CliBasedArtifactRepositoryTest {
+  private static final Logger logger = Logger.getLogger(CliBasedArtifactRepositoryTest.class);
 
   private final TestClientProvider testClientProvider = new TestClientProvider();
 
@@ -54,6 +54,7 @@ public class CliBasedArtifactRepositorySuite {
     repo.logArtifact(tempFile.toFile());
     Path returnFile = repo.downloadArtifacts(tempFile.getFileName().toString()).toPath();
     Assert.assertEquals(readFile(returnFile), "Hello, World!");
+    throw new RuntimeException();
   }
 
   @Test

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/TestClientProvider.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/TestClientProvider.java
@@ -18,7 +18,7 @@ import org.apache.log4j.Logger;
  * this allows running tests against existing servers. Otherwise, we will launch a local
  * server on an ephemeral port, and manage its lifecycle.
  */
-class TestClientProvider {
+public class TestClientProvider {
   private static final Logger logger = Logger.getLogger(TestClientProvider.class);
 
   private static final long MAX_SERVER_WAIT_TIME_MILLIS = 60 * 1000;
@@ -29,7 +29,7 @@ class TestClientProvider {
    * Intializes an MLflow client and, if necessary, a local MLflow server process as well.
    * Callers should always call {@link #cleanupClientAndServer()}.
    */
-  MlflowClient initializeClientAndServer() throws IOException {
+  public MlflowClient initializeClientAndServer() throws IOException {
     if (serverProcess != null) {
       throw new IllegalStateException("Previous server process not cleaned up");
     }
@@ -48,7 +48,7 @@ class TestClientProvider {
    * {@link #initializeClientAndServer()}. This is safe to call even if the client/server were
    * not initialized successfully.
    */
-  void cleanupClientAndServer() throws InterruptedException {
+  public void cleanupClientAndServer() throws InterruptedException {
     if (serverProcess != null) {
       serverProcess.destroy();
       // Do our best to ensure that the
@@ -77,7 +77,7 @@ class TestClientProvider {
     int freePort = getFreePort();
     String bindAddress = "127.0.0.1";
     pb.command("mlflow", "server", "--host", bindAddress, "--port", "" + freePort,
-      "--file-store", tempDir.toString());
+      "--file-store", tempDir.toString(), "--workers", "1");
     serverProcess = pb.start();
 
     // NB: We cannot use pb.inheritIO() because that interacts poorly with the Maven

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -124,6 +124,11 @@
         <artifactId>protobuf-java-util</artifactId>
         <version>${protobuf.version}</version>
       </dependency>
+      <dependency>
+        <groupId>javax.annotation</groupId>
+        <artifactId>javax.annotation-api</artifactId>
+        <version>1.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>

--- a/mlflow/java/scoring/pom.xml
+++ b/mlflow/java/scoring/pom.xml
@@ -68,12 +68,10 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.6</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.5</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
Adds a default ArtifactRepository in Java which allows use of arbitrary storage baceknds as long as the `mlflow` CLI is available on the local PATH. This is intended as a fallback mechanism to access backends which do not have native Java implementations (which is currently all backends).

This relies on #391 to be available locally, which also discusses the shortcomings of this approach.

This PR introduces the notion of a Java ArtifactRepository, but does not make it super convenient for a user to construct this (i.e., no layer of indirection given a Run) -- this PR is mostly intended for the review of the CLI-based ArtifactRepository.