### PR TITLE
[Java] CLI-backed Artifact Repository should pass-through HTTP auth

### DIFF
--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -49,10 +49,12 @@
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>1.3.9</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.ini4j</groupId>
@@ -92,6 +94,7 @@
               <include>commons-io:commons-io</include>
               <include>commons-logging:commons-logging</include>
               <include>org.apache.httpcomponents:httpcore</include>
+              <include>org.ini4j:ini4j</include>
             </includes>
           </artifactSet>
           <relocations>
@@ -113,8 +116,8 @@
               <shadedPattern>${mlflow.shade.packageName}.databricks</shadedPattern>
             </relocation>
             <relocation>
-              <pattern>org.yaml</pattern>
-              <shadedPattern>${mlflow.shade.packageName}.yaml</shadedPattern>
+              <pattern>org.ini4j</pattern>
+              <shadedPattern>${mlflow.shade.packageName}.ini4j</shadedPattern>
             </relocation>
           </relocations>
         </configuration>

--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -46,17 +46,6 @@
       <artifactId>commons-io</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>1.3.9</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.ini4j</groupId>
       <artifactId>ini4j</artifactId>
     </dependency>

--- a/mlflow/java/client/src/main/java/org/mlflow/artifacts/ArtifactRepository.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/artifacts/ArtifactRepository.java
@@ -1,6 +1,5 @@
 package org.mlflow.artifacts;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.util.List;
 
@@ -34,7 +33,7 @@ public interface ArtifactRepository {
    * @param artifactPath Artifact path relative to the run's root directory. Should NOT
    *                     start with a /.
    */
-  void logArtifact(File localFile, @Nonnull String artifactPath);
+  void logArtifact(File localFile, String artifactPath);
 
   /**
    * Uploads all files within the given local director the run's root artifact directory.
@@ -61,7 +60,7 @@ public interface ArtifactRepository {
    * @param artifactPath Artifact path relative to the run's root directory. Should NOT
    *                     start with a /.
    */
-  void logArtifacts(File localDir, @Nonnull String artifactPath);
+  void logArtifacts(File localDir, String artifactPath);
 
   /**
    * Lists the artifacts immediately under the run's root artifact directory. This does not
@@ -77,7 +76,7 @@ public interface ArtifactRepository {
    * @param artifactPath Artifact path relative to the run's root directory. Should NOT
    *                     start with a /.
    */
-  List<FileInfo> listArtifacts(@Nonnull String artifactPath);
+  List<FileInfo> listArtifacts(String artifactPath);
 
   /**
    * Returns a local directory containing *all* artifacts within the run's artifact directory.
@@ -100,5 +99,5 @@ public interface ArtifactRepository {
    * @param artifactPath Artifact path relative to the run's root directory. Should NOT
    *                     start with a /.
    */
-  File downloadArtifacts(@Nonnull String artifactPath);
+  File downloadArtifacts(String artifactPath);
 }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/creds/DatabricksConfigHostCredsProvider.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/creds/DatabricksConfigHostCredsProvider.java
@@ -68,7 +68,7 @@ public class DatabricksConfigHostCredsProvider implements MlflowHostCredsProvide
     String username = section.get("username");
     String password = section.get("password");
     String token = section.get("token");
-    boolean insecure = section.get("insecure", "false").equals("true");
+    boolean insecure = section.get("insecure", "false").toLowerCase().equals("true");
 
     if (host == null) {
       throw new IllegalStateException("No 'host' configured within Databricks config file" +

--- a/mlflow/java/client/src/test/java/org/mlflow/artifacts/CliBasedArtifactRepositoryTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/artifacts/CliBasedArtifactRepositoryTest.java
@@ -5,6 +5,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
@@ -14,11 +15,14 @@ import org.testng.Assert;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
+import org.testng.collections.Maps;
 
 import org.mlflow.api.proto.Service.FileInfo;
 import org.mlflow.api.proto.Service.RunInfo;
 import org.mlflow.tracking.MlflowClient;
 import org.mlflow.tracking.TestClientProvider;
+import org.mlflow.tracking.creds.BasicMlflowHostCreds;
+import org.mlflow.tracking.creds.MlflowHostCreds;
 
 public class CliBasedArtifactRepositoryTest {
   private static final Logger logger = Logger.getLogger(CliBasedArtifactRepositoryTest.class);
@@ -127,6 +131,55 @@ public class CliBasedArtifactRepositoryTest {
     Path subberpathArtifacts = repo.downloadArtifacts("subpath/subberpath").toPath();
     Assert.assertEquals(grandchildContents, readFile(subberpathArtifacts.resolve("grandchild")));
     Assert.assertEquals(subberpathArtifacts.toFile().list(), new String[] {"grandchild"});
+  }
+
+  @Test
+  public void testSettingProcessEnvBasic() {
+    CliBasedArtifactRepository repo = newRepo();
+    MlflowHostCreds hostCreds = new BasicMlflowHostCreds("just-host");
+    Map<String, String> env = Maps.newHashMap();
+    repo.setProcessEnvironment(env, hostCreds);
+    Map<String, String> expectedEnv = Maps.newHashMap();
+    expectedEnv.put("MLFLOW_TRACKING_URI", "just-host");
+    Assert.assertEquals(env, expectedEnv);
+  }
+
+  @Test
+  public void testSettingProcessEnvUserPass() {
+    CliBasedArtifactRepository repo = newRepo();
+    MlflowHostCreds hostCreds = new BasicMlflowHostCreds("just-host", "user", "pass");
+    Map<String, String> env = Maps.newHashMap();
+    repo.setProcessEnvironment(env, hostCreds);
+    Map<String, String> expectedEnv = Maps.newHashMap();
+    expectedEnv.put("MLFLOW_TRACKING_URI", "just-host");
+    expectedEnv.put("MLFLOW_TRACKING_USERNAME", "user");
+    expectedEnv.put("MLFLOW_TRACKING_PASSWORD", "pass");
+    Assert.assertEquals(env, expectedEnv);
+  }
+
+  @Test
+  public void testSettingProcessEnvToken() {
+    CliBasedArtifactRepository repo = newRepo();
+    MlflowHostCreds hostCreds = new BasicMlflowHostCreds("just-host", "token");
+    Map<String, String> env = Maps.newHashMap();
+    repo.setProcessEnvironment(env, hostCreds);
+    Map<String, String> expectedEnv = Maps.newHashMap();
+    expectedEnv.put("MLFLOW_TRACKING_URI", "just-host");
+    expectedEnv.put("MLFLOW_TRACKING_TOKEN", "token");
+    Assert.assertEquals(env, expectedEnv);
+  }
+
+  @Test
+  public void testSettingProcessEnvInsecure() {
+    CliBasedArtifactRepository repo = newRepo();
+    MlflowHostCreds hostCreds = new BasicMlflowHostCreds("insecure-host", null, null, null,
+      true);
+    Map<String, String> env = Maps.newHashMap();
+    repo.setProcessEnvironment(env, hostCreds);
+    Map<String, String> expectedEnv = Maps.newHashMap();
+    expectedEnv.put("MLFLOW_TRACKING_URI", "insecure-host");
+    expectedEnv.put("MLFLOW_TRACKING_INSECURE_TLS", "true");
+    Assert.assertEquals(env, expectedEnv);
   }
 
   private String readFile(Path path) throws IOException {

--- a/mlflow/java/client/src/test/java/org/mlflow/artifacts/CliBasedArtifactRepositoryTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/artifacts/CliBasedArtifactRepositoryTest.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -15,7 +16,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
-import org.testng.collections.Maps;
 
 import org.mlflow.api.proto.Service.FileInfo;
 import org.mlflow.api.proto.Service.RunInfo;
@@ -137,9 +137,9 @@ public class CliBasedArtifactRepositoryTest {
   public void testSettingProcessEnvBasic() {
     CliBasedArtifactRepository repo = newRepo();
     MlflowHostCreds hostCreds = new BasicMlflowHostCreds("just-host");
-    Map<String, String> env = Maps.newHashMap();
+    Map<String, String> env = new HashMap<>();
     repo.setProcessEnvironment(env, hostCreds);
-    Map<String, String> expectedEnv = Maps.newHashMap();
+    Map<String, String> expectedEnv = new HashMap<>();
     expectedEnv.put("MLFLOW_TRACKING_URI", "just-host");
     Assert.assertEquals(env, expectedEnv);
   }
@@ -148,9 +148,9 @@ public class CliBasedArtifactRepositoryTest {
   public void testSettingProcessEnvUserPass() {
     CliBasedArtifactRepository repo = newRepo();
     MlflowHostCreds hostCreds = new BasicMlflowHostCreds("just-host", "user", "pass");
-    Map<String, String> env = Maps.newHashMap();
+    Map<String, String> env = new HashMap<>();
     repo.setProcessEnvironment(env, hostCreds);
-    Map<String, String> expectedEnv = Maps.newHashMap();
+    Map<String, String> expectedEnv = new HashMap<>();
     expectedEnv.put("MLFLOW_TRACKING_URI", "just-host");
     expectedEnv.put("MLFLOW_TRACKING_USERNAME", "user");
     expectedEnv.put("MLFLOW_TRACKING_PASSWORD", "pass");
@@ -161,9 +161,9 @@ public class CliBasedArtifactRepositoryTest {
   public void testSettingProcessEnvToken() {
     CliBasedArtifactRepository repo = newRepo();
     MlflowHostCreds hostCreds = new BasicMlflowHostCreds("just-host", "token");
-    Map<String, String> env = Maps.newHashMap();
+    Map<String, String> env = new HashMap<>();
     repo.setProcessEnvironment(env, hostCreds);
-    Map<String, String> expectedEnv = Maps.newHashMap();
+    Map<String, String> expectedEnv = new HashMap<>();
     expectedEnv.put("MLFLOW_TRACKING_URI", "just-host");
     expectedEnv.put("MLFLOW_TRACKING_TOKEN", "token");
     Assert.assertEquals(env, expectedEnv);
@@ -174,9 +174,9 @@ public class CliBasedArtifactRepositoryTest {
     CliBasedArtifactRepository repo = newRepo();
     MlflowHostCreds hostCreds = new BasicMlflowHostCreds("insecure-host", null, null, null,
       true);
-    Map<String, String> env = Maps.newHashMap();
+    Map<String, String> env = new HashMap<>();
     repo.setProcessEnvironment(env, hostCreds);
-    Map<String, String> expectedEnv = Maps.newHashMap();
+    Map<String, String> expectedEnv = new HashMap<>();
     expectedEnv.put("MLFLOW_TRACKING_URI", "insecure-host");
     expectedEnv.put("MLFLOW_TRACKING_INSECURE_TLS", "true");
     Assert.assertEquals(env, expectedEnv);

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -42,7 +42,7 @@ public class MlflowClientTest {
     Assert.assertEquals(exp.getExperiment().getName(), expName);
   }
 
-  @Test(expectedExceptions = MlflowHttpServerException.class) // TODO: server should throw 406
+  @Test(expectedExceptions = MlflowClientException.class) // TODO: server should throw 406
   public void createExistingExperiment() {
     String expName = createExperimentName();
     client.createExperiment(expName);
@@ -86,7 +86,7 @@ public class MlflowClientTest {
 
     List<RunInfo> runInfos = client.listRunInfos(expId);
     Assert.assertEquals(runInfos.size(), 1);
-    Assert.assertEquals(runInfos.get(0).getName(), "Run 0"); // Weird, but the API returns this
+    Assert.assertEquals(runInfos.get(0).getSourceType(), SourceType.LOCAL);
     Assert.assertEquals(runInfos.get(0).getStatus(), RunStatus.RUNNING);
 
     // Log parameters
@@ -108,12 +108,11 @@ public class MlflowClientTest {
     GetExperiment.Response expResponse = client.getExperiment(expId);
     Experiment exp = expResponse.getExperiment();
     Assert.assertEquals(exp.getName(), expName);
-    assertRunInfo(expResponse.getRunsList().get(0), expId, user, sourceFile);
 
     // Assert run from getRun
     Run run = client.getRun(runId);
     RunInfo runInfo = run.getInfo();
-    assertRunInfo(runInfo, expId, user, sourceFile);
+    assertRunInfo(runInfo, expId, sourceFile);
   }
 
   @Test(dependsOnMethods = {"addGetRun"})

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
@@ -14,10 +14,10 @@ public class TestUtils {
     return a == b ? true : Math.abs(a - b) < EPSILON;
   }
 
-  static void assertRunInfo(RunInfo runInfo, long experimentId, String user, String sourceName) {
+  static void assertRunInfo(RunInfo runInfo, long experimentId, String sourceName) {
     Assert.assertEquals(runInfo.getExperimentId(), experimentId);
-    Assert.assertEquals(runInfo.getUserId(), user);
     Assert.assertEquals(runInfo.getSourceName(), sourceName);
+    Assert.assertNotEquals(runInfo.getUserId(), "");
   }
 
   public static void assertParam(List<Param> params, String key, String value) {

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/creds/DatabricksConfigHostCredsProviderTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/creds/DatabricksConfigHostCredsProviderTest.java
@@ -39,7 +39,7 @@ public class DatabricksConfigHostCredsProviderTest {
     Assert.assertEquals(provider.getHostCreds().getHost(), "https://boop.com");
     Assert.assertEquals(provider.getHostCreds().getToken(), "dapi");
 
-    String contents2 = "[DEFAULT]\nhost = https://boop.com\ntoken=dapi2\ninsecure = true";
+    String contents2 = "[DEFAULT]\nhost = https://boop.com\ntoken=dapi2\ninsecure = TrUe";
     FileUtils.writeStringToFile(databrickscfg, contents2, StandardCharsets.UTF_8);
     Assert.assertEquals(provider.getHostCreds().getToken(), "dapi");
     Assert.assertFalse(provider.getHostCreds().shouldIgnoreTlsVerification());


### PR DESCRIPTION
Requires #402 to actually work; this just passes the flags through the the mlflow CLI process so we can access artifactories which requires auth.

I only did unit testing here; we should have an end-to-end test confirming the Java API can read and write artifacts from authenticated backends.