### PR TITLE
[Java] Switch log4j dependency to slf4j-api

### DIFF
--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -28,28 +28,12 @@
 
   <dependencies>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -66,6 +50,18 @@
     <dependency>
       <groupId>org.ini4j</groupId>
       <artifactId>ini4j</artifactId>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-jdk14</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -35,6 +35,11 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>

--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -31,6 +31,11 @@
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>1.2.17</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/mlflow/java/client/src/main/java/org/mlflow/artifacts/CliBasedArtifactRepository.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/artifacts/CliBasedArtifactRepository.java
@@ -17,7 +17,8 @@ import com.google.gson.reflect.TypeToken;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.mlflow.api.proto.Service;
 import org.mlflow.tracking.MlflowClientException;
@@ -32,7 +33,7 @@ import org.mlflow.tracking.creds.MlflowHostCredsProvider;
  * We require that 'mlflow' is available in the system path.
  */
 public class CliBasedArtifactRepository implements ArtifactRepository {
-  private static final Logger logger = Logger.getLogger(CliBasedArtifactRepository.class);
+  private static final Logger logger = LoggerFactory.getLogger(CliBasedArtifactRepository.class);
 
   // Global check if we ever successfully loaded 'mlflow'. This allows us to print a more
   // helpful error message if the executable is not in the path.

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
@@ -1,5 +1,13 @@
 package org.mlflow.tracking;
 
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -12,22 +20,15 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.http.util.EntityUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.mlflow.tracking.creds.MlflowHostCreds;
 import org.mlflow.tracking.creds.MlflowHostCredsProvider;
 
-import java.io.IOException;
-import java.net.URI;
-import java.nio.charset.StandardCharsets;
-import java.security.KeyManagementException;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.util.Base64;
-
 
 class MlflowHttpCaller {
-  private static final Logger logger = Logger.getLogger(MlflowHttpCaller.class);
+  private static final Logger logger = LoggerFactory.getLogger(MlflowHttpCaller.class);
   private static final String BASE_API_PATH = "api/2.0/preview/mlflow";
   private HttpClient httpClient;
   private final MlflowHostCredsProvider hostCredsProvider;

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/creds/DatabricksDynamicHostCredsProvider.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/creds/DatabricksDynamicHostCredsProvider.java
@@ -3,10 +3,12 @@ package org.mlflow.tracking.creds;
 import java.util.Map;
 
 import com.google.common.annotations.VisibleForTesting;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DatabricksDynamicHostCredsProvider implements MlflowHostCredsProvider {
-  private static final Logger logger = Logger.getLogger(DatabricksDynamicHostCredsProvider.class);
+  private static final Logger logger = LoggerFactory.getLogger(
+    DatabricksDynamicHostCredsProvider.class);
 
   private final Map<String, String> configProvider;
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/creds/HostCredsProviderChain.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/creds/HostCredsProviderChain.java
@@ -1,15 +1,16 @@
 package org.mlflow.tracking.creds;
 
-import org.apache.log4j.Logger;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import org.mlflow.tracking.MlflowClientException;
 
 public class HostCredsProviderChain implements MlflowHostCredsProvider {
-  private static final Logger logger = Logger.getLogger(HostCredsProviderChain.class);
+  private static final Logger logger = LoggerFactory.getLogger(HostCredsProviderChain.class);
 
   private final List<MlflowHostCredsProvider> hostCredsProviders = new ArrayList<>();
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/QuickStartDriver.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/QuickStartDriver.java
@@ -3,9 +3,6 @@ package org.mlflow.tracking.samples;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.log4j.Level;
-import org.apache.log4j.LogManager;
-
 import org.mlflow.api.proto.Service.*;
 import org.mlflow.tracking.MlflowClient;
 
@@ -24,11 +21,6 @@ public class QuickStartDriver {
       client = new MlflowClient();
     } else {
       client = new MlflowClient(args[0]);
-    }
-
-    boolean verbose = args.length >= 2 && "true".equals(args[1]);
-    if (verbose) {
-      LogManager.getLogger("org.mlflow.client").setLevel(Level.DEBUG);
     }
 
     System.out.println("====== createExperiment");

--- a/mlflow/java/client/src/test/java/org/mlflow/artifacts/CliBasedArtifactRepositoryTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/artifacts/CliBasedArtifactRepositoryTest.java
@@ -11,7 +11,8 @@ import java.util.Set;
 
 import com.google.common.collect.Sets;
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
@@ -25,7 +26,8 @@ import org.mlflow.tracking.creds.BasicMlflowHostCreds;
 import org.mlflow.tracking.creds.MlflowHostCreds;
 
 public class CliBasedArtifactRepositoryTest {
-  private static final Logger logger = Logger.getLogger(CliBasedArtifactRepositoryTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(
+    CliBasedArtifactRepositoryTest.class);
 
   private final TestClientProvider testClientProvider = new TestClientProvider();
 

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -1,23 +1,25 @@
 package org.mlflow.tracking;
 
-import java.io.*;
-import java.net.URI;
+import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.*;
+import java.util.List;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.annotations.*;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import org.mlflow.api.proto.Service.*;
 
 import static org.mlflow.tracking.TestUtils.*;
 
-import org.mlflow.api.proto.Service.*;
-import org.mlflow.artifacts.ArtifactRepository;
-
 public class MlflowClientTest {
-  private static final Logger logger = Logger.getLogger(MlflowClientTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(MlflowClientTest.class);
 
   private static float ACCURACY_SCORE = 0.9733333333333334F;
   private static float ZERO_ONE_LOSS = 0.026666666666666616F;

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/TestClientProvider.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/TestClientProvider.java
@@ -10,9 +10,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import org.mlflow.tracking.creds.MlflowHostCreds;
 import org.mlflow.tracking.creds.MlflowHostCredsProvider;
 
 /**
@@ -22,7 +22,7 @@ import org.mlflow.tracking.creds.MlflowHostCredsProvider;
  * server on an ephemeral port, and manage its lifecycle.
  */
 public class TestClientProvider {
-  private static final Logger logger = Logger.getLogger(TestClientProvider.class);
+  private static final Logger logger = LoggerFactory.getLogger(TestClientProvider.class);
 
   private static final long MAX_SERVER_WAIT_TIME_MILLIS = 60 * 1000;
 

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -5,8 +5,8 @@
   <artifactId>mlflow-parent</artifactId>
   <version>0.7.0</version>
   <packaging>pom</packaging>
-  <name>mlflow-parent</name>
-  <url>http://maven.apache.org</url>
+  <name>MLflow Parent POM</name>
+  <url>http://mlflow.org</url>
   <properties>
     <mlflow-version>0.5.1</mlflow-version>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -102,6 +102,11 @@
         <groupId>log4j</groupId>
         <artifactId>log4j</artifactId>
         <version>1.2.17</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>1.7.25</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -89,28 +89,18 @@
         <version>9.4.11.v20180605</version>
       </dependency>
       <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-jdk14</artifactId>
-        <version>1.7.25</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>1.7.25</version>
-      </dependency>
-      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.5</version>
       </dependency>
       <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>1.2.17</version>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>1.7.25</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
+        <artifactId>slf4j-jdk14</artifactId>
         <version>1.7.25</version>
       </dependency>
       <dependency>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -17,6 +17,7 @@
     <protobuf.version>3.6.0</protobuf.version>
     <scalapb.version>0.6.7</scalapb.version>
     <testng.version>6.14.3</testng.version>
+    <slf4j.version>1.7.25</slf4j.version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
@@ -96,12 +97,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.25</version>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-jdk14</artifactId>
-        <version>1.7.25</version>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -94,6 +94,11 @@
         <version>1.7.25</version>
       </dependency>
       <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-log4j12</artifactId>
+        <version>1.7.25</version>
+      </dependency>
+      <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
         <version>2.5</version>

--- a/mlflow/java/scoring/pom.xml
+++ b/mlflow/java/scoring/pom.xml
@@ -77,6 +77,10 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/mlflow/java/scoring/pom.xml
+++ b/mlflow/java/scoring/pom.xml
@@ -77,10 +77,6 @@
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
Currently, MLflow depends on log4j v1 as a compile-time dependency -- this switches it to slf4j-api, so that downstream clients don't have to use log4j.