### PR TITLE
GET requests uses params instead of json 

### DIFF
--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -54,8 +54,14 @@ class RestStore(AbstractStore):
         if json_body:
             json_body = json.loads(json_body)
         host_creds = self.get_host_creds()
-        response = http_request_safe(
-            host_creds=host_creds, endpoint=endpoint, method=method, json=json_body)
+
+        if method == 'GET':
+            response = http_request_safe(
+                host_creds=host_creds, endpoint=endpoint, method=method, params=json_body)
+        else:
+            response = http_request_safe(
+                host_creds=host_creds, endpoint=endpoint, method=method, json=json_body)
+
         js_dict = json.loads(response.text)
         parse_dict(js_dict=js_dict, message=response_proto)
         return response_proto

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -22,7 +22,7 @@ class TestRestStore(unittest.TestCase):
             kwargs = dict((k, v) for k, v in six.iteritems(kwargs) if v is not None)
             assert kwargs == {
                 'method': 'GET',
-                'json': {'view_type': 'ACTIVE_ONLY'},
+                'params': {'view_type': 'ACTIVE_ONLY'},
                 'url': 'https://hello/api/2.0/preview/mlflow/experiments/list',
                 'headers': {},
                 'verify': True,


### PR DESCRIPTION
Info
---
Version: 0.8.1
OS: macOS 10.14.2 client + Ubuntu 1804 server

Issue
---
GET requests fails when we include a json field in kwargs. This is because the HTTP request is malformed.

Resolution
---
pass data using params instead of json for GET requests in MLFlow rest store

Error
---
This is an example of the error, but you'd get this for any GET request.
```
Traceback (most recent call last):
  File "test_mlflow.py", line 7, in <module>
    mlflow.set_experiment('alpha')
  File "/Users/dev/mlflow-poc/venv/lib/python3.7/site-packages/mlflow/tracking/fluent.py", line 216, in log_artifact
    MlflowClient().log_artifact(run_id, local_path, artifact_path)
  File "/Users/dev/mlflow-poc/venv/lib/python3.7/site-packages/mlflow/tracking/client.py", line 161, in log_artifact
    run = self.get_run(run_id)
  File "/Users/dev/mlflow-poc/venv/lib/python3.7/site-packages/mlflow/tracking/client.py", line 37, in get_run
    return self.store.get_run(run_id)
  File "/Users/dev/mlflow-poc/venv/lib/python3.7/site-packages/mlflow/store/rest_store.py", line 124, in get_run
    response_proto = self._call_endpoint(GetRun, req_body)
  File "/Users/dev/mlflow-poc/venv/lib/python3.7/site-packages/mlflow/store/rest_store.py", line 59, in _call_endpoint
    host_creds=host_creds, endpoint=endpoint, method=method, json=json_body, params=params)
  File "/Users/dev/mlflow-poc/venv/lib/python3.7/site-packages/mlflow/utils/rest_utils.py", line 80, in http_request_safe
    raise MlflowException("%s. Response body: '%s'" % (base_msg, response.text))

mlflow.exceptions.MlflowException: API request to endpoint /api/2.0/preview/mlflow/runs/get failed with error code 400 != 200.
```