### PR TITLE
[Java] Publish mlflow-parent to Maven as well

### DIFF
--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -9,13 +9,15 @@
   <url>http://mlflow.org</url>
 
   <description>Open source platform for the machine learning lifecycle</description>
+
+  <!-- The following sections (licenses, developers, scm, and distributionManagement) are needed to
+       publish pom-only packages to Maven -->
   <licenses>
     <license>
       <name>The Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
-
   <developers>
     <developer>
       <name>Matei Zaharia</name>
@@ -24,12 +26,18 @@
       <organizationUrl>http://www.databricks.com</organizationUrl>
     </developer>
   </developers>
-
   <scm>
     <connection>scm:git:git://github.com/mlflow/mlflow.git</connection>
     <developerConnection>scm:git:ssh://github.com:mlflow/mlflow.git</developerConnection>
     <url>http://github.com/mlflow/mlflow/tree/master</url>
   </scm>
+  <distributionManagement>
+    <repository>
+      <id>bintray</id>
+      <name>mlflow</name>
+      <url>https://api.bintray.com/maven/mlflow/mlflow/mlflow-parent/;publish=1</url>
+    </repository>
+  </distributionManagement>
 
   <properties>
     <mlflow-version>0.5.1</mlflow-version>
@@ -50,14 +58,6 @@
     <module>scoring</module>
     <module>client</module>
   </modules>
-
-  <distributionManagement>
-    <repository>
-      <id>bintray</id>
-      <name>mlflow</name>
-      <url>https://api.bintray.com/maven/mlflow/mlflow/mlflow-parent/;publish=1</url>
-    </repository>
-  </distributionManagement>
 
   <dependencyManagement>
     <dependencies>
@@ -240,12 +240,5 @@
         </plugin>
       </plugins>
     </pluginManagement>
-
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-source-plugin</artifactId>
-      </plugin>
-    </plugins>
   </build>
 </project>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -7,6 +7,30 @@
   <packaging>pom</packaging>
   <name>MLflow Parent POM</name>
   <url>http://mlflow.org</url>
+
+  <description>Open source platform for the machine learning lifecycle</description>
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Matei Zaharia</name>
+      <email>matei@databricks.com</email>
+      <organization>Databricks</organization>
+      <organizationUrl>http://www.databricks.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:git://github.com/mlflow/mlflow.git</connection>
+    <developerConnection>scm:git:ssh://github.com:mlflow/mlflow.git</developerConnection>
+    <url>http://github.com/mlflow/mlflow/tree/master</url>
+  </scm>
+
   <properties>
     <mlflow-version>0.5.1</mlflow-version>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -21,10 +45,20 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
+
   <modules>
     <module>scoring</module>
     <module>client</module>
   </modules>
+
+  <distributionManagement>
+    <repository>
+      <id>bintray</id>
+      <name>mlflow</name>
+      <url>https://api.bintray.com/maven/mlflow/mlflow/mlflow-parent/;publish=1</url>
+    </repository>
+  </distributionManagement>
+
   <dependencyManagement>
     <dependencies>
       <dependency>
@@ -206,5 +240,12 @@
         </plugin>
       </plugins>
     </pluginManagement>
+
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+    </plugins>
   </build>
 </project>


### PR DESCRIPTION
Turns out that we need to publish not just mlflow-client, but also mlflow-parent in order for Maven to have a good time depending on mlflow-client. Since [spark](https://mvnrepository.com/artifact/org.apache.spark/spark-parent) seems to do this, I think this the right approach.

Bintray has some issues publishing pom-only projects, seemingly. Even though packaging is correctly set to "pom", it still wants source, doc, and binary jars. I found a way to trick Bintray into creating the project, and to allow me to sync to Maven, but this approach seems to avoid the automatic injection of the Bintray project metadata into the pom.xml, so we have to manually enter the license, developer, and SCM sections (per the [Maven package](https://central.sonatype.org/pages/requirements.html) requirements).