### PR TITLE
Support downloading Mlflow scoring jar from Maven during scoring container build

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -140,6 +140,7 @@ def build_image(name=DEFAULT_IMAGE_NAME, mlflow_home=None):
                 " -DoutputDirectory=/opt/java/jars\n"
                 "RUN cd /opt/java && mv mlflow-scoring-{version}.pom pom.xml &&" 
                 " mvn --batch-mode dependency:copy-dependencies -DoutputDirectory=/opt/java/jars\n"
+                "RUN rm /opt/java/pom.xml\n"
             ).format(version=mlflow.version.VERSION)
         
         with open(os.path.join(cwd, "Dockerfile"), "w") as f:

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -125,18 +125,21 @@ def build_image(name=DEFAULT_IMAGE_NAME, mlflow_home=None):
                 "RUN pip install /opt/mlflow\n"
                 "RUN cd /opt/mlflow/mlflow/java/scoring &&"
                 " mvn --batch-mode package -DskipTests &&"
-                " mkdir /opt/java &&"
-                " mv /opt/mlflow/mlflow/java/scoring/target/mlflow-scoring-*.jar /opt/java/jars\n"
+                " mkdir -p /opt/java/jars &&"
+                " mv /opt/mlflow/mlflow/java/scoring/target/"
+                "mlflow-scoring-*-with-dependencies.jar /opt/java/jars\n"
             ).format(mlflow_dir=mlflow_dir)
         else:
             install_mlflow = (
                 "RUN pip install mlflow=={version}\n"
-                "RUN mvn dependency:copy -Dartifact=org.mlflow:mlflow-scoring:{version}:pom"
+                "RUN mvn --batch-mode dependency:copy" 
+                " -Dartifact=org.mlflow:mlflow-scoring:{version}:pom"
                 " -DoutputDirectory=/opt/java\n"
-                "RUN mvn dependency:copy -Dartifact=org.mlflow:mlflow-scoring:{version}:jar"
+                "RUN mvn --batch-mode dependency:copy" 
+                " -Dartifact=org.mlflow:mlflow-scoring:{version}:jar" 
                 " -DoutputDirectory=/opt/java/jars\n"
                 "RUN cd /opt/java && mv mlflow-scoring-{version}.pom pom.xml &&" 
-                " mvn dependency:copy-dependencies -DoutputDirectory=/opt/java/jars\n"
+                " mvn --batch-mode dependency:copy-dependencies -DoutputDirectory=/opt/java/jars\n"
             ).format(version=mlflow.version.VERSION)
         
         with open(os.path.join(cwd, "Dockerfile"), "w") as f:

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -132,17 +132,17 @@ def build_image(name=DEFAULT_IMAGE_NAME, mlflow_home=None):
         else:
             install_mlflow = (
                 "RUN pip install mlflow=={version}\n"
-                "RUN mvn --batch-mode dependency:copy" 
+                "RUN mvn --batch-mode dependency:copy"
                 " -Dartifact=org.mlflow:mlflow-scoring:{version}:pom"
                 " -DoutputDirectory=/opt/java\n"
-                "RUN mvn --batch-mode dependency:copy" 
-                " -Dartifact=org.mlflow:mlflow-scoring:{version}:jar" 
+                "RUN mvn --batch-mode dependency:copy"
+                " -Dartifact=org.mlflow:mlflow-scoring:{version}:jar"
                 " -DoutputDirectory=/opt/java/jars\n"
-                "RUN cd /opt/java && mv mlflow-scoring-{version}.pom pom.xml &&" 
+                "RUN cd /opt/java && mv mlflow-scoring-{version}.pom pom.xml &&"
                 " mvn --batch-mode dependency:copy-dependencies -DoutputDirectory=/opt/java/jars\n"
                 "RUN rm /opt/java/pom.xml\n"
             ).format(version=mlflow.version.VERSION)
-        
+
         with open(os.path.join(cwd, "Dockerfile"), "w") as f:
             f.write(_DOCKERFILE_TEMPLATE % install_mlflow)
         eprint("building docker image")

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -116,29 +116,29 @@ def build_image(name=DEFAULT_IMAGE_NAME, mlflow_home=None):
                         current directory if not specified.
     """
     with TempDir() as tmp:
-        install_mlflow = (
-            "RUN pip install mlflow=={version}"
-            "RUN mvn dependency:get -DgroupId=org.mlflow -DartifactId=mlflow-scoring"
-            " -Dversion={version} -Dtransitive=False"
-        ).format(version=mlflow.version.VERSION)
         cwd = tmp.path()
         if mlflow_home:
             mlflow_dir = _copy_project(
-                src_path=mlflow_home, dst_path=tmp.path())
+                src_path=mlflow_home, dst_path=cwd)
             install_mlflow = (
-                    "COPY {mlflow_dir} /opt/mlflow\n"
-                    "RUN cd /opt/mlflow/mlflow/java/scoring &&"
-                    " mvn --batch-mode package -DskipTests &&"
-                    " mkdir /opt/java &&"
-                    " mv /opt/mlflow/mlflow/java/scoring/target/mlflow-scoring-* /opt/java \n"
-                    " RUN pip install /opt/mlflow\n"
-            )
-            install_mlflow = install_mlflow.format(mlflow_dir=mlflow_dir)
+                "COPY {mlflow_dir} /opt/mlflow\n"
+                "RUN pip install /opt/mlflow\n"
+                "RUN cd /opt/mlflow/mlflow/java/scoring &&"
+                " mvn --batch-mode package -DskipTests &&"
+                " mkdir /opt/java &&"
+                " mv /opt/mlflow/mlflow/java/scoring/target/mlflow-scoring-*.jar /opt/java/jars\n"
+            ).format(mlflow_dir=mlflow_dir)
         else:
-            eprint("`mlflow_home` was not specified. The image will install"
-                   " MLflow from pip instead. As a result, the container will"
-                   " not support the MLeap flavor.")
-
+            install_mlflow = (
+                "RUN pip install mlflow=={version}\n"
+                "RUN mvn dependency:copy -Dartifact=org.mlflow:mlflow-scoring:{version}:pom"
+                " -DoutputDirectory=/opt/java\n"
+                "RUN mvn dependency:copy -Dartifact=org.mlflow:mlflow-scoring:{version}:jar"
+                " -DoutputDirectory=/opt/java/jars\n"
+                "RUN cd /opt/java && mv mlflow-scoring-{version}.pom pom.xml &&" 
+                " mvn dependency:copy-dependencies -DoutputDirectory=/opt/java/jars\n"
+            ).format(version=mlflow.version.VERSION)
+        
         with open(os.path.join(cwd, "Dockerfile"), "w") as f:
             f.write(_DOCKERFILE_TEMPLATE % install_mlflow)
         eprint("building docker image")

--- a/mlflow/sagemaker/container/__init__.py
+++ b/mlflow/sagemaker/container/__init__.py
@@ -130,8 +130,7 @@ def _serve_pyfunc(model):
 
 
 def _serve_mleap():
-    serve_cmd = ["java", "-cp", "/opt/mlflow/mlflow/java/scoring/target/mlflow-scoring-*"
-                 "-with-dependencies.jar".format(
+    serve_cmd = ["java", "-cp", "/opt/java/mlflow-scoring-*-with-dependencies.jar".format(
                     mlflow_version=mlflow.version.VERSION),
                  "org.mlflow.sagemaker.ScoringServer",
                  MODEL_PATH, str(DEFAULT_SAGEMAKER_SERVER_PORT)]

--- a/mlflow/sagemaker/container/__init__.py
+++ b/mlflow/sagemaker/container/__init__.py
@@ -130,9 +130,7 @@ def _serve_pyfunc(model):
 
 
 def _serve_mleap():
-    serve_cmd = ["java", "-cp", "/opt/java/mlflow-scoring-*-with-dependencies.jar".format(
-                    mlflow_version=mlflow.version.VERSION),
-                 "org.mlflow.sagemaker.ScoringServer",
+    serve_cmd = ["java", "-cp", "\"/opt/java/jars/*\"", "org.mlflow.sagemaker.ScoringServer",
                  MODEL_PATH, str(DEFAULT_SAGEMAKER_SERVER_PORT)]
     # Invoke `Popen` with a single string command in the shell to support wildcard usage
     # with the mlflow jar version.

--- a/mlflow/sagemaker/container/__init__.py
+++ b/mlflow/sagemaker/container/__init__.py
@@ -80,15 +80,7 @@ def _serve():
         serving_flavor = pyfunc.FLAVOR_NAME
 
     if serving_flavor == mleap.FLAVOR_NAME:
-        # TODO(dbczumar): Host the scoring Java package on Maven Central so that we no
-        # longer require the container source for this flavor.
-        if _container_includes_mlflow_source():
-            _serve_mleap()
-        else:
-            raise Exception("The container does not support the specified deployment flavor:"
-                            " `{mleap_flavor}`. Please build the container with the `mlflow_home`"
-                            " parameter specified to enable this feature.".format(
-                                mleap_flavor=mleap.FLAVOR_NAME))
+        _serve_mleap()
     elif pyfunc.FLAVOR_NAME in m.flavors:
         _serve_pyfunc(m)
     else:

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,4 +1,5 @@
 # Copyright 2018 Databricks, Inc.
 
 
-VERSION = '0.7.0.dev'
+# VERSION = '0.7.0.dev'
+VERSION = '0.6.0'

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,5 +1,4 @@
 # Copyright 2018 Databricks, Inc.
 
 
-# VERSION = '0.7.0.dev'
-VERSION = '0.6.0'
+VERSION = '0.7.0.dev'


### PR DESCRIPTION
* When building the Mlflow scoring Docker image, the scoring jar will be downloaded from Maven central if `mlflow_home` is not specified.