### PR TITLE
Pass cookie when loading text artifacts

### DIFF
--- a/mlflow/server/js/src/components/artifact-view-components/ShowArtifactTextView.js
+++ b/mlflow/server/js/src/components/artifact-view-components/ShowArtifactTextView.js
@@ -60,7 +60,7 @@ class ShowArtifactTextView extends Component {
     const getArtifactRequest = new Request(getSrc(this.props.path, this.props.runUuid), {
       method: 'GET',
       redirect: 'follow',
-      headers: new Headers(getRequestHeaders())
+      headers: new Headers(getRequestHeaders(document.cookie))
     });
     fetch(getArtifactRequest).then((response) => {
       return response.blob();


### PR DESCRIPTION
Small bugfix - pass the current document's [cookie](https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie) when loading text artifacts