### PR TITLE
Relaxes the format requirements for metric search criteria

### DIFF
--- a/mlflow/server/js/src/utils/SearchUtils.js
+++ b/mlflow/server/js/src/utils/SearchUtils.js
@@ -9,7 +9,7 @@ export class SearchUtils {
   }
 }
 
-const METRIC_CLAUSE_REGEX = /metrics\.([a-zA-z0-9]+)\s{0,}(=|!=|>|>=|<=|<)\s{0,}(\d+\.{0,}\d{0,})/;
+const METRIC_CLAUSE_REGEX = /metrics\.([a-zA-z0-9]+)\s{0,}(=|!=|>|>=|<=|<)\s{0,}(\d+\.{0,}\d{0,}|\.+\d+)/;
 const PARAM_CLAUSE_REGEX = /params\.([a-zA-z0-9]+)\s{0,}(=|!=)\s{0,}"(.*)"/;
 class Private {
   static parseSearchClause(searchClauseString) {


### PR DESCRIPTION
Makes the integer part of a floating point number optional when it is zero.
For example, `.01`is a now a valid floating number but not before this change.
This is consistent with most programming languages including Python.

This is to address issue #801 