### PR TITLE
AzureML: Fix pandas dataframe deserialization error

### DIFF
--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -324,6 +324,6 @@ def init():
 
 def run(json_input):
     input_df = parse_json_input(json_input=json_input, orient="split")
-    return get_jsonable_obj(model.predict(input_df))
+    return get_jsonable_obj(model.predict(input_df), pandas_orient="records")
 
 """

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -323,7 +323,7 @@ def init():
 
 
 def run(json_input):
-    input_df = parse_json_input(json_input=json_input, orientation="split")
+    input_df = parse_json_input(json_input=json_input, orient="split")
     return get_jsonable_obj(model.predict(input_df))
 
 """

--- a/mlflow/pyfunc/scoring_server.py
+++ b/mlflow/pyfunc/scoring_server.py
@@ -48,23 +48,23 @@ CONTENT_TYPES = [
 _logger = logging.getLogger(__name__)
 
 
-def parse_json_input(json_input, orientation="split"):
+def parse_json_input(json_input, orient="split"):
     """
     :param json_input: A JSON-formatted string representation of a Pandas DataFrame, or a stream
                        containing such a string representation.
-    :param orientation: The Pandas DataFrame orientation of the JSON input. This is either 'split'
-                        or 'records'.
+    :param orient: The Pandas DataFrame orientation of the JSON input. This is either 'split'
+                   or 'records'.
     """
     # pylint: disable=broad-except
     try:
-        return pd.read_json(json_input, orient=orientation)
+        return pd.read_json(json_input, orient=orient)
     except Exception:
         _handle_serving_error(
                 error_message=(
                     "Failed to parse input as a Pandas DataFrame. Ensure that the input is"
-                    " a valid JSON-formatted Pandas DataFrame with the `{orientation}` orientation"
-                    " produced using the `pandas.DataFrame.to_json(..., orient='{orientation}')`"
-                    " method.".format(orientation=orientation)),
+                    " a valid JSON-formatted Pandas DataFrame with the `{orient}` orient"
+                    " produced using the `pandas.DataFrame.to_json(..., orient='{orient}')`"
+                    " method.".format(orient=orient)),
                 error_code=MALFORMED_REQUEST)
 
 
@@ -142,25 +142,25 @@ def init(model):
                 _logger.warning(
                     "**IMPORTANT UPDATE**: Starting in MLflow 0.9.0, requests received with a"
                     " `Content-Type` header value of `%s` will be interpreted"
-                    " as JSON-serialized Pandas DataFrames with the `split` orientation, instead"
-                    " of the `records` orientation. The `records` orientation is unsafe because"
+                    " as JSON-serialized Pandas DataFrames with the `split` orient, instead"
+                    " of the `records` orient. The `records` orient is unsafe because"
                     " it may not preserve column ordering. Client code should be updated to"
-                    " either send serialized DataFrames with the `split` orientation and the"
+                    " either send serialized DataFrames with the `split` orient and the"
                     " `%s` content type (recommended) or use the `%s` content type with the"
-                    " `records` orientation. For more information, see"
+                    " `records` orient. For more information, see"
                     " https://www.mlflow.org/docs/latest/models.html#pyfunc-deployment.\n",
                     CONTENT_TYPE_JSON,
                     CONTENT_TYPE_JSON_SPLIT_ORIENTED,
                     CONTENT_TYPE_JSON_RECORDS_ORIENTED)
                 logged_pandas_records_format_warning = True
             data = parse_json_input(json_input=flask.request.data.decode('utf-8'),
-                                    orientation="records")
+                                    orient="records")
         elif flask.request.content_type == CONTENT_TYPE_JSON_RECORDS_ORIENTED:
             data = parse_json_input(json_input=flask.request.data.decode('utf-8'),
-                                    orientation="records")
+                                    orient="records")
         elif flask.request.content_type == CONTENT_TYPE_JSON_SPLIT_ORIENTED:
             data = parse_json_input(json_input=flask.request.data.decode('utf-8'),
-                                    orientation="split")
+                                    orient="split")
         else:
             return flask.Response(
                     response=("This predictor only supports the following content types,"
@@ -182,7 +182,7 @@ def init(model):
                         " inference."),
                     error_code=BAD_REQUEST)
 
-        predictions = get_jsonable_obj(raw_predictions, pandas_orientation="records")
+        predictions = get_jsonable_obj(raw_predictions, pandas_orient="records")
         result = json.dumps(predictions, cls=NumpyEncoder)
         return flask.Response(response=result, status=200, mimetype='application/json')
 

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -21,7 +21,7 @@ def ndarray2list(ndarray):
     return [ndarray2list(ndarray[i, :]) for i in range(0, ndarray.shape[0])]
 
 
-def get_jsonable_obj(data, pandas_orientation=None):
+def get_jsonable_obj(data, pandas_orientation="records"):
     """Attempt to make the data json-able via standard library.
     Look for some commonly used types that are not jsonable and convert them into json-able ones.
     Unknown data types are returned as is.

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -21,21 +21,21 @@ def ndarray2list(ndarray):
     return [ndarray2list(ndarray[i, :]) for i in range(0, ndarray.shape[0])]
 
 
-def get_jsonable_obj(data, pandas_orientation="records"):
+def get_jsonable_obj(data, pandas_orient="records"):
     """Attempt to make the data json-able via standard library.
     Look for some commonly used types that are not jsonable and convert them into json-able ones.
     Unknown data types are returned as is.
 
     :param data: data to be converted, works with pandas and numpy, rest will be returned as is.
-    :param pandas_orientation: If `data` is a Pandas DataFrame, it will be converted to a JSON
-                               dictionary using this Pandas serialization orientation.
+    :param pandas_orient: If `data` is a Pandas DataFrame, it will be converted to a JSON
+                          dictionary using this Pandas serialization orientation.
     """
     if isinstance(data, np.ndarray):
         return ndarray2list(data)
     if isinstance(data, pd.DataFrame):
-        return data.to_dict(orient=pandas_orientation)
+        return data.to_dict(orient=pandas_orient)
     if isinstance(data, pd.Series):
-        return pd.DataFrame(data).to_dict(orient=pandas_orientation)
+        return pd.DataFrame(data).to_dict(orient=pandas_orient)
     else:  # by default just return whatever this is and hope for the best
         return data
 

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -91,7 +91,7 @@ def keras_data():
 
 @pytest.fixture(scope="module")
 def keras_model(keras_data):
-    x, y = keras_data 
+    x, y = keras_data
     model = Sequential()
     model.add(Dense(3, input_dim=4))
     model.add(Dense(1))

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -416,9 +416,10 @@ def test_execution_script_run_method_scores_pandas_dataframes_successfully(
         # pylint: disable=undefined-variable
         init()
 
+        input_data = pd.DataFrame(datasets.load_iris().data[:, :2])
+        assert isinstance(input_data, pd.DataFrame) 
         # Invoke the `run` method of the execution script with sample input data and verify that
         # reasonable output data is produced
-        input_data = datasets.load_iris().data[:, :2]
         # pylint: disable=undefined-variable
         output_data = run(pd.DataFrame(data=input_data).to_json(orient="split"))
         assert len(output_data) == len(input_data)

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -417,7 +417,7 @@ def test_execution_script_run_method_scores_pandas_dataframes_successfully(
         init()
 
         input_data = pd.DataFrame(datasets.load_iris().data[:, :2])
-        assert isinstance(input_data, pd.DataFrame) 
+        assert isinstance(input_data, pd.DataFrame)
         # Invoke the `run` method of the execution script with sample input data and verify that
         # reasonable output data is produced
         # pylint: disable=undefined-variable

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -6,16 +6,20 @@ import json
 import pytest
 import yaml
 import mock
+import numpy as np
 from mock import Mock
 
 import pandas as pd
 import sklearn.datasets as datasets
 import sklearn.linear_model as glm
+from keras.models import Sequential
+from keras.layers import Dense
 from click.testing import CliRunner
 
 import mlflow
 import mlflow.azureml
 import mlflow.azureml.cli
+import mlflow.keras
 import mlflow.sklearn
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
@@ -59,14 +63,41 @@ def get_azure_workspace():
     return Workspace.get("test_workspace")
 
 
-@pytest.fixture(scope="session")
-def sklearn_model():
+@pytest.fixture(scope="module")
+def sklearn_data():
     iris = datasets.load_iris()
-    X = iris.data[:, :2]  # we only take the first two features.
+    x = iris.data[:, :2]  # we only take the first two features.
     y = iris.target
+    return x, y
+
+
+@pytest.fixture(scope="module")
+def sklearn_model(sklearn_data):
+    x, y = sklearn_data
     linear_lr = glm.LogisticRegression()
-    linear_lr.fit(X, y)
+    linear_lr.fit(x, y)
     return linear_lr
+
+
+@pytest.fixture(scope="module")
+def keras_data():
+    iris = datasets.load_iris()
+    data = pd.DataFrame(data=np.c_[iris['data'], iris['target']],
+                        columns=iris['feature_names'] + ['target'])
+    y = data['target']
+    x = data.drop('target', axis=1)
+    return x, y
+
+
+@pytest.fixture(scope="module")
+def keras_model(keras_data):
+    x, y = keras_data 
+    model = Sequential()
+    model.add(Dense(3, input_dim=4))
+    model.add(Dense(1))
+    model.compile(loss='mean_squared_error', optimizer='SGD')
+    model.fit(x, y)
+    return model
 
 
 @pytest.fixture
@@ -390,9 +421,13 @@ def test_execution_script_init_method_attempts_to_load_correct_azure_ml_model(
         assert get_model_path_call_kwargs["version"] == model_version
 
 
-def test_execution_script_run_method_scores_pandas_dataframes_successfully(
-        sklearn_model, model_path):
+def test_execution_script_run_method_scores_pandas_dfs_successfully_when_model_outputs_numpy_arrays(
+        sklearn_model, sklearn_data, model_path):
     mlflow.sklearn.save_model(sk_model=sklearn_model, path=model_path)
+
+    pyfunc_model = mlflow.pyfunc.load_pyfunc(path=model_path)
+    pyfunc_outputs = pyfunc_model.predict(sklearn_data[0])
+    assert isinstance(pyfunc_outputs, np.ndarray)
 
     model_mock = Mock()
     model_mock.name = "model_name"
@@ -416,13 +451,47 @@ def test_execution_script_run_method_scores_pandas_dataframes_successfully(
         # pylint: disable=undefined-variable
         init()
 
-        input_data = pd.DataFrame(datasets.load_iris().data[:, :2])
-        assert isinstance(input_data, pd.DataFrame)
         # Invoke the `run` method of the execution script with sample input data and verify that
         # reasonable output data is produced
         # pylint: disable=undefined-variable
-        output_data = run(pd.DataFrame(data=input_data).to_json(orient="split"))
-        assert len(output_data) == len(input_data)
+        output_data = run(pd.DataFrame(data=sklearn_data[0]).to_json(orient="split"))
+        assert len(output_data) == len(sklearn_data[0])
+
+
+def test_execution_script_run_method_scores_pandas_dfs_successfully_when_model_outputs_pandas_dfs(
+        keras_model, keras_data, model_path):
+    mlflow.keras.save_model(keras_model=keras_model, path=model_path)
+    pyfunc_model = mlflow.pyfunc.load_pyfunc(path=model_path)
+    pyfunc_outputs = pyfunc_model.predict(keras_data[0])
+    assert isinstance(pyfunc_outputs, pd.DataFrame)
+
+    model_mock = Mock()
+    model_mock.name = "model_name"
+    model_mock.version = 1
+
+    with TempDir() as tmp:
+        execution_script_path = tmp.path("dest")
+        mlflow.azureml._create_execution_script(
+                output_path=execution_script_path, azure_model=model_mock)
+
+        with open(execution_script_path, "r") as f:
+            execution_script = f.read()
+
+    # Define the `init` and `score` methods contained in the execution script
+    # pylint: disable=exec-used
+    exec(execution_script, globals())
+    with AzureMLMocks() as aml_mocks:
+        aml_mocks["get_model_path"].side_effect = lambda *args, **kwargs: model_path
+        # Execute the `init` method of the execution script and load the sklearn model from the
+        # mocked path
+        # pylint: disable=undefined-variable
+        init()
+
+        # Invoke the `run` method of the execution script with sample input data and verify that
+        # reasonable output data is produced
+        # pylint: disable=undefined-variable
+        output_data = run(pd.DataFrame(data=keras_data[0]).to_json(orient="split"))
+        assert len(output_data) == len(keras_data[0])
 
 
 @mock.patch("mlflow.azureml.mlflow_version", "0.7.0")


### PR DESCRIPTION
The default parameter value of `pandas_orientation=None` used by `mlflow.utils.get_jsonable_obj` is not a valid Pandas DataFrame orientation. The Azure container entrypoint script used this default value, causing output failures when used with models that produce Pandas DataFrames (most *pyfunc* models).

This PR changes the default parameter value to `pandas_orientation="records"` *and* changes the AzureML entrypoint to explicitly specify `pandas_orientation="records"`. Finally, it introduces an additional unit test designed to verify that Pandas DataFrame outputs are serialized correctly by the Azure container.