### PR TITLE
Fix TF model export to work with TensorFlow 1.12

### DIFF
--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -189,11 +189,9 @@ def _load_model(tf_saved_model_dir, tf_sess, tf_meta_graph_tags, tf_signature_de
             sess=tf_sess,
             tags=tf_meta_graph_tags,
             export_dir=tf_saved_model_dir)
-    # TODO: Stop relying on `tf.contrib` when it becomes deprecated. For reference, see the
-    #       Tensorflow roadmap: https://www.tensorflow.org/community/roadmap#roadmap_2.
-    signature_def = tf.contrib.saved_model.get_signature_def_by_key(
-            meta_graph_def, tf_signature_def_key)
-    return signature_def
+    if tf_signature_def_key not in meta_graph_def.signature_def:
+        raise MlflowException("Could not find signature def key %s" % tf_signature_def_key)
+    return meta_graph_def.signature_def[tf_signature_def_key]
 
 
 def _load_pyfunc(path):

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -15,9 +15,9 @@ import tensorflow as tf
 
 import mlflow
 import mlflow.tensorflow
+from mlflow.exceptions import MlflowException
 from mlflow import pyfunc
 from mlflow.models import Model
-from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, INVALID_PARAMETER_VALUE
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.tracking.utils import _get_model_log_dir
 SavedModelInfo = collections.namedtuple(
@@ -236,32 +236,29 @@ def test_save_model_with_invalid_path_signature_def_or_metagraph_tags_throws_exc
         tmpdir, saved_tf_iris_model):
     model_path = os.path.join(str(tmpdir), "model")
 
-    with pytest.raises(IOError) as e:
+    with pytest.raises(IOError):
         mlflow.tensorflow.save_model(tf_saved_model_dir="not_a_valid_tf_model_dir",
                                      tf_meta_graph_tags=saved_tf_iris_model.meta_graph_tags,
                                      tf_signature_def_key=saved_tf_iris_model.signature_def_key,
                                      path=model_path)
 
-    with pytest.raises(RuntimeError) as e:
+    with pytest.raises(RuntimeError):
         mlflow.tensorflow.save_model(tf_saved_model_dir=saved_tf_iris_model.path,
                                      tf_meta_graph_tags=["bad tags"],
                                      tf_signature_def_key=saved_tf_iris_model.signature_def_key,
                                      path=model_path)
-        assert e.error_code == INVALID_PARAMETER_VALUE
 
-    with pytest.raises(ValueError) as e:
+    with pytest.raises(MlflowException):
         mlflow.tensorflow.save_model(tf_saved_model_dir=saved_tf_iris_model.path,
                                      tf_meta_graph_tags=saved_tf_iris_model.meta_graph_tags,
                                      tf_signature_def_key="bad signature",
                                      path=model_path)
-        assert e.error_code == INVALID_PARAMETER_VALUE
 
-    with pytest.raises(IOError) as e:
+    with pytest.raises(IOError):
         mlflow.tensorflow.save_model(tf_saved_model_dir="bad path",
                                      tf_meta_graph_tags="bad tags",
                                      tf_signature_def_key="bad signature",
                                      path=model_path)
-        assert e.error_code == RESOURCE_DOES_NOT_EXIST
 
 
 def test_load_model_loads_artifacts_from_specified_model_directory(tmpdir, saved_tf_iris_model):


### PR DESCRIPTION
As per the [TF 1.12 release notes](https://github.com/tensorflow/tensorflow/blob/61c6c84964b4aec80aeace187aab8cb2c3e55a72/RELEASE.md#bug-fixes-and-other-changes), the `tf.contrib.get_signature_def_by_key(metagraph_def, signature_def_key)` API has been removed and should be replaced with `eta_graph_def.signature_def[signature_def_key]`. This PR makes that change (I also manually tested against TF 1.10 to check that things still work with older TF versions, since our travis tests only run against the latest TF).