### PR TITLE
Convert input data schema to an mleap schema prior to serialization

### DIFF
--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -181,10 +181,12 @@ def _get_mleap_schema(dataframe):
     from pyspark.ml.util import _jvm
     ReflectionUtil = _jvm().py4j.reflection.ReflectionUtil
 
+    # Convert the Spark dataframe's schema to an MLeap schema object
     tc_clazz = ReflectionUtil.classForName("org.apache.spark.sql.mleap.TypeConverters$")
     tc_inst = tc_clazz.getField("MODULE$").get(tc_clazz)
     mleap_schema_struct = tc_inst.sparkSchemaToMleapSchema(dataframe._jdf)
 
+    # Obtain a JSON representation of the MLeap schema object
     js_clazz = ReflectionUtil.classForName("ml.combust.mleap.json.JsonSupport$")
     js_inst = js_clazz.getField("MODULE$").get(js_clazz)
     mleap_schema_json = js_inst.MleapStructTypeFormat().write(mleap_schema_struct)

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -188,14 +188,14 @@ def _get_mleap_schema(dataframe):
     ReflectionUtil = _jvm().py4j.reflection.ReflectionUtil
 
     # Convert the Spark dataframe's schema to an MLeap schema object.
-    # This is equivalent to the Scala function call 
+    # This is equivalent to the Scala function call
     # `org.apache.spark.sql.mleap.TypeConverters.sparkSchemaToMleapSchema(dataframe)`
     tc_clazz = ReflectionUtil.classForName("org.apache.spark.sql.mleap.TypeConverters$")
     tc_inst = tc_clazz.getField("MODULE$").get(tc_clazz)
     mleap_schema_struct = tc_inst.sparkSchemaToMleapSchema(dataframe._jdf)
 
     # Obtain a JSON representation of the MLeap schema object
-    # This is equivalent to the Scala function call 
+    # This is equivalent to the Scala function call
     # `ml.combust.mleap.json.JsonSupport.MleapStructTypeFormat().write(mleap_schema_struct)`
     js_clazz = ReflectionUtil.classForName("ml.combust.mleap.json.JsonSupport$")
     js_inst = js_clazz.getField("MODULE$").get(js_clazz)
@@ -206,7 +206,7 @@ def _get_mleap_schema(dataframe):
 def _handle_py4j_error(reraised_error_type, reraised_error_text):
     """
     Logs information about an exception that is currently being handled
-    and reraises it with the specified error text as a message. 
+    and reraises it with the specified error text as a message.
     """
     traceback.print_exc()
     tb = sys.exc_info()[2]

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -150,16 +150,16 @@ def add_to_model(mlflow_model, path, spark_model, sample_input):
                                       dataset=dataset)
     except Py4JError:
         _handle_py4j_error(
-                "MLeap encountered an error while serializing the model. Ensure that the model is" 
+                "MLeap encountered an error while serializing the model. Ensure that the model is"
                 " compatible with MLeap (i.e does not contain any custom transformers).")
 
     try:
         input_schema = _get_mleap_schema(sample_input)
     except Py4JError:
         _handle_py4j_error(
-                "Encountered an error while converting the schema of the sample input dataframe to" 
+                "Encountered an error while converting the schema of the sample input dataframe to"
                 " MLeap format. Please ensure that this dataframe is compatible with MLeap.")
-        
+
     mleap_schemapath_sub = os.path.join("mleap", "schema.json")
     mleap_schemapath_full = os.path.join(path, mleap_schemapath_sub)
     with open(mleap_schemapath_full, "w") as out:
@@ -175,7 +175,7 @@ def _get_mleap_schema(dataframe):
     """
     :param dataframe: A PySpark dataframe object
 
-    :return: The schema of the supplied dataframe, in MLeap format. This serialized object of type 
+    :return: The schema of the supplied dataframe, in MLeap format. This serialized object of type
     `ml.combust.mleap.core.types.StructType`, represented as a JSON dictionary.
     """
     from pyspark.ml.util import _jvm

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -210,7 +210,7 @@ def _handle_py4j_error(reraised_error_type, reraised_error_text):
     """
     traceback.print_exc()
     tb = sys.exc_info()[2]
-    reraise(reraised_error_type, reraised_error_text, tb)
+    reraise(reraised_error_type, reraised_error_type(reraised_error_text), tb)
 
 
 class MLeapSerializationException(MlflowException):

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -226,7 +226,7 @@ def test_mleap_output_json_format(spark_model_iris, model_path):
 
     ReflectionUtil = _jvm().py4j.reflection.ReflectionUtil
     # Parse the json schema as a Spray JSON `JsValue` object that MLeap's
-    # schema parser can process
+    # schema parser can process.
     input_creator_clazz = ReflectionUtil.classForName("spray.json.ParserInput$")
     input_creator_inst = input_creator_clazz.getField("MODULE$").get(input_creator_clazz)
     input_item = input_creator_inst.apply(json_schema_str)
@@ -299,5 +299,6 @@ def test_save_fails_with_sample_input_containing_unsupported_data_type(spark_con
     unsupported_df = unsupported_df.withColumn("_2", unsupported_df._2.cast(DateType()))
     pipeline = Pipeline(stages=[])
     model = pipeline.fit(unsupported_df)
+    # The Spark `DateType` is not supported by MLeap, so we expect serialization to fail.
     with pytest.raises(Exception):
         sparkm.save_model(spark_model=model, path=model_path, sample_input=unsupported_df)

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -220,22 +220,6 @@ def test_mleap_output_json_format(spark_model_iris, model_path):
     assert type(json_schema["fields"][0]) == dict
     assert "name" in json_schema["fields"][0]
 
-    json_schema_str = json.dumps(json_schema)
-
-    ReflectionUtil = _jvm().py4j.reflection.ReflectionUtil
-    # Parse the json schema as a Spray JSON `JsValue` object that MLeap's
-    # schema parser can process.
-    input_creator_clazz = ReflectionUtil.classForName("spray.json.ParserInput$")
-    input_creator_inst = input_creator_clazz.getField("MODULE$").get(input_creator_clazz)
-    input_item = input_creator_inst.apply(json_schema_str)
-    input_item_js_value = _jvm().spray.json.JsonParser(input_item).parseJsValue()
-
-    # Parse the `JsValue` representation of the JSON schema. If the schema is a valid
-    # MLeap schema, we expect this method to succeed.
-    mleap_parser_clazz = ReflectionUtil.classForName("ml.combust.mleap.json.JsonSupport$")
-    mleap_parser_inst = mleap_parser_clazz.getField("MODULE$").get(mleap_parser_clazz)
-    mleap_parsed_schema = mleap_parser_inst.MleapStructTypeFormat().read(input_item_js_value)
-
 
 def test_spark_module_model_save_with_mleap_and_unsupported_transformer_raises_exception(
         spark_model_iris, model_path):
@@ -246,7 +230,7 @@ def test_spark_module_model_save_with_mleap_and_unsupported_transformer_raises_e
     unsupported_pipeline = Pipeline(stages=[CustomTransformer()])
     unsupported_model = unsupported_pipeline.fit(spark_model_iris.spark_df)
 
-    with pytest.raises(Exception):
+    with pytest.raises(mleap.MLeapSerializationException):
         sparkm.save_model(spark_model=unsupported_model,
                           path=model_path,
                           sample_input=spark_model_iris.spark_df)
@@ -276,7 +260,7 @@ def test_mleap_module_model_save_with_invalid_sample_input_type_raises_exception
                           sample_input=invalid_input)
 
 
-def test_mleap_module_model_save_with_unsupported_transformer_raises_exception(
+def test_mleap_module_model_save_with_unsupported_transformer_raises_serialization_exception(
         spark_model_iris, model_path):
     class CustomTransformer(JavaModel):
         def _transform(self, dataset):
@@ -285,18 +269,19 @@ def test_mleap_module_model_save_with_unsupported_transformer_raises_exception(
     unsupported_pipeline = Pipeline(stages=[CustomTransformer()])
     unsupported_model = unsupported_pipeline.fit(spark_model_iris.spark_df)
 
-    with pytest.raises(Exception):
+    with pytest.raises(mleap.MLeapSerializationException):
         mleap.save_model(spark_model=unsupported_model,
                          path=model_path,
                          sample_input=spark_model_iris.spark_df)
 
 
-def test_save_fails_with_sample_input_containing_unsupported_data_type(spark_context, model_path):
+def test_save_with_sample_input_containing_unsupported_data_type_raises_serialization_exception(
+        spark_context, model_path):
     sql_context = SQLContext(spark_context)
     unsupported_df = sql_context.createDataFrame([(1, "2016-09-30"), (2, "2017-02-27")])
     unsupported_df = unsupported_df.withColumn("_2", unsupported_df._2.cast(DateType()))
     pipeline = Pipeline(stages=[])
     model = pipeline.fit(unsupported_df)
     # The Spark `DateType` is not supported by MLeap, so we expect serialization to fail.
-    with pytest.raises(Exception):
+    with pytest.raises(mleap.MLeapSerializationException):
         sparkm.save_model(spark_model=model, path=model_path, sample_input=unsupported_df)

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -222,6 +222,8 @@ def test_mleap_output_json_format(spark_model_iris, model_path):
     assert type(json_schema["fields"][0]) == dict
     assert "name" in json_schema["fields"][0]
 
+    json_schema_str = json.dumps(json_schema)
+
     ReflectionUtil = _jvm().py4j.reflection.ReflectionUtil
     # Parse the json schema as a Spray JSON `JsValue` object that MLeap's
     # schema parser can process

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -10,7 +10,7 @@ from pyspark.ml.wrapper import JavaModel
 from pyspark.ml.util import _jvm
 from pyspark.version import __version__ as pyspark_version
 from pyspark.sql import SQLContext
-from pyspark.sql.types import DateType 
+from pyspark.sql.types import DateType
 import pytest
 from sklearn import datasets
 import shutil
@@ -27,8 +27,6 @@ from tests.helper_functions import score_model_in_sagemaker_docker_container
 
 from tests.pyfunc.test_spark import score_model_as_udf
 
-import logging
-logging.getLogger("py4j").setLevel(logging.ERROR)
 
 @pytest.fixture
 def spark_conda_env(tmpdir):


### PR DESCRIPTION
* Fixes an incompatibility issue caused by attempting to interpret a serialized Spark schema as an MLeap schema.