### PR TITLE
Simple refactor

### DIFF
--- a/mlflow/entities/__init__.py
+++ b/mlflow/entities/__init__.py
@@ -14,6 +14,7 @@ from mlflow.entities.run_status import RunStatus
 from mlflow.entities.run_tag import RunTag
 from mlflow.entities.source_type import SourceType
 from mlflow.entities.view_type import ViewType
+from mlflow.entities.lifecycle_stage import LifecycleStage
 
 __all__ = [
     "Experiment",
@@ -26,5 +27,6 @@ __all__ = [
     "RunStatus",
     "RunTag",
     "SourceType",
-    "ViewType"
+    "ViewType",
+    "LifecycleStage"
 ]

--- a/mlflow/entities/experiment.py
+++ b/mlflow/entities/experiment.py
@@ -1,4 +1,5 @@
 from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.protos.service_pb2 import Experiment as ProtoExperiment
 
 
@@ -7,14 +8,13 @@ class Experiment(_MLflowObject):
     Experiment object.
     """
     DEFAULT_EXPERIMENT_ID = 0
-    ACTIVE_LIFECYCLE = 'active'
-    DELETED_LIFECYCLE = 'deleted'
 
     def __init__(self, experiment_id, name, artifact_location, lifecycle_stage):
         super(Experiment, self).__init__()
         self._experiment_id = experiment_id
         self._name = name
         self._artifact_location = artifact_location
+        assert(LifecycleStage.is_valid(lifecycle_stage))
         self._lifecycle_stage = lifecycle_stage
 
     @property

--- a/mlflow/entities/experiment.py
+++ b/mlflow/entities/experiment.py
@@ -1,5 +1,4 @@
 from mlflow.entities._mlflow_object import _MLflowObject
-from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.protos.service_pb2 import Experiment as ProtoExperiment
 
 

--- a/mlflow/entities/experiment.py
+++ b/mlflow/entities/experiment.py
@@ -14,7 +14,6 @@ class Experiment(_MLflowObject):
         self._experiment_id = experiment_id
         self._name = name
         self._artifact_location = artifact_location
-        assert(LifecycleStage.is_valid(lifecycle_stage))
         self._lifecycle_stage = lifecycle_stage
 
     @property

--- a/mlflow/entities/lifecycle_stage.py
+++ b/mlflow/entities/lifecycle_stage.py
@@ -8,7 +8,7 @@ class LifecycleStage(object):
     _VALID_STAGES = set([ACTIVE, DELETED])
 
     @classmethod
-    def matching_view_type(cls, view_type=ViewType.ALL):
+    def view_type_to_stages(cls, view_type=ViewType.ALL):
         stages = []
         if view_type == ViewType.ACTIVE_ONLY or view_type == ViewType.ALL:
             stages.append(cls.ACTIVE)

--- a/mlflow/entities/lifecycle_stage.py
+++ b/mlflow/entities/lifecycle_stage.py
@@ -1,0 +1,35 @@
+from mlflow.entities.view_type import ViewType
+from mlflow.exceptions import ExecutionException
+
+
+class LifecycleStage(object):
+    ACTIVE = "active"
+    DELETED = "deleted"
+    _VALID_STAGES = set([ACTIVE, DELETED])
+
+    @classmethod
+    def matching_view_type(cls, view_type=ViewType.ALL):
+        stages = []
+        if view_type == ViewType.ACTIVE_ONLY or view_type == ViewType.ALL:
+            stages.append(cls.ACTIVE)
+        if view_type == ViewType.DELETED_ONLY or view_type == ViewType.ALL:
+            stages.append(cls.DELETED)
+        return stages
+
+    @classmethod
+    def is_valid(cls, lifecycle_stage):
+        return lifecycle_stage in cls._VALID_STAGES
+
+    @classmethod
+    def matches_view_type(cls, view_type, lifecycle_stage):
+        if not cls.is_valid(lifecycle_stage):
+            raise ExecutionException("Invalid lifecycle stage '%s'" % str(lifecycle_stage))
+
+        if view_type == ViewType.ALL:
+            return True
+        elif view_type == ViewType.ACTIVE_ONLY:
+            return lifecycle_stage == LifecycleStage.ACTIVE
+        elif view_type == ViewType.DELETED_ONLY:
+            return lifecycle_stage == LifecycleStage.DELETED
+        else:
+            raise ExecutionException("Invalid view type '%s'" % str(view_type))

--- a/mlflow/entities/lifecycle_stage.py
+++ b/mlflow/entities/lifecycle_stage.py
@@ -1,5 +1,5 @@
 from mlflow.entities.view_type import ViewType
-from mlflow.exceptions import ExecutionException
+from mlflow.exceptions import MlflowException
 
 
 class LifecycleStage(object):
@@ -23,7 +23,7 @@ class LifecycleStage(object):
     @classmethod
     def matches_view_type(cls, view_type, lifecycle_stage):
         if not cls.is_valid(lifecycle_stage):
-            raise ExecutionException("Invalid lifecycle stage '%s'" % str(lifecycle_stage))
+            raise MlflowException("Invalid lifecycle stage '%s'" % str(lifecycle_stage))
 
         if view_type == ViewType.ALL:
             return True
@@ -32,4 +32,4 @@ class LifecycleStage(object):
         elif view_type == ViewType.DELETED_ONLY:
             return lifecycle_stage == LifecycleStage.DELETED
         else:
-            raise ExecutionException("Invalid view type '%s'" % str(view_type))
+            raise MlflowException("Invalid view type '%s'" % str(view_type))

--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -1,17 +1,18 @@
 from mlflow.entities._mlflow_object import _MLflowObject
+from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.exceptions import MlflowException
 
 from mlflow.protos.service_pb2 import RunInfo as ProtoRunInfo
 
 
 def check_run_is_active(run_info):
-    if run_info.lifecycle_stage != RunInfo.ACTIVE_LIFECYCLE:
+    if run_info.lifecycle_stage != LifecycleStage.ACTIVE:
         raise MlflowException('The run {} must be in an active lifecycle_stage.'
                               .format(run_info.run_uuid))
 
 
 def check_run_is_deleted(run_info):
-    if run_info.lifecycle_stage != RunInfo.DELETED_LIFECYCLE:
+    if run_info.lifecycle_stage != LifecycleStage.DELETED:
         raise MlflowException('The run {} must be in an deleted lifecycle_stage.'
                               .format(run_info.run_uuid))
 
@@ -20,8 +21,6 @@ class RunInfo(_MLflowObject):
     """
     Metadata about a run.
     """
-    ACTIVE_LIFECYCLE = "active"
-    DELETED_LIFECYCLE = "deleted"
 
     def __init__(self, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
                  user_id, status, start_time, end_time, source_version, lifecycle_stage,
@@ -53,6 +52,7 @@ class RunInfo(_MLflowObject):
         self._start_time = start_time
         self._end_time = end_time
         self._source_version = source_version
+        assert(LifecycleStage.is_valid(lifecycle_stage))
         self._lifecycle_stage = lifecycle_stage
         self._artifact_uri = artifact_uri
 

--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -52,7 +52,6 @@ class RunInfo(_MLflowObject):
         self._start_time = start_time
         self._end_time = end_time
         self._source_version = source_version
-        assert(LifecycleStage.is_valid(lifecycle_stage))
         self._lifecycle_stage = lifecycle_stage
         self._artifact_uri = artifact_uri
 

--- a/mlflow/store/dbmodels/models.py
+++ b/mlflow/store/dbmodels/models.py
@@ -61,7 +61,7 @@ class SqlExperiment(Base):
 
     __table_args__ = (
         CheckConstraint(
-            lifecycle_stage.in_(LifecycleStage.matching_view_type(ViewType.ALL)),
+            lifecycle_stage.in_(LifecycleStage.view_type_to_stages(ViewType.ALL)),
             name='lifecycle_stage'),
         PrimaryKeyConstraint('experiment_id', name='experiment_pk')
     )
@@ -94,7 +94,7 @@ class SqlRun(Base):
     __table_args__ = (
         CheckConstraint(source_type.in_(SourceTypes), name='source_type'),
         CheckConstraint(status.in_(RunStatusTypes), name='status'),
-        CheckConstraint(lifecycle_stage.in_(LifecycleStage.matching_view_type(ViewType.ALL)),
+        CheckConstraint(lifecycle_stage.in_(LifecycleStage.view_type_to_stages(ViewType.ALL)),
                         name='lifecycle_stage'),
         PrimaryKeyConstraint('run_uuid', name='run_pk')
     )

--- a/mlflow/store/dbmodels/models.py
+++ b/mlflow/store/dbmodels/models.py
@@ -6,15 +6,11 @@ from sqlalchemy import (
 from sqlalchemy.ext.declarative import declarative_base
 from mlflow.entities import (
     Experiment, RunTag, Metric, Param, RunData, RunInfo,
-    SourceType, RunStatus, Run)
+    SourceType, RunStatus, Run, ViewType)
+from mlflow.entities.lifecycle_stage import LifecycleStage
 
 Base = declarative_base()
 
-
-ExperimentLifecycleStageTypes = [
-    Experiment.ACTIVE_LIFECYCLE,
-    Experiment.DELETED_LIFECYCLE
-]
 
 SourceTypes = [
     SourceType.to_string(SourceType.NOTEBOOK),
@@ -29,11 +25,6 @@ RunStatusTypes = [
     RunStatus.to_string(RunStatus.FAILED),
     RunStatus.to_string(RunStatus.FINISHED),
     RunStatus.to_string(RunStatus.RUNNING)
-]
-
-RunLifecycleStageTypes = [
-    RunInfo.ACTIVE_LIFECYCLE,
-    RunInfo.DELETED_LIFECYCLE
 ]
 
 
@@ -66,11 +57,12 @@ class SqlExperiment(Base):
     experiment_id = Column(Integer, autoincrement=True)
     name = Column(String(256), unique=True, nullable=False)
     artifact_location = Column(String(256), nullable=True)
-    lifecycle_stage = Column(String(32), default=Experiment.ACTIVE_LIFECYCLE)
+    lifecycle_stage = Column(String(32), default=LifecycleStage.ACTIVE)
 
     __table_args__ = (
         CheckConstraint(
-            lifecycle_stage.in_(ExperimentLifecycleStageTypes), name='lifecycle_stage'),
+            lifecycle_stage.in_(LifecycleStage.matching_view_type(ViewType.ALL)),
+            name='lifecycle_stage'),
         PrimaryKeyConstraint('experiment_id', name='experiment_pk')
     )
 
@@ -94,7 +86,7 @@ class SqlRun(Base):
     start_time = Column(BigInteger, default=int(time.time()))
     end_time = Column(BigInteger, nullable=True, default=None)
     source_version = Column(String(50))
-    lifecycle_stage = Column(String(20), default=RunInfo.ACTIVE_LIFECYCLE)
+    lifecycle_stage = Column(String(20), default=LifecycleStage.ACTIVE)
     artifact_uri = Column(String(20), default=None)
     experiment_id = Column(Integer, ForeignKey('experiments.experiment_id'))
     experiment = relationship('SqlExperiment', backref=backref('runs', cascade='all'))
@@ -102,7 +94,8 @@ class SqlRun(Base):
     __table_args__ = (
         CheckConstraint(source_type.in_(SourceTypes), name='source_type'),
         CheckConstraint(status.in_(RunStatusTypes), name='status'),
-        CheckConstraint(lifecycle_stage.in_(RunLifecycleStageTypes), name='lifecycle_stage'),
+        CheckConstraint(lifecycle_stage.in_(LifecycleStage.matching_view_type(ViewType.ALL)),
+                        name='lifecycle_stage'),
         PrimaryKeyConstraint('run_uuid', name='run_pk')
     )
 

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -8,7 +8,7 @@ from mlflow.entities import Experiment, Metric, Param, Run, RunData, RunInfo, Ru
                             ViewType
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.entities.run_info import check_run_is_active, check_run_is_deleted
-from mlflow.exceptions import MlflowException, MissingConfigException, ExecutionException
+from mlflow.exceptions import MlflowException, MissingConfigException
 import mlflow.protos.databricks_pb2 as databricks_pb2
 from mlflow.store.abstract_store import AbstractStore
 from mlflow.utils.validation import _validate_metric_name, _validate_param_name, _validate_run_id, \

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -6,6 +6,7 @@ import six
 
 from mlflow.entities import Experiment, Metric, Param, Run, RunData, RunInfo, RunStatus, RunTag, \
                             ViewType
+from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.entities.run_info import check_run_is_active, check_run_is_deleted
 from mlflow.exceptions import MlflowException, MissingConfigException, ExecutionException
 import mlflow.protos.databricks_pb2 as databricks_pb2
@@ -39,7 +40,7 @@ def _make_persisted_run_info_dict(run_info):
 def _read_persisted_run_info_dict(run_info_dict):
     dict_copy = run_info_dict.copy()
     if 'lifecycle_stage' not in dict_copy:
-        dict_copy['lifecycle_stage'] = RunInfo.ACTIVE_LIFECYCLE
+        dict_copy['lifecycle_stage'] = LifecycleStage.ACTIVE
     return RunInfo.from_dictionary(dict_copy)
 
 
@@ -155,7 +156,7 @@ class FileStore(AbstractStore):
         self._check_root_dir()
         meta_dir = mkdir(self.root_directory, str(experiment_id))
         artifact_uri = artifact_uri or build_path(self.artifact_root_uri, str(experiment_id))
-        experiment = Experiment(experiment_id, name, artifact_uri, Experiment.ACTIVE_LIFECYCLE)
+        experiment = Experiment(experiment_id, name, artifact_uri, LifecycleStage.ACTIVE)
         write_yaml(meta_dir, FileStore.META_DATA_FILE_NAME, dict(experiment))
         return experiment_id
 
@@ -166,7 +167,7 @@ class FileStore(AbstractStore):
                                   databricks_pb2.INVALID_PARAMETER_VALUE)
         experiment = self.get_experiment_by_name(name)
         if experiment is not None:
-            if experiment.lifecycle_stage == Experiment.DELETED_LIFECYCLE:
+            if experiment.lifecycle_stage == LifecycleStage.DELETED:
                 raise MlflowException(
                     "Experiment '%s' already exists in deleted state. "
                     "You can restore the experiment, or permanently delete the experiment "
@@ -194,9 +195,9 @@ class FileStore(AbstractStore):
                                   databricks_pb2.RESOURCE_DOES_NOT_EXIST)
         meta = read_yaml(experiment_dir, FileStore.META_DATA_FILE_NAME)
         if experiment_dir.startswith(self.trash_folder):
-            meta['lifecycle_stage'] = Experiment.DELETED_LIFECYCLE
+            meta['lifecycle_stage'] = LifecycleStage.DELETED
         else:
-            meta['lifecycle_stage'] = Experiment.ACTIVE_LIFECYCLE
+            meta['lifecycle_stage'] = LifecycleStage.ACTIVE
         experiment = Experiment.from_dictionary(meta)
         if int(experiment_id) != experiment.experiment_id:
             logging.warning("Experiment ID mismatch for exp %s. ID recorded as '%s' in meta data. "
@@ -253,7 +254,7 @@ class FileStore(AbstractStore):
             raise MlflowException("Experiment '%s' does not exist." % experiment_id,
                                   databricks_pb2.RESOURCE_DOES_NOT_EXIST)
         experiment._set_name(new_name)
-        if experiment.lifecycle_stage != Experiment.ACTIVE_LIFECYCLE:
+        if experiment.lifecycle_stage != LifecycleStage.ACTIVE:
             raise Exception("Cannot rename experiment in non-active lifecycle stage."
                             " Current stage: %s" % experiment.lifecycle_stage)
         write_yaml(meta_dir, FileStore.META_DATA_FILE_NAME, dict(experiment), overwrite=True)
@@ -264,7 +265,7 @@ class FileStore(AbstractStore):
             raise MlflowException("Run '%s' metadata is in invalid state." % run_id,
                                   databricks_pb2.INVALID_STATE)
         check_run_is_active(run_info)
-        new_info = run_info._copy_with_overrides(lifecycle_stage=RunInfo.DELETED_LIFECYCLE)
+        new_info = run_info._copy_with_overrides(lifecycle_stage=LifecycleStage.DELETED)
         self._overwrite_run_info(new_info)
 
     def restore_run(self, run_id):
@@ -273,7 +274,7 @@ class FileStore(AbstractStore):
             raise MlflowException("Run '%s' metadata is in invalid state." % run_id,
                                   databricks_pb2.INVALID_STATE)
         check_run_is_deleted(run_info)
-        new_info = run_info._copy_with_overrides(lifecycle_stage=RunInfo.ACTIVE_LIFECYCLE)
+        new_info = run_info._copy_with_overrides(lifecycle_stage=LifecycleStage.ACTIVE)
         self._overwrite_run_info(new_info)
 
     def _find_experiment_folder(self, run_path):
@@ -315,7 +316,7 @@ class FileStore(AbstractStore):
                     "Could not create run under experiment with ID %s - no such experiment "
                     "exists." % experiment_id,
                     databricks_pb2.RESOURCE_DOES_NOT_EXIST)
-        if experiment.lifecycle_stage != Experiment.ACTIVE_LIFECYCLE:
+        if experiment.lifecycle_stage != LifecycleStage.ACTIVE:
             raise MlflowException(
                     "Could not create run under non-active experiment with ID "
                     "%s." % experiment_id,
@@ -328,7 +329,7 @@ class FileStore(AbstractStore):
                            source_name=source_name,
                            entry_point_name=entry_point_name, user_id=user_id,
                            status=RunStatus.RUNNING, start_time=start_time, end_time=None,
-                           source_version=source_version, lifecycle_stage=RunInfo.ACTIVE_LIFECYCLE)
+                           source_version=source_version, lifecycle_stage=LifecycleStage.ACTIVE)
         # Persist run metadata and create directories for logging metrics, parameters, artifacts
         run_dir = self._get_run_dir(run_info.experiment_id, run_info.run_uuid)
         mkdir(run_dir)
@@ -489,16 +490,6 @@ class FileStore(AbstractStore):
             tags.append(self._get_tag_from_file(parent_path, tag_file))
         return tags
 
-    def _lifecycle_stage_valid_for_view_type(self, view_type, lifecycle_stage):
-        if view_type == ViewType.ALL:
-            return True
-        elif view_type == ViewType.ACTIVE_ONLY:
-            return lifecycle_stage == RunInfo.ACTIVE_LIFECYCLE
-        elif view_type == ViewType.DELETED_ONLY:
-            return lifecycle_stage == RunInfo.DELETED_LIFECYCLE
-        else:
-            raise ExecutionException("Invalid view type '%s'" % str(view_type))
-
     def _list_run_infos(self, experiment_id, view_type):
         self._check_root_dir()
         if not self._has_experiment(experiment_id):
@@ -512,7 +503,7 @@ class FileStore(AbstractStore):
                 run_info = self._get_run_info(r_id)
                 if run_info is None:
                     continue
-                if self._lifecycle_stage_valid_for_view_type(view_type, run_info.lifecycle_stage):
+                if LifecycleStage.matches_view_type(view_type, run_info.lifecycle_stage):
                     run_infos.append(run_info)
             except MissingConfigException as rnfe:
                 # trap malformed run exception and log warning

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -1,5 +1,7 @@
 import sqlalchemy
 import uuid
+
+from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.store.dbmodels.models import Base, SqlExperiment, SqlRun, SqlMetric, SqlParam, SqlTag
 from mlflow.entities import Experiment, RunInfo, RunStatus, SourceType
 from mlflow.store.abstract_store import AbstractStore
@@ -51,7 +53,7 @@ class SqlAlchemyStore(AbstractStore):
             raise MlflowException('Invalid experiment name', INVALID_PARAMETER_VALUE)
         try:
             experiment = SqlExperiment(
-                name=name, lifecycle_stage=Experiment.ACTIVE_LIFECYCLE,
+                name=name, lifecycle_stage=LifecycleStage.ACTIVE,
                 artifact_location=artifact_location
             )
             self.session.add(experiment)
@@ -65,12 +67,7 @@ class SqlAlchemyStore(AbstractStore):
         return experiment.to_mlflow_entity()
 
     def _list_experiments(self, experiments, view_type=ViewType.ACTIVE_ONLY):
-        stages = []
-        if view_type == ViewType.ACTIVE_ONLY or view_type == ViewType.ALL:
-            stages.append(Experiment.ACTIVE_LIFECYCLE)
-        if view_type == ViewType.DELETED_ONLY or view_type == ViewType.ALL:
-            stages.append(Experiment.DELETED_LIFECYCLE)
-
+        stages = LifecycleStage.matching_view_type(view_type)
         conditions = [SqlExperiment.lifecycle_stage.in_(stages)]
 
         if len(experiments) > 0:
@@ -97,17 +94,17 @@ class SqlAlchemyStore(AbstractStore):
 
     def delete_experiment(self, experiment_id):
         experiment = self._get_experiment(experiment_id, ViewType.ACTIVE_ONLY)
-        experiment.lifecycle_stage = Experiment.DELETED_LIFECYCLE
+        experiment.lifecycle_stage = LifecycleStage.DELETED
         self._save_to_db(experiment)
 
     def restore_experiment(self, experiment_id):
         experiment = self._get_experiment(experiment_id, ViewType.DELETED_ONLY)
-        experiment.lifecycle_stage = Experiment.ACTIVE_LIFECYCLE
+        experiment.lifecycle_stage = LifecycleStage.ACTIVE
         self._save_to_db(experiment)
 
     def rename_experiment(self, experiment_id, new_name):
         experiment = self._get_experiment(experiment_id, ViewType.ALL)
-        if experiment.lifecycle_stage != Experiment.ACTIVE_LIFECYCLE:
+        if experiment.lifecycle_stage != LifecycleStage.ACTIVE:
             raise MlflowException('Cannot rename a non-active experiment.', INVALID_STATE)
 
         experiment.name = new_name
@@ -117,7 +114,7 @@ class SqlAlchemyStore(AbstractStore):
                    entry_point_name, start_time, source_version, tags, parent_run_id):
         experiment = self.get_experiment(experiment_id)
 
-        if experiment.lifecycle_stage != Experiment.ACTIVE_LIFECYCLE:
+        if experiment.lifecycle_stage != LifecycleStage.ACTIVE:
             raise MlflowException('Experiment id={} must be active'.format(experiment_id),
                                   INVALID_STATE)
         status = RunStatus.to_string(RunStatus.RUNNING)
@@ -126,7 +123,7 @@ class SqlAlchemyStore(AbstractStore):
                      experiment_id=experiment_id, source_type=SourceType.to_string(source_type),
                      source_name=source_name, entry_point_name=entry_point_name,
                      user_id=user_id, status=status, start_time=start_time, end_time=None,
-                     source_version=source_version, lifecycle_stage=RunInfo.ACTIVE_LIFECYCLE)
+                     source_version=source_version, lifecycle_stage=LifecycleStage.ACTIVE)
 
         for tag in tags:
             run.tags.append(SqlTag(key=tag.key, value=tag.value))
@@ -140,12 +137,7 @@ class SqlAlchemyStore(AbstractStore):
         return run.to_mlflow_entity()
 
     def _get_run(self, run_uuid, view_type):
-        stages = []
-        if view_type == ViewType.ACTIVE_ONLY or view_type == ViewType.ALL:
-            stages.append(RunInfo.ACTIVE_LIFECYCLE)
-        if view_type == ViewType.DELETED_ONLY or view_type == ViewType.ALL:
-            stages.append(RunInfo.DELETED_LIFECYCLE)
-
+        stages = LifecycleStage.matching_view_type(view_type)
         runs = self.session.query(SqlRun).filter(SqlRun.run_uuid == run_uuid,
                                                  SqlRun.lifecycle_stage.in_(stages)).all()
 
@@ -175,12 +167,12 @@ class SqlAlchemyStore(AbstractStore):
 
     def restore_run(self, run_id):
         run = self._get_run(run_id, ViewType.DELETED_ONLY)
-        run.lifecycle_stage = RunInfo.ACTIVE_LIFECYCLE
+        run.lifecycle_stage = LifecycleStage.ACTIVE
         self._save_to_db(run)
 
     def delete_run(self, run_id):
         run = self._get_run(run_id, ViewType.ACTIVE_ONLY)
-        run.lifecycle_stage = RunInfo.DELETED_LIFECYCLE
+        run.lifecycle_stage = LifecycleStage.DELETED
         self._save_to_db(run)
 
     def log_metric(self, run_uuid, metric):

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -3,7 +3,7 @@ import uuid
 
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.store.dbmodels.models import Base, SqlExperiment, SqlRun, SqlMetric, SqlParam, SqlTag
-from mlflow.entities import Experiment, RunInfo, RunStatus, SourceType
+from mlflow.entities import RunStatus, SourceType
 from mlflow.store.abstract_store import AbstractStore
 from mlflow.entities import ViewType
 from mlflow.exceptions import MlflowException
@@ -67,7 +67,7 @@ class SqlAlchemyStore(AbstractStore):
         return experiment.to_mlflow_entity()
 
     def _list_experiments(self, experiments, view_type=ViewType.ACTIVE_ONLY):
-        stages = LifecycleStage.matching_view_type(view_type)
+        stages = LifecycleStage.view_type_to_stages(view_type)
         conditions = [SqlExperiment.lifecycle_stage.in_(stages)]
 
         if len(experiments) > 0:
@@ -137,7 +137,7 @@ class SqlAlchemyStore(AbstractStore):
         return run.to_mlflow_entity()
 
     def _get_run(self, run_uuid, view_type):
-        stages = LifecycleStage.matching_view_type(view_type)
+        stages = LifecycleStage.view_type_to_stages(view_type)
         runs = self.session.query(SqlRun).filter(SqlRun.run_uuid == run_uuid,
                                                  SqlRun.lifecycle_stage.in_(stages)).all()
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -15,6 +15,7 @@ import logging
 
 import mlflow.tracking.utils
 from mlflow.entities import Experiment, Run, SourceType, RunInfo, RunStatus
+from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils import env
@@ -48,7 +49,7 @@ def set_experiment(experiment_name):
     if exp_id is None:  # id can be 0
         print("INFO: '{}' does not exist. Creating a new experiment".format(experiment_name))
         exp_id = client.create_experiment(experiment_name)
-    elif experiment.lifecycle_stage == Experiment.DELETED_LIFECYCLE:
+    elif experiment.lifecycle_stage == LifecycleStage.DELETED:
         raise MlflowException(
             "Cannot set a deleted experiment '%s' as the active experiment."
             " You can restore the experiment, or permanently delete the "
@@ -113,7 +114,7 @@ def start_run(run_uuid=None, experiment_id=None, source_name=None, source_versio
     if existing_run_uuid:
         _validate_run_id(existing_run_uuid)
         active_run_obj = MlflowClient().get_run(existing_run_uuid)
-        if active_run_obj.info.lifecycle_stage == RunInfo.DELETED_LIFECYCLE:
+        if active_run_obj.info.lifecycle_stage == LifecycleStage.DELETED:
             raise MlflowException("Cannot start run with ID {} because it is in the "
                                   "deleted state.".format(existing_run_uuid))
     else:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -14,7 +14,7 @@ import time
 import logging
 
 import mlflow.tracking.utils
-from mlflow.entities import Experiment, Run, SourceType, RunInfo, RunStatus
+from mlflow.entities import Experiment, Run, SourceType, RunStatus
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     package_data={"mlflow": js_files + sagmaker_server_files},
     install_requires=[
         'click>=6.7',
-        'cloudpickle',
+        'cloudpickle==0.6.1',
         'databricks-cli>=0.8.0',
         'requests>=2.17.3',
         'six>=1.10.0',

--- a/tests/entities/test_experiment.py
+++ b/tests/entities/test_experiment.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mlflow.entities import Experiment
+from mlflow.entities import Experiment, LifecycleStage
 from tests.helper_functions import random_int, random_file
 
 
@@ -15,7 +15,7 @@ class TestExperiment(unittest.TestCase):
     def test_creation_and_hydration(self):
         exp_id = random_int()
         name = "exp_%d_%d" % (random_int(), random_int())
-        lifecycle_stage = Experiment.ACTIVE_LIFECYCLE
+        lifecycle_stage = LifecycleStage.ACTIVE
         location = random_file(".json")
 
         exp = Experiment(exp_id, name, location, lifecycle_stage)
@@ -34,6 +34,6 @@ class TestExperiment(unittest.TestCase):
 
     def test_string_repr(self):
         exp = Experiment(experiment_id=0, name="myname", artifact_location="hi",
-                         lifecycle_stage=Experiment.ACTIVE_LIFECYCLE)
+                         lifecycle_stage=LifecycleStage.ACTIVE)
         assert str(exp) == "<Experiment: artifact_location='hi', experiment_id=0, " \
                            "lifecycle_stage='active', name='myname'>"

--- a/tests/entities/test_run.py
+++ b/tests/entities/test_run.py
@@ -1,4 +1,4 @@
-from mlflow.entities import Run, Metric, RunData, SourceType, RunStatus, RunInfo
+from mlflow.entities import Run, Metric, RunData, SourceType, RunStatus, RunInfo, LifecycleStage
 from tests.entities.test_run_data import TestRunData
 from tests.entities.test_run_info import TestRunInfo
 
@@ -52,7 +52,7 @@ class TestRun(TestRunInfo, TestRunData):
             run_uuid="hi", experiment_id=0, name="name", source_type=SourceType.PROJECT,
             source_name="source-name", entry_point_name="entry-point-name",
             user_id="user-id", status=RunStatus.FAILED, start_time=0, end_time=1,
-            source_version="version", lifecycle_stage=RunInfo.ACTIVE_LIFECYCLE)
+            source_version="version", lifecycle_stage=LifecycleStage.ACTIVE)
         metrics = [Metric("key", i, 0) for i in range(5)]
         run_data = RunData(metrics=metrics, params=[], tags=[])
         run1 = Run(run_info, run_data)

--- a/tests/entities/test_run_info.py
+++ b/tests/entities/test_run_info.py
@@ -1,7 +1,7 @@
 import unittest
 import uuid
 
-from mlflow.entities import RunInfo
+from mlflow.entities import RunInfo, LifecycleStage
 from tests.helper_functions import random_str, random_int
 
 
@@ -37,7 +37,7 @@ class TestRunInfo(unittest.TestCase):
         start_time = random_int(1, 10)
         end_time = start_time + random_int(1, 10)
         source_version = random_str(random_int(10, 40))
-        lifecycle_stage = RunInfo.ACTIVE_LIFECYCLE
+        lifecycle_stage = LifecycleStage.ACTIVE
         artifact_uri = random_str(random_int(10, 40))
         ri = RunInfo(run_uuid=run_uuid, experiment_id=experiment_id, name=name,
                      source_type=source_type, source_name=source_name,

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -9,7 +9,7 @@ import uuid
 import mock
 import pytest
 
-from mlflow.entities import Experiment, Metric, Param, RunTag, ViewType, RunInfo
+from mlflow.entities import Experiment, Metric, Param, RunTag, ViewType, RunInfo, LifecycleStage
 from mlflow.exceptions import MlflowException, MissingConfigException
 from mlflow.store.file_store import FileStore
 from mlflow.utils.file_utils import write_yaml, read_yaml
@@ -200,8 +200,7 @@ class TestFileStore(unittest.TestCase):
         self.assertTrue(exp_id not in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY)))
         self.assertTrue(exp_id in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY)))
         self.assertTrue(exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL)))
-        self.assertEqual(fs.get_experiment(exp_id).lifecycle_stage,
-                         Experiment.DELETED_LIFECYCLE)
+        self.assertEqual(fs.get_experiment(exp_id).lifecycle_stage, LifecycleStage.DELETED)
 
         # restore it
         fs.restore_experiment(exp_id)
@@ -214,8 +213,7 @@ class TestFileStore(unittest.TestCase):
         self.assertTrue(exp_id in self._extract_ids(fs.list_experiments(ViewType.ACTIVE_ONLY)))
         self.assertTrue(exp_id not in self._extract_ids(fs.list_experiments(ViewType.DELETED_ONLY)))
         self.assertTrue(exp_id in self._extract_ids(fs.list_experiments(ViewType.ALL)))
-        self.assertEqual(fs.get_experiment(exp_id).lifecycle_stage,
-                         Experiment.ACTIVE_LIFECYCLE)
+        self.assertEqual(fs.get_experiment(exp_id).lifecycle_stage, LifecycleStage.ACTIVE)
 
     def test_rename_experiment(self):
         fs = FileStore(self.test_root)
@@ -270,7 +268,7 @@ class TestFileStore(unittest.TestCase):
                 run_info.pop("metrics")
                 run_info.pop("params")
                 run_info.pop("tags")
-                run_info['lifecycle_stage'] = RunInfo.ACTIVE_LIFECYCLE
+                run_info['lifecycle_stage'] = LifecycleStage.ACTIVE
                 self.assertEqual(run_info, dict(run.info))
 
     def test_list_run_infos(self):
@@ -283,7 +281,7 @@ class TestFileStore(unittest.TestCase):
                 dict_run_info.pop("metrics")
                 dict_run_info.pop("params")
                 dict_run_info.pop("tags")
-                dict_run_info['lifecycle_stage'] = RunInfo.ACTIVE_LIFECYCLE
+                dict_run_info['lifecycle_stage'] = LifecycleStage.ACTIVE
                 self.assertEqual(dict_run_info, dict(run_info))
 
     def test_get_metric(self):
@@ -441,7 +439,7 @@ class TestFileStore(unittest.TestCase):
         run_id = self.exp_data[exp_id]['runs'][0]
         fs.delete_run(run_id)
 
-        assert fs.get_run(run_id).info.lifecycle_stage == RunInfo.DELETED_LIFECYCLE
+        assert fs.get_run(run_id).info.lifecycle_stage == LifecycleStage.DELETED
         with pytest.raises(MlflowException):
             fs.set_tag(run_id, RunTag('a', 'b'))
         with pytest.raises(MlflowException):
@@ -461,7 +459,7 @@ class TestFileStore(unittest.TestCase):
         fs = FileStore(self.test_root)
         fs.delete_experiment(Experiment.DEFAULT_EXPERIMENT_ID)
         fs = FileStore(self.test_root)
-        assert fs.get_experiment(0).lifecycle_stage == Experiment.DELETED_LIFECYCLE
+        assert fs.get_experiment(0).lifecycle_stage == LifecycleStage.DELETED
 
     def test_malformed_experiment(self):
         fs = FileStore(self.test_root)

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -9,7 +9,7 @@ import uuid
 import mock
 import pytest
 
-from mlflow.entities import Experiment, Metric, Param, RunTag, ViewType, RunInfo, LifecycleStage
+from mlflow.entities import Experiment, Metric, Param, RunTag, ViewType, LifecycleStage
 from mlflow.exceptions import MlflowException, MissingConfigException
 from mlflow.store.file_store import FileStore
 from mlflow.utils.file_utils import write_yaml, read_yaml

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -29,7 +29,7 @@ class TestRestStore(unittest.TestCase):
             }
             response = mock.MagicMock
             response.status_code = 200
-            response.text = '{"experiments": [{"name": "Exp!"}]}'
+            response.text = '{"experiments": [{"name": "Exp!", "lifecycle_stage": "active"}]}'
             return response
 
         request.side_effect = mock_request
@@ -56,6 +56,7 @@ class TestRestStore(unittest.TestCase):
             "experiment_id": 1,
             "name": "My experiment",
             "artifact_location": "foo",
+            "lifecycle_stage": "deleted",
             "OMG_WHAT_IS_THIS_FIELD": "Hooly cow",
         }
 

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -54,7 +54,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         actual = self.session.query(models.SqlExperiment).get(exp.experiment_id)
         self.assertEqual(len(self.store.list_experiments()), len(experiments) - 1)
 
-        self.assertEqual(actual.lifecycle_stage, entities.Experiment.DELETED_LIFECYCLE)
+        self.assertEqual(actual.lifecycle_stage, entities.LifecycleStage.DELETED)
 
     def test_get_experiment(self):
         name = 'goku'
@@ -166,14 +166,14 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
             'name': 'test run',
             'user_id': 'Anderson',
             'run_uuid': 'test',
-            'status': entities.RunInfo.ACTIVE_LIFECYCLE,
+            'status': entities.LifecycleStage.ACTIVE,
             'source_type': entities.SourceType.LOCAL,
             'source_name': 'Python application',
             'entry_point_name': 'main.py',
             'start_time': int(time.time()),
             'end_time': int(time.time()),
             'source_version': mlflow.__version__,
-            'lifecycle_stage': entities.RunInfo.ACTIVE_LIFECYCLE,
+            'lifecycle_stage': entities.LifecycleStage.ACTIVE,
             'artifact_uri': '//'
         }
         run = models.SqlRun(**config).to_mlflow_entity()
@@ -203,7 +203,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
             'start_time': int(time.time()),
             'end_time': int(time.time()),
             'source_version': mlflow.__version__,
-            'lifecycle_stage': entities.RunInfo.ACTIVE_LIFECYCLE,
+            'lifecycle_stage': entities.LifecycleStage.ACTIVE,
             'artifact_uri': '//'
         }
 
@@ -294,7 +294,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         run_uuid = run.run_uuid
         self.store.delete_run(run_uuid)
         actual = self.session.query(models.SqlRun).filter_by(run_uuid=run_uuid).first()
-        self.assertEqual(actual.lifecycle_stage, entities.RunInfo.DELETED_LIFECYCLE)
+        self.assertEqual(actual.lifecycle_stage, entities.LifecycleStage.DELETED)
 
         deleted_run = self.store.get_run(run_uuid)
         self.assertEqual(actual.run_uuid, deleted_run.info.run_uuid)
@@ -469,32 +469,32 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
     def test_restore_experiment(self):
         exp = self._experiment_factory('helloexp')
-        self.assertEqual(exp.lifecycle_stage, entities.Experiment.ACTIVE_LIFECYCLE)
+        self.assertEqual(exp.lifecycle_stage, entities.LifecycleStage.ACTIVE)
 
         experiment_id = exp.experiment_id
         self.store.delete_experiment(experiment_id)
 
         deleted = self.store.get_experiment(experiment_id)
         self.assertEqual(deleted.experiment_id, experiment_id)
-        self.assertEqual(deleted.lifecycle_stage, entities.Experiment.DELETED_LIFECYCLE)
+        self.assertEqual(deleted.lifecycle_stage, entities.LifecycleStage.DELETED)
 
         self.store.restore_experiment(exp.experiment_id)
         restored = self.store.get_experiment(exp.experiment_id)
         self.assertEqual(restored.experiment_id, experiment_id)
-        self.assertEqual(restored.lifecycle_stage, entities.Experiment.ACTIVE_LIFECYCLE)
+        self.assertEqual(restored.lifecycle_stage, entities.LifecycleStage.ACTIVE)
 
     def test_restore_run(self):
         run = self._run_factory()
-        self.assertEqual(run.lifecycle_stage, entities.RunInfo.ACTIVE_LIFECYCLE)
+        self.assertEqual(run.lifecycle_stage, entities.LifecycleStage.ACTIVE)
 
         run_uuid = run.run_uuid
         self.store.delete_run(run_uuid)
 
         deleted = self.store.get_run(run_uuid)
         self.assertEqual(deleted.info.run_uuid, run_uuid)
-        self.assertEqual(deleted.info.lifecycle_stage, entities.RunInfo.DELETED_LIFECYCLE)
+        self.assertEqual(deleted.info.lifecycle_stage, entities.LifecycleStage.DELETED)
 
         self.store.restore_run(run_uuid)
         restored = self.store.get_run(run_uuid)
         self.assertEqual(restored.info.run_uuid, run_uuid)
-        self.assertEqual(restored.info.lifecycle_stage, entities.RunInfo.ACTIVE_LIFECYCLE)
+        self.assertEqual(restored.info.lifecycle_stage, entities.LifecycleStage.ACTIVE)

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -9,7 +9,7 @@ import pytest
 
 import mlflow
 from mlflow import tracking
-from mlflow.entities import Experiment, RunStatus
+from mlflow.entities import Experiment, RunStatus, LifecycleStage
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.fluent import start_run, end_run
@@ -86,7 +86,7 @@ def test_set_experiment_with_zero_id(reset_mock, reset_active_experiment):
     reset_mock(MlflowClient, "get_experiment_by_name",
                mock.Mock(return_value=attrdict.AttrDict(
                    experiment_id=0,
-                   lifecycle_stage=Experiment.ACTIVE_LIFECYCLE)))
+                   lifecycle_stage=LifecycleStage.ACTIVE)))
     reset_mock(MlflowClient, "create_experiment", mock.Mock())
 
     mlflow.set_experiment("my_exp")

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -9,7 +9,7 @@ import pytest
 
 import mlflow
 from mlflow import tracking
-from mlflow.entities import Experiment, RunStatus, LifecycleStage
+from mlflow.entities import RunStatus, LifecycleStage
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.fluent import start_run, end_run


### PR DESCRIPTION
## Simple refactor.

1. Unifying `Experiment.{ACTIVE_LIFECYCLE, DELETED_LIFECYCLE}` and `RunInfo.{ACTIVE_LIFECYCLE, DELETED_LIFECYCLE}` int `entities.LifecycleStage.{ACTIVE, DELETED}`.
2. Removed all duplicated code in all stores and tracking APIs to map view type to lifecycle stages.
3. Fixed tests
