### PR TITLE
Adding support for MLflow packages in ZIP files

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -28,6 +28,8 @@ from mlflow.utils.mlflow_tags import MLFLOW_GIT_REPO_URL
 
 # TODO: this should be restricted to just Git repos and not S3 and stuff like that
 _GIT_URI_REGEX = re.compile(r"^[^/]*:")
+_FILE_URI_REGEX = re.compile(r"^file://.+")
+_ZIP_URI_REGEX = re.compile(r".+\.zip$")
 # Environment variable indicating a path to a conda installation. MLflow will default to running
 # "conda" if unset
 MLFLOW_CONDA_HOME = "MLFLOW_CONDA_HOME"
@@ -233,9 +235,19 @@ def _expand_uri(uri):
     return uri
 
 
+def _is_file_uri(uri):
+    """Returns True if the passed-in URI is a file:// URI."""
+    return _FILE_URI_REGEX.match(uri)
+
+
 def _is_local_uri(uri):
     """Returns True if the passed-in URI should be interpreted as a path on the local filesystem."""
     return not _GIT_URI_REGEX.match(uri)
+
+
+def _is_zip_uri(uri):
+    """Returns True if the passed-in URI points to a ZIP file."""
+    return _ZIP_URI_REGEX.match(uri)
 
 
 def _is_valid_branch_name(work_dir, version):
@@ -258,15 +270,22 @@ def _fetch_project(uri, force_tempdir, version=None, git_username=None, git_pass
     """
     Fetch a project into a local directory, returning the path to the local project directory.
     :param force_tempdir: If True, will fetch the project into a temporary directory. Otherwise,
-                          will fetch Git projects into a temporary directory but simply return the
-                          path of local projects (i.e. perform a no-op for local projects).
+                          will fetch ZIP or Git projects into a temporary directory but simply return
+                          the path of local projects (i.e. perform a no-op for local projects).
     """
     parsed_uri, subdirectory = _parse_subdirectory(uri)
-    use_temp_dst_dir = force_tempdir or not _is_local_uri(parsed_uri)
+    use_temp_dst_dir = force_tempdir or _is_zip_uri(parsed_uri) or not _is_local_uri(parsed_uri)
     dst_dir = tempfile.mkdtemp() if use_temp_dst_dir else parsed_uri
     if use_temp_dst_dir:
         _logger.info("=== Fetching project from %s into %s ===", uri, dst_dir)
-    if _is_local_uri(uri):
+    if _is_zip_uri(parsed_uri):
+        if _is_local_uri(parsed_uri):
+            _unzip_repo(parsed_uri, dst_dir)
+        elif _is_file_uri(parsed_uri):
+            _unzip_repo(parsed_uri[7:], dst_dir)
+        else:
+            _fetch_zip_repo(parsed_uri, dst_dir)
+    elif _is_local_uri(uri):
         if version is not None:
             raise ExecutionException("Setting a version is only supported for Git project URIs")
         if use_temp_dst_dir:
@@ -278,6 +297,23 @@ def _fetch_project(uri, force_tempdir, version=None, git_username=None, git_pass
     if not os.path.exists(res):
         raise ExecutionException("Could not find subdirectory %s of %s" % (subdirectory, dst_dir))
     return res
+
+
+def _unzip_repo(uri, dst_dir):
+    import zipfile
+    with zipfile.ZipFile(uri) as zip_file:
+        zip_file.extractall(dst_dir)
+
+
+def _fetch_zip_repo(uri, dst_dir):
+    import requests
+    import zipfile
+    from io import BytesIO
+    response = requests.get(uri)
+    if requests.codes.ok != response.status_code:
+        raise ExecutionException("Unable to retrieve ZIP file %s" % uri)
+    with zipfile.ZipFile(BytesIO(response.content)) as zip_file:
+        zip_file.extractall(dst_dir)
 
 
 def _fetch_git_repo(uri, version, dst_dir, git_username, git_password):

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -270,8 +270,9 @@ def _fetch_project(uri, force_tempdir, version=None, git_username=None, git_pass
     """
     Fetch a project into a local directory, returning the path to the local project directory.
     :param force_tempdir: If True, will fetch the project into a temporary directory. Otherwise,
-                          will fetch ZIP or Git projects into a temporary directory but simply return
-                          the path of local projects (i.e. perform a no-op for local projects).
+                          will fetch ZIP or Git projects into a temporary directory but simply
+                          return the path of local projects (i.e. perform a no-op for local
+                          projects).
     """
     parsed_uri, subdirectory = _parse_subdirectory(uri)
     use_temp_dst_dir = force_tempdir or _is_zip_uri(parsed_uri) or not _is_local_uri(parsed_uri)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -25,3 +25,4 @@ keras
 attrdict==2.0.0
 azureml-sdk; python_version >= "3.0"
 cloudpickle
+pytest-localserver

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -50,7 +50,7 @@ def zipped_repo(tmpdir):
     import zipfile
     zip_name = tmpdir.join('%s.zip' % TEST_PROJECT_NAME).strpath
     with zipfile.ZipFile(zip_name, 'w', zipfile.ZIP_DEFLATED) as zip_file:
-        for root, dirs, files in os.walk(TEST_PROJECT_DIR):  # pylint: disable=unused-variable
+        for root, _, files in os.walk(TEST_PROJECT_DIR):
             for file in files:
                 file_name = os.path.join(root, file)
                 zip_file.write(file_name, file_name[len(TEST_PROJECT_DIR)+len(os.sep):])

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -45,17 +45,45 @@ def local_git_repo_uri(local_git_repo):
     return "file://%s" % local_git_repo
 
 
-def test_fetch_project(local_git_repo, local_git_repo_uri):
+@pytest.fixture()
+def zipped_repo(tmpdir):
+    import zipfile
+    zip_name = tmpdir.join('%s.zip' % TEST_PROJECT_NAME).strpath
+    with zipfile.ZipFile(zip_name, 'w', zipfile.ZIP_DEFLATED) as zip_file:
+        for root, dirs, files in os.walk(TEST_PROJECT_DIR):
+            for file in files:
+                file_name = os.path.join(root, file)
+                zip_file.write(file_name, file_name[len(TEST_PROJECT_DIR)+len(os.sep):])
+    return zip_name
+
+
+def test_is_zip_uri():
+    assert mlflow.projects._is_zip_uri('http://foo.bar/moo.zip')
+    assert mlflow.projects._is_zip_uri('https://foo.bar/moo.zip')
+    assert mlflow.projects._is_zip_uri('file:///moo.zip')
+    assert mlflow.projects._is_zip_uri('file://C:/moo.zip')
+    assert mlflow.projects._is_zip_uri('/moo.zip')
+    assert mlflow.projects._is_zip_uri(('C:/moo.zip'))
+
+
+def test_fetch_project(local_git_repo, local_git_repo_uri, zipped_repo, httpserver):
+    httpserver.serve_content(open(zipped_repo, 'rb').read())
     # The tests are as follows:
     # 1. Fetching a locally saved project.
     # 2. Fetching a project located in a Git repo root directory.
     # 3. Fetching a project located in a Git repo subdirectory.
     # 4. Passing a subdirectory works for local directories.
+    # 5. Fetching a remote ZIP file
+    # 6. Using a local ZIP file
+    # 7. Using a file:// URL to a local ZIP file
     test_list = [
         (TEST_PROJECT_DIR, '', TEST_PROJECT_DIR),
         (local_git_repo_uri, '', local_git_repo),
         (local_git_repo_uri, 'example_project', os.path.join(local_git_repo, 'example_project')),
         (os.path.dirname(TEST_PROJECT_DIR), os.path.basename(TEST_PROJECT_DIR), TEST_PROJECT_DIR),
+        (httpserver.url + '/%s.zip' % TEST_PROJECT_NAME, '', TEST_PROJECT_DIR),
+        (zipped_repo, '', TEST_PROJECT_DIR),
+        ('file://%s' % zipped_repo, '', TEST_PROJECT_DIR),
     ]
     for base_uri, subdirectory, expected in test_list:
         work_dir = mlflow.projects._fetch_project(

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -50,7 +50,7 @@ def zipped_repo(tmpdir):
     import zipfile
     zip_name = tmpdir.join('%s.zip' % TEST_PROJECT_NAME).strpath
     with zipfile.ZipFile(zip_name, 'w', zipfile.ZIP_DEFLATED) as zip_file:
-        for root, dirs, files in os.walk(TEST_PROJECT_DIR):
+        for root, dirs, files in os.walk(TEST_PROJECT_DIR):  # pylint: disable=unused-variable
             for file in files:
                 file_name = os.path.join(root, file)
                 zip_file.write(file_name, file_name[len(TEST_PROJECT_DIR)+len(os.sep):])


### PR DESCRIPTION
To make it easier to support CI packaged MLflow packages this adds support for ZIP files (local and remote) to be used in addition to local folders and git repositories.  Passes all project tests and lint.sh correctly.  Please let me know if I need to do anything further to make this able to be merged in.  This is being contributed by Expedia Group. Thank you very much!