### PR TITLE
add logging as alternative to raising an exception

### DIFF
--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 from flask import Flask, send_from_directory, make_response
@@ -13,6 +14,10 @@ STATIC_PREFIX_ENV_VAR = "MLFLOW_STATIC_PREFIX"
 REL_STATIC_DIR = "js/build"
 app = Flask(__name__, static_folder=REL_STATIC_DIR)
 STATIC_DIR = os.path.join(app.root_path, REL_STATIC_DIR)
+
+gunicorn_logger = logging.getLogger('gunicorn.error')
+app.logger.handlers = gunicorn_logger.handlers
+app.logger.setLevel(gunicorn_logger.level)
 
 for http_path, handler, methods in handlers.get_endpoints():
     app.add_url_rule(http_path, handler.__name__, handler, methods=methods)

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import uuid
@@ -20,6 +21,8 @@ from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME
 from mlflow.utils.search_utils import does_run_match_clause
 
 _TRACKING_DIR_ENV_VAR = "MLFLOW_TRACKING_DIR"
+
+gunicorn_logger = logging.getLogger('gunicorn.error')
 
 
 def _default_root_dir():
@@ -357,10 +360,12 @@ class FileStore(AbstractStore):
         _validate_param_name(param_name)
         param_data = read_file_lines(parent_path, param_name)
         if len(param_data) == 0:
-            raise Exception("Param '%s' is malformed. No data found." % param_name)
+            gunicorn_logger.error("Param '%s' is malformed. No data found." % param_name)
+            return Param(param_name, "")
         if len(param_data) > 1:
-            raise Exception("Unexpected data for param '%s'. Param recorded more than once"
-                            % param_name)
+            gunicorn_logger.error("Unexpected data for param '%s'. Param recorded more than once"
+                                  % param_name)
+            return Param(param_name, "")
         return Param(param_name, str(param_data[0].strip()))
 
     @staticmethod


### PR DESCRIPTION
This is a proposed solution to: https://github.com/mlflow/mlflow/issues/155

The larger issue is that with malformed input, the server crashes, requiring a hard reboot. The proposal is to log the error using the gunicorn logger as opposed to raising an exception. If this is seen as a viable solution to the problem, testing can be written around the logging mechanism. 