### PR TITLE
ignore run if experiment_id recorded in meta data does not match folder structure

### DIFF
--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -351,7 +351,7 @@ class FileStore(AbstractStore):
         meta = read_yaml(run_dir, FileStore.META_DATA_FILE_NAME)
         run_info = _read_persisted_run_info_dict(meta)
         if str(run_info.experiment_id) != str(exp_id):
-            logging.warning("Recorded experiment ID (%s) for run '%s', is wrong. Should be %s. "
+            logging.warning("Wrong experiment ID (%s) recorded for run '%s'. It should be %s. "
                             "Run will be ignored.", str(run_info.experiment_id),
                             str(run_info.run_uuid), str(exp_id), exc_info=True)
             return None

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -262,8 +262,8 @@ class FileStore(AbstractStore):
             runs = find(experiment_dir, run_uuid, full_path=True)
             if len(runs) == 0:
                 continue
-            return runs[0]
-        return None
+            return os.path.basename(os.path.abspath(experiment_dir)), runs[0]
+        return None, None
 
     def update_run_info(self, run_uuid, run_status, end_time):
         _validate_run_id(run_uuid)
@@ -334,10 +334,11 @@ class FileStore(AbstractStore):
         """
         Will get both active and deleted runs.
         """
-        run_dir = self._find_run_root(run_uuid)
+        exp_id, run_dir = self._find_run_root(run_uuid)
         if run_dir is not None:
             meta = read_yaml(run_dir, FileStore.META_DATA_FILE_NAME)
-            return _read_persisted_run_info_dict(meta)
+            run_info = _read_persisted_run_info_dict(meta)
+            return run_info
         raise MlflowException("Run '%s' not found" % run_uuid,
                               databricks_pb2.RESOURCE_DOES_NOT_EXIST)
 
@@ -351,7 +352,7 @@ class FileStore(AbstractStore):
             subfolder_name = FileStore.TAGS_FOLDER_NAME
         else:
             raise Exception("Looking for unknown resource under run.")
-        run_dir = self._find_run_root(run_uuid)
+        _, run_dir = self._find_run_root(run_uuid)
         if run_dir is None:
             raise MlflowException("Run '%s' not found" % run_uuid,
                                   databricks_pb2.RESOURCE_DOES_NOT_EXIST)
@@ -465,6 +466,14 @@ class FileStore(AbstractStore):
             try:
                 # trap and warn known issues, will raise unexpected exceptions to caller
                 run_info = self._get_run_info(r_id)
+                if run_info.experiment_id != experiment_id:
+                    logging.warning("Recorded experiment ID (%s) for run '%s', is wrong. "
+                                    "Should be %s",
+                                    str(run_info.experiment_id),
+                                    str(run_info.run_uuid),
+                                    str(experiment_id),
+                                    exc_info=True)
+                    continue
                 if self._lifecycle_stage_valid_for_view_type(view_type, run_info.lifecycle_stage):
                     run_infos.append(run_info)
             except MissingConfigException as rnfe:

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -520,7 +520,7 @@ class TestFileStore(unittest.TestCase):
 
         with pytest.raises(MlflowException) as e:
             fs.get_run(bad_run_id)
-            assert e.message.contains("Could not find experiment with ID")
+            assert e.message.contains("not found")
 
         valid_runs = fs.search_runs([exp_0.experiment_id], [], run_view_type=ViewType.ALL)
         assert len(valid_runs) == len(all_runs) - 1

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -12,7 +12,7 @@ import pytest
 from mlflow.entities import Experiment, Metric, Param, RunTag, ViewType, RunInfo
 from mlflow.exceptions import MlflowException, MissingConfigException
 from mlflow.store.file_store import FileStore
-from mlflow.utils.file_utils import write_yaml
+from mlflow.utils.file_utils import write_yaml, read_yaml
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID
 from tests.helper_functions import random_int, random_str
 
@@ -494,6 +494,33 @@ class TestFileStore(unittest.TestCase):
         with pytest.raises(MissingConfigException) as e:
             fs.get_run(bad_run_id)
             assert e.message.contains("does not exist")
+
+        valid_runs = fs.search_runs([exp_0.experiment_id], [], run_view_type=ViewType.ALL)
+        assert len(valid_runs) == len(all_runs) - 1
+
+        for rid in all_run_ids:
+            if rid != bad_run_id:
+                fs.get_run(rid)
+
+    def test_bad_experiment_id_recorded_for_run(self):
+        fs = FileStore(self.test_root)
+        exp_0 = fs.get_experiment(Experiment.DEFAULT_EXPERIMENT_ID)
+        all_runs = fs.search_runs([exp_0.experiment_id], [], run_view_type=ViewType.ALL)
+
+        all_run_ids = self.exp_data[exp_0.experiment_id]["runs"]
+        assert len(all_runs) == len(all_run_ids)
+
+        # change experiment pointer in run
+        bad_run_id = str(self.exp_data[exp_0.experiment_id]['runs'][0])
+        target = 1
+        path = os.path.join(self.test_root, str(exp_0.experiment_id), bad_run_id)
+        experiment_data = read_yaml(path, "meta.yaml")
+        experiment_data["experiment_id"] = 1
+        write_yaml(path, "meta.yaml", experiment_data, True)
+
+        with pytest.raises(MlflowException) as e:
+            fs.get_run(bad_run_id)
+            assert e.message.contains("Could not find experiment with ID")
 
         valid_runs = fs.search_runs([exp_0.experiment_id], [], run_view_type=ViewType.ALL)
         assert len(valid_runs) == len(all_runs) - 1

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -512,7 +512,6 @@ class TestFileStore(unittest.TestCase):
 
         # change experiment pointer in run
         bad_run_id = str(self.exp_data[exp_0.experiment_id]['runs'][0])
-        target = 1
         path = os.path.join(self.test_root, str(exp_0.experiment_id), bad_run_id)
         experiment_data = read_yaml(path, "meta.yaml")
         experiment_data["experiment_id"] = 1


### PR DESCRIPTION
Catches a human error caused due to moving runs in experiment folder. The large issue is that UI will pick up `experiment_id` recorded in `meta.yaml` while rendering URL. Any UI edits (like adding tag) will have downstream effects of creating a parallel run directory in wrong experiment.

`LIST` will log a warning and ignore run.
All other run API `GET`, `DELETE`, `GET_PARAM`... etc will raise error.