### PR TITLE
Mark MLflow as beta instead of alpha

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
-====================
-MLflow Alpha Release
-====================
+===================
+MLflow Beta Release
+===================
 
-**Note:** The current version of MLflow is an alpha release. This means that APIs and data formats
+**Note:** The current version of MLflow is a beta release. This means that APIs and data formats
 are subject to change!
 
 **Note 2:** We do not currently support running MLflow on Windows. Despite this, we would appreciate any contributions

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,5 +34,5 @@ Get started using the :ref:`quickstart` or by reading about the :ref:`key concep
 
 .. warning::
 
-    The current version of MLflow is an alpha release. This means that APIs and storage formats
+    The current version of MLflow is a beta release. This means that APIs and storage formats
     are subject to breaking change.


### PR DESCRIPTION
Update docs & README to state that MLflow is in beta.