### PR TITLE
Fix DBFS upload file-existence-checking logic

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -6,7 +6,7 @@ import tempfile
 import textwrap
 import time
 
-from six.moves import shlex_quote, urllib
+from six.moves import shlex_quote
 
 from mlflow.entities import RunStatus
 from mlflow.projects.submitted_run import SubmittedRun
@@ -304,7 +304,7 @@ class DatabricksSubmittedRun(SubmittedRun):
     POLL_STATUS_INTERVAL = 30
 
     def __init__(self, databricks_run_id, mlflow_run_id, databricks_job_runner):
-        super(DatabricksSubmittedRun, self).__init__()
+        super(DatabricksSudbmittedRun, self).__init__()
         self._databricks_run_id = databricks_run_id
         self._mlflow_run_id = mlflow_run_id
         self._job_runner = databricks_job_runner

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -304,7 +304,7 @@ class DatabricksSubmittedRun(SubmittedRun):
     POLL_STATUS_INTERVAL = 30
 
     def __init__(self, databricks_run_id, mlflow_run_id, databricks_job_runner):
-        super(DatabricksSudbmittedRun, self).__init__()
+        super(DatabricksSubmittedRun, self).__init__()
         self._databricks_run_id = databricks_run_id
         self._mlflow_run_id = mlflow_run_id
         self._job_runner = databricks_job_runner

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -116,7 +116,7 @@ class DatabricksJobRunner(object):
                 tarfile_hash = hashlib.sha256(tarred_project.read()).hexdigest()
             # TODO: Get subdirectory for experiment from the tracking server
             dbfs_path = os.path.join(DBFS_EXPERIMENT_DIR_BASE, str(experiment_id),
-                "projects-code", "%s.tar.gz" % tarfile_hash)
+                                     "projects-code", "%s.tar.gz" % tarfile_hash)
             dbfs_fuse_uri = os.path.join("/dbfs", dbfs_path)
             if not self._dbfs_path_exists(dbfs_path):
                 self._upload_to_dbfs(temp_tar_filename, dbfs_fuse_uri)


### PR DESCRIPTION
Fixes a bug where we'd pass a path of the form "/dbfs/..." to the DBFS get-status API when checking file existence while uploading projects to DBFS. Thanks to @tomasatdatabricks for helping find this bug!


Tested by manually running the same local project repeatedly against Databricks:
```
MLFLOW_TRACKING_URI=databricks mlflow run ~/code/mlflow-example -P alpha=0.1 -m databricks -c ~/code/misc/cluster_spec.json -P num_dimensions=3
```

Where ~/code/mlflow-example was a checkout of https://github.com/mlflow/mlflow-example