### PR TITLE
fix github.com url link in Tracking UI

### DIFF
--- a/example/tutorial/train.py
+++ b/example/tutorial/train.py
@@ -62,5 +62,6 @@ if __name__ == "__main__":
         mlflow.log_metric("rmse", rmse)
         mlflow.log_metric("r2", r2)
         mlflow.log_metric("mae", mae)
+        mlflow.log_metric("test", 123)
 
         mlflow.sklearn.log_model(lr, "model")

--- a/example/tutorial/train.py
+++ b/example/tutorial/train.py
@@ -62,6 +62,5 @@ if __name__ == "__main__":
         mlflow.log_metric("rmse", rmse)
         mlflow.log_metric("r2", r2)
         mlflow.log_metric("mae", mae)
-        mlflow.log_metric("test", 123)
 
         mlflow.sklearn.log_model(lr, "model")

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -95,7 +95,7 @@ class Utils {
   }
 
   static getGitHubRegex() {
-    return /[@/]github.com[:/]([^/.]+)\/([^/#]+)#{0,}(.*)/;
+    return /[@/]github.com[:/]([^/.]+)\/([^/#]+)#?(.*)/;
   }
 
   /**

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -108,8 +108,10 @@ class Utils {
     if (run.source_type === "PROJECT") {
       const match = run.source_name.match(Utils.getGitHubRegex());
       if (match) {
-        const url = "https://github.com/" + match[1] + "/" + match[2].replace(/.git/, '') +
-                    "/tree/master/" + match[3];
+        var url = "https://github.com/" + match[1] + "/" + match[2].replace(/.git/, '');
+        if (match[3]) {
+          url = url + "/tree/master/" + match[3];
+        }
         res = <a href={url}>{res}</a>;
       }
       return res;
@@ -171,8 +173,11 @@ class Utils {
       if (run.source_type === "PROJECT") {
         const match = run.source_name.match(Utils.getGitHubRegex());
         if (match) {
-          const url = ("https://github.com/" + match[1] + "/" + match[2].replace(/.git/, '') +
-                      "/tree/" + run.source_version + "/" + match[3]);
+          var url = ("https://github.com/" + match[1] + "/" + match[2].replace(/.git/, '') +
+                     "/tree/" + run.source_version);
+          if (match[3]) {
+            url = url + "/" + match[3];
+          }
           return <a href={url}>{shortVersion}</a>;
         }
         return shortVersion;

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -108,7 +108,7 @@ class Utils {
     if (run.source_type === "PROJECT") {
       const match = run.source_name.match(Utils.getGitHubRegex());
       if (match) {
-        var url = "https://github.com/" + match[1] + "/" + match[2].replace(/.git/, '');
+        let url = "https://github.com/" + match[1] + "/" + match[2].replace(/.git/, '');
         if (match[3]) {
           url = url + "/tree/master/" + match[3];
         }
@@ -173,11 +173,8 @@ class Utils {
       if (run.source_type === "PROJECT") {
         const match = run.source_name.match(Utils.getGitHubRegex());
         if (match) {
-          var url = ("https://github.com/" + match[1] + "/" + match[2].replace(/.git/, '') +
-                     "/tree/" + run.source_version);
-          if (match[3]) {
-            url = url + "/" + match[3];
-          }
+          const url = ("https://github.com/" + match[1] + "/" + match[2].replace(/.git/, '') +
+                     "/tree/" + run.source_version) + "/" + match[3];
           return <a href={url}>{shortVersion}</a>;
         }
         return shortVersion;

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -95,7 +95,7 @@ class Utils {
   }
 
   static getGitHubRegex() {
-    return /[@/]github.com[:/]([^/.]+)\/([^/.]+)/;
+    return /[@/]github.com[:/]([^/.]+)\/([^/#]+)#{0,}(.*)/;
   }
 
   /**
@@ -108,7 +108,8 @@ class Utils {
     if (run.source_type === "PROJECT") {
       const match = run.source_name.match(Utils.getGitHubRegex());
       if (match) {
-        const url = "https://github.com/" + match[1] + "/" + match[2];
+        const url = "https://github.com/" + match[1] + "/" + match[2].replace(/.git/, '') +
+                    "/tree/master/" + match[3];
         res = <a href={url}>{res}</a>;
       }
       return res;
@@ -170,8 +171,8 @@ class Utils {
       if (run.source_type === "PROJECT") {
         const match = run.source_name.match(Utils.getGitHubRegex());
         if (match) {
-          const url = ("https://github.com/" + match[1] + "/" + match[2] + "/tree/" +
-            run.source_version);
+          const url = ("https://github.com/" + match[1] + "/" + match[2].replace(/.git/, '') +
+                      "/tree/" + run.source_version + "/" + match[3]);
           return <a href={url}>{shortVersion}</a>;
         }
         return shortVersion;

--- a/mlflow/server/js/src/utils/Utils.test.js
+++ b/mlflow/server/js/src/utils/Utils.test.js
@@ -159,7 +159,7 @@ test("getGitHubRegex", () => {
   ];
   urlAndExpected.forEach((lst) => {
     const url = lst[0];
-    var match = url.match(gitHubRegex);
+    const match = url.match(gitHubRegex);
     if (match) {
       match[2] = match[2].replace(/.git/, '');
     }

--- a/mlflow/server/js/src/utils/Utils.test.js
+++ b/mlflow/server/js/src/utils/Utils.test.js
@@ -145,17 +145,24 @@ test("dropExtension", () => {
 test("getGitHubRegex", () => {
   const gitHubRegex = Utils.getGitHubRegex();
   const urlAndExpected = [
-    ["http://github.com/mlflow/mlflow-apps", ["/github.com/mlflow/mlflow-apps", "mlflow", "mlflow-apps"]],
-    ["https://github.com/mlflow/mlflow-apps", ["/github.com/mlflow/mlflow-apps", "mlflow", "mlflow-apps"]],
-    ["http://github.com/mlflow/mlflow-apps.git", ["/github.com/mlflow/mlflow-apps", "mlflow", "mlflow-apps"]],
-    ["https://github.com/mlflow/mlflow-apps.git", ["/github.com/mlflow/mlflow-apps", "mlflow", "mlflow-apps"]],
-    ["git@github.com:mlflow/mlflow-apps.git", ["@github.com:mlflow/mlflow-apps", "mlflow", "mlflow-apps"]],
+    ["http://github.com/mlflow/mlflow-apps", ["/github.com/mlflow/mlflow-apps", "mlflow", "mlflow-apps", ""]],
+    ["https://github.com/mlflow/mlflow-apps", ["/github.com/mlflow/mlflow-apps", "mlflow", "mlflow-apps", ""]],
+    ["http://github.com/mlflow/mlflow-apps.git", ["/github.com/mlflow/mlflow-apps.git", "mlflow", "mlflow-apps", ""]],
+    ["https://github.com/mlflow/mlflow-apps.git", ["/github.com/mlflow/mlflow-apps.git", "mlflow", "mlflow-apps", ""]],
+    ["https://github.com/mlflow/mlflow#example/tutorial",
+      ["/github.com/mlflow/mlflow#example/tutorial", "mlflow", "mlflow", "example/tutorial"]],
+    ["https://github.com/username/repo.name#mlproject",
+      ["/github.com/username/repo.name#mlproject", "username", "repo.name", "mlproject"]],
+    ["git@github.com:mlflow/mlflow-apps.git", ["@github.com:mlflow/mlflow-apps.git", "mlflow", "mlflow-apps", ""]],
     ["https://some-other-site.com?q=github.com/mlflow/mlflow-apps.git", [null]],
     ["ssh@some-server:mlflow/mlflow-apps.git", [null]],
   ];
   urlAndExpected.forEach((lst) => {
     const url = lst[0];
-    const match = url.match(gitHubRegex);
+    var match = url.match(gitHubRegex);
+    if (match) {
+      match[2] = match[2].replace(/.git/, '');
+    }
     expect([].concat(match)).toEqual(lst[1]);
   });
 });


### PR DESCRIPTION
1) fix url link in `Source` column of ExperimentView to go to the subdirectory of github repo with `https://github.com/mlflow/mlflow/tree/master/example/tutorial`, instead of `https://github.com/mlflow/mlflow#example` which is only navigating to root directory.
2) fix url link when a github repo name has `.` (dot) in it with `https://github.com/username/repo.name/mlproject` instead of `https://github.com/username/repo`.
3) fix `Version` column url link as above too.