### PR TITLE
Updating remote runs docs

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -196,12 +196,15 @@ useful if you quickly want to test a project in your existing shell environment.
 
 Remote Execution on Databricks
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Support for running projects on Databricks will be released soon -
-`sign up here <http://databricks.com/mlflow>`_ to receive updates.
+Support for running projects remotely on Databricks is in beta preview and requires a Databricks account. 
+To receive future updates about the feature please `sign up here <http://databricks.com/mlflow>`_.
 
 
-Launching a Run
-~~~~~~~~~~~~~~~
+Launching a Remote Execution on Databricks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+To use this feature, you need to have a Databricks account (Community Edition is not yet supported)
+and you must have set up the `Databricks Command Line utility <https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster>`_. Find more detailed instructions in the Databricks docs (`here for Azure Databricks <https://docs.databricks.com/applications/mlflow/index.html>`_, `here for Databricks on AWS <https://docs.databricks.com/applications/mlflow/index.html>`_). A brief overview of how to use the feature is as follows:
+
 First, create a JSON file containing the 
 `cluster specification <https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster>`_
 for your run. Then, run your project via


### PR DESCRIPTION
This updates the MLflow doc section about Remote Execution on Databricks.

Here is a screenshot of what the docs look like after the changes in this PR.

<img width="780" alt="screen shot 2018-11-29 at 3 05 15 pm" src="https://user-images.githubusercontent.com/228998/49257925-9a361d00-f3e8-11e8-99a3-7b93b936eecb.png">
