### PR TITLE
SageMaker deployment: Don't specify an S3 location constraint for us-east-1

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -470,8 +470,8 @@ def _get_default_s3_bucket(region_name):
     if bucket_name not in buckets:
         eprint("Default bucket `%s` not found. Creating..." % bucket_name)
         bucket_creation_kwargs = {
-            'ACL' : 'bucket-owner-full-control',
-            'Bucket' : bucket_name,
+            'ACL': 'bucket-owner-full-control',
+            'Bucket': bucket_name,
         }
         if region_name != "us-east-1":
             # The location constraint is required during bucket creation for all regions
@@ -480,7 +480,7 @@ def _get_default_s3_bucket(region_name):
             # add it if we are deploying outside of us-east-1.
             # See https://docs.aws.amazon.com/cli/latest/reference/s3api/create-bucket.html#examples
             bucket_creation_kwargs['CreateBucketConfiguration'] = {
-                'LocationConstraint' : region_name
+                'LocationConstraint': region_name
             }
         response = s3.create_bucket(**bucket_creation_kwargs)
         eprint(response)

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -469,7 +469,7 @@ def _get_default_s3_bucket(region_name):
     buckets = [b['Name'] for b in response["Buckets"]]
     if bucket_name not in buckets:
         eprint("Default bucket `%s` not found. Creating..." % bucket_name)
-        bucket_creation_args = {
+        bucket_creation_kwargs = {
             'ACL' : 'bucket-owner-full-control',
             'Bucket' : bucket_name,
         }
@@ -479,10 +479,10 @@ def _get_default_s3_bucket(region_name):
             # specifying it in this region results in a failure, so we will only
             # add it if we are deploying outside of us-east-1.
             # See https://docs.aws.amazon.com/cli/latest/reference/s3api/create-bucket.html#examples
-            bucket_creation_args['CreateBucketConfiguration'] = {
+            bucket_creation_kwargs['CreateBucketConfiguration'] = {
                 'LocationConstraint' : region_name
             }
-        response = s3.create_bucket(**bucket_creation_args)
+        response = s3.create_bucket(**bucket_creation_kwargs)
         eprint(response)
     else:
         eprint("Default bucket `%s` already exists. Skipping creation." %

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -469,13 +469,20 @@ def _get_default_s3_bucket(region_name):
     buckets = [b['Name'] for b in response["Buckets"]]
     if bucket_name not in buckets:
         eprint("Default bucket `%s` not found. Creating..." % bucket_name)
-        response = s3.create_bucket(
-            ACL='bucket-owner-full-control',
-            Bucket=bucket_name,
-            CreateBucketConfiguration={
-                'LocationConstraint': region_name,
-            },
-        )
+        bucket_creation_args = {
+            'ACL' : 'bucket-owner-full-control',
+            'Bucket' : bucket_name,
+        }
+        if region_name != "us-east-1":
+            # The location constraint is required during bucket creation for all regions
+            # outside of us-east-1. This constraint cannot be specified in us-east-1;
+            # specifying it in this region results in a failure, so we will only
+            # add it if we are deploying outside of us-east-1.
+            # See https://docs.aws.amazon.com/cli/latest/reference/s3api/create-bucket.html#examples
+            bucket_creation_args['CreateBucketConfiguration'] = {
+                'LocationConstraint' : region_name
+            }
+        response = s3.create_bucket(**bucket_creation_args)
         eprint(response)
     else:
         eprint("Default bucket `%s` already exists. Skipping creation." %


### PR DESCRIPTION
S3 bucket creation **requires** a location constraint in every region **except** us-east-1. In us-east-1, the location constraint **cannot** be specified (or an error occurs). Here's a boto issue that chronicles this strange behavior: https://github.com/boto/boto3/issues/125.

This PR modifies the deployment routine to only specify a location constraint if the deployment region is outside of us-east-1.