### PR TITLE
[Java] CliBasedArtifactRepository should rely on python module, not mlflow binary

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/artifacts/ArtifactRepository.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/artifacts/ArtifactRepository.java
@@ -101,7 +101,7 @@ public interface ArtifactRepository {
    *   <pre>
    *   downloadArtifacts("model") // returns a local directory containing "file1" and "file2"
    *   downloadArtifacts("model/file1") // returns a local *file* with the contents of file1.
-   *   </pre>
+   *   </MlflowJavaClientIntegrationSuite.scala>
    *
    * Note that this will download the entire subdirectory path, and so may be expensive if
    * the subdirectory a lot of data.

--- a/mlflow/java/client/src/main/java/org/mlflow/artifacts/ArtifactRepository.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/artifacts/ArtifactRepository.java
@@ -101,7 +101,7 @@ public interface ArtifactRepository {
    *   <pre>
    *   downloadArtifacts("model") // returns a local directory containing "file1" and "file2"
    *   downloadArtifacts("model/file1") // returns a local *file* with the contents of file1.
-   *   </MlflowJavaClientIntegrationSuite.scala>
+   *   </pre>
    *
    * Note that this will download the entire subdirectory path, and so may be expensive if
    * the subdirectory a lot of data.

--- a/mlflow/java/client/src/main/java/org/mlflow/artifacts/CliBasedArtifactRepository.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/artifacts/CliBasedArtifactRepository.java
@@ -7,6 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -37,8 +38,9 @@ public class CliBasedArtifactRepository implements ArtifactRepository {
   // helpful error message if the executable is not in the path.
   private static final AtomicBoolean mlflowSuccessfullyLoaded = new AtomicBoolean(false);
 
-  // Name of the mlflow CLI utility which can be exec'd directly.
-  private final String mlflowExecutable = "mlflow";
+  // Name of the Python CLI utility which can be exec'd directly, with MLflow on its path
+  private final String PYTHON_EXECUTABLE =
+    Optional.ofNullable(System.getenv("MLFLOW_PYTHON_EXECUTABLE")).orElse("python");
 
   // Base directory of the artifactory, used to let the user know why this repository was chosen.
   private final String artifactBaseDir;
@@ -70,10 +72,10 @@ public class CliBasedArtifactRepository implements ArtifactRepository {
     }
 
     List<String> baseCommand = Lists.newArrayList(
-      mlflowExecutable, "artifacts", "log-artifact", "--local-file", localFile.toString());
+      "artifacts", "log-artifact", "--local-file", localFile.toString());
     List<String> command = appendRunIdArtifactPath(baseCommand, runId, artifactPath);
     String tag = "log file " + localFile + " to " + getTargetIdentifier(artifactPath);
-    forkProcess(command, tag);
+    forkMlflowProcess(command, tag);
   }
 
   @Override
@@ -93,10 +95,10 @@ public class CliBasedArtifactRepository implements ArtifactRepository {
     }
 
     List<String> baseCommand = Lists.newArrayList(
-      mlflowExecutable, "artifacts", "log-artifacts", "--local-dir", localDir.toString());
+      "artifacts", "log-artifacts", "--local-dir", localDir.toString());
     List<String> command = appendRunIdArtifactPath(baseCommand, runId, artifactPath);
     String tag = "log dir " + localDir + " to " + getTargetIdentifier(artifactPath);
-    forkProcess(command, tag);
+    forkMlflowProcess(command, tag);
   }
 
   @Override
@@ -109,8 +111,8 @@ public class CliBasedArtifactRepository implements ArtifactRepository {
     checkMlflowAccessible();
     String tag = "download artifacts for " + getTargetIdentifier(artifactPath);
     List<String> command = appendRunIdArtifactPath(
-      Lists.newArrayList(mlflowExecutable, "artifacts", "download"), runId, artifactPath);
-    String localPath = forkProcess(command, tag).trim();
+      Lists.newArrayList("artifacts", "download"), runId, artifactPath);
+    String localPath = forkMlflowProcess(command, tag).trim();
     return new File(localPath);
   }
 
@@ -124,8 +126,8 @@ public class CliBasedArtifactRepository implements ArtifactRepository {
     checkMlflowAccessible();
     String tag = "list artifacts in " + getTargetIdentifier(artifactPath);
     List<String> command = appendRunIdArtifactPath(
-      Lists.newArrayList(mlflowExecutable, "artifacts", "list"), runId, artifactPath);
-    String jsonOutput = forkProcess(command, tag);
+      Lists.newArrayList("artifacts", "list"), runId, artifactPath);
+    String jsonOutput = forkMlflowProcess(command, tag);
     return parseFileInfos(jsonOutput);
   }
 
@@ -167,14 +169,14 @@ public class CliBasedArtifactRepository implements ArtifactRepository {
 
     try {
       String tag = "get mlflow version";
-      String mlflowVersion = forkProcess(Lists.newArrayList(mlflowExecutable, "--version"), tag);
-      logger.info("Found local mlflow executable with version=" + mlflowVersion);
+      forkMlflowProcess(Lists.newArrayList("--help"), tag);
+      logger.info("Found local mlflow executable");
       mlflowSuccessfullyLoaded.set(true);
     } catch (MlflowClientException e) {
-      String errorMessage = String.format("Failed to exec process %s, needed to access artifacts " +
-          "within the non-Java-native artifact store at '%s'. Please make sure mlflow is " +
-          "available on your local system path (e.g.," + "from 'pip install mlflow')",
-        mlflowExecutable, artifactBaseDir);
+      String errorMessage = String.format("Failed to exec '%s -m mlflow.cli --version', needed to" +
+          " access artifacts within the non-Java-native artifact store at '%s'. Please make" +
+          " sure mlflow is available on your local system path (e.g., from 'pip install mlflow')",
+        PYTHON_EXECUTABLE, artifactBaseDir);
       throw new MlflowClientException(errorMessage, e);
     }
   }
@@ -182,19 +184,21 @@ public class CliBasedArtifactRepository implements ArtifactRepository {
   /**
    * Forks the given mlflow command and awaits for its successful completion.
    *
-   * @param command Command used to fork the process.
+   * @param mlflowCommand List of arguments to invoke mlflow with.
    * @param tag User-facing tag which will be used to identify what we were trying to do
    *            in the case of a failure.
    * @return raw stdout of the process, decoded as a utf-8 string
    * @throws MlflowClientException if the process exits with a non-zero exit code, or anything
    *                               else goes wrong.
    */
-  private String forkProcess(List<String> command, String tag) {
+  private String forkMlflowProcess(List<String> mlflowCommand, String tag) {
     String stdout;
     Process process = null;
     try {
       MlflowHostCreds hostCreds = hostCredsProvider.getHostCreds();
-      ProcessBuilder pb = new ProcessBuilder(command);
+      List<String> fullCommand = Lists.newArrayList(PYTHON_EXECUTABLE, "-m", "mlflow.cli");
+      fullCommand.addAll(mlflowCommand);
+      ProcessBuilder pb = new ProcessBuilder(fullCommand);
       setProcessEnvironment(pb.environment(), hostCreds);
       process = pb.start();
       stdout = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
@@ -241,9 +245,9 @@ public class CliBasedArtifactRepository implements ArtifactRepository {
 
   /** Appends --run-id $runId and --artifact-path $artifactPath, omitting artifactPath if null. */
   private List<String> appendRunIdArtifactPath(
-    List<String> baseCommand,
-    String runId,
-    String artifactPath) {
+      List<String> baseCommand,
+      String runId,
+      String artifactPath) {
     baseCommand.add("--run-id");
     baseCommand.add(runId);
     if (artifactPath != null) {

--- a/mlflow/java/client/src/main/java/org/mlflow/artifacts/CliBasedArtifactRepository.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/artifacts/CliBasedArtifactRepository.java
@@ -173,7 +173,7 @@ public class CliBasedArtifactRepository implements ArtifactRepository {
       logger.info("Found local mlflow executable");
       mlflowSuccessfullyLoaded.set(true);
     } catch (MlflowClientException e) {
-      String errorMessage = String.format("Failed to exec '%s -m mlflow.cli --version', needed to" +
+      String errorMessage = String.format("Failed to exec '%s -m mlflow.cli', needed to" +
           " access artifacts within the non-Java-native artifact store at '%s'. Please make" +
           " sure mlflow is available on your local system path (e.g., from 'pip install mlflow')",
         PYTHON_EXECUTABLE, artifactBaseDir);

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@ h2o
 # TODO: don't pin boto version once https://github.com/spulec/moto/issues/1793 is addressed
 boto3==1.7.84
 mock==2.0.0
-moto
+moto==1.3.4
 prospector[with_pyroma]==0.12.7
 pep8==1.7.1
 pyarrow


### PR DESCRIPTION
In certain environments, installing MLflow does not cause the mlflow binary to be available on the PATH, but just makes the mlflow.cli module available to a particular Python. This changes the Java CliBasedArtifactRepository to fork Python instead, therefore, and invoke the appropriate module.