### PR TITLE
Allow to save local artifact URI as relative

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -458,6 +458,7 @@ def _invoke_mlflow_run_subprocess(
         mlflow_run_arr, _get_run_env_vars(run_id, experiment_id))
     return LocalSubmittedRun(run_id, mlflow_run_subprocess)
 
+
 __all__ = [
     "run",
     "SubmittedRun"

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -28,13 +28,15 @@ class AbstractStore:
         pass
 
     @abstractmethod
-    def create_experiment(self, name, artifact_location):
+    def create_experiment(self, name, artifact_location, artifact_relative):
         """
         Creates a new experiment.
         If an experiment with the given name already exists, throws exception.
 
         :param name: Desired name for an experiment
         :param artifact_location: Base location for artifacts in runs. May be None.
+        :param artifact_relative: Flag to make artifact location as relative, if
+                                  store supports that.
         :return: experiment_id (integer) for the newly created experiment if successful, else None
         """
         pass
@@ -96,7 +98,8 @@ class AbstractStore:
         pass
 
     def create_run(self, experiment_id, user_id, run_name, source_type, source_name,
-                   entry_point_name, start_time, source_version, tags, parent_run_id):
+                   entry_point_name, start_time, source_version, tags, parent_run_id,
+                   artifact_relative):
         """
         Creates a run under the specified experiment ID, setting the run's status to "RUNNING"
         and the start time to the current time.

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -69,7 +69,7 @@ class RestStore(AbstractStore):
         return [Experiment.from_proto(experiment_proto)
                 for experiment_proto in response_proto.experiments]
 
-    def create_experiment(self, name, artifact_location=None):
+    def create_experiment(self, name, artifact_location=None, artifact_relative=False):
         """
         Creates a new experiment.
         If an experiment with the given name already exists, throws exception.
@@ -131,7 +131,8 @@ class RestStore(AbstractStore):
         return RunInfo.from_proto(response_proto.run_info)
 
     def create_run(self, experiment_id, user_id, run_name, source_type, source_name,
-                   entry_point_name, start_time, source_version, tags, parent_run_id):
+                   entry_point_name, start_time, source_version, tags, parent_run_id,
+                   artifact_relative=False):
         """
         Creates a run under the specified experiment ID, setting the run's status to "RUNNING"
         and the start time to the current time.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -38,7 +38,7 @@ class MlflowClient(object):
 
     def create_run(self, experiment_id, user_id=None, run_name=None, source_type=None,
                    source_name=None, entry_point_name=None, start_time=None,
-                   source_version=None, tags=None, parent_run_id=None):
+                   source_version=None, tags=None, parent_run_id=None, artifact_relative=False):
         """
         Create a :py:class:`mlflow.entities.Run` object that can be associated with
         metrics, parameters, artifacts, etc.
@@ -64,6 +64,7 @@ class MlflowClient(object):
             source_version=source_version,
             tags=[RunTag(key, value) for (key, value) in iteritems(tags)],
             parent_run_id=parent_run_id,
+            artifact_relative=artifact_relative,
         )
 
     def list_run_infos(self, experiment_id, run_view_type=ViewType.ACTIVE_ONLY):
@@ -88,17 +89,20 @@ class MlflowClient(object):
         """
         return self.store.get_experiment_by_name(name)
 
-    def create_experiment(self, name, artifact_location=None):
+    def create_experiment(self, name, artifact_location=None, artifact_relative=False):
         """Create an experiment.
 
         :param name: The experiment name. Must be unique.
         :param artifact_location: The location to store run artifacts.
                                   If not provided, the server picks an appropriate default.
+        :param artifact_relative: Flag to define, if artifact location should be saved
+                                  as relative path, if artifact location is not provided.
         :return: Integer ID of the created experiment.
         """
         return self.store.create_experiment(
             name=name,
             artifact_location=artifact_location,
+            artifact_relative=artifact_relative,
         )
 
     def delete_experiment(self, experiment_id):

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -5,11 +5,21 @@ import shutil
 import tarfile
 import tempfile
 
+import psutil
 import yaml
 
 from mlflow.entities import FileInfo
 
 ENCODING = "utf-8"
+
+
+def is_fs_path(path):
+    if path.startswith("file:/"):
+        return True
+    for part in psutil.disk_partitions():
+        if path.startswith(part.mountpoint):
+            return True
+    return False
 
 
 def is_directory(name):

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         'Flask',
         'numpy',
         'pandas',
+        'psutil==5.4.7',
         'scipy',
         'scikit-learn',
         'python-dateutil',


### PR DESCRIPTION
Provides ability for experiment and run to save artifact URI as relative path optionally.
It will be helpful to provide portability of mlruns, to share them between several machines, to save to git repo, to capture in docker image, etc.