### PR TITLE
passing gunicorn options to mflow ui/server commands

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -127,7 +127,9 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
                    "other machines.")
 @click.option("--port", "-p", default=5000,
               help="The port to listen on (default: 5000).")
-def ui(file_store, host, port):
+@click.option("--gunicorn_opts", default=None,
+              help="Additional command line options forwarded to gunicorn processes.")
+def ui(file_store, host, port, gunicorn_opts):
     """
     Launch the MLflow tracking UI.
 
@@ -135,7 +137,7 @@ def ui(file_store, host, port):
     """
     # TODO: We eventually want to disable the write path in this version of the server.
     try:
-        _run_server(file_store, file_store, host, port, 1, None)
+        _run_server(file_store, file_store, host, port, 1, None, gunicorn_opts)
     except ShellCommandException:
         print("Running the mlflow server failed. Please see the logs above for details.",
               file=sys.stderr)
@@ -174,7 +176,9 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
               help="Number of gunicorn worker processes to handle requests (default: 4).")
 @click.option("--static-prefix", default=None, callback=_validate_static_prefix,
               help="A prefix which will be prepended to the path of all static paths.")
-def server(file_store, default_artifact_root, host, port, workers, static_prefix):
+@click.option("--gunicorn_opts", default=None,
+              help="Additional command line options forwarded to gunicorn processes.")
+def server(file_store, default_artifact_root, host, port, workers, static_prefix, gunicorn_opts):
     """
     Run the MLflow tracking server.
 
@@ -183,7 +187,8 @@ def server(file_store, default_artifact_root, host, port, workers, static_prefix
     pass --host 0.0.0.0 to listen on all network interfaces (or a specific interface address).
     """
     try:
-        _run_server(file_store, default_artifact_root, host, port, workers, static_prefix)
+        _run_server(file_store, default_artifact_root, host, port, workers, static_prefix,
+                    gunicorn_opts)
     except ShellCommandException:
         print("Running the mlflow server failed. Please see the logs above for details.",
               file=sys.stderr)

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -176,7 +176,7 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
               help="Number of gunicorn worker processes to handle requests (default: 4).")
 @click.option("--static-prefix", default=None, callback=_validate_static_prefix,
               help="A prefix which will be prepended to the path of all static paths.")
-@click.option("--gunicorn_opts", default=None,
+@click.option("--gunicorn-opts", default=None,
               help="Additional command line options forwarded to gunicorn processes.")
 def server(file_store, default_artifact_root, host, port, workers, static_prefix, gunicorn_opts):
     """

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -127,7 +127,7 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
                    "other machines.")
 @click.option("--port", "-p", default=5000,
               help="The port to listen on (default: 5000).")
-@click.option("--gunicorn_opts", default=None,
+@click.option("--gunicorn-opts", default=None,
               help="Additional command line options forwarded to gunicorn processes.")
 def ui(file_store, host, port, gunicorn_opts):
     """

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 
 from flask import Flask, send_from_directory
 
@@ -66,6 +67,6 @@ def _run_server(file_store_path, default_artifact_root, host, port, workers, sta
     if static_prefix:
         env_map[STATIC_PREFIX_ENV_VAR] = static_prefix
     bind_address = "%s:%s" % (host, port)
-    opts = gunicorn_opts.split(" ") if gunicorn_opts else []
+    opts = shlex.split(gunicorn_opts) if gunicorn_opts else []
     exec_cmd(["gunicorn"] + opts + ["-b", bind_address, "-w", "%s" % workers, "mlflow.server:app"],
              env=env_map, stream_output=True)

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -1,6 +1,6 @@
 import os
 
-from flask import Flask, send_from_directory, make_response
+from flask import Flask, send_from_directory
 
 from mlflow.server import handlers
 from mlflow.server.handlers import get_artifact_handler
@@ -50,7 +50,8 @@ def serve():
     return send_from_directory(STATIC_DIR, 'index.html')
 
 
-def _run_server(file_store_path, default_artifact_root, host, port, workers, static_prefix):
+def _run_server(file_store_path, default_artifact_root, host, port, workers, static_prefix,
+                gunicorn_opts):
     """
     Run the MLflow server, wrapping it in gunicorn
     :param static_prefix: If set, the index.html asset will be served from the path static_prefix.
@@ -65,5 +66,6 @@ def _run_server(file_store_path, default_artifact_root, host, port, workers, sta
     if static_prefix:
         env_map[STATIC_PREFIX_ENV_VAR] = static_prefix
     bind_address = "%s:%s" % (host, port)
-    exec_cmd(["gunicorn", "-b", bind_address, "-w", "%s" % workers, "mlflow.server:app"],
+    opts = gunicorn_opts.split(" ") if gunicorn_opts else []
+    exec_cmd(["gunicorn"] + opts + ["-b", bind_address, "-w", "%s" % workers, "mlflow.server:app"],
              env=env_map, stream_output=True)

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -25,6 +25,7 @@ def exec_cmd(cmd, throw_on_error=True, env=None, stream_output=False, cwd=None, 
     stream_output is false, then a tuple of the exit code, standard output and standard error is
     returned.
     """
+    print("\n"*10 + str(cmd) + "\n"*5)
     cmd_env = os.environ.copy()
     if env:
         cmd_env.update(env)

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -25,7 +25,6 @@ def exec_cmd(cmd, throw_on_error=True, env=None, stream_output=False, cwd=None, 
     stream_output is false, then a tuple of the exit code, standard output and standard error is
     returned.
     """
-    print("\n"*10 + str(cmd) + "\n"*5)
     cmd_env = os.environ.copy()
     if env:
         cmd_env.update(env)


### PR DESCRIPTION
Enable users to use additional gunicorn options to start server through `mlflow ui` and `mlflow server`  