### PR TITLE
Update Javadoc build script to delete existing files before copying them into docs

### DIFF
--- a/docs/build-javadoc.sh
+++ b/docs/build-javadoc.sh
@@ -2,8 +2,9 @@
 
 set -ex
 pushd ../mlflow/java/client/
-mvn javadoc:javadoc
+mvn clean javadoc:javadoc
 popd
+rm -rf build/html/java_api/
 mkdir -p build/html/java_api/
 cp -r ../mlflow/java/client/target/site/apidocs/* build/html/java_api/
 echo "Copied JavaDoc into docs/build/html/java_api/"


### PR DESCRIPTION
To ensure a reproducible build of the Javadocs / prevent undesired documentation left over from previous builds from sneaking into the docs.