### PR TITLE
Bump Python dependency (click) version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     packages=find_packages(exclude=['tests', 'tests.*']),
     package_data={"mlflow": js_files + sagmaker_server_files},
     install_requires=[
-        'click>=6.7',
+        'click>=7.0',
         'cloudpickle==0.6.1',
         'databricks-cli>=0.8.0',
         'requests>=2.17.3',


### PR DESCRIPTION
In #860 we added logic to allow `mlflow server` to run with a `--backend-store-uri` argument while preserving the legacy `--file-store` argument - this is useful functionality but only works with click 7.0, so we pin click 7.0 in this PR.

See example stderr from attempting to run mlflow server with click 6.7:

```
(mlflow_python3) ➜  mlflow git:(bump-click) mlflow server
Traceback (most recent call last):
  File "/Users/siddharthmurching/miniconda3/envs/mlflow_python3/bin/mlflow", line 11, in <module>
    load_entry_point('mlflow', 'console_scripts', 'mlflow')()
  File "/Users/siddharthmurching/miniconda3/envs/mlflow_python3/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/siddharthmurching/miniconda3/envs/mlflow_python3/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/siddharthmurching/miniconda3/envs/mlflow_python3/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/siddharthmurching/miniconda3/envs/mlflow_python3/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/siddharthmurching/miniconda3/envs/mlflow_python3/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
TypeError: server() got an unexpected keyword argument 'file_store'
(mlflow_python3) ➜  mlflow git:(bump-click) pip install --upgrade click
Collecting click
  Using cached https://files.pythonhosted.org/packages/fa/37/45185cb5abbc30d7257104c434fe0b07e5a195a6847506c074527aa599ec/Click-7.0-py2.py3-none-any.whl
mkl-random 1.0.1 requires cython, which is not installed.
pypi-publisher 0.0.4 has requirement gitpython==0.3.6, but you'll have gitpython 2.1.11 which is incompatible.
pylint-django 2.0.2 has requirement pylint>=2.0, but you'll have pylint 1.8.2 which is incompatible.
polyaxon-cli 0.2.8 has requirement click==6.7, but you'll have click 7.0 which is incompatible.
flake8 3.5.0 has requirement pyflakes<1.7.0,>=1.5.0, but you'll have pyflakes 2.0.0 which is incompatible.
azure-cli-core 2.0.54 has requirement requests>=2.20.0, but you'll have requests 2.19.1 which is incompatible.
azure-cli-core 2.0.54 has requirement wheel==0.30.0, but you'll have wheel 0.31.1 which is incompatible.
Installing collected packages: click
  Found existing installation: click 6.7
    Uninstalling click-6.7:
      Successfully uninstalled click-6.7
Successfully installed click-7.0
You are using pip version 10.0.1, however version 19.0.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
(mlflow_python3) ➜  mlflow git:(bump-click) mlflow server
[2019-02-04 19:46:50 -0800] [11664] [INFO] Starting gunicorn 19.9.0
[2019-02-04 19:46:50 -0800] [11664] [INFO] Listening at: http://127.0.0.1:5000 (11664)
[2019-02-04 19:46:50 -0800] [11664] [INFO] Using worker: sync
[2019-02-04 19:46:50 -0800] [11667] [INFO] Booting worker with pid: 11667
```