### PR TITLE
Add cloudpickle package to the dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         'querystring_parser',
         'simplejson',
         'mleap>=0.8.1',
-        'cloudpickle'
+        'cloudpickle',
     ],
     entry_points='''
         [console_scripts]

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setup(
         'querystring_parser',
         'simplejson',
         'mleap>=0.8.1',
+        'cloudpickle'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Currently `mlflow.sklearn.save_model`fails without manually installing cloudpickle