### PR TITLE
Update mlflow installation instruction using R

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -16,7 +16,7 @@ You install MLflow by running:
     .. code-block:: R
 
         devtools::install_github("mlflow/mlflow", subdir = "mlflow/R/mlflow")
-        mlflow_install()
+        mlflow::mlflow_install()
 
 .. note::
 


### PR DESCRIPTION
It seems `library(mlflow)` or `mlflow::` is needed for R users to get started.