### PR TITLE
Try to address potential race condition in nginx log linking during container startup

### DIFF
--- a/mlflow/sagemaker/container/__init__.py
+++ b/mlflow/sagemaker/container/__init__.py
@@ -102,11 +102,11 @@ def _serve_pyfunc(model):
         shutil.copyfile(os.path.join(MODEL_PATH, env), env_path_dst)
         os.system("conda env create -n custom_env -f {}".format(env_path_dst))
         bash_cmds += ["source /miniconda/bin/activate custom_env"] + _server_dependencies_cmds()
-    nginx_conf = resource_filename(mlflow.sagemaker.__name__, "container/scoring_server/nginx.conf")
-    nginx = Popen(['nginx', '-c', nginx_conf])
     # link the log streams to stdout/err so they will be logged to the container logs
     check_call(['ln', '-sf', '/dev/stdout', '/var/log/nginx/access.log'])
     check_call(['ln', '-sf', '/dev/stderr', '/var/log/nginx/error.log'])
+    nginx_conf = resource_filename(mlflow.sagemaker.__name__, "container/scoring_server/nginx.conf")
+    nginx = Popen(['nginx', '-c', nginx_conf])
     cpu_count = multiprocessing.cpu_count()
     os.system("pip -V")
     os.system("python -V")


### PR DESCRIPTION
Occasionally (maybe ~10% of the time), tests exercising the Sagemaker serving container will fail on Travis with an error message like:

```
ln: failed to create symbolic link '/var/log/nginx/error.log': File exists
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/opt/mlflow/mlflow/sagemaker/container/__init__.py", line 46, in _init
    _serve()
  File "/opt/mlflow/mlflow/sagemaker/container/__init__.py", line 85, in _serve
    _serve_pyfunc(m)
  File "/opt/mlflow/mlflow/sagemaker/container/__init__.py", line 109, in _serve_pyfunc
    check_call(['ln', '-sf', '/dev/stderr', '/var/log/nginx/error.log'])
  File "/miniconda/lib/python3.7/subprocess.py", line 328, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['ln', '-sf', '/dev/stderr', '/var/log/nginx/error.log']' returned non-zero exit status 1.!
...
The command "pytest --verbose tests/spark --large" exited with 1.
```

Looking at the [relevant SageMaker container initialization logic](https://github.com/mlflow/mlflow/blob/master/mlflow/sagemaker/container/__init__.py#L106), my best guess is that there's a race condition between Nginx starting and when the successive `ln -sf` calls run. However I'm not sure of this (haven't spent much time trying to repro) & it also seems strange that `ln` would fail despite being given the `-f` flag. It's possible that something is just weird about the environment in which Travis runs. 

Nonetheless, this PR attempts to debug the issue by linking the nginx log files before actually starting nginx, as is done by the [official nginx Dockerfiles](https://github.com/nginxinc/docker-nginx/blob/a22b9f46fe3a586b02d974f64441a4c07215dc5d/stable/alpine/Dockerfile).