### PR TITLE
Replace instances of eprint with python logger calls

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -40,9 +40,9 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E
 import mlflow.projects as projects  # noqa
 import mlflow.tracking as tracking  # noqa
 import mlflow.tracking.fluent
-from mlflow.utils.logging_utils import _configure_loggers
+from mlflow.utils.logging_utils import _configure_default_logger 
 
-_configure_loggers()
+_configure_default_logger()
 
 ActiveRun = mlflow.tracking.fluent.ActiveRun
 log_param = mlflow.tracking.fluent.log_param

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -40,9 +40,9 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E
 import mlflow.projects as projects  # noqa
 import mlflow.tracking as tracking  # noqa
 import mlflow.tracking.fluent
-from mlflow.utils.logging_utils import _configure_default_logger
+from mlflow.utils.logging_utils import _configure_mlflow_loggers 
 
-_configure_default_logger()
+_configure_mlflow_loggers()
 
 ActiveRun = mlflow.tracking.fluent.ActiveRun
 log_param = mlflow.tracking.fluent.log_param

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -40,7 +40,7 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E
 import mlflow.projects as projects  # noqa
 import mlflow.tracking as tracking  # noqa
 import mlflow.tracking.fluent
-from mlflow.utils.logging_utils import _configure_default_logger 
+from mlflow.utils.logging_utils import _configure_default_logger
 
 _configure_default_logger()
 

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -40,6 +40,9 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E
 import mlflow.projects as projects  # noqa
 import mlflow.tracking as tracking  # noqa
 import mlflow.tracking.fluent
+from mlflow.utils.logging_utils import _configure_default_logger
+
+_configure_default_logger()
 
 ActiveRun = mlflow.tracking.fluent.ActiveRun
 log_param = mlflow.tracking.fluent.log_param

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -40,7 +40,7 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E
 import mlflow.projects as projects  # noqa
 import mlflow.tracking as tracking  # noqa
 import mlflow.tracking.fluent
-from mlflow.utils.logging_utils import _configure_mlflow_loggers 
+from mlflow.utils.logging_utils import _configure_mlflow_loggers
 
 _configure_mlflow_loggers()
 

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -40,9 +40,9 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E
 import mlflow.projects as projects  # noqa
 import mlflow.tracking as tracking  # noqa
 import mlflow.tracking.fluent
-from mlflow.utils.logging_utils import _configure_default_logger
+from mlflow.utils.logging_utils import _configure_loggers
 
-_configure_default_logger()
+_configure_loggers()
 
 ActiveRun = mlflow.tracking.fluent.ActiveRun
 log_param = mlflow.tracking.fluent.log_param

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -42,7 +42,7 @@ import mlflow.tracking as tracking  # noqa
 import mlflow.tracking.fluent
 from mlflow.utils.logging_utils import _configure_mlflow_loggers
 
-_configure_mlflow_loggers()
+_configure_mlflow_loggers(root_module_name=__name__)
 
 ActiveRun = mlflow.tracking.fluent.ActiveRun
 log_param = mlflow.tracking.fluent.log_param

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -20,11 +20,10 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils import PYTHON_VERSION, get_unique_resource_id
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree, _copy_project
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.version import VERSION as mlflow_version
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 def build_image(model_path, workspace, run_id=None, image_name=None, model_name=None,

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -8,6 +8,7 @@ import sys
 import os
 import shutil
 import tempfile
+import logging
 
 from distutils.version import StrictVersion
 
@@ -18,9 +19,11 @@ from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils import PYTHON_VERSION, get_unique_resource_id
-from mlflow.utils.logging_utils import eprint
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree, _copy_project
 from mlflow.version import VERSION as mlflow_version
+
+
+_logger = logging.getLogger(__name__) 
 
 
 def build_image(model_path, workspace, run_id=None, image_name=None, model_name=None,
@@ -140,9 +143,8 @@ def build_image(model_path, workspace, run_id=None, image_name=None, model_name=
         registered_model = AzureModel.register(workspace=workspace, model_path=tmp_model_path,
                                                model_name=model_name, tags=tags,
                                                description=description)
-        eprint("Registered an Azure Model with name: `{model_name}` and version:"
-               " `{model_version}`".format(model_name=registered_model.name,
-                                           model_version=registered_model.version))
+        _logger.info("Registered an Azure Model with name: `%s` and version: `%s`",
+                     registered_model.name, registered_model.version)
 
         # Create an execution script (entry point) for the image's model server. Azure ML requires
         # the container's execution script to be located in the current working directory during
@@ -160,8 +162,10 @@ def build_image(model_path, workspace, run_id=None, image_name=None, model_name=
         execution_script_path = os.path.basename(execution_script_path)
 
         if mlflow_home is not None:
-            eprint("Copying the specified mlflow_home directory: `{mlflow_home}` to a temporary"
-                   " location for container creation".format(mlflow_home=mlflow_home))
+            _logger.info(
+                "Copying the specified mlflow_home directory: `%s` to a temporary location for" 
+                " container creation",
+                mlflow_home)
             mlflow_home = os.path.join(tmp.path(),
                                        _copy_project(src_path=mlflow_home, dst_path=tmp.path()))
             image_file_dependencies = [mlflow_home]
@@ -187,10 +191,8 @@ def build_image(model_path, workspace, run_id=None, image_name=None, model_name=
                                       name=image_name,
                                       image_config=image_configuration,
                                       models=[registered_model])
-        eprint("Building an Azure Container Image with name: `{image_name}` and version:"
-               " `{image_version}`".format(
-                   image_name=image.name,
-                   image_version=image.version))
+        _logger.info("Building an Azure Container Image with name: `%s` and version: `%s`", 
+                     image.name, image.version)
         if synchronous:
             image.wait_for_creation(show_output=True)
         return image, registered_model

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -23,7 +23,7 @@ from mlflow.utils.file_utils import TempDir, _copy_file_or_tree, _copy_project
 from mlflow.version import VERSION as mlflow_version
 
 
-_logger = logging.getLogger(__name__) 
+_logger = logging.getLogger(__name__)
 
 
 def build_image(model_path, workspace, run_id=None, image_name=None, model_name=None,
@@ -163,7 +163,7 @@ def build_image(model_path, workspace, run_id=None, image_name=None, model_name=
 
         if mlflow_home is not None:
             _logger.info(
-                "Copying the specified mlflow_home directory: `%s` to a temporary location for" 
+                "Copying the specified mlflow_home directory: `%s` to a temporary location for"
                 " container creation",
                 mlflow_home)
             mlflow_home = os.path.join(tmp.path(),
@@ -191,7 +191,7 @@ def build_image(model_path, workspace, run_id=None, image_name=None, model_name=
                                       name=image_name,
                                       image_config=image_configuration,
                                       models=[registered_model])
-        _logger.info("Building an Azure Container Image with name: `%s` and version: `%s`", 
+        _logger.info("Building an Azure Container Image with name: `%s` and version: `%s`",
                      image.name, image.version)
         if synchronous:
             image.wait_for_creation(show_output=True)

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -20,10 +20,11 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils import PYTHON_VERSION, get_unique_resource_id
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree, _copy_project
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.version import VERSION as mlflow_version
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 def build_image(model_path, workspace, run_id=None, image_name=None, model_name=None,

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import json
 import os
 import sys
+import logging
 
 import click
 from click import UsageError
@@ -17,11 +18,13 @@ import mlflow.sagemaker.cli
 
 from mlflow.entities.experiment import Experiment
 from mlflow.utils.process import ShellCommandException
-from mlflow.utils.logging_utils import eprint
 from mlflow.utils import cli_args
 from mlflow.server import _run_server
 from mlflow import tracking
 import mlflow.store.cli
+
+
+_logger = logging.getLogger(__name__)
 
 
 @click.group()
@@ -121,7 +124,7 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
             run_id=run_id,
         )
     except projects.ExecutionException as e:
-        eprint("=== %s ===" % e)
+        _logger.error("=== %s ===", e)
         sys.exit(1)
 
 

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -19,12 +19,13 @@ import mlflow.sagemaker.cli
 from mlflow.entities.experiment import Experiment
 from mlflow.utils.process import ShellCommandException
 from mlflow.utils import cli_args
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.server import _run_server
 from mlflow import tracking
 import mlflow.store.cli
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 @click.group()

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -19,13 +19,12 @@ import mlflow.sagemaker.cli
 from mlflow.entities.experiment import Experiment
 from mlflow.utils.process import ShellCommandException
 from mlflow.utils import cli_args
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.server import _run_server
 from mlflow import tracking
 import mlflow.store.cli
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 @click.group()

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -13,18 +13,18 @@ import subprocess
 import tempfile
 import logging
 
+import mlflow.tracking as tracking
+import mlflow.tracking.fluent as fluent
 from mlflow.projects.submitted_run import LocalSubmittedRun, SubmittedRun
 from mlflow.projects import _project_spec
 from mlflow.exceptions import ExecutionException
 from mlflow.entities import RunStatus, SourceType, Param
-import mlflow.tracking as tracking
 from mlflow.tracking.fluent import _get_experiment_id, _get_git_commit
-import mlflow.tracking.fluent as fluent
-
 
 import mlflow.projects.databricks
 from mlflow.utils import process
 from mlflow.utils.mlflow_tags import MLFLOW_GIT_BRANCH_NAME
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 
 # TODO: this should be restricted to just Git repos and not S3 and stuff like that
 _GIT_URI_REGEX = re.compile(r"^[^/]*:")
@@ -33,7 +33,7 @@ _GIT_URI_REGEX = re.compile(r"^[^/]*:")
 MLFLOW_CONDA_HOME = "MLFLOW_CONDA_HOME"
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 def _run(uri, entry_point="main", version=None, parameters=None, experiment_id=None,

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -367,7 +367,7 @@ def _get_entry_point_command(project, entry_point, parameters, conda_env_name, s
     """
     storage_dir_for_run = _get_storage_dir(storage_dir)
     _logger.info(
-        "=== Created directory %s for downloading remote URIs passed to arguments of" 
+        "=== Created directory %s for downloading remote URIs passed to arguments of"
         " type 'path' ===",
         storage_dir_for_run)
     commands = []

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -24,7 +24,6 @@ from mlflow.tracking.fluent import _get_experiment_id, _get_git_commit
 import mlflow.projects.databricks
 from mlflow.utils import process
 from mlflow.utils.mlflow_tags import MLFLOW_GIT_BRANCH_NAME
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 
 # TODO: this should be restricted to just Git repos and not S3 and stuff like that
 _GIT_URI_REGEX = re.compile(r"^[^/]*:")
@@ -33,7 +32,7 @@ _GIT_URI_REGEX = re.compile(r"^[^/]*:")
 MLFLOW_CONDA_HOME = "MLFLOW_CONDA_HOME"
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 def _run(uri, entry_point="main", version=None, parameters=None, experiment_id=None,

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -11,6 +11,7 @@ import os
 import re
 import subprocess
 import tempfile
+import logging
 
 from mlflow.projects.submitted_run import LocalSubmittedRun, SubmittedRun
 from mlflow.projects import _project_spec
@@ -23,7 +24,6 @@ import mlflow.tracking.fluent as fluent
 
 import mlflow.projects.databricks
 from mlflow.utils import process
-from mlflow.utils.logging_utils import eprint
 from mlflow.utils.mlflow_tags import MLFLOW_GIT_BRANCH_NAME
 
 # TODO: this should be restricted to just Git repos and not S3 and stuff like that
@@ -31,6 +31,9 @@ _GIT_URI_REGEX = re.compile(r"^[^/]*:")
 # Environment variable indicating a path to a conda installation. MLflow will default to running
 # "conda" if unset
 MLFLOW_CONDA_HOME = "MLFLOW_CONDA_HOME"
+
+
+_logger = logging.getLogger(__name__)
 
 
 def _run(uri, entry_point="main", version=None, parameters=None, experiment_id=None,
@@ -145,8 +148,9 @@ def run(uri, entry_point="main", version=None, parameters=None, experiment_id=No
             try:
                 cluster_spec_dict = json.load(handle)
             except ValueError:
-                eprint("Error when attempting to load and parse JSON cluster spec from file "
-                       "%s. " % cluster_spec)
+                _logger.error(
+                    "Error when attempting to load and parse JSON cluster spec from file %s",
+                    cluster_spec)
                 raise
     submitted_run_obj = _run(
         uri=uri, entry_point=entry_point, version=version, parameters=parameters,
@@ -167,13 +171,13 @@ def _wait_for(submitted_run_obj):
     try:
         active_run = tracking.MlflowClient().get_run(run_id) if run_id is not None else None
         if submitted_run_obj.wait():
-            eprint("=== Run (ID '%s') succeeded ===" % run_id)
+            _logger.info("=== Run (ID '%s') succeeded ===", run_id)
             _maybe_set_run_terminated(active_run, "FINISHED")
         else:
             _maybe_set_run_terminated(active_run, "FAILED")
             raise ExecutionException("Run (ID '%s') failed" % run_id)
     except KeyboardInterrupt:
-        eprint("=== Run (ID '%s') interrupted, cancelling run ===" % run_id)
+        _logger.error("=== Run (ID '%s') interrupted, cancelling run ===", run_id)
         submitted_run_obj.cancel()
         _maybe_set_run_terminated(active_run, "FAILED")
         raise
@@ -236,7 +240,7 @@ def _fetch_project(uri, force_tempdir, version=None, git_username=None, git_pass
     use_temp_dst_dir = force_tempdir or not _is_local_uri(parsed_uri)
     dst_dir = tempfile.mkdtemp() if use_temp_dst_dir else parsed_uri
     if use_temp_dst_dir:
-        eprint("=== Fetching project from %s into %s ===" % (uri, dst_dir))
+        _logger.info("=== Fetching project from %s into %s ===", uri, dst_dir)
     if _is_local_uri(uri):
         if version is not None:
             raise ExecutionException("Setting a version is only supported for Git project URIs")
@@ -326,7 +330,7 @@ def _get_or_create_conda_env(conda_env_path):
     env_names = [os.path.basename(env) for env in json.loads(stdout)['envs']]
     project_env_name = _get_conda_env_name(conda_env_path)
     if project_env_name not in env_names:
-        eprint('=== Creating conda environment %s ===' % project_env_name)
+        _logger.info('=== Creating conda environment %s ===', project_env_name)
         if conda_env_path:
             process.exec_cmd([conda_path, "env", "create", "-n", project_env_name, "--file",
                               conda_env_path], stream_output=True)
@@ -362,8 +366,10 @@ def _get_entry_point_command(project, entry_point, parameters, conda_env_name, s
                         arguments of type 'path'. If None, a temporary base directory is used.
     """
     storage_dir_for_run = _get_storage_dir(storage_dir)
-    eprint("=== Created directory %s for downloading remote URIs passed to arguments of "
-           "type 'path' ===" % storage_dir_for_run)
+    _logger.info(
+        "=== Created directory %s for downloading remote URIs passed to arguments of" 
+        " type 'path' ===",
+        storage_dir_for_run)
     commands = []
     if conda_env_name:
         activate_path = _get_conda_bin_executable("activate")
@@ -383,7 +389,7 @@ def _run_entry_point(command, work_dir, experiment_id, run_id):
     """
     env = os.environ.copy()
     env.update(_get_run_env_vars(run_id, experiment_id))
-    eprint("=== Running command '%s' in run with ID '%s' === " % (command, run_id))
+    _logger.info("=== Running command '%s' in run with ID '%s' === ", command, run_id)
     process = subprocess.Popen(["bash", "-c", command], close_fds=True, cwd=work_dir, env=env)
     return LocalSubmittedRun(run_id, process)
 
@@ -460,7 +466,7 @@ def _invoke_mlflow_run_subprocess(
     Run an MLflow project asynchronously by invoking ``mlflow run`` in a subprocess, returning
     a SubmittedRun that can be used to query run status.
     """
-    eprint("=== Asynchronously launching MLflow run with ID %s ===" % run_id)
+    _logger.info("=== Asynchronously launching MLflow run with ID %s ===", run_id)
     mlflow_run_arr = _build_mlflow_run_cmd(
         uri=work_dir, entry_point=entry_point, storage_dir=storage_dir, use_conda=use_conda,
         run_id=run_id, parameters=parameters)

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -73,7 +73,7 @@ class DatabricksJobRunner(object):
         Upload the file at `src_path` to the specified DBFS URI within the Databricks workspace
         corresponding to the default Databricks CLI profile.
         """
-        _logger.info("=== Uploading project to DBFS path %s ===", dbfs_fuse_uri) 
+        _logger.info("=== Uploading project to DBFS path %s ===", dbfs_fuse_uri)
         http_endpoint = dbfs_fuse_uri
         with open(src_path, 'rb') as f:
             self._databricks_api_request(endpoint=http_endpoint, method='POST', data=f)
@@ -128,7 +128,7 @@ class DatabricksJobRunner(object):
             dbfs_fuse_uri = os.path.join("/dbfs", dbfs_path)
             if not self._dbfs_path_exists(dbfs_path):
                 self._upload_to_dbfs(temp_tar_filename, dbfs_fuse_uri)
-                _logger.info("=== Finished uploading project to %s ===", dbfs_fuse_uri) 
+                _logger.info("=== Finished uploading project to %s ===", dbfs_fuse_uri)
             else:
                 _logger.info("=== Project already exists in DBFS ===")
         finally:
@@ -294,7 +294,7 @@ class DatabricksSubmittedRun(SubmittedRun):
 
     def _print_description_and_log_tags(self):
         _logger.info(
-            "=== Launched MLflow run as Databricks job run with ID %s." 
+            "=== Launched MLflow run as Databricks job run with ID %s."
             " Getting run status page URL... ===",
             self._databricks_run_id)
         run_info = self._job_runner.jobs_runs_get(self._databricks_run_id)

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 import textwrap
 import time
+import logging
 
 from six.moves import shlex_quote
 
@@ -13,7 +14,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.projects.submitted_run import SubmittedRun
 from mlflow.utils import rest_utils, file_utils, databricks_utils
 from mlflow.exceptions import ExecutionException
-from mlflow.utils.logging_utils import eprint
 from mlflow import tracking
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_RUN_URL, MLFLOW_DATABRICKS_SHELL_JOB_ID, \
     MLFLOW_DATABRICKS_SHELL_JOB_RUN_ID, MLFLOW_DATABRICKS_WEBAPP_URL
@@ -30,6 +30,9 @@ DB_PROJECTS_BASE = os.path.join(DB_CONTAINER_BASE, "projects")
 DB_TARFILE_ARCHIVE_NAME = "mlflow-project"
 # Base directory within DBFS for storing code for project runs for experiments
 DBFS_EXPERIMENT_DIR_BASE = "mlflow-experiments"
+
+
+_logger = logging.getLogger(__name__)
 
 
 def before_run_validations(tracking_uri, cluster_spec):
@@ -70,7 +73,7 @@ class DatabricksJobRunner(object):
         Upload the file at `src_path` to the specified DBFS URI within the Databricks workspace
         corresponding to the default Databricks CLI profile.
         """
-        eprint("=== Uploading project to DBFS path %s ===" % dbfs_fuse_uri)
+        _logger.info("=== Uploading project to DBFS path %s ===", dbfs_fuse_uri) 
         http_endpoint = dbfs_fuse_uri
         with open(src_path, 'rb') as f:
             self._databricks_api_request(endpoint=http_endpoint, method='POST', data=f)
@@ -125,9 +128,9 @@ class DatabricksJobRunner(object):
             dbfs_fuse_uri = os.path.join("/dbfs", dbfs_path)
             if not self._dbfs_path_exists(dbfs_path):
                 self._upload_to_dbfs(temp_tar_filename, dbfs_fuse_uri)
-                eprint("=== Finished uploading project to %s ===" % dbfs_fuse_uri)
+                _logger.info("=== Finished uploading project to %s ===", dbfs_fuse_uri) 
             else:
-                eprint("=== Project already exists in DBFS ===")
+                _logger.info("=== Project already exists in DBFS ===")
         finally:
             shutil.rmtree(temp_tarfile_dir)
         return dbfs_fuse_uri
@@ -171,7 +174,7 @@ class DatabricksJobRunner(object):
             tracking._TRACKING_URI_ENV_VAR: tracking_uri,
             tracking._EXPERIMENT_ID_ENV_VAR: experiment_id,
         }
-        eprint("=== Running entry point %s of project %s on Databricks ===" % (entry_point, uri))
+        _logger.info("=== Running entry point %s of project %s on Databricks ===", entry_point, uri)
         # Launch run on Databricks
         command = _get_databricks_run_cmd(dbfs_fuse_uri, run_id, entry_point, parameters)
         return self._run_shell_command_job(uri, command, env_vars, cluster_spec)
@@ -290,11 +293,13 @@ class DatabricksSubmittedRun(SubmittedRun):
         self._job_runner = databricks_job_runner
 
     def _print_description_and_log_tags(self):
-        eprint("=== Launched MLflow run as Databricks job run with ID %s. Getting run status "
-               "page URL... ===" % self._databricks_run_id)
+        _logger.info(
+            "=== Launched MLflow run as Databricks job run with ID %s." 
+            " Getting run status page URL... ===",
+            self._databricks_run_id)
         run_info = self._job_runner.jobs_runs_get(self._databricks_run_id)
         jobs_page_url = run_info["run_page_url"]
-        eprint("=== Check the run's status at %s ===" % jobs_page_url)
+        _logger.info("=== Check the run's status at %s ===", jobs_page_url)
         host_creds = databricks_utils.get_databricks_host_creds(self._job_runner.databricks_profile)
         tracking.MlflowClient().set_tag(self._mlflow_run_id,
                                         MLFLOW_DATABRICKS_RUN_URL, jobs_page_url)

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -13,7 +13,6 @@ from mlflow.entities import RunStatus
 from mlflow.exceptions import MlflowException
 from mlflow.projects.submitted_run import SubmittedRun
 from mlflow.utils import rest_utils, file_utils, databricks_utils
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.exceptions import ExecutionException
 from mlflow import tracking
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_RUN_URL, MLFLOW_DATABRICKS_SHELL_JOB_ID, \
@@ -33,7 +32,7 @@ DB_TARFILE_ARCHIVE_NAME = "mlflow-project"
 DBFS_EXPERIMENT_DIR_BASE = "mlflow-experiments"
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 def before_run_validations(tracking_uri, cluster_spec):

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -13,6 +13,7 @@ from mlflow.entities import RunStatus
 from mlflow.exceptions import MlflowException
 from mlflow.projects.submitted_run import SubmittedRun
 from mlflow.utils import rest_utils, file_utils, databricks_utils
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.exceptions import ExecutionException
 from mlflow import tracking
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_RUN_URL, MLFLOW_DATABRICKS_SHELL_JOB_ID, \
@@ -32,7 +33,7 @@ DB_TARFILE_ARCHIVE_NAME = "mlflow-project"
 DBFS_EXPERIMENT_DIR_BASE = "mlflow-experiments"
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 def before_run_validations(tracking_uri, cluster_spec):

--- a/mlflow/projects/submitted_run.py
+++ b/mlflow/projects/submitted_run.py
@@ -2,9 +2,12 @@ from abc import abstractmethod
 
 import os
 import signal
+import logging
 
 from mlflow.entities import RunStatus
-from mlflow.utils.logging_utils import eprint
+
+
+_logger = logging.getLogger(__name__)
 
 
 class SubmittedRun(object):
@@ -84,9 +87,10 @@ class LocalSubmittedRun(SubmittedRun):
             except OSError:
                 # The child process may have exited before we attempted to terminate it, so we
                 # ignore OSErrors raised during child process termination
-                eprint("Failed to terminate child process (PID %s) corresponding to MLflow "
-                       "run with ID %s. The process may have already "
-                       "exited." % (self.command_proc.pid, self._run_id))
+                _logger.info(
+                    "Failed to terminate child process (PID %s) corresponding to MLflow "
+                    "run with ID %s. The process may have already exited.",
+                    self.command_proc.pid, self._run_id)
             self.command_proc.wait()
 
     def _get_status(self):

--- a/mlflow/projects/submitted_run.py
+++ b/mlflow/projects/submitted_run.py
@@ -5,9 +5,10 @@ import signal
 import logging
 
 from mlflow.entities import RunStatus
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 class SubmittedRun(object):

--- a/mlflow/projects/submitted_run.py
+++ b/mlflow/projects/submitted_run.py
@@ -5,10 +5,9 @@ import signal
 import logging
 
 from mlflow.entities import RunStatus
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 class SubmittedRun(object):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -79,13 +79,13 @@ import os
 import shutil
 import sys
 import pandas
+import logging
 
 from mlflow.tracking.fluent import active_run, log_artifacts
 from mlflow import tracking
 from mlflow.models import Model
 from mlflow.utils import PYTHON_VERSION, get_major_minor_py_version
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree
-from mlflow.utils.logging_utils import eprint
 
 FLAVOR_NAME = "python_function"
 MAIN = "loader_module"
@@ -93,6 +93,9 @@ CODE = "code"
 DATA = "data"
 ENV = "env"
 PY_VERSION = "python_version"
+
+
+_logger = logging.getLogger(__name__)
 
 
 def add_to_model(model, loader_module, data=None, code=None, env=None):
@@ -171,15 +174,16 @@ def load_pyfunc(path, run_id=None, suppress_warnings=False):
 
 def _warn_potentially_incompatible_py_version_if_necessary(model_py_version):
     if model_py_version is None:
-        eprint("The specified model does not have a specified Python version. It may be"
-               " incompatible with the version of Python that is currently running:"
-               " Python {version}".format(
-                   version=PYTHON_VERSION))
+        _logger.warning(
+            "The specified model does not have a specified Python version. It may be"
+            " incompatible with the version of Python that is currently running: Python %s",
+            PYTHON_VERSION)
     elif get_major_minor_py_version(model_py_version) != get_major_minor_py_version(PYTHON_VERSION):
-        eprint("The version of Python that the model was saved in, Python {model_version}, differs"
-               " from the version of Python that is currently running, Python {system_version},"
-               " and may be incompatible".format(
-                   model_version=model_py_version, system_version=PYTHON_VERSION))
+        _logger.warning(
+            "The version of Python that the model was saved in, `Python %s`, differs"
+            " from the version of Python that is currently running, `Python %s`,"
+            " and may be incompatible",
+            model_py_version, PYTHON_VERSION)
 
 
 def _get_code_dirs(src_code_path, dst_code_path=None):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -86,7 +86,6 @@ from mlflow import tracking
 from mlflow.models import Model
 from mlflow.utils import PYTHON_VERSION, get_major_minor_py_version
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 
 FLAVOR_NAME = "python_function"
 MAIN = "loader_module"
@@ -96,7 +95,7 @@ ENV = "env"
 PY_VERSION = "python_version"
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 def add_to_model(model, loader_module, data=None, code=None, env=None):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -86,6 +86,7 @@ from mlflow import tracking
 from mlflow.models import Model
 from mlflow.utils import PYTHON_VERSION, get_major_minor_py_version
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 
 FLAVOR_NAME = "python_function"
 MAIN = "loader_module"
@@ -95,7 +96,7 @@ ENV = "env"
 PY_VERSION = "python_version"
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 def add_to_model(model, loader_module, data=None, code=None, env=None):

--- a/mlflow/pyfunc/cli.py
+++ b/mlflow/pyfunc/cli.py
@@ -9,13 +9,14 @@ import logging
 import click
 import pandas
 
+from mlflow.projects import _get_conda_bin_executable, _get_or_create_conda_env
 from mlflow.pyfunc import load_pyfunc, scoring_server, _load_model_env
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils import cli_args
-from mlflow.projects import _get_conda_bin_executable, _get_or_create_conda_env
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 def _rerun_in_conda(conda_env_path):

--- a/mlflow/pyfunc/cli.py
+++ b/mlflow/pyfunc/cli.py
@@ -4,7 +4,7 @@ import os
 from six.moves import shlex_quote
 import subprocess
 import sys
-
+import logging
 
 import click
 import pandas
@@ -12,8 +12,10 @@ import pandas
 from mlflow.pyfunc import load_pyfunc, scoring_server, _load_model_env
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils import cli_args
-from mlflow.utils.logging_utils import eprint
 from mlflow.projects import _get_conda_bin_executable, _get_or_create_conda_env
+
+
+_logger = logging.getLogger(__name__)
 
 
 def _rerun_in_conda(conda_env_path):
@@ -25,7 +27,7 @@ def _rerun_in_conda(conda_env_path):
     safe_argv = [shlex_quote(arg) for arg in sys.argv]
     commands.append(" ".join(safe_argv) + " --no-conda")
     commandline = " && ".join(commands)
-    eprint("=== Running command '{}'".format(commandline))
+    _logger.info("=== Running command '%s'", commandline)
     child = subprocess.Popen(["bash", "-c", commandline], close_fds=True)
     exit_code = child.wait()
     return exit_code

--- a/mlflow/pyfunc/cli.py
+++ b/mlflow/pyfunc/cli.py
@@ -13,10 +13,9 @@ from mlflow.projects import _get_conda_bin_executable, _get_or_create_conda_env
 from mlflow.pyfunc import load_pyfunc, scoring_server, _load_model_env
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils import cli_args
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 def _rerun_in_conda(conda_env_path):

--- a/mlflow/pyfunc/scoring_server.py
+++ b/mlflow/pyfunc/scoring_server.py
@@ -23,6 +23,7 @@ from six import reraise
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import MALFORMED_REQUEST, BAD_REQUEST
 from mlflow.utils.rest_utils import NumpyEncoder
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.server.handlers import catch_mlflow_exception
 
 try:
@@ -45,7 +46,11 @@ CONTENT_TYPES = [
 ]
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+
+
+def test():
+    _logger.info("CAT A TEXT")
 
 
 def parse_json_input(json_input, orientation="split"):

--- a/mlflow/pyfunc/scoring_server.py
+++ b/mlflow/pyfunc/scoring_server.py
@@ -23,7 +23,6 @@ from six import reraise
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import MALFORMED_REQUEST, BAD_REQUEST
 from mlflow.utils.rest_utils import NumpyEncoder
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.server.handlers import catch_mlflow_exception
 
 try:
@@ -46,11 +45,7 @@ CONTENT_TYPES = [
 ]
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
-
-
-def test():
-    _logger.info("CAT A TEXT")
+_logger = logging.getLogger(__name__)
 
 
 def parse_json_input(json_input, orientation="split"):

--- a/mlflow/pyfunc/scoring_server.py
+++ b/mlflow/pyfunc/scoring_server.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 
 import json
 import traceback
+import logging
 
 import pandas as pd
 import flask
@@ -22,7 +23,6 @@ from six import reraise
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import MALFORMED_REQUEST, BAD_REQUEST
 from mlflow.utils.rest_utils import NumpyEncoder
-from mlflow.utils.logging_utils import eprint
 from mlflow.server.handlers import catch_mlflow_exception
 
 try:
@@ -43,6 +43,9 @@ CONTENT_TYPES = [
     CONTENT_TYPE_JSON_RECORDS_ORIENTED,
     CONTENT_TYPE_JSON_SPLIT_ORIENTED
 ]
+
+
+_logger = logging.getLogger(__name__)
 
 
 def parse_json_input(json_input, orientation="split"):
@@ -136,20 +139,19 @@ def init(model):
         elif flask.request.content_type == CONTENT_TYPE_JSON:
             global logged_pandas_records_format_warning
             if not logged_pandas_records_format_warning:
-                eprint(
+                _logger.warning(
                     "**IMPORTANT UPDATE**: Starting in MLflow 0.9.0, requests received with a"
-                    " `Content-Type` header value of `{json_content_type}` will be interpreted"
+                    " `Content-Type` header value of `%s` will be interpreted"
                     " as JSON-serialized Pandas DataFrames with the `split` orientation, instead"
                     " of the `records` orientation. The `records` orientation is unsafe because"
                     " it may not preserve column ordering. Client code should be updated to"
                     " either send serialized DataFrames with the `split` orientation and the"
-                    " `{split_json_content_type}` content type (recommended) or use the"
-                    " `{records_json_content_type}` content type with the `records` orientation."
-                    " For more information, see"
-                    " https://www.mlflow.org/docs/latest/models.html#pyfunc-deployment.\n".format(
-                        json_content_type=CONTENT_TYPE_JSON,
-                        split_json_content_type=CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-                        records_json_content_type=CONTENT_TYPE_JSON_RECORDS_ORIENTED))
+                    " `%s` content type (recommended) or use the `%s` content type with the" 
+                    " `records` orientation. For more information, see"
+                    " https://www.mlflow.org/docs/latest/models.html#pyfunc-deployment.\n",
+                    CONTENT_TYPE_JSON, 
+                    CONTENT_TYPE_JSON_SPLIT_ORIENTED, 
+                    CONTENT_TYPE_JSON_RECORDS_ORIENTED)
                 logged_pandas_records_format_warning = True
             data = parse_json_input(json_input=flask.request.data.decode('utf-8'),
                                     orientation="records")

--- a/mlflow/pyfunc/scoring_server.py
+++ b/mlflow/pyfunc/scoring_server.py
@@ -146,11 +146,11 @@ def init(model):
                     " of the `records` orientation. The `records` orientation is unsafe because"
                     " it may not preserve column ordering. Client code should be updated to"
                     " either send serialized DataFrames with the `split` orientation and the"
-                    " `%s` content type (recommended) or use the `%s` content type with the" 
+                    " `%s` content type (recommended) or use the `%s` content type with the"
                     " `records` orientation. For more information, see"
                     " https://www.mlflow.org/docs/latest/models.html#pyfunc-deployment.\n",
-                    CONTENT_TYPE_JSON, 
-                    CONTENT_TYPE_JSON_SPLIT_ORIENTED, 
+                    CONTENT_TYPE_JSON,
+                    CONTENT_TYPE_JSON_SPLIT_ORIENTED,
                     CONTENT_TYPE_JSON_RECORDS_ORIENTED)
                 logged_pandas_records_format_warning = True
             data = parse_json_input(json_input=flask.request.data.decode('utf-8'),

--- a/mlflow/rfunc/cli.py
+++ b/mlflow/rfunc/cli.py
@@ -3,10 +3,13 @@ from __future__ import absolute_import
 import click
 import os
 import subprocess
+import logging
 
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils import cli_args
-from mlflow.utils.logging_utils import eprint
+
+
+_logger = logging.getLogger(__name__)
 
 
 @click.group("rfunc")
@@ -21,7 +24,7 @@ def commands():
 
 
 def execute(command):
-    eprint("=== Rscript -e %s) ===" % command)
+    _logger.info("=== Rscript -e %s) ===", command)
     env = os.environ.copy()
     process = subprocess.Popen(["Rscript", "-e", command], close_fds=True, env=env)
     process.wait()

--- a/mlflow/rfunc/cli.py
+++ b/mlflow/rfunc/cli.py
@@ -7,10 +7,9 @@ import logging
 
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils import cli_args
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 @click.group("rfunc")

--- a/mlflow/rfunc/cli.py
+++ b/mlflow/rfunc/cli.py
@@ -7,9 +7,10 @@ import logging
 
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils import cli_args
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 @click.group("rfunc")

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -158,7 +158,7 @@ def build_image(name=DEFAULT_IMAGE_NAME, mlflow_home=None):
                      stderr=STDOUT,
                      universal_newlines=True)
         for x in iter(proc.stdout.readline, ""):
-            _logger.info(x, end='')
+            _logger.info(x)
 
 
 _full_template = "{account}.dkr.ecr.{region}.amazonaws.com/{image}:{version}"
@@ -442,7 +442,7 @@ def run_local(model_path, run_id=None, port=5000, image=DEFAULT_IMAGE_NAME, flav
     import signal
     signal.signal(signal.SIGTERM, _sigterm_handler)
     for x in iter(proc.stdout.readline, ""):
-        _logger.info(x, end='')
+        _logger.info(x)
 
 
 def _get_default_image_url(region_name):

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -22,6 +22,7 @@ from mlflow.models import Model
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils import get_unique_resource_id
 from mlflow.utils.file_utils import TempDir, _copy_project
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.sagemaker.container import SUPPORTED_FLAVORS as SUPPORTED_DEPLOYMENT_FLAVORS
 from mlflow.sagemaker.container import DEPLOYMENT_CONFIG_KEY_FLAVOR_NAME
 
@@ -80,7 +81,7 @@ ENTRYPOINT ["python", "-c", "import sys; from mlflow.sagemaker import container 
 C._init(sys.argv[1])"]
 """
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 def _docker_ignore(mlflow_root):

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -22,7 +22,6 @@ from mlflow.models import Model
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils import get_unique_resource_id
 from mlflow.utils.file_utils import TempDir, _copy_project
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.sagemaker.container import SUPPORTED_FLAVORS as SUPPORTED_DEPLOYMENT_FLAVORS
 from mlflow.sagemaker.container import DEPLOYMENT_CONFIG_KEY_FLAVOR_NAME
 
@@ -81,7 +80,7 @@ ENTRYPOINT ["python", "-c", "import sys; from mlflow.sagemaker import container 
 C._init(sys.argv[1])"]
 """
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 def _docker_ignore(mlflow_root):

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -674,7 +674,7 @@ def _create_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
             },
         ],
     )
-    _logger.info("Created endpoint configuration with arn: %s", 
+    _logger.info("Created endpoint configuration with arn: %s",
                  endpoint_config_response["EndpointConfigArn"])
 
     endpoint_response = sage_client.create_endpoint(
@@ -761,7 +761,7 @@ def _update_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
             },
         ],
     )
-    _logger.info("Created new endpoint configuration with arn: %s", 
+    _logger.info("Created new endpoint configuration with arn: %s",
                  endpoint_config_response["EndpointConfigArn"])
 
     sage_client.update_endpoint(EndpointName=endpoint_name,

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -22,6 +22,7 @@ from mlflow.models import Model
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils import get_unique_resource_id
 from mlflow.utils.file_utils import TempDir, _copy_project
+from mlflow.utils.logging_utils import eprint
 from mlflow.sagemaker.container import SUPPORTED_FLAVORS as SUPPORTED_DEPLOYMENT_FLAVORS
 from mlflow.sagemaker.container import DEPLOYMENT_CONFIG_KEY_FLAVOR_NAME
 
@@ -157,7 +158,7 @@ def build_image(name=DEFAULT_IMAGE_NAME, mlflow_home=None):
                      stderr=STDOUT,
                      universal_newlines=True)
         for x in iter(proc.stdout.readline, ""):
-            _logger.info(x)
+            eprint(x, end='')
 
 
 _full_template = "{account}.dkr.ecr.{region}.amazonaws.com/{image}:{version}"
@@ -441,7 +442,7 @@ def run_local(model_path, run_id=None, port=5000, image=DEFAULT_IMAGE_NAME, flav
     import signal
     signal.signal(signal.SIGTERM, _sigterm_handler)
     for x in iter(proc.stdout.readline, ""):
-        _logger.info(x)
+        eprint(x, end='')
 
 
 def _get_default_image_url(region_name):
@@ -502,7 +503,7 @@ def _get_default_s3_bucket(region_name):
                 'LocationConstraint': region_name
             }
         response = s3.create_bucket(**bucket_creation_kwargs)
-        _logger.info(response)
+        _logger.info("Bucket creation response: %s", response)
     else:
         _logger.info("Default bucket `%s` already exists. Skipping creation.", bucket_name)
     return bucket_name

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -10,6 +10,7 @@ from six.moves import urllib
 import tarfile
 import uuid
 import shutil
+import logging
 
 import base64
 import boto3
@@ -20,7 +21,6 @@ from mlflow import pyfunc, mleap
 from mlflow.models import Model
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils import get_unique_resource_id
-from mlflow.utils.logging_utils import eprint
 from mlflow.utils.file_utils import TempDir, _copy_project
 from mlflow.sagemaker.container import SUPPORTED_FLAVORS as SUPPORTED_DEPLOYMENT_FLAVORS
 from mlflow.sagemaker.container import DEPLOYMENT_CONFIG_KEY_FLAVOR_NAME
@@ -79,6 +79,8 @@ WORKDIR /opt/mlflow
 ENTRYPOINT ["python", "-c", "import sys; from mlflow.sagemaker import container as C; \
 C._init(sys.argv[1])"]
 """
+
+_logger = logging.getLogger(__name__)
 
 
 def _docker_ignore(mlflow_root):
@@ -147,7 +149,7 @@ def build_image(name=DEFAULT_IMAGE_NAME, mlflow_home=None):
 
         with open(os.path.join(cwd, "Dockerfile"), "w") as f:
             f.write(_DOCKERFILE_TEMPLATE % install_mlflow)
-        eprint("building docker image")
+        _logger.info("building docker image")
         os.system('find {cwd}/'.format(cwd=cwd))
         proc = Popen(["docker", "build", "-t", name, "-f", "Dockerfile", "."],
                      cwd=cwd,
@@ -155,7 +157,7 @@ def build_image(name=DEFAULT_IMAGE_NAME, mlflow_home=None):
                      stderr=STDOUT,
                      universal_newlines=True)
         for x in iter(proc.stdout.readline, ""):
-            eprint(x, end='')
+            _logger.info(x, end='')
 
 
 _full_template = "{account}.dkr.ecr.{region}.amazonaws.com/{image}:{version}"
@@ -169,7 +171,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
 
     :param image: Docker image name.
     """
-    eprint("Pushing image to ECR")
+    _logger.info("Pushing image to ECR")
     client = boto3.client("sts")
     caller_id = client.get_caller_identity()
     account = caller_id['Account']
@@ -177,8 +179,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
     region = my_session.region_name or "us-west-2"
     fullname = _full_template.format(account=account, region=region, image=image,
                                      version=mlflow.version.VERSION)
-    eprint("Pushing docker image {image} to {repo}".format(
-        image=image, repo=fullname))
+    _logger.info("Pushing docker image %s to %s", image=image, repo=fullname)
     ecr_client = boto3.client('ecr')
     try:
         ecr_client.describe_repositories(repositoryNames=[image])['repositories']
@@ -302,7 +303,7 @@ def deploy(app_name, model_path, execution_role_arn=None, bucket=None, run_id=No
         execution_role_arn = _get_assumed_role_arn()
 
     if not bucket:
-        eprint("No model data bucket specified, using the default bucket")
+        _logger.info("No model data bucket specified, using the default bucket")
         bucket = _get_default_s3_bucket(region_name)
 
     model_s3_path = _upload_s3(
@@ -381,7 +382,7 @@ def delete(app_name, region_name="us-west-2", archive=False):
     endpoint_arn = endpoint_info["EndpointArn"]
 
     sage_client.delete_endpoint(EndpointName=app_name)
-    eprint("Deleted endpoint with arn: {earn}".format(earn=endpoint_arn))
+    _logger.info("Deleted endpoint with arn: %s", endpoint_arn)
 
     if not archive:
         config_name = endpoint_info["EndpointConfigName"]
@@ -389,14 +390,12 @@ def delete(app_name, region_name="us-west-2", archive=False):
             EndpointConfigName=config_name)
         config_arn = config_info["EndpointConfigArn"]
         sage_client.delete_endpoint_config(EndpointConfigName=config_name)
-        eprint("Deleted associated endpoint configuration with arn: {carn}".format(
-            carn=config_arn))
+        _logger.info("Deleted associated endpoint configuration with arn: %s", config_arn)
         for pv in config_info["ProductionVariants"]:
             model_name = pv["ModelName"]
             model_arn = _delete_sagemaker_model(
                 model_name, sage_client, s3_client)
-            eprint("Deleted associated model with arn: {marn}".format(
-                marn=model_arn))
+            _logger.info("Deleted associated model with arn: %s", model_arn)
 
 
 def run_local(model_path, run_id=None, port=5000, image=DEFAULT_IMAGE_NAME, flavor=None):
@@ -427,22 +426,22 @@ def run_local(model_path, run_id=None, port=5000, image=DEFAULT_IMAGE_NAME, flav
 
     deployment_config = _get_deployment_config(flavor_name=flavor)
 
-    eprint("launching docker image with path {}".format(model_path))
+    _logger.info("launching docker image with path %s", model_path)
     cmd = ["docker", "run", "-v", "{}:/opt/ml/model/".format(model_path), "-p", "%d:8080" % port]
     for key, value in deployment_config.items():
         cmd += ["-e", "{key}={value}".format(key=key, value=value)]
     cmd += ["--rm", image, "serve"]
-    eprint('executing', ' '.join(cmd))
+    _logger.info('executing: %s', ' '.join(cmd))
     proc = Popen(cmd, stdout=PIPE, stderr=STDOUT, universal_newlines=True)
 
     def _sigterm_handler(*_):
-        eprint("received termination signal => killing docker process")
+        _logger.info("received termination signal => killing docker process")
         proc.send_signal(signal.SIGINT)
 
     import signal
     signal.signal(signal.SIGTERM, _sigterm_handler)
     for x in iter(proc.stdout.readline, ""):
-        eprint(x, end='')
+        _logger.info(x, end='')
 
 
 def _get_default_image_url(region_name):
@@ -488,7 +487,7 @@ def _get_default_s3_bucket(region_name):
     response = s3.list_buckets()
     buckets = [b['Name'] for b in response["Buckets"]]
     if bucket_name not in buckets:
-        eprint("Default bucket `%s` not found. Creating..." % bucket_name)
+        _logger.info("Default bucket `%s` not found. Creating...", bucket_name)
         bucket_creation_kwargs = {
             'ACL': 'bucket-owner-full-control',
             'Bucket': bucket_name,
@@ -503,10 +502,9 @@ def _get_default_s3_bucket(region_name):
                 'LocationConstraint': region_name
             }
         response = s3.create_bucket(**bucket_creation_kwargs)
-        eprint(response)
+        _logger.info(response)
     else:
-        eprint("Default bucket `%s` already exists. Skipping creation." %
-               bucket_name)
+        _logger.info("Default bucket `%s` already exists. Skipping creation.", bucket_name)
     return bucket_name
 
 
@@ -541,7 +539,7 @@ def _upload_s3(local_model_path, bucket, prefix):
                 Key=key,
                 Tagging={'TagSet': [{'Key': 'SageMaker', 'Value': 'true'}, ]}
             )
-            eprint('tag response', response)
+            _logger.info('tag response: %s', response)
             return '{}/{}/{}'.format(s3.meta.endpoint_url, bucket, key)
 
 
@@ -645,8 +643,7 @@ def _create_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
     :param role: SageMaker execution ARN role
     :param sage_client: A boto3 client for SageMaker
     """
-    eprint("Creating new endpoint with name: {en} ...".format(
-        en=endpoint_name))
+    _logger.info("Creating new endpoint with name: %s ...", endpoint_name)
 
     model_name = _get_sagemaker_model_name(endpoint_name)
     model_response = _create_sagemaker_model(model_name=model_name,
@@ -657,7 +654,7 @@ def _create_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
                                              image_url=image_url,
                                              execution_role=role,
                                              sage_client=sage_client)
-    eprint("Created model with arn: %s" % model_response["ModelArn"])
+    _logger.info("Created model with arn: %s", model_response["ModelArn"])
 
     production_variant = {
         'VariantName': model_name,
@@ -677,15 +674,15 @@ def _create_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
             },
         ],
     )
-    eprint("Created endpoint configuration with arn: %s"
-           % endpoint_config_response["EndpointConfigArn"])
+    _logger.info("Created endpoint configuration with arn: %s", 
+                 endpoint_config_response["EndpointConfigArn"])
 
     endpoint_response = sage_client.create_endpoint(
         EndpointName=endpoint_name,
         EndpointConfigName=config_name,
         Tags=[],
     )
-    eprint("Created endpoint with arn: %s" % endpoint_response["EndpointArn"])
+    _logger.info("Created endpoint with arn: %s", endpoint_response["EndpointArn"])
 
 
 def _update_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, flavor,
@@ -722,8 +719,7 @@ def _update_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
     deployed_config_arn = deployed_config_info["EndpointConfigArn"]
     deployed_production_variants = deployed_config_info["ProductionVariants"]
 
-    eprint("Found active endpoint with arn: {earn}. Updating...".format(
-        earn=endpoint_arn))
+    _logger.info("Found active endpoint with arn: %s. Updating...", endpoint_arn)
 
     new_model_name = _get_sagemaker_model_name(endpoint_name)
     new_model_response = _create_sagemaker_model(model_name=new_model_name,
@@ -734,7 +730,7 @@ def _update_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
                                                  image_url=image_url,
                                                  execution_role=role,
                                                  sage_client=sage_client)
-    eprint("Created new model with arn: %s" % new_model_response["ModelArn"])
+    _logger.info("Created new model with arn: %s", new_model_response["ModelArn"])
 
     if mode == DEPLOYMENT_MODE_ADD:
         new_model_weight = 0
@@ -765,29 +761,27 @@ def _update_sagemaker_endpoint(endpoint_name, image_url, model_s3_path, run_id, 
             },
         ],
     )
-    eprint("Created new endpoint configuration with arn: %s"
-           % endpoint_config_response["EndpointConfigArn"])
+    _logger.info("Created new endpoint configuration with arn: %s", 
+                 endpoint_config_response["EndpointConfigArn"])
 
     sage_client.update_endpoint(EndpointName=endpoint_name,
                                 EndpointConfigName=new_config_name)
-    eprint("Updated endpoint with new configuration!")
+    _logger.info("Updated endpoint with new configuration!")
 
     # If applicable, clean up unused models and old configurations
     if not archive:
-        eprint("Cleaning up unused resources...")
+        _logger.info("Cleaning up unused resources...")
         if mode == DEPLOYMENT_MODE_REPLACE:
             s3_client = boto3.client('s3')
             for pv in deployed_production_variants:
                 deployed_model_arn = _delete_sagemaker_model(model_name=pv["ModelName"],
                                                              sage_client=sage_client,
                                                              s3_client=s3_client)
-                eprint("Deleted model with arn: {marn}".format(
-                    marn=deployed_model_arn))
+                _logger.info("Deleted model with arn: %s", deployed_model_arn)
 
         sage_client.delete_endpoint_config(
             EndpointConfigName=deployed_config_name)
-        eprint("Deleted endpoint configuration with arn: {carn}".format(
-            carn=deployed_config_arn))
+        _logger.info("Deleted endpoint configuration with arn: %s", deployed_config_arn)
 
 
 def _create_sagemaker_model(model_name, model_s3_path, flavor, vpc_config, run_id, image_url,

--- a/mlflow/sagemaker/container/__init__.py
+++ b/mlflow/sagemaker/container/__init__.py
@@ -21,7 +21,6 @@ import mlflow.version
 
 from mlflow import pyfunc, mleap
 from mlflow.models import Model
-from mlflow.utils.logging_utils import eprint
 from mlflow.version import VERSION as MLFLOW_VERSION
 
 MODEL_PATH = "/opt/ml/model"

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -34,7 +34,6 @@ import mlflow
 from mlflow import pyfunc, mleap
 from mlflow.models import Model
 from mlflow.utils.environment import _mlflow_conda_env
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.utils.model_utils import _get_flavor_configuration
 
 FLAVOR_NAME = "spark"
@@ -51,7 +50,7 @@ DEFAULT_CONDA_ENV = _mlflow_conda_env(
 )
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 def log_model(spark_model, artifact_path, conda_env=None, jars=None, dfs_tmpdir=None,

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -24,6 +24,7 @@ from __future__ import absolute_import
 import os
 import shutil
 import yaml
+import logging
 
 import pyspark
 from pyspark import SparkContext
@@ -33,7 +34,6 @@ import mlflow
 from mlflow import pyfunc, mleap
 from mlflow.models import Model
 from mlflow.utils.model_utils import _get_flavor_configuration
-from mlflow.utils.logging_utils import eprint
 from mlflow.utils.environment import _mlflow_conda_env
 
 FLAVOR_NAME = "spark"
@@ -48,6 +48,9 @@ DEFAULT_CONDA_ENV = _mlflow_conda_env(
     additional_pip_deps=None,
     additional_conda_channels=None,
 )
+
+
+_logger = logging.getLogger(__name__)
 
 
 def log_model(spark_model, artifact_path, conda_env=None, jars=None, dfs_tmpdir=None,
@@ -158,7 +161,7 @@ class _HadoopFileSystem:
         if qualified_local_path == "file:" + local_path.toString():
             return local_path.toString()
         cls.copy_from_local_file(src, dst, remove_src=False)
-        eprint("Copied SparkML model to %s" % dst)
+        _logger.info("Copied SparkML model to %s", dst)
         return dst
 
     @classmethod

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -33,8 +33,9 @@ from pyspark.ml.pipeline import PipelineModel
 import mlflow
 from mlflow import pyfunc, mleap
 from mlflow.models import Model
-from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.utils.environment import _mlflow_conda_env
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
+from mlflow.utils.model_utils import _get_flavor_configuration
 
 FLAVOR_NAME = "spark"
 
@@ -50,7 +51,7 @@ DEFAULT_CONDA_ENV = _mlflow_conda_env(
 )
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 def log_model(spark_model, artifact_path, conda_env=None, jars=None, dfs_tmpdir=None,

--- a/mlflow/store/cli.py
+++ b/mlflow/store/cli.py
@@ -1,10 +1,13 @@
-from mlflow.utils.logging_utils import eprint
+import logging
 
 import click
 
 from mlflow.tracking import _get_store
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.utils.proto_json_utils import message_to_json
+
+
+_logger = logging.getLogger(__name__)
 
 
 @click.group("artifacts")
@@ -36,7 +39,8 @@ def log_artifact(local_file, run_id, artifact_path):
     artifact_uri = store.get_run(run_id).info.artifact_uri
     artifact_repo = ArtifactRepository.from_artifact_uri(artifact_uri, store)
     artifact_repo.log_artifact(local_file, artifact_path)
-    eprint("Logged artifact from local file %s to artifact_path=%s" % (local_file, artifact_path))
+    _logger.info("Logged artifact from local file %s to artifact_path=%s", 
+                 local_file, artifact_path)
 
 
 @commands.command("log-artifacts")
@@ -57,7 +61,7 @@ def log_artifacts(local_dir, run_id, artifact_path):
     artifact_uri = store.get_run(run_id).info.artifact_uri
     artifact_repo = ArtifactRepository.from_artifact_uri(artifact_uri, store)
     artifact_repo.log_artifacts(local_dir, artifact_path)
-    eprint("Logged artifact from local dir %s to artifact_path=%s" % (local_dir, artifact_path))
+    _logger.info("Logged artifact from local dir %s to artifact_path=%s", local_dir, artifact_path)
 
 
 @commands.command("list")

--- a/mlflow/store/cli.py
+++ b/mlflow/store/cli.py
@@ -39,7 +39,7 @@ def log_artifact(local_file, run_id, artifact_path):
     artifact_uri = store.get_run(run_id).info.artifact_uri
     artifact_repo = ArtifactRepository.from_artifact_uri(artifact_uri, store)
     artifact_repo.log_artifact(local_file, artifact_path)
-    _logger.info("Logged artifact from local file %s to artifact_path=%s", 
+    _logger.info("Logged artifact from local file %s to artifact_path=%s",
                  local_file, artifact_path)
 
 

--- a/mlflow/store/cli.py
+++ b/mlflow/store/cli.py
@@ -4,11 +4,10 @@ import click
 
 from mlflow.tracking import _get_store
 from mlflow.store.artifact_repo import ArtifactRepository
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.utils.proto_json_utils import message_to_json
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 @click.group("artifacts")

--- a/mlflow/store/cli.py
+++ b/mlflow/store/cli.py
@@ -4,10 +4,11 @@ import click
 
 from mlflow.tracking import _get_store
 from mlflow.store.artifact_repo import ArtifactRepository
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.utils.proto_json_utils import message_to_json
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 @click.group("artifacts")

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 import os
 import shutil
 import yaml
+import logging
 
 import pandas
 import tensorflow as tf
@@ -27,7 +28,6 @@ from mlflow.protos.databricks_pb2 import DIRECTORY_NOT_EMPTY
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import _copy_file_or_tree
-from mlflow.utils.logging_utils import eprint
 from mlflow.utils.model_utils import _get_flavor_configuration
 
 FLAVOR_NAME = "tensorflow"
@@ -39,6 +39,9 @@ DEFAULT_CONDA_ENV = _mlflow_conda_env(
     additional_pip_deps=None,
     additional_conda_channels=None,
 )
+
+
+_logger = logging.getLogger(__name__)
 
 
 def log_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, artifact_path,
@@ -103,12 +106,13 @@ def save_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, pat
                       ``mlflow.tensorflow.DEFAULT_CONDA_ENV`` environment will be added to the
                       model.
     """
-    eprint("Validating the specified Tensorflow model by attempting to load it in a new Tensorflow"
-           " graph...")
+    _logger.info(
+        "Validating the specified Tensorflow model by attempting to load it in a new Tensorflow"
+        " graph...")
     _validate_saved_model(tf_saved_model_dir=tf_saved_model_dir,
                           tf_meta_graph_tags=tf_meta_graph_tags,
                           tf_signature_def_key=tf_signature_def_key)
-    eprint("Validation succeeded!")
+    _logger.info("Validation succeeded!")
 
     if os.path.exists(path):
         raise MlflowException("Path '{}' already exists".format(path), DIRECTORY_NOT_EMPTY)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -28,6 +28,7 @@ from mlflow.protos.databricks_pb2 import DIRECTORY_NOT_EMPTY
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import _copy_file_or_tree
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.utils.model_utils import _get_flavor_configuration
 
 FLAVOR_NAME = "tensorflow"
@@ -41,7 +42,7 @@ DEFAULT_CONDA_ENV = _mlflow_conda_env(
 )
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 def log_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, artifact_path,

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -28,7 +28,6 @@ from mlflow.protos.databricks_pb2 import DIRECTORY_NOT_EMPTY
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import _copy_file_or_tree
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.utils.model_utils import _get_flavor_configuration
 
 FLAVOR_NAME = "tensorflow"
@@ -42,7 +41,7 @@ DEFAULT_CONDA_ENV = _mlflow_conda_env(
 )
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 def log_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, artifact_path,

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -19,7 +19,6 @@ from mlflow.tracking.client import MlflowClient
 from mlflow.utils import env
 from mlflow.utils.databricks_utils import is_in_databricks_notebook, get_notebook_id, \
     get_notebook_path, get_webapp_url
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_WEBAPP_URL, \
     MLFLOW_DATABRICKS_NOTEBOOK_PATH, \
     MLFLOW_DATABRICKS_NOTEBOOK_ID
@@ -31,7 +30,7 @@ _active_run_stack = []
 _active_experiment_id = None
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 def set_experiment(experiment_name):

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -19,6 +19,7 @@ from mlflow.tracking.client import MlflowClient
 from mlflow.utils import env
 from mlflow.utils.databricks_utils import is_in_databricks_notebook, get_notebook_id, \
     get_notebook_path, get_webapp_url
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_WEBAPP_URL, \
     MLFLOW_DATABRICKS_NOTEBOOK_PATH, \
     MLFLOW_DATABRICKS_NOTEBOOK_ID
@@ -30,7 +31,7 @@ _active_run_stack = []
 _active_experiment_id = None
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 def set_experiment(experiment_name):

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -286,8 +286,8 @@ def _get_git_commit(path):
     try:
         from git import Repo, InvalidGitRepositoryError, GitCommandNotFound, NoSuchPathError
     except ImportError as e:
-        _logger.error(
-            "Notice: failed to import Git (the Git executable is probably not on your PATH),"
+        _logger.warning(
+            "Failed to import Git (the Git executable is probably not on your PATH),"
             " so Git SHA is not available. Error: %s", e)
         return None
     try:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -11,6 +11,7 @@ import os
 import atexit
 import sys
 import time
+import logging
 
 from mlflow.entities import Experiment, Run, SourceType, RunInfo
 from mlflow.exceptions import MlflowException
@@ -18,7 +19,6 @@ from mlflow.tracking.client import MlflowClient
 from mlflow.utils import env
 from mlflow.utils.databricks_utils import is_in_databricks_notebook, get_notebook_id, \
     get_notebook_path, get_webapp_url
-from mlflow.utils.logging_utils import eprint
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_WEBAPP_URL, \
     MLFLOW_DATABRICKS_NOTEBOOK_PATH, \
     MLFLOW_DATABRICKS_NOTEBOOK_ID
@@ -28,6 +28,9 @@ _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"
 _RUN_ID_ENV_VAR = "MLFLOW_RUN_ID"
 _active_run_stack = []
 _active_experiment_id = None
+
+
+_logger = logging.getLogger(__name__)
 
 
 def set_experiment(experiment_name):
@@ -194,8 +197,8 @@ def log_metric(key, value):
     :param value: Metric value (float).
     """
     if not isinstance(value, numbers.Number):
-        eprint("WARNING: The metric {}={} was not logged because the value is not a number.".format(
-            key, value))
+        _logger.warning(
+            "The metric %s=%s was not logged because the value is not a number.", key, value)
         return
     run_id = _get_or_start_run().info.run_uuid
     MlflowClient().log_metric(run_id, key, value, int(time.time()))
@@ -283,8 +286,9 @@ def _get_git_commit(path):
     try:
         from git import Repo, InvalidGitRepositoryError, GitCommandNotFound, NoSuchPathError
     except ImportError as e:
-        eprint("Notice: failed to import Git (the Git executable is probably not on your PATH),"
-               " so Git SHA is not available. Error: %s" % e)
+        _logger.error(
+            "Notice: failed to import Git (the Git executable is probably not on your PATH),"
+            " so Git SHA is not available. Error: %s", e)
         return None
     try:
         if os.path.isfile(path):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -74,7 +74,7 @@ def get_databricks_host_creds(profile=None):
     """
     if not hasattr(provider, 'get_config'):
         _logger.warning(
-            "Support for databricks-cli<0.8.0 is deprecated and will be removed" 
+            "Support for databricks-cli<0.8.0 is deprecated and will be removed"
             " in a future version.")
         config = provider.get_config_for_profile(profile)
     elif profile:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1,7 +1,11 @@
+import logging
+
 from mlflow.exceptions import MlflowException
 from mlflow.utils.rest_utils import MlflowHostCreds
-from mlflow.utils.logging_utils import eprint
 from databricks_cli.configure import provider
+
+
+_logger = logging.getLogger(__name__)
 
 
 def _get_dbutils():
@@ -69,8 +73,9 @@ def get_databricks_host_creds(profile=None):
         authentication information necessary to talk to the Databricks server.
     """
     if not hasattr(provider, 'get_config'):
-        eprint("Warning: support for databricks-cli<0.8.0 is deprecated and will be removed"
-               " in a future version.")
+        _logger.warning(
+            "Support for databricks-cli<0.8.0 is deprecated and will be removed" 
+            " in a future version.")
         config = provider.get_config_for_profile(profile)
     elif profile:
         config = provider.ProfileConfigProvider(profile).get_config()

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1,11 +1,12 @@
 import logging
 
 from mlflow.exceptions import MlflowException
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.utils.rest_utils import MlflowHostCreds
 from databricks_cli.configure import provider
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 def _get_dbutils():

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1,12 +1,11 @@
 import logging
 
 from mlflow.exceptions import MlflowException
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.utils.rest_utils import MlflowHostCreds
 from databricks_cli.configure import provider
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 def _get_dbutils():

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -8,7 +8,7 @@ import mlflow
 LOGGING_LINE_FORMAT = "%(asctime)s %(levelname)s %(filename)s:%(lineno)d: %(message)s"
 LOGGING_DATETIME_FORMAT = "%Y/%m/%d %H:%M:%S"
 
-DEFAULT_LOGGER_NAME = mlflow.__name__ 
+DEFAULT_LOGGER_NAME = mlflow.__name__
 
 
 def _configure_default_logger():
@@ -33,7 +33,7 @@ def _configure_default_logger():
             DEFAULT_LOGGER_NAME : {
                 'handlers': ['default'],
                 'level': 'INFO',
-                'propagate': False, 
+                'propagate': False,
             },
         },
     })

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -1,17 +1,20 @@
+from __future__ import print_function
+
 import sys
 import logging
 import logging.config
 
 import mlflow
 
-
+# Logging format example:
+# 2018/11/20 12:36:37 INFO mlflow.sagemaker: Creating new SageMaker endpoint
 LOGGING_LINE_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
 LOGGING_DATETIME_FORMAT = "%Y/%m/%d %H:%M:%S"
 
 DEFAULT_LOGGER_NAME = mlflow.__name__
 
 
-def _configure_default_logger():
+def _configure_mlflow_loggers():
     logging.config.dictConfig({
         'version': 1,
         'disable_existing_loggers': False,
@@ -37,3 +40,7 @@ def _configure_default_logger():
             },
         },
     })
+
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -5,7 +5,7 @@ import logging.config
 import mlflow
 
 
-LOGGING_LINE_FORMAT = "%(asctime)s %(levelname)s %(filename)s:%(lineno)d: %(message)s"
+LOGGING_LINE_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
 LOGGING_DATETIME_FORMAT = "%Y/%m/%d %H:%M:%S"
 
 DEFAULT_LOGGER_NAME = mlflow.__name__
@@ -16,22 +16,22 @@ def _configure_default_logger():
         'version': 1,
         'disable_existing_loggers': False,
         'formatters': {
-            'standard': {
+            'mlflow_formatter': {
                 'format': LOGGING_LINE_FORMAT,
                 'datefmt': LOGGING_DATETIME_FORMAT,
             },
         },
         'handlers': {
-            'default': {
+            'mlflow_handler': {
                 'level': 'INFO',
-                'formatter': 'standard',
+                'formatter': 'mlflow_formatter',
                 'class': 'logging.StreamHandler',
                 'stream': sys.stderr,
             },
         },
         'loggers': {
-            DEFAULT_LOGGER_NAME : {
-                'handlers': ['default'],
+            DEFAULT_LOGGER_NAME: {
+                'handlers': ['mlflow_handler'],
                 'level': 'INFO',
                 'propagate': False,
             },

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -1,13 +1,17 @@
 import sys
-
+import logging
 import logging.config
+
+import mlflow
 
 
 LOGGING_LINE_FORMAT = "%(asctime)s %(levelname)s %(filename)s:%(lineno)d: %(message)s"
 LOGGING_DATETIME_FORMAT = "%Y/%m/%d %H:%M:%S"
 
+DEFAULT_LOGGER_NAME = mlflow.__name__ 
 
-def _configure_loggers():
+
+def _configure_default_logger():
     logging.config.dictConfig({
         'version': 1,
         'disable_existing_loggers': False,
@@ -26,10 +30,10 @@ def _configure_loggers():
             },
         },
         'loggers': {
-            '': {
+            DEFAULT_LOGGER_NAME : {
                 'handlers': ['default'],
                 'level': 'INFO',
-                'propagate': True
+                'propagate': False, 
             },
         },
     })

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -1,6 +1,35 @@
-from __future__ import print_function
 import sys
 
+import logging.config
 
-def eprint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
+
+LOGGING_LINE_FORMAT = "%(asctime)s %(levelname)s %(filename)s:%(lineno)d: %(message)s"
+LOGGING_DATETIME_FORMAT = "%Y/%m/%d %H:%M:%S"
+
+
+def _configure_default_logger():
+    logging.config.dictConfig({
+        'version': 1,
+        'disable_existing_loggers': False,
+        'formatters': {
+            'standard': {
+                'format': LOGGING_LINE_FORMAT,
+                'datefmt': LOGGING_DATETIME_FORMAT,
+            },
+        },
+        'handlers': {
+            'default': {
+                'level': 'INFO',
+                'formatter': 'standard',
+                'class': 'logging.StreamHandler',
+                'stream': sys.stderr,
+            },
+        },
+        'loggers': {
+            '': {
+                'handlers': ['default'],
+                'level': 'INFO',
+                'propagate': True
+            },
+        },
+    })

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -7,7 +7,7 @@ LOGGING_LINE_FORMAT = "%(asctime)s %(levelname)s %(filename)s:%(lineno)d: %(mess
 LOGGING_DATETIME_FORMAT = "%Y/%m/%d %H:%M:%S"
 
 
-def _configure_default_logger():
+def _configure_loggers():
     logging.config.dictConfig({
         'version': 1,
         'disable_existing_loggers': False,

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -4,17 +4,14 @@ import sys
 import logging
 import logging.config
 
-import mlflow
 
 # Logging format example:
 # 2018/11/20 12:36:37 INFO mlflow.sagemaker: Creating new SageMaker endpoint
 LOGGING_LINE_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
 LOGGING_DATETIME_FORMAT = "%Y/%m/%d %H:%M:%S"
 
-DEFAULT_LOGGER_NAME = mlflow.__name__
 
-
-def _configure_mlflow_loggers():
+def _configure_mlflow_loggers(root_module_name):
     logging.config.dictConfig({
         'version': 1,
         'disable_existing_loggers': False,
@@ -33,7 +30,7 @@ def _configure_mlflow_loggers():
             },
         },
         'loggers': {
-            DEFAULT_LOGGER_NAME: {
+            root_module_name: {
                 'handlers': ['mlflow_handler'],
                 'level': 'INFO',
                 'propagate': False,

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -1,17 +1,20 @@
 import base64
 import time
+import logging
 import json
 from json import JSONEncoder
 
 import numpy
 import requests
 
-from mlflow.utils.logging_utils import eprint
 from mlflow.utils.string_utils import strip_suffix
 from mlflow.exceptions import MlflowException, RestException
 
 
 RESOURCE_DOES_NOT_EXIST = 'RESOURCE_DOES_NOT_EXIST'
+
+
+_logger = logging.getLogger(__name__)
 
 
 def http_request(host_creds, endpoint, retries=3, retry_interval=3, **kwargs):
@@ -46,9 +49,10 @@ def http_request(host_creds, endpoint, retries=3, retry_interval=3, **kwargs):
         if response.status_code >= 200 and response.status_code < 500:
             return response
         else:
-            eprint("API request to %s failed with code %s != 200, retrying up to %s more times. "
-                   "API response body: %s" % (url, response.status_code, retries - i - 1,
-                                              response.text))
+            _logger.error(
+                "API request to %s failed with code %s != 200, retrying up to %s more times. "
+                "API response body: %s",
+                url, response.status_code, retries - i - 1, response.text)
             time.sleep(retry_interval)
     raise MlflowException("API request to %s failed to return code 200 after %s tries" %
                           (url, retries))

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -7,6 +7,7 @@ from json import JSONEncoder
 import numpy
 import requests
 
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.utils.string_utils import strip_suffix
 from mlflow.exceptions import MlflowException, RestException
 
@@ -14,7 +15,7 @@ from mlflow.exceptions import MlflowException, RestException
 RESOURCE_DOES_NOT_EXIST = 'RESOURCE_DOES_NOT_EXIST'
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 def http_request(host_creds, endpoint, retries=3, retry_interval=3, **kwargs):

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -7,7 +7,6 @@ from json import JSONEncoder
 import numpy
 import requests
 
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from mlflow.utils.string_utils import strip_suffix
 from mlflow.exceptions import MlflowException, RestException
 
@@ -15,7 +14,7 @@ from mlflow.exceptions import MlflowException, RestException
 RESOURCE_DOES_NOT_EXIST = 'RESOURCE_DOES_NOT_EXIST'
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 def http_request(host_creds, endpoint, retries=3, retry_interval=3, **kwargs):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,3 @@
-from mlflow.utils.logging_utils import _configure_mlflow_loggers 
+from mlflow.utils.logging_utils import _configure_mlflow_loggers
 
 _configure_mlflow_loggers(root_module_name=__name__)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+from mlflow.utils.logging_utils import _configure_mlflow_loggers 
+
+_configure_mlflow_loggers(root_module_name=__name__)

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -8,7 +8,7 @@ from click.testing import CliRunner
 import pytest
 
 from mlflow import cli
-from mlflow.utils import process 
+from mlflow.utils import process
 from tests.integration.utils import invoke_cli_runner
 from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_URI,\
     TEST_NO_SPEC_PROJECT_DIR

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -2,16 +2,20 @@ import json
 import hashlib
 import mock
 import os
+import logging
 
 from click.testing import CliRunner
 import pytest
 
 from mlflow import cli
-from mlflow.utils import process, logging_utils
+from mlflow.utils import process 
 from tests.integration.utils import invoke_cli_runner
 from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_URI,\
     TEST_NO_SPEC_PROJECT_DIR
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
+
+
+_logger = logging.getLogger(__name__)
 
 
 @pytest.mark.large
@@ -31,9 +35,9 @@ def test_run_local_conda_env(tracking_uri_mock):  # pylint: disable=unused-argum
     try:
         process.exec_cmd(cmd=["conda", "env", "remove", "--name", expected_env_name])
     except process.ShellCommandException:
-        logging_utils.eprint(
+        _logger.error(
             "Unable to remove conda environment %s. The environment may not have been present, "
-            "continuing with running the test." % expected_env_name)
+            "continuing with running the test.", expected_env_name)
     invoke_cli_runner(cli.run, [TEST_PROJECT_DIR, "-e", "check_conda_env", "-P",
                                 "conda_env_name=%s" % expected_env_name])
 

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -15,7 +15,6 @@ from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 
-# _logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 _logger = logging.getLogger(__name__)
 
 
@@ -28,11 +27,11 @@ def test_run_local_params(tracking_uri_mock):  # pylint: disable=unused-argument
                                 "-P", "excitement=%s" % excitement_arg])
 
 
-# @pytest.mark.large
+@pytest.mark.large
 def test_run_local_conda_env(tracking_uri_mock):  # pylint: disable=unused-argument
-    # with open(os.path.join(TEST_PROJECT_DIR, "conda.yaml"), "r") as handle:
-    #     conda_env_contents = handle.read()
-    # expected_env_name = "mlflow-%s" % hashlib.sha1(conda_env_contents.encode("utf-8")).hexdigest()
+    with open(os.path.join(TEST_PROJECT_DIR, "conda.yaml"), "r") as handle:
+        conda_env_contents = handle.read()
+    expected_env_name = "mlflow-%s" % hashlib.sha1(conda_env_contents.encode("utf-8")).hexdigest()
     try:
         _logger.info("AIAOSHFDSFUHAU")
         process.exec_cmd(cmd=["conda", "env", "remove", "--name", expected_env_name])

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -9,13 +9,14 @@ import pytest
 
 from mlflow import cli
 from mlflow.utils import process
+from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from tests.integration.utils import invoke_cli_runner
 from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_URI,\
     TEST_NO_SPEC_PROJECT_DIR
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 
-_logger = logging.getLogger(__name__)
+_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
 
 
 @pytest.mark.large

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -33,7 +33,6 @@ def test_run_local_conda_env(tracking_uri_mock):  # pylint: disable=unused-argum
         conda_env_contents = handle.read()
     expected_env_name = "mlflow-%s" % hashlib.sha1(conda_env_contents.encode("utf-8")).hexdigest()
     try:
-        _logger.info("AIAOSHFDSFUHAU")
         process.exec_cmd(cmd=["conda", "env", "remove", "--name", expected_env_name])
     except process.ShellCommandException:
         _logger.error(

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -9,14 +9,14 @@ import pytest
 
 from mlflow import cli
 from mlflow.utils import process
-from mlflow.utils.logging_utils import DEFAULT_LOGGER_NAME
 from tests.integration.utils import invoke_cli_runner
 from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_URI,\
     TEST_NO_SPEC_PROJECT_DIR
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 
-_logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+# _logger = logging.getLogger(DEFAULT_LOGGER_NAME)
+_logger = logging.getLogger(__name__)
 
 
 @pytest.mark.large
@@ -28,12 +28,13 @@ def test_run_local_params(tracking_uri_mock):  # pylint: disable=unused-argument
                                 "-P", "excitement=%s" % excitement_arg])
 
 
-@pytest.mark.large
+# @pytest.mark.large
 def test_run_local_conda_env(tracking_uri_mock):  # pylint: disable=unused-argument
-    with open(os.path.join(TEST_PROJECT_DIR, "conda.yaml"), "r") as handle:
-        conda_env_contents = handle.read()
-    expected_env_name = "mlflow-%s" % hashlib.sha1(conda_env_contents.encode("utf-8")).hexdigest()
+    # with open(os.path.join(TEST_PROJECT_DIR, "conda.yaml"), "r") as handle:
+    #     conda_env_contents = handle.read()
+    # expected_env_name = "mlflow-%s" % hashlib.sha1(conda_env_contents.encode("utf-8")).hexdigest()
     try:
+        _logger.info("AIAOSHFDSFUHAU")
         process.exec_cmd(cmd=["conda", "env", "remove", "--name", expected_env_name])
     except process.ShellCommandException:
         _logger.error(

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -272,7 +272,7 @@ def test_model_log_uses_cloudpickle_serialization_format_by_default(sklearn_knn_
     assert sklearn_conf["serialization_format"] == mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE
 
 
-@pytest.mark.release
+# @pytest.mark.release
 def test_sagemaker_docker_model_scoring_with_default_conda_env(sklearn_knn_model, model_path):
     mlflow.sklearn.save_model(sk_model=sklearn_knn_model.model, path=model_path, conda_env=None)
     reloaded_knn_pyfunc = pyfunc.load_pyfunc(path=model_path)

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -272,7 +272,7 @@ def test_model_log_uses_cloudpickle_serialization_format_by_default(sklearn_knn_
     assert sklearn_conf["serialization_format"] == mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE
 
 
-# @pytest.mark.release
+@pytest.mark.release
 def test_sagemaker_docker_model_scoring_with_default_conda_env(sklearn_knn_model, model_path):
     mlflow.sklearn.save_model(sk_model=sklearn_knn_model.model, path=model_path, conda_env=None)
     reloaded_knn_pyfunc = pyfunc.load_pyfunc(path=model_path)


### PR DESCRIPTION
This PR introduces a standard logging format across MLflow and replaces most invocations of the `mlflow.logging_utils.eprint` function with calls to instances of `logging.Logger.info/error/warning`.

Motivation: Using Python's logging module allows us to incorporate useful metadata like timestamps and the name of the calling modules into log messages, providing information such as the duration of a long-running operation or the source of an error log.

Example:

Logs emitted from the `mlflow.sagemaker` package now provide timestamp and module information:

OLD:
```
Deleted endpoint with arn: arn:aws:sagemaker:us-west-2:12345678910:endpoint/testendpoint
```

NEW:
```
2018/11/20 13:11:28 INFO mlflow.sagemaker: Deleted endpoint with arn: arn:aws:sagemaker:us-west-2:12345678910:endpoint/testendpoint
```