### PR TITLE
Add get_artifact_uri() and _download_artifact_from_uri convenience functions

### DIFF
--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -77,7 +77,7 @@ class ArtifactRepository:
         # without downloading it, or to get a pre-signed URL for cloud storage.
 
         def download_artifacts_into(artifact_path, dest_dir):
-            basename = os.path.basename(artifact_path)
+            basename = self.get_path_module().basename(artifact_path)
             local_path = build_path(dest_dir, basename)
             listing = self.list_artifacts(artifact_path)
             if len(listing) > 0:

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -1,8 +1,9 @@
 import os
 from abc import abstractmethod, ABCMeta
 
-from mlflow.store.rest_store import RestStore
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST
+from mlflow.store.rest_store import RestStore
 from mlflow.utils.file_utils import build_path, TempDir
 
 
@@ -16,6 +17,14 @@ class ArtifactRepository:
 
     def __init__(self, artifact_uri):
         self.artifact_uri = artifact_uri
+
+    @abstractmethod
+    def get_path_module(self):
+        """
+        :return: The Python path module that should be used for parsing and modifying artifact
+                 paths. For example, if the artifact repository's URI scheme uses POSIX paths,
+                 this method may return the ``posixpath`` module.
+        """
 
     @abstractmethod
     def log_artifact(self, local_file, artifact_path=None):
@@ -51,13 +60,17 @@ class ArtifactRepository:
         """
         pass
 
-    def download_artifacts(self, artifact_path):
+    def download_artifacts(self, artifact_path, dst_path=None):
         """
         Download an artifact file or directory to a local directory if applicable, and return a
         local path for it.
         The caller is responsible for managing the lifecycle of the downloaded artifacts.
-        :param path: Relative source path to the desired artifact
-        :return: Full path desired artifact.
+        :param path: Relative source path to the desired artifacts.
+        :param dst_path: Absolute path of the local filesystem destination directory to which to
+                         download the specified artifacts. This directory must already exist. If
+                         unspecified, the artifacts will be downloaded to a new, uniquely-named
+                         directory on the local filesystem.
+        :return: Absolute path of the local filesystem location containing the downloaded artifacts.
         """
         # TODO: Probably need to add a more efficient method to stream just a single artifact
         # without downloading it, or to get a pre-signed URL for cloud storage.
@@ -76,8 +89,24 @@ class ArtifactRepository:
                 self._download_file(remote_file_path=artifact_path, local_path=local_path)
             return local_path
 
-        with TempDir(remove_on_exit=False) as tmp:
-            return download_artifacts_into(artifact_path, tmp.path())
+        if dst_path is not None:
+            if not os.path.exists(dst_path):
+                raise MlflowException(
+                        message=(
+                            "The specified destination path for downloaded artifacts does not"
+                            " exist! Specified path: {dst_path}".format(dst_path=dst_path)),
+                        error_code=RESOURCE_DOES_NOT_EXIST)
+            elif not os.path.isdir(dst_path):
+                raise MlflowException(
+                        message=(
+                            "The specified destination path for downloaded artifacts must be a"
+                            " directory! Specified path: {dst_path}".format(dst_path=dst_path)),
+                        error_code=INVALID_PARAMETER_VALUE)
+
+            return download_artifacts_into(artifact_path, dst_path)
+        else:
+            with TempDir(remove_on_exit=False) as tmp:
+                return download_artifacts_into(artifact_path, tmp.path())
 
     @abstractmethod
     def _download_file(self, remote_file_path, local_path):

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -5,7 +5,7 @@ from abc import abstractmethod, ABCMeta
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST
 from mlflow.store.rest_store import RestStore
-from mlflow.utils.file_utils import build_path 
+from mlflow.utils.file_utils import build_path
 
 
 class ArtifactRepository:
@@ -102,7 +102,7 @@ class ArtifactRepository:
         elif not os.path.isdir(dst_path):
             raise MlflowException(
                     message=(
-                        "The destination path for downloaded artifacts must be a directory!" 
+                        "The destination path for downloaded artifacts must be a directory!"
                         " Destination path: {dst_path}".format(dst_path=dst_path)),
                     error_code=INVALID_PARAMETER_VALUE)
 

--- a/mlflow/store/azure_blob_artifact_repo.py
+++ b/mlflow/store/azure_blob_artifact_repo.py
@@ -1,12 +1,10 @@
 import os
 import re
-import posixpath
 
 from six.moves import urllib
 
 from mlflow.entities import FileInfo
 from mlflow.store.artifact_repo import ArtifactRepository
-from mlflow.utils.file_utils import build_path, get_relative_path
 
 
 class AzureBlobArtifactRepository(ArtifactRepository):
@@ -58,35 +56,38 @@ class AzureBlobArtifactRepository(ArtifactRepository):
             path = path[1:]
         return container, storage_account, path
 
+    def get_path_module(self):
+        import posixpath
+        return posixpath
+
     def log_artifact(self, local_file, artifact_path=None):
         (container, _, dest_path) = self.parse_wasbs_uri(self.artifact_uri)
         if artifact_path:
-            dest_path = build_path(dest_path, artifact_path)
-        dest_path = build_path(dest_path, os.path.basename(local_file))
+            dest_path = self.get_path_module().join(dest_path, artifact_path)
+        dest_path = self.get_path_module().join(dest_path, os.path.basename(local_file))
         self.client.create_blob_from_path(container, dest_path, local_file)
 
     def log_artifacts(self, local_dir, artifact_path=None):
         (container, _, dest_path) = self.parse_wasbs_uri(self.artifact_uri)
         if artifact_path:
-            dest_path = build_path(dest_path, artifact_path)
+            dest_path = self.get_path_module().join(dest_path, artifact_path)
         local_dir = os.path.abspath(local_dir)
         for (root, _, filenames) in os.walk(local_dir):
             upload_path = dest_path
             if root != local_dir:
-                rel_path = get_relative_path(local_dir, root)
-                upload_path = build_path(dest_path, rel_path)
+                rel_path = self.get_path_module().relpath(root, local_dir)
+                upload_path = self.get_path_module().join(dest_path, rel_path)
             for f in filenames:
-                path = build_path(upload_path, f)
-                self.client.create_blob_from_path(container, path, build_path(root, f))
+                path = self.get_path_module().join(upload_path, f)
+                self.client.create_blob_from_path(
+                    container, path, self.get_path_module().join(root, f))
 
     def list_artifacts(self, path=None):
         from azure.storage.blob.models import BlobPrefix
         (container, _, artifact_path) = self.parse_wasbs_uri(self.artifact_uri)
         dest_path = artifact_path
         if path:
-            # Separator needs to be fixed as '/' because of azure blob storage pattern.
-            # Do not change to os.path.join because in Windows system path separator is '\'
-            dest_path = posixpath.join(dest_path, path)
+            dest_path = self.get_path_module().join(dest_path, path)
         infos = []
         prefix = dest_path + "/"
         marker = None  # Used to make next list request if this one exceeded the result limit
@@ -99,16 +100,12 @@ class AzureBlobArtifactRepository(ArtifactRepository):
                         " artifact path. Artifact path: {artifact_path}. Blob name:"
                         " {blob_name}".format(artifact_path=artifact_path, blob_name=r.name))
                 if isinstance(r, BlobPrefix):   # This is a prefix for items in a subdirectory
-                    # Separator needs to be fixed as '/' because of azure blob storage pattern.
-                    # Do not change to os.relpath because in Windows system path separator is '\'
-                    subdir = posixpath.relpath(path=r.name, start=artifact_path)
+                    subdir = self.get_path_module().relpath(path=r.name, start=artifact_path)
                     if subdir.endswith("/"):
                         subdir = subdir[:-1]
                     infos.append(FileInfo(subdir, True, None))
                 else:  # Just a plain old blob
-                    # Separator needs to be fixed as '/' because of azure blob storage pattern.
-                    # Do not change to os.relpath because in Windows system path separator is '\'
-                    file_name = posixpath.relpath(path=r.name, start=artifact_path)
+                    file_name = self.get_path_module().relpath(path=r.name, start=artifact_path)
                     infos.append(FileInfo(file_name, False, r.properties.content_length))
             # Check whether a new marker is returned, meaning we have to make another request
             if results.next_marker:
@@ -119,7 +116,5 @@ class AzureBlobArtifactRepository(ArtifactRepository):
 
     def _download_file(self, remote_file_path, local_path):
         (container, _, remote_root_path) = self.parse_wasbs_uri(self.artifact_uri)
-        # Separator needs to be fixed as '/' because of azure blob storage pattern.
-        # Do not change to os.path.join because in Windows system path separator is '\'
-        remote_full_path = posixpath.join(remote_root_path, remote_file_path)
+        remote_full_path = self.get_path_module().join(remote_root_path, remote_file_path)
         self.client.get_blob_to_path(container, remote_full_path, local_path)

--- a/mlflow/store/azure_blob_artifact_repo.py
+++ b/mlflow/store/azure_blob_artifact_repo.py
@@ -64,14 +64,15 @@ class AzureBlobArtifactRepository(ArtifactRepository):
         (container, _, dest_path) = self.parse_wasbs_uri(self.artifact_uri)
         if artifact_path:
             dest_path = self.get_path_module().join(dest_path, artifact_path)
-        dest_path = self.get_path_module().join(dest_path, os.path.basename(local_file))
+        dest_path = self.get_path_module().join(
+                dest_path, self.get_path_module().basename(local_file))
         self.client.create_blob_from_path(container, dest_path, local_file)
 
     def log_artifacts(self, local_dir, artifact_path=None):
         (container, _, dest_path) = self.parse_wasbs_uri(self.artifact_uri)
         if artifact_path:
             dest_path = self.get_path_module().join(dest_path, artifact_path)
-        local_dir = os.path.abspath(local_dir)
+        local_dir = self.get_path_module().abspath(local_dir)
         for (root, _, filenames) in os.walk(local_dir):
             upload_path = dest_path
             if root != local_dir:

--- a/mlflow/store/ftp_artifact_repo.py
+++ b/mlflow/store/ftp_artifact_repo.py
@@ -7,7 +7,7 @@ from six.moves import urllib
 
 from mlflow.entities.file_info import FileInfo
 from mlflow.store.artifact_repo import ArtifactRepository
-from mlflow.utils.file_utils import TempDir, build_path, get_relative_path
+from mlflow.utils.file_utils import TempDir
 
 
 class FTPArtifactRepository(ArtifactRepository):
@@ -51,7 +51,7 @@ class FTPArtifactRepository(ArtifactRepository):
             try:
                 ftp.mkd(artifact_dir)
             except ftplib.error_perm:
-                head, _ = os.path.split(artifact_dir)
+                head, _ = self.get_path_module().split(artifact_dir)
                 self._mkdir(head)
                 self._mkdir(artifact_dir)
 
@@ -62,61 +62,57 @@ class FTPArtifactRepository(ArtifactRepository):
             ftp.voidcmd('TYPE A')
         return size
 
-    def download_files(self, path, destination):
-        with self.get_ftp_client() as ftp:
-            ftp.cwd(path)
-            if not os.path.isdir(destination):
-                os.makedirs(destination)
-
-            filelist = ftp.nlst()
-
-            for ftp_file in filelist:
-                if self._is_dir(build_path(path, ftp_file)):
-                    self.download_files(build_path(path, ftp_file),
-                                        build_path(destination, ftp_file))
-                else:
-                    with open(os.path.join(destination, ftp_file), "wb") as f:
-                        ftp.retrbinary("RETR "+ftp_file, f)
+    def get_path_module(self):
+        import posixpath
+        return posixpath
 
     def log_artifact(self, local_file, artifact_path=None):
         with self.get_ftp_client() as ftp:
-            artifact_dir = os.path.join(self.path, artifact_path) \
+            artifact_dir = self.get_path_module().join(self.path, artifact_path) \
                 if artifact_path else self.path
             self._mkdir(artifact_dir)
             with open(local_file, 'rb') as f:
                 ftp.cwd(artifact_dir)
-                ftp.storbinary('STOR ' + os.path.basename(local_file), f)
+                ftp.storbinary('STOR ' + self.get_path_module().basename(local_file), f)
 
     def log_artifacts(self, local_dir, artifact_path=None):
-        dest_path = os.path.join(self.path, artifact_path) \
+        dest_path = self.get_path_module().join(self.path, artifact_path) \
             if artifact_path else self.path
 
-        dest_path = build_path(dest_path, os.path.split(local_dir)[1])
-        dest_path_re = os.path.split(local_dir)[1]
+        dest_path = self.get_path_module().join(
+            dest_path, self.get_path_module().split(local_dir)[1])
+        dest_path_re = self.get_path_module().split(local_dir)[1]
         if artifact_path:
-            dest_path_re = build_path(artifact_path, os.path.split(local_dir)[1])
+            dest_path_re = self.get_path_module().join(
+                artifact_path, self.get_path_module().split(local_dir)[1])
 
-        local_dir = os.path.abspath(local_dir)
+        local_dir = self.get_path_module().abspath(local_dir)
         for (root, _, filenames) in os.walk(local_dir):
             upload_path = dest_path
             if root != local_dir:
-                rel_path = get_relative_path(local_dir, root)
-                upload_path = build_path(dest_path_re, rel_path)
+                rel_path = self.get_path_module().relpath(root, local_dir)
+                upload_path = self.get_path_module().join(dest_path_re, rel_path)
             if not filenames:
-                self._mkdir(build_path(self.path, upload_path))
+                self._mkdir(self.get_path_module().join(self.path, upload_path))
             for f in filenames:
-                if os.path.isfile(build_path(root, f)):
-                    self.log_artifact(build_path(root, f), upload_path)
+                if self.get_path_module().isfile(self.get_path_module().join(root, f)):
+                    self.log_artifact(self.get_path_module().join(root, f), upload_path)
 
     def list_artifacts(self, path=None):
         with self.get_ftp_client() as ftp:
             artifact_dir = self.path
-            list_dir = os.path.join(artifact_dir, path) if path else artifact_dir
+            list_dir = self.get_path_module().join(artifact_dir, path) if path else artifact_dir
+
+            print(list_dir, self._is_dir(list_dir))
+            if not self._is_dir(list_dir):
+                return []
+
             artifact_files = ftp.nlst(list_dir)
             infos = []
             for file_name in artifact_files:
-                file_path = file_name if path is None else os.path.join(path, file_name)
-                full_file_path = os.path.join(list_dir, file_name)
+                file_path = (file_name if path is None
+                             else self.get_path_module().join(path, file_name))
+                full_file_path = self.get_path_module().join(list_dir, file_name)
                 if self._is_dir(full_file_path):
                     infos.append(FileInfo(file_path, True, None))
                 else:
@@ -124,27 +120,9 @@ class FTPArtifactRepository(ArtifactRepository):
                     infos.append(FileInfo(file_path, False, size))
         return infos
 
-    def download_artifacts(self, artifact_path=None):
-        with self.get_ftp_client() as ftp:
-            full_path = os.path.join(self.path, artifact_path) \
-                if artifact_path else self.path
-            return_path = None
-            with TempDir(remove_on_exit=False) as tmp:
-                tmp_path = tmp.path()
-                if self._is_dir(full_path):
-                    self.download_files(full_path, tmp_path)
-                    return_path = tmp_path
-                else:
-                    local_file = os.path.join(tmp_path, os.path.basename(full_path))
-                    with open(local_file, 'wb') as f:
-                        ftp.retrbinary('RETR ' + full_path, f)
-                    return_path = local_file
-        return return_path
-
     def _download_file(self, remote_file_path, local_path):
-        remote_full_path = os.path.join(self.path, remote_file_path) \
+        remote_full_path = self.get_path_module().join(self.path, remote_file_path) \
                 if remote_file_path else self.path
         with self.get_ftp_client() as ftp:
-            local_file = os.path.join(local_path, os.path.basename(remote_full_path))
-            with open(local_file, 'wb') as f:
+            with open(local_path, 'wb') as f:
                 ftp.retrbinary('RETR ' + remote_full_path, f)

--- a/mlflow/store/ftp_artifact_repo.py
+++ b/mlflow/store/ftp_artifact_repo.py
@@ -62,7 +62,7 @@ class FTPArtifactRepository(ArtifactRepository):
         return size
 
     def get_path_module(self):
-        return os.path 
+        return os.path
 
     def log_artifact(self, local_file, artifact_path=None):
         with self.get_ftp_client() as ftp:

--- a/mlflow/store/ftp_artifact_repo.py
+++ b/mlflow/store/ftp_artifact_repo.py
@@ -7,7 +7,6 @@ from six.moves import urllib
 
 from mlflow.entities.file_info import FileInfo
 from mlflow.store.artifact_repo import ArtifactRepository
-from mlflow.utils.file_utils import TempDir
 
 
 class FTPArtifactRepository(ArtifactRepository):
@@ -101,10 +100,8 @@ class FTPArtifactRepository(ArtifactRepository):
         with self.get_ftp_client() as ftp:
             artifact_dir = self.path
             list_dir = self.get_path_module().join(artifact_dir, path) if path else artifact_dir
-
             if not self._is_dir(list_dir):
                 return []
-
             artifact_files = ftp.nlst(list_dir)
             infos = []
             for file_name in artifact_files:

--- a/mlflow/store/ftp_artifact_repo.py
+++ b/mlflow/store/ftp_artifact_repo.py
@@ -63,8 +63,7 @@ class FTPArtifactRepository(ArtifactRepository):
         return size
 
     def get_path_module(self):
-        import posixpath
-        return posixpath
+        return os.path 
 
     def log_artifact(self, local_file, artifact_path=None):
         with self.get_ftp_client() as ftp:
@@ -103,7 +102,6 @@ class FTPArtifactRepository(ArtifactRepository):
             artifact_dir = self.path
             list_dir = self.get_path_module().join(artifact_dir, path) if path else artifact_dir
 
-            print(list_dir, self._is_dir(list_dir))
             if not self._is_dir(list_dir):
                 return []
 

--- a/mlflow/store/gcs_artifact_repo.py
+++ b/mlflow/store/gcs_artifact_repo.py
@@ -4,7 +4,6 @@ from six.moves import urllib
 
 from mlflow.entities import FileInfo
 from mlflow.store.artifact_repo import ArtifactRepository
-from mlflow.utils.file_utils import build_path, get_relative_path
 
 
 class GCSArtifactRepository(ArtifactRepository):
@@ -34,11 +33,16 @@ class GCSArtifactRepository(ArtifactRepository):
             path = path[1:]
         return parsed.netloc, path
 
+    def get_path_module(self):
+        import posixpath
+        return posixpath
+
     def log_artifact(self, local_file, artifact_path=None):
         (bucket, dest_path) = self.parse_gcs_uri(self.artifact_uri)
         if artifact_path:
-            dest_path = build_path(dest_path, artifact_path)
-        dest_path = build_path(dest_path, os.path.basename(local_file))
+            dest_path = self.get_path_module().join(dest_path, artifact_path)
+        dest_path = self.get_path_module().join(
+            dest_path, self.get_path_module().basename(local_file))
 
         gcs_bucket = self.gcs.Client().get_bucket(bucket)
         blob = gcs_bucket.blob(dest_path)
@@ -47,24 +51,24 @@ class GCSArtifactRepository(ArtifactRepository):
     def log_artifacts(self, local_dir, artifact_path=None):
         (bucket, dest_path) = self.parse_gcs_uri(self.artifact_uri)
         if artifact_path:
-            dest_path = build_path(dest_path, artifact_path)
+            dest_path = self.get_path_module().join(dest_path, artifact_path)
         gcs_bucket = self.gcs.Client().get_bucket(bucket)
 
-        local_dir = os.path.abspath(local_dir)
+        local_dir = self.get_path_module().abspath(local_dir)
         for (root, _, filenames) in os.walk(local_dir):
             upload_path = dest_path
             if root != local_dir:
-                rel_path = get_relative_path(local_dir, root)
-                upload_path = build_path(dest_path, rel_path)
+                rel_path = self.get_path_module().relpath(local_dir, root)
+                upload_path = self.get_path_module().join(dest_path, rel_path)
             for f in filenames:
-                path = build_path(upload_path, f)
-                gcs_bucket.blob(path).upload_from_filename(build_path(root, f))
+                path = self.get_path_module().join(upload_path, f)
+                gcs_bucket.blob(path).upload_from_filename(self.get_path_module().join(root, f))
 
     def list_artifacts(self, path=None):
         (bucket, artifact_path) = self.parse_gcs_uri(self.artifact_uri)
         dest_path = artifact_path
         if path:
-            dest_path = build_path(dest_path, path)
+            dest_path = self.get_path_module().join(dest_path, path)
         prefix = dest_path + "/"
 
         bkt = self.gcs.Client().get_bucket(bucket)
@@ -88,6 +92,6 @@ class GCSArtifactRepository(ArtifactRepository):
 
     def _download_file(self, remote_file_path, local_path):
         (bucket, remote_root_path) = self.parse_gcs_uri(self.artifact_uri)
-        remote_full_path = build_path(remote_root_path, remote_file_path)
+        remote_full_path = self.get_path_module().join(remote_root_path, remote_file_path)
         gcs_bucket = self.gcs.Client().get_bucket(bucket)
         gcs_bucket.get_blob(remote_full_path).download_to_filename(local_path)

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -1,23 +1,25 @@
-import os
 import distutils.dir_util as dir_util
 import shutil
 
 from mlflow.store.artifact_repo import ArtifactRepository
-from mlflow.utils.file_utils import (build_path, exists, mkdir, list_all, get_file_info,
-                                     get_relative_path)
+from mlflow.utils.file_utils import mkdir, list_all, get_file_info
 from mlflow.utils.validation import path_not_unique, bad_path_message
 
 
 class LocalArtifactRepository(ArtifactRepository):
     """Stores artifacts as files in a local directory."""
 
+    def get_path_module(self):
+        import os
+        return os.path
+
     def log_artifact(self, local_file, artifact_path=None):
         if artifact_path and path_not_unique(artifact_path):
             raise Exception("Invalid artifact path: '%s'. %s" % (artifact_path,
                                                                  bad_path_message(artifact_path)))
-        artifact_dir = build_path(self.artifact_uri, artifact_path) \
+        artifact_dir = self.get_path_module().join(self.artifact_uri, artifact_path) \
             if artifact_path else self.artifact_uri
-        if not exists(artifact_dir):
+        if not self.get_path_module().exists(artifact_dir):
             mkdir(artifact_dir)
         shutil.copy(local_file, artifact_dir)
 
@@ -25,21 +27,23 @@ class LocalArtifactRepository(ArtifactRepository):
         if artifact_path and path_not_unique(artifact_path):
             raise Exception("Invalid artifact path: '%s'. %s" % (artifact_path,
                                                                  bad_path_message(artifact_path)))
-        artifact_dir = build_path(self.artifact_uri, artifact_path) \
+        artifact_dir = self.get_path_module().join(self.artifact_uri, artifact_path) \
             if artifact_path else self.artifact_uri
-        if not exists(artifact_dir):
+        if not self.get_path_module().exists(artifact_dir):
             mkdir(artifact_dir)
         dir_util.copy_tree(src=local_dir, dst=artifact_dir)
 
     def list_artifacts(self, path=None):
         artifact_dir = self.artifact_uri
-        list_dir = build_path(artifact_dir, path) if path else artifact_dir
-        if os.path.isdir(list_dir):
+        list_dir = self.get_path_module().join(artifact_dir, path) if path else artifact_dir
+        if self.get_path_module().isdir(list_dir):
             artifact_files = list_all(list_dir, full_path=True)
-            infos = [get_file_info(f, get_relative_path(artifact_dir, f)) for f in artifact_files]
+            infos = [get_file_info(f, self.get_path_module().relpath(f, artifact_dir))
+                     for f in artifact_files]
             return sorted(infos, key=lambda f: f.path)
         else:
             return []
 
     def _download_file(self, remote_file_path, local_path):
-        shutil.copyfile(os.path.join(self.artifact_uri, remote_file_path), local_path)
+        shutil.copyfile(
+            self.get_path_module().join(self.artifact_uri, remote_file_path), local_path)

--- a/mlflow/store/s3_artifact_repo.py
+++ b/mlflow/store/s3_artifact_repo.py
@@ -6,7 +6,6 @@ from six.moves import urllib
 from mlflow import data
 from mlflow.entities import FileInfo
 from mlflow.store.artifact_repo import ArtifactRepository
-from mlflow.utils.file_utils import build_path, get_relative_path
 
 
 class S3ArtifactRepository(ArtifactRepository):
@@ -27,33 +26,41 @@ class S3ArtifactRepository(ArtifactRepository):
         s3_endpoint_url = os.environ.get('MLFLOW_S3_ENDPOINT_URL')
         return boto3.client('s3', endpoint_url=s3_endpoint_url)
 
+    def get_path_module(self):
+        import posixpath
+        return posixpath
+
     def log_artifact(self, local_file, artifact_path=None):
         (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)
         if artifact_path:
-            dest_path = build_path(dest_path, artifact_path)
-        dest_path = build_path(dest_path, os.path.basename(local_file))
+            dest_path = self.get_path_module().join(dest_path, artifact_path)
+        dest_path = self.get_path_module().join(
+            dest_path, self.get_path_module().basename(local_file))
         s3_client = self._get_s3_client()
         s3_client.upload_file(local_file, bucket, dest_path)
 
     def log_artifacts(self, local_dir, artifact_path=None):
         (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)
         if artifact_path:
-            dest_path = build_path(dest_path, artifact_path)
+            dest_path = self.get_path_module().join(dest_path, artifact_path)
         s3_client = self._get_s3_client()
-        local_dir = os.path.abspath(local_dir)
+        local_dir = self.get_path_module().abspath(local_dir)
         for (root, _, filenames) in os.walk(local_dir):
             upload_path = dest_path
             if root != local_dir:
-                rel_path = get_relative_path(local_dir, root)
-                upload_path = build_path(dest_path, rel_path)
+                rel_path = self.get_path_module().relpath(root, local_dir)
+                upload_path = self.get_path_module().join(dest_path, rel_path)
             for f in filenames:
-                s3_client.upload_file(build_path(root, f), bucket, build_path(upload_path, f))
+                s3_client.upload_file(
+                        self.get_path_module().join(root, f),
+                        bucket,
+                        self.get_path_module().join(upload_path, f))
 
     def list_artifacts(self, path=None):
         (bucket, artifact_path) = data.parse_s3_uri(self.artifact_uri)
         dest_path = artifact_path
         if path:
-            dest_path = build_path(dest_path, path)
+            dest_path = self.get_path_module().join(dest_path, path)
         infos = []
         prefix = dest_path + "/"
         s3_client = self._get_s3_client()
@@ -75,6 +82,6 @@ class S3ArtifactRepository(ArtifactRepository):
 
     def _download_file(self, remote_file_path, local_path):
         (bucket, s3_root_path) = data.parse_s3_uri(self.artifact_uri)
-        s3_full_path = build_path(s3_root_path, remote_file_path)
+        s3_full_path = self.get_path_module().join(s3_root_path, remote_file_path)
         s3_client = self._get_s3_client()
         s3_client.download_file(bucket, s3_full_path, local_path)

--- a/mlflow/store/sftp_artifact_repo.py
+++ b/mlflow/store/sftp_artifact_repo.py
@@ -29,8 +29,8 @@ class SFTPArtifactRepository(ArtifactRepository):
                 self.config['host'] = 'localhost'
 
             ssh_config = paramiko.SSHConfig()
-            user_config_file = self.get_path_module().expanduser("~/.ssh/config")
-            if self.get_path_module().exists(user_config_file):
+            user_config_file = os.path.expanduser("~/.ssh/config")
+            if os.path.exists(user_config_file):
                 with open(user_config_file) as f:
                     ssh_config.parse(f)
 
@@ -50,8 +50,7 @@ class SFTPArtifactRepository(ArtifactRepository):
         super(SFTPArtifactRepository, self).__init__(artifact_uri)
 
     def get_path_module(self):
-        import posixpath
-        return posixpath
+        return os.path 
 
     def log_artifact(self, local_file, artifact_path=None):
         artifact_dir = self.get_path_module().join(self.path, artifact_path) \

--- a/mlflow/store/sftp_artifact_repo.py
+++ b/mlflow/store/sftp_artifact_repo.py
@@ -50,7 +50,7 @@ class SFTPArtifactRepository(ArtifactRepository):
         super(SFTPArtifactRepository, self).__init__(artifact_uri)
 
     def get_path_module(self):
-        return os.path 
+        return os.path
 
     def log_artifact(self, local_file, artifact_path=None):
         artifact_dir = self.get_path_module().join(self.path, artifact_path) \

--- a/mlflow/store/sftp_artifact_repo.py
+++ b/mlflow/store/sftp_artifact_repo.py
@@ -69,6 +69,8 @@ class SFTPArtifactRepository(ArtifactRepository):
     def list_artifacts(self, path=None):
         artifact_dir = self.path
         list_dir = self.get_path_module().join(artifact_dir, path) if path else artifact_dir
+        if not self.sftp.isdir(list_dir):
+            return []
         artifact_files = self.sftp.listdir(list_dir)
         infos = []
         for file_name in artifact_files:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -247,14 +247,14 @@ def get_artifact_uri(artifact_path=None):
     run will be returned; calls to ``log_artifact`` and ``log_artifacts`` write
     artifact(s) to subdirectories of the artifact root URI.
 
-    :param artifact_path: The run-relative artifact path for which to obtain an absolute URI. 
-                          For example, "path/to/artifact". If unspecified, the artifact root URI 
+    :param artifact_path: The run-relative artifact path for which to obtain an absolute URI.
+                          For example, "path/to/artifact". If unspecified, the artifact root URI
                           for the currently active run will be returned.
-    :return: An *absolute* URI referring to the specified artifact or the currently adtive run's 
-             artifact root. For example, if an artifact path is provided and the currently active 
+    :return: An *absolute* URI referring to the specified artifact or the currently adtive run's
+             artifact root. For example, if an artifact path is provided and the currently active
              run uses an S3-backed store, this may be a uri of the form
              ``s3://<bucket_name>/path/to/artifact/root/path/to/artifact``. If an artifact path
-             is not provided and the currently active run uses an S3-backed store, this may be a 
+             is not provided and the currently active run uses an S3-backed store, this may be a
              URI of the form ``s3://<bucket_name>/path/to/artifact/root``.
     """
     return mlflow.tracking.utils.get_artifact_uri(

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -13,6 +13,7 @@ import sys
 import time
 import logging
 
+import mlflow.tracking.utils
 from mlflow.entities import Experiment, Run, SourceType, RunInfo
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient
@@ -239,12 +240,25 @@ def create_experiment(name, artifact_location=None):
     return MlflowClient().create_experiment(name, artifact_location)
 
 
-def get_artifact_uri():
+def get_artifact_uri(artifact_path=None):
     """
-    Get the artifact URI of the currently active run. Calls to ``log_artifact`` and
-    ``log_artifacts`` write artifact(s) to subdirectories of the returned URI.
+    Get the absolute URI of the specified artifact in the currently active run.
+    If `path` is not specified, the artifact root URI of the currently active
+    run will be returned; calls to ``log_artifact`` and ``log_artifacts`` write
+    artifact(s) to subdirectories of the artifact root URI.
+
+    :param artifact_path: The run-relative artifact path for which to obtain an absolute URI. 
+                          For example, "path/to/artifact". If unspecified, the artifact root URI 
+                          for the currently active run will be returned.
+    :return: An *absolute* URI referring to the specified artifact or the currently adtive run's 
+             artifact root. For example, if an artifact path is provided and the currently active 
+             run uses an S3-backed store, this may be a uri of the form
+             ``s3://<bucket_name>/path/to/artifact/root/path/to/artifact``. If an artifact path
+             is not provided and the currently active run uses an S3-backed store, this may be a 
+             URI of the form ``s3://<bucket_name>/path/to/artifact/root``.
     """
-    return _get_or_start_run().info.artifact_uri
+    return mlflow.tracking.utils.get_artifact_uri(
+        run_id=_get_or_start_run().info.run_uuid, artifact_path=artifact_path)
 
 
 def _get_or_start_run():

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -73,7 +73,8 @@ def get_tracking_uri():
 
 def get_artifact_uri(artifact_path, run_id):
     """
-    :param artifact_path: The run-relative artifact path.
+    :param artifact_path: The run-relative artifact path. For example,
+                          ``path/to/artifact``.
     :param run_id: The ID of the run containing the specified artifact.
     :return: An *absolute* URI referring to the specified artifact. For example, if the artifact
              belongs to an S3-backed store, this may be a uri of the form
@@ -104,7 +105,7 @@ def _download_artifact_from_uri(artifact_uri, output_path):
     artifact_src_dir = artifact_path_module.dirname(artifact_uri)
     artifact_src_relative_path = artifact_path_module.basename(artifact_uri)
     artifact_repo = ArtifactRepository.from_artifact_uri(
-            artifact_uri=artifact_src_dir, store=_get_store())
+            artifact_uri=artifact_src_dir, store=store)
     return artifact_repo.download_artifacts(
             artifact_path=artifact_src_relative_path, dst_path=output_path)
 

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -71,33 +71,46 @@ def get_tracking_uri():
         return os.path.abspath("./mlruns")
 
 
-def get_artifact_uri(artifact_path, run_id):
+def get_artifact_uri(run_id, artifact_path=None):
     """
+    Get the absolute URI of the specified artifact in the specified run. If `path` is not specified, 
+    the artifact root URI of the specified run will be returned; calls to ``log_artifact`` 
+    and ``log_artifacts`` write artifact(s) to subdirectories of the artifact root URI.
+
+    :param run_id: The ID of the run for which to obtain an absolute artifact URI.
     :param artifact_path: The run-relative artifact path. For example,
-                          ``path/to/artifact``.
-    :param run_id: The ID of the run containing the specified artifact.
-    :return: An *absolute* URI referring to the specified artifact. For example, if the artifact
-             belongs to an S3-backed store, this may be a uri of the form
-             ``s3://<bucket_name>/path/to/artifact``.
+                          ``path/to/artifact``. If unspecified, the artifact root URI for the
+                          specified run will be returned.
+    :return: An *absolute* URI referring to the specified artifact or the specified run's artifact
+             root. For example, if an artifact path is provided and the specified run uses an 
+             S3-backed  store, this may be a uri of the form
+             ``s3://<bucket_name>/path/to/artifact/root/path/to/artifact``. If an artifact path
+             is not provided and the specified run uses an S3-backed store, this may be a URI of 
+             the form ``s3://<bucket_name>/path/to/artifact/root``.
     """
     if not run_id:
         raise MlflowException(
                 message="A run_id must be specified in order to obtain an artifact uri!",
                 error_code=INVALID_PARAMETER_VALUE)
+
     store = _get_store()
     run = store.get_run(run_id)
-    # Path separators may not be consistent across all artifact repositories. Therefore, when
-    # joining the run's artifact root directory with the artifact's relative path, we use the
-    # path module defined by the appropriate artifact repository
-    artifact_path_module =\
-        ArtifactRepository.from_artifact_uri(run.info.artifact_uri, store).get_path_module()
-    return artifact_path_module.join(run.info.artifact_uri, artifact_path)
+    if artifact_path is None:
+        return run.info.artifact_uri
+    else:
+        # Path separators may not be consistent across all artifact repositories. Therefore, when
+        # joining the run's artifact root directory with the artifact's relative path, we use the
+        # path module defined by the appropriate artifact repository
+        artifact_path_module =\
+            ArtifactRepository.from_artifact_uri(run.info.artifact_uri, store).get_path_module()
+        return artifact_path_module.join(run.info.artifact_uri, artifact_path)
 
 
-def _download_artifact_from_uri(artifact_uri, output_path):
+def _download_artifact_from_uri(artifact_uri, output_path=None):
     """
     :param artifact_uri: The *absolute* URI of the artifact to download.
-    :param output_path: The local filesystem path to which to download the artifact.
+    :param output_path: The local filesystem path to which to download the artifact. If unspecified,
+                        a local output path will be created.
     """
     store = _get_store()
     artifact_path_module =\

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -76,7 +76,7 @@ def get_artifact_uri(artifact_path, run_id):
     :param artifact_path: The run-relative artifact path.
     :param run_id: The ID of the run containing the specified artifact.
     :return: An *absolute* URI referring to the specified artifact. For example, if the artifact
-             belongs to an S3-backed store, this may be a uri of the form 
+             belongs to an S3-backed store, this may be a uri of the form
              ``s3://<bucket_name>/path/to/artifact``.
     """
     if not run_id:
@@ -85,7 +85,12 @@ def get_artifact_uri(artifact_path, run_id):
                 error_code=INVALID_PARAMETER_VALUE)
     store = _get_store()
     run = store.get_run(run_id)
-    return os.path.join(run.info.artifact_uri, artifact_path)
+    # Path separators may not be consistent across all artifact repositories. Therefore, when
+    # joining the run's artifact root directory with the artifact's relative path, we use the
+    # path module defined by the appropriate artifact repository
+    artifact_path_module =\
+        ArtifactRepository.from_artifact_uri(run.info.artifact_uri, store).get_path_module()
+    return artifact_path_module.join(run.info.artifact_uri, artifact_path)
 
 
 def _download_artifact_from_uri(artifact_uri, output_path):

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -73,8 +73,8 @@ def get_tracking_uri():
 
 def get_artifact_uri(run_id, artifact_path=None):
     """
-    Get the absolute URI of the specified artifact in the specified run. If `path` is not specified, 
-    the artifact root URI of the specified run will be returned; calls to ``log_artifact`` 
+    Get the absolute URI of the specified artifact in the specified run. If `path` is not specified,
+    the artifact root URI of the specified run will be returned; calls to ``log_artifact``
     and ``log_artifacts`` write artifact(s) to subdirectories of the artifact root URI.
 
     :param run_id: The ID of the run for which to obtain an absolute artifact URI.
@@ -82,10 +82,10 @@ def get_artifact_uri(run_id, artifact_path=None):
                           ``path/to/artifact``. If unspecified, the artifact root URI for the
                           specified run will be returned.
     :return: An *absolute* URI referring to the specified artifact or the specified run's artifact
-             root. For example, if an artifact path is provided and the specified run uses an 
+             root. For example, if an artifact path is provided and the specified run uses an
              S3-backed  store, this may be a uri of the form
              ``s3://<bucket_name>/path/to/artifact/root/path/to/artifact``. If an artifact path
-             is not provided and the specified run uses an S3-backed store, this may be a URI of 
+             is not provided and the specified run uses an S3-backed store, this may be a URI of
              the form ``s3://<bucket_name>/path/to/artifact/root``.
     """
     if not run_id:

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -114,7 +114,7 @@ def _download_artifact_from_uri(artifact_uri, output_path=None):
     """
     store = _get_store()
     artifact_path_module =\
-            ArtifactRepository.from_artifact_uri(artifact_uri, store).get_path_module()
+        ArtifactRepository.from_artifact_uri(artifact_uri, store).get_path_module()
     artifact_src_dir = artifact_path_module.dirname(artifact_uri)
     artifact_src_relative_path = artifact_path_module.basename(artifact_uri)
     artifact_repo = ArtifactRepository.from_artifact_uri(

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -98,8 +98,11 @@ def _download_artifact_from_uri(artifact_uri, output_path):
     :param artifact_uri: The *absolute* URI of the artifact to download.
     :param output_path: The local filesystem path to which to download the artifact.
     """
-    artifact_src_dir = os.path.dirname(artifact_uri)
-    artifact_src_relative_path = os.path.basename(artifact_uri)
+    store = _get_store()
+    artifact_path_module =\
+            ArtifactRepository.from_artifact_uri(artifact_uri, store).get_path_module()
+    artifact_src_dir = artifact_path_module.dirname(artifact_uri)
+    artifact_src_relative_path = artifact_path_module.basename(artifact_uri)
     artifact_repo = ArtifactRepository.from_artifact_uri(
             artifact_uri=artifact_src_dir, store=_get_store())
     return artifact_repo.download_artifacts(

--- a/tests/store/test_azure_blob_artifact_repo.py
+++ b/tests/store/test_azure_blob_artifact_repo.py
@@ -310,13 +310,11 @@ def test_tracking_download_file_artifact_from_absolute_azure_uri_succeeds(mock_c
             return orig_from_uri(artifact_uri, store)
 
     with mock.patch(
-            "mlflow.store.artifact_repo.ArtifactRepository.from_artifact_uri", 
+            "mlflow.store.artifact_repo.ArtifactRepository.from_artifact_uri",
             side_effect=mock_from_artifact_uri):
         uri = os.path.join(TEST_BLOB_CONTAINER_ROOT, "test.txt")
         output_path = _download_artifact_from_uri(uri, output_path=tmpdir.strpath)
 
-    mock_client.get_blob_to_path.assert_called_with(
-        "container", TEST_ROOT_PATH + "/test.txt", mock.ANY)
     assert os.path.exists(output_path)
     with open(output_path, "r") as f:
         assert f.read() == expected_file_text
@@ -327,7 +325,7 @@ def test_tracking_download_directory_artifact_from_absolute_azure_uri_succeeds(m
     artifact_uri = os.path.join(TEST_BLOB_CONTAINER_ROOT, artifact_dir_subpath)
 
     dir_prefix = BlobPrefix()
-    dir_prefix.name = artifact_dir_subpath 
+    dir_prefix.name = artifact_dir_subpath
 
     file_path_1 = "file_1"
     file_path_2 = "file_2"
@@ -373,7 +371,7 @@ def test_tracking_download_directory_artifact_from_absolute_azure_uri_succeeds(m
             return orig_from_uri(artifact_uri, store)
 
     with mock.patch(
-            "mlflow.store.artifact_repo.ArtifactRepository.from_artifact_uri", 
+            "mlflow.store.artifact_repo.ArtifactRepository.from_artifact_uri",
             side_effect=mock_from_artifact_uri):
         _download_artifact_from_uri(artifact_uri, output_path=tmpdir.strpath)
 

--- a/tests/store/test_azure_blob_artifact_repo.py
+++ b/tests/store/test_azure_blob_artifact_repo.py
@@ -6,6 +6,7 @@ from azure.storage.blob import Blob, BlobPrefix, BlobProperties, BlockBlobServic
 
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.store.azure_blob_artifact_repo import AzureBlobArtifactRepository
+from mlflow.tracking.utils import _download_artifact_from_uri
 
 
 TEST_ROOT_PATH = "some/path"
@@ -284,4 +285,99 @@ def test_download_artifact_throws_value_error_when_listed_blobs_do_not_contain_a
     with pytest.raises(ValueError) as exc:
         repo.download_artifacts("")
 
-    assert "Azure blob does not begin with the specified artifact path" in str(exc)
+    assert "Azure blob does not begin with the specified artifact path" in exc.value.message
+
+
+def test_tracking_download_file_artifact_from_absolute_azure_uri_succeeds(mock_client, tmpdir):
+    os.environ['AZURE_STORAGE_ACCESS_KEY'] = ''
+
+    mock_client.list_blobs.return_value = MockBlobList([])
+
+    expected_file_text = "hello world!"
+    def create_file(container, cloud_path, local_path):
+        # pylint: disable=unused-argument
+        local_path = os.path.basename(local_path)
+        f = tmpdir.join(local_path)
+        f.write(expected_file_text)
+
+    mock_client.get_blob_to_path.side_effect = create_file
+
+    orig_from_uri = ArtifactRepository.from_artifact_uri
+    def mock_from_artifact_uri(artifact_uri, store):
+        if artifact_uri.startswith("wasbs:/"):
+            return AzureBlobArtifactRepository(artifact_uri, mock_client)
+        else:
+            return orig_from_uri(artifact_uri, store)
+
+    with mock.patch(
+            "mlflow.store.artifact_repo.ArtifactRepository.from_artifact_uri", 
+            side_effect=mock_from_artifact_uri):
+        uri = os.path.join(TEST_BLOB_CONTAINER_ROOT, "test.txt")
+        output_path = _download_artifact_from_uri(uri, output_path=tmpdir.strpath)
+
+    mock_client.get_blob_to_path.assert_called_with(
+        "container", TEST_ROOT_PATH + "/test.txt", mock.ANY)
+    assert os.path.exists(output_path)
+    with open(output_path, "r") as f:
+        assert f.read() == expected_file_text
+
+
+def test_tracking_download_directory_artifact_from_absolute_azure_uri_succeeds(mock_client, tmpdir):
+    artifact_dir_subpath = "mydirectory"
+    artifact_uri = os.path.join(TEST_BLOB_CONTAINER_ROOT, artifact_dir_subpath)
+
+    dir_prefix = BlobPrefix()
+    dir_prefix.name = artifact_dir_subpath 
+
+    file_path_1 = "file_1"
+    file_path_2 = "file_2"
+
+    blob_props_1 = BlobProperties()
+    blob_props_1.content_length = 42
+    blob_1 = Blob(os.path.join(artifact_dir_subpath, file_path_1), props=blob_props_1)
+
+    blob_props_2 = BlobProperties()
+    blob_props_2.content_length = 42
+    blob_2 = Blob(os.path.join(artifact_dir_subpath, file_path_2), props=blob_props_2)
+
+    def get_mock_listing(*args, **kwargs):
+        """
+        Produces a mock listing that only contains content if the specified prefix is the artifact
+        root or a relevant subdirectory. This allows us to mock `list_artifacts` during the
+        `_download_artifacts_into` subroutine without recursively listing the same artifacts at
+        every level of the directory traversal.
+        """
+        # pylint: disable=unused-argument
+        if os.path.abspath(kwargs["prefix"]) == "/":
+            return MockBlobList([dir_prefix])
+        if os.path.abspath(kwargs["prefix"]) == os.path.abspath(artifact_dir_subpath):
+            return MockBlobList([blob_1, blob_2])
+        else:
+            return MockBlobList([])
+
+    expected_file_text = "hello world!"
+    def create_file(container, cloud_path, local_path):
+        # pylint: disable=unused-argument
+        local_path = os.path.basename(local_path)
+        f = tmpdir.join(local_path)
+        f.write(expected_file_text)
+
+    mock_client.list_blobs.side_effect = get_mock_listing
+    mock_client.get_blob_to_path.side_effect = create_file
+
+    orig_from_uri = ArtifactRepository.from_artifact_uri
+    def mock_from_artifact_uri(artifact_uri, store):
+        if artifact_uri.startswith("wasbs:/"):
+            return AzureBlobArtifactRepository(artifact_uri, mock_client)
+        else:
+            return orig_from_uri(artifact_uri, store)
+
+    with mock.patch(
+            "mlflow.store.artifact_repo.ArtifactRepository.from_artifact_uri", 
+            side_effect=mock_from_artifact_uri):
+        _download_artifact_from_uri(artifact_uri, output_path=tmpdir.strpath)
+
+    # Ensure that the `mkfile` side effect copied all of the download artifacts into `tmpdir`
+    dir_contents = os.listdir(tmpdir.strpath)
+    assert file_path_1 in dir_contents
+    assert file_path_2 in dir_contents

--- a/tests/store/test_azure_blob_artifact_repo.py
+++ b/tests/store/test_azure_blob_artifact_repo.py
@@ -6,7 +6,6 @@ from azure.storage.blob import Blob, BlobPrefix, BlobProperties, BlockBlobServic
 
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.store.azure_blob_artifact_repo import AzureBlobArtifactRepository
-from mlflow.tracking.utils import _download_artifact_from_uri
 
 
 TEST_ROOT_PATH = "some/path"
@@ -285,97 +284,4 @@ def test_download_artifact_throws_value_error_when_listed_blobs_do_not_contain_a
     with pytest.raises(ValueError) as exc:
         repo.download_artifacts("")
 
-    assert "Azure blob does not begin with the specified artifact path" in exc.value.message
-
-
-def test_tracking_download_file_artifact_from_absolute_azure_uri_succeeds(mock_client, tmpdir):
-    os.environ['AZURE_STORAGE_ACCESS_KEY'] = ''
-
-    mock_client.list_blobs.return_value = MockBlobList([])
-
-    expected_file_text = "hello world!"
-    def create_file(container, cloud_path, local_path):
-        # pylint: disable=unused-argument
-        local_path = os.path.basename(local_path)
-        f = tmpdir.join(local_path)
-        f.write(expected_file_text)
-
-    mock_client.get_blob_to_path.side_effect = create_file
-
-    orig_from_uri = ArtifactRepository.from_artifact_uri
-    def mock_from_artifact_uri(artifact_uri, store):
-        if artifact_uri.startswith("wasbs:/"):
-            return AzureBlobArtifactRepository(artifact_uri, mock_client)
-        else:
-            return orig_from_uri(artifact_uri, store)
-
-    with mock.patch(
-            "mlflow.store.artifact_repo.ArtifactRepository.from_artifact_uri",
-            side_effect=mock_from_artifact_uri):
-        uri = os.path.join(TEST_BLOB_CONTAINER_ROOT, "test.txt")
-        output_path = _download_artifact_from_uri(uri, output_path=tmpdir.strpath)
-
-    assert os.path.exists(output_path)
-    with open(output_path, "r") as f:
-        assert f.read() == expected_file_text
-
-
-def test_tracking_download_directory_artifact_from_absolute_azure_uri_succeeds(mock_client, tmpdir):
-    artifact_dir_subpath = "mydirectory"
-    artifact_uri = os.path.join(TEST_BLOB_CONTAINER_ROOT, artifact_dir_subpath)
-
-    dir_prefix = BlobPrefix()
-    dir_prefix.name = artifact_dir_subpath
-
-    file_path_1 = "file_1"
-    file_path_2 = "file_2"
-
-    blob_props_1 = BlobProperties()
-    blob_props_1.content_length = 42
-    blob_1 = Blob(os.path.join(artifact_dir_subpath, file_path_1), props=blob_props_1)
-
-    blob_props_2 = BlobProperties()
-    blob_props_2.content_length = 42
-    blob_2 = Blob(os.path.join(artifact_dir_subpath, file_path_2), props=blob_props_2)
-
-    def get_mock_listing(*args, **kwargs):
-        """
-        Produces a mock listing that only contains content if the specified prefix is the artifact
-        root or a relevant subdirectory. This allows us to mock `list_artifacts` during the
-        `_download_artifacts_into` subroutine without recursively listing the same artifacts at
-        every level of the directory traversal.
-        """
-        # pylint: disable=unused-argument
-        if os.path.abspath(kwargs["prefix"]) == "/":
-            return MockBlobList([dir_prefix])
-        if os.path.abspath(kwargs["prefix"]) == os.path.abspath(artifact_dir_subpath):
-            return MockBlobList([blob_1, blob_2])
-        else:
-            return MockBlobList([])
-
-    expected_file_text = "hello world!"
-    def create_file(container, cloud_path, local_path):
-        # pylint: disable=unused-argument
-        local_path = os.path.basename(local_path)
-        f = tmpdir.join(local_path)
-        f.write(expected_file_text)
-
-    mock_client.list_blobs.side_effect = get_mock_listing
-    mock_client.get_blob_to_path.side_effect = create_file
-
-    orig_from_uri = ArtifactRepository.from_artifact_uri
-    def mock_from_artifact_uri(artifact_uri, store):
-        if artifact_uri.startswith("wasbs:/"):
-            return AzureBlobArtifactRepository(artifact_uri, mock_client)
-        else:
-            return orig_from_uri(artifact_uri, store)
-
-    with mock.patch(
-            "mlflow.store.artifact_repo.ArtifactRepository.from_artifact_uri",
-            side_effect=mock_from_artifact_uri):
-        _download_artifact_from_uri(artifact_uri, output_path=tmpdir.strpath)
-
-    # Ensure that the `mkfile` side effect copied all of the download artifacts into `tmpdir`
-    dir_contents = os.listdir(tmpdir.strpath)
-    assert file_path_1 in dir_contents
-    assert file_path_2 in dir_contents
+    assert "Azure blob does not begin with the specified artifact path" in str(exc)

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -258,3 +258,16 @@ def test_start_run_exp_id_0(tracking_uri_mock, reset_active_experiment):
     # Set experiment ID to 0 when creating a run, verify that the specified experiment ID is honored
     with mlflow.start_run(experiment_id=0) as active_run:
         assert active_run.info.experiment_id == 0
+
+
+def test_get_artifact_uri_with_artifact_path_unspecified_returns_artifact_root_dir():
+    with mlflow.start_run() as active_run:
+        assert mlflow.get_artifact_uri(artifact_path=None) == active_run.info.artifact_uri
+
+
+def test_get_artifact_uri_uses_currently_active_run_id():
+    artifact_path = "artifact"
+    with mlflow.start_run() as active_run:
+        assert mlflow.get_artifact_uri(artifact_path=artifact_path) ==\
+            tracking.utils.get_artifact_uri(
+                run_id=active_run.info.run_uuid, artifact_path=artifact_path) 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -270,4 +270,4 @@ def test_get_artifact_uri_uses_currently_active_run_id():
     with mlflow.start_run() as active_run:
         assert mlflow.get_artifact_uri(artifact_path=artifact_path) ==\
             tracking.utils.get_artifact_uri(
-                run_id=active_run.info.run_uuid, artifact_path=artifact_path) 
+                run_id=active_run.info.run_uuid, artifact_path=artifact_path)

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -3,7 +3,6 @@ import os
 import pytest
 
 import mlflow
-import mlflow.tracking.utils
 from mlflow.store.file_store import FileStore
 from mlflow.store.rest_store import RestStore
 from mlflow.tracking.utils import _get_store, _TRACKING_URI_ENV_VAR, _TRACKING_USERNAME_ENV_VAR, \

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -141,8 +141,7 @@ def test_artifact_can_be_downloaded_from_absolute_uri_successfully(tmpdir):
         assert f.read() == artifact_text
 
 
-def test_download_artifact_from_absolute_uri_persists_data_to_specified_output_directory(
-    tmpdir):
+def test_download_artifact_from_absolute_uri_persists_data_to_specified_output_directory(tmpdir):
     artifact_file_name = "artifact.txt"
     artifact_text = "Sample artifact text"
     local_artifact_path = tmpdir.join(artifact_file_name).strpath
@@ -160,6 +159,6 @@ def test_download_artifact_from_absolute_uri_persists_data_to_specified_output_d
     assert logged_artifact_subdir in os.listdir(artifact_output_path)
     assert artifact_file_name in os.listdir(
         os.path.join(artifact_output_path, logged_artifact_subdir))
-    with open(
-        os.path.join(artifact_output_path, logged_artifact_subdir, artifact_file_name), "r") as f:
+    with open(os.path.join(
+            artifact_output_path, logged_artifact_subdir, artifact_file_name), "r") as f:
         assert f.read() == artifact_text

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -139,3 +139,27 @@ def test_artifact_can_be_downloaded_from_absolute_uri_successfully(tmpdir):
     assert downloaded_artifact_path != logged_artifact_path
     with open(downloaded_artifact_path, "r") as f:
         assert f.read() == artifact_text
+
+
+def test_download_artifact_from_absolute_uri_persists_data_to_specified_output_directory(
+    tmpdir):
+    artifact_file_name = "artifact.txt"
+    artifact_text = "Sample artifact text"
+    local_artifact_path = tmpdir.join(artifact_file_name).strpath
+    with open(local_artifact_path, "w") as out:
+        out.write(artifact_text)
+
+    logged_artifact_subdir = "logged_artifact"
+    with mlflow.start_run():
+        mlflow.log_artifact(local_path=local_artifact_path, artifact_path=logged_artifact_subdir)
+        artifact_uri = mlflow.get_artifact_uri(artifact_path=logged_artifact_subdir)
+
+    artifact_output_path = tmpdir.join("artifact_output").strpath
+    os.makedirs(artifact_output_path)
+    _download_artifact_from_uri(artifact_uri=artifact_uri, output_path=artifact_output_path)
+    assert logged_artifact_subdir in os.listdir(artifact_output_path)
+    assert artifact_file_name in os.listdir(
+        os.path.join(artifact_output_path, logged_artifact_subdir))
+    with open(
+        os.path.join(artifact_output_path, logged_artifact_subdir, artifact_file_name), "r") as f:
+        assert f.read() == artifact_text


### PR DESCRIPTION
In order to implement the solution for custom inference logic, we should provide users with a mechanism for obtaining an absolute artifact URI from a run ID and path. Furthermore, we should introduce logic for downloading artifacts from absolute URIs. This PR attempts to achieve both of these goals.

When implementing `get_artifact_uri(path, run_id)`, we join the specified run's artifact root directory with the specified path. The path separator used by this join depends on the artifact repository implementation associated with the artifact root URI. Therefore, this PR also introduces an abstract `get_path_module()` method within the `ArtifactRepository` class that specifies which module should be used to manipulate paths.

TODOs:

- Add tests for the correctness of `_download_artifact_from_uri()` and `get_artifact_uri()`.