### PR TITLE
Fix anchor link offset in documentation

### DIFF
--- a/docs/theme/mlflow/layout.html
+++ b/docs/theme/mlflow/layout.html
@@ -115,7 +115,7 @@
   <page>
     {# SIDE NAV BAR, TOGGLES ON MOBILE #}
 
-    <nav data-toggle="wy-nav-shift" class="wy-nav-side">
+    <nav data-toggle="wy-nav-shift" class="wy-nav-side relative">
       {% include "side_nav.html" %}
     </nav>
 

--- a/docs/theme/mlflow/static/css/custom.css
+++ b/docs/theme/mlflow/static/css/custom.css
@@ -261,12 +261,7 @@ table > colgroup:first-child {
   height: 55px;
 }
 
-page nav.wy-nav-side {
-  padding-bottom: 75px; /* Need to account for the header push. */
-}
-
 .wy-nav-top.header {
-  position: fixed;
   top: 0;
   left: 0;
   width: 100%;
@@ -400,7 +395,6 @@ page nav.wy-nav-side {
  */
 
 .wy-nav-side {
-  top: 55px;
   background-color: #FFF;
   color: #000;
   border-right: 1px solid #C9C9C9;

--- a/docs/theme/mlflow/static/css/theme.css
+++ b/docs/theme/mlflow/static/css/theme.css
@@ -4636,7 +4636,6 @@ div[class^='highlight'] pre {
     height: 100%
 }
 .wy-nav-side {
-    position: fixed;
     top: 0;
     bottom: 0;
     left: 0;
@@ -4647,6 +4646,13 @@ div[class^='highlight'] pre {
     min-height: 100%;
     background: #343131;
     z-index: 8
+}
+.wy-nav-side.fixed {
+  position: fixed;
+  top: 0;
+}
+.wy-nav-side.relative {
+  position: relative;
 }
 .wy-side-scroll {
     width: 320px;

--- a/docs/theme/mlflow/static/js/custom.js
+++ b/docs/theme/mlflow/static/js/custom.js
@@ -250,3 +250,18 @@ function setupSearch() {
         }]
     });
 }
+
+// Affix the sidebar to the side if we scroll past the header,
+// which is 55px. This ensures the sidebar is always visible,
+// but makes room for the header if and only if the header is
+// visible.
+$(window).scroll(function() {
+    var scrollTop = $(window).scrollTop();
+    if (scrollTop <= 55) {
+        $('.wy-nav-side').removeClass("fixed");
+        $('.wy-nav-side').addClass("relative");
+    } else {
+        $('.wy-nav-side').addClass("fixed");
+        $('.wy-nav-side').removeClass("relative");
+    }
+});


### PR DESCRIPTION
Currently, anchor links are offset by the fixed-length header. Example, where I link to the `Param` object: https://mlflow.org/docs/latest/python_api/mlflow.entities.html#mlflow.entities.Param. This makes contextualizing the anchor somewhat harder; often, one's eye is drawn to the _next_ header.

The easiest fix I could think to this was to make the header not affixed to the top of the window. The main problem created by this change, though is related to how the sidebar is implemented. Since the sidebar is fixed-position, it is given a top margin equal to the header size so it doesn't intersect. As the top bar scrolls out of view, though, this no longer makes sense.

In order to solve this issue, I tried out two of the solutions from https://stackoverflow.com/a/41538173, the first being to constantly reset the top based on the current scroll, and the second to add and remove the `position: fixed` CSS. I found the second to be simpler to reason about and less prone to jitter -- our case is complicated by the fact that the sidebar _itself_ scrolls with the main page, so we needed to ensure it wouldn't do that until you scroll out of the header range.

There are two known issues that also exist in today's implementation issue, so I don't consider them blockers:
1. If you're linked to an anchor from an external page, the sidebar's internal scroll will jolt when you first scroll on the page. Click [here](https://mlflow.org/docs/latest/python_api/mlflow.entities.html#mlflow.entities.Param) and observe the sidebar when you first scroll to see what I'm talking about.
2. Documentation not compiled with `USE_ALGOLIA=1` does not actually scroll the sidebar with the main page! Observe the main page scrolling on the [0.5.0 docs](https://mlflow.org/docs/0.5.0/python_api/mlflow.entities.html#mlflow.entities.Param) and compare them to [latest](https://mlflow.org/docs/latest/python_api/mlflow.entities.html#mlflow.entities.Param).