### PR TITLE
Fix sphinx version to 1.7.9 to fix travis builds

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # Dev/Deployment
-sphinx
+sphinx==1.7.9
 sphinx_rtd_theme
 sphinx-autobuild
 nose

--- a/lint.sh
+++ b/lint.sh
@@ -7,3 +7,5 @@ cd "$FWDIR"
 
 pycodestyle --max-line-length=100 --exclude mlflow/protos,mlflow/server/js -- mlflow tests
 pylint --msg-template="{path} ({line},{column}): [{msg_id} {symbol}] {msg}" --rcfile="$FWDIR/pylintrc" -- mlflow tests
+
+rstcheck README.rst

--- a/lint.sh
+++ b/lint.sh
@@ -7,5 +7,3 @@ cd "$FWDIR"
 
 pycodestyle --max-line-length=100 --exclude mlflow/protos,mlflow/server/js -- mlflow tests
 pylint --msg-template="{path} ({line},{column}): [{msg_id} {symbol}] {msg}" --rcfile="$FWDIR/pylintrc" -- mlflow tests
-
-rstcheck README.rst


### PR DESCRIPTION
The latest Sphinx release seems to have broken rstcheck (as described in https://github.com/myint/rstcheck/issues/50). This PR fixes sphinx to 1.7.9 to try to address the issue. Thanks to @aarondav for suggesting this fix!