### PR TITLE
Add logging statement to invalid schema catch in mleap predictor

### DIFF
--- a/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/MLeapPredictor.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/MLeapPredictor.java
@@ -81,9 +81,7 @@ public class MLeapPredictor extends Predictor {
       logger.error(
           "Encountered an unknown error during conversion of Pandas dataframe to LeapFrame.", e);
       throw new PredictorEvaluationException(
-          "An unknown error occurred while converting the input dataframe to a LeapFrame."
-              + " Original exception text: %s",
-          e);
+          "An unknown error occurred while converting the input dataframe to a LeapFrame.", e);
     }
     // Create a single-element sequence of column names to select from the resulting dataframe.
     // This single-element is the `prediction` column; as is the case with the `pyfunc` wrapper

--- a/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/MLeapPredictor.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/MLeapPredictor.java
@@ -73,6 +73,8 @@ public class MLeapPredictor extends Predictor {
     try {
       leapFrame = pandasFrame.toLeapFrame(this.inputSchema);
     } catch (InvalidSchemaException e) {
+      logger.error(
+          "Encountered a schema mismatch when converting the input dataframe to a LeapFrame.", e);
       throw new PredictorEvaluationException(
           "Encountered a schema mismatch when converting the input dataframe to a LeapFrame.");
     } catch (Exception e) {


### PR DESCRIPTION
This makes it easier to debug mismatches between a query's schema and a model's schema when running remotely.