### PR TITLE
Bump R version to 0.8.2 and add small docs updates to changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Bug fixes:
 - [Models] PyTorch models can now be saved with code dependencies, allowing model classes to be loaded successfully in new environments (#842, #836, @dbczumar)
 - [Artifacts] Fixed a timeout when logging zero-length files to DBFS artifact stores (#818, @smurching)
 
-Small bug fixes and docs updates (#845, @stbof; #840, @grahamhealy20; #839, @wilderrodrigues)
+Small docs updates (#845, @stbof; #840, @grahamhealy20; #839, @wilderrodrigues)
 
 
 0.8.1 (2018-12-21)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Bug fixes:
 - [Models] PyTorch models can now be saved with code dependencies, allowing model classes to be loaded successfully in new environments (#842, #836, @dbczumar)
 - [Artifacts] Fixed a timeout when logging zero-length files to DBFS artifact stores (#818, @smurching)
 
+Small bug fixes and docs updates (#845, @stbof; #840, @grahamhealy20; #839, @wilderrodrigues)
+
 
 0.8.1 (2018-12-21)
 ------------------

--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mlflow
 Type: Package
 Title: Interface to 'MLflow'
-Version: 0.8.1
+Version: 0.8.2
 Authors@R: c(
   person("Matei", "Zaharia", email = "matei@databricks.com", role = c("aut", "cre")),
   person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut")),


### PR DESCRIPTION
#845, #840, and #839 were included in the release branch for `0.8.2`. This PR updates the changelog to reflect these inclusions. It also bumps the version of MLflow's R package to `0.8.2`.