### PR TITLE
Start experiment ID with 0 if no experiments exist

### DIFF
--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -160,7 +160,7 @@ class FileStore(AbstractStore):
         # Get all existing experiments and find the one with largest ID.
         # len(list_all(..)) would not work when experiments are deleted.
         experiments_ids = [e.experiment_id for e in self.list_experiments(ViewType.ALL)]
-        experiment_id = max(experiments_ids) + 1
+        experiment_id = max(experiments_ids) + 1 if experiments_ids else 0
         return self._create_experiment_with_id(name, experiment_id, artifact_location)
 
     def _has_experiment(self, experiment_id):

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -2,11 +2,11 @@
 # -*- coding: utf-8 -*-
 import os
 import shutil
+import time
 import unittest
 import uuid
 
-import time
-
+import mock
 import pytest
 
 from mlflow.entities import Experiment, Metric, Param, RunTag, ViewType, RunInfo
@@ -147,6 +147,15 @@ class TestFileStore(unittest.TestCase):
         for exp_names in set(random_str(15) for x in range(20)):
             exp = fs.get_experiment_by_name(exp_names)
             self.assertIsNone(exp)
+
+    def test_create_first_experiment(self):
+        fs = FileStore(self.test_root)
+        fs.list_experiments = mock.Mock(return_value=[])
+        fs._create_experiment_with_id = mock.Mock()
+        fs.create_experiment(random_str(1))
+        fs._create_experiment_with_id.assert_called_once()
+        experiment_id = fs._create_experiment_with_id.call_args[0][1]
+        self.assertEqual(experiment_id, 0)
 
     def test_create_experiment(self):
         fs = FileStore(self.test_root)


### PR DESCRIPTION
Actual for case, when custom folder is used for tracking, and no experiments were created there before.