### PR TITLE
Allow writing Spark models directly to the target artifact store when possible

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -21,7 +21,6 @@ Spark MLlib (native) format
 
 from __future__ import absolute_import
 
-import errno
 import os
 import yaml
 import logging

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -296,10 +296,6 @@ def save_model(spark_model, path, mlflow_model=Model(), conda_env=None, jars=Non
     >>> mlflow.spark.save_model(model, "spark-model")
     """
     _validate_model(spark_model, jars)
-
-    if sample_input is not None:
-        mleap.add_to_model(mlflow_model, path, spark_model, sample_input)
-
     # Spark ML stores the model on DFS if running on a cluster
     # Save it to a DFS temp dir first and copy it to local path
     if dfs_tmpdir is None:

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -21,6 +21,7 @@ Spark MLlib (native) format
 
 from __future__ import absolute_import
 
+import errno
 import os
 import yaml
 import logging
@@ -130,8 +131,9 @@ def log_model(spark_model, artifact_path, conda_env=None, jars=None, dfs_tmpdir=
         tmp_model_metadata_dir = tmp.path("model")
         try:
             os.mkdir(tmp_model_metadata_dir)
-        except FileExistsError:
-            pass
+        except OSError as e:
+            if e.errno != errno.EEXIST:
+                raise
         _save_model_metadata(
             tmp_model_metadata_dir, spark_model, mlflow_model, sample_input, conda_env)
         mlflow.tracking.fluent.log_artifacts(tmp_model_metadata_dir, artifact_path)

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -133,7 +133,7 @@ def log_model(spark_model, artifact_path, conda_env=None, jars=None, dfs_tmpdir=
         except FileExistsError:
             pass
         _save_model_metadata(
-            tmp_model_metadata_dir, spark_model, mlflow_model, sample_input, conda_env, jars)
+            tmp_model_metadata_dir, spark_model, mlflow_model, sample_input, conda_env)
         mlflow.tracking.fluent.log_artifacts(tmp_model_metadata_dir, artifact_path)
 
 
@@ -164,7 +164,6 @@ class _HadoopFileSystem:
     @classmethod
     def _fs(cls):
         if not cls._filesystem:
-            sc = SparkContext.getOrCreate()
             cls._filesystem = cls._jvm().org.apache.hadoop.fs.FileSystem.get(cls._conf())
         return cls._filesystem
 
@@ -214,7 +213,7 @@ class _HadoopFileSystem:
         cls._fs().delete(cls._remote_path(path), True)
 
 
-def _save_model_metadata(dst_dir, spark_model, mlflow_model, sample_input, conda_env, jars):
+def _save_model_metadata(dst_dir, spark_model, mlflow_model, sample_input, conda_env):
     """
     Saves model metadata into the passed-in directory. The persisted metadata assumes that a
     model can be loaded from a relative path to the metadata file (currently hard-coded to
@@ -306,7 +305,7 @@ def save_model(spark_model, path, mlflow_model=Model(), conda_env=None, jars=Non
     _HadoopFileSystem.copy_to_local_file(tmp_path, sparkml_data_path, remove_src=True)
     _save_model_metadata(
         dst_dir=path, spark_model=spark_model, mlflow_model=mlflow_model,
-        sample_input=sample_input, conda_env=conda_env, jars=jars)
+        sample_input=sample_input, conda_env=conda_env)
 
 
 def _load_model(model_path, dfs_tmpdir=None):

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -128,6 +128,14 @@ def test_hadoop_filesystem(tmpdir):
     assert not os.path.exists(FS._remote_path(remote).toString())  # skip file: prefix
 
 
+def test_hadoop_can_write_to_path():
+    from mlflow.spark import _HadoopFileSystem as FS
+    # On Databricks, this throws an error while looking up credentials
+    assert FS.can_write_to_path("s3://blah")
+    # Works on Databricks but fails locally, as expected
+    assert not FS.can_write_to_path("dbfs:/blah")
+
+
 def test_model_export(spark_model_iris, model_path, spark_custom_env):
     sparkm.save_model(spark_model_iris.model, path=model_path,
                       conda_env=spark_custom_env)

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -350,7 +350,7 @@ def test_spark_module_model_save_with_mleap_and_unsupported_transformer_raises_e
     unsupported_pipeline = Pipeline(stages=[CustomTransformer()])
     unsupported_model = unsupported_pipeline.fit(spark_model_iris.spark_df)
 
-    with pytest.raises(mleap.MLeapSerializationException):
+    with pytest.raises(ValueError):
         sparkm.save_model(spark_model=unsupported_model,
                           path=model_path,
                           sample_input=spark_model_iris.spark_df)

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -23,6 +23,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.tracking
 from mlflow import active_run, pyfunc, mleap
 from mlflow import spark as sparkm
+from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.tracking.utils import _get_model_log_dir
 from mlflow.utils.environment import _mlflow_conda_env
@@ -240,6 +241,19 @@ def test_sparkml_model_save_persists_specified_conda_env_in_mlflow_model_directo
     with open(saved_conda_env_path, "r") as f:
         saved_conda_env_parsed = yaml.safe_load(f)
     assert saved_conda_env_parsed == spark_custom_env_parsed
+
+def test_sparkml_model_log_invalid_args(spark_model_iris, model_path):
+    with pytest.raises(MlflowException) as e:
+        sparkm.log_model(
+            spark_model=spark_model_iris.model.stages[0],
+            artifact_path="model0")
+        assert e.message.contains("SparkML can only save PipelineModels")
+    with pytest.raises(MlflowException) as e:
+        sparkm.log_model(
+            spark_model=spark_model_iris.model,
+            artifact_path="model1",
+            jars=["something.jar"])
+        assert e.message.contains("JAR dependencies are not implemented")
 
 
 def test_sparkml_model_save_accepts_conda_env_as_dict(spark_model_iris, model_path):

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -242,6 +242,7 @@ def test_sparkml_model_save_persists_specified_conda_env_in_mlflow_model_directo
         saved_conda_env_parsed = yaml.safe_load(f)
     assert saved_conda_env_parsed == spark_custom_env_parsed
 
+
 def test_sparkml_model_log_invalid_args(spark_model_iris, model_path):
     with pytest.raises(MlflowException) as e:
         sparkm.log_model(

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -192,45 +192,36 @@ def test_sagemaker_docker_model_scoring_with_default_conda_env(spark_model_iris,
             decimal=4)
 
 
-@pytest.mark.parametrize(
-    "should_start_run,use_hdfs_tracking_uri",
-    [(True, True), (True, False), (False, True), (False, False)]
-)
-def test_sparkml_model_log(tmpdir, spark_model_iris, should_start_run, use_hdfs_tracking_uri):
+def test_sparkml_model_log(tmpdir, spark_model_iris):
     # Print the coefficients and intercept for multinomial logistic regression
     old_tracking_uri = mlflow.get_tracking_uri()
     cnt = 0
     # should_start_run tests whether or not calling log_model() automatically starts a run.
-    for dfs_tmp_dir in [None, os.path.join(str(tmpdir), "test")]:
-        print("should_start_run =", should_start_run, "dfs_tmp_dir =", dfs_tmp_dir)
-        try:
-            tracking_dir = os.path.abspath(str(tmpdir.join("mlruns")))
-            if use_hdfs_tracking_uri:
+    for should_start_run in [False, True]:
+        for dfs_tmp_dir in [None, os.path.join(str(tmpdir), "test")]:
+            print("should_start_run =", should_start_run, "dfs_tmp_dir =", dfs_tmp_dir)
+            try:
+                tracking_dir = os.path.abspath(str(tmpdir.join("mlruns")))
                 mlflow.set_tracking_uri("file://%s" % tracking_dir)
-            else:
-                mlflow.set_tracking_uri(tracking_dir)
-            if should_start_run:
-                mlflow.start_run()
-            artifact_path = "model%d" % cnt
-            cnt += 1
-            sparkm.log_model(artifact_path=artifact_path, spark_model=spark_model_iris.model,
-                             dfs_tmpdir=dfs_tmp_dir)
-            run_id = active_run().info.run_uuid
-            # test reloaded model
-            reloaded_model = sparkm.load_model(artifact_path, run_id=run_id,
-                                               dfs_tmpdir=dfs_tmp_dir)
-            preds_df = reloaded_model.transform(spark_model_iris.spark_df)
-            preds = [x.prediction for x in preds_df.select("prediction").collect()]
-            assert spark_model_iris.predictions == preds
-        finally:
-            mlflow.end_run()
-            mlflow.set_tracking_uri(old_tracking_uri)
-            x = dfs_tmp_dir or sparkm.DFS_TMP
-            if use_hdfs_tracking_uri:
+                if should_start_run:
+                    mlflow.start_run()
+                artifact_path = "model%d" % cnt
+                cnt += 1
+                sparkm.log_model(artifact_path=artifact_path, spark_model=spark_model_iris.model,
+                                 dfs_tmpdir=dfs_tmp_dir)
+                run_id = active_run().info.run_uuid
+                # test reloaded model
+                reloaded_model = sparkm.load_model(artifact_path, run_id=run_id,
+                                                   dfs_tmpdir=dfs_tmp_dir)
+                preds_df = reloaded_model.transform(spark_model_iris.spark_df)
+                preds = [x.prediction for x in preds_df.select("prediction").collect()]
+                assert spark_model_iris.predictions == preds
+            finally:
+                mlflow.end_run()
+                mlflow.set_tracking_uri(old_tracking_uri)
+                x = dfs_tmp_dir or sparkm.DFS_TMP
                 shutil.rmtree(x)
                 shutil.rmtree(tracking_dir)
-            else:
-                assert not os.path.exists(dfs_tmp_dir)
 
 
 def test_sparkml_model_save_persists_specified_conda_env_in_mlflow_model_directory(


### PR DESCRIPTION
Allow writing Spark models directly to the target artifact store when possible. This allows for persisting large models (e.g. ALS) & in the case of the DBFS artifact repo, helps avoid making many file-upload requests in short succession.