### PR TITLE
Add boto3 version dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         'protobuf>=3.6.0',
         'gitpython>=2.1.0',
         'pyyaml',
-        'boto3',
+        'boto3>=1.7.12',
         'querystring_parser',
         'simplejson',
         'mleap>=0.8.1',


### PR DESCRIPTION
* Fixes the following issue with SageMaker deployment: older version of boto3 do not implement certain functions required by the deployment routine; because Mlflow does not currently depend on a specific version of boto3, this can result in deployment-time failures.