### PR TITLE
Fixes for R API doc generation

### DIFF
--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -213,30 +213,6 @@ specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
 
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
-
 Create Run
 ==========
 
@@ -301,33 +277,6 @@ specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
 
-.. _seealso-1:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
-
 Delete Experiment
 =================
 
@@ -363,32 +312,6 @@ specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
 
-.. _seealso-2:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
-
 Delete a Run
 ============
 
@@ -420,33 +343,6 @@ The Tracking Client family of functions require an MLflow client to be
 specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
-
-.. _seealso-3:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
 
 Download Artifacts
 ==================
@@ -483,31 +379,6 @@ specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
 
-.. _seealso-4:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
-
 Get Experiment by Name
 ======================
 
@@ -539,31 +410,6 @@ The Tracking Client family of functions require an MLflow client to be
 specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
-
-.. _seealso-5:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
 
 Get Experiment
 ==============
@@ -597,31 +443,6 @@ specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
 
-.. _seealso-6:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
-
 Get Run
 =======
 
@@ -654,33 +475,6 @@ The Tracking Client family of functions require an MLflow client to be
 specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
-
-.. _seealso-7:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
 
 List artifacts
 ==============
@@ -718,31 +512,6 @@ specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
 
-.. _seealso-8:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
-
 List Experiments
 ================
 
@@ -777,31 +546,6 @@ The Tracking Client family of functions require an MLflow client to be
 specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
-
-.. _seealso-9:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
 
 Log Artifact
 ============
@@ -848,32 +592,6 @@ Additionally, at least the ``AWS_ACCESS_KEY_ID`` and
 ``AWS_SECRET_ACCESS_KEY`` environment variables must be set to the
 corresponding key and secrets provided by Amazon IAM.
 
-.. _seealso-10:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
-
 Log Metric
 ==========
 
@@ -917,32 +635,6 @@ specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
 
-.. _seealso-11:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
-
 Log Parameter
 =============
 
@@ -982,32 +674,6 @@ specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
 
-.. _seealso-12:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
-
 Restore Experiment
 ==================
 
@@ -1046,32 +712,6 @@ specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
 
-.. _seealso-13:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
-
 Restore a Run
 =============
 
@@ -1103,32 +743,6 @@ The Tracking Client family of functions require an MLflow client to be
 specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
-
-.. _seealso-14:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
 
 Set Tag
 =======
@@ -1170,32 +784,6 @@ specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
 
-.. _seealso-15:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_terminated`` <mlflow_client_set_terminated.html>`__
-
 Terminate a Run
 ===============
 
@@ -1234,32 +822,6 @@ The Tracking Client family of functions require an MLflow client to be
 specified explicitly. These functions allow for greater control of where
 the operations take place in terms of services and runs, but are more
 verbose compared to the Fluent API.
-
-.. _seealso-16:
-
-Seealso
--------
-
-Other Tracking client functions:
-```mlflow_client_create_experiment`` <mlflow_client_create_experiment.html>`__
-, ```mlflow_client_create_run`` <mlflow_client_create_run.html>`__ ,
-```mlflow_client_delete_experiment`` <mlflow_client_delete_experiment.html>`__
-, ```mlflow_client_delete_run`` <mlflow_client_delete_run.html>`__ ,
-```mlflow_client_download_artifacts`` <mlflow_client_download_artifacts.html>`__
-,
-```mlflow_client_get_experiment_by_name`` <mlflow_client_get_experiment_by_name.html>`__
-,
-```mlflow_client_get_experiment`` <mlflow_client_get_experiment.html>`__
-, ```mlflow_client_get_run`` <mlflow_client_get_run.html>`__ ,
-```mlflow_client_list_artifacts`` <mlflow_client_list_artifacts.html>`__
-,
-```mlflow_client_list_experiments`` <mlflow_client_list_experiments.html>`__
-, ```mlflow_client_log_artifact`` <mlflow_client_log_artifact.html>`__ ,
-```mlflow_client_log_metric`` <mlflow_client_log_metric.html>`__ ,
-```mlflow_client_log_param`` <mlflow_client_log_param.html>`__ ,
-```mlflow_client_restore_experiment`` <mlflow_client_restore_experiment.html>`__
-, ```mlflow_client_restore_run`` <mlflow_client_restore_run.html>`__ ,
-```mlflow_client_set_tag`` <mlflow_client_set_tag.html>`__
 
 Initialize an MLflow client
 ===========================
@@ -1319,19 +881,6 @@ determined by the service set by ``mlflow_set_tracking_uri()``. For
 operations involving a run it adopts the current active run, or, if one
 does not exist, starts one through the implied service.
 
-.. _seealso-17:
-
-Seealso
--------
-
-Other Fluent API functions: ```mlflow_end_run`` <mlflow_end_run.html>`__
-, ```mlflow_log_artifact`` <mlflow_log_artifact.html>`__ ,
-```mlflow_log_metric`` <mlflow_log_metric.html>`__ ,
-```mlflow_log_param`` <mlflow_log_param.html>`__ ,
-```mlflow_set_experiment`` <mlflow_set_experiment.html>`__ ,
-```mlflow_set_tag`` <mlflow_set_tag.html>`__ ,
-```mlflow_start_run`` <mlflow_start_run.html>`__
-
 End a Run
 =========
 
@@ -1361,20 +910,6 @@ The fluent API family of functions operate with an implied MLflow client
 determined by the service set by ``mlflow_set_tracking_uri()``. For
 operations involving a run it adopts the current active run, or, if one
 does not exist, starts one through the implied service.
-
-.. _seealso-18:
-
-Seealso
--------
-
-Other Fluent API functions:
-```mlflow_create_experiment`` <mlflow_create_experiment.html>`__ ,
-```mlflow_log_artifact`` <mlflow_log_artifact.html>`__ ,
-```mlflow_log_metric`` <mlflow_log_metric.html>`__ ,
-```mlflow_log_param`` <mlflow_log_param.html>`__ ,
-```mlflow_set_experiment`` <mlflow_set_experiment.html>`__ ,
-```mlflow_set_tag`` <mlflow_set_tag.html>`__ ,
-```mlflow_start_run`` <mlflow_start_run.html>`__
 
 Get Remote Tracking URI
 =======================
@@ -1511,20 +1046,6 @@ Additionally, at least the ``AWS_ACCESS_KEY_ID`` and
 ``AWS_SECRET_ACCESS_KEY`` environment variables must be set to the
 corresponding key and secrets provided by Amazon IAM.
 
-.. _seealso-19:
-
-Seealso
--------
-
-Other Fluent API functions:
-```mlflow_create_experiment`` <mlflow_create_experiment.html>`__ ,
-```mlflow_end_run`` <mlflow_end_run.html>`__ ,
-```mlflow_log_metric`` <mlflow_log_metric.html>`__ ,
-```mlflow_log_param`` <mlflow_log_param.html>`__ ,
-```mlflow_set_experiment`` <mlflow_set_experiment.html>`__ ,
-```mlflow_set_tag`` <mlflow_set_tag.html>`__ ,
-```mlflow_start_run`` <mlflow_start_run.html>`__
-
 .. _log-metric-1:
 
 Log Metric
@@ -1565,20 +1086,6 @@ The fluent API family of functions operate with an implied MLflow client
 determined by the service set by ``mlflow_set_tracking_uri()``. For
 operations involving a run it adopts the current active run, or, if one
 does not exist, starts one through the implied service.
-
-.. _seealso-20:
-
-Seealso
--------
-
-Other Fluent API functions:
-```mlflow_create_experiment`` <mlflow_create_experiment.html>`__ ,
-```mlflow_end_run`` <mlflow_end_run.html>`__ ,
-```mlflow_log_artifact`` <mlflow_log_artifact.html>`__ ,
-```mlflow_log_param`` <mlflow_log_param.html>`__ ,
-```mlflow_set_experiment`` <mlflow_set_experiment.html>`__ ,
-```mlflow_set_tag`` <mlflow_set_tag.html>`__ ,
-```mlflow_start_run`` <mlflow_start_run.html>`__
 
 Log Model
 =========
@@ -1641,20 +1148,6 @@ The fluent API family of functions operate with an implied MLflow client
 determined by the service set by ``mlflow_set_tracking_uri()``. For
 operations involving a run it adopts the current active run, or, if one
 does not exist, starts one through the implied service.
-
-.. _seealso-21:
-
-Seealso
--------
-
-Other Fluent API functions:
-```mlflow_create_experiment`` <mlflow_create_experiment.html>`__ ,
-```mlflow_end_run`` <mlflow_end_run.html>`__ ,
-```mlflow_log_artifact`` <mlflow_log_artifact.html>`__ ,
-```mlflow_log_metric`` <mlflow_log_metric.html>`__ ,
-```mlflow_set_experiment`` <mlflow_set_experiment.html>`__ ,
-```mlflow_set_tag`` <mlflow_set_tag.html>`__ ,
-```mlflow_start_run`` <mlflow_start_run.html>`__
 
 Read Command Line Parameter
 ===========================
@@ -2098,20 +1591,6 @@ determined by the service set by ``mlflow_set_tracking_uri()``. For
 operations involving a run it adopts the current active run, or, if one
 does not exist, starts one through the implied service.
 
-.. _seealso-22:
-
-Seealso
--------
-
-Other Fluent API functions:
-```mlflow_create_experiment`` <mlflow_create_experiment.html>`__ ,
-```mlflow_end_run`` <mlflow_end_run.html>`__ ,
-```mlflow_log_artifact`` <mlflow_log_artifact.html>`__ ,
-```mlflow_log_metric`` <mlflow_log_metric.html>`__ ,
-```mlflow_log_param`` <mlflow_log_param.html>`__ ,
-```mlflow_set_tag`` <mlflow_set_tag.html>`__ ,
-```mlflow_start_run`` <mlflow_start_run.html>`__
-
 .. _set-tag-1:
 
 Set Tag
@@ -2149,20 +1628,6 @@ The fluent API family of functions operate with an implied MLflow client
 determined by the service set by ``mlflow_set_tracking_uri()``. For
 operations involving a run it adopts the current active run, or, if one
 does not exist, starts one through the implied service.
-
-.. _seealso-23:
-
-Seealso
--------
-
-Other Fluent API functions:
-```mlflow_create_experiment`` <mlflow_create_experiment.html>`__ ,
-```mlflow_end_run`` <mlflow_end_run.html>`__ ,
-```mlflow_log_artifact`` <mlflow_log_artifact.html>`__ ,
-```mlflow_log_metric`` <mlflow_log_metric.html>`__ ,
-```mlflow_log_param`` <mlflow_log_param.html>`__ ,
-```mlflow_set_experiment`` <mlflow_set_experiment.html>`__ ,
-```mlflow_start_run`` <mlflow_start_run.html>`__
 
 Set Remote Tracking URI
 =======================
@@ -2275,20 +1740,6 @@ The fluent API family of functions operate with an implied MLflow client
 determined by the service set by ``mlflow_set_tracking_uri()``. For
 operations involving a run it adopts the current active run, or, if one
 does not exist, starts one through the implied service.
-
-.. _seealso-24:
-
-Seealso
--------
-
-Other Fluent API functions:
-```mlflow_create_experiment`` <mlflow_create_experiment.html>`__ ,
-```mlflow_end_run`` <mlflow_end_run.html>`__ ,
-```mlflow_log_artifact`` <mlflow_log_artifact.html>`__ ,
-```mlflow_log_metric`` <mlflow_log_metric.html>`__ ,
-```mlflow_log_param`` <mlflow_log_param.html>`__ ,
-```mlflow_set_experiment`` <mlflow_set_experiment.html>`__ ,
-```mlflow_set_tag`` <mlflow_set_tag.html>`__
 
 .. _examples-5:
 

--- a/mlflow/R/mlflow/man-roxygen/roxlate-client.R
+++ b/mlflow/R/mlflow/man-roxygen/roxlate-client.R
@@ -1,6 +1,5 @@
 #' @param client An `mlflow_client` object.
 #' @keywords internal
-#' @family Tracking client functions
 #' @details The Tracking Client family of functions require an MLflow client to be
 #'   specified explicitly. These functions allow for greater control of where the
 #'   operations take place in terms of services and runs, but are more verbose

--- a/mlflow/R/mlflow/man-roxygen/roxlate-fluent.R
+++ b/mlflow/R/mlflow/man-roxygen/roxlate-fluent.R
@@ -2,4 +2,3 @@
 #'   determined by the service set by `mlflow_set_tracking_uri()`. For operations
 #'   involving a run it adopts the current active run, or, if one does not exist,
 #'   starts one through the implied service.
-#' @family Fluent API functions

--- a/mlflow/R/mlflow/man/mlflow_client_create_experiment.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_create_experiment.Rd
@@ -23,23 +23,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_create_run.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_create_run.Rd
@@ -41,23 +41,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_delete_experiment.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_delete_experiment.Rd
@@ -21,23 +21,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_delete_run.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_delete_run.Rd
@@ -20,23 +20,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_download_artifacts.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_download_artifacts.Rd
@@ -23,23 +23,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_get_experiment.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_get_experiment.Rd
@@ -20,23 +20,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_get_experiment_by_name.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_get_experiment_by_name.Rd
@@ -20,23 +20,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_get_run.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_get_run.Rd
@@ -20,23 +20,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_list_artifacts.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_list_artifacts.Rd
@@ -23,23 +23,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_list_experiments.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_list_experiments.Rd
@@ -21,23 +21,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_log_artifact.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_log_artifact.Rd
@@ -53,23 +53,4 @@ Additionally, at least the \code{AWS_ACCESS_KEY_ID} and \code{AWS_SECRET_ACCESS_
 environment variables must be set to the corresponding key and secrets provided
 by Amazon IAM.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_log_metric.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_log_metric.Rd
@@ -28,23 +28,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_log_param.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_log_param.Rd
@@ -27,23 +27,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_restore_experiment.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_restore_experiment.Rd
@@ -24,23 +24,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_restore_run.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_restore_run.Rd
@@ -20,23 +20,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_set_tag}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_set_tag.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_set_tag.Rd
@@ -25,23 +25,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_terminated}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_client_set_terminated.Rd
+++ b/mlflow/R/mlflow/man/mlflow_client_set_terminated.Rd
@@ -27,23 +27,4 @@ The Tracking Client family of functions require an MLflow client to be
   operations take place in terms of services and runs, but are more verbose
   compared to the Fluent API.
 }
-\seealso{
-Other Tracking client functions: \code{\link{mlflow_client_create_experiment}},
-  \code{\link{mlflow_client_create_run}},
-  \code{\link{mlflow_client_delete_experiment}},
-  \code{\link{mlflow_client_delete_run}},
-  \code{\link{mlflow_client_download_artifacts}},
-  \code{\link{mlflow_client_get_experiment_by_name}},
-  \code{\link{mlflow_client_get_experiment}},
-  \code{\link{mlflow_client_get_run}},
-  \code{\link{mlflow_client_list_artifacts}},
-  \code{\link{mlflow_client_list_experiments}},
-  \code{\link{mlflow_client_log_artifact}},
-  \code{\link{mlflow_client_log_metric}},
-  \code{\link{mlflow_client_log_param}},
-  \code{\link{mlflow_client_restore_experiment}},
-  \code{\link{mlflow_client_restore_run}},
-  \code{\link{mlflow_client_set_tag}}
-}
-\concept{Tracking client functions}
 \keyword{internal}

--- a/mlflow/R/mlflow/man/mlflow_create_experiment.Rd
+++ b/mlflow/R/mlflow/man/mlflow_create_experiment.Rd
@@ -21,13 +21,3 @@ The fluent API family of functions operate with an implied MLflow client
   involving a run it adopts the current active run, or, if one does not exist,
   starts one through the implied service.
 }
-\seealso{
-Other Fluent API functions: \code{\link{mlflow_end_run}},
-  \code{\link{mlflow_log_artifact}},
-  \code{\link{mlflow_log_metric}},
-  \code{\link{mlflow_log_param}},
-  \code{\link{mlflow_set_experiment}},
-  \code{\link{mlflow_set_tag}},
-  \code{\link{mlflow_start_run}}
-}
-\concept{Fluent API functions}

--- a/mlflow/R/mlflow/man/mlflow_end_run.Rd
+++ b/mlflow/R/mlflow/man/mlflow_end_run.Rd
@@ -18,13 +18,3 @@ The fluent API family of functions operate with an implied MLflow client
   involving a run it adopts the current active run, or, if one does not exist,
   starts one through the implied service.
 }
-\seealso{
-Other Fluent API functions: \code{\link{mlflow_create_experiment}},
-  \code{\link{mlflow_log_artifact}},
-  \code{\link{mlflow_log_metric}},
-  \code{\link{mlflow_log_param}},
-  \code{\link{mlflow_set_experiment}},
-  \code{\link{mlflow_set_tag}},
-  \code{\link{mlflow_start_run}}
-}
-\concept{Fluent API functions}

--- a/mlflow/R/mlflow/man/mlflow_log_artifact.Rd
+++ b/mlflow/R/mlflow/man/mlflow_log_artifact.Rd
@@ -49,13 +49,3 @@ Additionally, at least the \code{AWS_ACCESS_KEY_ID} and \code{AWS_SECRET_ACCESS_
 environment variables must be set to the corresponding key and secrets provided
 by Amazon IAM.
 }
-\seealso{
-Other Fluent API functions: \code{\link{mlflow_create_experiment}},
-  \code{\link{mlflow_end_run}},
-  \code{\link{mlflow_log_metric}},
-  \code{\link{mlflow_log_param}},
-  \code{\link{mlflow_set_experiment}},
-  \code{\link{mlflow_set_tag}},
-  \code{\link{mlflow_start_run}}
-}
-\concept{Fluent API functions}

--- a/mlflow/R/mlflow/man/mlflow_log_metric.Rd
+++ b/mlflow/R/mlflow/man/mlflow_log_metric.Rd
@@ -24,13 +24,3 @@ The fluent API family of functions operate with an implied MLflow client
   involving a run it adopts the current active run, or, if one does not exist,
   starts one through the implied service.
 }
-\seealso{
-Other Fluent API functions: \code{\link{mlflow_create_experiment}},
-  \code{\link{mlflow_end_run}},
-  \code{\link{mlflow_log_artifact}},
-  \code{\link{mlflow_log_param}},
-  \code{\link{mlflow_set_experiment}},
-  \code{\link{mlflow_set_tag}},
-  \code{\link{mlflow_start_run}}
-}
-\concept{Fluent API functions}

--- a/mlflow/R/mlflow/man/mlflow_log_param.Rd
+++ b/mlflow/R/mlflow/man/mlflow_log_param.Rd
@@ -23,13 +23,3 @@ The fluent API family of functions operate with an implied MLflow client
   involving a run it adopts the current active run, or, if one does not exist,
   starts one through the implied service.
 }
-\seealso{
-Other Fluent API functions: \code{\link{mlflow_create_experiment}},
-  \code{\link{mlflow_end_run}},
-  \code{\link{mlflow_log_artifact}},
-  \code{\link{mlflow_log_metric}},
-  \code{\link{mlflow_set_experiment}},
-  \code{\link{mlflow_set_tag}},
-  \code{\link{mlflow_start_run}}
-}
-\concept{Fluent API functions}

--- a/mlflow/R/mlflow/man/mlflow_set_experiment.Rd
+++ b/mlflow/R/mlflow/man/mlflow_set_experiment.Rd
@@ -19,13 +19,3 @@ The fluent API family of functions operate with an implied MLflow client
   involving a run it adopts the current active run, or, if one does not exist,
   starts one through the implied service.
 }
-\seealso{
-Other Fluent API functions: \code{\link{mlflow_create_experiment}},
-  \code{\link{mlflow_end_run}},
-  \code{\link{mlflow_log_artifact}},
-  \code{\link{mlflow_log_metric}},
-  \code{\link{mlflow_log_param}},
-  \code{\link{mlflow_set_tag}},
-  \code{\link{mlflow_start_run}}
-}
-\concept{Fluent API functions}

--- a/mlflow/R/mlflow/man/mlflow_set_tag.Rd
+++ b/mlflow/R/mlflow/man/mlflow_set_tag.Rd
@@ -21,13 +21,3 @@ The fluent API family of functions operate with an implied MLflow client
   involving a run it adopts the current active run, or, if one does not exist,
   starts one through the implied service.
 }
-\seealso{
-Other Fluent API functions: \code{\link{mlflow_create_experiment}},
-  \code{\link{mlflow_end_run}},
-  \code{\link{mlflow_log_artifact}},
-  \code{\link{mlflow_log_metric}},
-  \code{\link{mlflow_log_param}},
-  \code{\link{mlflow_set_experiment}},
-  \code{\link{mlflow_start_run}}
-}
-\concept{Fluent API functions}

--- a/mlflow/R/mlflow/man/mlflow_start_run.Rd
+++ b/mlflow/R/mlflow/man/mlflow_start_run.Rd
@@ -43,13 +43,3 @@ with(mlflow_start_run(), {
 }
 
 }
-\seealso{
-Other Fluent API functions: \code{\link{mlflow_create_experiment}},
-  \code{\link{mlflow_end_run}},
-  \code{\link{mlflow_log_artifact}},
-  \code{\link{mlflow_log_metric}},
-  \code{\link{mlflow_log_param}},
-  \code{\link{mlflow_set_experiment}},
-  \code{\link{mlflow_set_tag}}
-}
-\concept{Fluent API functions}


### PR DESCRIPTION
The R API comes with handy scripts / tooling for autogenerating RST documentation. The process for generating docs looks like (AFAICT):
* Remove the existing mlflow/R/mlflow/man directory (`rm -rf mlflow/R/mlflow/man`)
* Run `Rscript -e "roxygen2::roxygenise()"` to generate .Rd files under `man` with [Roxygen](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd.html)
* Run `Rscript document.R`, which generates a markdown file containing all the R API docs (Reference_Manual_mlflow.md), then converts that file into R-api.rst under the `docs` subdirectory

Currently, the generated RST file looks a bit strange - it contains a number of duplicated "seealso" sections that aren't well-formed RST:
<img width="1280" alt="screen shot 2018-10-01 at 11 39 54 pm" src="https://user-images.githubusercontent.com/2358483/46332968-55059280-c5d3-11e8-8a20-d2c6f856e8f7.png">


This PR updates the roxygen template files, removing the @family annotation that leads to the generation of the "seealso" sections. Based on [the Roxygen docs](https://cran.r-project.org/web/packages/roxygen2/vignettes/rd.html) (cmd+f for "Do repeat yourself"), the seealso sections seem intentional / helpful to R users, so this may not be the best approach - an alternative could be parsing/modifying the generated `Reference_Manual_mlflow.md` file to get rid of the seealso sections. 
