### PR TITLE
Print errors when the Databricks run fails to start

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -11,7 +11,7 @@ from six.moves import shlex_quote, urllib
 from mlflow.entities import RunStatus
 from mlflow.projects.submitted_run import SubmittedRun
 from mlflow.utils import rest_utils, file_utils
-from mlflow.exceptions import ExecutionException, MlflowException
+from mlflow.exceptions import ExecutionException
 from mlflow.utils.logging_utils import eprint
 from mlflow import tracking
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_RUN_URL, MLFLOW_DATABRICKS_SHELL_JOB_ID, \
@@ -50,7 +50,6 @@ class DatabricksJobRunner(object):
         return json.loads(response.text)
 
     def _jobs_runs_submit(self, json):
-        print 'here'
         return self.databricks_api_request(
             endpoint="/api/2.0/jobs/runs/submit", method="POST", json=json)
 
@@ -149,11 +148,7 @@ class DatabricksJobRunner(object):
             "libraries": [{"pypi": {"package": "'mlflow<=%s'" % VERSION}}],
         }
         run_submit_res = self._jobs_runs_submit(req_body_json)
-        try:
-            databricks_run_id = run_submit_res["run_id"]
-        except KeyError:
-            raise MlflowException("The Databricks run failed to start. Error: {}".format(
-                run_submit_res))
+        databricks_run_id = run_submit_res["run_id"]
         return databricks_run_id
 
     def _before_run_validations(self, tracking_uri, cluster_spec):

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -11,7 +11,7 @@ from six.moves import shlex_quote, urllib
 from mlflow.entities import RunStatus
 from mlflow.projects.submitted_run import SubmittedRun
 from mlflow.utils import rest_utils, file_utils
-from mlflow.exceptions import ExecutionException
+from mlflow.exceptions import ExecutionException, MlflowException
 from mlflow.utils.logging_utils import eprint
 from mlflow import tracking
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_RUN_URL, MLFLOW_DATABRICKS_SHELL_JOB_ID, \
@@ -50,6 +50,7 @@ class DatabricksJobRunner(object):
         return json.loads(response.text)
 
     def _jobs_runs_submit(self, json):
+        print 'here'
         return self.databricks_api_request(
             endpoint="/api/2.0/jobs/runs/submit", method="POST", json=json)
 
@@ -148,7 +149,11 @@ class DatabricksJobRunner(object):
             "libraries": [{"pypi": {"package": "'mlflow<=%s'" % VERSION}}],
         }
         run_submit_res = self._jobs_runs_submit(req_body_json)
-        databricks_run_id = run_submit_res["run_id"]
+        try:
+            databricks_run_id = run_submit_res["run_id"]
+        except KeyError:
+            raise MlflowException("The Databricks run failed to start. Error: {}".format(
+                run_submit_res))
         return databricks_run_id
 
     def _before_run_validations(self, tracking_uri, cluster_spec):

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -73,10 +73,8 @@ class DatabricksJobRunner(object):
         """
         eprint("=== Uploading project to DBFS path %s ===" % dbfs_fuse_uri)
         http_endpoint = dbfs_fuse_uri
-        host_creds = databricks_utils.get_databricks_host_creds(self.databricks_profile)
         with open(src_path, 'rb') as f:
-            rest_utils.http_request(
-                host_creds=host_creds, endpoint=http_endpoint, method='POST', data=f)
+            self._databricks_api_request(endpoint=http_endpoint, method='POST', data=f)
 
     def _dbfs_path_exists(self, dbfs_uri):
         """

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -74,7 +74,8 @@ class DatabricksJobRunner(object):
         eprint("=== Uploading project to DBFS path %s ===" % dbfs_fuse_uri)
         http_endpoint = dbfs_fuse_uri
         with open(src_path, 'rb') as f:
-            self._databricks_api_request(endpoint=http_endpoint, method='POST', data=f)
+            response = self._databricks_api_request(endpoint=http_endpoint, method='POST', data=f)
+            _check_response_status_code(response)
 
     def _dbfs_path_exists(self, dbfs_uri):
         """

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -9,6 +9,7 @@ import databricks_cli
 import pytest
 
 import mlflow
+from mlflow.exceptions import MlflowException
 from mlflow.projects.databricks import DatabricksJobRunner
 from mlflow.entities import RunStatus
 from mlflow.projects import databricks, ExecutionException
@@ -250,6 +251,12 @@ def test_get_tracking_uri_for_run():
     with mock.patch.dict(os.environ, {mlflow.tracking._TRACKING_URI_ENV_VAR: "http://some-uri"}):
         assert mlflow.tracking.utils.get_tracking_uri() == "http://some-uri"
 
+def test_run_databricks_failed():
+    with mock.patch('mlflow.projects.databricks.DatabricksJobRunner._jobs_runs_submit') as m:
+        m.return_value = {'message': 'Node type not supported'}
+        runner = DatabricksJobRunner('profile')
+        with pytest.raises(MlflowException):
+            runner._run_shell_command_job('/project', 'command', {}, {})
 
 class MockProfileConfigProvider:
     def __init__(self, profile):

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -9,7 +9,6 @@ import databricks_cli
 import pytest
 
 import mlflow
-from mlflow.exceptions import MlflowException
 from mlflow.projects.databricks import DatabricksJobRunner
 from mlflow.entities import RunStatus
 from mlflow.projects import databricks, ExecutionException
@@ -251,12 +250,6 @@ def test_get_tracking_uri_for_run():
     with mock.patch.dict(os.environ, {mlflow.tracking._TRACKING_URI_ENV_VAR: "http://some-uri"}):
         assert mlflow.tracking.utils.get_tracking_uri() == "http://some-uri"
 
-def test_run_databricks_failed():
-    with mock.patch('mlflow.projects.databricks.DatabricksJobRunner._jobs_runs_submit') as m:
-        m.return_value = {'message': 'Node type not supported'}
-        runner = DatabricksJobRunner('profile')
-        with pytest.raises(MlflowException):
-            runner._run_shell_command_job('/project', 'command', {}, {})
 
 class MockProfileConfigProvider:
     def __init__(self, profile):

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -9,6 +9,7 @@ import databricks_cli
 import pytest
 
 import mlflow
+from mlflow.exceptions import MlflowException
 from mlflow.projects.databricks import DatabricksJobRunner
 from mlflow.entities import RunStatus
 from mlflow.projects import databricks, ExecutionException
@@ -163,7 +164,7 @@ def test_run_databricks_validations(
     Tests that running on Databricks fails before making any API requests if validations fail.
     """
     with mock.patch("mlflow.projects.databricks.DatabricksJobRunner._check_auth_available"),\
-        mock.patch("mlflow.projects.databricks.DatabricksJobRunner.databricks_api_request")\
+        mock.patch("mlflow.projects.databricks.DatabricksJobRunner._databricks_api_request")\
             as db_api_req_mock:
         # Test bad tracking URI
         tracking_uri_mock.return_value = tmpdir.strpath
@@ -283,11 +284,19 @@ def test_databricks_http_request_integration(get_config, request):
     get_config.return_value = \
         DatabricksConfig("host", "user", "pass", None, insecure=False)
 
-    response = DatabricksJobRunner(databricks_profile=None).databricks_api_request(
+    response = DatabricksJobRunner(databricks_profile=None)._databricks_api_request(
         '/clusters/list', 'PUT', json={'a': 'b'})
-    assert response == {'OK': 'woo'}
+    assert json.loads(response.text) == {'OK': 'woo'}
     get_config.reset_mock()
-    response = DatabricksJobRunner(databricks_profile="my-profile").databricks_api_request(
+    response = DatabricksJobRunner(databricks_profile="my-profile")._databricks_api_request(
         '/clusters/list', 'PUT', json={'a': 'b'})
-    assert response == {'OK': 'woo'}
+    assert json.loads(response.text) == {'OK': 'woo'}
     assert get_config.call_count == 0
+
+
+def test_run_databricks_failed():
+    with mock.patch('mlflow.projects.databricks.DatabricksJobRunner._databricks_api_request') as m:
+        m.return_value = mock.Mock(text="{'message': 'Node type not supported'}", status_code=400)
+        runner = DatabricksJobRunner('profile')
+        with pytest.raises(MlflowException):
+            runner._run_shell_command_job('/project', 'command', {}, {})


### PR DESCRIPTION
If the cluster spec is wrong, you'll usually get an error looking like
```
....
  File "/Users/andrew/mlflow/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/andrew/mlflow/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/andrew/mlflow/mlflow/cli.py", line 110, in run
    run_id=run_id,
  File "/Users/andrew/mlflow/mlflow/projects/__init__.py", line 121, in run
    storage_dir=storage_dir, block=block, run_id=run_id)
  File "/Users/andrew/mlflow/mlflow/projects/__init__.py", line 54, in _run
    experiment_id=exp_id, cluster_spec=cluster_spec)
  File "/Users/andrew/mlflow/mlflow/projects/databricks.py", line 261, in run_databricks
    db_run_id = _run_shell_command_job(uri, command, env_vars, cluster_spec)
  File "/Users/andrew/mlflow/mlflow/projects/databricks.py", line 192, in _run_shell_command_job
    databricks_run_id = run_submit_res["run_id"]
KeyError: 'run_id'
```
Let's catch the `KeyError` and throw something nicer.