### PR TITLE
Docker Image of MLFLow Tracking Server

### DIFF
--- a/tests/tracking/Docker/.dockerignore
+++ b/tests/tracking/Docker/.dockerignore
@@ -1,0 +1,5 @@
+*
+!Dockerfile
+!files/run.sh
+!.travis/docker_push.sh
+!.travis.yml

--- a/tests/tracking/Docker/Dockerfile
+++ b/tests/tracking/Docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.7.0
+
+LABEL maintainer "Florian Muchow <flmuchow@gmail.com>"
+
+RUN pip install mlflow
+
+ENV PORT 5000
+
+COPY files/run.sh /
+
+ENTRYPOINT ["/run.sh"]

--- a/tests/tracking/Docker/README.md
+++ b/tests/tracking/Docker/README.md
@@ -1,0 +1,35 @@
+# Docker Image of MLFLow Tracking Server
+
+This subfolder provides a docker image of [MLFLow Tracking Server](https://www.mlflow.org/docs/latest/tracking.html) based on a simple file system (=storage model) for [files and artifacts](https://www.mlflow.org/docs/latest/tracking.html#storage).
+
+## Run
+
+```bash
+$ docker build -t mlflow-tracking-server .
+```
+
+```bash
+$ docker run \
+    --rm \
+    --name mlflow-tracking-server \
+    -p 5000:5000 \
+    -e PORT=5000 \
+    -e FILE_DIR=/mlflow \
+    mlflow-tracking-server
+```
+
+Access to http://127.0.0.1:5000
+
+## Environment variables
+
+### Required
+
+|Key|Description|
+|---|---|
+|`FILE_DIR`|Directory for artifacts and metadata (e.g. parameters, metrics)|
+
+### Optional
+
+|Key|Description|Default|
+|---|---|---|
+|`PORT`|Value for `listen` directive|`5000`|

--- a/tests/tracking/Docker/files/run.sh
+++ b/tests/tracking/Docker/files/run.sh
@@ -9,4 +9,5 @@ fi
 
 mkdir $FILE_DIR && mlflow server \
     --file-store $FILE_DIR \
-    --host 0.0.0.0
+    --host 0.0.0.0 \
+    --port $PORT

--- a/tests/tracking/Docker/files/run.sh
+++ b/tests/tracking/Docker/files/run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+if [ -z $FILE_DIR ]; then
+  echo >&2 "FILE_DIR must be set"
+  exit 1
+fi
+
+mkdir $FILE_DIR && mlflow server \
+    --file-store $FILE_DIR \
+    --host 0.0.0.0


### PR DESCRIPTION
I have created a subfolder to build a docker image for the MLFlow Tracking Server: See corresponding [README](https://github.com/flmu/mlflow/tree/ac1bcc55f411351e5a3dfce400960c0a00b894e2/tests/tracking/Docker).