### PR TITLE
Change log_param from float to double

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
@@ -498,7 +498,7 @@ public final class Service {
      * Value associated with this metric.
      * </pre>
      *
-     * <code>optional float value = 2;</code>
+     * <code>optional double value = 2;</code>
      */
     boolean hasValue();
     /**
@@ -506,9 +506,9 @@ public final class Service {
      * Value associated with this metric.
      * </pre>
      *
-     * <code>optional float value = 2;</code>
+     * <code>optional double value = 2;</code>
      */
-    float getValue();
+    double getValue();
 
     /**
      * <pre>
@@ -545,7 +545,7 @@ public final class Service {
     }
     private Metric() {
       key_ = "";
-      value_ = 0F;
+      value_ = 0D;
       timestamp_ = 0L;
     }
 
@@ -579,9 +579,9 @@ public final class Service {
               key_ = bs;
               break;
             }
-            case 21: {
+            case 17: {
               bitField0_ |= 0x00000002;
-              value_ = input.readFloat();
+              value_ = input.readDouble();
               break;
             }
             case 24: {
@@ -677,13 +677,13 @@ public final class Service {
     }
 
     public static final int VALUE_FIELD_NUMBER = 2;
-    private float value_;
+    private double value_;
     /**
      * <pre>
      * Value associated with this metric.
      * </pre>
      *
-     * <code>optional float value = 2;</code>
+     * <code>optional double value = 2;</code>
      */
     public boolean hasValue() {
       return ((bitField0_ & 0x00000002) == 0x00000002);
@@ -693,9 +693,9 @@ public final class Service {
      * Value associated with this metric.
      * </pre>
      *
-     * <code>optional float value = 2;</code>
+     * <code>optional double value = 2;</code>
      */
-    public float getValue() {
+    public double getValue() {
       return value_;
     }
 
@@ -740,7 +740,7 @@ public final class Service {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, key_);
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        output.writeFloat(2, value_);
+        output.writeDouble(2, value_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeInt64(3, timestamp_);
@@ -759,7 +759,7 @@ public final class Service {
       }
       if (((bitField0_ & 0x00000002) == 0x00000002)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeFloatSize(2, value_);
+          .computeDoubleSize(2, value_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
@@ -789,8 +789,8 @@ public final class Service {
       result = result && (hasValue() == other.hasValue());
       if (hasValue()) {
         result = result && (
-            java.lang.Float.floatToIntBits(getValue())
-            == java.lang.Float.floatToIntBits(
+            java.lang.Double.doubleToLongBits(getValue())
+            == java.lang.Double.doubleToLongBits(
                 other.getValue()));
       }
       result = result && (hasTimestamp() == other.hasTimestamp());
@@ -815,8 +815,8 @@ public final class Service {
       }
       if (hasValue()) {
         hash = (37 * hash) + VALUE_FIELD_NUMBER;
-        hash = (53 * hash) + java.lang.Float.floatToIntBits(
-            getValue());
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            java.lang.Double.doubleToLongBits(getValue()));
       }
       if (hasTimestamp()) {
         hash = (37 * hash) + TIMESTAMP_FIELD_NUMBER;
@@ -962,7 +962,7 @@ public final class Service {
         super.clear();
         key_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        value_ = 0F;
+        value_ = 0D;
         bitField0_ = (bitField0_ & ~0x00000002);
         timestamp_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000004);
@@ -1196,13 +1196,13 @@ public final class Service {
         return this;
       }
 
-      private float value_ ;
+      private double value_ ;
       /**
        * <pre>
        * Value associated with this metric.
        * </pre>
        *
-       * <code>optional float value = 2;</code>
+       * <code>optional double value = 2;</code>
        */
       public boolean hasValue() {
         return ((bitField0_ & 0x00000002) == 0x00000002);
@@ -1212,9 +1212,9 @@ public final class Service {
        * Value associated with this metric.
        * </pre>
        *
-       * <code>optional float value = 2;</code>
+       * <code>optional double value = 2;</code>
        */
-      public float getValue() {
+      public double getValue() {
         return value_;
       }
       /**
@@ -1222,9 +1222,9 @@ public final class Service {
        * Value associated with this metric.
        * </pre>
        *
-       * <code>optional float value = 2;</code>
+       * <code>optional double value = 2;</code>
        */
-      public Builder setValue(float value) {
+      public Builder setValue(double value) {
         bitField0_ |= 0x00000002;
         value_ = value;
         onChanged();
@@ -1235,11 +1235,11 @@ public final class Service {
        * Value associated with this metric.
        * </pre>
        *
-       * <code>optional float value = 2;</code>
+       * <code>optional double value = 2;</code>
        */
       public Builder clearValue() {
         bitField0_ = (bitField0_ & ~0x00000002);
-        value_ = 0F;
+        value_ = 0D;
         onChanged();
         return this;
       }
@@ -8622,6 +8622,7 @@ public final class Service {
     /**
      * <pre>
      * Current life cycle stage of the experiment: "active" or "deleted".
+     * Deleted experiments are not returned by APIs.
      * </pre>
      *
      * <code>optional string lifecycle_stage = 4;</code>
@@ -8630,6 +8631,7 @@ public final class Service {
     /**
      * <pre>
      * Current life cycle stage of the experiment: "active" or "deleted".
+     * Deleted experiments are not returned by APIs.
      * </pre>
      *
      * <code>optional string lifecycle_stage = 4;</code>
@@ -8638,6 +8640,7 @@ public final class Service {
     /**
      * <pre>
      * Current life cycle stage of the experiment: "active" or "deleted".
+     * Deleted experiments are not returned by APIs.
      * </pre>
      *
      * <code>optional string lifecycle_stage = 4;</code>
@@ -8930,6 +8933,7 @@ public final class Service {
     /**
      * <pre>
      * Current life cycle stage of the experiment: "active" or "deleted".
+     * Deleted experiments are not returned by APIs.
      * </pre>
      *
      * <code>optional string lifecycle_stage = 4;</code>
@@ -8940,6 +8944,7 @@ public final class Service {
     /**
      * <pre>
      * Current life cycle stage of the experiment: "active" or "deleted".
+     * Deleted experiments are not returned by APIs.
      * </pre>
      *
      * <code>optional string lifecycle_stage = 4;</code>
@@ -8961,6 +8966,7 @@ public final class Service {
     /**
      * <pre>
      * Current life cycle stage of the experiment: "active" or "deleted".
+     * Deleted experiments are not returned by APIs.
      * </pre>
      *
      * <code>optional string lifecycle_stage = 4;</code>
@@ -9727,6 +9733,7 @@ public final class Service {
       /**
        * <pre>
        * Current life cycle stage of the experiment: "active" or "deleted".
+       * Deleted experiments are not returned by APIs.
        * </pre>
        *
        * <code>optional string lifecycle_stage = 4;</code>
@@ -9737,6 +9744,7 @@ public final class Service {
       /**
        * <pre>
        * Current life cycle stage of the experiment: "active" or "deleted".
+       * Deleted experiments are not returned by APIs.
        * </pre>
        *
        * <code>optional string lifecycle_stage = 4;</code>
@@ -9758,6 +9766,7 @@ public final class Service {
       /**
        * <pre>
        * Current life cycle stage of the experiment: "active" or "deleted".
+       * Deleted experiments are not returned by APIs.
        * </pre>
        *
        * <code>optional string lifecycle_stage = 4;</code>
@@ -9778,6 +9787,7 @@ public final class Service {
       /**
        * <pre>
        * Current life cycle stage of the experiment: "active" or "deleted".
+       * Deleted experiments are not returned by APIs.
        * </pre>
        *
        * <code>optional string lifecycle_stage = 4;</code>
@@ -9795,6 +9805,7 @@ public final class Service {
       /**
        * <pre>
        * Current life cycle stage of the experiment: "active" or "deleted".
+       * Deleted experiments are not returned by APIs.
        * </pre>
        *
        * <code>optional string lifecycle_stage = 4;</code>
@@ -9808,6 +9819,7 @@ public final class Service {
       /**
        * <pre>
        * Current life cycle stage of the experiment: "active" or "deleted".
+       * Deleted experiments are not returned by APIs.
        * </pre>
        *
        * <code>optional string lifecycle_stage = 4;</code>
@@ -23255,20 +23267,20 @@ public final class Service {
 
     /**
      * <pre>
-     * Float value of the metric being logged.
+     * Double value of the metric being logged.
      * </pre>
      *
-     * <code>optional float value = 3 [(.validate_required) = true];</code>
+     * <code>optional double value = 3 [(.validate_required) = true];</code>
      */
     boolean hasValue();
     /**
      * <pre>
-     * Float value of the metric being logged.
+     * Double value of the metric being logged.
      * </pre>
      *
-     * <code>optional float value = 3 [(.validate_required) = true];</code>
+     * <code>optional double value = 3 [(.validate_required) = true];</code>
      */
-    float getValue();
+    double getValue();
 
     /**
      * <pre>
@@ -23302,7 +23314,7 @@ public final class Service {
     private LogMetric() {
       runUuid_ = "";
       key_ = "";
-      value_ = 0F;
+      value_ = 0D;
       timestamp_ = 0L;
     }
 
@@ -23342,9 +23354,9 @@ public final class Service {
               key_ = bs;
               break;
             }
-            case 29: {
+            case 25: {
               bitField0_ |= 0x00000004;
-              value_ = input.readFloat();
+              value_ = input.readDouble();
               break;
             }
             case 32: {
@@ -23906,25 +23918,25 @@ public final class Service {
     }
 
     public static final int VALUE_FIELD_NUMBER = 3;
-    private float value_;
+    private double value_;
     /**
      * <pre>
-     * Float value of the metric being logged.
+     * Double value of the metric being logged.
      * </pre>
      *
-     * <code>optional float value = 3 [(.validate_required) = true];</code>
+     * <code>optional double value = 3 [(.validate_required) = true];</code>
      */
     public boolean hasValue() {
       return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
      * <pre>
-     * Float value of the metric being logged.
+     * Double value of the metric being logged.
      * </pre>
      *
-     * <code>optional float value = 3 [(.validate_required) = true];</code>
+     * <code>optional double value = 3 [(.validate_required) = true];</code>
      */
-    public float getValue() {
+    public double getValue() {
       return value_;
     }
 
@@ -23972,7 +23984,7 @@ public final class Service {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, key_);
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        output.writeFloat(3, value_);
+        output.writeDouble(3, value_);
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeInt64(4, timestamp_);
@@ -23994,7 +24006,7 @@ public final class Service {
       }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeFloatSize(3, value_);
+          .computeDoubleSize(3, value_);
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
@@ -24029,8 +24041,8 @@ public final class Service {
       result = result && (hasValue() == other.hasValue());
       if (hasValue()) {
         result = result && (
-            java.lang.Float.floatToIntBits(getValue())
-            == java.lang.Float.floatToIntBits(
+            java.lang.Double.doubleToLongBits(getValue())
+            == java.lang.Double.doubleToLongBits(
                 other.getValue()));
       }
       result = result && (hasTimestamp() == other.hasTimestamp());
@@ -24059,8 +24071,8 @@ public final class Service {
       }
       if (hasValue()) {
         hash = (37 * hash) + VALUE_FIELD_NUMBER;
-        hash = (53 * hash) + java.lang.Float.floatToIntBits(
-            getValue());
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            java.lang.Double.doubleToLongBits(getValue()));
       }
       if (hasTimestamp()) {
         hash = (37 * hash) + TIMESTAMP_FIELD_NUMBER;
@@ -24204,7 +24216,7 @@ public final class Service {
         bitField0_ = (bitField0_ & ~0x00000001);
         key_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
-        value_ = 0F;
+        value_ = 0D;
         bitField0_ = (bitField0_ & ~0x00000004);
         timestamp_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000008);
@@ -24547,35 +24559,35 @@ public final class Service {
         return this;
       }
 
-      private float value_ ;
+      private double value_ ;
       /**
        * <pre>
-       * Float value of the metric being logged.
+       * Double value of the metric being logged.
        * </pre>
        *
-       * <code>optional float value = 3 [(.validate_required) = true];</code>
+       * <code>optional double value = 3 [(.validate_required) = true];</code>
        */
       public boolean hasValue() {
         return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
        * <pre>
-       * Float value of the metric being logged.
+       * Double value of the metric being logged.
        * </pre>
        *
-       * <code>optional float value = 3 [(.validate_required) = true];</code>
+       * <code>optional double value = 3 [(.validate_required) = true];</code>
        */
-      public float getValue() {
+      public double getValue() {
         return value_;
       }
       /**
        * <pre>
-       * Float value of the metric being logged.
+       * Double value of the metric being logged.
        * </pre>
        *
-       * <code>optional float value = 3 [(.validate_required) = true];</code>
+       * <code>optional double value = 3 [(.validate_required) = true];</code>
        */
-      public Builder setValue(float value) {
+      public Builder setValue(double value) {
         bitField0_ |= 0x00000004;
         value_ = value;
         onChanged();
@@ -24583,14 +24595,14 @@ public final class Service {
       }
       /**
        * <pre>
-       * Float value of the metric being logged.
+       * Double value of the metric being logged.
        * </pre>
        *
-       * <code>optional float value = 3 [(.validate_required) = true];</code>
+       * <code>optional double value = 3 [(.validate_required) = true];</code>
        */
       public Builder clearValue() {
         bitField0_ = (bitField0_ & ~0x00000004);
-        value_ = 0F;
+        value_ = 0D;
         onChanged();
         return this;
       }
@@ -33057,7 +33069,8 @@ public final class Service {
 
     /**
      * <pre>
-     * Float clause for comparison.
+     * [Deprecated in 0.7.0, to be removed in future version] 
+     * Float clause for comparison. Use 'double' instead.
      * </pre>
      *
      * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33065,7 +33078,8 @@ public final class Service {
     boolean hasFloat();
     /**
      * <pre>
-     * Float clause for comparison.
+     * [Deprecated in 0.7.0, to be removed in future version] 
+     * Float clause for comparison. Use 'double' instead.
      * </pre>
      *
      * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33073,12 +33087,38 @@ public final class Service {
     org.mlflow.api.proto.Service.FloatClause getFloat();
     /**
      * <pre>
-     * Float clause for comparison.
+     * [Deprecated in 0.7.0, to be removed in future version] 
+     * Float clause for comparison. Use 'double' instead.
      * </pre>
      *
      * <code>optional .mlflow.FloatClause float = 2;</code>
      */
     org.mlflow.api.proto.Service.FloatClauseOrBuilder getFloatOrBuilder();
+
+    /**
+     * <pre>
+     * Double clause of comparison
+     * </pre>
+     *
+     * <code>optional .mlflow.DoubleClause double = 3;</code>
+     */
+    boolean hasDouble();
+    /**
+     * <pre>
+     * Double clause of comparison
+     * </pre>
+     *
+     * <code>optional .mlflow.DoubleClause double = 3;</code>
+     */
+    org.mlflow.api.proto.Service.DoubleClause getDouble();
+    /**
+     * <pre>
+     * Double clause of comparison
+     * </pre>
+     *
+     * <code>optional .mlflow.DoubleClause double = 3;</code>
+     */
+    org.mlflow.api.proto.Service.DoubleClauseOrBuilder getDoubleOrBuilder();
 
     public org.mlflow.api.proto.Service.MetricSearchExpression.ClauseCase getClauseCase();
   }
@@ -33142,6 +33182,20 @@ public final class Service {
               clauseCase_ = 2;
               break;
             }
+            case 26: {
+              org.mlflow.api.proto.Service.DoubleClause.Builder subBuilder = null;
+              if (clauseCase_ == 3) {
+                subBuilder = ((org.mlflow.api.proto.Service.DoubleClause) clause_).toBuilder();
+              }
+              clause_ =
+                  input.readMessage(org.mlflow.api.proto.Service.DoubleClause.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom((org.mlflow.api.proto.Service.DoubleClause) clause_);
+                clause_ = subBuilder.buildPartial();
+              }
+              clauseCase_ = 3;
+              break;
+            }
             default: {
               if (!parseUnknownField(
                   input, unknownFields, extensionRegistry, tag)) {
@@ -33180,6 +33234,7 @@ public final class Service {
     public enum ClauseCase
         implements com.google.protobuf.Internal.EnumLite {
       FLOAT(2),
+      DOUBLE(3),
       CLAUSE_NOT_SET(0);
       private final int value;
       private ClauseCase(int value) {
@@ -33196,6 +33251,7 @@ public final class Service {
       public static ClauseCase forNumber(int value) {
         switch (value) {
           case 2: return FLOAT;
+          case 3: return DOUBLE;
           case 0: return CLAUSE_NOT_SET;
           default: return null;
         }
@@ -33268,7 +33324,8 @@ public final class Service {
     public static final int FLOAT_FIELD_NUMBER = 2;
     /**
      * <pre>
-     * Float clause for comparison.
+     * [Deprecated in 0.7.0, to be removed in future version] 
+     * Float clause for comparison. Use 'double' instead.
      * </pre>
      *
      * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33278,7 +33335,8 @@ public final class Service {
     }
     /**
      * <pre>
-     * Float clause for comparison.
+     * [Deprecated in 0.7.0, to be removed in future version] 
+     * Float clause for comparison. Use 'double' instead.
      * </pre>
      *
      * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33291,7 +33349,8 @@ public final class Service {
     }
     /**
      * <pre>
-     * Float clause for comparison.
+     * [Deprecated in 0.7.0, to be removed in future version] 
+     * Float clause for comparison. Use 'double' instead.
      * </pre>
      *
      * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33301,6 +33360,44 @@ public final class Service {
          return (org.mlflow.api.proto.Service.FloatClause) clause_;
       }
       return org.mlflow.api.proto.Service.FloatClause.getDefaultInstance();
+    }
+
+    public static final int DOUBLE_FIELD_NUMBER = 3;
+    /**
+     * <pre>
+     * Double clause of comparison
+     * </pre>
+     *
+     * <code>optional .mlflow.DoubleClause double = 3;</code>
+     */
+    public boolean hasDouble() {
+      return clauseCase_ == 3;
+    }
+    /**
+     * <pre>
+     * Double clause of comparison
+     * </pre>
+     *
+     * <code>optional .mlflow.DoubleClause double = 3;</code>
+     */
+    public org.mlflow.api.proto.Service.DoubleClause getDouble() {
+      if (clauseCase_ == 3) {
+         return (org.mlflow.api.proto.Service.DoubleClause) clause_;
+      }
+      return org.mlflow.api.proto.Service.DoubleClause.getDefaultInstance();
+    }
+    /**
+     * <pre>
+     * Double clause of comparison
+     * </pre>
+     *
+     * <code>optional .mlflow.DoubleClause double = 3;</code>
+     */
+    public org.mlflow.api.proto.Service.DoubleClauseOrBuilder getDoubleOrBuilder() {
+      if (clauseCase_ == 3) {
+         return (org.mlflow.api.proto.Service.DoubleClause) clause_;
+      }
+      return org.mlflow.api.proto.Service.DoubleClause.getDefaultInstance();
     }
 
     private byte memoizedIsInitialized = -1;
@@ -33323,6 +33420,9 @@ public final class Service {
       if (clauseCase_ == 2) {
         output.writeMessage(2, (org.mlflow.api.proto.Service.FloatClause) clause_);
       }
+      if (clauseCase_ == 3) {
+        output.writeMessage(3, (org.mlflow.api.proto.Service.DoubleClause) clause_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -33338,6 +33438,10 @@ public final class Service {
       if (clauseCase_ == 2) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, (org.mlflow.api.proto.Service.FloatClause) clause_);
+      }
+      if (clauseCase_ == 3) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(3, (org.mlflow.api.proto.Service.DoubleClause) clause_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -33368,6 +33472,10 @@ public final class Service {
           result = result && getFloat()
               .equals(other.getFloat());
           break;
+        case 3:
+          result = result && getDouble()
+              .equals(other.getDouble());
+          break;
         case 0:
         default:
       }
@@ -33390,6 +33498,10 @@ public final class Service {
         case 2:
           hash = (37 * hash) + FLOAT_FIELD_NUMBER;
           hash = (53 * hash) + getFloat().hashCode();
+          break;
+        case 3:
+          hash = (37 * hash) + DOUBLE_FIELD_NUMBER;
+          hash = (53 * hash) + getDouble().hashCode();
           break;
         case 0:
         default:
@@ -33570,6 +33682,13 @@ public final class Service {
             result.clause_ = floatBuilder_.build();
           }
         }
+        if (clauseCase_ == 3) {
+          if (doubleBuilder_ == null) {
+            result.clause_ = clause_;
+          } else {
+            result.clause_ = doubleBuilder_.build();
+          }
+        }
         result.bitField0_ = to_bitField0_;
         result.clauseCase_ = clauseCase_;
         onBuilt();
@@ -33628,6 +33747,10 @@ public final class Service {
         switch (other.getClauseCase()) {
           case FLOAT: {
             mergeFloat(other.getFloat());
+            break;
+          }
+          case DOUBLE: {
+            mergeDouble(other.getDouble());
             break;
           }
           case CLAUSE_NOT_SET: {
@@ -33783,7 +33906,8 @@ public final class Service {
           org.mlflow.api.proto.Service.FloatClause, org.mlflow.api.proto.Service.FloatClause.Builder, org.mlflow.api.proto.Service.FloatClauseOrBuilder> floatBuilder_;
       /**
        * <pre>
-       * Float clause for comparison.
+       * [Deprecated in 0.7.0, to be removed in future version] 
+       * Float clause for comparison. Use 'double' instead.
        * </pre>
        *
        * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33793,7 +33917,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * Float clause for comparison.
+       * [Deprecated in 0.7.0, to be removed in future version] 
+       * Float clause for comparison. Use 'double' instead.
        * </pre>
        *
        * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33813,7 +33938,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * Float clause for comparison.
+       * [Deprecated in 0.7.0, to be removed in future version] 
+       * Float clause for comparison. Use 'double' instead.
        * </pre>
        *
        * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33833,7 +33959,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * Float clause for comparison.
+       * [Deprecated in 0.7.0, to be removed in future version] 
+       * Float clause for comparison. Use 'double' instead.
        * </pre>
        *
        * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33851,7 +33978,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * Float clause for comparison.
+       * [Deprecated in 0.7.0, to be removed in future version] 
+       * Float clause for comparison. Use 'double' instead.
        * </pre>
        *
        * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33877,7 +34005,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * Float clause for comparison.
+       * [Deprecated in 0.7.0, to be removed in future version] 
+       * Float clause for comparison. Use 'double' instead.
        * </pre>
        *
        * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33900,7 +34029,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * Float clause for comparison.
+       * [Deprecated in 0.7.0, to be removed in future version] 
+       * Float clause for comparison. Use 'double' instead.
        * </pre>
        *
        * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33910,7 +34040,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * Float clause for comparison.
+       * [Deprecated in 0.7.0, to be removed in future version] 
+       * Float clause for comparison. Use 'double' instead.
        * </pre>
        *
        * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33927,7 +34058,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * Float clause for comparison.
+       * [Deprecated in 0.7.0, to be removed in future version] 
+       * Float clause for comparison. Use 'double' instead.
        * </pre>
        *
        * <code>optional .mlflow.FloatClause float = 2;</code>
@@ -33949,6 +34081,178 @@ public final class Service {
         clauseCase_ = 2;
         onChanged();;
         return floatBuilder_;
+      }
+
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.mlflow.api.proto.Service.DoubleClause, org.mlflow.api.proto.Service.DoubleClause.Builder, org.mlflow.api.proto.Service.DoubleClauseOrBuilder> doubleBuilder_;
+      /**
+       * <pre>
+       * Double clause of comparison
+       * </pre>
+       *
+       * <code>optional .mlflow.DoubleClause double = 3;</code>
+       */
+      public boolean hasDouble() {
+        return clauseCase_ == 3;
+      }
+      /**
+       * <pre>
+       * Double clause of comparison
+       * </pre>
+       *
+       * <code>optional .mlflow.DoubleClause double = 3;</code>
+       */
+      public org.mlflow.api.proto.Service.DoubleClause getDouble() {
+        if (doubleBuilder_ == null) {
+          if (clauseCase_ == 3) {
+            return (org.mlflow.api.proto.Service.DoubleClause) clause_;
+          }
+          return org.mlflow.api.proto.Service.DoubleClause.getDefaultInstance();
+        } else {
+          if (clauseCase_ == 3) {
+            return doubleBuilder_.getMessage();
+          }
+          return org.mlflow.api.proto.Service.DoubleClause.getDefaultInstance();
+        }
+      }
+      /**
+       * <pre>
+       * Double clause of comparison
+       * </pre>
+       *
+       * <code>optional .mlflow.DoubleClause double = 3;</code>
+       */
+      public Builder setDouble(org.mlflow.api.proto.Service.DoubleClause value) {
+        if (doubleBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          clause_ = value;
+          onChanged();
+        } else {
+          doubleBuilder_.setMessage(value);
+        }
+        clauseCase_ = 3;
+        return this;
+      }
+      /**
+       * <pre>
+       * Double clause of comparison
+       * </pre>
+       *
+       * <code>optional .mlflow.DoubleClause double = 3;</code>
+       */
+      public Builder setDouble(
+          org.mlflow.api.proto.Service.DoubleClause.Builder builderForValue) {
+        if (doubleBuilder_ == null) {
+          clause_ = builderForValue.build();
+          onChanged();
+        } else {
+          doubleBuilder_.setMessage(builderForValue.build());
+        }
+        clauseCase_ = 3;
+        return this;
+      }
+      /**
+       * <pre>
+       * Double clause of comparison
+       * </pre>
+       *
+       * <code>optional .mlflow.DoubleClause double = 3;</code>
+       */
+      public Builder mergeDouble(org.mlflow.api.proto.Service.DoubleClause value) {
+        if (doubleBuilder_ == null) {
+          if (clauseCase_ == 3 &&
+              clause_ != org.mlflow.api.proto.Service.DoubleClause.getDefaultInstance()) {
+            clause_ = org.mlflow.api.proto.Service.DoubleClause.newBuilder((org.mlflow.api.proto.Service.DoubleClause) clause_)
+                .mergeFrom(value).buildPartial();
+          } else {
+            clause_ = value;
+          }
+          onChanged();
+        } else {
+          if (clauseCase_ == 3) {
+            doubleBuilder_.mergeFrom(value);
+          }
+          doubleBuilder_.setMessage(value);
+        }
+        clauseCase_ = 3;
+        return this;
+      }
+      /**
+       * <pre>
+       * Double clause of comparison
+       * </pre>
+       *
+       * <code>optional .mlflow.DoubleClause double = 3;</code>
+       */
+      public Builder clearDouble() {
+        if (doubleBuilder_ == null) {
+          if (clauseCase_ == 3) {
+            clauseCase_ = 0;
+            clause_ = null;
+            onChanged();
+          }
+        } else {
+          if (clauseCase_ == 3) {
+            clauseCase_ = 0;
+            clause_ = null;
+          }
+          doubleBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <pre>
+       * Double clause of comparison
+       * </pre>
+       *
+       * <code>optional .mlflow.DoubleClause double = 3;</code>
+       */
+      public org.mlflow.api.proto.Service.DoubleClause.Builder getDoubleBuilder() {
+        return getDoubleFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       * Double clause of comparison
+       * </pre>
+       *
+       * <code>optional .mlflow.DoubleClause double = 3;</code>
+       */
+      public org.mlflow.api.proto.Service.DoubleClauseOrBuilder getDoubleOrBuilder() {
+        if ((clauseCase_ == 3) && (doubleBuilder_ != null)) {
+          return doubleBuilder_.getMessageOrBuilder();
+        } else {
+          if (clauseCase_ == 3) {
+            return (org.mlflow.api.proto.Service.DoubleClause) clause_;
+          }
+          return org.mlflow.api.proto.Service.DoubleClause.getDefaultInstance();
+        }
+      }
+      /**
+       * <pre>
+       * Double clause of comparison
+       * </pre>
+       *
+       * <code>optional .mlflow.DoubleClause double = 3;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.mlflow.api.proto.Service.DoubleClause, org.mlflow.api.proto.Service.DoubleClause.Builder, org.mlflow.api.proto.Service.DoubleClauseOrBuilder> 
+          getDoubleFieldBuilder() {
+        if (doubleBuilder_ == null) {
+          if (!(clauseCase_ == 3)) {
+            clause_ = org.mlflow.api.proto.Service.DoubleClause.getDefaultInstance();
+          }
+          doubleBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              org.mlflow.api.proto.Service.DoubleClause, org.mlflow.api.proto.Service.DoubleClause.Builder, org.mlflow.api.proto.Service.DoubleClauseOrBuilder>(
+                  (org.mlflow.api.proto.Service.DoubleClause) clause_,
+                  getParentForChildren(),
+                  isClean());
+          clause_ = null;
+        }
+        clauseCase_ = 3;
+        onChanged();;
+        return doubleBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -36573,6 +36877,759 @@ public final class Service {
 
     @java.lang.Override
     public org.mlflow.api.proto.Service.FloatClause getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface DoubleClauseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mlflow.DoubleClause)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * OneOf ("&gt;", "&gt;=", "==", "!=", "&lt;=", "&lt;")
+     * </pre>
+     *
+     * <code>optional string comparator = 1;</code>
+     */
+    boolean hasComparator();
+    /**
+     * <pre>
+     * OneOf ("&gt;", "&gt;=", "==", "!=", "&lt;=", "&lt;")
+     * </pre>
+     *
+     * <code>optional string comparator = 1;</code>
+     */
+    java.lang.String getComparator();
+    /**
+     * <pre>
+     * OneOf ("&gt;", "&gt;=", "==", "!=", "&lt;=", "&lt;")
+     * </pre>
+     *
+     * <code>optional string comparator = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getComparatorBytes();
+
+    /**
+     * <pre>
+     * Float value for comparison.
+     * </pre>
+     *
+     * <code>optional double value = 2;</code>
+     */
+    boolean hasValue();
+    /**
+     * <pre>
+     * Float value for comparison.
+     * </pre>
+     *
+     * <code>optional double value = 2;</code>
+     */
+    double getValue();
+  }
+  /**
+   * Protobuf type {@code mlflow.DoubleClause}
+   */
+  public  static final class DoubleClause extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:mlflow.DoubleClause)
+      DoubleClauseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use DoubleClause.newBuilder() to construct.
+    private DoubleClause(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private DoubleClause() {
+      comparator_ = "";
+      value_ = 0D;
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private DoubleClause(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              comparator_ = bs;
+              break;
+            }
+            case 17: {
+              bitField0_ |= 0x00000002;
+              value_ = input.readDouble();
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.mlflow.api.proto.Service.internal_static_mlflow_DoubleClause_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.mlflow.api.proto.Service.internal_static_mlflow_DoubleClause_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.mlflow.api.proto.Service.DoubleClause.class, org.mlflow.api.proto.Service.DoubleClause.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int COMPARATOR_FIELD_NUMBER = 1;
+    private volatile java.lang.Object comparator_;
+    /**
+     * <pre>
+     * OneOf ("&gt;", "&gt;=", "==", "!=", "&lt;=", "&lt;")
+     * </pre>
+     *
+     * <code>optional string comparator = 1;</code>
+     */
+    public boolean hasComparator() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <pre>
+     * OneOf ("&gt;", "&gt;=", "==", "!=", "&lt;=", "&lt;")
+     * </pre>
+     *
+     * <code>optional string comparator = 1;</code>
+     */
+    public java.lang.String getComparator() {
+      java.lang.Object ref = comparator_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          comparator_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * OneOf ("&gt;", "&gt;=", "==", "!=", "&lt;=", "&lt;")
+     * </pre>
+     *
+     * <code>optional string comparator = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getComparatorBytes() {
+      java.lang.Object ref = comparator_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        comparator_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int VALUE_FIELD_NUMBER = 2;
+    private double value_;
+    /**
+     * <pre>
+     * Float value for comparison.
+     * </pre>
+     *
+     * <code>optional double value = 2;</code>
+     */
+    public boolean hasValue() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <pre>
+     * Float value for comparison.
+     * </pre>
+     *
+     * <code>optional double value = 2;</code>
+     */
+    public double getValue() {
+      return value_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, comparator_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        output.writeDouble(2, value_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, comparator_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeDoubleSize(2, value_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.mlflow.api.proto.Service.DoubleClause)) {
+        return super.equals(obj);
+      }
+      org.mlflow.api.proto.Service.DoubleClause other = (org.mlflow.api.proto.Service.DoubleClause) obj;
+
+      boolean result = true;
+      result = result && (hasComparator() == other.hasComparator());
+      if (hasComparator()) {
+        result = result && getComparator()
+            .equals(other.getComparator());
+      }
+      result = result && (hasValue() == other.hasValue());
+      if (hasValue()) {
+        result = result && (
+            java.lang.Double.doubleToLongBits(getValue())
+            == java.lang.Double.doubleToLongBits(
+                other.getValue()));
+      }
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasComparator()) {
+        hash = (37 * hash) + COMPARATOR_FIELD_NUMBER;
+        hash = (53 * hash) + getComparator().hashCode();
+      }
+      if (hasValue()) {
+        hash = (37 * hash) + VALUE_FIELD_NUMBER;
+        hash = (53 * hash) + com.google.protobuf.Internal.hashLong(
+            java.lang.Double.doubleToLongBits(getValue()));
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static org.mlflow.api.proto.Service.DoubleClause parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.Service.DoubleClause parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.DoubleClause parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.Service.DoubleClause parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.DoubleClause parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.Service.DoubleClause parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.DoubleClause parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.Service.DoubleClause parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.DoubleClause parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.Service.DoubleClause parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.DoubleClause parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.Service.DoubleClause parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.mlflow.api.proto.Service.DoubleClause prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mlflow.DoubleClause}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mlflow.DoubleClause)
+        org.mlflow.api.proto.Service.DoubleClauseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_DoubleClause_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_DoubleClause_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.Service.DoubleClause.class, org.mlflow.api.proto.Service.DoubleClause.Builder.class);
+      }
+
+      // Construct using org.mlflow.api.proto.Service.DoubleClause.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        comparator_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        value_ = 0D;
+        bitField0_ = (bitField0_ & ~0x00000002);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_DoubleClause_descriptor;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.DoubleClause getDefaultInstanceForType() {
+        return org.mlflow.api.proto.Service.DoubleClause.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.DoubleClause build() {
+        org.mlflow.api.proto.Service.DoubleClause result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.DoubleClause buildPartial() {
+        org.mlflow.api.proto.Service.DoubleClause result = new org.mlflow.api.proto.Service.DoubleClause(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.comparator_ = comparator_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.value_ = value_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.mlflow.api.proto.Service.DoubleClause) {
+          return mergeFrom((org.mlflow.api.proto.Service.DoubleClause)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.mlflow.api.proto.Service.DoubleClause other) {
+        if (other == org.mlflow.api.proto.Service.DoubleClause.getDefaultInstance()) return this;
+        if (other.hasComparator()) {
+          bitField0_ |= 0x00000001;
+          comparator_ = other.comparator_;
+          onChanged();
+        }
+        if (other.hasValue()) {
+          setValue(other.getValue());
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.mlflow.api.proto.Service.DoubleClause parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.mlflow.api.proto.Service.DoubleClause) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object comparator_ = "";
+      /**
+       * <pre>
+       * OneOf ("&gt;", "&gt;=", "==", "!=", "&lt;=", "&lt;")
+       * </pre>
+       *
+       * <code>optional string comparator = 1;</code>
+       */
+      public boolean hasComparator() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <pre>
+       * OneOf ("&gt;", "&gt;=", "==", "!=", "&lt;=", "&lt;")
+       * </pre>
+       *
+       * <code>optional string comparator = 1;</code>
+       */
+      public java.lang.String getComparator() {
+        java.lang.Object ref = comparator_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            comparator_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * OneOf ("&gt;", "&gt;=", "==", "!=", "&lt;=", "&lt;")
+       * </pre>
+       *
+       * <code>optional string comparator = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getComparatorBytes() {
+        java.lang.Object ref = comparator_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          comparator_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * OneOf ("&gt;", "&gt;=", "==", "!=", "&lt;=", "&lt;")
+       * </pre>
+       *
+       * <code>optional string comparator = 1;</code>
+       */
+      public Builder setComparator(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        comparator_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * OneOf ("&gt;", "&gt;=", "==", "!=", "&lt;=", "&lt;")
+       * </pre>
+       *
+       * <code>optional string comparator = 1;</code>
+       */
+      public Builder clearComparator() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        comparator_ = getDefaultInstance().getComparator();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * OneOf ("&gt;", "&gt;=", "==", "!=", "&lt;=", "&lt;")
+       * </pre>
+       *
+       * <code>optional string comparator = 1;</code>
+       */
+      public Builder setComparatorBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        comparator_ = value;
+        onChanged();
+        return this;
+      }
+
+      private double value_ ;
+      /**
+       * <pre>
+       * Float value for comparison.
+       * </pre>
+       *
+       * <code>optional double value = 2;</code>
+       */
+      public boolean hasValue() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <pre>
+       * Float value for comparison.
+       * </pre>
+       *
+       * <code>optional double value = 2;</code>
+       */
+      public double getValue() {
+        return value_;
+      }
+      /**
+       * <pre>
+       * Float value for comparison.
+       * </pre>
+       *
+       * <code>optional double value = 2;</code>
+       */
+      public Builder setValue(double value) {
+        bitField0_ |= 0x00000002;
+        value_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Float value for comparison.
+       * </pre>
+       *
+       * <code>optional double value = 2;</code>
+       */
+      public Builder clearValue() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        value_ = 0D;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:mlflow.DoubleClause)
+    }
+
+    // @@protoc_insertion_point(class_scope:mlflow.DoubleClause)
+    private static final org.mlflow.api.proto.Service.DoubleClause DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.mlflow.api.proto.Service.DoubleClause();
+    }
+
+    public static org.mlflow.api.proto.Service.DoubleClause getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<DoubleClause>
+        PARSER = new com.google.protobuf.AbstractParser<DoubleClause>() {
+      @java.lang.Override
+      public DoubleClause parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new DoubleClause(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<DoubleClause> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<DoubleClause> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public org.mlflow.api.proto.Service.DoubleClause getDefaultInstanceForType() {
       return DEFAULT_INSTANCE;
     }
 
@@ -44730,6 +45787,11 @@ public final class Service {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_mlflow_FloatClause_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_DoubleClause_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_DoubleClause_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mlflow_SearchRuns_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -44785,7 +45847,7 @@ public final class Service {
     java.lang.String[] descriptorData = {
       "\n\rservice.proto\022\006mlflow\032\025scalapb/scalapb" +
       ".proto\032\020databricks.proto\"7\n\006Metric\022\013\n\003ke" +
-      "y\030\001 \001(\t\022\r\n\005value\030\002 \001(\002\022\021\n\ttimestamp\030\003 \001(" +
+      "y\030\001 \001(\t\022\r\n\005value\030\002 \001(\001\022\021\n\ttimestamp\030\003 \001(" +
       "\003\"#\n\005Param\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"C" +
       "\n\003Run\022\035\n\004info\030\001 \001(\0132\017.mlflow.RunInfo\022\035\n\004" +
       "data\030\002 \001(\0132\017.mlflow.RunData\"g\n\007RunData\022\037" +
@@ -44840,7 +45902,7 @@ public final class Service {
       "\024\n\006run_id\030\001 \001(\tB\004\210\265\030\001\032\n\n\010Response:+\342?(\n&" +
       "com.databricks.rpc.RPC[$this.Response]\"\235" +
       "\001\n\tLogMetric\022\026\n\010run_uuid\030\001 \001(\tB\004\210\265\030\001\022\021\n\003" +
-      "key\030\002 \001(\tB\004\210\265\030\001\022\023\n\005value\030\003 \001(\002B\004\210\265\030\001\022\027\n\t" +
+      "key\030\002 \001(\tB\004\210\265\030\001\022\023\n\005value\030\003 \001(\001B\004\210\265\030\001\022\027\n\t" +
       "timestamp\030\004 \001(\003B\004\210\265\030\001\032\n\n\010Response:+\342?(\n&" +
       "com.databricks.rpc.RPC[$this.Response]\"\203" +
       "\001\n\010LogParam\022\026\n\010run_uuid\030\001 \001(\tB\004\210\265\030\001\022\021\n\003k" +
@@ -44863,99 +45925,102 @@ public final class Service {
       "esponse]\"\212\001\n\020SearchExpression\0220\n\006metric\030" +
       "\001 \001(\0132\036.mlflow.MetricSearchExpressionH\000\022" +
       "6\n\tparameter\030\002 \001(\0132!.mlflow.ParameterSea" +
-      "rchExpressionH\000B\014\n\nexpression\"U\n\026MetricS" +
+      "rchExpressionH\000B\014\n\nexpression\"}\n\026MetricS" +
       "earchExpression\022\013\n\003key\030\001 \001(\t\022$\n\005float\030\002 " +
-      "\001(\0132\023.mlflow.FloatClauseH\000B\010\n\006clause\"Z\n\031" +
+      "\001(\0132\023.mlflow.FloatClauseH\000\022&\n\006double\030\003 \001" +
+      "(\0132\024.mlflow.DoubleClauseH\000B\010\n\006clause\"Z\n\031" +
       "ParameterSearchExpression\022\013\n\003key\030\001 \001(\t\022&" +
       "\n\006string\030\002 \001(\0132\024.mlflow.StringClauseH\000B\010" +
       "\n\006clause\"1\n\014StringClause\022\022\n\ncomparator\030\001" +
       " \001(\t\022\r\n\005value\030\002 \001(\t\"0\n\013FloatClause\022\022\n\nco" +
-      "mparator\030\001 \001(\t\022\r\n\005value\030\002 \001(\002\"\343\001\n\nSearch" +
-      "Runs\022\026\n\016experiment_ids\030\001 \003(\003\0223\n\021anded_ex" +
-      "pressions\030\002 \003(\0132\030.mlflow.SearchExpressio" +
-      "n\0224\n\rrun_view_type\030\003 \001(\0162\020.mlflow.ViewTy" +
-      "pe:\013ACTIVE_ONLY\032%\n\010Response\022\031\n\004runs\030\001 \003(" +
-      "\0132\013.mlflow.Run:+\342?(\n&com.databricks.rpc." +
-      "RPC[$this.Response]\"\233\001\n\rListArtifacts\022\020\n" +
-      "\010run_uuid\030\001 \001(\t\022\014\n\004path\030\002 \001(\t\032=\n\010Respons" +
-      "e\022\020\n\010root_uri\030\001 \001(\t\022\037\n\005files\030\002 \003(\0132\020.mlf" +
-      "low.FileInfo:+\342?(\n&com.databricks.rpc.RP" +
-      "C[$this.Response]\";\n\010FileInfo\022\014\n\004path\030\001 " +
-      "\001(\t\022\016\n\006is_dir\030\002 \001(\010\022\021\n\tfile_size\030\003 \001(\003\"f" +
-      "\n\013GetArtifact\022\020\n\010run_uuid\030\001 \001(\t\022\014\n\004path\030" +
-      "\002 \001(\t\032\n\n\010Response:+\342?(\n&com.databricks.r" +
-      "pc.RPC[$this.Response]\"\236\001\n\020GetMetricHist" +
-      "ory\022\026\n\010run_uuid\030\001 \001(\tB\004\210\265\030\001\022\030\n\nmetric_ke" +
-      "y\030\002 \001(\tB\004\210\265\030\001\032+\n\010Response\022\037\n\007metrics\030\001 \003" +
-      "(\0132\016.mlflow.Metric:+\342?(\n&com.databricks." +
-      "rpc.RPC[$this.Response]*6\n\010ViewType\022\017\n\013A" +
-      "CTIVE_ONLY\020\001\022\020\n\014DELETED_ONLY\020\002\022\007\n\003ALL\020\003*" +
-      "I\n\nSourceType\022\014\n\010NOTEBOOK\020\001\022\007\n\003JOB\020\002\022\013\n\007" +
-      "PROJECT\020\003\022\t\n\005LOCAL\020\004\022\014\n\007UNKNOWN\020\350\007*M\n\tRu" +
-      "nStatus\022\013\n\007RUNNING\020\001\022\r\n\tSCHEDULED\020\002\022\014\n\010F" +
-      "INISHED\020\003\022\n\n\006FAILED\020\004\022\n\n\006KILLED\020\0052\217\023\n\rMl" +
-      "flowService\022\234\001\n\020createExperiment\022\030.mlflo" +
-      "w.CreateExperiment\032!.mlflow.CreateExperi" +
-      "ment.Response\"K\202\265\030G\n0\n\004POST\022\"/preview/ml" +
-      "flow/experiments/create\032\004\010\002\020\000\020\001*\021Create " +
-      "Experiment\022\225\001\n\017listExperiments\022\027.mlflow." +
-      "ListExperiments\032 .mlflow.ListExperiments" +
-      ".Response\"G\202\265\030C\n-\n\003GET\022 /preview/mlflow/" +
-      "experiments/list\032\004\010\002\020\000\020\001*\020List Experimen" +
-      "ts\022\214\001\n\rgetExperiment\022\025.mlflow.GetExperim" +
-      "ent\032\036.mlflow.GetExperiment.Response\"D\202\265\030" +
-      "@\n,\n\003GET\022\037/preview/mlflow/experiments/ge" +
-      "t\032\004\010\002\020\000\020\001*\016Get Experiment\022\234\001\n\020deleteExpe" +
-      "riment\022\030.mlflow.DeleteExperiment\032!.mlflo" +
-      "w.DeleteExperiment.Response\"K\202\265\030G\n0\n\004POS" +
-      "T\022\"/preview/mlflow/experiments/delete\032\004\010" +
-      "\002\020\000\020\001*\021Delete Experiment\022\241\001\n\021restoreExpe" +
-      "riment\022\031.mlflow.RestoreExperiment\032\".mlfl" +
-      "ow.RestoreExperiment.Response\"M\202\265\030I\n1\n\004P" +
-      "OST\022#/preview/mlflow/experiments/restore" +
-      "\032\004\010\002\020\000\020\001*\022Restore Experiment\022y\n\tcreateRu" +
-      "n\022\021.mlflow.CreateRun\032\032.mlflow.CreateRun." +
-      "Response\"=\202\265\0309\n)\n\004POST\022\033/preview/mlflow/" +
-      "runs/create\032\004\010\002\020\000\020\001*\nCreate Run\022y\n\tupdat" +
-      "eRun\022\021.mlflow.UpdateRun\032\032.mlflow.UpdateR" +
-      "un.Response\"=\202\265\0309\n)\n\004POST\022\033/preview/mlfl" +
-      "ow/runs/update\032\004\010\002\020\000\020\001*\nUpdate Run\022m\n\tde" +
-      "leteRun\022\021.mlflow.DeleteRun\032\032.mlflow.Dele" +
-      "teRun.Response\"1\202\265\030-\n)\n\004POST\022\033/preview/m" +
-      "lflow/runs/delete\032\004\010\002\020\000\020\001\022q\n\nrestoreRun\022" +
-      "\022.mlflow.RestoreRun\032\033.mlflow.RestoreRun." +
-      "Response\"2\202\265\030.\n*\n\004POST\022\034/preview/mlflow/" +
-      "runs/restore\032\004\010\002\020\000\020\001\022}\n\tlogMetric\022\021.mlfl" +
-      "ow.LogMetric\032\032.mlflow.LogMetric.Response" +
-      "\"A\202\265\030=\n-\n\004POST\022\037/preview/mlflow/runs/log" +
-      "-metric\032\004\010\002\020\000\020\001*\nLog Metric\022|\n\010logParam\022" +
-      "\020.mlflow.LogParam\032\031.mlflow.LogParam.Resp" +
-      "onse\"C\202\265\030?\n0\n\004POST\022\"/preview/mlflow/runs" +
-      "/log-parameter\032\004\010\002\020\000\020\001*\tLog Param\022n\n\006set" +
-      "Tag\022\016.mlflow.SetTag\032\027.mlflow.SetTag.Resp" +
-      "onse\";\202\265\0307\n*\n\004POST\022\034/preview/mlflow/runs" +
-      "/set-tag\032\004\010\002\020\000\020\001*\007Set Tag\022i\n\006getRun\022\016.ml" +
-      "flow.GetRun\032\027.mlflow.GetRun.Response\"6\202\265" +
-      "\0302\n%\n\003GET\022\030/preview/mlflow/runs/get\032\004\010\002\020" +
-      "\000\020\001*\007Get Run\022x\n\tgetMetric\022\021.mlflow.GetMe" +
-      "tric\032\032.mlflow.GetMetric.Response\"<\202\265\0308\n(" +
-      "\n\003GET\022\033/preview/mlflow/metrics/get\032\004\010\002\020\000" +
-      "\020\001*\nGet Metric\022s\n\010getParam\022\020.mlflow.GetP" +
-      "aram\032\031.mlflow.GetParam.Response\":\202\265\0306\n\'\n" +
-      "\003GET\022\032/preview/mlflow/params/get\032\004\010\002\020\000\020\001" +
-      "*\tGet Param\022\247\001\n\nsearchRuns\022\022.mlflow.Sear" +
-      "chRuns\032\033.mlflow.SearchRuns.Response\"h\202\265\030" +
-      "d\n)\n\004POST\022\033/preview/mlflow/runs/search\032\004" +
-      "\010\002\020\000\n(\n\003GET\022\033/preview/mlflow/runs/search" +
-      "\032\004\010\002\020\000\020\001*\013Search Runs\022\213\001\n\rlistArtifacts\022" +
-      "\025.mlflow.ListArtifacts\032\036.mlflow.ListArti" +
-      "facts.Response\"C\202\265\030?\n+\n\003GET\022\036/preview/ml" +
-      "flow/artifacts/list\032\004\010\002\020\000\020\001*\016List Artifa" +
-      "cts\022\235\001\n\020getMetricHistory\022\030.mlflow.GetMet" +
-      "ricHistory\032!.mlflow.GetMetricHistory.Res" +
-      "ponse\"L\202\265\030H\n0\n\003GET\022#/preview/mlflow/metr" +
-      "ics/get-history\032\004\010\002\020\000\020\001*\022Get Metric Hist" +
-      "oryB\036\n\024org.mlflow.api.proto\220\001\001\342?\002\020\001"
+      "mparator\030\001 \001(\t\022\r\n\005value\030\002 \001(\002\"1\n\014DoubleC" +
+      "lause\022\022\n\ncomparator\030\001 \001(\t\022\r\n\005value\030\002 \001(\001" +
+      "\"\343\001\n\nSearchRuns\022\026\n\016experiment_ids\030\001 \003(\003\022" +
+      "3\n\021anded_expressions\030\002 \003(\0132\030.mlflow.Sear" +
+      "chExpression\0224\n\rrun_view_type\030\003 \001(\0162\020.ml" +
+      "flow.ViewType:\013ACTIVE_ONLY\032%\n\010Response\022\031" +
+      "\n\004runs\030\001 \003(\0132\013.mlflow.Run:+\342?(\n&com.data" +
+      "bricks.rpc.RPC[$this.Response]\"\233\001\n\rListA" +
+      "rtifacts\022\020\n\010run_uuid\030\001 \001(\t\022\014\n\004path\030\002 \001(\t" +
+      "\032=\n\010Response\022\020\n\010root_uri\030\001 \001(\t\022\037\n\005files\030" +
+      "\002 \003(\0132\020.mlflow.FileInfo:+\342?(\n&com.databr" +
+      "icks.rpc.RPC[$this.Response]\";\n\010FileInfo" +
+      "\022\014\n\004path\030\001 \001(\t\022\016\n\006is_dir\030\002 \001(\010\022\021\n\tfile_s" +
+      "ize\030\003 \001(\003\"f\n\013GetArtifact\022\020\n\010run_uuid\030\001 \001" +
+      "(\t\022\014\n\004path\030\002 \001(\t\032\n\n\010Response:+\342?(\n&com.d" +
+      "atabricks.rpc.RPC[$this.Response]\"\236\001\n\020Ge" +
+      "tMetricHistory\022\026\n\010run_uuid\030\001 \001(\tB\004\210\265\030\001\022\030" +
+      "\n\nmetric_key\030\002 \001(\tB\004\210\265\030\001\032+\n\010Response\022\037\n\007" +
+      "metrics\030\001 \003(\0132\016.mlflow.Metric:+\342?(\n&com." +
+      "databricks.rpc.RPC[$this.Response]*6\n\010Vi" +
+      "ewType\022\017\n\013ACTIVE_ONLY\020\001\022\020\n\014DELETED_ONLY\020" +
+      "\002\022\007\n\003ALL\020\003*I\n\nSourceType\022\014\n\010NOTEBOOK\020\001\022\007" +
+      "\n\003JOB\020\002\022\013\n\007PROJECT\020\003\022\t\n\005LOCAL\020\004\022\014\n\007UNKNO" +
+      "WN\020\350\007*M\n\tRunStatus\022\013\n\007RUNNING\020\001\022\r\n\tSCHED" +
+      "ULED\020\002\022\014\n\010FINISHED\020\003\022\n\n\006FAILED\020\004\022\n\n\006KILL" +
+      "ED\020\0052\217\023\n\rMlflowService\022\234\001\n\020createExperim" +
+      "ent\022\030.mlflow.CreateExperiment\032!.mlflow.C" +
+      "reateExperiment.Response\"K\202\265\030G\n0\n\004POST\022\"" +
+      "/preview/mlflow/experiments/create\032\004\010\002\020\000" +
+      "\020\001*\021Create Experiment\022\225\001\n\017listExperiment" +
+      "s\022\027.mlflow.ListExperiments\032 .mlflow.List" +
+      "Experiments.Response\"G\202\265\030C\n-\n\003GET\022 /prev" +
+      "iew/mlflow/experiments/list\032\004\010\002\020\000\020\001*\020Lis" +
+      "t Experiments\022\214\001\n\rgetExperiment\022\025.mlflow" +
+      ".GetExperiment\032\036.mlflow.GetExperiment.Re" +
+      "sponse\"D\202\265\030@\n,\n\003GET\022\037/preview/mlflow/exp" +
+      "eriments/get\032\004\010\002\020\000\020\001*\016Get Experiment\022\234\001\n" +
+      "\020deleteExperiment\022\030.mlflow.DeleteExperim" +
+      "ent\032!.mlflow.DeleteExperiment.Response\"K" +
+      "\202\265\030G\n0\n\004POST\022\"/preview/mlflow/experiment" +
+      "s/delete\032\004\010\002\020\000\020\001*\021Delete Experiment\022\241\001\n\021" +
+      "restoreExperiment\022\031.mlflow.RestoreExperi" +
+      "ment\032\".mlflow.RestoreExperiment.Response" +
+      "\"M\202\265\030I\n1\n\004POST\022#/preview/mlflow/experime" +
+      "nts/restore\032\004\010\002\020\000\020\001*\022Restore Experiment\022" +
+      "y\n\tcreateRun\022\021.mlflow.CreateRun\032\032.mlflow" +
+      ".CreateRun.Response\"=\202\265\0309\n)\n\004POST\022\033/prev" +
+      "iew/mlflow/runs/create\032\004\010\002\020\000\020\001*\nCreate R" +
+      "un\022y\n\tupdateRun\022\021.mlflow.UpdateRun\032\032.mlf" +
+      "low.UpdateRun.Response\"=\202\265\0309\n)\n\004POST\022\033/p" +
+      "review/mlflow/runs/update\032\004\010\002\020\000\020\001*\nUpdat" +
+      "e Run\022m\n\tdeleteRun\022\021.mlflow.DeleteRun\032\032." +
+      "mlflow.DeleteRun.Response\"1\202\265\030-\n)\n\004POST\022" +
+      "\033/preview/mlflow/runs/delete\032\004\010\002\020\000\020\001\022q\n\n" +
+      "restoreRun\022\022.mlflow.RestoreRun\032\033.mlflow." +
+      "RestoreRun.Response\"2\202\265\030.\n*\n\004POST\022\034/prev" +
+      "iew/mlflow/runs/restore\032\004\010\002\020\000\020\001\022}\n\tlogMe" +
+      "tric\022\021.mlflow.LogMetric\032\032.mlflow.LogMetr" +
+      "ic.Response\"A\202\265\030=\n-\n\004POST\022\037/preview/mlfl" +
+      "ow/runs/log-metric\032\004\010\002\020\000\020\001*\nLog Metric\022|" +
+      "\n\010logParam\022\020.mlflow.LogParam\032\031.mlflow.Lo" +
+      "gParam.Response\"C\202\265\030?\n0\n\004POST\022\"/preview/" +
+      "mlflow/runs/log-parameter\032\004\010\002\020\000\020\001*\tLog P" +
+      "aram\022n\n\006setTag\022\016.mlflow.SetTag\032\027.mlflow." +
+      "SetTag.Response\";\202\265\0307\n*\n\004POST\022\034/preview/" +
+      "mlflow/runs/set-tag\032\004\010\002\020\000\020\001*\007Set Tag\022i\n\006" +
+      "getRun\022\016.mlflow.GetRun\032\027.mlflow.GetRun.R" +
+      "esponse\"6\202\265\0302\n%\n\003GET\022\030/preview/mlflow/ru" +
+      "ns/get\032\004\010\002\020\000\020\001*\007Get Run\022x\n\tgetMetric\022\021.m" +
+      "lflow.GetMetric\032\032.mlflow.GetMetric.Respo" +
+      "nse\"<\202\265\0308\n(\n\003GET\022\033/preview/mlflow/metric" +
+      "s/get\032\004\010\002\020\000\020\001*\nGet Metric\022s\n\010getParam\022\020." +
+      "mlflow.GetParam\032\031.mlflow.GetParam.Respon" +
+      "se\":\202\265\0306\n\'\n\003GET\022\032/preview/mlflow/params/" +
+      "get\032\004\010\002\020\000\020\001*\tGet Param\022\247\001\n\nsearchRuns\022\022." +
+      "mlflow.SearchRuns\032\033.mlflow.SearchRuns.Re" +
+      "sponse\"h\202\265\030d\n)\n\004POST\022\033/preview/mlflow/ru" +
+      "ns/search\032\004\010\002\020\000\n(\n\003GET\022\033/preview/mlflow/" +
+      "runs/search\032\004\010\002\020\000\020\001*\013Search Runs\022\213\001\n\rlis" +
+      "tArtifacts\022\025.mlflow.ListArtifacts\032\036.mlfl" +
+      "ow.ListArtifacts.Response\"C\202\265\030?\n+\n\003GET\022\036" +
+      "/preview/mlflow/artifacts/list\032\004\010\002\020\000\020\001*\016" +
+      "List Artifacts\022\235\001\n\020getMetricHistory\022\030.ml" +
+      "flow.GetMetricHistory\032!.mlflow.GetMetric" +
+      "History.Response\"L\202\265\030H\n0\n\003GET\022#/preview/" +
+      "mlflow/metrics/get-history\032\004\010\002\020\000\020\001*\022Get " +
+      "Metric HistoryB\036\n\024org.mlflow.api.proto\220\001" +
+      "\001\342?\002\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -45204,7 +46269,7 @@ public final class Service {
     internal_static_mlflow_MetricSearchExpression_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_MetricSearchExpression_descriptor,
-        new java.lang.String[] { "Key", "Float", "Clause", });
+        new java.lang.String[] { "Key", "Float", "Double", "Clause", });
     internal_static_mlflow_ParameterSearchExpression_descriptor =
       getDescriptor().getMessageTypes().get(24);
     internal_static_mlflow_ParameterSearchExpression_fieldAccessorTable = new
@@ -45223,8 +46288,14 @@ public final class Service {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_FloatClause_descriptor,
         new java.lang.String[] { "Comparator", "Value", });
-    internal_static_mlflow_SearchRuns_descriptor =
+    internal_static_mlflow_DoubleClause_descriptor =
       getDescriptor().getMessageTypes().get(27);
+    internal_static_mlflow_DoubleClause_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_DoubleClause_descriptor,
+        new java.lang.String[] { "Comparator", "Value", });
+    internal_static_mlflow_SearchRuns_descriptor =
+      getDescriptor().getMessageTypes().get(28);
     internal_static_mlflow_SearchRuns_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_SearchRuns_descriptor,
@@ -45236,7 +46307,7 @@ public final class Service {
         internal_static_mlflow_SearchRuns_Response_descriptor,
         new java.lang.String[] { "Runs", });
     internal_static_mlflow_ListArtifacts_descriptor =
-      getDescriptor().getMessageTypes().get(28);
+      getDescriptor().getMessageTypes().get(29);
     internal_static_mlflow_ListArtifacts_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_ListArtifacts_descriptor,
@@ -45248,13 +46319,13 @@ public final class Service {
         internal_static_mlflow_ListArtifacts_Response_descriptor,
         new java.lang.String[] { "RootUri", "Files", });
     internal_static_mlflow_FileInfo_descriptor =
-      getDescriptor().getMessageTypes().get(29);
+      getDescriptor().getMessageTypes().get(30);
     internal_static_mlflow_FileInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_FileInfo_descriptor,
         new java.lang.String[] { "Path", "IsDir", "FileSize", });
     internal_static_mlflow_GetArtifact_descriptor =
-      getDescriptor().getMessageTypes().get(30);
+      getDescriptor().getMessageTypes().get(31);
     internal_static_mlflow_GetArtifact_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetArtifact_descriptor,
@@ -45266,7 +46337,7 @@ public final class Service {
         internal_static_mlflow_GetArtifact_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_GetMetricHistory_descriptor =
-      getDescriptor().getMessageTypes().get(31);
+      getDescriptor().getMessageTypes().get(32);
     internal_static_mlflow_GetMetricHistory_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetMetricHistory_descriptor,

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -161,7 +161,7 @@ public class MlflowClient {
    * Logs a new metric against the given run, as a key-value pair.
    * New values for the same metric may be recorded over time, and are marked with a timestamp.
    * */
-  public void logMetric(String runUuid, String key, float value) {
+  public void logMetric(String runUuid, String key, double value) {
     sendPost("runs/log-metric", mapper.makeLogMetric(runUuid, key, value,
       System.currentTimeMillis()));
   }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
@@ -22,7 +22,7 @@ class MlflowProtobufMapper {
     return print(builder);
   }
 
-  String makeLogMetric(String runUuid, String key, float value, long timestamp) {
+  String makeLogMetric(String runUuid, String key, double value, long timestamp) {
     LogMetric.Builder builder = LogMetric.newBuilder();
     builder.setRunUuid(runUuid);
     builder.setKey(key);

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -21,8 +21,9 @@ import static org.mlflow.tracking.TestUtils.*;
 public class MlflowClientTest {
   private static final Logger logger = LoggerFactory.getLogger(MlflowClientTest.class);
 
-  private static float ACCURACY_SCORE = 0.9733333333333334F;
-  private static float ZERO_ONE_LOSS = 0.026666666666666616F;
+  private static double ACCURACY_SCORE = 0.9733333333333334D;
+  // NB: This can only be represented as a double (not float)
+  private static double ZERO_ONE_LOSS = 123.456789123456789D;
   private static String MIN_SAMPLES_LEAF = "2";
   private static String MAX_DEPTH = "3";
   private static String USER_EMAIL = "some@email.com";

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
@@ -8,9 +8,9 @@ import org.mlflow.api.proto.Service.*;
 
 public class TestUtils {
 
-  final static float EPSILON = 0.0001F;
+  final static double EPSILON = 0.0001F;
 
-  static boolean equals(float a, float b) {
+  static boolean equals(double a, double b) {
     return a == b ? true : Math.abs(a - b) < EPSILON;
   }
 
@@ -24,7 +24,7 @@ public class TestUtils {
     Assert.assertTrue(params.stream().filter(e -> e.getKey().equals(key) && e.getValue().equals(value)).findFirst().isPresent());
   }
 
-  public static void assertMetric(List<Metric> metrics, String key, float value) {
+  public static void assertMetric(List<Metric> metrics, String key, double value) {
     Assert.assertTrue(metrics.stream().filter(e -> e.getKey().equals(key) && equals(e.getValue(), value)).findFirst().isPresent());
   }
 

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -349,7 +349,7 @@ message Metric {
   optional string key = 1;
 
   // Value associated with this metric.
-  optional float value = 2;
+  optional double value = 2;
 
   // The timestamp at which this metric was recorded.
   optional int64 timestamp = 3;
@@ -446,6 +446,7 @@ message Experiment {
   optional string artifact_location = 3;
 
   // Current life cycle stage of the experiment: "active" or "deleted".
+  // Deleted experiments are not returned by APIs.
   optional string lifecycle_stage = 4;
 
   // Last update time
@@ -512,8 +513,21 @@ message DeleteExperiment {
 message RestoreExperiment {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
+  // Identifier to get an experiment
+  optional int64 experiment_id = 1 [(validate_required) = true];
+
+  message Response {
+  }
+}
+
+message UpdateExperiment {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
   // ID of the associated experiment.
   optional int64 experiment_id = 1 [(validate_required) = true];
+
+  // If provided, the experiment's name will be changed to this. The new name must be unique.
+  optional string new_name = 2;
 
   message Response {
   }
@@ -603,8 +617,8 @@ message LogMetric {
   // Name of the metric.
   optional string key = 2 [(validate_required) = true];
 
-  // Float value of the metric being logged.
-  optional float value = 3 [(validate_required) = true];
+  // Double value of the metric being logged.
+  optional double value = 3 [(validate_required) = true];
 
   // Unix timestamp in milliseconds at the time metric was logged.
   optional int64 timestamp = 4 [(validate_required) = true];
@@ -702,8 +716,12 @@ message MetricSearchExpression {
   optional string key = 1;
 
   oneof clause {
-    // Float clause for comparison.
+    // [Deprecated in 0.7.0, to be removed in future version] 
+    // Float clause for comparison. Use 'double' instead.
     FloatClause float = 2;
+
+    // Double clause of comparison
+    DoubleClause double = 3;
   }
 }
 
@@ -731,6 +749,14 @@ message FloatClause {
 
   // Float value for comparison.
   optional float value = 2;
+}
+
+message DoubleClause {
+  // OneOf (">", ">=", "==", "!=", "<=", "<")
+  optional string comparator = 1;
+
+  // Float value for comparison.
+  optional double value = 2;
 }
 
 message SearchRuns {

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -513,21 +513,8 @@ message DeleteExperiment {
 message RestoreExperiment {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
-  // Identifier to get an experiment
-  optional int64 experiment_id = 1 [(validate_required) = true];
-
-  message Response {
-  }
-}
-
-message UpdateExperiment {
-  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
-
   // ID of the associated experiment.
   optional int64 experiment_id = 1 [(validate_required) = true];
-
-  // If provided, the experiment's name will be changed to this. The new name must be unique.
-  optional string new_name = 2;
 
   message Response {
   }

--- a/mlflow/protos/service_pb2.py
+++ b/mlflow/protos/service_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\024org.mlflow.api.proto\220\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"7\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xb9\x02\n\x07RunInfo\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\x03\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x16\n\x0esource_version\x18\n \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x0b \x01(\t\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\x96\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x01\n\x0fListExperiments\x12#\n\tview_type\x18\x01 \x01(\x0e\x32\x10.mlflow.ViewType\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1aQ\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12\x1d\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xd1\x02\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x10\n\x08run_name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x06 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x16\n\x0esource_version\x18\x08 \x01(\t\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x12\x15\n\rparent_run_id\x18\n \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb4\x01\n\tUpdateRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9d\x01\n\tLogMetric\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\x02\x42\x04\x88\xb5\x18\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x83\x01\n\x08LogParam\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x81\x01\n\x06SetTag\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"s\n\x06GetRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\tGetMetric\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a*\n\x08Response\x12\x1e\n\x06metric\x18\x01 \x01(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x97\x01\n\x08GetParam\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nparam_name\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a,\n\x08Response\x12 \n\tparameter\x18\x01 \x01(\x0b\x32\r.mlflow.Param:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8a\x01\n\x10SearchExpression\x12\x30\n\x06metric\x18\x01 \x01(\x0b\x32\x1e.mlflow.MetricSearchExpressionH\x00\x12\x36\n\tparameter\x18\x02 \x01(\x0b\x32!.mlflow.ParameterSearchExpressionH\x00\x42\x0c\n\nexpression\"U\n\x16MetricSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05\x66loat\x18\x02 \x01(\x0b\x32\x13.mlflow.FloatClauseH\x00\x42\x08\n\x06\x63lause\"Z\n\x19ParameterSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x06string\x18\x02 \x01(\x0b\x32\x14.mlflow.StringClauseH\x00\x42\x08\n\x06\x63lause\"1\n\x0cStringClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x0b\x46loatClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02\"\xe3\x01\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\x03\x12\x33\n\x11\x61nded_expressions\x18\x02 \x03(\x0b\x32\x18.mlflow.SearchExpression\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x1a%\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9b\x01\n\rListArtifacts\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"f\n\x0bGetArtifact\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9e\x01\n\x10GetMetricHistory\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\x8f\x13\n\rMlflowService\x12\x9c\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"K\x82\xb5\x18G\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\x95\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"G\x82\xb5\x18\x43\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\x8c\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"D\x82\xb5\x18@\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\x9c\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"K\x82\xb5\x18G\n0\n\x04POST\x12\"/preview/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\xa1\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"M\x82\xb5\x18I\n1\n\x04POST\x12#/preview/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12y\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"=\x82\xb5\x18\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12y\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"=\x82\xb5\x18\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12m\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"1\x82\xb5\x18-\n)\n\x04POST\x12\x1b/preview/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01\x12q\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"2\x82\xb5\x18.\n*\n\x04POST\x12\x1c/preview/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01\x12}\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"A\x82\xb5\x18=\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12|\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"C\x82\xb5\x18?\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12n\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\";\x82\xb5\x18\x37\n*\n\x04POST\x12\x1c/preview/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12i\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"6\x82\xb5\x18\x32\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12x\n\tgetMetric\x12\x11.mlflow.GetMetric\x1a\x1a.mlflow.GetMetric.Response\"<\x82\xb5\x18\x38\n(\n\x03GET\x12\x1b/preview/mlflow/metrics/get\x1a\x04\x08\x02\x10\x00\x10\x01*\nGet Metric\x12s\n\x08getParam\x12\x10.mlflow.GetParam\x1a\x19.mlflow.GetParam.Response\":\x82\xb5\x18\x36\n\'\n\x03GET\x12\x1a/preview/mlflow/params/get\x1a\x04\x08\x02\x10\x00\x10\x01*\tGet Param\x12\xa7\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"h\x82\xb5\x18\x64\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\x8b\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"C\x82\xb5\x18?\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\x9d\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"L\x82\xb5\x18H\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric HistoryB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"7\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xb9\x02\n\x07RunInfo\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\x03\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x16\n\x0esource_version\x18\n \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x0b \x01(\t\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\x96\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x01\n\x0fListExperiments\x12#\n\tview_type\x18\x01 \x01(\x0e\x32\x10.mlflow.ViewType\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1aQ\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12\x1d\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xd1\x02\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\x03\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x10\n\x08run_name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x06 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x16\n\x0esource_version\x18\x08 \x01(\t\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x12\x15\n\rparent_run_id\x18\n \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb4\x01\n\tUpdateRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9d\x01\n\tLogMetric\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\x88\xb5\x18\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x83\x01\n\x08LogParam\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x81\x01\n\x06SetTag\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"s\n\x06GetRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\tGetMetric\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a*\n\x08Response\x12\x1e\n\x06metric\x18\x01 \x01(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x97\x01\n\x08GetParam\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nparam_name\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a,\n\x08Response\x12 \n\tparameter\x18\x01 \x01(\x0b\x32\r.mlflow.Param:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8a\x01\n\x10SearchExpression\x12\x30\n\x06metric\x18\x01 \x01(\x0b\x32\x1e.mlflow.MetricSearchExpressionH\x00\x12\x36\n\tparameter\x18\x02 \x01(\x0b\x32!.mlflow.ParameterSearchExpressionH\x00\x42\x0c\n\nexpression\"}\n\x16MetricSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05\x66loat\x18\x02 \x01(\x0b\x32\x13.mlflow.FloatClauseH\x00\x12&\n\x06\x64ouble\x18\x03 \x01(\x0b\x32\x14.mlflow.DoubleClauseH\x00\x42\x08\n\x06\x63lause\"Z\n\x19ParameterSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x06string\x18\x02 \x01(\x0b\x32\x14.mlflow.StringClauseH\x00\x42\x08\n\x06\x63lause\"1\n\x0cStringClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x0b\x46loatClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02\"1\n\x0c\x44oubleClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\"\xe3\x01\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\x03\x12\x33\n\x11\x61nded_expressions\x18\x02 \x03(\x0b\x32\x18.mlflow.SearchExpression\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x1a%\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9b\x01\n\rListArtifacts\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"f\n\x0bGetArtifact\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9e\x01\n\x10GetMetricHistory\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\x8f\x13\n\rMlflowService\x12\x9c\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"K\x82\xb5\x18G\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\x95\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"G\x82\xb5\x18\x43\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\x8c\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"D\x82\xb5\x18@\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\x9c\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"K\x82\xb5\x18G\n0\n\x04POST\x12\"/preview/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\xa1\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"M\x82\xb5\x18I\n1\n\x04POST\x12#/preview/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12y\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"=\x82\xb5\x18\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12y\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"=\x82\xb5\x18\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12m\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"1\x82\xb5\x18-\n)\n\x04POST\x12\x1b/preview/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01\x12q\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"2\x82\xb5\x18.\n*\n\x04POST\x12\x1c/preview/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01\x12}\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"A\x82\xb5\x18=\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12|\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"C\x82\xb5\x18?\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12n\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\";\x82\xb5\x18\x37\n*\n\x04POST\x12\x1c/preview/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12i\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"6\x82\xb5\x18\x32\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12x\n\tgetMetric\x12\x11.mlflow.GetMetric\x1a\x1a.mlflow.GetMetric.Response\"<\x82\xb5\x18\x38\n(\n\x03GET\x12\x1b/preview/mlflow/metrics/get\x1a\x04\x08\x02\x10\x00\x10\x01*\nGet Metric\x12s\n\x08getParam\x12\x10.mlflow.GetParam\x1a\x19.mlflow.GetParam.Response\":\x82\xb5\x18\x36\n\'\n\x03GET\x12\x1a/preview/mlflow/params/get\x1a\x04\x08\x02\x10\x00\x10\x01*\tGet Param\x12\xa7\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"h\x82\xb5\x18\x64\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\x8b\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"C\x82\xb5\x18?\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\x9d\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"L\x82\xb5\x18H\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric HistoryB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -49,8 +49,8 @@ _VIEWTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4225,
-  serialized_end=4279,
+  serialized_start=4316,
+  serialized_end=4370,
 )
 _sym_db.RegisterEnumDescriptor(_VIEWTYPE)
 
@@ -84,8 +84,8 @@ _SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4281,
-  serialized_end=4354,
+  serialized_start=4372,
+  serialized_end=4445,
 )
 _sym_db.RegisterEnumDescriptor(_SOURCETYPE)
 
@@ -119,8 +119,8 @@ _RUNSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4356,
-  serialized_end=4433,
+  serialized_start=4447,
+  serialized_end=4524,
 )
 _sym_db.RegisterEnumDescriptor(_RUNSTATUS)
 
@@ -157,7 +157,7 @@ _METRIC = _descriptor.Descriptor(
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='mlflow.Metric.value', index=1,
-      number=2, type=2, cpp_type=6, label=1,
+      number=2, type=1, cpp_type=5, label=1,
       has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -1184,7 +1184,7 @@ _LOGMETRIC = _descriptor.Descriptor(
       serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
       name='value', full_name='mlflow.LogMetric.value', index=2,
-      number=3, type=2, cpp_type=6, label=1,
+      number=3, type=1, cpp_type=5, label=1,
       has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
@@ -1608,6 +1608,13 @@ _METRICSEARCHEXPRESSION = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='double', full_name='mlflow.MetricSearchExpression.double', index=2,
+      number=3, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -1624,7 +1631,7 @@ _METRICSEARCHEXPRESSION = _descriptor.Descriptor(
       index=0, containing_type=None, fields=[]),
   ],
   serialized_start=3231,
-  serialized_end=3316,
+  serialized_end=3356,
 )
 
 
@@ -1664,8 +1671,8 @@ _PARAMETERSEARCHEXPRESSION = _descriptor.Descriptor(
       name='clause', full_name='mlflow.ParameterSearchExpression.clause',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=3318,
-  serialized_end=3408,
+  serialized_start=3358,
+  serialized_end=3448,
 )
 
 
@@ -1702,8 +1709,8 @@ _STRINGCLAUSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3410,
-  serialized_end=3459,
+  serialized_start=3450,
+  serialized_end=3499,
 )
 
 
@@ -1740,8 +1747,46 @@ _FLOATCLAUSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3461,
-  serialized_end=3509,
+  serialized_start=3501,
+  serialized_end=3549,
+)
+
+
+_DOUBLECLAUSE = _descriptor.Descriptor(
+  name='DoubleClause',
+  full_name='mlflow.DoubleClause',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='comparator', full_name='mlflow.DoubleClause.comparator', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='mlflow.DoubleClause.value', index=1,
+      number=2, type=1, cpp_type=5, label=1,
+      has_default_value=False, default_value=float(0),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto2',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3551,
+  serialized_end=3600,
 )
 
 
@@ -1771,8 +1816,8 @@ _SEARCHRUNS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3657,
-  serialized_end=3694,
+  serialized_start=3748,
+  serialized_end=3785,
 )
 
 _SEARCHRUNS = _descriptor.Descriptor(
@@ -1815,8 +1860,8 @@ _SEARCHRUNS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3512,
-  serialized_end=3739,
+  serialized_start=3603,
+  serialized_end=3830,
 )
 
 
@@ -1853,8 +1898,8 @@ _LISTARTIFACTS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3791,
-  serialized_end=3852,
+  serialized_start=3882,
+  serialized_end=3943,
 )
 
 _LISTARTIFACTS = _descriptor.Descriptor(
@@ -1890,8 +1935,8 @@ _LISTARTIFACTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3742,
-  serialized_end=3897,
+  serialized_start=3833,
+  serialized_end=3988,
 )
 
 
@@ -1935,8 +1980,8 @@ _FILEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3899,
-  serialized_end=3958,
+  serialized_start=3990,
+  serialized_end=4049,
 )
 
 
@@ -1996,8 +2041,8 @@ _GETARTIFACT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3960,
-  serialized_end=4062,
+  serialized_start=4051,
+  serialized_end=4153,
 )
 
 
@@ -2027,8 +2072,8 @@ _GETMETRICHISTORY_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4135,
-  serialized_end=4178,
+  serialized_start=4226,
+  serialized_end=4269,
 )
 
 _GETMETRICHISTORY = _descriptor.Descriptor(
@@ -2064,8 +2109,8 @@ _GETMETRICHISTORY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4065,
-  serialized_end=4223,
+  serialized_start=4156,
+  serialized_end=4314,
 )
 
 _RUN.fields_by_name['info'].message_type = _RUNINFO
@@ -2111,9 +2156,13 @@ _SEARCHEXPRESSION.oneofs_by_name['expression'].fields.append(
   _SEARCHEXPRESSION.fields_by_name['parameter'])
 _SEARCHEXPRESSION.fields_by_name['parameter'].containing_oneof = _SEARCHEXPRESSION.oneofs_by_name['expression']
 _METRICSEARCHEXPRESSION.fields_by_name['float'].message_type = _FLOATCLAUSE
+_METRICSEARCHEXPRESSION.fields_by_name['double'].message_type = _DOUBLECLAUSE
 _METRICSEARCHEXPRESSION.oneofs_by_name['clause'].fields.append(
   _METRICSEARCHEXPRESSION.fields_by_name['float'])
 _METRICSEARCHEXPRESSION.fields_by_name['float'].containing_oneof = _METRICSEARCHEXPRESSION.oneofs_by_name['clause']
+_METRICSEARCHEXPRESSION.oneofs_by_name['clause'].fields.append(
+  _METRICSEARCHEXPRESSION.fields_by_name['double'])
+_METRICSEARCHEXPRESSION.fields_by_name['double'].containing_oneof = _METRICSEARCHEXPRESSION.oneofs_by_name['clause']
 _PARAMETERSEARCHEXPRESSION.fields_by_name['string'].message_type = _STRINGCLAUSE
 _PARAMETERSEARCHEXPRESSION.oneofs_by_name['clause'].fields.append(
   _PARAMETERSEARCHEXPRESSION.fields_by_name['string'])
@@ -2154,6 +2203,7 @@ DESCRIPTOR.message_types_by_name['MetricSearchExpression'] = _METRICSEARCHEXPRES
 DESCRIPTOR.message_types_by_name['ParameterSearchExpression'] = _PARAMETERSEARCHEXPRESSION
 DESCRIPTOR.message_types_by_name['StringClause'] = _STRINGCLAUSE
 DESCRIPTOR.message_types_by_name['FloatClause'] = _FLOATCLAUSE
+DESCRIPTOR.message_types_by_name['DoubleClause'] = _DOUBLECLAUSE
 DESCRIPTOR.message_types_by_name['SearchRuns'] = _SEARCHRUNS
 DESCRIPTOR.message_types_by_name['ListArtifacts'] = _LISTARTIFACTS
 DESCRIPTOR.message_types_by_name['FileInfo'] = _FILEINFO
@@ -2473,6 +2523,13 @@ FloatClause = _reflection.GeneratedProtocolMessageType('FloatClause', (_message.
   ))
 _sym_db.RegisterMessage(FloatClause)
 
+DoubleClause = _reflection.GeneratedProtocolMessageType('DoubleClause', (_message.Message,), dict(
+  DESCRIPTOR = _DOUBLECLAUSE,
+  __module__ = 'service_pb2'
+  # @@protoc_insertion_point(class_scope:mlflow.DoubleClause)
+  ))
+_sym_db.RegisterMessage(DoubleClause)
+
 SearchRuns = _reflection.GeneratedProtocolMessageType('SearchRuns', (_message.Message,), dict(
 
   Response = _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), dict(
@@ -2592,8 +2649,8 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=4436,
-  serialized_end=6883,
+  serialized_start=4527,
+  serialized_end=6974,
   methods=[
   _descriptor.MethodDescriptor(
     name='createExperiment',

--- a/mlflow/server/js/src/utils/SearchUtils.js
+++ b/mlflow/server/js/src/utils/SearchUtils.js
@@ -19,7 +19,7 @@ class Private {
       return {
         metric: {
           key: metricMatches[1],
-          float: {
+          double: {
             comparator: metricMatches[2],
             value: parseFloat(metricMatches[3]),
           }

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -2,8 +2,15 @@ def does_run_match_clause(run, search_expression):
     key_type = search_expression.WhichOneof('expression')
     if key_type == 'metric':
         key = search_expression.metric.key
-        comparator = search_expression.metric.float.comparator
-        value = search_expression.metric.float.value
+        metric_type = search_expression.metric.WhichOneof('clause')
+        if metric_type == 'float':
+            comparator = search_expression.metric.float.comparator
+            value = search_expression.metric.float.value
+        elif metric_type == 'double':
+            comparator = search_expression.metric.double.comparator
+            value = search_expression.metric.double.value
+        else:
+            raise Exception("Invalid metric type: '%s', expected float or double")
         metric = next((m for m in run.data.metrics if m.key == key), None)
         if metric is None:
             return False


### PR DESCRIPTION
Not a huge change, and Python anyway can't handle the full double precision, but it makes the API a little easier to use from Java. I tested backwards and forwards compatibility of the various components (i.e., old and new Java and Python clients against a new server).