### PR TITLE
Disable CRAN install while r is published to CRAN

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -15,7 +15,7 @@ You install MLflow by running:
 
     .. code-block:: R
 
-        install.packages("mlflow")
+        devtools::install_github("mlflow/mlflow", subdir = "mlflow/R/mlflow")
         mlflow_install()
 
 .. note::

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -40,7 +40,7 @@ What You'll Need
       To run this tutorial, you'll need to:
 
        - Install `conda <https://conda.io/docs/user-guide/install/index.html#>`_
-       - Install the MLflow package (via ``install.packages("mlflow")``)
+       - Install the MLflow package (via ``devtools::install_github("mlflow/mlflow", subdir = "mlflow/R/mlflow")``)
        - Install MLflow (via ``mlflow::mlflow_install()``)
        - Clone (download) the MLflow repository via ``git clone https://github.com/mlflow/mlflow``
        - `setwd()` into the directory within your clone of MLflow - we'll use this working
@@ -235,7 +235,7 @@ Comparing the Models
       You can  use the search feature to quickly filter out many models. For example, the query ``metrics.rmse < 0.8``
       returns all the models with root mean squared error less than 0.8. For more complex manipulations,
       you can download this table as a CSV and use your favorite data munging software to analyze it.
-      
+
 Packaging the Training Code
 ---------------------------
 

--- a/mlflow/R/mlflow/README.Rmd
+++ b/mlflow/R/mlflow/README.Rmd
@@ -22,16 +22,16 @@ unlink("mlruns", recursive = T)
 
 ## Installation
 
-Install `mlflow` from CRAN followed by installing the `mlflow` runtime as follows:
+Install `mlflow` followed by installing the `mlflow` runtime as follows:
 
 ```{r eval=FALSE}
-install.packages("mlflow")
+devtools::install_github("mlflow/mlflow", subdir = "mlflow/R/mlflow")
 mlflow::mlflow_install()
 ```
 
 Notice also that [Anaconda](https://www.anaconda.com/download/) or [Miniconda](https://conda.io/miniconda.html) need to be manually installed.
 
-### Developemnt
+### Development
 
 Install the `mlflow` package as follows:
 

--- a/mlflow/R/mlflow/README.md
+++ b/mlflow/R/mlflow/README.md
@@ -13,11 +13,10 @@ Status](https://travis-ci.org/rstudio/mlflow.svg?branch=master)](https://travis-
 
 ## Installation
 
-Install `mlflow` from CRAN followed by installing the `mlflow` runtime
-as follows:
+Install `mlflow` followed by installing the `mlflow` runtime as follows:
 
 ``` r
-install.packages("mlflow")
+devtools::install_github("mlflow/mlflow", subdir = "mlflow/R/mlflow")
 mlflow::mlflow_install()
 ```
 
@@ -25,7 +24,7 @@ Notice also that [Anaconda](https://www.anaconda.com/download/) or
 [Miniconda](https://conda.io/miniconda.html) need to be manually
 installed.
 
-### Developemnt
+### Development
 
 Install the `mlflow` package as follows:
 
@@ -210,8 +209,8 @@ cat(paste(readLines("model/MLmodel"), collapse = "\n"))
     ##   crate:
     ##     version: 0.1.0
     ##     model: crate.bin
-    ## time_created: 18-09-27T19:06:55.55.85
-    ## run_id: c2e91ac015564ccaa711480c3effd917
+    ## time_created: 18-10-03T22:18:25.25.55
+    ## run_id: 4286a3d27974487b95b19e01b7b3caab
 
 Later on, the R model can be deployed which will perform predictions
 using


### PR DESCRIPTION
We should disable CRAN installs from our docs until `mlflow` releases in CRAN.

CC: @tomasatdatabricks @smurching