### PR TITLE
Add "code paths" parameter to pytorch model persistence functions

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -200,6 +200,7 @@ from copy import deepcopy
 
 import mlflow
 import mlflow.pyfunc.model
+import mlflow.pyfunc.utils
 from mlflow.tracking.fluent import active_run, log_artifacts
 from mlflow import tracking
 from mlflow.models import Model
@@ -283,7 +284,7 @@ def load_pyfunc(path, run_id=None, suppress_warnings=False):
         _warn_potentially_incompatible_py_version_if_necessary(model_py_version=model_py_version)
     if CODE in conf and conf[CODE]:
         code_path = os.path.join(path, conf[CODE])
-        sys.path = [code_path] + _get_code_dirs(code_path) + sys.path
+        mlflow.pyfunc.utils._add_code_to_system_path(code_path=code_path)
     data_path = os.path.join(path, conf[DATA]) if (DATA in conf) else path
     return importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
 
@@ -305,21 +306,6 @@ def _warn_potentially_incompatible_py_version_if_necessary(model_py_version=None
             " from the version of Python that is currently running, `Python %s`,"
             " and may be incompatible",
             model_py_version, PYTHON_VERSION)
-
-
-def _get_code_dirs(src_code_path, dst_code_path=None):
-    """
-    Obtains the names of the subdirectories contained under the specified source code
-    path and joins them with the specified destination code path.
-
-    :param src_code_path: The path of the source code directory for which to list subdirectories.
-    :param dst_code_path: The destination directory path to which subdirectory names should be
-                          joined.
-    """
-    if not dst_code_path:
-        dst_code_path = src_code_path
-    return [(os.path.join(dst_code_path, x)) for x in os.listdir(src_code_path)
-            if os.path.isdir(x) and not x == "__pycache__"]
 
 
 def spark_udf(spark, path, run_id=None, result_type="double"):
@@ -699,8 +685,8 @@ def get_module_loader_src(src_path, dst_path):
     if CODE in conf and conf[CODE]:
         src_code_path = os.path.join(src_path, conf[CODE])
         dst_code_path = os.path.join(dst_path, conf[CODE])
-        code_path = ["os.path.abspath('%s')" % x
-                     for x in [dst_code_path] + _get_code_dirs(src_code_path, dst_code_path)]
+        code_path = ["os.path.abspath('%s')" % x for x in [dst_code_path] +
+                     mlflow.pyfunc.utils._get_code_dirs(src_code_path, dst_code_path)]
         update_path = "sys.path = {} + sys.path; ".format("[%s]" % ",".join(code_path))
 
     data_path = os.path.join(dst_path, conf[DATA]) if (DATA in conf) else dst_path

--- a/mlflow/pyfunc/utils.py
+++ b/mlflow/pyfunc/utils.py
@@ -1,0 +1,21 @@
+import os
+import sys
+
+
+def _add_code_to_system_path(code_path):
+    sys.path = [code_path] + _get_code_dirs(code_path) + sys.path
+
+
+def _get_code_dirs(src_code_path, dst_code_path=None):
+    """
+    Obtains the names of the subdirectories contained under the specified source code
+    path and joins them with the specified destination code path.
+
+    :param src_code_path: The path of the source code directory for which to list subdirectories.
+    :param dst_code_path: The destination directory path to which subdirectory names should be
+                          joined.
+    """
+    if not dst_code_path:
+        dst_code_path = src_code_path
+    return [(os.path.join(dst_code_path, x)) for x in os.listdir(src_code_path)
+            if os.path.isdir(x) and not x == "__pycache__"]

--- a/mlflow/pytorch.py
+++ b/mlflow/pytorch.py
@@ -74,8 +74,7 @@ def log_model(pytorch_model, artifact_path, conda_env=None, code_paths=None, **k
 
     :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
                        containing file dependencies). These files will be *prepended* to the system
-                       path when the model is as a generic python function via
-                       :func:`mlflow.pyfunc.load_pyfunc`.
+                       path when the model is loaded.
     :param kwargs: kwargs to pass to ``torch.save`` method.
 
     >>> import torch
@@ -159,8 +158,7 @@ def save_model(pytorch_model, path, conda_env=None, mlflow_model=Model(), code_p
     :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
     :param code_paths: A list of local filesystem paths to Python file dependencies (or directories
                        containing file dependencies). These files will be *prepended* to the system
-                       path when the model is as a generic python function via
-                       :func:`mlflow.pyfunc.load_pyfunc`.
+                       path when the model is loaded.
     :param kwargs: kwargs to pass to ``torch.save`` method.
 
     >>> import torch

--- a/mlflow/pytorch.py
+++ b/mlflow/pytorch.py
@@ -244,7 +244,6 @@ def load_model(path, run_id=None, **kwargs):
         path = mlflow.tracking.utils._get_model_log_dir(model_name=path, run_id=run_id)
     path = os.path.abspath(path)
 
-<<<<<<< HEAD
     try:
         pyfunc_conf = _get_flavor_configuration(model_path=path, flavor_name=pyfunc.FLAVOR_NAME)
     except MlflowException:
@@ -255,18 +254,10 @@ def load_model(path, run_id=None, **kwargs):
 
     pytorch_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
     if torch.__version__ != pytorch_conf["pytorch_version"]:
-        raise ValueError("Stored model version '{}' does not match "
-                         "installed PyTorch version '{}'"
-                         .format(pytorch_conf["pytorch_version"], torch.__version__))
-
-    torch_model_artifacts_path = os.path.join(path, pytorch_conf['model_data'])
-=======
-    if torch.__version__ != flavor_conf["pytorch_version"]:
         _logger.warning(
             "Stored model version '%s' does not match installed PyTorch version '%s'",
-            flavor_conf["pytorch_version"], torch.__version__)
-    torch_model_artifacts_path = os.path.join(path, flavor_conf['model_data'])
->>>>>>> origin/master
+            pytorch_conf["pytorch_version"], torch.__version__)
+    torch_model_artifacts_path = os.path.join(path, pytorch_conf['model_data'])
     return _load_model(path=torch_model_artifacts_path, **kwargs)
 
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -290,8 +290,8 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
     assert conda_env == mlflow.pytorch.DEFAULT_CONDA_ENV
 
 
-def test_load_model_with_differing_pytorch_version_logs_warning(model, model_path):
-    mlflow.pytorch.save_model(pytorch_model=model, path=model_path)
+def test_load_model_with_differing_pytorch_version_logs_warning(sequential_model, model_path):
+    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path)
     saver_pytorch_version = "1.0"
     model_config_path = os.path.join(model_path, "MLmodel")
     model_config = Model.load(model_config_path)

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -321,10 +321,10 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
         conda_env=None,
         code_paths=[__file__])
 
-
     # Define a custom pyfunc model that loads a PyTorch model artifact using
     # `mlflow.pytorch.load_model`
     class TorchValidatorModel(pyfunc.PythonModel):
+
         def load_context(self, context):
             self.pytorch_model = mlflow.pytorch.load_model(context.artifacts["pytorch_model"])
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -88,7 +88,7 @@ class SubclassedModel(torch.nn.Module):
 
     def __init__(self):
         super(SubclassedModel, self).__init__()
-        self.linear = torch.nn.Linear(4, 1) 
+        self.linear = torch.nn.Linear(4, 1)
 
     def forward(self, x):
         y_pred = self.linear(x)
@@ -290,8 +290,8 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 def test_pyfunc_model_serving_with_subclassed_nn_model_and_default_conda_env(
         subclassed_model, model_path, data, subclassed_predicted):
     mlflow.pytorch.save_model(
-        path=model_path, 
-        pytorch_model=subclassed_model, 
+        path=model_path,
+        pytorch_model=subclassed_model,
         conda_env=None,
         code_paths=[__file__])
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -52,6 +52,7 @@ def get_dataset(data):
                for xi, yi in zip(x.values, y.values)]
     return dataset
 
+
 def train_model(model, data):
     dataset = get_dataset(data)
     criterion = nn.MSELoss()

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 import os
+import logging
 import json
 
 import pytest
@@ -22,7 +23,17 @@ from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 
-from tests.helper_functions import score_model_in_sagemaker_docker_container
+_logger = logging.getLogger(__name__)
+
+# This test suite is included as a code dependency when testing PyTorch model scoring in new
+# processes and docker containers. In these environments, the `tests` module is not available.
+# Therefore, we attempt to import from `tests` and gracefully emit a warning if it's unavailable.
+try:
+    from tests.helper_functions import pyfunc_serve_and_score_model
+    from tests.helper_functions import score_model_in_sagemaker_docker_container
+except ImportError:
+    _logger.warning(
+        "Failed to import test helper functions. Tests depending on these functions may fail!")
 
 
 @pytest.fixture(scope='module')
@@ -41,26 +52,17 @@ def get_dataset(data):
                for xi, yi in zip(x.values, y.values)]
     return dataset
 
-
-@pytest.fixture(scope='module')
-def model(data):
+def train_model(model, data):
     dataset = get_dataset(data)
-    model = nn.Sequential(
-        nn.Linear(4, 3),
-        nn.ReLU(),
-        nn.Linear(3, 1),
-    )
-
     criterion = nn.MSELoss()
     optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
-
     batch_size = 16
     num_workers = 4
     dataloader = DataLoader(dataset, batch_size=batch_size,
                             num_workers=num_workers, shuffle=True, drop_last=False)
 
     model.train()
-    for epoch in range(5):
+    for _ in range(5):
         for batch in dataloader:
             optimizer.zero_grad()
             batch_size = batch[0].shape[0]
@@ -69,6 +71,34 @@ def model(data):
             loss.backward()
             optimizer.step()
 
+
+@pytest.fixture(scope='module')
+def sequential_model(data):
+    model = nn.Sequential(
+        nn.Linear(4, 3),
+        nn.ReLU(),
+        nn.Linear(3, 1),
+    )
+
+    train_model(model=model, data=data)
+    return model
+
+
+class SubclassedModel(torch.nn.Module):
+
+    def __init__(self):
+        super(SubclassedModel, self).__init__()
+        self.linear = torch.nn.Linear(4, 1) 
+
+    def forward(self, x):
+        y_pred = self.linear(x)
+        return y_pred
+
+
+@pytest.fixture(scope='module')
+def subclassed_model(data):
+    model = SubclassedModel()
+    train_model(model=model, data=data)
     return model
 
 
@@ -103,11 +133,16 @@ def _predict(model, data):
 
 
 @pytest.fixture(scope='module')
-def predicted(model, data):
-    return _predict(model, data)
+def sequential_predicted(sequential_model, data):
+    return _predict(sequential_model, data)
 
 
-def test_log_model(model, data, predicted):
+@pytest.fixture(scope='module')
+def subclassed_predicted(subclassed_model, data):
+    return _predict(subclassed_model, data)
+
+
+def test_log_model(sequential_model, data, sequential_predicted):
     old_uri = tracking.get_tracking_uri()
     # should_start_run tests whether or not calling log_model() automatically starts a run.
     for should_start_run in [False, True]:
@@ -117,20 +152,20 @@ def test_log_model(model, data, predicted):
                 if should_start_run:
                     mlflow.start_run()
 
-                mlflow.pytorch.log_model(model, artifact_path="pytorch")
+                mlflow.pytorch.log_model(sequential_model, artifact_path="pytorch")
 
                 # Load model
                 run_id = mlflow.active_run().info.run_uuid
-                model_loaded = mlflow.pytorch.load_model("pytorch", run_id=run_id)
+                sequential_model_loaded = mlflow.pytorch.load_model("pytorch", run_id=run_id)
 
-                test_predictions = _predict(model_loaded, data)
-                np.testing.assert_array_equal(test_predictions, predicted)
+                test_predictions = _predict(sequential_model_loaded, data)
+                np.testing.assert_array_equal(test_predictions, sequential_predicted)
             finally:
                 mlflow.end_run()
                 tracking.set_tracking_uri(old_uri)
 
 
-def test_raise_exception(model):
+def test_raise_exception(sequential_model):
     with TempDir(chdr=True, remove_on_exit=True) as tmp:
         path = tmp.path("model")
         with pytest.raises(MlflowException):
@@ -139,9 +174,9 @@ def test_raise_exception(model):
         with pytest.raises(TypeError):
             mlflow.pytorch.save_model([1, 2, 3], path)
 
-        mlflow.pytorch.save_model(model, path)
+        mlflow.pytorch.save_model(sequential_model, path)
         with pytest.raises(RuntimeError):
-            mlflow.pytorch.save_model(model, path)
+            mlflow.pytorch.save_model(sequential_model, path)
 
         from mlflow import sklearn
         import sklearn.neighbors as knn
@@ -156,24 +191,23 @@ def test_raise_exception(model):
             mlflow.pytorch.load_model(path)
 
 
-def test_save_and_load_model(model, model_path, data, predicted):
-    x, y = data
-    mlflow.pytorch.save_model(model, model_path)
+def test_save_and_load_model(sequential_model, model_path, data, sequential_predicted):
+    mlflow.pytorch.save_model(sequential_model, model_path)
 
     # Loading pytorch model
-    model_loaded = mlflow.pytorch.load_model(model_path)
-    np.testing.assert_array_equal(_predict(model_loaded, data), predicted)
+    sequential_model_loaded = mlflow.pytorch.load_model(model_path)
+    np.testing.assert_array_equal(_predict(sequential_model_loaded, data), sequential_predicted)
 
     # Loading pyfunc model
     pyfunc_loaded = mlflow.pyfunc.load_pyfunc(model_path)
     np.testing.assert_array_almost_equal(
-            pyfunc_loaded.predict(x).values[:, 0], predicted, decimal=4)
+        pyfunc_loaded.predict(data[0]).values[:, 0], sequential_predicted, decimal=4)
 
 
 def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
-        model, model_path, pytorch_custom_env):
+        sequential_model, model_path, pytorch_custom_env):
     mlflow.pytorch.save_model(
-            pytorch_model=model, path=model_path, conda_env=pytorch_custom_env)
+            pytorch_model=sequential_model, path=model_path, conda_env=pytorch_custom_env)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -187,10 +221,10 @@ def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
     assert saved_conda_env_text == pytorch_custom_env_text
 
 
-def test_model_save_accepts_conda_env_as_dict(model, model_path):
+def test_model_save_accepts_conda_env_as_dict(sequential_model, model_path):
     conda_env = dict(mlflow.pytorch.DEFAULT_CONDA_ENV)
     conda_env["dependencies"].append("pytest")
-    mlflow.pytorch.save_model(pytorch_model=model, path=model_path, conda_env=conda_env)
+    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path, conda_env=conda_env)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -202,10 +236,10 @@ def test_model_save_accepts_conda_env_as_dict(model, model_path):
 
 
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
-        model, pytorch_custom_env):
+        sequential_model, pytorch_custom_env):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.pytorch.log_model(pytorch_model=model,
+        mlflow.pytorch.log_model(pytorch_model=sequential_model,
                                  artifact_path=artifact_path,
                                  conda_env=pytorch_custom_env)
         run_id = mlflow.active_run().info.run_uuid
@@ -224,8 +258,8 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
 
 
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
-        model, model_path):
-    mlflow.pytorch.save_model(pytorch_model=model, path=model_path, conda_env=None)
+        sequential_model, model_path):
+    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path, conda_env=None)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -236,10 +270,10 @@ def test_model_save_without_specified_conda_env_uses_default_env_with_expected_d
 
 
 def test_model_log_without_specified_conda_env_uses_default_env_with_expected_dependencies(
-        model):
+        sequential_model):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.pytorch.log_model(pytorch_model=model,
+        mlflow.pytorch.log_model(pytorch_model=sequential_model,
                                  artifact_path=artifact_path,
                                  conda_env=None)
         run_id = mlflow.active_run().info.run_uuid
@@ -253,8 +287,27 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
     assert conda_env == mlflow.pytorch.DEFAULT_CONDA_ENV
 
 
+def test_pyfunc_model_serving_with_subclassed_nn_model_and_default_conda_env(
+        subclassed_model, model_path, data, subclassed_predicted):
+    mlflow.pytorch.save_model(
+        path=model_path, 
+        pytorch_model=subclassed_model, 
+        conda_env=None,
+        code_paths=[__file__])
+
+    scoring_response = pyfunc_serve_and_score_model(
+            model_path=model_path,
+            data=data[0],
+            content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+            extra_args=["--no-conda"])
+    assert scoring_response.status_code == 200
+
+    print("SCORING RESPONSE", scoring_response, type(scoring_response))
+
+
 @pytest.mark.release
-def test_sagemaker_docker_model_scoring_with_default_conda_env(model, model_path, data, predicted):
+def test_sagemaker_docker_model_scoring_with_sequential_model_and_default_conda_env(
+        model, model_path, data, sequential_predicted):
     mlflow.pytorch.save_model(pytorch_model=model, path=model_path, conda_env=None)
 
     scoring_response = score_model_in_sagemaker_docker_container(
@@ -267,5 +320,5 @@ def test_sagemaker_docker_model_scoring_with_default_conda_env(model, model_path
 
     np.testing.assert_array_almost_equal(
         deployed_model_preds.values[:, 0],
-        predicted,
+        sequential_predicted,
         decimal=4)

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -310,7 +310,6 @@ def test_pyfunc_model_serving_with_subclassed_nn_model_and_default_conda_env(
         decimal=4)
 
 
-
 @pytest.mark.release
 def test_sagemaker_docker_model_scoring_with_sequential_model_and_default_conda_env(
         model, model_path, data, sequential_predicted):

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -303,7 +303,12 @@ def test_pyfunc_model_serving_with_subclassed_nn_model_and_default_conda_env(
             extra_args=["--no-conda"])
     assert scoring_response.status_code == 200
 
-    print("SCORING RESPONSE", scoring_response, type(scoring_response))
+    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
+    np.testing.assert_array_almost_equal(
+        deployed_model_preds.values[:, 0],
+        subclassed_predicted,
+        decimal=4)
+
 
 
 @pytest.mark.release


### PR DESCRIPTION
When users save PyTorch models, their model class (which extends `torch.nn.Module`) and its dependencies may be defined in external modules that need to be included in the bundled model. This PR introduces a `code_paths` parameter to `mlflow.pytorch.save_model` and `mlflow.pytorch.log_model` to allow these modules to be specified as paths to python files.

~~This PR adds the specified `code_paths` to the **pyfunc** representation of the model; they will only be prepended to the system path if the model is loaded via `load_pyfunc()`. **I propose following up with a PR to preprend the code to the system path when the model is loaded via `mlflow.pytorch.load_model`**.~~