### PR TITLE
Cast tag values to strings in Python set_tag implementation

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -139,7 +139,7 @@ class MlflowClient(object):
         Set a tag on the run ID. Value is converted to a string.
         """
         _validate_tag_name(key)
-        tag = RunTag(key, value)
+        tag = RunTag(key, str(value))
         self.store.set_tag(run_id, tag)
 
     def log_artifact(self, run_id, local_path, artifact_path=None):


### PR DESCRIPTION
Cast `set_tag` values to strings in the Python `set_tag` implementation - failing to do this can cause us to send non-string values to the REST API, resulting in request failures