### PR TITLE
Pin Keras version to 2.2.2 to fix tests

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -19,4 +19,5 @@ tensorflow
 torch
 torchvision
 pysftp
-keras
+# TODO: don't pin Keras version once https://github.com/keras-team/keras/issues/11276 is addressed
+keras==2.2.2


### PR DESCRIPTION
Work around https://github.com/keras-team/keras/issues/11269 / https://github.com/keras-team/keras/issues/11276 by pinning Keras to 2.2.2, which will hopefully fix our builds.