### PR TITLE
Add cloudpickle version to custom pyfunc conf + version mismatch warning

### DIFF
--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -190,16 +190,16 @@ def _load_pyfunc(model_path):
     python_model_cloudpickle_version = pyfunc_config.get(CONFIG_KEY_CLOUDPICKLE_VERSION, None)
     if python_model_cloudpickle_version is None:
         raise MlflowException(
-            "The version of CloudPickle used to save the model was not specified in the model"
+            "The version of CloudPickle used to save the model could not be found in the MLmodel"
             " configuration")
     elif python_model_cloudpickle_version != cloudpickle.__version__:
         # CloudPickle does not have a well-defined cross-version compatibility policy. Micro version
         # releases have been known to cause incompatibilities. Therefore, we match on the full
         # library version
         mlflow.pyfunc._logger.warning(
-            "The version of CloudPickle that was used to save the model was saved in, `%s`, differs"
-            " from the version of CloudPickle that is currently running, `%s`, and may be"
-            " incompatible",
+            "The version of CloudPickle that was used to save the model, `CloudPickle %s`, differs"
+            " from the version of CloudPickle that is currently running, `CloudPickle %s`, and may"
+            " be incompatible",
             python_model_cloudpickle_version, cloudpickle.__version__)
 
     python_model_subpath = pyfunc_config.get(CONFIG_KEY_PYTHON_MODEL, None)

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -189,7 +189,7 @@ def _load_pyfunc(model_path):
 
     python_model_cloudpickle_version = pyfunc_config.get(CONFIG_KEY_CLOUDPICKLE_VERSION, None)
     if python_model_cloudpickle_version is None:
-        raise MlflowException(
+        mlflow.pyfunc._logger.warning(
             "The version of CloudPickle used to save the model could not be found in the MLmodel"
             " configuration")
     elif python_model_cloudpickle_version != cloudpickle.__version__:

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -36,6 +36,7 @@ CONFIG_KEY_ARTIFACTS = "artifacts"
 CONFIG_KEY_ARTIFACT_RELATIVE_PATH = "path"
 CONFIG_KEY_ARTIFACT_URI = "uri"
 CONFIG_KEY_PYTHON_MODEL = "python_model"
+CONFIG_KEY_CLOUDPICKLE_VERSION = "cloudpickle_version"
 
 
 class PythonModel(object):
@@ -127,7 +128,9 @@ def _save_model_with_class_artifacts_params(path, python_model, artifacts=None, 
                 error_code=RESOURCE_ALREADY_EXISTS)
     os.makedirs(path)
 
-    custom_model_config_kwargs = {}
+    custom_model_config_kwargs = {
+        CONFIG_KEY_CLOUDPICKLE_VERSION: cloudpickle.__version__,
+    }
     if isinstance(python_model, PythonModel):
         saved_python_model_subpath = "python_model.pkl"
         with open(os.path.join(path, saved_python_model_subpath), "wb") as out:
@@ -183,6 +186,22 @@ def _save_model_with_class_artifacts_params(path, python_model, artifacts=None, 
 def _load_pyfunc(model_path):
     pyfunc_config = _get_flavor_configuration(
             model_path=model_path, flavor_name=mlflow.pyfunc.FLAVOR_NAME)
+
+    python_model_cloudpickle_version = pyfunc_config.get(CONFIG_KEY_CLOUDPICKLE_VERSION, None)
+    if python_model_cloudpickle_version is None:
+        raise MlflowException(
+            "The version of CloudPickle used to save the model was not specified in the model"
+            " configuration")
+    elif python_model_cloudpickle_version != cloudpickle.__version__:
+        # CloudPickle does not have a well-defined cross-version compatibility policy. Micro version
+        # releases have been known to cause incompatibilities. Therefore, we match on the full
+        # library version
+        mlflow.pyfunc._logger.warning(
+            "The version of CloudPickle that was used to save the model was saved in, `%s`, differs"
+            " from the version of CloudPickle that is currently running, `%s`, and may be"
+            " incompatible",
+            python_model_cloudpickle_version, cloudpickle.__version__)
+
     python_model_subpath = pyfunc_config.get(CONFIG_KEY_PYTHON_MODEL, None)
     if python_model_subpath is None:
         raise MlflowException(

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import os
 import json
+import mock
 from subprocess import Popen, STDOUT
 
 import numpy as np
@@ -551,6 +552,40 @@ def test_log_model_with_unsupported_argument_combinations_throws_exception():
                                 python_model=None,
                                 loader_module=None)
     assert "Either `loader_module` or `python_model` must be specified" in str(exc_info)
+
+
+def test_load_model_with_differing_cloudpickle_version_at_micro_granularity_logs_warning(
+        model_path):
+    class TestModel(mlflow.pyfunc.PythonModel):
+        def predict(self, context, model_input):
+            return model_input
+
+    mlflow.pyfunc.save_model(dst_path=model_path, python_model=TestModel())
+    saver_cloudpickle_version = "0.5.8"
+    model_config_path = os.path.join(model_path, "MLmodel")
+    model_config = Model.load(model_config_path)
+    model_config.flavors[mlflow.pyfunc.FLAVOR_NAME][
+        mlflow.pyfunc.model.CONFIG_KEY_CLOUDPICKLE_VERSION] = saver_cloudpickle_version
+    model_config.save(model_config_path)
+
+    log_messages = []
+
+    def custom_warn(message_text, *args, **kwargs):
+        log_messages.append(message_text % args % kwargs)
+
+    loader_cloudpickle_version = "0.5.7"
+    with mock.patch("mlflow.pyfunc._logger.warning") as warn_mock,\
+            mock.patch("cloudpickle.__version__") as cloudpickle_version_mock:
+        cloudpickle_version_mock.__str__ = lambda *args, **kwargs: loader_cloudpickle_version
+        warn_mock.side_effect = custom_warn
+        mlflow.pyfunc.load_pyfunc(path=model_path)
+
+    assert any([
+        "differs from the version of CloudPickle that is currently running" in log_message and
+        saver_cloudpickle_version in log_message and
+        loader_cloudpickle_version in log_message
+        for log_message in log_messages
+    ])
 
 
 @pytest.mark.large


### PR DESCRIPTION
This PR adds the version of CloudPickle that was used to save a custom pyfunc model to its MLmodel configuration. It also introduces a model load time warning that is printed if the version of CloudPickle that is currently running does not match the version of CloudPickle that was used to save the model.