### PR TITLE
Change Tracking Service's exposed log_artifact & log_artifacts to take run_id

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -165,14 +165,14 @@ def log_metric(key, value):
 
 def log_artifact(local_path, artifact_path=None):
     """Log a local file or directory as an artifact of the currently active run."""
-    artifact_uri = _get_or_start_run().info.artifact_uri
-    get_service().log_artifact(artifact_uri, local_path, artifact_path)
+    run_id = _get_or_start_run().info.run_uuid
+    get_service().log_artifact(run_id, local_path, artifact_path)
 
 
 def log_artifacts(local_dir, artifact_path=None):
     """Log all the contents of a local directory as artifacts of the run."""
-    artifact_uri = _get_or_start_run().info.artifact_uri
-    get_service().log_artifacts(artifact_uri, local_dir, artifact_path)
+    run_id = _get_or_start_run().info.run_uuid
+    get_service().log_artifacts(run_id, local_dir, artifact_path)
 
 
 def create_experiment(name, artifact_location=None):

--- a/mlflow/tracking/service.py
+++ b/mlflow/tracking/service.py
@@ -116,20 +116,24 @@ class MLflowService(object):
         tag = RunTag(key, str(value))
         self.store.set_tag(run_id, tag)
 
-    def log_artifact(self, artifact_uri, local_path, artifact_path=None):
-        """Writes a local file to the remote artifact_uri.
+    def log_artifact(self, run_id, local_path, artifact_path=None):
+        """Writes a local file to the run's artifact directory.
 
         :param local_path: of the file to write
-        :param artifact_path: If provided, will be directory in artifact_uri to write to"""
-        artifact_repo = ArtifactRepository.from_artifact_uri(artifact_uri, self.store)
+        :param artifact_path: If provided, will be directory in the run to write into
+        """
+        run = self.get_run(run_id)
+        artifact_repo = ArtifactRepository.from_artifact_uri(run.info.artifact_uri, self.store)
         artifact_repo.log_artifact(local_path, artifact_path)
 
-    def log_artifacts(self, artifact_uri, local_dir, artifact_path=None):
-        """Writes a directory of files to the remote artifact_uri.
+    def log_artifacts(self, run_id, local_dir, artifact_path=None):
+        """Writes a directory of files to the run's artifact directory.
 
-        :param local_dir: of the file to write
-        :param artifact_path: If provided, will be directory in artifact_uri to write to"""
-        artifact_repo = ArtifactRepository.from_artifact_uri(artifact_uri, self.store)
+        :param local_dir: of the files to write
+        :param artifact_path: If provided, will be directory in the run to write into
+        """
+        run = self.get_run(run_id)
+        artifact_repo = ArtifactRepository.from_artifact_uri(run.info.artifact_uri, self.store)
         artifact_repo.log_artifacts(local_dir, artifact_path)
 
     def list_artifacts(self, run_id, path=None):


### PR DESCRIPTION
Related to #438, this PR makes the artifact-related APIs exposed by the Tracking API all take run_ids. list_artifacts and download_artifacts already do, and the only internal usage already has a run_id available.