### PR TITLE
[R] Fix local serving of rfunc models

### DIFF
--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mlflow
 Type: Package
 Title: Interface to 'MLflow'
-Version: 0.8.3
+Version: 0.8.3.9001
 Authors@R: c(
   person("Matei", "Zaharia", email = "matei@databricks.com", role = c("aut", "cre")),
   person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut")),

--- a/mlflow/R/mlflow/R/model-serve.R
+++ b/mlflow/R/mlflow/R/model-serve.R
@@ -149,11 +149,7 @@ serve_handlers <- function(host, port) {
         )
       )
     },
-    "^/[^/]*$" = function(req, model) {
-      serve_static_file_response("swagger", file.path("dist", req$PATH_INFO))
-    },
     "^/predict" = function(req, model) {
-
       json_raw <- req$rook.input$read()
 
       results <- serve_prediction(json_raw, model)
@@ -167,6 +163,9 @@ serve_handlers <- function(host, port) {
           jsonlite::toJSON(list(predictions = results), auto_unbox = TRUE)
         ))
       )
+    },
+    "^/[^/]*$" = function(req, model) {
+      serve_static_file_response("swagger", file.path("dist", req$PATH_INFO))
     },
     ".*" = function(req, sess, model) {
       stop("Invalid path.")


### PR DESCRIPTION
This change enables both the `predict` and `predict/` endpoints to work properly; previously the latter failed because we were matching it to invalid.