### PR TITLE
Fix typoe in R-API docs and source code

### DIFF
--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -131,7 +131,7 @@ Retrieves the active run.
 MLflow Command
 ==============
 
-Executes a generic MLflow command through the commmand line interface.
+Executes a generic MLflow command through the command line interface.
 
 .. code:: r
 
@@ -1445,7 +1445,7 @@ Arguments
 Value
 -----
 
-This funciton must return a list of flavors that conform to the MLmodel
+This function must return a list of flavors that conform to the MLmodel
 specification.
 
 Save MLflow Model Flavor
@@ -1486,7 +1486,7 @@ Arguments
 Value
 -----
 
-This funciton must return a list of flavors that conform to the MLmodel
+This function must return a list of flavors that conform to the MLmodel
 specification.
 
 Save Model for MLflow

--- a/mlflow/R/mlflow/R/cli.R
+++ b/mlflow/R/mlflow/R/cli.R
@@ -1,6 +1,6 @@
 #' MLflow Command
 #'
-#' Executes a generic MLflow command through the commmand line interface.
+#' Executes a generic MLflow command through the command line interface.
 #'
 #' @param ... The parameters to pass to the command line.
 #' @param background Should this command be triggered as a background task?

--- a/mlflow/R/mlflow/R/model-flavor.R
+++ b/mlflow/R/mlflow/R/model-flavor.R
@@ -11,7 +11,7 @@
 #'   or \code{conda.yaml}.
 #' @param conda_env Path to Conda dependencies file.
 #'
-#' @return This funciton must return a list of flavors that conform to
+#' @return This function must return a list of flavors that conform to
 #'   the MLmodel specification.
 #'
 #' @export

--- a/mlflow/R/mlflow/R/model-keras.R
+++ b/mlflow/R/mlflow/R/model-keras.R
@@ -10,7 +10,7 @@
 #'   or \code{conda.yaml}.
 #' @param conda_env Path to Conda dependencies file.
 #'
-#' @return This funciton must return a list of flavors that conform to
+#' @return This function must return a list of flavors that conform to
 #'   the MLmodel specification.
 #'
 #' @export

--- a/mlflow/R/mlflow/man/mlflow_cli.Rd
+++ b/mlflow/R/mlflow/man/mlflow_cli.Rd
@@ -22,7 +22,7 @@ Defaults to \code{FALSE}.}
 A \code{processx} task.
 }
 \description{
-Executes a generic MLflow command through the commmand line interface.
+Executes a generic MLflow command through the command line interface.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
Small typo in R-API documents and source code comments.