### PR TITLE
[UI] Add link from child run to parent

### DIFF
--- a/mlflow/server/js/src/components/RunView.css
+++ b/mlflow/server/js/src/components/RunView.css
@@ -26,7 +26,7 @@
 }
 
 .run-info {
-  min-width: 440px;
+  min-width: 450px;
   margin-bottom: 12px;
   margin-right: 12px;
 }

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -252,7 +252,8 @@ class RunView extends Component {
             <div className="run-info">
               <span className="metadata-header">Parent Run: </span>
               <span className="metadata-info">
-                <Link to={Routes.getRunPageRoute(this.props.experimentId, tags['mlflow.parentRunId'].value)}>
+                <Link to={Routes.getRunPageRoute(this.props.experimentId,
+                    tags['mlflow.parentRunId'].value)}>
                   {tags['mlflow.parentRunId'].value}
                 </Link>
               </span>

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -223,14 +223,10 @@ class RunView extends Component {
               {Utils.renderSource(run, tags)}
             </span>
           </div>
-          {tags['mlflow.parentRunId'] !== undefined ?
+          {run.source_version ?
             <div className="run-info">
-              <span className="metadata-header">Parent Run: </span>
-              <span className="metadata-info">
-                <Link to={Routes.getRunPageRoute(this.props.experimentId, tags['mlflow.parentRunId'].value)}>
-                  {tags['mlflow.parentRunId'].value}
-                </Link>
-              </span>
+              <span className="metadata-header">Git Commit: </span>
+              <span className="metadata-info">{Utils.renderVersion(run, false)}</span>
             </div>
             : null
           }
@@ -238,13 +234,6 @@ class RunView extends Component {
             <div className="run-info">
               <span className="metadata-header">Entry Point: </span>
               <span className="metadata-info">{run.entry_point_name || "main"}</span>
-            </div>
-            : null
-          }
-          {run.source_version ?
-            <div className="run-info">
-              <span className="metadata-header">Git Commit: </span>
-              <span className="metadata-info">{Utils.renderVersion(run, false)}</span>
             </div>
             : null
           }
@@ -256,6 +245,17 @@ class RunView extends Component {
             <div className="run-info">
               <span className="metadata-header">Duration: </span>
               <span className="metadata-info">{Utils.formatDuration(duration)}</span>
+            </div>
+            : null
+          }
+          {tags['mlflow.parentRunId'] !== undefined ?
+            <div className="run-info">
+              <span className="metadata-header">Parent Run: </span>
+              <span className="metadata-info">
+                <Link to={Routes.getRunPageRoute(this.props.experimentId, tags['mlflow.parentRunId'].value)}>
+                  {tags['mlflow.parentRunId'].value}
+                </Link>
+              </span>
             </div>
             : null
           }

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import './RunView.css';
 import HtmlTableView from './HtmlTableView';
 import { Link } from 'react-router-dom';
+import Routes from '../Routes';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 import ArtifactPage from './ArtifactPage';
 import { getLatestMetrics } from '../reducers/MetricReducer';
@@ -222,10 +223,14 @@ class RunView extends Component {
               {Utils.renderSource(run, tags)}
             </span>
           </div>
-          {run.source_version ?
+          {tags['mlflow.parentRunId'] !== undefined ?
             <div className="run-info">
-              <span className="metadata-header">Git Commit: </span>
-              <span className="metadata-info">{Utils.renderVersion(run, false)}</span>
+              <span className="metadata-header">Parent Run: </span>
+              <span className="metadata-info">
+                <Link to={Routes.getRunPageRoute(this.props.experimentId, tags['mlflow.parentRunId'].value)}>
+                  {tags['mlflow.parentRunId'].value}
+                </Link>
+              </span>
             </div>
             : null
           }
@@ -233,6 +238,13 @@ class RunView extends Component {
             <div className="run-info">
               <span className="metadata-header">Entry Point: </span>
               <span className="metadata-info">{run.entry_point_name || "main"}</span>
+            </div>
+            : null
+          }
+          {run.source_version ?
+            <div className="run-info">
+              <span className="metadata-header">Git Commit: </span>
+              <span className="metadata-info">{Utils.renderVersion(run, false)}</span>
             </div>
             : null
           }


### PR DESCRIPTION
If there's a parent run, we should display this run and a link to it.

Note that this implementation does assume that the parent run is in the same experiment as the child, but this is likely to be the case (and we don't have enough info to avoid this dependency today).

![image](https://user-images.githubusercontent.com/1400247/46746373-cdb7bf00-cc63-11e8-8b5c-cc954b7f672c.png)
