### PR TITLE
Correctly check whether experiment ID is specified in Python fluent API

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -115,7 +115,7 @@ def start_run(run_uuid=None, experiment_id=None, source_name=None, source_versio
         else:
             parent_run_id = None
 
-        exp_id_for_run = experiment_id or _get_experiment_id()
+        exp_id_for_run = experiment_id if experiment_id is not None else _get_experiment_id()
         if is_in_databricks_notebook():
             databricks_tags = {}
             notebook_id = get_notebook_id()

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -255,5 +255,6 @@ def test_start_run_exp_id_0(tracking_uri_mock, reset_active_experiment):
         exp_id = active_run.info.experiment_id
         assert exp_id != 0
         assert MlflowClient().get_experiment(exp_id).name == "some-experiment"
+    # Set experiment ID to 0 when creating a run, verify that the specified experiment ID is honored
     with mlflow.start_run(experiment_id=0) as active_run:
         assert active_run.info.experiment_id == 0

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -250,6 +250,7 @@ def test_start_deleted_run():
 
 def test_start_run_exp_id_0(tracking_uri_mock, reset_active_experiment):
     mlflow.set_experiment("some-experiment")
+    # Create a run and verify that the current active experiment is the one we just set
     with mlflow.start_run() as active_run:
         exp_id = active_run.info.experiment_id
         assert exp_id != 0

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -246,3 +246,13 @@ def test_start_deleted_run():
         with mlflow.start_run(run_uuid=run_id):
             pass
     assert mlflow.active_run() is None
+
+
+def test_start_run_exp_id_0(tracking_uri_mock, reset_active_experiment):
+    mlflow.set_experiment("some-experiment")
+    with mlflow.start_run() as active_run:
+        exp_id = active_run.info.experiment_id
+        assert exp_id != 0
+        assert MlflowClient().get_experiment(exp_id).name == "some-experiment"
+    with mlflow.start_run(experiment_id=0) as active_run:
+        assert active_run.info.experiment_id == 0


### PR DESCRIPTION
Fixes a bug where the experiment ID would silently be ignored when doing `mlflow.start_run(experiment_id=0)`, and adds a regression test