### PR TITLE
[UI] Improve perf of rendering many table rows by lazily constructing JSX per row

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -8,7 +8,7 @@ from functools import wraps
 from flask import Response, request, send_file
 from querystring_parser import parser
 
-from mlflow.entities import Metric, Param, RunTag, ViewType, Run, RunData, RunInfo
+from mlflow.entities import Metric, Param, RunTag, ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.protos import databricks_pb2
 from mlflow.protos.service_pb2 import CreateExperiment, MlflowService, GetExperiment, \
@@ -267,17 +267,9 @@ def _search_runs():
     run_view_type = ViewType.ACTIVE_ONLY
     if request_message.HasField('run_view_type'):
         run_view_type = ViewType.from_proto(request_message.run_view_type)
-    # run_entities = _get_store().search_runs(request_message.experiment_ids,
-    #                                         request_message.anded_expressions,
-    #                                         run_view_type)
-    metrics = [Metric(key="metric %s" % i, value=i, timestamp=0) for i in range(3)]
-    params = [Param(key="param %s" % i, value="asdf") for i in range(3)]
-    tags = [RunTag(key="tag %s" % i, value="asdf") for i in range(3)]
-    numRuns = 50
-    run_info = [RunInfo(run_uuid="abc %s" % i, experiment_id=0, start_time=3, user_id="Sid", name="abc", source_type=1, entry_point_name="ef", status=3, end_time=5, source_version="asdf", lifecycle_stage='active', source_name="ieowjf") for i in range(numRuns)]
-    run_data = [RunData(metrics=metrics, params=params, tags=tags + ([ RunTag(key="mlflow.parentRunId", value="abc %s" % (i // 10))] if i % 10 != 0 else [])) for i in range(numRuns)]
-    # run_data = [RunData(metrics=metrics, params=params, tags=tags) for i in range(numRuns)]
-    run_entities = [Run(run_info=run_info[i], run_data=run_data[i]) for i in range(numRuns)]
+    run_entities = _get_store().search_runs(request_message.experiment_ids,
+                                            request_message.anded_expressions,
+                                            run_view_type)
     response_message.runs.extend([r.to_proto() for r in run_entities])
     response = Response(mimetype='application/json')
     response.set_data(message_to_json(response_message))

--- a/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
@@ -400,8 +400,9 @@ class ExperimentRunsTableCompactView extends PureComponent {
               const showBaggedParams = this.shouldShowBaggedColumn(true);
               const showBaggedMetrics = this.shouldShowBaggedColumn(false);
               const runMetadataWidth = runMetadataColWidths.reduce((a, b) => a + b);
-              const tableMinWidth = BAGGED_COL_WIDTH * (showBaggedParams + showBaggedMetrics)
-                + runMetadataWidth + (UNBAGGED_COL_WIDTH * (unbaggedMetrics.length + unbaggedParams.length));
+              const tableMinWidth = (BAGGED_COL_WIDTH * (showBaggedParams + showBaggedMetrics))
+                + runMetadataWidth +
+                (UNBAGGED_COL_WIDTH * (unbaggedMetrics.length + unbaggedParams.length));
               // If we aren't showing bagged metrics or params (bagged metrics & params are the
               // only cols that use the CellMeasurer component), set the row height statically
               const cellMeasurerProps = {};

--- a/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
@@ -355,7 +355,6 @@ class ExperimentRunsTableCompactView extends PureComponent {
       sortState,
       tagsList,
       runsExpanded});
-    console.log("@SID got " + rows.length + " rows");
 
     const headerCells = [
       ExperimentViewUtil.getSelectAllCheckbox(onCheckAll, isAllChecked, "div"),

--- a/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
@@ -350,31 +350,12 @@ class ExperimentRunsTableCompactView extends PureComponent {
       unbaggedParams,
     } = this.props;
 
-    // Compute metadata for row generation, don't actually generate though
-    // const rowData = ExperimentViewUtil.getRowGenerationMetadata({
-    //   runInfos,
-    //   tagsList,
-    //   runsExpanded});
-    // How do we render a row given its index? Can we actually do that?
-    // Maybe: have a map of row index to the metadata needed to generate the row, then generate
-    // the row separately. Compute the map by looking through the expanded runs. The dependencies
-    // of row-generation are
-    // { idx, isParent, hasExpander, expanderOpen, childrenIds }
-    // However this assumes that computing all this metadata isn't the bottleneck, should probs
-    // check that - seems true in dev, just not super sure if it holds in prod.
-
     const rows = ExperimentViewUtil.getRowRenderMetadata({
       runInfos,
       sortState,
       tagsList,
       runsExpanded});
-
-    // const rows = ExperimentViewUtil.getRows({
-    //   runInfos,
-    //   sortState,
-    //   tagsList,
-    //   runsExpanded,
-    //   getRow: this.getRow });
+    console.log("@SID got " + rows.length + " rows");
 
     const headerCells = [
       ExperimentViewUtil.getSelectAllCheckbox(onCheckAll, isAllChecked, "div"),

--- a/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
@@ -344,6 +344,8 @@ class ExperimentRunsTableCompactView extends PureComponent {
       isAllChecked,
       onSortBy,
       sortState,
+      metricsList,
+      paramsList,
       tagsList,
       runsExpanded,
       unbaggedMetrics,
@@ -354,6 +356,8 @@ class ExperimentRunsTableCompactView extends PureComponent {
       runInfos,
       sortState,
       tagsList,
+      metricsList,
+      paramsList,
       runsExpanded});
 
     const headerCells = [
@@ -393,20 +397,27 @@ class ExperimentRunsTableCompactView extends PureComponent {
                 100, // 'Source' column width
                 80, // 'Version' column width
               ];
-              const runMetadataWidth = runMetadataColWidths.reduce((a, b) => a + b);
-              const tableMinWidth = (BAGGED_COL_WIDTH * 2) + runMetadataWidth +
-                (UNBAGGED_COL_WIDTH * (unbaggedMetrics.length + unbaggedParams.length));
               const showBaggedParams = this.shouldShowBaggedColumn(true);
               const showBaggedMetrics = this.shouldShowBaggedColumn(false);
+              const runMetadataWidth = runMetadataColWidths.reduce((a, b) => a + b);
+              const tableMinWidth = BAGGED_COL_WIDTH * (showBaggedParams + showBaggedMetrics)
+                + runMetadataWidth + (UNBAGGED_COL_WIDTH * (unbaggedMetrics.length + unbaggedParams.length));
+              // If we aren't showing bagged metrics or params (bagged metrics & params are the
+              // only cols that use the CellMeasurer component), set the row height statically
+              const cellMeasurerProps = {};
+              if (showBaggedMetrics || showBaggedParams) {
+                cellMeasurerProps.rowHeight = this._cache.rowHeight;
+                cellMeasurerProps.deferredMeasurementCache = this._cache;
+              } else {
+                cellMeasurerProps.rowHeight = 32;
+              }
               return (<Table
+                {...cellMeasurerProps}
                 width={
                   Math.max(width, tableMinWidth)
                 }
-                deferredMeasurementCache={this._cache}
                 height={Math.max(height - TABLE_HEADER_HEIGHT, 200)}
                 headerHeight={TABLE_HEADER_HEIGHT}
-                overscanRowCount={2}
-                rowHeight={this._cache.rowHeight}
                 rowCount={rows.length}
                 gridStyle={{
                   borderLeft: BORDER_STYLE,
@@ -448,9 +459,7 @@ class ExperimentRunsTableCompactView extends PureComponent {
                     width={UNBAGGED_COL_WIDTH}
                     headerRenderer={() => headerCells[NUM_RUN_METADATA_COLS + idx]}
                     style={styles.columnStyle}
-                    cellRenderer={({rowData}) => {
-                      return rowData.contents[NUM_RUN_METADATA_COLS + idx];
-                    }}
+                    cellRenderer={({rowData}) => rowData.contents[NUM_RUN_METADATA_COLS + idx]}
                   />;
                 })}
                 {showBaggedParams && <Column

--- a/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
@@ -194,11 +194,8 @@ class ExperimentRunsTableCompactView extends PureComponent {
         </div>
       );
     }
-    const sortValue = ExperimentViewUtil.computeSortValue(
-      sortState, metricsMap, paramsMap, runInfo, tagsList[idx]);
     return {
       key: runInfo.run_uuid,
-      sortValue,
       contents: rowContents,
       isChild: !isParent,
     };
@@ -419,6 +416,7 @@ class ExperimentRunsTableCompactView extends PureComponent {
                 }
                 height={Math.max(height - TABLE_HEADER_HEIGHT, 200)}
                 headerHeight={TABLE_HEADER_HEIGHT}
+                overscanRowCount={2}
                 rowCount={rows.length}
                 gridStyle={{
                   borderLeft: BORDER_STYLE,

--- a/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView.js
@@ -147,10 +147,14 @@ class ExperimentRunsTableMultiColumnView extends Component {
       runsExpanded,
       paramKeyList,
       metricKeyList,
+      paramsList,
+      metricsList
     } = this.props;
     const rows = ExperimentViewUtil.getRows({
       runInfos,
       sortState,
+      paramsList,
+      metricsList,
       tagsList,
       runsExpanded,
       getRow: this.getRow

--- a/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView.js
@@ -46,7 +46,6 @@ class ExperimentRunsTableMultiColumnView extends Component {
       paramKeyList,
       metricKeyList,
       onCheckbox,
-      sortState,
       runsSelected,
       tagsList,
       onExpand,
@@ -79,11 +78,8 @@ class ExperimentRunsTableMultiColumnView extends Component {
     if (numMetrics === 0) {
       rowContents.push(<td className="left-border" key="meta-metric-empty" />);
     }
-    const sortValue = ExperimentViewUtil.computeSortValue(
-      sortState, metricsMap, paramsMap, runInfo, tagsList[idx]);
     return {
       key: runInfo.run_uuid,
-      sortValue: sortValue,
       contents: rowContents,
       isChild: !isParent,
     };

--- a/mlflow/server/js/src/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/components/ExperimentViewUtil.js
@@ -334,7 +334,8 @@ export default class ExperimentViewUtil {
     }
   }
 
-  static getRowRenderMetadata({ runInfos, sortState, paramsList, metricsList, tagsList, runsExpanded }) {
+  static getRowRenderMetadata(
+    { runInfos, sortState, paramsList, metricsList, tagsList, runsExpanded }) {
     const runIdToIdx = {};
     runInfos.forEach((r, idx) => {
       runIdToIdx[r.run_uuid] = idx;
@@ -374,7 +375,8 @@ export default class ExperimentViewUtil {
         hasExpander = true;
         childrenIds = parentIdToChildren[runId].map((cIdx => runInfos[cIdx].run_uuid));
       }
-      const sortValue = ExperimentViewUtil.getSortValue({metricsList, paramsList, tagsList, idx, sortState, runInfo: runInfos[idx]});
+      const sortValue = ExperimentViewUtil.getSortValue(
+        {metricsList, paramsList, tagsList, idx, sortState, runInfo: runInfos[idx]});
       return [{
         idx,
         isParent: true,
@@ -394,7 +396,8 @@ export default class ExperimentViewUtil {
       if (childrenIdxs) {
         if (ExperimentViewUtil.isExpanderOpen(runsExpanded, runId)) {
           const childrenRows = childrenIdxs.map((idx) => {
-            const sortValue = ExperimentViewUtil.getSortValue({metricsList, paramsList, tagsList, idx, sortState, runInfo: runInfos[idx]});
+            const sortValue = ExperimentViewUtil.getSortValue(
+              {metricsList, paramsList, tagsList, idx, sortState, runInfo: runInfos[idx]});
             return { idx, isParent: false, hasExpander: false, sortValue };
           });
           ExperimentViewUtil.sortRows(childrenRows, sortState);

--- a/mlflow/server/js/src/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/components/ExperimentViewUtil.js
@@ -326,7 +326,7 @@ export default class ExperimentViewUtil {
     }
   }
 
-  static getRows({ runInfos, sortState, tagsList, runsExpanded, getRow }) {
+  static getRowRenderMetadata({ runInfos, sortState, tagsList, runsExpanded }) {
     const runIdToIdx = {};
     runInfos.forEach((r, idx) => {
       runIdToIdx[r.run_uuid] = idx;
@@ -366,13 +366,13 @@ export default class ExperimentViewUtil {
         hasExpander = true;
         childrenIds = parentIdToChildren[runId].map((cIdx => runInfos[cIdx].run_uuid));
       }
-      return [getRow({
+      return [{
         idx,
         isParent: true,
         hasExpander,
         expanderOpen: ExperimentViewUtil.isExpanderOpen(runsExpanded, runId),
         childrenIds,
-      })];
+      }];
     });
     ExperimentViewUtil.sortRows(parentRows, sortState);
     const mergedRows = [];
@@ -383,13 +383,19 @@ export default class ExperimentViewUtil {
       if (childrenIdxs) {
         if (ExperimentViewUtil.isExpanderOpen(runsExpanded, runId)) {
           const childrenRows = childrenIdxs.map((idx) =>
-            getRow({ idx, isParent: false, hasExpander: false }));
+            ({ idx, isParent: false, hasExpander: false }));
           ExperimentViewUtil.sortRows(childrenRows, sortState);
           mergedRows.push(...childrenRows);
         }
       }
     });
     return mergedRows;
+  }
+
+  static getRows({ runInfos, sortState, tagsList, runsExpanded, getRow }) {
+    const mergedRows = ExperimentViewUtil.getRowRenderMetadata(
+      { runInfos, sortState, tagsList, runsExpanded });
+    return mergedRows.map((rowMetadata) => getRow(rowMetadata));
   }
 
   static renderRows(rows) {

--- a/mlflow/server/js/src/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/components/ExperimentViewUtil.js
@@ -83,14 +83,6 @@ export default class ExperimentViewUtil {
     ];
   }
 
-  static getSortValue({metricsList, paramsList, tagsList, idx, sortState, runInfo}) {
-    return ExperimentViewUtil.computeSortValue(sortState,
-      ExperimentViewUtil.toMetricsMap(metricsList[idx]),
-      ExperimentViewUtil.toParamsMap(paramsList[idx]),
-      runInfo,
-      tagsList[idx]);
-  }
-
   /**
    * Returns an icon for sorting the metric or param column with the specified key. The icon
    * is visible if we're currently sorting by the corresponding column. Otherwise, the icon is
@@ -375,8 +367,9 @@ export default class ExperimentViewUtil {
         hasExpander = true;
         childrenIds = parentIdToChildren[runId].map((cIdx => runInfos[cIdx].run_uuid));
       }
-      const sortValue = ExperimentViewUtil.getSortValue(
-        {metricsList, paramsList, tagsList, idx, sortState, runInfo: runInfos[idx]});
+      const sortValue = ExperimentViewUtil.computeSortValue(sortState,
+        ExperimentViewUtil.toMetricsMap(metricsList[idx]),
+        ExperimentViewUtil.toParamsMap(paramsList[idx]), runInfos[idx], tagsList[idx]);
       return [{
         idx,
         isParent: true,
@@ -396,8 +389,9 @@ export default class ExperimentViewUtil {
       if (childrenIdxs) {
         if (ExperimentViewUtil.isExpanderOpen(runsExpanded, runId)) {
           const childrenRows = childrenIdxs.map((idx) => {
-            const sortValue = ExperimentViewUtil.getSortValue(
-              {metricsList, paramsList, tagsList, idx, sortState, runInfo: runInfos[idx]});
+            const sortValue = ExperimentViewUtil.computeSortValue(sortState,
+              ExperimentViewUtil.toMetricsMap(metricsList[idx]),
+              ExperimentViewUtil.toParamsMap(paramsList[idx]), runInfos[idx], tagsList[idx]);
             return { idx, isParent: false, hasExpander: false, sortValue };
           });
           ExperimentViewUtil.sortRows(childrenRows, sortState);

--- a/mlflow/server/js/src/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/components/ExperimentViewUtil.js
@@ -291,6 +291,7 @@ export default class ExperimentViewUtil {
   static isExpanderOpen(runsExpanded, runId) {
     let expanderOpen = DEFAULT_EXPANDED_VALUE;
     if (runsExpanded[runId] !== undefined) expanderOpen = runsExpanded[runId];
+    console.log("isExpanderOpen for " + runId + ": " + expanderOpen);
     return expanderOpen;
   }
 
@@ -354,12 +355,14 @@ export default class ExperimentViewUtil {
         } else {
           newList = [idx];
         }
+        console.log("Assigning child idxs " + JSON.stringify(newList) + " to id " + root.value);
         parentIdToChildren[root.value] = newList;
       }
     });
     const parentRows = [...Array(runInfos.length).keys()].flatMap((idx) => {
       if (treeNodes[idx].isCycle() || !treeNodes[idx].isRoot()) return [];
       const runId = runInfos[idx].run_uuid;
+      console.log("Processing parent run with id " + runId);
       let hasExpander = false;
       let childrenIds = undefined;
       if (parentIdToChildren[runId]) {
@@ -372,16 +375,19 @@ export default class ExperimentViewUtil {
         hasExpander,
         expanderOpen: ExperimentViewUtil.isExpanderOpen(runsExpanded, runId),
         childrenIds,
+        runId,
       }];
     });
     ExperimentViewUtil.sortRows(parentRows, sortState);
     const mergedRows = [];
     parentRows.forEach((r) => {
-      const runId = r.key;
+      const runId = r.runId;
       mergedRows.push(r);
       const childrenIdxs = parentIdToChildren[runId];
+      console.log("Got children Idxs " + JSON.stringify(childrenIdxs) + " for run with id " + runId);
       if (childrenIdxs) {
         if (ExperimentViewUtil.isExpanderOpen(runsExpanded, runId)) {
+          console.log("Looping through children rows");
           const childrenRows = childrenIdxs.map((idx) =>
             ({ idx, isParent: false, hasExpander: false }));
           ExperimentViewUtil.sortRows(childrenRows, sortState);

--- a/mlflow/server/js/src/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/components/ExperimentViewUtil.js
@@ -291,7 +291,6 @@ export default class ExperimentViewUtil {
   static isExpanderOpen(runsExpanded, runId) {
     let expanderOpen = DEFAULT_EXPANDED_VALUE;
     if (runsExpanded[runId] !== undefined) expanderOpen = runsExpanded[runId];
-    console.log("isExpanderOpen for " + runId + ": " + expanderOpen);
     return expanderOpen;
   }
 
@@ -355,14 +354,12 @@ export default class ExperimentViewUtil {
         } else {
           newList = [idx];
         }
-        console.log("Assigning child idxs " + JSON.stringify(newList) + " to id " + root.value);
         parentIdToChildren[root.value] = newList;
       }
     });
     const parentRows = [...Array(runInfos.length).keys()].flatMap((idx) => {
       if (treeNodes[idx].isCycle() || !treeNodes[idx].isRoot()) return [];
       const runId = runInfos[idx].run_uuid;
-      console.log("Processing parent run with id " + runId);
       let hasExpander = false;
       let childrenIds = undefined;
       if (parentIdToChildren[runId]) {
@@ -384,10 +381,8 @@ export default class ExperimentViewUtil {
       const runId = r.runId;
       mergedRows.push(r);
       const childrenIdxs = parentIdToChildren[runId];
-      console.log("Got children Idxs " + JSON.stringify(childrenIdxs) + " for run with id " + runId);
       if (childrenIdxs) {
         if (ExperimentViewUtil.isExpanderOpen(runsExpanded, runId)) {
-          console.log("Looping through children rows");
           const childrenRows = childrenIdxs.map((idx) =>
             ({ idx, isParent: false, hasExpander: false }));
           ExperimentViewUtil.sortRows(childrenRows, sortState);


### PR DESCRIPTION
Refactors the meat of `ExperimentViewUtil.getRows` into a new `ExperimentViewUtil.getRowRenderMetadata` helper that returns an array of valid arguments (one array element per row) to `ExperimentRunsTableCompact.getRow`, `ExperimentRunsTableMultiColumnView.getRow`. This enables lazily computing the JSX for each row rather than computing it all upfront in `ExperimentRunsTableCompact`, which dramatically speeds up rendering large numbers of rows.