### PR TITLE
Add forward compatibility to entity deserialization from dictionaries

### DIFF
--- a/mlflow/entities/_mlflow_object.py
+++ b/mlflow/entities/_mlflow_object.py
@@ -20,7 +20,8 @@ class _MLflowObject(object):
 
     @classmethod
     def from_dictionary(cls, the_dict):
-        return cls(**the_dict)
+        filtered_dict = {key: value for key, value in the_dict.items() if key in cls._properties()}
+        return cls(**filtered_dict)
 
     def __repr__(self):
         return to_string(self)

--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -174,15 +174,6 @@ class RunInfo(_MLflowObject):
                    proto.artifact_uri)
 
     @classmethod
-    def from_dictionary(cls, the_dict):
-        dict_copy = the_dict.copy()
-        # 'tags' was moved from RunInfo to RunData, so we must remove it from the serialzed copy.
-        if 'tags' in dict_copy:
-            del dict_copy['tags']
-        info = cls(**dict_copy)
-        return info
-
-    @classmethod
     def _properties(cls):
         # TODO: Hard coding this list of props for now. There has to be a clearer way...
         return ["run_uuid", "experiment_id", "name", "source_type", "source_name",

--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -24,7 +24,7 @@ class RunInfo(_MLflowObject):
     DELETED_LIFECYCLE = "deleted"
 
     def __init__(self, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
-                 user_id, status, start_time, end_time, source_version, lifecycle_stage,
+                 user_id, status, start_time, end_time, source_version, lifecycle_stage=None,
                  artifact_uri=None):
         if run_uuid is None:
             raise Exception("run_uuid cannot be None")
@@ -53,7 +53,7 @@ class RunInfo(_MLflowObject):
         self._start_time = start_time
         self._end_time = end_time
         self._source_version = source_version
-        self._lifecycle_stage = lifecycle_stage
+        self._lifecycle_stage = lifecycle_stage or RunInfo.ACTIVE_LIFECYCLE
         self._artifact_uri = artifact_uri
 
     def __eq__(self, other):

--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -24,7 +24,7 @@ class RunInfo(_MLflowObject):
     DELETED_LIFECYCLE = "deleted"
 
     def __init__(self, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
-                 user_id, status, start_time, end_time, source_version, lifecycle_stage=None,
+                 user_id, status, start_time, end_time, source_version, lifecycle_stage,
                  artifact_uri=None):
         if run_uuid is None:
             raise Exception("run_uuid cannot be None")
@@ -53,7 +53,7 @@ class RunInfo(_MLflowObject):
         self._start_time = start_time
         self._end_time = end_time
         self._source_version = source_version
-        self._lifecycle_stage = lifecycle_stage or RunInfo.ACTIVE_LIFECYCLE
+        self._lifecycle_stage = lifecycle_stage
         self._artifact_uri = artifact_uri
 
     def __eq__(self, other):

--- a/tests/entities/test_run_info.py
+++ b/tests/entities/test_run_info.py
@@ -82,3 +82,10 @@ class TestRunInfo(unittest.TestCase):
         self._check(ri3, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
                     user_id, status, start_time, end_time, source_version, lifecycle_stage,
                     artifact_uri)
+        # Test that we can add a field to RunInfo and still deserialize it from a dictionary
+        dict_copy = as_dict.copy()
+        dict_copy["my_new_field"] = "new field value"
+        ri4 = RunInfo.from_dictionary(dict_copy)
+        self._check(ri4, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
+                    user_id, status, start_time, end_time, source_version, lifecycle_stage,
+                    artifact_uri)

--- a/tests/entities/test_run_info.py
+++ b/tests/entities/test_run_info.py
@@ -83,9 +83,17 @@ class TestRunInfo(unittest.TestCase):
                     user_id, status, start_time, end_time, source_version, lifecycle_stage,
                     artifact_uri)
         # Test that we can add a field to RunInfo and still deserialize it from a dictionary
-        dict_copy = as_dict.copy()
-        dict_copy["my_new_field"] = "new field value"
-        ri4 = RunInfo.from_dictionary(dict_copy)
+        dict_copy_0 = as_dict.copy()
+        dict_copy_0["my_new_field"] = "new field value"
+        ri4 = RunInfo.from_dictionary(dict_copy_0)
         self._check(ri4, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
+                    user_id, status, start_time, end_time, source_version, lifecycle_stage,
+                    artifact_uri)
+        # Test that we can deserialize a RunInfo without lifecycle_stage set (i.e. a RunInfo
+        # persisted before the introduction of lifecycle_stage)
+        dict_copy_1 = as_dict.copy()
+        dict_copy_1.pop("lifecycle_stage")
+        ri5 = RunInfo.from_dictionary(dict_copy_0)
+        self._check(ri5, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
                     user_id, status, start_time, end_time, source_version, lifecycle_stage,
                     artifact_uri)

--- a/tests/entities/test_run_info.py
+++ b/tests/entities/test_run_info.py
@@ -89,11 +89,3 @@ class TestRunInfo(unittest.TestCase):
         self._check(ri4, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
                     user_id, status, start_time, end_time, source_version, lifecycle_stage,
                     artifact_uri)
-        # Test that we can deserialize a RunInfo without lifecycle_stage set (i.e. a RunInfo
-        # persisted before the introduction of lifecycle_stage)
-        dict_copy_1 = as_dict.copy()
-        dict_copy_1.pop("lifecycle_stage")
-        ri5 = RunInfo.from_dictionary(dict_copy_0)
-        self._check(ri5, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
-                    user_id, status, start_time, end_time, source_version, lifecycle_stage,
-                    artifact_uri)


### PR DESCRIPTION
As discovered in #418, our entity-deserialization-from-dict implementation (`from_dictionary`) currently leads to forward-compatibility issues because:
* mlflow.projects.run creates a `RunInfo` in the client, persists it as YAML (when running against the FileStore), and reloads the run in an entry point subprocess that's executed within a conda environment
* The conda environment may contain an older version of MLflow that's not aware of new fields added e.g. to `RunInfo`
* The RunInfo from the newer MLflow version is loaded in the older MLflow version using `from_dictionary`, which passes all key-value pairs in the YAML file as constructor args, resulting in unexpected constructor args

This PR addresses the issue by modifying `from_dictionary` to exclude unknown fields. Thanks to @andrewmchen for helping think through this :)