### PR TITLE
Fix sparkml pyfunc loader to work on spark driver. 

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -122,30 +122,30 @@ class _HadoopFileSystem:
         return cls._jvm().org.apache.hadoop.fs.Path(path)
 
     @classmethod
-    def copy_to_local_file(cls, src, dst, removeSrc):
-        cls._fs().copyToLocalFile(removeSrc, cls._remote_path(src), cls._local_path(dst))
+    def copy_to_local_file(cls, src, dst, remove_src):
+        cls._fs().copyToLocalFile(remove_src, cls._remote_path(src), cls._local_path(dst))
 
     @classmethod
-    def copy_from_local_file(cls, src, dst, removeSrc):
-        cls._fs().copyFromLocalFile(removeSrc, cls._local_path(src), cls._remote_path(dst))
+    def copy_from_local_file(cls, src, dst, remove_src):
+        cls._fs().copyFromLocalFile(remove_src, cls._local_path(src), cls._remote_path(dst))
 
     @classmethod
     def qualified_local_path(cls, path):
         return cls._fs().makeQualified(cls._local_path(path)).toString()
 
     @classmethod
-    def maybe_copy_from_local_file(cls, src, dst, removeSrc):
+    def maybe_copy_from_local_file(cls, src, dst):
         """
-        Conditionally copy the file to the Hadoop FS.
+        Conditionally copy the file to the Hadoop DFS.
         The file is copied iff the configuration has distributed filesystem.
 
-        :return: If copied, return new target location, return absolute source path.
+        :return: If copied, return new target location, otherwise return (absolute) source path.
         """
         local_path = cls._local_path(src)
         qualified_local_path = cls._fs().makeQualified(local_path).toString()
         if qualified_local_path == "file:" + local_path.toString():
             return local_path
-        cls._fs().copyFromLocalFile(removeSrc, local_path, cls._remote_path(dst))
+        cls.copy_from_local_file(src, dst)
         return dst
 
     @classmethod

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -144,8 +144,9 @@ class _HadoopFileSystem:
         local_path = cls._local_path(src)
         qualified_local_path = cls._fs().makeQualified(local_path).toString()
         if qualified_local_path == "file:" + local_path.toString():
-            return local_path
-        cls.copy_from_local_file(src, dst)
+            return local_path.toString()
+        cls.copy_from_local_file(src, dst, remove_src=False)
+        eprint("Copied SparkML model to %s" % dst)
         return dst
 
     @classmethod
@@ -201,7 +202,7 @@ def save_model(spark_model, path, mlflow_model=Model(), conda_env=None, jars=Non
     spark_model.save(tmp_path)
     sparkml_data_path_sub = "sparkml"
     sparkml_data_path = os.path.abspath(os.path.join(path, sparkml_data_path_sub))
-    _HadoopFileSystem.copy_to_local_file(tmp_path, sparkml_data_path, removeSrc=True)
+    _HadoopFileSystem.copy_to_local_file(tmp_path, sparkml_data_path, remove_src=True)
     pyspark_version = pyspark.version.__version__
     model_conda_env = None
     if conda_env:
@@ -221,7 +222,7 @@ def _load_model(model_path, dfs_tmpdir=None):
     # Spark ML expects the model to be stored on DFS
     # Copy the model to a temp DFS location first. We cannot delete this file, as
     # Spark may read from it at any point.
-    model_path = _HadoopFileSystem.maybe_copy_from_local_file(model_path, tmp_path, removeSrc=False)
+    model_path = _HadoopFileSystem.maybe_copy_from_local_file(model_path, tmp_path)
     return PipelineModel.load(model_path)
 
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -154,7 +154,7 @@ class _HadoopFileSystem:
 
 
 def save_model(spark_model, path, mlflow_model=Model(), conda_env=None, jars=None,
-               dfs_tmpdir=DFS_TMP, sample_input=None):
+               dfs_tmpdir=None, sample_input=None):
     """
     Save a Spark MLlib PipelineModel to a local path.
 
@@ -195,6 +195,8 @@ def save_model(spark_model, path, mlflow_model=Model(), conda_env=None, jars=Non
 
     # Spark ML stores the model on DFS if running on a cluster
     # Save it to a DFS temp dir first and copy it to local path
+    if dfs_tmpdir is None:
+        dfs_tmpdir = DFS_TMP
     tmp_path = _tmp_path(dfs_tmpdir)
     spark_model.save(tmp_path)
     sparkml_data_path_sub = "sparkml"
@@ -213,6 +215,8 @@ def save_model(spark_model, path, mlflow_model=Model(), conda_env=None, jars=Non
 
 
 def _load_model(model_path, dfs_tmpdir=None):
+    if dfs_tmpdir is None:
+        dfs_tmpdir = DFS_TMP
     tmp_path = _tmp_path(dfs_tmpdir)
     # Spark ML expects the model to be stored on DFS
     # Copy the model to a temp DFS location first. We cannot delete this file, as
@@ -221,7 +225,7 @@ def _load_model(model_path, dfs_tmpdir=None):
     return PipelineModel.load(model_path)
 
 
-def load_model(path, run_id=None, dfs_tmpdir=DFS_TMP):
+def load_model(path, run_id=None, dfs_tmpdir=None):
     """
     Load the Spark MLlib model from the path.
 
@@ -282,7 +286,7 @@ class _PyFuncModelWrapper(object):
         """
         Generate predictions given input data in a pandas DataFrame.
 
-        :param pandas_df: pandas Dataframe containing input data.
+        :param pandas_df: pandas DataFrame containing input data.
         :return: List with model predictions.
         """
         spark_df = self.spark.createDataFrame(pandas_df)

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -176,8 +176,11 @@ def test_sparkml_model_log(tmpdir, spark_model_iris):
                                  dfs_tmpdir=dfs_tmp_dir)
                 run_id = active_run().info.run_uuid
                 # test reloaded model
-                reloaded_model = sparkm.load_model(artifact_path, run_id=run_id,
-                                                   dfs_tmpdir=dfs_tmp_dir)
+                if dfs_tmp_dir:
+                    reloaded_model = sparkm.load_model(artifact_path, run_id=run_id,
+                                                       dfs_tmpdir=dfs_tmp_dir)
+                else:
+                    reloaded_model = sparkm.load_model(artifact_path, run_id=run_id)
                 preds_df = reloaded_model.transform(spark_model_iris.spark_df)
                 preds = [x.prediction for x in preds_df.select("prediction").collect()]
                 assert spark_model_iris.predictions == preds

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -93,6 +93,8 @@ def test_hadoop_filesystem(tmpdir):
     with open(test_file_1, "w") as f:
         f.write("test1")
     remote = "/tmp/mlflow/test0"
+    # File should not be copied in this case
+    assert "file:" + test_dir_0 == FS.maybe_copy_from_local_file(test_dir_0, remote)
     FS.copy_from_local_file(test_dir_0, remote, removeSrc=False)
     local = os.path.join(str(tmpdir), "actual")
     FS.copy_to_local_file(remote, local, removeSrc=True)


### PR DESCRIPTION
Copy the model to the Hadoop DFS before loading. Previously this was done only for spark_model, pyfunc loader was loading from local file. This was assumed to be ok as it creates its own local context. However, it still fails if there already is pre-existing non-local spark context.