### PR TITLE
Make compact view default

### DIFF
--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -391,18 +391,18 @@ class ExperimentView extends Component {
             <span style={{cursor: "pointer"}}>
                 <ButtonGroup style={styles.tableToggleButtonGroup}>
                 <Button
-                  onClick={() => this.setShowMultiColumns(true)}
-                  title="Grid view"
-                  className={classNames({ "active": this.state.persistedState.showMultiColumns })}
-                >
-                  <i className={"fas fa-table"}/>
-                </Button>
-                <Button
                   onClick={() => this.setShowMultiColumns(false)}
                   title="Compact view"
                   className={classNames({ "active": !this.state.persistedState.showMultiColumns })}
                 >
                   <i className={"fas fa-list"}/>
+                </Button>
+                <Button
+                  onClick={() => this.setShowMultiColumns(true)}
+                  title="Grid view"
+                  className={classNames({ "active": this.state.persistedState.showMultiColumns })}
+                >
+                  <i className={"fas fa-table"}/>
                 </Button>
                 </ButtonGroup>
             </span>

--- a/mlflow/server/js/src/sdk/MlflowLocalStorageMessages.js
+++ b/mlflow/server/js/src/sdk/MlflowLocalStorageMessages.js
@@ -53,7 +53,7 @@ export const ExperimentViewPersistedState = Immutable.Record({
     key: "start_time"
   },
   // If true, shows the multi-column table view instead of the compact table view.
-  showMultiColumns: true,
+  showMultiColumns: false,
   // Arrays of "unbagged", or split-out metric and param keys (strings). We maintain these as lists
   // to help keep them ordered (i.e. splitting out a column shouldn't change the ordering of columns
   // that have already been split out)


### PR DESCRIPTION
Originally, we made the compact view non-default because it didn't support column-splitting or persistence -- now that we have both of these, we should go ahead and make this view default. Users can still switch back to the old view, and that choice will be persisted.

Also switched ordering of the icons so the default is on the left.