### PR TITLE
log_artifact for FileStore to use relative path fot logging artifacts

### DIFF
--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -4,7 +4,7 @@ import shutil
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import (build_path, exists, mkdir, list_all, get_file_info,
                                      get_relative_path)
-from mlflow.utils.validation import path_not_unique
+from mlflow.utils.validation import path_not_unique, bad_path_message
 
 
 class LocalArtifactRepository(ArtifactRepository):
@@ -12,8 +12,8 @@ class LocalArtifactRepository(ArtifactRepository):
 
     def log_artifact(self, local_file, artifact_path=None):
         if artifact_path and path_not_unique(artifact_path):
-            raise Exception("Artifact path should be relative to artifact_uri "
-                            "and cannot start with '/' or '.'")
+            raise Exception("Invalid artifact path: '%s'. %s" % (artifact_path,
+                                                                 bad_path_message(artifact_path)))
         artifact_dir = build_path(self.artifact_uri, artifact_path) \
             if artifact_path else self.artifact_uri
         if not exists(artifact_dir):
@@ -22,8 +22,8 @@ class LocalArtifactRepository(ArtifactRepository):
 
     def log_artifacts(self, local_dir, artifact_path=None):
         if artifact_path and path_not_unique(artifact_path):
-            raise Exception("Artifact path should be relative to artifact_uri "
-                            "and cannot start with '/' or '.'")
+            raise Exception("Invalid artifact path: '%s'. %s" % (artifact_path,
+                                                                 bad_path_message(artifact_path)))
         artifact_dir = build_path(self.artifact_uri, artifact_path) \
             if artifact_path else self.artifact_uri
         if not exists(artifact_dir):

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -10,6 +10,9 @@ class LocalArtifactRepository(ArtifactRepository):
     """Stores artifacts as files in a local directory."""
 
     def log_artifact(self, local_file, artifact_path=None):
+        if artifact_path and (artifact_path.startswith("/") or artifact_path.startswith(".")):
+            raise Exception("Artifact path should be relative to artifact_uri "
+                            "and cannot start with '/' or '.'")
         artifact_dir = build_path(self.artifact_uri, artifact_path) \
             if artifact_path else self.artifact_uri
         if not exists(artifact_dir):
@@ -17,6 +20,9 @@ class LocalArtifactRepository(ArtifactRepository):
         shutil.copy(local_file, artifact_dir)
 
     def log_artifacts(self, local_dir, artifact_path=None):
+        if artifact_path and (artifact_path.startswith("/") or artifact_path.startswith(".")):
+            raise Exception("Artifact path should be relative to artifact_uri "
+                            "and cannot start with '/' or '.'")
         artifact_dir = build_path(self.artifact_uri, artifact_path) \
             if artifact_path else self.artifact_uri
         if not exists(artifact_dir):

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -4,13 +4,14 @@ import shutil
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import (build_path, exists, mkdir, list_all, get_file_info,
                                      get_relative_path)
+from mlflow.utils.validation import path_not_unique
 
 
 class LocalArtifactRepository(ArtifactRepository):
     """Stores artifacts as files in a local directory."""
 
     def log_artifact(self, local_file, artifact_path=None):
-        if artifact_path and (artifact_path.startswith("/") or artifact_path.startswith(".")):
+        if artifact_path and path_not_unique(artifact_path):
             raise Exception("Artifact path should be relative to artifact_uri "
                             "and cannot start with '/' or '.'")
         artifact_dir = build_path(self.artifact_uri, artifact_path) \
@@ -20,7 +21,7 @@ class LocalArtifactRepository(ArtifactRepository):
         shutil.copy(local_file, artifact_dir)
 
     def log_artifacts(self, local_dir, artifact_path=None):
-        if artifact_path and (artifact_path.startswith("/") or artifact_path.startswith(".")):
+        if artifact_path and path_not_unique(artifact_path):
             raise Exception("Artifact path should be relative to artifact_uri "
                             "and cannot start with '/' or '.'")
         artifact_dir = build_path(self.artifact_uri, artifact_path) \

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -95,7 +95,7 @@ def mkdir(root, name=None):  # noqa
     target = os.path.join(root, name) if name is not None else root
     try:
         if not exists(target):
-            os.mkdir(target)
+            os.makedirs(target)
             return target
     except OSError as e:
         raise e

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -15,7 +15,7 @@ _BAD_CHARACTERS_MESSAGE = (
 )
 
 
-def _bad_path_message(name):
+def bad_path_message(name):
     return (
         "Names may be treated as files in certain cases, and must not resolve to other names"
         " when treated as such. This name would resolve to '%s'"
@@ -32,7 +32,7 @@ def _validate_metric_name(name):
     if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
         raise Exception("Invalid metric name: '%s'. %s" % (name, _BAD_CHARACTERS_MESSAGE))
     if path_not_unique(name):
-        raise Exception("Invalid metric name: '%s'. %s" % (name, _bad_path_message(name)))
+        raise Exception("Invalid metric name: '%s'. %s" % (name, bad_path_message(name)))
 
 
 def _validate_param_name(name):
@@ -40,7 +40,7 @@ def _validate_param_name(name):
     if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
         raise Exception("Invalid parameter name: '%s'. %s" % (name, _BAD_CHARACTERS_MESSAGE))
     if path_not_unique(name):
-        raise Exception("Invalid parameter name: '%s'. %s" % (name, _bad_path_message(name)))
+        raise Exception("Invalid parameter name: '%s'. %s" % (name, bad_path_message(name)))
 
 
 def _validate_tag_name(name):
@@ -49,7 +49,7 @@ def _validate_tag_name(name):
     if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
         raise Exception("Invalid tag name: '%s'. %s" % (name, _BAD_CHARACTERS_MESSAGE))
     if path_not_unique(name):
-        raise Exception("Invalid tag name: '%s'. %s" % (name, _bad_path_message(name)))
+        raise Exception("Invalid tag name: '%s'. %s" % (name, bad_path_message(name)))
 
 
 def _validate_run_id(run_id):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -22,7 +22,7 @@ def _bad_path_message(name):
     ) % os.path.normpath(name)
 
 
-def _path_not_unique(name):
+def path_not_unique(name):
     norm = os.path.normpath(name)
     return norm != name or norm == '.' or norm.startswith('..') or norm.startswith('/')
 
@@ -31,7 +31,7 @@ def _validate_metric_name(name):
     """Check that `name` is a valid metric name and raise an exception if it isn't."""
     if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
         raise Exception("Invalid metric name: '%s'. %s" % (name, _BAD_CHARACTERS_MESSAGE))
-    if _path_not_unique(name):
+    if path_not_unique(name):
         raise Exception("Invalid metric name: '%s'. %s" % (name, _bad_path_message(name)))
 
 
@@ -39,7 +39,7 @@ def _validate_param_name(name):
     """Check that `name` is a valid parameter name and raise an exception if it isn't."""
     if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
         raise Exception("Invalid parameter name: '%s'. %s" % (name, _BAD_CHARACTERS_MESSAGE))
-    if _path_not_unique(name):
+    if path_not_unique(name):
         raise Exception("Invalid parameter name: '%s'. %s" % (name, _bad_path_message(name)))
 
 
@@ -48,7 +48,7 @@ def _validate_tag_name(name):
     # Reuse param & metric check.
     if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
         raise Exception("Invalid tag name: '%s'. %s" % (name, _BAD_CHARACTERS_MESSAGE))
-    if _path_not_unique(name):
+    if path_not_unique(name):
         raise Exception("Invalid tag name: '%s'. %s" % (name, _bad_path_message(name)))
 
 

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -9,6 +9,9 @@ from mlflow.utils.file_utils import TempDir
 
 
 class TestLocalArtifactRepo(unittest.TestCase):
+    def _get_contents(self, repo, dir_name):
+        return sorted([(f.path, f.is_dir, f.file_size) for f in repo.list_artifacts(dir_name)])
+
     def test_basic_functions(self):
         with TempDir() as test_root, TempDir() as tmp:
             repo = ArtifactRepository.from_artifact_uri(test_root.path(), Mock())
@@ -18,14 +21,31 @@ class TestLocalArtifactRepo(unittest.TestCase):
                 open(repo.download_artifacts("test.txt")).read()
 
             # Create and log a test.txt file directly
-            with open(tmp.path("test.txt"), "w") as f:
+            artifact_name = "test.txt"
+            local_file = tmp.path(artifact_name)
+            with open(local_file, "w") as f:
                 f.write("Hello world!")
-            repo.log_artifact(tmp.path("test.txt"))
-            text = open(repo.download_artifacts("test.txt")).read()
+            repo.log_artifact(local_file)
+            text = open(repo.download_artifacts(artifact_name)).read()
             self.assertEqual(text, "Hello world!")
             # Check that it actually got written in the expected place
-            text = open(os.path.join(test_root.path(), "test.txt")).read()
+            text = open(os.path.join(test_root.path(), artifact_name)).read()
             self.assertEqual(text, "Hello world!")
+
+            # log artifact in subdir
+            repo.log_artifact(local_file, "aaa")
+            text = open(repo.download_artifacts(os.path.join("aaa", artifact_name))).read()
+            self.assertEqual(text, "Hello world!")
+
+            # log artifacts in deep nested subdirs
+            nested_subdir = "bbb/ccc/ddd/eee/fghi"
+            repo.log_artifact(local_file, nested_subdir)
+            text = open(repo.download_artifacts(os.path.join(nested_subdir, artifact_name))).read()
+            self.assertEqual(text, "Hello world!")
+
+            for bad_path in ["/", "//", "/tmp", "/bad_path", ".", "../terrible_path"]:
+                with self.assertRaises(Exception):
+                    repo.log_artifact(local_file, bad_path)
 
             # Create a subdirectory for log_artifacts
             os.mkdir(tmp.path("subdir"))
@@ -43,15 +63,27 @@ class TestLocalArtifactRepo(unittest.TestCase):
             self.assertEqual(text, "B")
             text = open(repo.download_artifacts("nested/c.txt")).read()
             self.assertEqual(text, "C")
-            infos = sorted([(f.path, f.is_dir, f.file_size) for f in repo.list_artifacts()])
+            infos = self._get_contents(repo, None)
             self.assertListEqual(infos, [
                 ("a.txt", False, 1),
+                ("aaa", True, None),
                 ("b.txt", False, 1),
+                ("bbb", True, None),
                 ("nested", True, None),
-                ("test.txt", False, 12)
+                ("test.txt", False, 12),
             ])
-            infos = sorted([(f.path, f.is_dir, f.file_size) for f in repo.list_artifacts("nested")])
-            self.assertListEqual(infos, [("nested/c.txt", False, 1)])
+
+            # Verify contents of subdirectories
+            self.assertListEqual(self._get_contents(repo, "nested"), [("nested/c.txt", False, 1)])
+            self.assertListEqual(self._get_contents(repo, "aaa"), [("aaa/test.txt", False, 12)])
+            self.assertListEqual(self._get_contents(repo, "bbb"), [("bbb/ccc", True, None)])
+            self.assertListEqual(self._get_contents(repo, "bbb/ccc"), [("bbb/ccc/ddd", True, None)])
+
+            infos = self._get_contents(repo, "bbb/ccc/ddd/eee")
+            self.assertListEqual(infos, [("bbb/ccc/ddd/eee/fghi", True, None)])
+
+            infos = self._get_contents(repo, "bbb/ccc/ddd/eee/fghi")
+            self.assertListEqual(infos, [("bbb/ccc/ddd/eee/fghi/test.txt", False, 12)])
 
             # Download a subdirectory
             downloaded_dir = repo.download_artifacts("nested")

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -37,6 +37,14 @@ class TestLocalArtifactRepo(unittest.TestCase):
             text = open(repo.download_artifacts(os.path.join("aaa", artifact_name))).read()
             self.assertEqual(text, "Hello world!")
 
+            # log a hidden artifact
+            hidden_file = tmp.path(".mystery")
+            with open(hidden_file, 'w') as f:
+                f.write("42")
+            repo.log_artifact(hidden_file, "aaa")
+            hidden_text = open(repo.download_artifacts(os.path.join("aaa", hidden_file))).read()
+            self.assertEqual(hidden_text, "42")
+
             # log artifacts in deep nested subdirs
             nested_subdir = "bbb/ccc/ddd/eee/fghi"
             repo.log_artifact(local_file, nested_subdir)
@@ -75,7 +83,9 @@ class TestLocalArtifactRepo(unittest.TestCase):
 
             # Verify contents of subdirectories
             self.assertListEqual(self._get_contents(repo, "nested"), [("nested/c.txt", False, 1)])
-            self.assertListEqual(self._get_contents(repo, "aaa"), [("aaa/test.txt", False, 12)])
+
+            infos = self._get_contents(repo, "aaa")
+            self.assertListEqual(infos, [("aaa/.mystery", False, 2), ("aaa/test.txt", False, 12)])
             self.assertListEqual(self._get_contents(repo, "bbb"), [("bbb/ccc", True, None)])
             self.assertListEqual(self._get_contents(repo, "bbb/ccc"), [("bbb/ccc/ddd", True, None)])
 

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -33,7 +33,7 @@ class TestModelExport(unittest.TestCase):
         # Logging the TensorFlow model just saved.
         tensorflow.log_saved_model(saved_model_dir=saved_estimator_path,
                                    signature_def_key="predict",
-                                   artifact_path=tmp.path("hello"))
+                                   artifact_path="hello")
         # Loading the saved TensorFlow model as a pyfunc.
         x = pyfunc.load_pyfunc(saved_estimator_path)
         # Predicting on the dataset using the pyfunc.


### PR DESCRIPTION
`FileStore` artifacts to use only relative paths, with `artifact_path` argument provided: Code fixes and unit tests.