### PR TITLE
add JRE to mlflow dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN pip install -r dev-requirements.txt && \
     pip install -r test-requirements.txt && \
     pip install -e . && \
     apt-get update && apt-get install -y gnupg && \
+    apt-get install -y openjdk-8-jre-headless && \
     curl -sL https://deb.nodesource.com/setup_10.x | bash - && \
     apt-get update && apt-get install -y nodejs && \
     cd mlflow/server/js && \


### PR DESCRIPTION
Fix for Issue #815 - unable to run h2o example in mlflow docker container because JRE is missing.