### PR TITLE
Allow specifying HTTP auth via environment variables via REST store

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -1,6 +1,7 @@
 """
 MLflow integration for Spark MLlib models.
 This module enables the exporting of Spark MLlib models with the following flavors (formats):
+
     1. Spark MLlib (native) format - Allows models to be loaded as Spark Transformers for scoring
                                      in a Spark session. Models with this flavor can be loaded
                                      back as PySpark PipelineModel objects in Python. This

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod, ABCMeta
 
-from mlflow.exceptions import MlflowException
-from mlflow.store.rest_store import DatabricksStore
+from mlflow.store.rest_store import RestStore
 
 
 class ArtifactRepository:
@@ -66,7 +65,6 @@ class ArtifactRepository:
         Given an artifact URI for an Experiment Run (e.g., /local/file/path or s3://my/bucket),
         returns an ArtifactReposistory instance capable of logging and downloading artifacts
         on behalf of this URI.
-        :param store: An instance of AbstractStore which the artifacts are registered in.
         """
         if artifact_uri.startswith("s3:/"):
             # Import these locally to avoid creating a circular import loop
@@ -83,9 +81,9 @@ class ArtifactRepository:
             return SFTPArtifactRepository(artifact_uri)
         elif artifact_uri.startswith("dbfs:/"):
             from mlflow.store.dbfs_artifact_repo import DbfsArtifactRepository
-            if not isinstance(store, DatabricksStore):
-                raise MlflowException('`store` must be an instance of DatabricksStore.')
-            return DbfsArtifactRepository(artifact_uri, store.http_request_kwargs)
+            if not isinstance(store, RestStore):
+                raise MlflowException('`store` must be an instance of RestStore.')
+            return DbfsArtifactRepository(artifact_uri, store.get_host_creds)
         else:
             from mlflow.store.local_artifact_repo import LocalArtifactRepository
             return LocalArtifactRepository(artifact_uri)

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod, ABCMeta
 
 from mlflow.store.rest_store import RestStore
+from mlflow.exceptions import MlflowException
 
 
 class ArtifactRepository:
@@ -65,6 +66,7 @@ class ArtifactRepository:
         Given an artifact URI for an Experiment Run (e.g., /local/file/path or s3://my/bucket),
         returns an ArtifactReposistory instance capable of logging and downloading artifacts
         on behalf of this URI.
+        :param store: An instance of AbstractStore which the artifacts are registered in.
         """
         if artifact_uri.startswith("s3:/"):
             # Import these locally to avoid creating a circular import loop

--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -18,7 +18,7 @@ class DbfsArtifactRepository(ArtifactRepository):
     Stores artifacts on DBFS.
 
     This repository is used with URIs of the form ``dbfs:/<path>``. The repository can only be used
-    together with the DatabricksStore.
+    together with the RestStore.
     """
 
     def __init__(self, artifact_uri, get_host_creds):
@@ -33,15 +33,9 @@ class DbfsArtifactRepository(ArtifactRepository):
         return http_request(host_creds, **kwargs)
 
     def _dbfs_list_api(self, json):
-        """
-        Pulled out to make it easier to mock.
-        """
         return self._databricks_api_request(endpoint=LIST_API_ENDPOINT, method='GET', json=json)
 
     def _dbfs_download(self, output_path, endpoint):
-        """
-        Pulled out to make it easier to mock.
-        """
         with open(output_path, 'wb') as f:
             response = self._databricks_api_request(endpoint=endpoint, method='GET', stream=True)
             try:
@@ -57,7 +51,7 @@ class DbfsArtifactRepository(ArtifactRepository):
         try:
             return json_response['is_dir']
         except KeyError:
-            raise Exception('DBFS path %s does not exist' % dbfs_path)
+            raise MlflowException('DBFS path %s does not exist' % dbfs_path)
 
     def _get_dbfs_path(self, artifact_path):
         return '/%s/%s' % (strip_prefix(self.artifact_uri, 'dbfs:/'),

--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -7,42 +7,11 @@ from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import build_path, get_relative_path, TempDir
 from mlflow.utils.rest_utils import http_request, RESOURCE_DOES_NOT_EXIST
 from mlflow.utils.string_utils import strip_prefix
+from mlflow.utils import databricks_utils
 
 LIST_API_ENDPOINT = '/api/2.0/dbfs/list'
 GET_STATUS_ENDPOINT = '/api/2.0/dbfs/get-status'
 DOWNLOAD_CHUNK_SIZE = 1024
-
-
-def _dbfs_list_api(json, http_request_kwargs):
-    """
-    Pulled out to make it easier to mock.
-    """
-    return http_request(endpoint=LIST_API_ENDPOINT, method='GET',
-                        json=json, **http_request_kwargs)
-
-
-def _dbfs_download(output_path, endpoint, http_request_kwargs):
-    """
-    Pulled out to make it easier to mock.
-    """
-    with open(output_path, 'wb') as f:
-        response = http_request(endpoint=endpoint, method='GET', stream=True,
-                                **http_request_kwargs)
-        try:
-            for content in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
-                f.write(content)
-        finally:
-            response.close()
-
-
-def _dbfs_is_dir(dbfs_path, http_request_kwargs):
-    response = http_request(endpoint=GET_STATUS_ENDPOINT, method='GET',
-                            json={'path': dbfs_path}, **http_request_kwargs)
-    json_response = json.loads(response.text)
-    try:
-        return json_response['is_dir']
-    except KeyError:
-        raise Exception('DBFS path %s does not exist' % dbfs_path)
 
 
 class DbfsArtifactRepository(ArtifactRepository):
@@ -53,17 +22,43 @@ class DbfsArtifactRepository(ArtifactRepository):
     together with the DatabricksStore.
     """
 
-    def __init__(self, artifact_uri, http_request_kwargs):
-        """
-        :param http_request_kwargs arguments to add to rest_utils.http_request for all requests
-            'hostname', 'headers', and 'verify' are required.
-            Should include authentication information to Databricks.
-        """
+    def __init__(self, artifact_uri, get_host_creds):
         cleaned_artifact_uri = artifact_uri.rstrip('/')
         super(DbfsArtifactRepository, self).__init__(cleaned_artifact_uri)
+        self.get_host_creds = get_host_creds
         if not cleaned_artifact_uri.startswith('dbfs:/'):
             raise MlflowException('DbfsArtifactRepository URI must start with dbfs:/')
-        self.http_request_kwargs = http_request_kwargs
+
+    def _databricks_api_request(self, **kwargs):
+        host_creds = self.get_host_creds()
+        return http_request(host_creds, **kwargs)
+
+    def _dbfs_list_api(self, json):
+        """
+        Pulled out to make it easier to mock.
+        """
+        return self._databricks_api_request(endpoint=LIST_API_ENDPOINT, method='GET', json=json)
+
+    def _dbfs_download(self, output_path, endpoint):
+        """
+        Pulled out to make it easier to mock.
+        """
+        with open(output_path, 'wb') as f:
+            response = self._databricks_api_request(endpoint=endpoint, method='GET', stream=True)
+            try:
+                for content in response.iter_content(chunk_size=DOWNLOAD_CHUNK_SIZE):
+                    f.write(content)
+            finally:
+                response.close()
+
+    def _dbfs_is_dir(self, dbfs_path):
+        response = self._databricks_api_request(
+            endpoint=GET_STATUS_ENDPOINT, method='GET', json={'path': dbfs_path})
+        json_response = json.loads(response.text)
+        try:
+            return json_response['is_dir']
+        except KeyError:
+            raise Exception('DBFS path %s does not exist' % dbfs_path)
 
     def _get_dbfs_path(self, artifact_path):
         return '/%s/%s' % (strip_prefix(self.artifact_uri, 'dbfs:/'),
@@ -81,8 +76,8 @@ class DbfsArtifactRepository(ArtifactRepository):
         else:
             http_endpoint = self._get_dbfs_endpoint(os.path.basename(local_file))
         with open(local_file, 'rb') as f:
-            response = http_request(endpoint=http_endpoint, method='POST', data=f,
-                                    allow_redirects=False, **self.http_request_kwargs)
+            response = self._databricks_api_request(
+                endpoint=http_endpoint, method='POST', data=f, allow_redirects=False)
             if response.status_code == 409:
                 raise MlflowException('File already exists at {} and can\'t be overwritten.'
                                       .format(http_endpoint))
@@ -103,8 +98,8 @@ class DbfsArtifactRepository(ArtifactRepository):
             for name in filenames:
                 endpoint = build_path(dir_http_endpoint, name)
                 with open(build_path(dirpath, name), 'rb') as f:
-                    response = http_request(endpoint=endpoint, method='POST', data=f,
-                                            allow_redirects=False, **self.http_request_kwargs)
+                    response = self._databricks_api_request(
+                        endpoint=endpoint, method='POST', data=f, allow_redirects=False)
                 if response.status_code == 409:
                     raise MlflowException('File already exists at {} and can\'t be overwritten.'
                                           .format(endpoint))
@@ -117,7 +112,7 @@ class DbfsArtifactRepository(ArtifactRepository):
             dbfs_list_json = {'path': self._get_dbfs_path(path)}
         else:
             dbfs_list_json = {'path': self._get_dbfs_path('')}
-        response = _dbfs_list_api(dbfs_list_json, self.http_request_kwargs)
+        response = self._dbfs_list_api(dbfs_list_json)
         json_response = json.loads(response.text)
         # /api/2.0/dbfs/list will not have the 'files' key in the response for empty directories.
         infos = []
@@ -141,13 +136,13 @@ class DbfsArtifactRepository(ArtifactRepository):
         basename = os.path.basename(artifact_path)
         local_path = build_path(dest_dir, basename)
         dbfs_path = self._get_dbfs_path(artifact_path)
-        if _dbfs_is_dir(dbfs_path, self.http_request_kwargs):
+        if self._dbfs_is_dir(dbfs_path):
             # Artifact_path is a directory, so make a directory for it and download everything
             if not os.path.exists(local_path):
                 os.mkdir(local_path)
             for file_info in self.list_artifacts(artifact_path):
                 self._download_artifacts_into(file_info.path, local_path)
         else:
-            _dbfs_download(output_path=local_path, endpoint=self._get_dbfs_endpoint(artifact_path),
-                           http_request_kwargs=self.http_request_kwargs)
+            self._dbfs_download(output_path=local_path,
+                                endpoint=self._get_dbfs_endpoint(artifact_path))
         return local_path

--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -7,7 +7,6 @@ from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import build_path, get_relative_path, TempDir
 from mlflow.utils.rest_utils import http_request, RESOURCE_DOES_NOT_EXIST
 from mlflow.utils.string_utils import strip_prefix
-from mlflow.utils import databricks_utils
 
 LIST_API_ENDPOINT = '/api/2.0/dbfs/list'
 GET_STATUS_ENDPOINT = '/api/2.0/dbfs/get-status'

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -46,15 +46,14 @@ class RestException(Exception):
 class RestStore(AbstractStore):
     """
     Client for a remote tracking server accessed via REST API calls
-    :param http_request_kwargs arguments to add to rest_utils.http_request for all requests.
-                               'hostname' is required.
+    :param get_host_creds: Method to be invoked prior to every REST request to get the
+      :py:class:`mlflow.rest_utils.MlflowHostCreds` for the request. Note that this
+      is a function so that we can obtain fresh credentials in the case of expiry.
     """
 
-    def __init__(self, http_request_kwargs):
+    def __init__(self, get_host_creds):
         super(RestStore, self).__init__()
-        self.http_request_kwargs = http_request_kwargs
-        if not http_request_kwargs['hostname']:
-            raise Exception('hostname must be provided to RestStore')
+        self.get_host_creds = get_host_creds
 
     def _call_endpoint(self, api, json_body):
         endpoint, method = _METHOD_TO_INFO[api]
@@ -62,8 +61,9 @@ class RestStore(AbstractStore):
         # Convert json string to json dictionary, to pass to requests
         if json_body:
             json_body = json.loads(json_body)
-        response = http_request(endpoint=endpoint, method=method,
-                                json=json_body, **self.http_request_kwargs)
+        host_creds = self.get_host_creds()
+        response = http_request(host_creds=host_creds, endpoint=endpoint, method=method,
+                                json=json_body)
         js_dict = json.loads(response.text)
 
         if 'error_code' in js_dict:
@@ -241,19 +241,3 @@ class RestStore(AbstractStore):
         """
         runs = self.search_runs(experiment_ids=[experiment_id], search_expressions=[])
         return [run.info for run in runs]
-
-
-class DatabricksStore(RestStore):
-    """
-    A specific type of RestStore which includes authentication information to Databricks.
-    :param http_request_kwargs arguments to add to rest_utils.http_request for all requests.
-                               'hostname', 'headers', and 'secure_verify' are required.
-    """
-    def __init__(self, http_request_kwargs):
-        if http_request_kwargs['hostname'] is None:
-            raise Exception('hostname must be provided to DatabricksStore')
-        if http_request_kwargs['headers'] is None:
-            raise Exception('headers must be provided to DatabricksStore')
-        if http_request_kwargs['verify'] is None:
-            raise Exception('verify must be provided to DatabricksStore')
-        super(DatabricksStore, self).__init__(http_request_kwargs)

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -100,7 +100,7 @@ def _get_file_store(store_uri):
 
 def _get_rest_store(store_uri):
     def get_default_host_creds():
-        rest_utils.MlflowHostCreds(
+        return rest_utils.MlflowHostCreds(
             host=store_uri,
             username=os.environ.get("MLFLOW_TRACKING_USERNAME"),
             password=os.environ.get("MLFLOW_TRACKING_PASSWORD"),

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -16,6 +16,14 @@ _TRACKING_URI_ENV_VAR = "MLFLOW_TRACKING_URI"
 _LOCAL_FS_URI_PREFIX = "file:///"
 _REMOTE_URI_PREFIX = "http://"
 
+# Extra environment variables which take precedence for setting the basic/bearer
+# auth on http requests.
+_TRACKING_USERNAME_ENV_VAR = "MLFLOW_TRACKING_USERNAME"
+_TRACKING_PASSWORD_ENV_VAR = "MLFLOW_TRACKING_PASSWORD"
+_TRACKING_TOKEN_ENV_VAR = "MLFLOW_TRACKING_TOKEN"
+_TRACKING_INSECURE_TLS_ENV_VAR = "MLFLOW_TRACKING_INSECURE_TLS"
+
+
 _tracking_uri = None
 
 
@@ -102,10 +110,10 @@ def _get_rest_store(store_uri):
     def get_default_host_creds():
         return rest_utils.MlflowHostCreds(
             host=store_uri,
-            username=os.environ.get("MLFLOW_TRACKING_USERNAME"),
-            password=os.environ.get("MLFLOW_TRACKING_PASSWORD"),
-            token=os.environ.get("MLFLOW_TRACKING_TOKEN"),
-            ignore_tls_verification=os.environ.get("MLFLOW_TRACKING_INSECURE_TLS", False),
+            username=os.environ.get(_TRACKING_USERNAME_ENV_VAR),
+            password=os.environ.get(_TRACKING_PASSWORD_ENV_VAR),
+            token=os.environ.get(_TRACKING_TOKEN_ENV_VAR),
+            ignore_tls_verification=os.environ.get(_TRACKING_INSECURE_TLS_ENV_VAR) == 'true',
         )
     return RestStore(get_default_host_creds)
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1,3 +1,8 @@
+from mlflow.utils.rest_utils import MlflowHostCreds
+from mlflow.utils.logging_utils import eprint
+from databricks_cli.configure import provider
+
+
 def _get_dbutils():
     try:
         import IPython
@@ -44,3 +49,42 @@ def get_notebook_path():
 def get_webapp_url():
     """Should only be called if is_in_databricks_notebook is true"""
     return _get_extra_context("api_url")
+
+
+def _fail_malformed_databricks_auth(profile):
+    raise Exception("Got malformed Databricks CLI profile '%s'. Please make sure the Databricks "
+                    "CLI is properly configured as described at "
+                    "https://github.com/databricks/databricks-cli." % profile)
+
+
+def get_databricks_host_creds(profile=None):
+    """
+    Reads in configuration necessary to make HTTP requests to a Databricks server. This
+    uses the Databricks CLI's ConfigProvider interface to load the DatabricksConfig object.
+    This method will throw an exception if sufficient auth cannot be found.
+
+    :param profile: Databricks CLI profile. If not provided, we will read the default profile.
+    :return: Dictionary with parameters that can be passed to http_request(). This will
+             at least include the hostname and headers sufficient to authenticate to Databricks.
+    """
+    if not hasattr(provider, 'get_config'):
+        eprint("Warning: support for databricks-cli<0.8.0 is deprecated and will be removed"
+               " in a future version.")
+        config = provider.get_config_for_profile(profile)
+    elif profile:
+        config = provider.ProfileConfigProvider(profile).get_config()
+    else:
+        config = provider.get_config()
+
+    hostname = config.host
+    if not hostname:
+        _fail_malformed_databricks_auth(profile)
+
+    insecure = hasattr(config, 'insecure') and config.insecure
+
+    if config.username is not None and config.password is not None:
+        return MlflowHostCreds(hostname, username=config.username, password=config.password,
+                               ignore_tls_verification=insecure)
+    elif config.token:
+        return MlflowHostCreds(hostname, token=config.token, ignore_tls_verification=insecure)
+    _fail_malformed_databricks_auth(profile)

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -64,8 +64,8 @@ def get_databricks_host_creds(profile=None):
     This method will throw an exception if sufficient auth cannot be found.
 
     :param profile: Databricks CLI profile. If not provided, we will read the default profile.
-    :return: Dictionary with parameters that can be passed to http_request(). This will
-             at least include the hostname and headers sufficient to authenticate to Databricks.
+    :return: :py:class:`mlflow.rest_utils.MlflowHostCreds` which includes the hostname and
+        authentication information necessary to talk to the Databricks server.
     """
     if not hasattr(provider, 'get_config'):
         eprint("Warning: support for databricks-cli<0.8.0 is deprecated and will be removed"

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -76,15 +76,14 @@ def get_databricks_host_creds(profile=None):
     else:
         config = provider.get_config()
 
-    hostname = config.host
-    if not hostname:
+    if not config or not config.host:
         _fail_malformed_databricks_auth(profile)
 
     insecure = hasattr(config, 'insecure') and config.insecure
 
     if config.username is not None and config.password is not None:
-        return MlflowHostCreds(hostname, username=config.username, password=config.password,
+        return MlflowHostCreds(config.host, username=config.username, password=config.password,
                                ignore_tls_verification=insecure)
     elif config.token:
-        return MlflowHostCreds(hostname, token=config.token, ignore_tls_verification=insecure)
+        return MlflowHostCreds(config.host, token=config.token, ignore_tls_verification=insecure)
     _fail_malformed_databricks_auth(profile)

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1,3 +1,4 @@
+from mlflow.exceptions import MlflowException
 from mlflow.utils.rest_utils import MlflowHostCreds
 from mlflow.utils.logging_utils import eprint
 from databricks_cli.configure import provider

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -52,9 +52,9 @@ def get_webapp_url():
 
 
 def _fail_malformed_databricks_auth(profile):
-    raise Exception("Got malformed Databricks CLI profile '%s'. Please make sure the Databricks "
-                    "CLI is properly configured as described at "
-                    "https://github.com/databricks/databricks-cli." % profile)
+    raise MlflowException("Got malformed Databricks CLI profile '%s'. Please make sure the "
+                          "Databricks CLI is properly configured as described at "
+                          "https://github.com/databricks/databricks-cli." % profile)
 
 
 def get_databricks_host_creds(profile=None):

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -3,85 +3,47 @@ import time
 from json import JSONEncoder
 
 import numpy
-from databricks_cli.configure import provider
 import requests
 
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.string_utils import strip_suffix
+from mlflow.exceptions import MlflowException
 
 
 RESOURCE_DOES_NOT_EXIST = 'RESOURCE_DOES_NOT_EXIST'
 
 
-def _fail_malformed_databricks_auth(profile):
-    raise Exception("Got malformed Databricks CLI profile '%s'. Please make sure the Databricks "
-                    "CLI is properly configured as described at "
-                    "https://github.com/databricks/databricks-cli." % profile)
-
-
-def get_databricks_http_request_kwargs_or_fail(profile=None):
-    """
-    Reads in configuration necessary to make HTTP requests to a Databricks server. This
-    uses the Databricks CLI's ConfigProvider interface to load the DatabricksConfig object.
-    This method will throw an exception if sufficient auth cannot be found.
-
-    :param profile: Databricks CLI profile. If not provided, we will read the default profile.
-    :return: Dictionary with parameters that can be passed to http_request(). This will
-             at least include the hostname and headers sufficient to authenticate to Databricks.
-    """
-    if not hasattr(provider, 'get_config'):
-        eprint("Warning: support for databricks-cli<0.8.0 is deprecated and will be removed"
-               " in a future version.")
-        config = provider.get_config_for_profile(profile)
-    elif profile:
-        config = provider.ProfileConfigProvider(profile).get_config()
-    else:
-        config = provider.get_config()
-
-    hostname = config.host
-    if not hostname:
-        _fail_malformed_databricks_auth(profile)
-
-    auth_str = None
-    if config.username is not None and config.password is not None:
-        basic_auth_str = ("%s:%s" % (config.username, config.password)).encode("utf-8")
-        auth_str = "Basic " + base64.standard_b64encode(basic_auth_str).decode("utf-8")
-    elif config.token:
-        auth_str = "Bearer %s" % config.token
-    else:
-        _fail_malformed_databricks_auth(profile)
-
-    headers = {
-        "Authorization": auth_str,
-    }
-
-    verify = True
-    if hasattr(config, 'insecure') and config.insecure:
-        verify = False
-
-    return {
-        'hostname': hostname,
-        'headers': headers,
-        'verify': verify,
-    }
-
-
-def http_request(hostname, endpoint, retries=3, retry_interval=3, **kwargs):
+def http_request(host_creds, endpoint, retries=3, retry_interval=3, **kwargs):
     """
     Makes an HTTP request with the specified method to the specified hostname/endpoint. Retries
     up to `retries` times if a request fails with a server error (e.g. error code 500), waiting
     `retry_interval` seconds between successive retries. Parses the API response (assumed to be
     JSON) into a Python object and returns it.
 
-    :param headers: Request headers to use when making the HTTP request
+    :param host_creds: A :py:class:`mlflow.rest_utils.MlflowHostCreds` object containing
+        hostname and optional authentication.
     :param req_body_json: Dictionary containing the request body
     :param params: Query parameters for the request
     :return: Parsed API response
     """
+    hostname = host_creds.host
+    auth_str = None
+    if host_creds.username and host_creds.password:
+        basic_auth_str = ("%s:%s" % (host_creds.username, host_creds.password)).encode("utf-8")
+        auth_str = "Basic " + base64.standard_b64encode(basic_auth_str).decode("utf-8")
+    elif host_creds.token:
+        auth_str = "Bearer %s" % host_creds.token
+
+    headers = {}
+    if auth_str:
+        headers['Authorization'] = auth_str
+
+    verify = not host_creds.ignore_tls_verification
+
     cleaned_hostname = strip_suffix(hostname, '/')
     url = "%s%s" % (cleaned_hostname, endpoint)
     for i in range(retries):
-        response = requests.request(url=url, **kwargs)
+        response = requests.request(url=url, headers=headers, verify=verify, **kwargs)
         if response.status_code >= 200 and response.status_code < 500:
             return response
         else:
@@ -89,7 +51,8 @@ def http_request(hostname, endpoint, retries=3, retry_interval=3, **kwargs):
                    "API response body: %s" % (url, response.status_code, retries - i - 1,
                                               response.text))
             time.sleep(retry_interval)
-    raise Exception("API request to %s failed to return code 200 after %s tries" % (url, retries))
+    raise MlflowException("API request to %s failed to return code 200 after %s tries" %
+                          (url, retries))
 
 
 class NumpyEncoder(JSONEncoder):
@@ -103,3 +66,28 @@ class NumpyEncoder(JSONEncoder):
         if isinstance(o, numpy.generic):
             return numpy.asscalar(o)
         return JSONEncoder.default(self, o)
+
+
+class MlflowHostCreds:
+    """
+    Provides a hostname and optional authentication for talking to an MLflow tracking server.
+    :param host: Hostname (e.g., http://localhost:5000) to MLflow server. Required.
+    :param username: Username to use with Basic authentication when talking to server.
+        If this is specified, password must also be specified.
+    :param password: Password to use with Basic authentication when talking to server.
+        If this is specified, username must also be specified.
+    :param token: Token to use with Bearer authentication when talking to server.
+        If provided, user/password authentication will be ignored.
+    :param ignore_tls_verification: If true, we will not verify the server's hostname or TLS
+        certificate. This is useful for certain testing situations, but should never be
+        true in production.
+    """
+    def __init__(self, host, username=None, password=None, token=None,
+                 ignore_tls_verification=False):
+        if not host:
+            raise MlflowException("host is a required parameter for MlflowHostCreds")
+        self.host = host
+        self.username = username
+        self.password = password
+        self.token = token
+        self.ignore_tls_verification = ignore_tls_verification

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -22,8 +22,6 @@ def http_request(host_creds, endpoint, retries=3, retry_interval=3, **kwargs):
 
     :param host_creds: A :py:class:`mlflow.rest_utils.MlflowHostCreds` object containing
         hostname and optional authentication.
-    :param req_body_json: Dictionary containing the request body
-    :param params: Query parameters for the request
     :return: Parsed API response
     """
     hostname = host_creds.host
@@ -68,7 +66,7 @@ class NumpyEncoder(JSONEncoder):
         return JSONEncoder.default(self, o)
 
 
-class MlflowHostCreds:
+class MlflowHostCreds(object):
     """
     Provides a hostname and optional authentication for talking to an MLflow tracking server.
     :param host: Hostname (e.g., http://localhost:5000) to MLflow server. Required.

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -99,12 +99,6 @@ def set_tag_mock():
         yield mlflow_service_mock.set_tag
 
 
-@pytest.fixture()
-def get_databricks_http_request_kwargs_or_fail_mock():
-    with mock.patch("mlflow.projects.databricks.get_databricks_http_request_kwargs_or_fail") as m:
-        yield m
-
-
 def _get_mock_run_state(succeeded):
     if succeeded is None:
         return {"life_cycle_state": "RUNNING", "state_message": ""}
@@ -157,12 +151,12 @@ def test_upload_existing_project_to_dbfs(dbfs_path_exists_mock):  # pylint: disa
 
 def test_run_databricks_validations(
         tmpdir, cluster_spec_mock,  # pylint: disable=unused-argument
-        tracking_uri_mock, dbfs_mocks, set_tag_mock,  # pylint: disable=unused-argument
-        get_databricks_http_request_kwargs_or_fail_mock):  # pylint: disable=unused-argument
+        tracking_uri_mock, dbfs_mocks, set_tag_mock):  # pylint: disable=unused-argument
     """
     Tests that running on Databricks fails before making any API requests if validations fail.
     """
     with mock.patch("mlflow.projects.databricks.DatabricksJobRunner._check_auth_available"),\
+        mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host'}),\
         mock.patch("mlflow.projects.databricks.DatabricksJobRunner.databricks_api_request")\
             as db_api_req_mock:
         # Test bad tracking URI
@@ -193,49 +187,48 @@ def test_run_databricks_validations(
 def test_run_databricks(
         before_run_validations_mock,  # pylint: disable=unused-argument
         tracking_uri_mock, runs_cancel_mock, dbfs_mocks,  # pylint: disable=unused-argument
-        runs_submit_mock, runs_get_mock, cluster_spec_mock, set_tag_mock,
-        get_databricks_http_request_kwargs_or_fail_mock):
+        runs_submit_mock, runs_get_mock, cluster_spec_mock, set_tag_mock):
     """Test running on Databricks with mocks."""
-    get_databricks_http_request_kwargs_or_fail_mock.return_value = {'hostname': 'test-host'}
-    # Test that MLflow gets the correct run status when performing a Databricks run
-    for run_succeeded, expected_status in [(True, RunStatus.FINISHED), (False, RunStatus.FAILED)]:
-        runs_get_mock.return_value = mock_runs_get_result(succeeded=run_succeeded)
-        submitted_run = run_databricks_project(cluster_spec_mock)
-        assert submitted_run.wait() == run_succeeded
-        assert submitted_run.run_id is not None
-        assert runs_submit_mock.call_count == 1
-        assert set_tag_mock.call_count == 3
-        set_tag_args, _ = set_tag_mock.call_args_list[0]
-        assert set_tag_args[1] == MLFLOW_DATABRICKS_RUN_URL
-        assert set_tag_args[2] == 'test_url'
-        set_tag_args, _ = set_tag_mock.call_args_list[1]
-        assert set_tag_args[1] == MLFLOW_DATABRICKS_SHELL_JOB_RUN_ID
-        assert set_tag_args[2] == '-1'
-        set_tag_args, _ = set_tag_mock.call_args_list[2]
-        assert set_tag_args[1] == MLFLOW_DATABRICKS_WEBAPP_URL
-        assert set_tag_args[2] == 'test-host'
-        set_tag_mock.reset_mock()
-        runs_submit_mock.reset_mock()
-        validate_exit_status(submitted_run.get_status(), expected_status)
+    with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host'}):
+        # Test that MLflow gets the correct run status when performing a Databricks run
+        for run_succeeded, expect_status in [(True, RunStatus.FINISHED), (False, RunStatus.FAILED)]:
+            runs_get_mock.return_value = mock_runs_get_result(succeeded=run_succeeded)
+            submitted_run = run_databricks_project(cluster_spec_mock)
+            assert submitted_run.wait() == run_succeeded
+            assert submitted_run.run_id is not None
+            assert runs_submit_mock.call_count == 1
+            assert set_tag_mock.call_count == 3
+            set_tag_args, _ = set_tag_mock.call_args_list[0]
+            assert set_tag_args[1] == MLFLOW_DATABRICKS_RUN_URL
+            assert set_tag_args[2] == 'test_url'
+            set_tag_args, _ = set_tag_mock.call_args_list[1]
+            assert set_tag_args[1] == MLFLOW_DATABRICKS_SHELL_JOB_RUN_ID
+            assert set_tag_args[2] == '-1'
+            set_tag_args, _ = set_tag_mock.call_args_list[2]
+            assert set_tag_args[1] == MLFLOW_DATABRICKS_WEBAPP_URL
+            assert set_tag_args[2] is not None
+            set_tag_mock.reset_mock()
+            runs_submit_mock.reset_mock()
+            validate_exit_status(submitted_run.get_status(), expect_status)
 
 
 def test_run_databricks_cancel(
         before_run_validations_mock, tracking_uri_mock,  # pylint: disable=unused-argument
         runs_submit_mock, dbfs_mocks, set_tag_mock,  # pylint: disable=unused-argument
-        get_databricks_http_request_kwargs_or_fail_mock,  # pylint: disable=unused-argument
         runs_cancel_mock, runs_get_mock, cluster_spec_mock):
     # Test that MLflow properly handles Databricks run cancellation. We mock the result of
     # the runs-get API to indicate run failure so that cancel() exits instead of blocking while
     # waiting for run status.
-    runs_get_mock.return_value = mock_runs_get_result(succeeded=False)
-    submitted_run = run_databricks_project(cluster_spec_mock)
-    submitted_run.cancel()
-    validate_exit_status(submitted_run.get_status(), RunStatus.FAILED)
-    assert runs_cancel_mock.call_count == 1
-    # Test that we raise an exception when a blocking Databricks run fails
-    runs_get_mock.return_value = mock_runs_get_result(succeeded=False)
-    with pytest.raises(mlflow.projects.ExecutionException):
-        run_databricks_project(cluster_spec_mock, block=True)
+    with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host'}):
+        runs_get_mock.return_value = mock_runs_get_result(succeeded=False)
+        submitted_run = run_databricks_project(cluster_spec_mock)
+        submitted_run.cancel()
+        validate_exit_status(submitted_run.get_status(), RunStatus.FAILED)
+        assert runs_cancel_mock.call_count == 1
+        # Test that we raise an exception when a blocking Databricks run fails
+        runs_get_mock.return_value = mock_runs_get_result(succeeded=False)
+        with pytest.raises(mlflow.projects.ExecutionException):
+            run_databricks_project(cluster_spec_mock, block=True)
 
 
 def test_get_tracking_uri_for_run():

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -156,7 +156,7 @@ def test_run_databricks_validations(
     Tests that running on Databricks fails before making any API requests if validations fail.
     """
     with mock.patch("mlflow.projects.databricks.DatabricksJobRunner._check_auth_available"),\
-        mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host'}),\
+        mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}),\
         mock.patch("mlflow.projects.databricks.DatabricksJobRunner.databricks_api_request")\
             as db_api_req_mock:
         # Test bad tracking URI
@@ -189,7 +189,7 @@ def test_run_databricks(
         tracking_uri_mock, runs_cancel_mock, dbfs_mocks,  # pylint: disable=unused-argument
         runs_submit_mock, runs_get_mock, cluster_spec_mock, set_tag_mock):
     """Test running on Databricks with mocks."""
-    with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host'}):
+    with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
         # Test that MLflow gets the correct run status when performing a Databricks run
         for run_succeeded, expect_status in [(True, RunStatus.FINISHED), (False, RunStatus.FAILED)]:
             runs_get_mock.return_value = mock_runs_get_result(succeeded=run_succeeded)
@@ -206,7 +206,7 @@ def test_run_databricks(
             assert set_tag_args[2] == '-1'
             set_tag_args, _ = set_tag_mock.call_args_list[2]
             assert set_tag_args[1] == MLFLOW_DATABRICKS_WEBAPP_URL
-            assert set_tag_args[2] is not None
+            assert set_tag_args[2] == 'test-host'
             set_tag_mock.reset_mock()
             runs_submit_mock.reset_mock()
             validate_exit_status(submitted_run.get_status(), expect_status)
@@ -219,7 +219,7 @@ def test_run_databricks_cancel(
     # Test that MLflow properly handles Databricks run cancellation. We mock the result of
     # the runs-get API to indicate run failure so that cancel() exits instead of blocking while
     # waiting for run status.
-    with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host'}):
+    with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
         runs_get_mock.return_value = mock_runs_get_result(succeeded=False)
         submitted_run = run_databricks_project(cluster_spec_mock)
         submitted_run.cancel()

--- a/tests/store/test_dbfs_artifact_repo.py
+++ b/tests/store/test_dbfs_artifact_repo.py
@@ -67,7 +67,7 @@ class TestDbfsArtifactRepository(object):
             endpoints = []
             data = []
 
-            def my_http_request(host_creds, **kwargs):
+            def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
                 endpoints.append(kwargs['endpoint'])
                 data.append(kwargs['data'].read())
                 return Mock(status_code=200)
@@ -96,7 +96,7 @@ class TestDbfsArtifactRepository(object):
             endpoints = []
             data = []
 
-            def my_http_request(host_creds, **kwargs):
+            def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
                 endpoints.append(kwargs['endpoint'])
                 data.append(kwargs['data'].read())
                 return Mock(status_code=200)
@@ -127,7 +127,7 @@ class TestDbfsArtifactRepository(object):
         with mock.patch('mlflow.store.dbfs_artifact_repo.http_request') as http_request_mock:
             endpoints = []
 
-            def my_http_request(host_creds, **kwargs):
+            def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
                 endpoints.append(kwargs['endpoint'])
                 return Mock(status_code=200)
             http_request_mock.side_effect = my_http_request

--- a/tests/store/test_dbfs_artifact_repo.py
+++ b/tests/store/test_dbfs_artifact_repo.py
@@ -7,15 +7,18 @@ from mock import Mock
 
 from mlflow.exceptions import IllegalArtifactPathError, MlflowException
 from mlflow.store.dbfs_artifact_repo import DbfsArtifactRepository
+from mlflow.utils.rest_utils import MlflowHostCreds
 
 
 @pytest.fixture()
 def dbfs_artifact_repo():
-    return DbfsArtifactRepository('dbfs:/test/', {})
+    return DbfsArtifactRepository('dbfs:/test/', lambda: MlflowHostCreds('http://host'))
 
 TEST_FILE_1_CONTENT = u"Hello 🍆🍔".encode("utf-8")
 TEST_FILE_2_CONTENT = u"World 🍆🍔🍆".encode("utf-8")
 TEST_FILE_3_CONTENT = u"¡🍆🍆🍔🍆🍆!".encode("utf-8")
+
+DBFS_ARTIFACT_REPOSITORY_PACKAGE = 'mlflow.store.dbfs_artifact_repo.DbfsArtifactRepository'
 
 
 @pytest.fixture()
@@ -50,10 +53,10 @@ LIST_ARTIFACTS_RESPONSE = {
 
 class TestDbfsArtifactRepository(object):
     def test_init_validation_and_cleaning(self):
-        repo = DbfsArtifactRepository('dbfs:/test/', {})
+        repo = DbfsArtifactRepository('dbfs:/test/', lambda: MlflowHostCreds('http://host'))
         assert repo.artifact_uri == 'dbfs:/test'
         with pytest.raises(MlflowException):
-            DbfsArtifactRepository('s3://test', {})
+            DbfsArtifactRepository('s3://test', lambda: MlflowHostCreds('http://host'))
 
     @pytest.mark.parametrize("artifact_path,expected_endpoint", [
         (None, '/dbfs/test/test.txt'),
@@ -64,7 +67,7 @@ class TestDbfsArtifactRepository(object):
             endpoints = []
             data = []
 
-            def my_http_request(**kwargs):
+            def my_http_request(host_creds, **kwargs):
                 endpoints.append(kwargs['endpoint'])
                 data.append(kwargs['data'].read())
                 return Mock(status_code=200)
@@ -93,7 +96,7 @@ class TestDbfsArtifactRepository(object):
             endpoints = []
             data = []
 
-            def my_http_request(**kwargs):
+            def my_http_request(host_creds, **kwargs):
                 endpoints.append(kwargs['endpoint'])
                 data.append(kwargs['data'].read())
                 return Mock(status_code=200)
@@ -124,7 +127,7 @@ class TestDbfsArtifactRepository(object):
         with mock.patch('mlflow.store.dbfs_artifact_repo.http_request') as http_request_mock:
             endpoints = []
 
-            def my_http_request(**kwargs):
+            def my_http_request(host_creds, **kwargs):
                 endpoints.append(kwargs['endpoint'])
                 return Mock(status_code=200)
             http_request_mock.side_effect = my_http_request
@@ -144,9 +147,9 @@ class TestDbfsArtifactRepository(object):
             assert artifacts[1].file_size is None
 
     def test_download_artifacts(self, dbfs_artifact_repo):
-        with mock.patch('mlflow.store.dbfs_artifact_repo._dbfs_is_dir') as is_dir_mock,\
-                mock.patch('mlflow.store.dbfs_artifact_repo._dbfs_list_api') as list_mock, \
-                mock.patch('mlflow.store.dbfs_artifact_repo._dbfs_download') as download_mock:
+        with mock.patch(DBFS_ARTIFACT_REPOSITORY_PACKAGE + '._dbfs_is_dir') as is_dir_mock,\
+                mock.patch(DBFS_ARTIFACT_REPOSITORY_PACKAGE + '._dbfs_list_api') as list_mock, \
+                mock.patch(DBFS_ARTIFACT_REPOSITORY_PACKAGE + '._dbfs_download') as download_mock:
             is_dir_mock.side_effect = [
                 True,
                 False,

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -1,0 +1,116 @@
+import mock
+import os
+import pytest
+
+from mlflow.store.file_store import FileStore
+from mlflow.store.rest_store import RestStore
+from mlflow.tracking.utils import _get_store, _TRACKING_URI_ENV_VAR, _TRACKING_USERNAME_ENV_VAR, \
+                                  _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, \
+                                  _TRACKING_INSECURE_TLS_ENV_VAR
+
+
+def test_get_store_file_store(tmpdir):
+    env = {}
+    with mock.patch.dict(os.environ, env):
+        store = _get_store()
+        assert isinstance(store, FileStore)
+        assert store.root_directory == os.path.abspath("mlruns")
+
+        # Make sure we look at the parameter...
+        store = _get_store(tmpdir.strpath)
+        assert isinstance(store, FileStore)
+        assert store.root_directory == tmpdir
+
+
+def test_get_store_basic_rest_store(tmpdir):
+    env = {
+        _TRACKING_URI_ENV_VAR: "https://my-tracking-server:5050"
+    }
+    with mock.patch.dict(os.environ, env):
+        store = _get_store()
+        assert isinstance(store, RestStore)
+        assert store.get_host_creds().host == "https://my-tracking-server:5050"
+        assert store.get_host_creds().token is None
+
+
+def test_get_store_rest_store_with_password(tmpdir):
+    env = {
+        _TRACKING_URI_ENV_VAR: "https://my-tracking-server:5050",
+        _TRACKING_USERNAME_ENV_VAR: "Bob",
+        _TRACKING_PASSWORD_ENV_VAR: "Ross",
+    }
+    with mock.patch.dict(os.environ, env):
+        store = _get_store()
+        assert isinstance(store, RestStore)
+        assert store.get_host_creds().host == "https://my-tracking-server:5050"
+        assert store.get_host_creds().username == "Bob"
+        assert store.get_host_creds().password == "Ross"
+
+
+def test_get_store_rest_store_with_token(tmpdir):
+    env = {
+        _TRACKING_URI_ENV_VAR: "https://my-tracking-server:5050",
+        _TRACKING_TOKEN_ENV_VAR: "my-token",
+    }
+    with mock.patch.dict(os.environ, env):
+        store = _get_store()
+        assert isinstance(store, RestStore)
+        assert store.get_host_creds().token == "my-token"
+
+
+def test_get_store_rest_store_with_insecure(tmpdir):
+    env = {
+        _TRACKING_URI_ENV_VAR: "https://my-tracking-server:5050",
+        _TRACKING_INSECURE_TLS_ENV_VAR: "true",
+    }
+    with mock.patch.dict(os.environ, env):
+        store = _get_store()
+        assert isinstance(store, RestStore)
+        assert store.get_host_creds().ignore_tls_verification
+
+
+def test_get_store_rest_store_with_no_insecure(tmpdir):
+    env = {
+        _TRACKING_URI_ENV_VAR: "https://my-tracking-server:5050",
+        _TRACKING_INSECURE_TLS_ENV_VAR: "false",
+    }
+    with mock.patch.dict(os.environ, env):
+        store = _get_store()
+        assert isinstance(store, RestStore)
+        assert not store.get_host_creds().ignore_tls_verification
+
+    # By default, should not ignore verification.
+    env = {
+        _TRACKING_URI_ENV_VAR: "https://my-tracking-server:5050",
+    }
+    with mock.patch.dict(os.environ, env):
+        store = _get_store()
+        assert isinstance(store, RestStore)
+        assert not store.get_host_creds().ignore_tls_verification
+
+
+def test_get_store_databricks(tmpdir):
+    env = {
+        _TRACKING_URI_ENV_VAR: "databricks",
+        'DATABRICKS_HOST': "https://my-tracking-server",
+        'DATABRICKS_TOKEN': "abcdef",
+    }
+    with mock.patch.dict(os.environ, env):
+        store = _get_store()
+        assert isinstance(store, RestStore)
+        assert store.get_host_creds().host == "https://my-tracking-server"
+        assert store.get_host_creds().token == "abcdef"
+
+
+def test_get_store_databricks_profile(tmpdir):
+    env = {
+        _TRACKING_URI_ENV_VAR: "databricks://mycoolprofile",
+    }
+    # It's kind of annoying to setup a profile, and we're not really trying to test
+    # that anyway, so just check if we raise a relevant exception.
+    with mock.patch.dict(os.environ, env):
+        store = _get_store()
+        assert isinstance(store, RestStore)
+        with pytest.raises(Exception) as e_info:
+            store.get_host_creds()
+        assert 'mycoolprofile' in str(e_info.value)

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -1,4 +1,8 @@
+import mock
+import pytest
+
 from mlflow.utils import databricks_utils
+from databricks_cli.configure.provider import DatabricksConfig
 
 
 def test_no_throw():
@@ -7,3 +11,61 @@ def test_no_throw():
     None.
     """
     assert not databricks_utils.is_in_databricks_notebook()
+
+
+@mock.patch('databricks_cli.configure.provider.get_config')
+def test_databricks_params_token(get_config):
+    get_config.return_value = \
+        DatabricksConfig("host", None, None, "mytoken", insecure=False)
+    params = databricks_utils.get_databricks_host_creds()
+    assert params.host == 'host'
+    assert params.token == 'mytoken'
+    assert not params.ignore_tls_verification
+
+
+@mock.patch('databricks_cli.configure.provider.get_config')
+def test_databricks_params_user_password(get_config):
+    get_config.return_value = \
+        DatabricksConfig("host", "user", "pass", None, insecure=False)
+    params = databricks_utils.get_databricks_host_creds()
+    assert params.host == 'host'
+    assert params.username == 'user'
+    assert params.password == 'pass'
+
+
+@mock.patch('databricks_cli.configure.provider.get_config')
+def test_databricks_params_no_verify(get_config):
+    get_config.return_value = \
+        DatabricksConfig("host", "user", "pass", None, insecure=True)
+    params = databricks_utils.get_databricks_host_creds()
+    assert params.ignore_tls_verification
+
+
+@mock.patch('databricks_cli.configure.provider.ProfileConfigProvider')
+def test_databricks_params_custom_profile(ProfileConfigProvider):
+    mock_provider = mock.MagicMock()
+    mock_provider.get_config.return_value = \
+        DatabricksConfig("host", "user", "pass", None, insecure=True)
+    ProfileConfigProvider.return_value = mock_provider
+    params = databricks_utils.get_databricks_host_creds("profile")
+    assert params.ignore_tls_verification
+    ProfileConfigProvider.assert_called_with("profile")
+
+
+@mock.patch('databricks_cli.configure.provider.ProfileConfigProvider')
+def test_databricks_params_throws_errors(ProfileConfigProvider):
+    # No hostname
+    mock_provider = mock.MagicMock()
+    mock_provider.get_config.return_value = \
+        DatabricksConfig(None, "user", "pass", None, insecure=True)
+    ProfileConfigProvider.return_value = mock_provider
+    with pytest.raises(Exception):
+        databricks_utils.get_databricks_host_creds()
+
+    # No authentication
+    mock_provider = mock.MagicMock()
+    mock_provider.get_config.return_value = \
+        DatabricksConfig("host", None, None, None, insecure=True)
+    ProfileConfigProvider.return_value = mock_provider
+    with pytest.raises(Exception):
+        databricks_utils.get_databricks_host_creds()

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -1,77 +1,85 @@
 #!/usr/bin/env python
+
 import mock
 import numpy
 import pytest
 
-from databricks_cli.configure.provider import DatabricksConfig
-from mlflow.utils import rest_utils
-from mlflow.utils.rest_utils import NumpyEncoder
+from mlflow.utils.rest_utils import NumpyEncoder, http_request, MlflowHostCreds
 
 
-@mock.patch('databricks_cli.configure.provider.get_config')
-def test_databricks_params_token(get_config):
-    get_config.return_value = \
-        DatabricksConfig("host", None, None, "mytoken", insecure=False)
-    params = rest_utils.get_databricks_http_request_kwargs_or_fail()
-    assert params == {
-        'hostname': 'host',
-        'headers': {
-            'Authorization': 'Bearer mytoken'
-        },
-        'verify': True,
-    }
+@mock.patch('requests.request')
+def test_http_request_hostonly(request):
+    host_only = MlflowHostCreds("http://my-host")
+    response = mock.MagicMock()
+    response.status_code = 200
+    request.return_value = response
+    http_request(host_only, '/my/endpoint')
+    request.assert_called_with(
+        url='http://my-host/my/endpoint',
+        verify=True,
+        headers={},
+    )
 
 
-@mock.patch('databricks_cli.configure.provider.get_config')
-def test_databricks_params_user_password(get_config):
-    get_config.return_value = \
-        DatabricksConfig("host", "user", "pass", None, insecure=False)
-    params = rest_utils.get_databricks_http_request_kwargs_or_fail()
-    assert params == {
-        'hostname': 'host',
-        'headers': {
+@mock.patch('requests.request')
+def test_http_request_cleans_hostname(request):
+    # Add a trailing slash, should be removed.
+    host_only = MlflowHostCreds("http://my-host/")
+    response = mock.MagicMock()
+    response.status_code = 200
+    request.return_value = response
+    http_request(host_only, '/my/endpoint')
+    request.assert_called_with(
+        url='http://my-host/my/endpoint',
+        verify=True,
+        headers={},
+    )
+
+
+@mock.patch('requests.request')
+def test_http_request_with_basic_auth(request):
+    host_only = MlflowHostCreds("http://my-host", username='user', password='pass')
+    response = mock.MagicMock()
+    response.status_code = 200
+    request.return_value = response
+    http_request(host_only, '/my/endpoint')
+    request.assert_called_with(
+        url='http://my-host/my/endpoint',
+        verify=True,
+        headers={
             'Authorization': 'Basic dXNlcjpwYXNz'
         },
-        'verify': True,
-    }
+    )
 
 
-@mock.patch('databricks_cli.configure.provider.get_config')
-def test_databricks_params_no_verify(get_config):
-    get_config.return_value = \
-        DatabricksConfig("host", "user", "pass", None, insecure=True)
-    params = rest_utils.get_databricks_http_request_kwargs_or_fail()
-    assert params['verify'] is False
+@mock.patch('requests.request')
+def test_http_request_with_token(request):
+    host_only = MlflowHostCreds("http://my-host", token='my-token')
+    response = mock.MagicMock()
+    response.status_code = 200
+    request.return_value = response
+    http_request(host_only, '/my/endpoint')
+    request.assert_called_with(
+        url='http://my-host/my/endpoint',
+        verify=True,
+        headers={
+            'Authorization': 'Bearer my-token'
+        },
+    )
 
 
-@mock.patch('databricks_cli.configure.provider.ProfileConfigProvider')
-def test_databricks_params_custom_profile(ProfileConfigProvider):
-    mock_provider = mock.MagicMock()
-    mock_provider.get_config.return_value = \
-        DatabricksConfig("host", "user", "pass", None, insecure=True)
-    ProfileConfigProvider.return_value = mock_provider
-    params = rest_utils.get_databricks_http_request_kwargs_or_fail("profile")
-    assert params['verify'] is False
-    ProfileConfigProvider.assert_called_with("profile")
-
-
-@mock.patch('databricks_cli.configure.provider.ProfileConfigProvider')
-def test_databricks_params_throws_errors(ProfileConfigProvider):
-    # No hostname
-    mock_provider = mock.MagicMock()
-    mock_provider.get_config.return_value = \
-        DatabricksConfig(None, "user", "pass", None, insecure=True)
-    ProfileConfigProvider.return_value = mock_provider
-    with pytest.raises(Exception):
-        rest_utils.get_databricks_http_request_kwargs_or_fail()
-
-    # No authentication
-    mock_provider = mock.MagicMock()
-    mock_provider.get_config.return_value = \
-        DatabricksConfig("host", None, None, None, insecure=True)
-    ProfileConfigProvider.return_value = mock_provider
-    with pytest.raises(Exception):
-        rest_utils.get_databricks_http_request_kwargs_or_fail()
+@mock.patch('requests.request')
+def test_http_request_with_insecure(request):
+    host_only = MlflowHostCreds("http://my-host", ignore_tls_verification=True)
+    response = mock.MagicMock()
+    response.status_code = 200
+    request.return_value = response
+    http_request(host_only, '/my/endpoint')
+    request.assert_called_with(
+        url='http://my-host/my/endpoint',
+        verify=False,
+        headers={},
+    )
 
 
 def test_numpy_encoder():


### PR DESCRIPTION
The main goal of this PR is to supplement the support added in #391 which allows non-Python clients to leverage the ArtifactRepository API. In particular, we need a way to pass authentication over the command line so that our REST calls will be successful -- currently, we only support passing the MLFLOW_TRACKING_URI.

This PR introduces four new environment variables:

  - `MLFLOW_TRACKING_USERNAME`
  - `MLFLOW_TRACKING_PASSWORD`
  - `MLFLOW_TRACKING_TOKEN`
  - `MLFLOW_TRACKING_INSECURE_TLS`

When specified, these will be added to the http request as appropriate (e.g., as Basic or Bearer Authentication headers).

The majority of this PR is simply refactoring the existing logic which knows how to inject these headers, which was previously specific to DatabricksConfig. We introduce an `MlflowHostCreds` class to capture these parameters, identical to the [Java version](https://github.com/mlflow/mlflow/blob/643ab70ef274b7dbab064be49dde3a31958cbf1e/mlflow/java/client/src/main/java/org/mlflow/tracking/creds/MlflowHostCreds.java).