### PR TITLE
Added Bash command for UI

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -208,8 +208,18 @@ Comparing the Models
 --------------------
 
 
-Next, use the MLflow UI to compare the models that you have produced. Run ``mlflow_ui()``
-in the same current working directory as the one that contains the ``mlruns``.
+Next, use the MLflow UI to compare the models that you have produced. In the same current working directory 
+as the one that contains the ``mlruns`` run:
+
+.. code-section::
+    .. code-block:: bash
+
+        mlflow ui
+    .. code-block:: R
+
+        mlflow_ui()
+
+and view it at `<http://localhost:5000>`_.
 
 On this page, you can see a list of experiment runs with metrics you can use to compare the models.
 


### PR DESCRIPTION
In section "Comparing the Models" the command to launch the MLflow UI was given for R mlflow_ui(), but not for Bash mlflow ui. This took me a bit to figure out since I needed the Bash command because I'm working in Python.  

I copied the relevant part from the Quickstart page to include commands for both, as well as the link to the page to view the results.