### PR TITLE
Search API: allowing param value to have any content for checks

### DIFF
--- a/mlflow/server/js/src/utils/SearchUtils.js
+++ b/mlflow/server/js/src/utils/SearchUtils.js
@@ -10,7 +10,7 @@ export class SearchUtils {
 }
 
 const METRIC_CLAUSE_REGEX = /metrics\.([a-zA-z0-9]+)\s{0,}(=|!=|>|>=|<=|<)\s{0,}(\d+\.{0,}\d{0,})/;
-const PARAM_CLAUSE_REGEX = /params\.([a-zA-z0-9]+)\s{0,}(=|!=)\s{0,}"([a-zA-Z0-9.-]+)"/;
+const PARAM_CLAUSE_REGEX = /params\.([a-zA-z0-9]+)\s{0,}(=|!=)\s{0,}"(.*)"/;
 class Private {
   static parseSearchClause(searchClauseString) {
     const trimmedInput = searchClauseString.trim();


### PR DESCRIPTION
Search string currently allows search param values that only contain alphanumeric characters and `.` and `-`. This change allows match/mismatch with any content within quotes.

Search syntax is as before -- `params`.<key> <comparator> "<any value>". 

## Examples:
![image](https://user-images.githubusercontent.com/6900999/50620832-e0364300-0eb6-11e9-82ce-c15b8dbb201b.png)
![image](https://user-images.githubusercontent.com/6900999/50620846-fc39e480-0eb6-11e9-8032-7a280a3c1fa5.png)
![image](https://user-images.githubusercontent.com/6900999/50620855-0cea5a80-0eb7-11e9-9776-abcacd34c09d.png)


## SQL injection concerns:
Regardless of content passed through value, it would be wrapped in quotes and used for equality/non-equality checks and would be passed down as a string for comparison.

