### PR TITLE
mlflow.projects.run should inherit parent_run_id

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -18,6 +18,7 @@ from mlflow.exceptions import ExecutionException
 from mlflow.entities import RunStatus, SourceType, Param
 import mlflow.tracking as tracking
 from mlflow.tracking.fluent import _get_experiment_id, _get_git_commit
+import mlflow.tracking.fluent as fluent
 
 
 import mlflow.projects.databricks
@@ -416,12 +417,18 @@ def _create_run(uri, experiment_id, work_dir, entry_point):
         source_name = tracking.utils._get_git_url_if_present(_expand_uri(uri))
     else:
         source_name = _expand_uri(uri)
+    existing_run = fluent.active_run()
+    if existing_run:
+        parent_run_id = existing_run.info.run_uuid
+    else:
+        parent_run_id = None
     active_run = tracking.MlflowClient().create_run(
         experiment_id=experiment_id,
         source_name=source_name,
         source_version=_get_git_commit(work_dir),
         entry_point_name=entry_point,
-        source_type=SourceType.PROJECT)
+        source_type=SourceType.PROJECT,
+        parent_run_id=parent_run_id)
     return active_run
 
 

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -12,6 +12,7 @@ from mlflow.entities import RunStatus, ViewType
 from mlflow.exceptions import ExecutionException
 from mlflow.store.file_store import FileStore
 from mlflow.utils import env
+from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID
 
 from tests.projects.utils import TEST_PROJECT_DIR, TEST_PROJECT_NAME, GIT_PROJECT_URI, \
     validate_exit_status, assert_dirs_equal
@@ -226,6 +227,22 @@ def test_run(tmpdir, tracking_uri_mock, use_start_run):  # pylint: disable=unuse
     assert len(run.data.metrics) == len(expected_metrics)
     for metric in run.data.metrics:
         assert metric.value == expected_metrics[metric.key]
+
+
+def test_run_with_parent(tmpdir, tracking_uri_mock):  # pylint: disable=unused-argument
+    """Verify that if we are in a nested run, mlflow.projects.run() will have a parent_run_id."""
+    with mlflow.start_run():
+        parent_run_id = mlflow.active_run().info.run_uuid
+        submitted_run = mlflow.projects.run(
+            TEST_PROJECT_DIR, entry_point="test_tracking",
+            parameters={"use_start_run": "1"},
+            use_conda=False, experiment_id=0)
+    assert submitted_run.run_id is not None
+    validate_exit_status(submitted_run.get_status(), RunStatus.FINISHED)
+    run_uuid = submitted_run.run_id
+    run = mlflow.tracking.MlflowClient().get_run(run_uuid)
+    parent_run_id_tag = [tag.value for tag in run.data.tags if tag.key == MLFLOW_PARENT_RUN_ID]
+    assert parent_run_id_tag == [parent_run_id]
 
 
 def test_run_async(tracking_uri_mock):  # pylint: disable=unused-argument


### PR DESCRIPTION
This allows nesting when run with the `examples/multistep_workflow`.