### PR TITLE
Fix bug in Python entity deserialization from Proto

### DIFF
--- a/mlflow/entities/run.py
+++ b/mlflow/entities/run.py
@@ -34,7 +34,7 @@ class Run(_MLflowObject):
 
     @classmethod
     def from_proto(cls, proto):
-        return cls(proto.info, proto.data)
+        return cls(RunInfo.from_proto(proto.info), RunData.from_proto(proto.data))
 
     @classmethod
     def from_dictionary(cls, the_dict):

--- a/tests/entities/test_experiment.py
+++ b/tests/entities/test_experiment.py
@@ -6,6 +6,7 @@ from tests.helper_functions import random_int, random_file
 
 class TestExperiment(unittest.TestCase):
     def _check(self, exp, exp_id, name, location):
+        self.assertIsInstance(exp, Experiment)
         self.assertEqual(exp.experiment_id, exp_id)
         self.assertEqual(exp.name, name)
         self.assertEqual(exp.artifact_location, location)

--- a/tests/entities/test_file_info.py
+++ b/tests/entities/test_file_info.py
@@ -6,6 +6,7 @@ from tests.helper_functions import random_str, random_int
 
 class TestRunInfo(unittest.TestCase):
     def _check(self, fi, path, is_dir, size_in_bytes):
+        self.assertIsInstance(fi, FileInfo)
         self.assertEqual(fi.path, path)
         self.assertEqual(fi.is_dir, is_dir)
         self.assertEqual(fi.file_size, size_in_bytes)

--- a/tests/entities/test_metric.py
+++ b/tests/entities/test_metric.py
@@ -7,6 +7,7 @@ from tests.helper_functions import random_str
 
 class TestMetric(unittest.TestCase):
     def _check(self, metric, key, value, timestamp):
+        self.assertIsInstance(metric, Metric)
         self.assertEqual(metric.key, key)
         self.assertEqual(metric.value, value)
         self.assertEqual(metric.timestamp, timestamp)

--- a/tests/entities/test_param.py
+++ b/tests/entities/test_param.py
@@ -5,9 +5,10 @@ from tests.helper_functions import random_str, random_int
 
 
 class TestParam(unittest.TestCase):
-    def _check(self, metric, key, value):
-        self.assertEqual(metric.key, key)
-        self.assertEqual(metric.value, value)
+    def _check(self, param, key, value):
+        self.assertIsInstance(param, Param)
+        self.assertEqual(param.key, key)
+        self.assertEqual(param.value, value)
 
     def test_creation_and_hydration(self):
         key = random_str(random_int(10, 25))  # random string on size in range [10, 25]

--- a/tests/entities/test_run.py
+++ b/tests/entities/test_run.py
@@ -39,9 +39,9 @@ class TestRun(TestRunInfo, TestRunData):
                             "tags": tags}}
         self.assertEqual(run1.to_dictionary(), as_dict)
 
-        # proto = run1.to_proto()
-        # run2 = Run.from_proto(proto)
-        # self._check_run(run2, run_info, run_data)
+        proto = run1.to_proto()
+        run2 = Run.from_proto(proto)
+        self._check_run(run2, run_info, run_data)
 
         run3 = Run.from_dictionary(as_dict)
         self._check_run(run3, run_info, run_data)

--- a/tests/entities/test_run_data.py
+++ b/tests/entities/test_run_data.py
@@ -7,20 +7,27 @@ from tests.helper_functions import random_str, random_int
 
 class TestRunData(unittest.TestCase):
     def _check_metrics(self, metrics_1, metrics_2):
+        for metric in metrics_1:
+            self.assertIsInstance(metric, Metric)
         self.assertEqual(set([m.key for m in metrics_1]), set([m.key for m in metrics_2]))
         self.assertEqual(set([m.value for m in metrics_1]), set([m.value for m in metrics_2]))
         self.assertEqual(set([m.timestamp for m in metrics_1]),
                          set([m.timestamp for m in metrics_2]))
 
     def _check_params(self, params_1, params_2):
+        for param in params_1:
+            self.assertIsInstance(param, Param)
         self.assertEqual(set([p.key for p in params_1]), set([p.key for p in params_2]))
         self.assertEqual(set([p.value for p in params_1]), set([p.value for p in params_2]))
 
     def _check_tags(self, tags_1, tags_2):
+        for tag in tags_1:
+            self.assertIsInstance(tag, RunTag)
         self.assertEqual(set([t.key for t in tags_1]), set([t.key for t in tags_2]))
         self.assertEqual(set([t.value for t in tags_2]), set([t.value for t in tags_2]))
 
     def _check(self, rd, metrics, params, tags):
+        self.assertIsInstance(rd, RunData)
         self._check_metrics(rd.metrics, metrics)
         self._check_params(rd.params, params)
         self._check_tags(rd.tags, tags)

--- a/tests/entities/test_run_info.py
+++ b/tests/entities/test_run_info.py
@@ -9,6 +9,7 @@ class TestRunInfo(unittest.TestCase):
     def _check(self, ri, run_uuid, experiment_id, name, source_type, source_name,
                entry_point_name, user_id, status, start_time, end_time, source_version,
                artifact_uri):
+        self.assertIsInstance(ri, RunInfo)
         self.assertEqual(ri.run_uuid, run_uuid)
         self.assertEqual(ri.experiment_id, experiment_id)
         self.assertEqual(ri.name, name)


### PR DESCRIPTION
Fixes a bug in mlflow/entities/run.py where our deserialization of a protobuf `Run` wouldn't recursively deserialize the `RunData` and `RunInfo` protos. This caused the string representation of runs obtained from a remote tracking URI (e.g. via `mlflow.get_service.get_run()`) to appear strangely. 

This PR also updates existing unit tests to verify that our proto deserialization methods return the expected Python entity type.