### PR TITLE
Fix container heights on experiment view

### DIFF
--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -258,7 +258,7 @@ class ExperimentView extends Component {
     const paramKeyList = paramKeyFilter.apply(this.props.paramKeyList);
     const metricKeyList = metricKeyFilter.apply(this.props.metricKeyList);
     const unbaggedParamKeyList = paramKeyFilter.apply(this.state.persistedState.unbaggedParams);
-    const unbaggedMetricKeyList = paramKeyFilter.apply(this.state.persistedState.unbaggedMetrics);
+    const unbaggedMetricKeyList = metricKeyFilter.apply(this.state.persistedState.unbaggedMetrics);
 
     const compareDisabled = Object.keys(this.state.runsSelected).length < 2;
     const deleteDisabled = Object.keys(this.state.runsSelected).length < 1;

--- a/mlflow/server/js/src/components/HomeView.js
+++ b/mlflow/server/js/src/components/HomeView.js
@@ -30,9 +30,11 @@ class HomeView extends Component {
   }
 
   render() {
+    const headerHeight = process.env.HIDE_HEADER === 'true' ? 0 : 60;
+    const containerHeight = "calc(100% - " + headerHeight + "px)";
     if (process.env.HIDE_EXPERIMENT_LIST === 'true') {
       return (
-        <div className="experiment-page-container">
+        <div className="experiment-page-container" style={{height: containerHeight}}>
           { this.props.experimentId !== undefined ?
             <ExperimentPage experimentId={this.props.experimentId}/> :
             <NoExperimentView/>
@@ -42,7 +44,7 @@ class HomeView extends Component {
     }
     if (this.state.listExperimentsExpanded) {
       return (
-        <div className="outer-container">
+        <div className="outer-container" style={{height: containerHeight}}>
           <div className="HomePage-experiment-list-container">
             <div className="collapsed-expander-container">
               <ExperimentListView
@@ -62,13 +64,13 @@ class HomeView extends Component {
       );
     } else {
       return (
-        <div>
+        <div className="outer-container" style={{height: containerHeight}}>
           <div className="collapsed-expander-container">
             <i onClick={this.onClickListExperiments}
                title="Show experiment list"
                className="expander fa fa-chevron-right login-icon"/>
           </div>
-          <div className="experiment-page-container" style={{height: "100vh"}}>
+          <div className="experiment-page-container">
             { this.props.experimentId !== undefined ?
               <ExperimentPage experimentId={this.props.experimentId}/> :
               <NoExperimentView/>


### PR DESCRIPTION
Small follow-up to #745 - fixes a styling bug where the container element of the experiment view would have an unspecified height (and therefore often the wrong height) when:
* The experiments list was collapsed
* The UI header was hidden (test by setting the `HIDE_HEADER` env variable to "true")
* The experiments list was hidden (test by setting the `HIDE_EXPERIMENT_LIST` env variable to "true")

This bug would cause the runs table (which grows to fill available vertical space in its parent container) to have the wrong height (specifically, to display at its min-height of 200px). We fix this bug by always setting the height of the container element so that the runs table can fill all available vertical space.

Tested by running the dev UI with the following combinations (should be all possible combos):
* `npm start`
* `HIDE_EXPERIMENT_LIST=true HIDE_HEADER=true npm start`
* `HIDE_EXPERIMENT_LIST=true npm start`
* `HIDE_HEADER=true npm start`


