### PR TITLE
Add support for optional cloudpickle serialization to sklearn module

### DIFF
--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -26,8 +26,11 @@ from mlflow import pyfunc
 from mlflow.models import Model
 import mlflow.tracking
 
+SERIALIZATION_FORMAT_PICKLE = "pickle"
+SERIALIZATION_FORMAT_CLOUDPICKLE = "cloudpickle"
 
-def save_model(sk_model, path, conda_env=None, mlflow_model=Model()):
+def save_model(sk_model, path, conda_env=None, mlflow_model=Model(), 
+               serialization_format=SERIALIZATION_FORMAT_PICKLE):
     """
     Save a scikit-learn model to a path on the local file system.
 
@@ -37,6 +40,9 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model()):
            this model should be run in. At minimum, it should specify python, scikit-learn,
            and mlflow with appropriate versions.
     :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
+    :param serialization_format: The format in which to serialize the model. This should be one of
+                                 the following: `mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE`,
+                                 `mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE`.
 
     >>> import mlflow.sklearn
     >>> from sklearn.datasets import load_iris
@@ -51,22 +57,23 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model()):
     if os.path.exists(path):
         raise Exception("Path '{}' already exists".format(path))
     os.makedirs(path)
-    model_file = os.path.join(path, "model.pkl")
-    with open(model_file, "wb") as out:
-        pickle.dump(sk_model, out)
+    model_data_subpath = "model.pkl"
+    _save_model(sk_model=sk_model, output_path=os.path.join(path, model_data_subpath), 
+                serialization_format=serialization_format)
     model_conda_env = None
     if conda_env:
         model_conda_env = os.path.basename(os.path.abspath(conda_env))
         shutil.copyfile(conda_env, os.path.join(path, model_conda_env))
-    pyfunc.add_to_model(mlflow_model, loader_module="mlflow.sklearn", data="model.pkl",
+    pyfunc.add_to_model(mlflow_model, loader_module="mlflow.sklearn", data=model_data_subpath,
                         env=model_conda_env)
     mlflow_model.add_flavor("sklearn",
-                            pickled_model="model.pkl",
+                            pickled_model=model_data_subpath,
                             sklearn_version=sklearn.__version__)
     mlflow_model.save(os.path.join(path, "MLmodel"))
 
 
-def log_model(sk_model, artifact_path, conda_env=None):
+def log_model(sk_model, artifact_path, conda_env=None, 
+              serialization_format=SERIALIZATION_FORMAT_PICKLE):
     """
     Log a scikit-learn model as an MLflow artifact for the current run.
 
@@ -75,6 +82,9 @@ def log_model(sk_model, artifact_path, conda_env=None):
     :param conda_env: Path to a Conda environment file. If provided, this decribes the environment
            this model should be run in. At minimum, it should specify python, scikit-learn,
            and mlflow with appropriate versions.
+    :param serialization_format: The format in which to serialize the model. This should be one of
+                                 the following: `mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE`,
+                                 `mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE`.
 
     >>> import mlflow
     >>> import mlflow.sklearn
@@ -93,7 +103,8 @@ def log_model(sk_model, artifact_path, conda_env=None):
     return Model.log(artifact_path=artifact_path,
                      flavor=mlflow.sklearn,
                      sk_model=sk_model,
-                     conda_env=conda_env)
+                     conda_env=conda_env,
+                     serialization_format=serialization_format)
 
 
 def _load_model_from_local_file(path):
@@ -112,6 +123,22 @@ def _load_pyfunc(path):
     """
     with open(path, "rb") as f:
         return pickle.load(f)
+
+
+def _save_model(sk_model, output_path, serialization_format):
+    """
+    :param sk_model: The Scikit-learn model to serialize.
+    :param output_path: The file path to which to write the serialized model. 
+    :param serialization_format: The format in which to serialize the model. This should be one of
+                                 the following: `mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE`,
+                                 `mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE`.
+    """
+    with open(output_path, "wb") as out:
+        if serialization_format == SERIALIZATION_FORMAT_PICKLE:
+            pickle.dump(sk_model, out)
+        elif serialization_format == SERIALIZATION_FORMAT_CLOUDPICKLE:
+            import cloudpickle
+            cloudpickle.dump(sk_model, out)
 
 
 def load_model(path, run_id=None):

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -23,7 +23,7 @@ import sklearn
 
 from mlflow.utils import cli_args
 from mlflow import pyfunc
-from mlflow.exceptions import MlflowException 
+from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, INTERNAL_ERROR
 import mlflow.tracking
@@ -36,7 +36,8 @@ SUPPORTED_SERIALIZATION_FORMATS = [
     SERIALIZATION_FORMAT_CLOUDPICKLE
 ]
 
-def save_model(sk_model, path, conda_env=None, mlflow_model=Model(), 
+
+def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
                serialization_format=SERIALIZATION_FORMAT_PICKLE):
     """
     Save a scikit-learn model to a path on the local file system.
@@ -48,7 +49,7 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
            and mlflow with appropriate versions.
     :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
     :param serialization_format: The format in which to serialize the model. This should be one of
-                                 the formats listed in 
+                                 the formats listed in
                                  `mlflow.sklearn.SUPPORTED_SERIALIZATION_FORMATS`.
     >>> import mlflow.sklearn
     >>> from sklearn.datasets import load_iris
@@ -73,7 +74,7 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
         raise Exception("Path '{}' already exists".format(path))
     os.makedirs(path)
     model_data_subpath = "model.pkl"
-    _save_model(sk_model=sk_model, output_path=os.path.join(path, model_data_subpath), 
+    _save_model(sk_model=sk_model, output_path=os.path.join(path, model_data_subpath),
                 serialization_format=serialization_format)
     model_conda_env = None
     if conda_env:
@@ -87,7 +88,7 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
     mlflow_model.save(os.path.join(path, "MLmodel"))
 
 
-def log_model(sk_model, artifact_path, conda_env=None, 
+def log_model(sk_model, artifact_path, conda_env=None,
               serialization_format=SERIALIZATION_FORMAT_PICKLE):
     """
     Log a scikit-learn model as an MLflow artifact for the current run.
@@ -143,7 +144,7 @@ def _load_pyfunc(path):
 def _save_model(sk_model, output_path, serialization_format):
     """
     :param sk_model: The Scikit-learn model to serialize.
-    :param output_path: The file path to which to write the serialized model. 
+    :param output_path: The file path to which to write the serialized model.
     :param serialization_format: The format in which to serialize the model. This should be one of
                                  the following: `mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE`,
                                  `mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE`.

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -50,7 +50,7 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
     :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
     :param serialization_format: The format in which to serialize the model. This should be one of
                                  the formats listed in
-                                 `mlflow.sklearn.SUPPORTED_SERIALIZATION_FORMATS`. The Cloudpickle 
+                                 `mlflow.sklearn.SUPPORTED_SERIALIZATION_FORMATS`. The Cloudpickle
                                  format, `mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE`, provides
                                  better cross-system compatibility by identifying and packaging
                                  code dependencies with the serialized model.
@@ -64,13 +64,13 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
     >>> #set path to location for persistence
     >>> sk_path_dir_1 = ...
     >>> mlflow.sklearn.save_model(
-    >>>         sk_model, sk_path_dir_1, 
+    >>>         sk_model, sk_path_dir_1,
     >>>         serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE)
     >>>
     >>> #Save the model in pickle format
     >>> #set path to location for persistence
     >>> sk_path_dir_2 = ...
-    >>> mlflow.sklearn.save_model(sk_model, sk_path_dir_2, 
+    >>> mlflow.sklearn.save_model(sk_model, sk_path_dir_2,
     >>>                           serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE)
     """
     if serialization_format not in SUPPORTED_SERIALIZATION_FORMATS:

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -84,7 +84,8 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
                         env=model_conda_env)
     mlflow_model.add_flavor("sklearn",
                             pickled_model=model_data_subpath,
-                            sklearn_version=sklearn.__version__)
+                            sklearn_version=sklearn.__version__,
+                            serialization_format=serialization_format)
     mlflow_model.save(os.path.join(path, "MLmodel"))
 
 
@@ -130,6 +131,8 @@ def _load_model_from_local_file(path):
     assert "sklearn" in model.flavors
     params = model.flavors["sklearn"]
     with open(os.path.join(path, params["pickled_model"]), "rb") as f:
+        # Models serialized with Cloudpickle can be deserialized using Pickle, so there
+        # is no need to check the serialization format of the model before deserializing
         return pickle.load(f)
 
 

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -60,13 +60,14 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
     >>> iris = load_iris()
     >>> sk_model = tree.DecisionTreeClassifier()
     >>> sk_model = sk_model.fit(iris.data, iris.target)
-    >>> #Save the model in pickle format
+    >>> #Save the model in cloudpickle format
     >>> #set path to location for persistence
     >>> sk_path_dir_1 = ...
-    >>> mlflow.sklearn.save_model(sk_model, sk_path_dir_1, 
-    >>>                           serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE)
+    >>> mlflow.sklearn.save_model(
+    >>>         sk_model, sk_path_dir_1, 
+    >>>         serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE)
     >>>
-    >>> #Save the model in cloudpickle format
+    >>> #Save the model in pickle format
     >>> #set path to location for persistence
     >>> sk_path_dir_2 = ...
     >>> mlflow.sklearn.save_model(sk_model, sk_path_dir_2, 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -20,3 +20,4 @@ torch
 torchvision
 pysftp
 keras
+cloudpickle

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -2,85 +2,109 @@ from __future__ import print_function
 
 import os
 import pickle
-import tempfile
-import unittest
+import pytest
+from collections import namedtuple
 
 import numpy as np
 import sklearn.datasets as datasets
 import sklearn.linear_model as glm
 import sklearn.neighbors as knn
+from sklearn.preprocessing import FunctionTransformer as SKFunctionTransformer
 
-from mlflow import sklearn, pyfunc
-import mlflow
+import mlflow.sklearn
+from mlflow import pyfunc
 from mlflow.models import Model
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.environment import _mlflow_conda_env
 
 
-def _load_pyfunc(path):
-    with open(path, "rb") as f:
-        return pickle.load(f)
+ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 
 
-class TestModelExport(unittest.TestCase):
-    def setUp(self):
-        self._tmp = tempfile.mkdtemp()
-        iris = datasets.load_iris()
-        self._X = iris.data[:, :2]  # we only take the first two features.
-        self._y = iris.target
-        self._knn = knn.KNeighborsClassifier()
-        self._knn.fit(self._X, self._y)
-        self._knn_predict = self._knn.predict(self._X)
-        self._linear_lr = glm.LogisticRegression()
-        self._linear_lr.fit(self._X, self._y)
-        self._linear_lr_predict = self._linear_lr.predict(self._X)
+@pytest.fixture(scope="session")
+def sklearn_knn_model():
+    iris = datasets.load_iris()
+    X = iris.data[:, :2]  # we only take the first two features.
+    y = iris.target
+    knn_model = knn.KNeighborsClassifier()
+    knn_model.fit(X, y)
+    return ModelWithData(model=knn_model, inference_data=X)
 
-    def test_model_save_load(self):
-        with TempDir(chdr=True, remove_on_exit=True) as tmp:
-            model_path = tmp.path("knn.pkl")
-            with open(model_path, "wb") as f:
-                pickle.dump(self._knn, f)
-            path = tmp.path("knn")
-            sklearn.save_model(self._knn, path=path)
-            x = sklearn.load_model(path)
-            xpred = x.predict(self._X)
-            np.testing.assert_array_equal(self._knn_predict, xpred)
-            # sklearn should also be stored as a valid pyfunc model
-            # test pyfunc compatibility
-            y = pyfunc.load_pyfunc(path)
-            ypred = y.predict(self._X)
-            np.testing.assert_array_equal(self._knn_predict, ypred)
 
-    def test_model_log(self):
-        old_uri = mlflow.get_tracking_uri()
-        # should_start_run tests whether or not calling log_model() automatically starts a run.
+@pytest.fixture(scope="session")
+def sklearn_logreg_model():
+    iris = datasets.load_iris()
+    X = iris.data[:, :2]  # we only take the first two features.
+    y = iris.target
+    linear_lr = glm.LogisticRegression()
+    linear_lr.fit(X, y)
+    return ModelWithData(model=linear_lr, inference_data=X)
+
+
+@pytest.fixture(scope="session")
+def sklearn_custom_transformer_model():
+    def transform(vec):
+        print("Invoking custom transformer!")
+        return vec + 1
+
+    transformer = SKFunctionTransformer(transform, validate=True)
+    return ModelWithData(transformer, inference_data=datasets.load_iris().data[:, :2])
+
+
+@pytest.fixture
+def model_path(tmpdir):
+    return os.path.join(str(tmpdir), "model")
+
+
+def test_model_save_load(sklearn_knn_model, model_path):
+    knn_model = sklearn_knn_model.model
+
+    mlflow.sklearn.save_model(sk_model=knn_model, path=model_path)
+    reloaded_knn_model = mlflow.sklearn.load_model(path=model_path)
+    reloaded_knn_pyfunc = pyfunc.load_pyfunc(path=model_path)
+
+    np.testing.assert_array_equal(
+            knn_model.predict(sklearn_knn_model.inference_data),
+            reloaded_knn_model.predict(sklearn_knn_model.inference_data))
+
+    np.testing.assert_array_equal(
+            reloaded_knn_model.predict(sklearn_knn_model.inference_data),
+            reloaded_knn_pyfunc.predict(sklearn_knn_model.inference_data))
+
+def test_model_log(sklearn_logreg_model, model_path):
+    old_uri = mlflow.get_tracking_uri()
+    with TempDir(chdr=True, remove_on_exit=True) as tmp:
         for should_start_run in [False, True]:
-            with TempDir(chdr=True, remove_on_exit=True) as tmp:
-                try:
-                    mlflow.set_tracking_uri("test")
-                    if should_start_run:
-                        mlflow.start_run()
-                    artifact_path = "linear"
-                    conda_env = os.path.join(tmp.path(), "conda_env.yaml")
-                    _mlflow_conda_env(conda_env, additional_pip_deps=["sklearn"])
-                    sklearn.log_model(sk_model=self._linear_lr,
-                                      artifact_path=artifact_path,
-                                      conda_env=conda_env)
-                    x = sklearn.load_model(artifact_path, run_id=mlflow.active_run().info.run_uuid)
-                    model_path = _get_model_log_dir(
-                            artifact_path, mlflow.active_run().info.run_uuid)
-                    model_config = Model.load(os.path.join(model_path, "MLmodel"))
-                    assert pyfunc.FLAVOR_NAME in model_config.flavors
-                    assert pyfunc.ENV in model_config.flavors[pyfunc.FLAVOR_NAME]
-                    env_path = model_config.flavors[pyfunc.FLAVOR_NAME][pyfunc.ENV]
-                    assert os.path.exists(os.path.join(model_path, env_path))
-                    xpred = x.predict(self._X)
-                    np.testing.assert_array_equal(self._linear_lr_predict, xpred)
-                finally:
-                    mlflow.end_run()
-                    mlflow.set_tracking_uri(old_uri)
+            try:
+                mlflow.set_tracking_uri("test")
+                if should_start_run:
+                    mlflow.start_run()
 
+                artifact_path = "linear"
+                conda_env = os.path.join(tmp.path(), "conda_env.yaml")
+                _mlflow_conda_env(conda_env, additional_pip_deps=["sklearn"])
 
-if __name__ == '__main__':
-    unittest.main()
+                mlflow.sklearn.log_model(
+                        sk_model=sklearn_logreg_model.model,
+                        artifact_path=artifact_path,
+                        conda_env=conda_env)
+                run_id = mlflow.active_run().info.run_uuid
+
+                reloaded_logreg_model = mlflow.sklearn.load_model(artifact_path, run_id)
+                np.testing.assert_array_equal(
+                        sklearn_logreg_model.model.predict(sklearn_logreg_model.inference_data),
+                        reloaded_logreg_model.predict(sklearn_logreg_model.inference_data))
+
+                model_path = _get_model_log_dir(
+                        artifact_path,
+                        run_id=run_id)
+                model_config = Model.load(os.path.join(model_path, "MLmodel"))
+                assert pyfunc.FLAVOR_NAME in model_config.flavors
+                assert pyfunc.ENV in model_config.flavors[pyfunc.FLAVOR_NAME]
+                env_path = model_config.flavors[pyfunc.FLAVOR_NAME][pyfunc.ENV]
+                assert os.path.exists(os.path.join(model_path, env_path))
+
+            finally:
+                mlflow.end_run()
+                mlflow.set_tracking_uri(old_uri)

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -15,8 +15,8 @@ from sklearn.preprocessing import FunctionTransformer as SKFunctionTransformer
 
 import mlflow.sklearn
 from mlflow import pyfunc
-from mlflow.exceptions import MlflowException 
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE 
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.models import Model
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils.file_utils import TempDir
@@ -77,6 +77,7 @@ def test_model_save_load(sklearn_knn_model, model_path):
             reloaded_knn_model.predict(sklearn_knn_model.inference_data),
             reloaded_knn_pyfunc.predict(sklearn_knn_model.inference_data))
 
+
 def test_model_log(sklearn_logreg_model, model_path):
     old_uri = mlflow.get_tracking_uri()
     with TempDir(chdr=True, remove_on_exit=True) as tmp:
@@ -129,15 +130,15 @@ def test_custom_transformer_can_be_saved_and_loaded_with_cloudpickle_format(
         expect_exception_context = pytest.raises(pickle.PicklingError)
     with expect_exception_context:
         pickle_format_model_path = os.path.join(str(tmpdir), "pickle_model")
-        mlflow.sklearn.save_model(sk_model=custom_transformer_model, 
+        mlflow.sklearn.save_model(sk_model=custom_transformer_model,
                                   path=pickle_format_model_path,
                                   serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE)
 
     cloudpickle_format_model_path = os.path.join(str(tmpdir), "cloud_pickle_model")
-    mlflow.sklearn.save_model(sk_model=custom_transformer_model, 
+    mlflow.sklearn.save_model(sk_model=custom_transformer_model,
                               path=cloudpickle_format_model_path,
                               serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE)
-    
+
     reloaded_custom_transformer_model = mlflow.sklearn.load_model(
             path=cloudpickle_format_model_path)
 
@@ -153,8 +154,8 @@ def test_save_model_throws_exception_if_serialization_format_is_unrecognized(
         mlflow.sklearn.save_model(sk_model=sklearn_knn_model.model, path=model_path,
                                   serialization_format="not a valid format")
 
-    # The unsupported serialization format should have been detected prior to the execution of 
-    # any directory creation or state-mutating persistence logic that would prevent a second 
+    # The unsupported serialization format should have been detected prior to the execution of
+    # any directory creation or state-mutating persistence logic that would prevent a second
     # serialization call with the same model path from succeeding
-    assert os.path.exists(model_path) != True
+    assert not os.path.exists(model_path)
     mlflow.sklearn.save_model(sk_model=sklearn_knn_model.model, path=model_path)

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import sys
 import os
 import pickle
 import pytest
@@ -9,10 +10,13 @@ import numpy as np
 import sklearn.datasets as datasets
 import sklearn.linear_model as glm
 import sklearn.neighbors as knn
+from sklearn.pipeline import Pipeline as SKPipeline
 from sklearn.preprocessing import FunctionTransformer as SKFunctionTransformer
 
 import mlflow.sklearn
 from mlflow import pyfunc
+from mlflow.exceptions import MlflowException 
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE 
 from mlflow.models import Model
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils.file_utils import TempDir
@@ -43,13 +47,14 @@ def sklearn_logreg_model():
 
 
 @pytest.fixture(scope="session")
-def sklearn_custom_transformer_model():
+def sklearn_custom_transformer_model(sklearn_knn_model):
     def transform(vec):
         print("Invoking custom transformer!")
         return vec + 1
 
     transformer = SKFunctionTransformer(transform, validate=True)
-    return ModelWithData(transformer, inference_data=datasets.load_iris().data[:, :2])
+    pipeline = SKPipeline([("custom_transformer", transformer), ("knn", sklearn_knn_model.model)])
+    return ModelWithData(pipeline, inference_data=datasets.load_iris().data[:, :2])
 
 
 @pytest.fixture
@@ -108,3 +113,48 @@ def test_model_log(sklearn_logreg_model, model_path):
             finally:
                 mlflow.end_run()
                 mlflow.set_tracking_uri(old_uri)
+
+
+def test_custom_transformer_can_be_saved_and_loaded_with_cloudpickle_format(
+        sklearn_custom_transformer_model, tmpdir):
+    custom_transformer_model = sklearn_custom_transformer_model.model
+
+    # Because the model contains a customer transformer that is not defined at the top level of the
+    # current test module, we expect pickle to fail when attempting to serialize it. In contrast,
+    # we expect cloudpickle to successfully locate the transformer definition and serialize the
+    # model successfully.
+    if sys.version_info >= (3, 0):
+        expect_exception_context = pytest.raises(AttributeError)
+    else:
+        expect_exception_context = pytest.raises(pickle.PicklingError)
+    with expect_exception_context:
+        pickle_format_model_path = os.path.join(str(tmpdir), "pickle_model")
+        mlflow.sklearn.save_model(sk_model=custom_transformer_model, 
+                                  path=pickle_format_model_path,
+                                  serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE)
+
+    cloudpickle_format_model_path = os.path.join(str(tmpdir), "cloud_pickle_model")
+    mlflow.sklearn.save_model(sk_model=custom_transformer_model, 
+                              path=cloudpickle_format_model_path,
+                              serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE)
+    
+    reloaded_custom_transformer_model = mlflow.sklearn.load_model(
+            path=cloudpickle_format_model_path)
+
+    np.testing.assert_array_equal(
+            custom_transformer_model.predict(sklearn_custom_transformer_model.inference_data),
+            reloaded_custom_transformer_model.predict(
+                sklearn_custom_transformer_model.inference_data))
+
+
+def test_save_model_throws_exception_if_serialization_format_is_unrecognized(
+        sklearn_knn_model, model_path):
+    with pytest.raises(MlflowException) as exc:
+        mlflow.sklearn.save_model(sk_model=sklearn_knn_model.model, path=model_path,
+                                  serialization_format="not a valid format")
+
+    # The unsupported serialization format should have been detected prior to the execution of 
+    # any directory creation or state-mutating persistence logic that would prevent a second 
+    # serialization call with the same model path from succeeding
+    assert os.path.exists(model_path) != True
+    mlflow.sklearn.save_model(sk_model=sklearn_knn_model.model, path=model_path)


### PR DESCRIPTION
Motivation: Using [Cloudpickle](https://github.com/cloudpipe/cloudpickle) allows models/transformers depending on custom code to be serialized and deserialized across host machines.

This PR also refactors the sklearn tests to use pytest.

