### PR TITLE
Remove keyword args from logger.info call

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -183,7 +183,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
     region = my_session.region_name or "us-west-2"
     fullname = _full_template.format(account=account, region=region, image=image,
                                      version=mlflow.version.VERSION)
-    _logger.info("Pushing docker image %s to %s", image=image, repo=fullname)
+    _logger.info("Pushing docker image %s to %s", image, fullname)
     ecr_client = boto3.client('ecr')
     try:
         ecr_client.describe_repositories(repositoryNames=[image])['repositories']


### PR DESCRIPTION
It looks like there was a minor error in refactoring the eprints with logger calls, where there are still keyword args used. This commit removes the keyword args.

I noticed this error when attempting to push a custom docker image to ECR via
```py
mlflow.sagemaker.push_image_to_ecr(image='mlflow-pyfunc-custom)
```
and received the following error:

![image](https://user-images.githubusercontent.com/7774865/50526274-99a3ab80-0aa6-11e9-9f1d-f446ebc54943.png)
