### PR TITLE
Fix #828: add cloudpickle package to conda.yaml in examples/sklearn_elasticnet_wine running in docker

### DIFF
--- a/examples/sklearn_elasticnet_wine/conda.yaml
+++ b/examples/sklearn_elasticnet_wine/conda.yaml
@@ -2,7 +2,7 @@ name: tutorial
 channels:
   - defaults
 dependencies:
-  - cloudpickle
+  - cloudpickle=0.6.1
   - python=3.6
   - numpy=1.14.3
   - pandas=0.22.0

--- a/examples/sklearn_elasticnet_wine/conda.yaml
+++ b/examples/sklearn_elasticnet_wine/conda.yaml
@@ -2,6 +2,7 @@ name: tutorial
 channels:
   - defaults
 dependencies:
+  - cloudpickle
   - python=3.6
   - numpy=1.14.3
   - pandas=0.22.0


### PR DESCRIPTION
Fix #828: ModuleNotFoundError: No module named 'cloudpickle' in examples/sklearn_elasticnet_wine when running in mlflow docker container

Attached is successful run after adding `cloudpickle` to `conda.yaml`.
[examples_sklearn_elasticnet_wine_after_fix.txt](https://github.com/mlflow/mlflow/files/2780731/examples_sklearn_elasticnet_wine_after_fix.txt)
