### PR TITLE
Fix value checking in `ml_param()`

### DIFF
--- a/mlflow/R/mlflow/R/project-param.R
+++ b/mlflow/R/mlflow/R/project-param.R
@@ -22,19 +22,20 @@ mlflow_param <- function(name, default = NULL, type = NULL, description = NULL) 
 
   caster <- switch(
     target_type,
-    numeric = forge::cast_scalar_double,
-    integer = forge::cast_scalar_integer,
-    purrr::compose(forge::cast_string, as.character)
+    integer = forge::cast_nullable_scalar_integer,
+    double = forge::cast_nullable_scalar_double,
+    numeric = forge::cast_nullable_scalar_double,
+    forge::cast_nullable_string
   )
 
-  tryCatch(
+  default <- tryCatch(
     if (!is.null(default)) caster(default),
     error = function(e) stop("`default` value for `", name, "` cannot be casted to type ",
                              type, ": ", conditionMessage(e), call. = FALSE)
   )
 
   tryCatch(
-    caster(.globals$run_params[[name]], allow_null = TRUE) %||% default,
+    caster(.globals$run_params[[name]]) %||% default,
     error = function(e) stop("Provided value for `", name,
                              "` cannot be casted to type ",
                              type, ": ", conditionMessage(e),

--- a/mlflow/R/mlflow/R/project-run.R
+++ b/mlflow/R/mlflow/R/project-run.R
@@ -51,7 +51,3 @@ mlflow_run <- function(entry_point = NULL, uri = ".", version = NULL, param_list
 
   invisible(run_uuid)
 }
-
-clear_run <- function() {
-  rlang::env_unbind(.globals, "run_params")
-}

--- a/mlflow/R/mlflow/R/project-source.R
+++ b/mlflow/R/mlflow/R/project-source.R
@@ -30,8 +30,15 @@ mlflow_source <- function(uri) {
       mlflow_end_run(status = "FAILED")
     },
     interrupt = function(cnd) mlflow_end_run(status = "KILLED"),
-    finally = mlflow_end_run()
+    finally = {
+      mlflow_end_run()
+      clear_run_params()
+    }
   )
 
   invisible(NULL)
+}
+
+clear_run_params <- function() {
+  rlang::env_unbind(.globals, "run_params")
 }

--- a/mlflow/R/mlflow/tests/testthat/test-params.R
+++ b/mlflow/R/mlflow/tests/testthat/test-params.R
@@ -24,3 +24,10 @@ test_that("mlflow can read typed command line parameters", {
   expect_true("my_num" %in% params_dir)
   expect_true("my_str" %in% params_dir)
 })
+
+test_that("ml_param() type checking works", {
+  expect_identical(mlflow_param("p1", "a", "string"), "a")
+  expect_identical(mlflow_param("p2", 42, "integer"), 42L)
+  expect_identical(mlflow_param("p3", 42L), 42L)
+  expect_identical(mlflow_param("p4", 12), 12)
+})


### PR DESCRIPTION
- Handle all param types in input checking.
- Clean up run params globals on `mlflow_source()` exit.

@javierluraschi 