### PR TITLE
[UI] Wrap bagged metrics/params in their own component + improve dropdown perf

### DIFF
--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -22,6 +22,7 @@
     "react-dom": "^16.3.2",
     "react-mde": "5.8.0",
     "react-modal": "^3.4.4",
+    "react-overlays": "^0.8.3",
     "react-redux": "5.0.7",
     "react-router": "4.2.0",
     "react-router-dom": "4.2.2",

--- a/mlflow/server/js/src/components/BaggedCell.js
+++ b/mlflow/server/js/src/components/BaggedCell.js
@@ -1,0 +1,90 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Dropdown, MenuItem } from 'react-bootstrap';
+import classNames from 'classnames';
+import ExperimentRunsSortToggle from './ExperimentRunsSortToggle';
+import EmptyIfClosedMenu from './EmptyIfClosedMenu';
+
+const styles = {
+  metricParamCellContent: {
+    display: "inline-block",
+    maxWidth: 120,
+  },
+};
+
+export default class BaggedCell extends Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  static propTypes = {
+    keyName: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
+    onHover: PropTypes.func.isRequired,
+    setSortByHandler: PropTypes.func.isRequired,
+    isParam: PropTypes.bool.isRequired,
+    isMetric: PropTypes.bool.isRequired,
+    isHovered: PropTypes.bool.isRequired,
+    onRemoveBagged: PropTypes.func.isRequired,
+    sortIcon: PropTypes.node,
+  };
+
+  shouldComponentUpdate(nextProps) {
+    return this.props.sortIcon !== nextProps.sortIcon;
+  }
+
+  render() {
+    const { keyName, value, onHover, setSortByHandler, isParam, isMetric, onRemoveBagged, sortIcon} = this.props;
+    const cellClass = classNames("metric-param-content", "metric-param-cell", "BaggedCell");
+    return (
+      <span
+        className={cellClass}
+        onMouseEnter={() => onHover({isParam: isParam, isMetric: isMetric, key: keyName})}
+        onMouseLeave={() => onHover({isParam: false, isMetric: false, key: ""})}
+      >
+          <Dropdown id="dropdown-custom-1" style={{width: 250}}>
+        <ExperimentRunsSortToggle
+          bsRole="toggle"
+          className={"metric-param-sort-toggle"}
+        >
+              <span
+                className="run-table-container underline-on-hover"
+                style={styles.metricParamCellContent}
+                title={keyName}
+              >
+                {sortIcon}
+                {keyName}:
+              </span>
+        </ExperimentRunsSortToggle>
+        <span
+          className="metric-param-value run-table-container"
+          style={styles.metricParamCellContent}
+        >
+              {value}
+        </span>
+        <EmptyIfClosedMenu className="mlflow-menu" bsRole="menu">
+          <MenuItem
+            className="mlflow-menu-item"
+            onClick={() => setSortByHandler(isMetric, isParam, keyName, true)}
+          >
+            Sort ascending
+          </MenuItem>
+          <MenuItem
+            className="mlflow-menu-item"
+            onClick={() => setSortByHandler(isMetric, isParam, keyName, false)}
+          >
+            Sort descending
+          </MenuItem>
+          <MenuItem
+            className="mlflow-menu-item"
+            onClick={() => onRemoveBagged(isParam, keyName)}
+          >
+            Display in own column
+          </MenuItem>
+        </EmptyIfClosedMenu>
+      </Dropdown>
+      </span>
+    );
+  }
+}

--- a/mlflow/server/js/src/components/BaggedCell.js
+++ b/mlflow/server/js/src/components/BaggedCell.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import { Dropdown, MenuItem } from 'react-bootstrap';
 import classNames from 'classnames';
@@ -12,7 +12,7 @@ const styles = {
   },
 };
 
-export default class BaggedCell extends Component {
+export default class BaggedCell extends PureComponent {
   static propTypes = {
     keyName: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired,
@@ -22,10 +22,6 @@ export default class BaggedCell extends Component {
     onRemoveBagged: PropTypes.func.isRequired,
     sortIcon: PropTypes.node,
   };
-
-  shouldComponentUpdate(nextProps) {
-    return this.props.sortIcon !== nextProps.sortIcon;
-  }
 
   render() {
     const { keyName, value, setSortByHandler, isParam, isMetric, onRemoveBagged,

--- a/mlflow/server/js/src/components/BaggedCell.js
+++ b/mlflow/server/js/src/components/BaggedCell.js
@@ -13,11 +13,6 @@ const styles = {
 };
 
 export default class BaggedCell extends Component {
-
-  constructor(props) {
-    super(props);
-  }
-
   static propTypes = {
     keyName: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired,
@@ -35,7 +30,8 @@ export default class BaggedCell extends Component {
   }
 
   render() {
-    const { keyName, value, onHover, setSortByHandler, isParam, isMetric, onRemoveBagged, sortIcon} = this.props;
+    const { keyName, value, onHover, setSortByHandler, isParam, isMetric, onRemoveBagged,
+      sortIcon } = this.props;
     const cellClass = classNames("metric-param-content", "metric-param-cell", "BaggedCell");
     return (
       <span

--- a/mlflow/server/js/src/components/BaggedCell.js
+++ b/mlflow/server/js/src/components/BaggedCell.js
@@ -16,11 +16,9 @@ export default class BaggedCell extends Component {
   static propTypes = {
     keyName: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired,
-    onHover: PropTypes.func.isRequired,
     setSortByHandler: PropTypes.func.isRequired,
     isParam: PropTypes.bool.isRequired,
     isMetric: PropTypes.bool.isRequired,
-    isHovered: PropTypes.bool.isRequired,
     onRemoveBagged: PropTypes.func.isRequired,
     sortIcon: PropTypes.node,
   };
@@ -30,16 +28,14 @@ export default class BaggedCell extends Component {
   }
 
   render() {
-    const { keyName, value, onHover, setSortByHandler, isParam, isMetric, onRemoveBagged,
+    const { keyName, value, setSortByHandler, isParam, isMetric, onRemoveBagged,
       sortIcon } = this.props;
     const cellClass = classNames("metric-param-content", "metric-param-cell", "BaggedCell");
     return (
       <span
         className={cellClass}
-        onMouseEnter={() => onHover({isParam: isParam, isMetric: isMetric, key: keyName})}
-        onMouseLeave={() => onHover({isParam: false, isMetric: false, key: ""})}
       >
-          <Dropdown id="dropdown-custom-1" style={{width: 250}}>
+      <Dropdown id="dropdown-custom-1" style={{width: 250}}>
         <ExperimentRunsSortToggle
           bsRole="toggle"
           className={"metric-param-sort-toggle"}

--- a/mlflow/server/js/src/components/EmptyIfClosedMenu.js
+++ b/mlflow/server/js/src/components/EmptyIfClosedMenu.js
@@ -1,0 +1,28 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Dropdown } from 'react-bootstrap';
+import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
+
+
+export default class EmptyIfClosedMenu extends Component {
+  static propTypes = {
+    children: PropTypes.array.isRequired,
+    open: PropTypes.bool,
+    onClose: PropTypes.func,
+  };
+
+  render() {
+    const {children, open, onClose, ...props} = this.props;
+      if (!open) {
+        return null;
+      }
+      return (
+        <RootCloseWrapper onRootClose={onClose}>
+          <Dropdown.Menu {...props} >
+            {children}
+          </Dropdown.Menu>
+        </RootCloseWrapper>
+      );
+  }
+
+}

--- a/mlflow/server/js/src/components/EmptyIfClosedMenu.js
+++ b/mlflow/server/js/src/components/EmptyIfClosedMenu.js
@@ -13,16 +13,15 @@ export default class EmptyIfClosedMenu extends Component {
 
   render() {
     const {children, open, onClose, ...props} = this.props;
-      if (!open) {
-        return null;
-      }
-      return (
-        <RootCloseWrapper onRootClose={onClose}>
-          <Dropdown.Menu {...props} >
-            {children}
-          </Dropdown.Menu>
-        </RootCloseWrapper>
-      );
+    if (!open) {
+      return null;
+    }
+    return (
+      <RootCloseWrapper onRootClose={onClose}>
+        <Dropdown.Menu {...props} >
+          {children}
+        </Dropdown.Menu>
+      </RootCloseWrapper>
+    );
   }
-
 }

--- a/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
@@ -37,7 +37,6 @@ const styles = {
 class ExperimentRunsTableCompactView extends Component {
   constructor(props) {
     super(props);
-    this.onHover = this.onHover.bind(this);
     this.getRow = this.getRow.bind(this);
   }
 
@@ -78,10 +77,6 @@ class ExperimentRunsTableCompactView extends Component {
     hoverState: {isMetric: false, isParam: false, key: ""},
   };
 
-  onHover({isParam, isMetric, key}) {
-    this.setState({ hoverState: {isParam, isMetric, key} });
-  }
-
   /** Returns a row of table content (i.e. a non-header row) corresponding to a single run. */
   getRow({ idx, isParent, hasExpander, expanderOpen, childrenIds }) {
     const {
@@ -101,7 +96,6 @@ class ExperimentRunsTableCompactView extends Component {
       unbaggedParams,
       onRemoveBagged,
     } = this.props;
-    const hoverState = this.state.hoverState;
     const runInfo = runInfos[idx];
     const paramsMap = ExperimentViewUtil.toParamsMap(paramsList[idx]);
     const metricsMap = ExperimentViewUtil.toMetricsMap(metricsList[idx]);
@@ -127,14 +121,15 @@ class ExperimentRunsTableCompactView extends Component {
     });
     // Add bagged params
     const paramsCellContents = baggedParams.map((paramKey) => {
-      const isHovered = hoverState.isParam && hoverState.key === paramKey;
       const keyname = "param-" + paramKey;
       const sortIcon = ExperimentViewUtil.getSortIcon(sortState, false, true, paramKey);
       return (<BaggedCell
         key={keyname}
         sortIcon={sortIcon}
-        keyName={paramKey} value={paramsMap[paramKey].getValue()} onHover={this.onHover}
-        setSortByHandler={setSortByHandler} isMetric={false} isParam isHovered={isHovered}
+        keyName={paramKey} value={paramsMap[paramKey].getValue()}
+        setSortByHandler={setSortByHandler}
+        isMetric={false}
+        isParam
         onRemoveBagged={onRemoveBagged}/>);
     });
     if (this.shouldShowBaggedColumn(true)) {
@@ -153,18 +148,15 @@ class ExperimentRunsTableCompactView extends Component {
     // Add bagged metrics
     const metricsCellContents = baggedMetrics.map((metricKey) => {
       const keyname = "metric-" + metricKey;
-      const isHovered = hoverState.isMetric && hoverState.key === metricKey;
       const sortIcon = ExperimentViewUtil.getSortIcon(sortState, true, false, metricKey);
       return (
         <BaggedCell key={keyname}
                     keyName={metricKey}
                     value={metricsMap[metricKey].getValue().toString()}
-                    onHover={this.onHover}
                     sortIcon={sortIcon}
                     setSortByHandler={setSortByHandler}
                     isMetric
                     isParam={false}
-                    isHovered={isHovered}
                     onRemoveBagged={onRemoveBagged}/>
       );
     });

--- a/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
@@ -7,7 +7,6 @@ import classNames from 'classnames';
 import { Table, Dropdown, MenuItem } from 'react-bootstrap';
 import ExperimentRunsSortToggle from './ExperimentRunsSortToggle';
 import BaggedCell from './BaggedCell';
-import Utils from '../utils/Utils';
 
 const styles = {
   sortArrow: {
@@ -135,7 +134,7 @@ class ExperimentRunsTableCompactView extends Component {
         key={keyname}
         sortIcon={sortIcon}
         keyName={paramKey} value={paramsMap[paramKey].getValue()} onHover={this.onHover}
-        setSortByHandler={setSortByHandler} isMetric={false} isParam={true} isHovered={isHovered}
+        setSortByHandler={setSortByHandler} isMetric={false} isParam isHovered={isHovered}
         onRemoveBagged={onRemoveBagged}/>);
     });
     if (this.shouldShowBaggedColumn(true)) {
@@ -158,9 +157,14 @@ class ExperimentRunsTableCompactView extends Component {
       const sortIcon = ExperimentViewUtil.getSortIcon(sortState, true, false, metricKey);
       return (
         <BaggedCell key={keyname}
-                    keyName={metricKey} value={metricsMap[metricKey].getValue().toString()} onHover={this.onHover}
+                    keyName={metricKey}
+                    value={metricsMap[metricKey].getValue().toString()}
+                    onHover={this.onHover}
                     sortIcon={sortIcon}
-                    setSortByHandler={setSortByHandler} isMetric={true} isParam={false} isHovered={isHovered}
+                    setSortByHandler={setSortByHandler}
+                    isMetric
+                    isParam={false}
+                    isHovered={isHovered}
                     onRemoveBagged={onRemoveBagged}/>
       );
     });

--- a/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
@@ -6,6 +6,7 @@ import { RunInfo } from '../sdk/MlflowMessages';
 import classNames from 'classnames';
 import { Table, Dropdown, MenuItem } from 'react-bootstrap';
 import ExperimentRunsSortToggle from './ExperimentRunsSortToggle';
+import BaggedCell from './BaggedCell';
 import Utils from '../utils/Utils';
 
 const styles = {
@@ -127,71 +128,15 @@ class ExperimentRunsTableCompactView extends Component {
     });
     // Add bagged params
     const paramsCellContents = baggedParams.map((paramKey) => {
-      const cellClass = classNames("metric-param-content",
-        { highlighted: hoverState.isParam && hoverState.key === paramKey });
+      const isHovered = hoverState.isParam && hoverState.key === paramKey;
       const keyname = "param-" + paramKey;
       const sortIcon = ExperimentViewUtil.getSortIcon(sortState, false, true, paramKey);
-      return (
-        <div
-          key={keyname}
-          className="metric-param-cell"
-        >
-          <span
-            className={cellClass}
-            onMouseEnter={() => this.onHover({isParam: true, isMetric: false, key: paramKey})}
-            onMouseLeave={() => this.onHover({isParam: false, isMetric: false, key: ""})}
-          >
-            <Dropdown id="dropdown-custom-1">
-              <ExperimentRunsSortToggle
-                bsRole="toggle"
-                className="metric-param-sort-toggle"
-              >
-                <span
-                  className="run-table-container underline-on-hover"
-                  style={styles.metricParamCellContent}
-                >
-                  <span style={{marginRight: sortIcon ? 2 : 0}}>
-                    {sortIcon}
-                  </span>
-                  <span className="metric-param-name" title={paramKey}>
-                    {paramKey}
-                  </span>
-                  <span>
-                    :
-                  </span>
-                </span>
-              </ExperimentRunsSortToggle>
-              <span
-                className="metric-param-value run-table-container"
-                style={styles.metricParamCellContent}
-                title={paramsMap[paramKey].getValue()}
-              >
-                  {paramsMap[paramKey].getValue()}
-              </span>
-              <Dropdown.Menu className="mlflow-menu">
-                <MenuItem
-                  className="mlflow-menu-item"
-                  onClick={() => setSortByHandler(false, true, paramKey, true)}
-                >
-                  Sort ascending
-                </MenuItem>
-                <MenuItem
-                  className="mlflow-menu-item"
-                  onClick={() => setSortByHandler(false, true, paramKey, false)}
-                >
-                  Sort descending
-                </MenuItem>
-                <MenuItem
-                  className="mlflow-menu-item"
-                  onClick={() => onRemoveBagged(true, paramKey)}
-                >
-                  Display in own column
-                </MenuItem>
-              </Dropdown.Menu>
-            </Dropdown>
-          </span>
-        </div>
-      );
+      return (<BaggedCell
+        key={keyname}
+        sortIcon={sortIcon}
+        keyName={paramKey} value={paramsMap[paramKey].getValue()} onHover={this.onHover}
+        setSortByHandler={setSortByHandler} isMetric={false} isParam={true} isHovered={isHovered}
+        onRemoveBagged={onRemoveBagged}/>);
     });
     if (this.shouldShowBaggedColumn(true)) {
       rowContents.push(
@@ -209,67 +154,14 @@ class ExperimentRunsTableCompactView extends Component {
     // Add bagged metrics
     const metricsCellContents = baggedMetrics.map((metricKey) => {
       const keyname = "metric-" + metricKey;
-      const cellClass = classNames("metric-param-content",
-        { highlighted: hoverState.isMetric && hoverState.key === metricKey });
+      const isHovered = hoverState.isMetric && hoverState.key === metricKey;
       const sortIcon = ExperimentViewUtil.getSortIcon(sortState, true, false, metricKey);
-      const metric = metricsMap[metricKey].getValue();
       return (
-        <span
-          key={keyname}
-          className={"metric-param-cell"}
-          onMouseEnter={() => this.onHover({isParam: false, isMetric: true, key: metricKey})}
-          onMouseLeave={() => this.onHover({isParam: false, isMetric: false, key: ""})}
-        >
-          <span className={cellClass}>
-            <Dropdown id="dropdown-custom-1">
-              <ExperimentRunsSortToggle
-                bsRole="toggle"
-                className={"metric-param-sort-toggle"}
-              >
-                <span
-                  className="run-table-container underline-on-hover"
-                  style={styles.metricParamCellContent}
-                >
-                  <span style={{marginRight: sortIcon ? 2 : 0}}>
-                    {sortIcon}
-                  </span>
-                  <span className="metric-param-name" title={metricKey}>
-                    {metricKey}
-                  </span>
-                  <span>
-                    :
-                  </span>
-                </span>
-              </ExperimentRunsSortToggle>
-              <span
-                className="metric-param-value run-table-container"
-                style={styles.metricParamCellContent}
-              >
-                {Utils.formatMetric(metric)}
-              </span>
-              <Dropdown.Menu className="mlflow-menu">
-                <MenuItem
-                  className="mlflow-menu-item"
-                  onClick={() => setSortByHandler(true, false, metricKey, true)}
-                >
-                  Sort ascending
-                </MenuItem>
-                <MenuItem
-                  className="mlflow-menu-item"
-                  onClick={() => setSortByHandler(true, false, metricKey, false)}
-                >
-                  Sort descending
-                </MenuItem>
-                <MenuItem
-                  className="mlflow-menu-item"
-                  onClick={() => onRemoveBagged(false, metricKey)}
-                >
-                  Display in own column
-                </MenuItem>
-              </Dropdown.Menu>
-            </Dropdown>
-          </span>
-        </span>
+        <BaggedCell key={keyname}
+                    keyName={metricKey} value={metricsMap[metricKey].getValue().toString()} onHover={this.onHover}
+                    sortIcon={sortIcon}
+                    setSortByHandler={setSortByHandler} isMetric={true} isParam={false} isHovered={isHovered}
+                    onRemoveBagged={onRemoveBagged}/>
       );
     });
     if (this.shouldShowBaggedColumn(false)) {


### PR DESCRIPTION
This PR contains part of #745  and improves performance of the compact runs table by:

1) Wrapping bagged metric & param key-value pairs in their own `BaggedCell` component (allows React to avoid re-computing the virtual DOM elements corresponding to a key-value pair each time the table is rendered). 
2) Using a custom dropdown menu that only renders its children when the dropdown is displayed, as described in https://github.com/react-bootstrap/react-bootstrap/issues/2056.
3) Removing the highlight-on-hover behavior of metric/param key-value pairs.

## Performance Impact
See [ChromePerformanceProfiles.zip](https://github.com/mlflow/mlflow/files/2656256/ChromePerformanceProfiles.zip), which contains the following Chrome performance profiles on an example experiment with 30 runs, each with 100 metrics and 100 params:

### Master
1) WithoutBaggedCell30RunsSort-0fa229c743e482786ad6d42b96f6b07f4bd6749e: sorting on the date column within the test experiment takes ~3.5 seconds (3 seconds scripting, 0.5 seconds rendering
2) WithoutBaggedCell30Runs-0fa229c743e482786ad6d42b96f6b07f4bd6749e: initial page load, takes ~5.5 seconds (4.8 seconds scripting and 0.7 seconds rendering)

### This branch
3) WithBaggedCell30RunsSort-285afab4042a0e53a90a18442b3b035634493317: sorting on the date column takes ~1 second (~0.6 seconds scripting, 0.4 seconds rendering)
4) WithBaggedCell30RunsPageLoad-285afab4042a0e53a90a18442b3b035634493317:  initial page load, takes 3 seconds, (2.25 seconds scripting and 0.6 seconds rendering).

In addition, hovering over an individual metric/param is quite a bit faster.
