### PR TITLE
[R] Increase timeout of REST calls from 1 second to 60 seconds

### DIFF
--- a/mlflow/R/mlflow/R/tracking-rest.R
+++ b/mlflow/R/mlflow/R/tracking-rest.R
@@ -27,7 +27,7 @@ mlflow_rest_headers <- function() {
 
 #' @importFrom httr timeout
 mlflow_rest_timeout <- function() {
-  timeout(getOption("mlflow.rest.timeout", 1))
+  timeout(getOption("mlflow.rest.timeout", 60))
 }
 
 #' @importFrom httr content


### PR DESCRIPTION
As reported in the [MLflow users mailing list](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/mlflow-users/6nWaATd4uTw/8pZz6KghBQAJ), the current timeout on REST calls is quite short, allowing reasonable calls to timeout. This PR sets the default timeout to a relatively high value of 60 seconds, making it unlikely to timeout successful calls (but taking longer to detect failure).