### PR TITLE
fix for missing run name in csv export

### DIFF
--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -684,8 +684,8 @@ class ExperimentView extends Component {
       const paramsMap = ExperimentViewUtil.toParamsMap(paramsList[index]);
       const metricsMap = ExperimentViewUtil.toMetricsMap(metricsList[index]);
 
-      /* add run name to export row */
-      row[1] = Utils.getRunName(tagsList[index]);
+      //add run name to export row
+      Utils.getRunName(tagsList[index]);
 
       paramKeyList.forEach((paramKey) => {
         if (paramsMap[paramKey]) {

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -675,17 +675,15 @@ class ExperimentView extends Component {
     const data = runInfos.map((runInfo, index) => {
       const row = [
         runInfo.run_uuid,
-        runInfo.name,
+        Utils.getRunName(tagsList[index]), // add run name to csv export row
         runInfo.source_type,
         runInfo.source_name,
         runInfo.user_id,
         runInfo.status,
       ];
+
       const paramsMap = ExperimentViewUtil.toParamsMap(paramsList[index]);
       const metricsMap = ExperimentViewUtil.toMetricsMap(metricsList[index]);
-
-      //add run name to export row
-      Utils.getRunName(tagsList[index]);
 
       paramKeyList.forEach((paramKey) => {
         if (paramsMap[paramKey]) {

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -22,6 +22,8 @@ import RestoreRunModal from './modals/RestoreRunModal';
 import LocalStorageUtils from "../utils/LocalStorageUtils";
 import { ExperimentViewPersistedState } from "../sdk/MlflowLocalStorageMessages";
 
+import Utils from '../utils/Utils';
+
 export const DEFAULT_EXPANDED_VALUE = false;
 
 
@@ -594,7 +596,8 @@ class ExperimentView extends Component {
       this.props.paramKeyFilter.apply(this.props.paramKeyList),
       this.props.metricKeyFilter.apply(this.props.metricKeyList),
       this.props.paramsList,
-      this.props.metricsList);
+      this.props.metricsList,
+      this.props.tagsList);
     const blob = new Blob([csv], { type: 'application/csv;charset=utf-8' });
     saveAs(blob, "runs.csv");
   }
@@ -652,7 +655,8 @@ class ExperimentView extends Component {
     paramKeyList,
     metricKeyList,
     paramsList,
-    metricsList) {
+    metricsList,
+    tagsList) {
     const columns = [
       "Run ID",
       "Name",
@@ -679,6 +683,10 @@ class ExperimentView extends Component {
       ];
       const paramsMap = ExperimentViewUtil.toParamsMap(paramsList[index]);
       const metricsMap = ExperimentViewUtil.toMetricsMap(metricsList[index]);
+
+      /* add run name to export row */
+      row[1] = Utils.getRunName(tagsList[index]);
+
       paramKeyList.forEach((paramKey) => {
         if (paramsMap[paramKey]) {
           row.push(paramsMap[paramKey].getValue());


### PR DESCRIPTION
Fix #856, Fix #813 

@smurching Here is the proposed fix.  This is the first time I'm working in JS, not sure if I used the correct coding constructs.  

Is the following a reasonable code fragment to populate the csv export (see screenshots) with the `Run Name`?  The thing I'm uncomfortable is the use of the `row[1]` array reference.  If a future enhancement changes the order of the attributes on a row, then this code will probably break.
```
      /* add run name to export row */
      row[1] = Utils.getRunName(tagsList[index]);
```

Here here is screen shot of mlflow ui:
<img width="1001" alt="screen shot 2019-02-03 at 11 29 28" src="https://user-images.githubusercontent.com/1425269/52179507-8e305800-27a9-11e9-9c98-7f6704a2a8a1.png">

Here is screen shot of exported csv data
<img width="897" alt="screen shot 2019-02-03 at 11 29 47" src="https://user-images.githubusercontent.com/1425269/52179515-a1dbbe80-27a9-11e9-81f6-f9be9a43ccec.png">

I've only tested this using the Javascript Dev Server.  I have not tried building a distributable artifact.  Do I need to build a distributable artifact to complete the PR?