### PR TITLE
add files last to make Dockerfile more friendly to development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM continuumio/miniconda
 
-WORKDIR /app
-
-ADD . /app
-
 RUN pip install -r dev-requirements.txt && \
     pip install -r test-requirements.txt && \
     pip install -e . && \
@@ -13,3 +9,8 @@ RUN pip install -r dev-requirements.txt && \
     cd mlflow/server/js && \
     npm install && \
     npm run build
+
+WORKDIR /app
+
+ADD . /app
+


### PR DESCRIPTION
Adding files (ADD and WORKDIR statements) before the provision statements means that changing files will trigger a lengthy reprovisioning during an image build. These files should be added after the provision statement so that changes can be made to the code base without triggering a reprovisioning during build. 