### PR TITLE
Bump package versions to 0.8.3 dev

### DIFF
--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mlflow
 Type: Package
 Title: Interface to 'MLflow'
-Version: 0.8.2
+Version: 0.8.3
 Authors@R: c(
   person("Matei", "Zaharia", email = "matei@databricks.com", role = c("aut", "cre")),
   person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut")),

--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -11,7 +11,6 @@
 
   <artifactId>mlflow-client</artifactId>
   <packaging>jar</packaging>
-  <version>0.8.3</version>
   <name>MLflow Tracking API</name>
   <url>http://mlflow.org</url>
   <properties>

--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -5,13 +5,13 @@
   <parent>
     <groupId>org.mlflow</groupId>
     <artifactId>mlflow-parent</artifactId>
-    <version>0.8.2</version>
+    <version>0.8.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>mlflow-client</artifactId>
   <packaging>jar</packaging>
-  <version>0.8.2</version>
+  <version>0.8.3</version>
   <name>MLflow Tracking API</name>
   <url>http://mlflow.org</url>
   <properties>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.mlflow</groupId>
   <artifactId>mlflow-parent</artifactId>
-  <version>0.8.2</version>
+  <version>0.8.3</version>
   <packaging>pom</packaging>
   <name>MLflow Parent POM</name>
   <url>http://mlflow.org</url>

--- a/mlflow/java/scoring/pom.xml
+++ b/mlflow/java/scoring/pom.xml
@@ -18,7 +18,6 @@
   </distributionManagement>
 
   <artifactId>mlflow-scoring</artifactId>
-  <version>0.8.3</version>
   <packaging>jar</packaging>
   <name>MLflow scoring server</name>
   <url>http://mlflow.org</url>

--- a/mlflow/java/scoring/pom.xml
+++ b/mlflow/java/scoring/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.mlflow</groupId>
     <artifactId>mlflow-parent</artifactId>
-    <version>0.8.2</version>
+    <version>0.8.3</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -18,7 +18,7 @@
   </distributionManagement>
 
   <artifactId>mlflow-scoring</artifactId>
-  <version>0.8.2</version>
+  <version>0.8.3</version>
   <packaging>jar</packaging>
   <name>MLflow scoring server</name>
   <url>http://mlflow.org</url>

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,4 +1,4 @@
 # Copyright 2018 Databricks, Inc.
 
 
-VERSION = '0.8.2'
+VERSION = '0.8.3.dev0'


### PR DESCRIPTION
This PR bumps the MLflow version in our Python, R, and Java packages to 0.8.3dev because 0.8.2 has been released.