### PR TITLE
Display full version number as abbreviation in experiment view

### DIFF
--- a/mlflow/server/js/src/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/components/ExperimentViewUtil.js
@@ -71,7 +71,7 @@ export default class ExperimentViewUtil {
       </td>,
       <td className="run-table-container" key="meta-version">
         <div className="truncate-text single-line" style={ExperimentViewUtil.styles.runInfoCell}>
-          {Utils.renderVersion(runInfo)}
+          <abbr title={Utils.renderVersion(runInfo, false)}>{Utils.renderVersion(runInfo)}</abbr>
         </div>
       </td>,
     ];

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -225,7 +225,7 @@ class RunView extends Component {
           </div>
           {run.source_version ?
             <div className="run-info">
-              <span className="metadata-header">Git Commit: </span>
+              <span className="metadata-header">Source version: </span>
               <span className="metadata-info">{Utils.renderVersion(run, false)}</span>
             </div>
             : null


### PR DESCRIPTION
When using experiment view, the version extracted from run info is truncated to 6 characters. In some cases where an alternative version number is supplied by the user, that might not necessarily be a git hash (e.g. semantic version), it is useful to still have a way of seeing the entire version number in the experiment view without cluttering the interface, hence the use of the `abbr` tag.
