### PR TITLE
Fix spark ml load_pyfunc 

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -27,6 +27,7 @@ import shutil
 import pyspark
 from pyspark import SparkContext
 from pyspark.ml.pipeline import PipelineModel
+from pyspark.sql import SparkSession
 
 import mlflow
 from mlflow import pyfunc, mleap
@@ -269,8 +270,9 @@ def load_pyfunc(path):
     :rtype: Pyfunc format model with function
             ``model.predict(pandas DataFrame) -> pandas DataFrame``.
     """
-    spark = SparkContext._active_spark_context or \
-            pyspark.sql.SparkSession.builder.config("spark.python.worker.reuse", True) \
+
+    spark = pyspark.sql.SparkSession._instantiatedSession or \
+            pyspark.sql.SparkSession.builder.config("spark.python.worker.reuse", True)\
             .master("local[1]").getOrCreate()
     return _PyFuncModelWrapper(spark, _load_model(model_path=path))
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -269,8 +269,9 @@ def load_pyfunc(path):
     :rtype: Pyfunc format model with function
             ``model.predict(pandas DataFrame) -> pandas DataFrame``.
     """
-    spark = pyspark.sql.SparkSession.builder.config("spark.python.worker.reuse", True) \
-        .master("local[1]").getOrCreate()
+    spark = SparkContext._active_spark_context or \
+            pyspark.sql.SparkSession.builder.config("spark.python.worker.reuse", True) \
+            .master("local[1]").getOrCreate()
     return _PyFuncModelWrapper(spark, _load_model(model_path=path))
 
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -27,7 +27,6 @@ import shutil
 import pyspark
 from pyspark import SparkContext
 from pyspark.ml.pipeline import PipelineModel
-from pyspark.sql import SparkSession
 
 import mlflow
 from mlflow import pyfunc, mleap
@@ -273,9 +272,10 @@ def load_pyfunc(path):
     # NOTE: The getOrCreate() call below may change settings of the active session which we do not
     # intend to do here. In particular, setting master to local[1] can break distributed clusters.
     # To avoid this problem, we explicitly check for an active session. This is not ideal but there
-    # is no good workaround at the moment.   
-    spark = pyspark.sql.SparkSession._instantiatedSession or \
-            pyspark.sql.SparkSession.builder.config("spark.python.worker.reuse", True)\
+    # is no good workaround at the moment.
+    spark = pyspark.sql.SparkSession._instantiatedSession
+    if spark is None:
+        pyspark.sql.SparkSession.builder.config("spark.python.worker.reuse", True)\
             .master("local[1]").getOrCreate()
     return _PyFuncModelWrapper(spark, _load_model(model_path=path))
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -275,7 +275,7 @@ def load_pyfunc(path):
     # is no good workaround at the moment.
     spark = pyspark.sql.SparkSession._instantiatedSession
     if spark is None:
-        pyspark.sql.SparkSession.builder.config("spark.python.worker.reuse", True)\
+        spark = pyspark.sql.SparkSession.builder.config("spark.python.worker.reuse", True)\
             .master("local[1]").getOrCreate()
     return _PyFuncModelWrapper(spark, _load_model(model_path=path))
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -270,7 +270,10 @@ def load_pyfunc(path):
     :rtype: Pyfunc format model with function
             ``model.predict(pandas DataFrame) -> pandas DataFrame``.
     """
-
+    # NOTE: The getOrCreate() call below may change settings of the active session which we do not
+    # intend to do here. In particular, setting master to local[1] can break distributed clusters.
+    # To avoid this problem, we explicitly check for an active session. This is not ideal but there
+    # is no good workaround at the moment.   
     spark = pyspark.sql.SparkSession._instantiatedSession or \
             pyspark.sql.SparkSession.builder.config("spark.python.worker.reuse", True)\
             .master("local[1]").getOrCreate()


### PR DESCRIPTION
This PR fixes a bug in mlflow.spark.load_pyfunc which can change settings of an active Spark session.

mlflow.spark.load_pyfunc is meant primarily for deploying spark ml models outside of Spark and it therefore attempts to create a new local spark session. However, if there is already existing spark session (i.e. if called inside of Spark driver) it can change its settings and break the cluster.

Fixed by checking if there is a pre-existing active session.

