### PR TITLE
Update Databricks project execution docs to clarify how to run against different workspaces

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -50,8 +50,11 @@ def cli():
 @click.option("--mode", "-m", metavar="MODE",
               help="Execution mode to use for run. Supported values: 'local' (runs project"
                    "locally) and 'databricks' (runs project on a Databricks cluster)."
-                   "Defaults to 'local'. If running against Databricks, will run against the "
-                   "Databricks workspace specified in the default Databricks CLI profile. "
+                   "Defaults to 'local'. If running against Databricks, will run against a "
+                   "Databricks workspace determined as follows: if a Databricks tracking URI "
+                   "(of the form 'databricks://profile') has been set, will run against the "
+                   "workspace specified by <profile>. Otherwise, runs against the workspace "
+                   "specified by the default Databricks CLI profile."
                    "See https://github.com/databricks/databricks-cli for more info on configuring "
                    "a Databricks CLI profile.")
 @click.option("--cluster-spec", "-c", metavar="FILE",

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -52,11 +52,12 @@ def cli():
                    "locally) and 'databricks' (runs project on a Databricks cluster)."
                    "Defaults to 'local'. If running against Databricks, will run against a "
                    "Databricks workspace determined as follows: if a Databricks tracking URI "
-                   "(of the form 'databricks://profile') has been set, will run against the "
+                   "of the form 'databricks://profile' has been set (e.g. by setting "
+                   "the MLFLOW_TRACKING_URI environment variable), will run against the "
                    "workspace specified by <profile>. Otherwise, runs against the workspace "
-                   "specified by the default Databricks CLI profile."
-                   "See https://github.com/databricks/databricks-cli for more info on configuring "
-                   "a Databricks CLI profile.")
+                   "specified by the default Databricks CLI profile. See "
+                   "https://github.com/databricks/databricks-cli for more info on configuring a "
+                   "Databricks CLI profile.")
 @click.option("--cluster-spec", "-c", metavar="FILE",
               help="Path to JSON file (must end in '.json') or JSON string describing the cluster"
                    "to use when launching a run on Databricks. See "

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -115,9 +115,10 @@ def run(uri, entry_point="main", version=None, parameters=None, experiment_id=No
     :param experiment_id: ID of experiment under which to launch the run.
     :param mode: Execution mode of the run: "local" or "databricks". If running against Databricks,
                  will run against a Databricks workspace determined as follows: if a Databricks
-                 tracking URI (of the form 'databricks://profile') has been set, will run
-                 against the workspace specified by <profile>. Otherwise, runs against the
-                 workspace specified by the default Databricks CLI profile.
+                 tracking URI of the form 'databricks://profile' has been set (e.g. by setting
+                 the MLFLOW_TRACKING_URI environment variable), will run against the workspace
+                 specified by <profile>. Otherwise, runs against the workspace specified by the
+                 default Databricks CLI profile.
     :param cluster_spec: When ``mode`` is "databricks", dictionary or path to a JSON file
                          containing a `Databricks cluster specification
                          <https://docs.databricks.com/api/latest/jobs.html#clusterspec>`_

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -113,7 +113,11 @@ def run(uri, entry_point="main", version=None, parameters=None, experiment_id=No
                         environment variable ``$SHELL``) to run ``.sh`` files.
     :param version: For Git-based projects, either a commit hash or a branch name.
     :param experiment_id: ID of experiment under which to launch the run.
-    :param mode: Execution mode of the run: "local" or "databricks".
+    :param mode: Execution mode of the run: "local" or "databricks". If running against Databricks,
+                 will run against a Databricks workspace determined as follows: if a Databricks
+                 tracking URI (of the form 'databricks://profile') has been set, will run
+                 against the workspace specified by <profile>. Otherwise, runs against the
+                 workspace specified by the default Databricks CLI profile.
     :param cluster_spec: When ``mode`` is "databricks", dictionary or path to a JSON file
                          containing a `Databricks cluster specification
                          <https://docs.databricks.com/api/latest/jobs.html#clusterspec>`_


### PR DESCRIPTION
Updates docstrings for the `mlflow run` CLI & `mlflow.run` Python API to describe how to run projects against different Databricks workspaces