### PR TITLE
Set tags when calling mlflow.projects.run() with mode=local from within a Databricks notebook

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -16,13 +16,9 @@ from mlflow.entities import Experiment, Run, SourceType, RunInfo
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils import env
-from mlflow.utils.databricks_utils import is_in_databricks_notebook, get_notebook_id, \
-    get_notebook_path, get_webapp_url
+from mlflow.utils.databricks_utils import is_in_databricks_notebook, get_notebook_path
 from mlflow.utils import databricks_utils
 from mlflow.utils.logging_utils import eprint
-from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_WEBAPP_URL, \
-    MLFLOW_DATABRICKS_NOTEBOOK_PATH, \
-    MLFLOW_DATABRICKS_NOTEBOOK_ID
 from mlflow.utils.validation import _validate_run_id
 
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -18,6 +18,7 @@ from mlflow.tracking.client import MlflowClient
 from mlflow.utils import env
 from mlflow.utils.databricks_utils import is_in_databricks_notebook, get_notebook_id, \
     get_notebook_path, get_webapp_url
+from mlflow.utils import databricks_utils
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_WEBAPP_URL, \
     MLFLOW_DATABRICKS_NOTEBOOK_PATH, \
@@ -114,16 +115,8 @@ def start_run(run_uuid=None, experiment_id=None, source_name=None, source_versio
 
         exp_id_for_run = experiment_id or _get_experiment_id()
         if is_in_databricks_notebook():
-            databricks_tags = {}
-            notebook_id = get_notebook_id()
+            databricks_tags = databricks_utils.get_databricks_tags()
             notebook_path = get_notebook_path()
-            webapp_url = get_webapp_url()
-            if notebook_id is not None:
-                databricks_tags[MLFLOW_DATABRICKS_NOTEBOOK_ID] = notebook_id
-            if notebook_path is not None:
-                databricks_tags[MLFLOW_DATABRICKS_NOTEBOOK_PATH] = notebook_path
-            if webapp_url is not None:
-                databricks_tags[MLFLOW_DATABRICKS_WEBAPP_URL] = webapp_url
             active_run_obj = MlflowClient().create_run(
                 experiment_id=exp_id_for_run,
                 run_name=run_name,

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -2,7 +2,9 @@ from mlflow.exceptions import MlflowException
 from mlflow.utils.rest_utils import MlflowHostCreds
 from mlflow.utils.logging_utils import eprint
 from databricks_cli.configure import provider
-from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_NOTEBOOK_ID, MLFLOW_DATABRICKS_NOTEBOOK_PATH, MLFLOW_DATABRICKS_WEBAPP_URL
+from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_NOTEBOOK_ID,\
+    MLFLOW_DATABRICKS_NOTEBOOK_PATH, MLFLOW_DATABRICKS_WEBAPP_URL
+
 
 def _get_dbutils():
     try:
@@ -32,6 +34,7 @@ def is_in_databricks_notebook():
         return _get_extra_context("aclPathOfAclRoot").startswith('/workspace')
     except Exception:  # pylint: disable=broad-except
         return False
+
 
 def get_databricks_tags():
     databricks_tags = {}

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -2,7 +2,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.utils.rest_utils import MlflowHostCreds
 from mlflow.utils.logging_utils import eprint
 from databricks_cli.configure import provider
-
+from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_NOTEBOOK_ID, MLFLOW_DATABRICKS_NOTEBOOK_PATH, MLFLOW_DATABRICKS_WEBAPP_URL
 
 def _get_dbutils():
     try:
@@ -32,6 +32,19 @@ def is_in_databricks_notebook():
         return _get_extra_context("aclPathOfAclRoot").startswith('/workspace')
     except Exception:  # pylint: disable=broad-except
         return False
+
+def get_databricks_tags():
+    databricks_tags = {}
+    notebook_id = get_notebook_id()
+    notebook_path = get_notebook_path()
+    webapp_url = get_webapp_url()
+    if notebook_id is not None:
+        databricks_tags[MLFLOW_DATABRICKS_NOTEBOOK_ID] = notebook_id
+    if notebook_path is not None:
+        databricks_tags[MLFLOW_DATABRICKS_NOTEBOOK_PATH] = notebook_path
+    if webapp_url is not None:
+        databricks_tags[MLFLOW_DATABRICKS_WEBAPP_URL] = webapp_url
+    return databricks_tags
 
 
 def get_notebook_id():


### PR DESCRIPTION
This PR sets Databricks-specific tags when calling the Python `mlflow.projects.run` API from within a notebook