### PR TITLE
Cli.py documentation/docstring fixes

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -85,7 +85,8 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
     """
     Run an MLflow project from the given URI.
 
-    For local runs, the run will block until it completes. Otherwise, the project will run asynchronously.
+    For local runs, the run will block until it completes. 
+    Otherwise, the project will run asynchronously.
 
     If running locally (the default), the URI can be either a Git repository URI or a local path.
     If running on Databricks, the URI must be a Git repository.

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -52,8 +52,8 @@ def cli():
                    Experiment.DEFAULT_EXPERIMENT_ID)
 # TODO: Add tracking server argument once we have it working.
 @click.option("--mode", "-m", metavar="MODE",
-              help="Execution mode to use for run. Supported values: 'local' (runs project"
-                   "locally) and 'databricks' (runs project on a Databricks cluster)."
+              help="Execution mode to use for run. Supported values: 'local' (runs project "
+                   "locally) and 'databricks' (runs project on a Databricks cluster). "
                    "Defaults to 'local'. If running against Databricks, will run against a "
                    "Databricks workspace determined as follows: if a Databricks tracking URI "
                    "of the form 'databricks://profile' has been set (e.g. by setting "
@@ -63,7 +63,7 @@ def cli():
                    "https://github.com/databricks/databricks-cli for more info on configuring a "
                    "Databricks CLI profile.")
 @click.option("--cluster-spec", "-c", metavar="FILE",
-              help="Path to JSON file (must end in '.json') or JSON string describing the cluster"
+              help="Path to JSON file (must end in '.json') or JSON string describing the cluster "
                    "to use when launching a run on Databricks. See "
                    "https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster for "
                    "more info. Note that MLflow runs are currently launched against a new cluster.")

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -85,7 +85,7 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
     """
     Run an MLflow project from the given URI.
 
-    For local runs, the run will block until it completes. 
+    For local runs, the run will block until it completes.
     Otherwise, the project will run asynchronously.
 
     If running locally (the default), the URI can be either a Git repository URI or a local path.

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -85,7 +85,7 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
     """
     Run an MLflow project from the given URI.
 
-    For local runs, blocks the run completes. Otherwise, runs the project asynchronously.
+    For local runs, the run will block until it completes. Otherwise, the project will run asynchronously.
 
     If running locally (the default), the URI can be either a Git repository URI or a local path.
     If running on Databricks, the URI must be a Git repository.


### PR DESCRIPTION
Rewording the english on line 88 in cli.py regarding execution mode. Also added some whitespace which was missing, causing words to be concatenated together.

Thanks,
Graham