### PR TITLE
Fix Dockerfile for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ ADD . /app
 RUN pip install -r dev-requirements.txt && \
     pip install -r test-requirements.txt && \
     pip install -e . && \
-    apt-get install -y gnupg && \
+    apt-get-update && apt-get install -y gnupg && \
     curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-    apt-get install -y nodejs && \
+    apt-get-update && apt-get install -y nodejs && \
     cd mlflow/server/js && \
     npm install && \
     npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,9 @@ ADD . /app
 RUN pip install -r dev-requirements.txt && \
     pip install -r test-requirements.txt && \
     pip install -e . && \
-    apt-get-update && apt-get install -y gnupg && \
+    apt-get update && apt-get install -y gnupg && \
     curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
-    apt-get-update && apt-get install -y nodejs && \
+    apt-get update && apt-get install -y nodejs && \
     cd mlflow/server/js && \
     npm install && \
     npm run build


### PR DESCRIPTION
It's not a well-supported pathway, but if we have the Dockerfile it should probably work. The current version complains with a 404 error message. I was able to successfully build this one locally:

```
 ---> fabbecc91782
Successfully built fabbecc91782
```