### PR TITLE
Fix slow pip installations breaking our Travis CI builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ target/
 # R notebooks
 .Rproj.user
 example/tutorial/R/*.nb.html
+
+# travis_wait command logs
+travis_wait*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,8 @@ install:
   - pip install --upgrade pip
   # Install Python test dependencies only if we're running Python tests
   - if [[ ! -z "$TRAVIS_PYTHON_VERSION" ]]; then
-      pip install -r dev-requirements.txt;
-      pip install -r test-requirements.txt;
+      travis_wait pip install -r dev-requirements.txt -q;
+      travis_wait pip install -r test-requirements.txt -q;
     fi
   - pip install .
   - export MLFLOW_HOME=$(pwd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,8 @@ install:
   - pip install --upgrade pip
   # Install Python test dependencies only if we're running Python tests
   - if [[ ! -z "$TRAVIS_PYTHON_VERSION" ]]; then
-      pip install -r dev-requirements.txt -q;
-      pip install -r test-requirements.txt -q;
+      travis_wait pip install -r dev-requirements.txt -q;
+      travis_wait pip install -r test-requirements.txt -q;
     fi
   - pip install .
   - export MLFLOW_HOME=$(pwd)

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,8 @@ install:
   - pip install --upgrade pip
   # Install Python test dependencies only if we're running Python tests
   - if [[ ! -z "$TRAVIS_PYTHON_VERSION" ]]; then
-      travis_wait pip install -r dev-requirements.txt -q;
-      travis_wait pip install -r test-requirements.txt -q;
+      pip install -r dev-requirements.txt;
+      pip install -r test-requirements.txt;
     fi
   - pip install .
   - export MLFLOW_HOME=$(pwd)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ azure-storage
 google-cloud-storage
 h2o
 # TODO: don't pin boto version once https://github.com/spulec/moto/issues/1793 is addressed
-boto3==1.7.84
+boto3==1.7.12
 mock==2.0.0
 moto==1.3.4
 prospector[with_pyroma]==0.12.7

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,7 +3,7 @@ azure-storage
 google-cloud-storage
 h2o
 # TODO: don't pin boto version once https://github.com/spulec/moto/issues/1793 is addressed
-boto3==1.7.12
+boto3==1.7.84
 mock==2.0.0
 moto==1.3.4
 prospector[with_pyroma]==0.12.7


### PR DESCRIPTION
Adds a `travis_wait` wrapper ([see docs](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received)) around the pip installation of test dependencies so that the installation steps can run for up to 20 minutes before timing out. 