### PR TITLE
Address some issues with compact runs view

### DIFF
--- a/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
@@ -104,10 +104,12 @@ class ExperimentRunsTableCompactView extends Component {
         <div
           key={keyname}
           className="metric-param-cell"
-          onMouseEnter={() => this.onHover({isParam: true, isMetric: false, key: paramKey})}
-          onMouseLeave={() => this.onHover({isParam: false, isMetric: false, key: ""})}
         >
-          <span className={cellClass}>
+          <span
+            className={cellClass}
+            onMouseEnter={() => this.onHover({isParam: true, isMetric: false, key: paramKey})}
+            onMouseLeave={() => this.onHover({isParam: false, isMetric: false, key: ""})}
+          >
             <Dropdown id="dropdown-custom-1">
               <ExperimentRunsSortToggle
                 bsRole="toggle"

--- a/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
@@ -116,7 +116,7 @@ class ExperimentRunsTableCompactView extends Component {
                 className="metric-param-sort-toggle"
               >
                 <span
-                  className="run-table-container"
+                  className="run-table-container underline-on-hover"
                   style={styles.metricParamCellContent}
                 >
                   <span style={{marginRight: sortIcon ? 2 : 0}}>
@@ -179,7 +179,7 @@ class ExperimentRunsTableCompactView extends Component {
                 className={"metric-param-sort-toggle"}
               >
                 <span
-                  className="run-table-container"
+                  className="run-table-container underline-on-hover"
                   style={styles.metricParamCellContent}
                 >
                   <span style={{marginRight: sortIcon ? 2 : 0}}>

--- a/mlflow/server/js/src/components/ExperimentView.css
+++ b/mlflow/server/js/src/components/ExperimentView.css
@@ -173,6 +173,10 @@ span.error-message {
   font-weight: bold;
 }
 
+.ExperimentView .metric-param-name:hover {
+  text-decoration: underline;
+}
+
 .ExperimentView .metric-param-value {
   margin-left: 4px;
 }

--- a/mlflow/server/js/src/components/ExperimentView.css
+++ b/mlflow/server/js/src/components/ExperimentView.css
@@ -173,7 +173,7 @@ span.error-message {
   font-weight: bold;
 }
 
-.ExperimentView .metric-param-name:hover {
+.ExperimentView .underline-on-hover:hover {
   text-decoration: underline;
 }
 

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -310,7 +310,7 @@ class ExperimentView extends Component {
                 </ButtonGroup>
               </span>
           </div>
-          <div style={styles.scrollableTable}>
+          <div>
             {this.state.showMultiColumns ?
               <ExperimentRunsTableMultiColumnView
                 onCheckbox={this.onCheckbox}
@@ -643,9 +643,6 @@ const styles = {
   },
   tableToggleButtonGroup: {
     marginLeft: '16px',
-  },
-  scrollableTable: {
-    overflow: "scroll",
   },
 };
 

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -310,7 +310,6 @@ class ExperimentView extends Component {
                 </ButtonGroup>
               </span>
           </div>
-          <div>
             {this.state.showMultiColumns ?
               <ExperimentRunsTableMultiColumnView
                 onCheckbox={this.onCheckbox}
@@ -346,7 +345,6 @@ class ExperimentView extends Component {
                 onExpand={this.onExpand}
               />
             }
-          </div>
         </div>
       </div>
     );

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -310,6 +310,7 @@ class ExperimentView extends Component {
                 </ButtonGroup>
               </span>
           </div>
+          <div style={styles.scrollableTable}>
             {this.state.showMultiColumns ?
               <ExperimentRunsTableMultiColumnView
                 onCheckbox={this.onCheckbox}
@@ -345,6 +346,7 @@ class ExperimentView extends Component {
                 onExpand={this.onExpand}
               />
             }
+          </div>
         </div>
       </div>
     );
@@ -641,6 +643,9 @@ const styles = {
   },
   tableToggleButtonGroup: {
     marginLeft: '16px',
+  },
+  scrollableTable: {
+    overflow: "scroll",
   },
 };
 


### PR DESCRIPTION
* Hovering over a metric/param name now underlines it to help show that it's clickable
* You now must hover over a metric/param name or value for it to be highlighted (previously we'd highlight if you hovered over the space around the name-or-value).

Note: I held off on addressing some other suggestions (like fixing the max-width of the table & adding horizontal scrolling on overflow) since doing those correctly might require some additional discussion (do we also add vertical scrolling, should we consider using a different table component to allow for fixed headers, etc)

