### PR TITLE
Allow dict values for `conda_env` parameter for model saving/logging

### DIFF
--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -39,7 +39,8 @@ def save_model(h2o_model, path, conda_env=None, mlflow_model=Model(), settings=N
 
     :param h2o_model: H2O model to be saved.
     :param path: Local path where the model is to be saved.
-    :param conda_env: Path to a Conda environment file. If provided, this decribes the environment
+    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
+                      Conda environment yaml file. If provided, this decribes the environment
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.h2o.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.h2o.DEFAULT_CONDA_ENV`` environment will be added to the model.
@@ -84,7 +85,8 @@ def log_model(h2o_model, artifact_path, conda_env=None, **kwargs):
 
     :param h2o_model: H2O model to be saved.
     :param artifact_path: Run-relative artifact path.
-    :param conda_env: Path to a Conda environment file. If provided, this decribes the environment
+    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
+                      Conda environment yaml file. If provided, this decribes the environment
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.h2o.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.h2o.DEFAULT_CONDA_ENV`` environment will be added to the model.

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -11,7 +11,6 @@ H20 (native) format
 from __future__ import absolute_import
 
 import os
-import shutil
 import yaml
 
 import h2o

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -44,7 +44,7 @@ def save_model(h2o_model, path, conda_env=None, mlflow_model=Model(), settings=N
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.h2o.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.h2o.DEFAULT_CONDA_ENV`` environment will be added to the model.
-                      The following is an *example* dictionary representation of a Conda 
+                      The following is an *example* dictionary representation of a Conda
                       environment::
 
                         {
@@ -106,7 +106,7 @@ def log_model(h2o_model, artifact_path, conda_env=None, **kwargs):
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.h2o.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.h2o.DEFAULT_CONDA_ENV`` environment will be added to the model.
-                      The following is an *example* dictionary representation of a Conda 
+                      The following is an *example* dictionary representation of a Conda
                       environment::
 
                         {

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -83,7 +83,7 @@ def save_model(h2o_model, path, conda_env=None, mlflow_model=Model(), settings=N
     if conda_env is None:
         conda_env = DEFAULT_CONDA_ENV
     elif not isinstance(conda_env, dict):
-        with open(os.path.join(path, conda_env), "r") as f:
+        with open(conda_env, "r") as f:
             conda_env = yaml.safe_load(f)
     with open(os.path.join(path, conda_env_subpath), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -44,6 +44,20 @@ def save_model(h2o_model, path, conda_env=None, mlflow_model=Model(), settings=N
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.h2o.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.h2o.DEFAULT_CONDA_ENV`` environment will be added to the model.
+                      The following is an *example* dictionary representation of a Conda 
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0',
+                                'pip': [
+                                    'h2o==3.20.0.8'
+                                ]
+                            ]
+                        }
+
     :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
     """
     path = os.path.abspath(path)
@@ -92,6 +106,20 @@ def log_model(h2o_model, artifact_path, conda_env=None, **kwargs):
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.h2o.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.h2o.DEFAULT_CONDA_ENV`` environment will be added to the model.
+                      The following is an *example* dictionary representation of a Conda 
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0',
+                                'pip': [
+                                    'h2o==3.20.0.8'
+                                ]
+                            ]
+                        }
+
     :param kwargs: kwargs to pass to ``h2o.save_model`` method.
     """
     Model.log(artifact_path=artifact_path, flavor=mlflow.h2o,

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -67,11 +67,13 @@ def save_model(h2o_model, path, conda_env=None, mlflow_model=Model(), settings=N
         yaml.safe_dump(settings, stream=settings_file)
 
     conda_env_subpath = "conda.yaml"
-    if conda_env:
-        shutil.copyfile(conda_env, os.path.join(path, conda_env_subpath))
-    else:
-        with open(os.path.join(path, conda_env_subpath), "w") as f:
-            yaml.safe_dump(DEFAULT_CONDA_ENV, stream=f, default_flow_style=False)
+    if conda_env is None:
+        conda_env = DEFAULT_CONDA_ENV
+    elif not isinstance(conda_env, dict):
+        with open(os.path.join(path, conda_env), "r") as f:
+            conda_env = yaml.safe_load(f)
+    with open(os.path.join(path, conda_env_subpath), "w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     pyfunc.add_to_model(mlflow_model, loader_module="mlflow.h2o",
                         data=model_data_subpath, env=conda_env_subpath)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -45,7 +45,8 @@ def save_model(keras_model, path, conda_env=None, mlflow_model=Model()):
 
     :param keras_model: Keras model to be saved.
     :param path: Local path where the model is to be saved.
-    :param conda_env: Path to a Conda environment file. If provided, this decribes the environment
+    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
+                      Conda environment yaml file. If provided, this decribes the environment
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.keras.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.keras.DEFAULT_CONDA_ENV`` environment will be added to the model.
@@ -69,11 +70,13 @@ def save_model(keras_model, path, conda_env=None, mlflow_model=Model()):
     keras_model.save(os.path.join(path, model_data_subpath))
 
     conda_env_subpath = "conda.yaml"
-    if conda_env is not None:
-        shutil.copyfile(conda_env, os.path.join(path, conda_env_subpath))
-    else:
-        with open(os.path.join(path, conda_env_subpath), "w") as f:
-            yaml.safe_dump(DEFAULT_CONDA_ENV, stream=f, default_flow_style=False)
+    if conda_env is None:
+        conda_env = DEFAULT_CONDA_ENV
+    elif not isinstance(conda_env, dict):
+        with open(os.path.join(path, conda_env), "r") as f:
+            conda_env = yaml.safe_load(f)
+    with open(os.path.join(path, conda_env_subpath), "w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     pyfunc.add_to_model(mlflow_model, loader_module="mlflow.keras",
                         data=model_data_subpath, env=conda_env_subpath)
@@ -87,7 +90,8 @@ def log_model(keras_model, artifact_path, conda_env=None, **kwargs):
 
     :param keras_model: Keras model to be saved.
     :param artifact_path: Run-relative artifact path.
-    :param conda_env: Path to a Conda environment file. If provided, this decribes the environment
+    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
+                      Conda environment yaml file. If provided, this decribes the environment
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.keras.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.keras.DEFAULT_CONDA_ENV`` environment will be added to the model.

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -51,14 +51,14 @@ def save_model(keras_model, path, conda_env=None, mlflow_model=Model()):
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.keras.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.keras.DEFAULT_CONDA_ENV`` environment will be added to the model.
-                      The following is an *example* dictionary representation of a Conda 
+                      The following is an *example* dictionary representation of a Conda
                       environment::
 
                         {
                             'name': 'mlflow-env',
                             'channels': ['defaults'],
                             'dependencies': [
-                                'python=3.7.0', 
+                                'python=3.7.0',
                                 'keras=2.2.4',
                                 'tensorflow=1.8.0'
                             ]
@@ -109,14 +109,14 @@ def log_model(keras_model, artifact_path, conda_env=None, **kwargs):
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.keras.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.keras.DEFAULT_CONDA_ENV`` environment will be added to the model.
-                      The following is an *example* dictionary representation of a Conda 
+                      The following is an *example* dictionary representation of a Conda
                       environment::
 
                         {
                             'name': 'mlflow-env',
                             'channels': ['defaults'],
                             'dependencies': [
-                                'python=3.7.0', 
+                                'python=3.7.0',
                                 'keras=2.2.4',
                                 'tensorflow=1.8.0'
                             ]

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -86,7 +86,7 @@ def save_model(keras_model, path, conda_env=None, mlflow_model=Model()):
     if conda_env is None:
         conda_env = DEFAULT_CONDA_ENV
     elif not isinstance(conda_env, dict):
-        with open(os.path.join(path, conda_env), "r") as f:
+        with open(conda_env, "r") as f:
             conda_env = yaml.safe_load(f)
     with open(os.path.join(path, conda_env_subpath), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -11,7 +11,6 @@ Keras (native) format
 from __future__ import absolute_import
 
 import os
-import shutil
 import yaml
 
 import keras

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -17,6 +17,7 @@ import yaml
 import keras
 import keras.backend as K
 import pandas as pd
+import tensorflow as tf
 
 from mlflow import pyfunc
 from mlflow.models import Model
@@ -32,7 +33,7 @@ DEFAULT_CONDA_ENV = _mlflow_conda_env(
         # The Keras pyfunc representation requires the Tensorflow
         # backend for Keras. Therefore, the conda environment must
         # include Tensorflow
-        "tensorflow",
+        "tensorflow=={}".format(tf.__version__),
     ],
     additional_pip_deps=None,
     additional_conda_channels=None,
@@ -50,6 +51,19 @@ def save_model(keras_model, path, conda_env=None, mlflow_model=Model()):
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.keras.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.keras.DEFAULT_CONDA_ENV`` environment will be added to the model.
+                      The following is an *example* dictionary representation of a Conda 
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0', 
+                                'keras=2.2.4',
+                                'tensorflow=1.8.0'
+                            ]
+                        }
+
     :param mlflow_model: MLflow model config this flavor is being added to.
 
     >>> import mlflow
@@ -95,6 +109,19 @@ def log_model(keras_model, artifact_path, conda_env=None, **kwargs):
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.keras.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.keras.DEFAULT_CONDA_ENV`` environment will be added to the model.
+                      The following is an *example* dictionary representation of a Conda 
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0', 
+                                'keras=2.2.4',
+                                'tensorflow=1.8.0'
+                            ]
+                        }
+
     :param kwargs: kwargs to pass to ``keras_model.save`` method.
 
     >>> from keras import Dense, layers
@@ -140,7 +167,6 @@ def _load_pyfunc(model_file):
     Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
     """
     if K._BACKEND == 'tensorflow':
-        import tensorflow as tf
         graph = tf.Graph()
         sess = tf.Session(graph=graph)
         # By default tf backed models depend on the global graph and session.

--- a/mlflow/pytorch.py
+++ b/mlflow/pytorch.py
@@ -50,6 +50,19 @@ def log_model(pytorch_model, artifact_path, conda_env=None, **kwargs):
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.pytorch.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.pytorch.DEFAULT_CONDA_ENV`` environment will be added to the model.
+                      The following is an *example* dictionary representation of a Conda 
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0', 
+                                'pytorch=0.4.1', 
+                                'torchvision=0.2.1'
+                            ]
+                        }
+
     :param kwargs: kwargs to pass to ``torch.save`` method.
 
     >>> import torch
@@ -109,6 +122,19 @@ def save_model(pytorch_model, path, conda_env=None, mlflow_model=Model(), **kwar
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.pytorch.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.pytorch.DEFAULT_CONDA_ENV`` environment will be added to the model.
+                      The following is an *example* dictionary representation of a Conda 
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0', 
+                                'pytorch=0.4.1', 
+                                'torchvision=0.2.1'
+                            ]
+                        }
+
     :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
     :param kwargs: kwargs to pass to ``torch.save`` method.
 

--- a/mlflow/pytorch.py
+++ b/mlflow/pytorch.py
@@ -104,7 +104,8 @@ def save_model(pytorch_model, path, conda_env=None, mlflow_model=Model(), **kwar
     :param pytorch_model: PyTorch model to be saved. Must accept a single ``torch.FloatTensor`` as
                           input and produce a single output tensor.
     :param path: Local path where the model is to be saved.
-    :param conda_env: Path to a Conda environment file. If provided, this decribes the environment
+    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
+                      Conda environment yaml file. If provided, this decribes the environment
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.pytorch.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.pytorch.DEFAULT_CONDA_ENV`` environment will be added to the model.
@@ -140,11 +141,13 @@ def save_model(pytorch_model, path, conda_env=None, mlflow_model=Model(), **kwar
     model_file = os.path.basename(model_path)
 
     conda_env_subpath = "conda.yaml"
-    if conda_env is not None:
-        shutil.copyfile(conda_env, os.path.join(path, conda_env_subpath))
-    else:
-        with open(os.path.join(path, conda_env_subpath), "w") as f:
-            yaml.safe_dump(DEFAULT_CONDA_ENV, stream=f, default_flow_style=False)
+    if conda_env is None:
+        conda_env = DEFAULT_CONDA_ENV
+    elif not isinstance(conda_env, dict):
+        with open(os.path.join(path, conda_env), "r") as f:
+            conda_env = yaml.safe_load(f)
+    with open(os.path.join(path, conda_env_subpath), "w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     mlflow_model.add_flavor(FLAVOR_NAME, model_data=model_file, pytorch_version=torch.__version__)
     pyfunc.add_to_model(mlflow_model, loader_module="mlflow.pytorch",

--- a/mlflow/pytorch.py
+++ b/mlflow/pytorch.py
@@ -169,7 +169,7 @@ def save_model(pytorch_model, path, conda_env=None, mlflow_model=Model(), **kwar
     if conda_env is None:
         conda_env = DEFAULT_CONDA_ENV
     elif not isinstance(conda_env, dict):
-        with open(os.path.join(path, conda_env), "r") as f:
+        with open(conda_env, "r") as f:
             conda_env = yaml.safe_load(f)
     with open(os.path.join(path, conda_env_subpath), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)

--- a/mlflow/pytorch.py
+++ b/mlflow/pytorch.py
@@ -50,15 +50,15 @@ def log_model(pytorch_model, artifact_path, conda_env=None, **kwargs):
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.pytorch.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.pytorch.DEFAULT_CONDA_ENV`` environment will be added to the model.
-                      The following is an *example* dictionary representation of a Conda 
+                      The following is an *example* dictionary representation of a Conda
                       environment::
 
                         {
                             'name': 'mlflow-env',
                             'channels': ['defaults'],
                             'dependencies': [
-                                'python=3.7.0', 
-                                'pytorch=0.4.1', 
+                                'python=3.7.0',
+                                'pytorch=0.4.1',
                                 'torchvision=0.2.1'
                             ]
                         }
@@ -122,15 +122,15 @@ def save_model(pytorch_model, path, conda_env=None, mlflow_model=Model(), **kwar
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.pytorch.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.pytorch.DEFAULT_CONDA_ENV`` environment will be added to the model.
-                      The following is an *example* dictionary representation of a Conda 
+                      The following is an *example* dictionary representation of a Conda
                       environment::
 
                         {
                             'name': 'mlflow-env',
                             'channels': ['defaults'],
                             'dependencies': [
-                                'python=3.7.0', 
-                                'pytorch=0.4.1', 
+                                'python=3.7.0',
+                                'pytorch=0.4.1',
                                 'torchvision=0.2.1'
                             ]
                         }

--- a/mlflow/pytorch.py
+++ b/mlflow/pytorch.py
@@ -11,7 +11,6 @@ PyTorch (native) format
 from __future__ import absolute_import
 
 import os
-import shutil
 import yaml
 
 import numpy as np

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -58,6 +58,18 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.sklearn.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.sklearn.DEFAULT_CONDA_ENV`` environment will be added to the model.
+                      The following is an *example* dictionary representation of a Conda 
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0', 
+                                'scikit-learn=0.19.2'
+                            ]
+                        }
+
     :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
     :param serialization_format: The format in which to serialize the model. This should be one of
                                  the formats listed in
@@ -65,6 +77,7 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
                                  format, ``mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE``,
                                  provides better cross-system compatibility by identifying and
                                  packaging code dependencies with the serialized model.
+
     >>> import mlflow.sklearn
     >>> from sklearn.datasets import load_iris
     >>> from sklearn import tree
@@ -131,6 +144,18 @@ def log_model(sk_model, artifact_path, conda_env=None,
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.sklearn.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.sklearn.DEFAULT_CONDA_ENV`` environment will be added to the model.
+                      The following is an *example* dictionary representation of a Conda 
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0', 
+                                'scikit-learn=0.19.2'
+                            ]
+                        }
+
     :param serialization_format: The format in which to serialize the model. This should be one of
                                  the formats listed in
                                  ``mlflow.sklearn.SUPPORTED_SERIALIZATION_FORMATS``. The Cloudpickle

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -117,7 +117,7 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
     if conda_env is None:
         conda_env = DEFAULT_CONDA_ENV
     elif not isinstance(conda_env, dict):
-        with open(os.path.join(path, conda_env), "r") as f:
+        with open(conda_env, "r") as f:
             conda_env = yaml.safe_load(f)
     with open(os.path.join(path, conda_env_subpath), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -58,14 +58,14 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.sklearn.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.sklearn.DEFAULT_CONDA_ENV`` environment will be added to the model.
-                      The following is an *example* dictionary representation of a Conda 
+                      The following is an *example* dictionary representation of a Conda
                       environment::
 
                         {
                             'name': 'mlflow-env',
                             'channels': ['defaults'],
                             'dependencies': [
-                                'python=3.7.0', 
+                                'python=3.7.0',
                                 'scikit-learn=0.19.2'
                             ]
                         }
@@ -144,14 +144,14 @@ def log_model(sk_model, artifact_path, conda_env=None,
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.sklearn.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.sklearn.DEFAULT_CONDA_ENV`` environment will be added to the model.
-                      The following is an *example* dictionary representation of a Conda 
+                      The following is an *example* dictionary representation of a Conda
                       environment::
 
                         {
                             'name': 'mlflow-env',
                             'channels': ['defaults'],
                             'dependencies': [
-                                'python=3.7.0', 
+                                'python=3.7.0',
                                 'scikit-learn=0.19.2'
                             ]
                         }

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -13,7 +13,6 @@ from __future__ import absolute_import
 
 import os
 import pickle
-import shutil
 import yaml
 
 import sklearn

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -94,7 +94,7 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
                 error_code=INVALID_PARAMETER_VALUE)
 
     if os.path.exists(path):
-        raise MlflowException(message="Path '{}' already exists".format(path), 
+        raise MlflowException(message="Path '{}' already exists".format(path),
                               error_code=RESOURCE_ALREADY_EXISTS)
     os.makedirs(path)
     model_data_subpath = "model.pkl"

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -22,6 +22,7 @@ from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, INTERNAL_ERROR
+from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
 import mlflow.tracking
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -52,7 +53,8 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
 
     :param sk_model: scikit-learn model to be saved.
     :param path: Local path where the model is to be saved.
-    :param conda_env: Path to a Conda environment file. If provided, this decribes the environment
+    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
+                      Conda environment yaml file. If provided, this decribes the environment
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.sklearn.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.sklearn.DEFAULT_CONDA_ENV`` environment will be added to the model.
@@ -92,18 +94,21 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
                 error_code=INVALID_PARAMETER_VALUE)
 
     if os.path.exists(path):
-        raise Exception("Path '{}' already exists".format(path))
+        raise MlflowException(message="Path '{}' already exists".format(path), 
+                              error_code=RESOURCE_ALREADY_EXISTS)
     os.makedirs(path)
     model_data_subpath = "model.pkl"
     _save_model(sk_model=sk_model, output_path=os.path.join(path, model_data_subpath),
                 serialization_format=serialization_format)
 
     conda_env_subpath = "conda.yaml"
-    if conda_env is not None:
-        shutil.copyfile(conda_env, os.path.join(path, conda_env_subpath))
-    else:
-        with open(os.path.join(path, conda_env_subpath), "w") as f:
-            yaml.safe_dump(DEFAULT_CONDA_ENV, stream=f, default_flow_style=False)
+    if conda_env is None:
+        conda_env = DEFAULT_CONDA_ENV
+    elif not isinstance(conda_env, dict):
+        with open(os.path.join(path, conda_env), "r") as f:
+            conda_env = yaml.safe_load(f)
+    with open(os.path.join(path, conda_env_subpath), "w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     pyfunc.add_to_model(mlflow_model, loader_module="mlflow.sklearn", data=model_data_subpath,
                         env=conda_env_subpath)
@@ -121,7 +126,8 @@ def log_model(sk_model, artifact_path, conda_env=None,
 
     :param sk_model: scikit-learn model to be saved.
     :param artifact_path: Run-relative artifact path.
-    :param conda_env: Path to a Conda environment file. If provided, this decribes the environment
+    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
+                      Conda environment yaml file. If provided, this decribes the environment
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.sklearn.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.sklearn.DEFAULT_CONDA_ENV`` environment will be added to the model.

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -252,7 +252,7 @@ def save_model(spark_model, path, mlflow_model=Model(), conda_env=None, jars=Non
     if conda_env is None:
         conda_env = DEFAULT_CONDA_ENV
     elif not isinstance(conda_env, dict):
-        with open(os.path.join(path, conda_env), "r") as f:
+        with open(conda_env, "r") as f:
             conda_env = yaml.safe_load(f)
     with open(os.path.join(path, conda_env_subpath), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -61,10 +61,11 @@ def log_model(spark_model, artifact_path, conda_env=None, jars=None, dfs_tmpdir=
 
     :param spark_model: PipelineModel to be saved.
     :param artifact_path: Run relative artifact path.
-    :param conda_env: Path to a conda environment file. if provided, this decribes the environment
-                      this model should be run in. at minimum, it should specify the dependencies
-                      contained in ``mlflow.pyspark.DEFAULT_CONDA_ENV``. if `none`, the default
-                      ``mlflow.pyspark.DEFAULT_CONDA_ENV`` environment will be added to the model.
+    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
+                      Conda environment yaml file. If provided, this decribes the environment
+                      this model should be run in. At minimum, it should specify the dependencies
+                      contained in ``mlflow.spark.DEFAULT_CONDA_ENV``. If `None`, the default
+                      ``mlflow.spark.DEFAULT_CONDA_ENV`` environment will be added to the model.
     :param jars: List of JARs needed by the model.
     :param dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
                        filesystem if running in local mode. The model will be writen in this
@@ -181,10 +182,11 @@ def save_model(spark_model, path, mlflow_model=Model(), conda_env=None, jars=Non
     :param spark_model: Spark PipelineModel to be saved. Can save only PipelineModels.
     :param path: Local path where the model is to be saved.
     :param mlflow_model: MLflow model config this flavor is being added to.
-    :param conda_env: Path to a conda environment file. if provided, this decribes the environment
-                      this model should be run in. at minimum, it should specify the dependencies
-                      contained in ``mlflow.pyspark.DEFAULT_CONDA_ENV``. if `none`, the default
-                      ``mlflow.pyspark.DEFAULT_CONDA_ENV`` environment will be added to the model.
+    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
+                      Conda environment yaml file. If provided, this decribes the environment
+                      this model should be run in. At minimum, it should specify the dependencies
+                      contained in ``mlflow.spark.DEFAULT_CONDA_ENV``. If `None`, the default
+                      ``mlflow.spark.DEFAULT_CONDA_ENV`` environment will be added to the model.
     :param jars: List of JARs needed by the model.
     :param dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
                        filesystem if running in local mode. The model will be written in this
@@ -224,11 +226,13 @@ def save_model(spark_model, path, mlflow_model=Model(), conda_env=None, jars=Non
     pyspark_version = pyspark.version.__version__
 
     conda_env_subpath = "conda.yaml"
-    if conda_env is not None:
-        shutil.copyfile(conda_env, os.path.join(path, conda_env_subpath))
-    else:
-        with open(os.path.join(path, conda_env_subpath), "w") as f:
-            yaml.safe_dump(DEFAULT_CONDA_ENV, stream=f, default_flow_style=False)
+    if conda_env is None:
+        conda_env = DEFAULT_CONDA_ENV
+    elif not isinstance(conda_env, dict):
+        with open(os.path.join(path, conda_env), "r") as f:
+            conda_env = yaml.safe_load(f)
+    with open(os.path.join(path, conda_env_subpath), "w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     mlflow_model.add_flavor(FLAVOR_NAME, pyspark_version=pyspark_version,
                             model_data=sparkml_data_path_sub)

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -66,14 +66,14 @@ def log_model(spark_model, artifact_path, conda_env=None, jars=None, dfs_tmpdir=
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.spark.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.spark.DEFAULT_CONDA_ENV`` environment will be added to the model.
-                      The following is an *example* dictionary representation of a Conda 
+                      The following is an *example* dictionary representation of a Conda
                       environment::
 
                         {
                             'name': 'mlflow-env',
                             'channels': ['defaults'],
                             'dependencies': [
-                                'python=3.7.0', 
+                                'python=3.7.0',
                                 'pyspark=2.3.0'
                             ]
                         }
@@ -199,14 +199,14 @@ def save_model(spark_model, path, mlflow_model=Model(), conda_env=None, jars=Non
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.spark.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.spark.DEFAULT_CONDA_ENV`` environment will be added to the model.
-                      The following is an *example* dictionary representation of a Conda 
+                      The following is an *example* dictionary representation of a Conda
                       environment::
 
                         {
                             'name': 'mlflow-env',
                             'channels': ['defaults'],
                             'dependencies': [
-                                'python=3.7.0', 
+                                'python=3.7.0',
                                 'pyspark=2.3.0'
                             ]
                         }

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -66,6 +66,18 @@ def log_model(spark_model, artifact_path, conda_env=None, jars=None, dfs_tmpdir=
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.spark.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.spark.DEFAULT_CONDA_ENV`` environment will be added to the model.
+                      The following is an *example* dictionary representation of a Conda 
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0', 
+                                'pyspark=2.3.0'
+                            ]
+                        }
+
     :param jars: List of JARs needed by the model.
     :param dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
                        filesystem if running in local mode. The model will be writen in this
@@ -187,6 +199,18 @@ def save_model(spark_model, path, mlflow_model=Model(), conda_env=None, jars=Non
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.spark.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.spark.DEFAULT_CONDA_ENV`` environment will be added to the model.
+                      The following is an *example* dictionary representation of a Conda 
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0', 
+                                'pyspark=2.3.0'
+                            ]
+                        }
+
     :param jars: List of JARs needed by the model.
     :param dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
                        filesystem if running in local mode. The model will be written in this

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -22,7 +22,6 @@ Spark MLlib (native) format
 from __future__ import absolute_import
 
 import os
-import shutil
 import yaml
 import logging
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -71,14 +71,14 @@ def log_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, arti
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.tensorflow.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.tensorflow.DEFAULT_CONDA_ENV`` environment will be added to the
-                      model. The following is an *example* dictionary representation of a Conda 
+                      model. The following is an *example* dictionary representation of a Conda
                       environment::
 
                         {
                             'name': 'mlflow-env',
                             'channels': ['defaults'],
                             'dependencies': [
-                                'python=3.7.0', 
+                                'python=3.7.0',
                                 'tensorflow=1.8.0'
                             ]
                         }
@@ -117,14 +117,14 @@ def save_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, pat
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.tensorflow.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.tensorflow.DEFAULT_CONDA_ENV`` environment will be added to the
-                      model. The following is an *example* dictionary representation of a Conda 
+                      model. The following is an *example* dictionary representation of a Conda
                       environment::
 
                         {
                             'name': 'mlflow-env',
                             'channels': ['defaults'],
                             'dependencies': [
-                                'python=3.7.0', 
+                                'python=3.7.0',
                                 'tensorflow=1.8.0'
                             ]
                         }

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -70,7 +70,7 @@ def log_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, arti
                       Conda environment yaml file. If provided, this decribes the environment
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.tensorflow.DEFAULT_CONDA_ENV``. If `None`, the default
-                      ``mlflow.tensorflow.DEFAULT_CONDA_ENV`` environment will be added to the 
+                      ``mlflow.tensorflow.DEFAULT_CONDA_ENV`` environment will be added to the
                       model.
     """
     return Model.log(artifact_path=artifact_path, flavor=mlflow.tensorflow,
@@ -105,7 +105,7 @@ def save_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, pat
                       Conda environment yaml file. If provided, this decribes the environment
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.tensorflow.DEFAULT_CONDA_ENV``. If `None`, the default
-                      ``mlflow.tensorflow.DEFAULT_CONDA_ENV`` environment will be added to the 
+                      ``mlflow.tensorflow.DEFAULT_CONDA_ENV`` environment will be added to the
                       model.
     """
     _logger.info(

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -66,10 +66,11 @@ def log_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, arti
                                  `signature_def_map` parameter of the
                                  `tf.saved_model.builder.SavedModelBuilder` method.
     :param artifact_path: The run-relative path to which to log model artifacts.
-    :param conda_env: Path to a Conda environment file. If provided, this decribes the environment
+    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
+                      Conda environment yaml file. If provided, this decribes the environment
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.tensorflow.DEFAULT_CONDA_ENV``. If `None`, the default
-                      ``mlflow.tensorflow.DEFAULT_CONDA_ENV`` environment will be added to the
+                      ``mlflow.tensorflow.DEFAULT_CONDA_ENV`` environment will be added to the 
                       model.
     """
     return Model.log(artifact_path=artifact_path, flavor=mlflow.tensorflow,
@@ -100,10 +101,11 @@ def save_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, pat
                                  `tf.saved_model.builder.savedmodelbuilder` method.
     :param path: Local path where the MLflow model is to be saved.
     :param mlflow_model: MLflow model configuration to which this flavor will be added.
-    :param conda_env: Path to a Conda environment file. If provided, this decribes the environment
+    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
+                      Conda environment yaml file. If provided, this decribes the environment
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.tensorflow.DEFAULT_CONDA_ENV``. If `None`, the default
-                      ``mlflow.tensorflow.DEFAULT_CONDA_ENV`` environment will be added to the
+                      ``mlflow.tensorflow.DEFAULT_CONDA_ENV`` environment will be added to the 
                       model.
     """
     _logger.info(
@@ -122,11 +124,13 @@ def save_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, pat
     shutil.move(os.path.join(path, root_relative_path), os.path.join(path, model_dir_subpath))
 
     conda_env_subpath = "conda.yaml"
-    if conda_env is not None:
-        shutil.copyfile(conda_env, os.path.join(path, conda_env_subpath))
-    else:
-        with open(os.path.join(path, conda_env_subpath), "w") as f:
-            yaml.safe_dump(DEFAULT_CONDA_ENV, stream=f, default_flow_style=False)
+    if conda_env is None:
+        conda_env = DEFAULT_CONDA_ENV
+    elif not isinstance(conda_env, dict):
+        with open(os.path.join(path, conda_env), "r") as f:
+            conda_env = yaml.safe_load(f)
+    with open(os.path.join(path, conda_env_subpath), "w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     mlflow_model.add_flavor(FLAVOR_NAME, saved_model_dir=model_dir_subpath,
                             meta_graph_tags=tf_meta_graph_tags,

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -149,7 +149,7 @@ def save_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, pat
     if conda_env is None:
         conda_env = DEFAULT_CONDA_ENV
     elif not isinstance(conda_env, dict):
-        with open(os.path.join(path, conda_env), "r") as f:
+        with open(conda_env, "r") as f:
             conda_env = yaml.safe_load(f)
     with open(os.path.join(path, conda_env_subpath), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -71,7 +71,18 @@ def log_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, arti
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.tensorflow.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.tensorflow.DEFAULT_CONDA_ENV`` environment will be added to the
-                      model.
+                      model. The following is an *example* dictionary representation of a Conda 
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0', 
+                                'tensorflow=1.8.0'
+                            ]
+                        }
+
     """
     return Model.log(artifact_path=artifact_path, flavor=mlflow.tensorflow,
                      tf_saved_model_dir=tf_saved_model_dir, tf_meta_graph_tags=tf_meta_graph_tags,
@@ -106,7 +117,18 @@ def save_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, pat
                       this model should be run in. At minimum, it should specify the dependencies
                       contained in ``mlflow.tensorflow.DEFAULT_CONDA_ENV``. If `None`, the default
                       ``mlflow.tensorflow.DEFAULT_CONDA_ENV`` environment will be added to the
-                      model.
+                      model. The following is an *example* dictionary representation of a Conda 
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0', 
+                                'tensorflow=1.8.0'
+                            ]
+                        }
+
     """
     _logger.info(
         "Validating the specified Tensorflow model by attempting to load it in a new Tensorflow"

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -4,6 +4,7 @@ import sys
 import os
 import json
 import pytest
+import yaml
 import mock
 from mock import Mock
 
@@ -202,7 +203,7 @@ def test_build_image_passes_model_conda_environment_to_azure_image_creation_rout
             image_config = create_image_call_kwargs["image_config"]
             assert image_config.conda_file is not None
             with open(image_config.conda_file, "r") as f:
-                assert f.read() == sklearn_conda_env_text
+                assert yaml.safe_load(f.read()) == yaml.safe_load(sklearn_conda_env_text)
 
 
 @mock.patch("mlflow.azureml.mlflow_version", "0.7.0")

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -152,7 +152,7 @@ def test_model_save_accepts_conda_env_as_dict(h2o_iris_model, model_path):
 
     with open(saved_conda_env_path, "r") as f:
         saved_conda_env_parsed = yaml.safe_load(f)
-    assert saved_conda_env_parsed == conda_env 
+    assert saved_conda_env_parsed == conda_env
 
 
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -141,6 +141,20 @@ def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
     assert saved_conda_env_text == h2o_custom_env_text
 
 
+def test_model_save_accepts_conda_env_as_dict(h2o_iris_model, model_path):
+    conda_env = dict(mlflow.h2o.DEFAULT_CONDA_ENV)
+    conda_env["dependencies"].append("pytest")
+    mlflow.h2o.save_model(h2o_model=h2o_iris_model.model, path=model_path, conda_env=conda_env)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == conda_env 
+
+
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
         h2o_iris_model, h2o_custom_env):
     artifact_path = "model"

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -126,6 +126,20 @@ def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
     assert saved_conda_env_parsed == keras_custom_env_parsed
 
 
+def test_model_save_accepts_conda_env_as_dict(model, model_path):
+    conda_env = dict(mlflow.keras.DEFAULT_CONDA_ENV)
+    conda_env["dependencies"].append("pytest")
+    mlflow.keras.save_model(keras_model=model, path=model_path, conda_env=conda_env)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == conda_env 
+
+
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(model, keras_custom_env):
     artifact_path = "model"
     with mlflow.start_run():

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -137,7 +137,7 @@ def test_model_save_accepts_conda_env_as_dict(model, model_path):
 
     with open(saved_conda_env_path, "r") as f:
         saved_conda_env_parsed = yaml.safe_load(f)
-    assert saved_conda_env_parsed == conda_env 
+    assert saved_conda_env_parsed == conda_env
 
 
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(model, keras_custom_env):

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -187,6 +187,20 @@ def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
     assert saved_conda_env_text == pytorch_custom_env_text
 
 
+def test_model_save_accepts_conda_env_as_dict(model, model_path):
+    conda_env = dict(mlflow.pytorch.DEFAULT_CONDA_ENV)
+    conda_env["dependencies"].append("pytest")
+    mlflow.pytorch.save_model(pytorch_model=model, path=model_path, conda_env=conda_env)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == conda_env 
+
+
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
         model, pytorch_custom_env):
     artifact_path = "model"

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -198,7 +198,7 @@ def test_model_save_accepts_conda_env_as_dict(model, model_path):
 
     with open(saved_conda_env_path, "r") as f:
         saved_conda_env_parsed = yaml.safe_load(f)
-    assert saved_conda_env_parsed == conda_env 
+    assert saved_conda_env_parsed == conda_env
 
 
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -183,6 +183,21 @@ def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
     assert saved_conda_env_parsed == sklearn_custom_env_parsed
 
 
+def test_model_save_accepts_conda_env_as_dict(sklearn_knn_model, model_path):
+    conda_env = dict(mlflow.sklearn.DEFAULT_CONDA_ENV)
+    conda_env["dependencies"].append("pytest")
+    mlflow.sklearn.save_model(
+            sk_model=sklearn_knn_model.model, path=model_path, conda_env=conda_env)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == conda_env 
+
+
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
         sklearn_knn_model, sklearn_custom_env):
     artifact_path = "model"

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -195,7 +195,7 @@ def test_model_save_accepts_conda_env_as_dict(sklearn_knn_model, model_path):
 
     with open(saved_conda_env_path, "r") as f:
         saved_conda_env_parsed = yaml.safe_load(f)
-    assert saved_conda_env_parsed == conda_env 
+    assert saved_conda_env_parsed == conda_env
 
 
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -242,6 +242,22 @@ def test_sparkml_model_save_persists_specified_conda_env_in_mlflow_model_directo
     assert saved_conda_env_parsed == spark_custom_env_parsed
 
 
+def test_sparkml_model_save_accepts_conda_env_as_dict(spark_model_iris, model_path):
+    conda_env = dict(mlflow.spark.DEFAULT_CONDA_ENV)
+    conda_env["dependencies"].append("pytest")
+    sparkm.save_model(spark_model=spark_model_iris.model,
+                      path=model_path,
+                      conda_env=conda_env)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == conda_env 
+
+
 def test_sparkml_model_log_persists_specified_conda_env_in_mlflow_model_directory(
         spark_model_iris, model_path, spark_custom_env):
     artifact_path = "model"

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -255,7 +255,7 @@ def test_sparkml_model_save_accepts_conda_env_as_dict(spark_model_iris, model_pa
 
     with open(saved_conda_env_path, "r") as f:
         saved_conda_env_parsed = yaml.safe_load(f)
-    assert saved_conda_env_parsed == conda_env 
+    assert saved_conda_env_parsed == conda_env
 
 
 def test_sparkml_model_log_persists_specified_conda_env_in_mlflow_model_directory(

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -333,6 +333,24 @@ def test_save_model_persists_specified_conda_env_in_mlflow_model_directory(
     assert saved_conda_env_text == tf_custom_env_text
 
 
+def test_save_model_accepts_conda_env_as_dict(saved_tf_iris_model, model_path):
+    conda_env = dict(mlflow.tensorflow.DEFAULT_CONDA_ENV)
+    conda_env["dependencies"].append("pytest")
+    mlflow.tensorflow.save_model(tf_saved_model_dir=saved_tf_iris_model.path,
+                                 tf_meta_graph_tags=saved_tf_iris_model.meta_graph_tags,
+                                 tf_signature_def_key=saved_tf_iris_model.signature_def_key,
+                                 path=model_path,
+                                 conda_env=conda_env)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == conda_env 
+
+
 def test_log_model_persists_specified_conda_env_in_mlflow_model_directory(
         saved_tf_iris_model, tf_custom_env):
     artifact_path = "model"

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -348,7 +348,7 @@ def test_save_model_accepts_conda_env_as_dict(saved_tf_iris_model, model_path):
 
     with open(saved_conda_env_path, "r") as f:
         saved_conda_env_parsed = yaml.safe_load(f)
-    assert saved_conda_env_parsed == conda_env 
+    assert saved_conda_env_parsed == conda_env
 
 
 def test_log_model_persists_specified_conda_env_in_mlflow_model_directory(


### PR DESCRIPTION
Currently, users have to persist conda environments to a filesystem path for inclusion in a saved MLflow model. This PR introduces the option to specify a conda-compatible environment dictionary directly.