### PR TITLE
Fix issue with mlflow.start_run(run_uuid=<deleted_run>)

### DIFF
--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -226,6 +226,7 @@ def test_parent_create_run(tracking_uri_mock):
     mlflow.end_run()
     assert mlflow.active_run() is None
 
+
 def test_start_deleted_run():
     run_id = None
     with mlflow.start_run() as active_run:


### PR DESCRIPTION
Small bug-fix for the case where we start a run with a deleted run as the run_uuid. In this case, we need to raise an exception and not allow the client to start the run.