### PR TITLE
Only set run-name tag if run name is specified

### DIFF
--- a/examples/remote_store/remote_server.py
+++ b/examples/remote_store/remote_server.py
@@ -6,12 +6,13 @@ import sys
 import random
 import tempfile
 
-from mlflow.store.rest_store import RestStore
+import mlflow
 from mlflow import log_metric, log_param, log_artifacts, get_artifact_uri, active_run,\
-    get_tracking_uri, log_artifact
+    get_tracking_uri, log_artifact, start_run
 
 if __name__ == "__main__":
     print("Running {} with tracking URI {}".format(sys.argv[0], get_tracking_uri()))
+    start_run(run_name="My run name")
     log_param("param1", 5)
     log_metric("foo", 5)
     log_metric("foo", 6)
@@ -21,7 +22,7 @@ if __name__ == "__main__":
     print("In run with UUID: %s" % run.info.run_uuid)
     tracking_uri = get_tracking_uri()
     if tracking_uri.startswith("http://"):
-        store = RestStore(get_tracking_uri())
+        store = mlflow.tracking.get_service().store
         metric_obj = store.get_metric(run.info.run_uuid, "foo")
         metric_history = store.get_metric_history(run.info.run_uuid, "foo")
         param_obj = store.get_param(run.info.run_uuid, "param1")

--- a/examples/remote_store/remote_server.py
+++ b/examples/remote_store/remote_server.py
@@ -8,11 +8,10 @@ import tempfile
 
 import mlflow
 from mlflow import log_metric, log_param, log_artifacts, get_artifact_uri, active_run,\
-    get_tracking_uri, log_artifact, start_run
+    get_tracking_uri, log_artifact
 
 if __name__ == "__main__":
     print("Running {} with tracking URI {}".format(sys.argv[0], get_tracking_uri()))
-    start_run(run_name="My run name")
     log_param("param1", 5)
     log_metric("foo", 5)
     log_metric("foo", 6)

--- a/examples/remote_store/remote_server.py
+++ b/examples/remote_store/remote_server.py
@@ -17,17 +17,11 @@ if __name__ == "__main__":
     log_metric("foo", 6)
     log_metric("foo", 7)
     log_metric("random_int", random.randint(0, 100))
-    run = active_run()
-    print("In run with UUID: %s" % run.info.run_uuid)
-    tracking_uri = get_tracking_uri()
-    if tracking_uri.startswith("http://"):
-        store = mlflow.tracking.get_service().store
-        metric_obj = store.get_metric(run.info.run_uuid, "foo")
-        metric_history = store.get_metric_history(run.info.run_uuid, "foo")
-        param_obj = store.get_param(run.info.run_uuid, "param1")
-        print("Got metric %s, %s" % (metric_obj.key, metric_obj.value))
-        print("Got param %s, %s" % (param_obj.key, param_obj.value))
-        print("Got metric history %s" % metric_history)
+    run_uuid = active_run().info.run_uuid
+    # Get run metadata & data from the tracking server
+    service = mlflow.tracking.get_service()
+    run = service.get_run(run_uuid)
+    print("Metadata & data for run with UUID %s: %s" % (run_uuid, run))
     local_dir = tempfile.mkdtemp()
     message = "test artifact written during run %s within artifact URI %s\n" \
               % (active_run().info.run_uuid, get_artifact_uri())

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -211,7 +211,6 @@ class FileStore(AbstractStore):
                             "exists." % experiment_id)
         run_uuid = uuid.uuid4().hex
         artifact_uri = self._get_artifact_dir(experiment_id, run_uuid)
-        num_runs = len(self._list_run_uuids(experiment_id))
         run_info = RunInfo(run_uuid=run_uuid, experiment_id=experiment_id,
                            name="",
                            artifact_uri=artifact_uri, source_type=source_type,
@@ -228,8 +227,8 @@ class FileStore(AbstractStore):
         mkdir(run_dir, FileStore.ARTIFACTS_FOLDER_NAME)
         for tag in tags:
             self.set_tag(run_uuid, tag)
-        self.set_tag(run_uuid, RunTag(
-            key=MLFLOW_RUN_NAME, value=run_name or "Run %s" % num_runs))
+        if run_name:
+            self.set_tag(run_uuid, RunTag(key=MLFLOW_RUN_NAME, value=run_name))
         return Run(run_info=run_info, run_data=None)
 
     def _make_run_info_dict(self, run_info):

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -148,7 +148,8 @@ class RestStore(AbstractStore):
             start_time=start_time, source_version=source_version, tags=tag_protos))
         response_proto = self._call_endpoint(CreateRun, req_body)
         run = Run.from_proto(response_proto.run)
-        self.set_tag(run.info.run_uuid, RunTag(key=MLFLOW_RUN_NAME, value=run_name))
+        if run_name:
+            self.set_tag(run.info.run_uuid, RunTag(key=MLFLOW_RUN_NAME, value=run_name))
         return run
 
     def log_metric(self, run_uuid, metric):


### PR DESCRIPTION
In #382, we set a tag for run name indiscriminately while creating a run ([see here](https://github.com/mlflow/mlflow/commit/910c7687c9b450694d9dcea626643e001e4c149c#diff-0c033907303d1beb526d1a168a366cc4R151)), which can fail in the REST API case when no run name is specified since the value of a tag is a required field. This PR addresses the issue by setting the tag only when run name is specified.

Tested manually by  launching a local server via `mlflow server` & running the remote server example (had to make some small tweaks to get it to run) via `MLFLOW_TRACKING_URI=http://localhost:5000 python examples/remote_store/remote_server.py`.