### PR TITLE
Corrects model serving command line in a tutorial

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -373,11 +373,11 @@ in MLflow saved the model as an artifact within the run.
 
       In this example, you can use this MLmodel format with MLflow to deploy a local REST server that can serve predictions.
 
-      To deploy the server, run:
+      To deploy the server, run (replace the path with your model's actual path):
 
       .. code::
 
-          mlflow pyfunc serve /Users/mlflow/mlflow-prototype/mlruns/0/7c1a0d5c42844dcdb8f5191146925174/artifacts/model -p 1234
+          mlflow pyfunc serve -m /Users/mlflow/mlflow-prototype/mlruns/0/7c1a0d5c42844dcdb8f5191146925174/artifacts/model -p 1234
 
       .. note::
 


### PR DESCRIPTION
The command line without this fix would give the error below:

`Error: Missing option "--model-path" / "-m".`