### PR TITLE
Fix exception when ECR repository doesnt exist

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -182,7 +182,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
         ecr_client.describe_repositories(repositoryNames=[image])['repositories']
     except ecr_client.exceptions.RepositoryNotFoundException:
         ecr_client.create_repository(repositoryName=image)
-        print("Created new ECR repository: {image}".format(image=image))
+        print("Created new ECR repository: {repository_name}".format(repository_name=image))
     # TODO: it would be nice to translate the docker login, tag and push to python api.
     # x = ecr_client.get_authorization_token()['authorizationData'][0]
     # docker_login_cmd = "docker login -u AWS -p {token} {url}".format(token=x['authorizationToken']

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -178,8 +178,11 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
     eprint("Pushing docker image {image} to {repo}".format(
         image=image, repo=fullname))
     ecr_client = boto3.client('ecr')
-    if not ecr_client.describe_repositories(repositoryNames=[image])['repositories']:
+    try:
+        ecr_client.describe_repositories(repositoryNames=[image])['repositories']
+    except RepositoryNotFoundException:
         ecr_client.create_repository(repositoryName=image)
+        print("Created new ECR repository: {image}".format(image=image))
     # TODO: it would be nice to translate the docker login, tag and push to python api.
     # x = ecr_client.get_authorization_token()['authorizationData'][0]
     # docker_login_cmd = "docker login -u AWS -p {token} {url}".format(token=x['authorizationToken']

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -180,7 +180,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
     ecr_client = boto3.client('ecr')
     try:
         ecr_client.describe_repositories(repositoryNames=[image])['repositories']
-    except RepositoryNotFoundException:
+    except ecr_client.exceptions.RepositoryNotFoundException:
         ecr_client.create_repository(repositoryName=image)
         print("Created new ECR repository: {image}".format(image=image))
     # TODO: it would be nice to translate the docker login, tag and push to python api.


### PR DESCRIPTION
When a repository doesn't exist in AWS ECR, an exception is raised and the repository isn't created. This will handle the exception and create the new repository.

Details about exception here: https://docs.aws.amazon.com/AmazonECR/latest/APIReference/API_DescribeRepositories.html