### PR TITLE
Fix bug in "Clear" search button in experiment view

### DIFF
--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -450,7 +450,8 @@ class ExperimentView extends Component {
     const paramKeyFilter = new KeyFilter();
     const metricKeyFilter = new KeyFilter();
     const andedExpressions = [];
-    this.props.onSearch(paramKeyFilter, metricKeyFilter, andedExpressions, "");
+    this.props.onSearch(paramKeyFilter, metricKeyFilter, andedExpressions, "",
+      LIFECYCLE_FILTER.ACTIVE);
   }
 
   onCompare() {


### PR DESCRIPTION
Currently, we don't pass a lifecycle filter to the `onSearch` handler function when the "Clear" button is pressed to clear search filters in the experiment view, which causes the search page to misbehave (the ExperimentView renders with an `undefined` lifecycle filter, which leads to only deleted runs being displayed).