### PR TITLE
using mlflow dependency from pypi rather than relying on local setup file

### DIFF
--- a/examples/multistep_workflow/conda.yaml
+++ b/examples/multistep_workflow/conda.yaml
@@ -8,4 +8,4 @@ dependencies:
   - requests
   - click
   - pip:
-    - -e ../../
+    - mlflow


### PR DESCRIPTION
This enables running on cloud by pulling `mlflow` dependency directly from pypi