### PR TITLE
add --host option to Cli.py

### DIFF
--- a/mlflow/pyfunc/cli.py
+++ b/mlflow/pyfunc/cli.py
@@ -41,8 +41,9 @@ def commands():
 @cli_args.MODEL_PATH
 @cli_args.RUN_ID
 @click.option("--port", "-p", default=5000, help="Server port. [default: 5000]")
+@click.option("--host", "-h", default="127.0.0.1", help="Server host. [default: 127.0.0.1]")
 @cli_args.NO_CONDA
-def serve(model_path, run_id, port, no_conda):
+def serve(model_path, run_id, port, host, no_conda):
     """
     Serve a PythonFunction model saved with MLflow.
 
@@ -58,7 +59,7 @@ def serve(model_path, run_id, port, no_conda):
         return _rerun_in_conda(conda_env_path)
 
     app = scoring_server.init(load_pyfunc(model_path))
-    app.run(port=port)
+    app.run(port=port, host=host)
 
 
 @commands.command("predict")


### PR DESCRIPTION
add --host option to "pyfunc serve", in order to pass other bind adress than 127.0.0.1  (e.g 0.0.0.0, or IP adress etc...), just like the "Server" options ( -p myport -h myhost)