### PR TITLE
Pin scikit-learn version in test requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,6 +13,9 @@ pyspark
 pytest==3.2.1
 pytest-cov
 rstcheck==3.2
+# TODO: Stop pinning the version of scikit-learn when the latest version of the
+# library on Anaconda catches up to pip
+scikit-learn==0.20.0
 scipy
 tensorflow
 torch


### PR DESCRIPTION
The latest version of scikit-learn (`0.21.0`) is only available on pip. It has not yet been released on Anaconda. This causes test failures when attempting to resolve default conda environments: conda attempts to install a version of the scikit-learn dependency that is not available.

To resolve this issue, we will temporarily pin the version of scikit-learn to the latest available version on Anaconda (`0.20.0`).