### PR TITLE
Fix pyfunc serve ENV bug

### DIFF
--- a/mlflow/sagemaker/container/__init__.py
+++ b/mlflow/sagemaker/container/__init__.py
@@ -134,7 +134,7 @@ def _serve_mleap():
 
 
 def _container_includes_mlflow_source():
-    return os.path.isdir("/opt/mlflow") and os.path.exists("/opt/mlflow/setup.py")
+    return os.path.exists("/opt/mlflow/setup.py")
 
 def _train():
     raise Exception("Train is not implemented.")

--- a/mlflow/sagemaker/container/__init__.py
+++ b/mlflow/sagemaker/container/__init__.py
@@ -136,6 +136,7 @@ def _serve_mleap():
 def _container_includes_mlflow_source():
     return os.path.exists("/opt/mlflow/setup.py")
 
+
 def _train():
     raise Exception("Train is not implemented.")
 

--- a/mlflow/sagemaker/container/__init__.py
+++ b/mlflow/sagemaker/container/__init__.py
@@ -134,8 +134,7 @@ def _serve_mleap():
 
 
 def _container_includes_mlflow_source():
-    return os.path.isdir("/opt/mlflow")
-
+    return os.path.isdir("/opt/mlflow") and os.path.exists("/opt/mlflow/setup.py")
 
 def _train():
     raise Exception("Train is not implemented.")


### PR DESCRIPTION
When a pyfunc model for sagemaker requires ENV, it fails serving because mlflow fails to install from source.  The reason this happens is because _container_includes_mlflow_source() is always true due to the MKDIR directive from the pyfunc Dockerfile (see https://github.com/mlflow/mlflow/blob/master/mlflow/sagemaker/__init__.py#L76), causing mlflow to run always run ```pip install /opt/mlflow .``` on the empty directory.