### PR TITLE
Fix #849: updated mlflow api set used in the tensorflow example

### DIFF
--- a/examples/tensorflow/train_predict.py
+++ b/examples/tensorflow/train_predict.py
@@ -6,7 +6,6 @@ import mlflow
 from mlflow import tracking, pyfunc
 import numpy as np
 import pandas as pd
-import os.path
 import shutil
 import tempfile
 import tensorflow as tf

--- a/examples/tensorflow/train_predict.py
+++ b/examples/tensorflow/train_predict.py
@@ -44,7 +44,7 @@ def main(argv):
                                         tf_signature_def_key="predict",
                                         artifact_path="model")
             # Reloading the model
-            pyfunc_model = pyfunc.load_pyfunc(os.path.join(mlflow.get_artifact_uri(),'model'))
+            pyfunc_model = pyfunc.load_pyfunc(mlflow.get_artifact_uri('model'))
             df = pd.DataFrame(data=x_test, columns=["features"] * x_train.shape[1])
             # Predicting on the loaded Python Function
             predict_df = pyfunc_model.predict(df)

--- a/examples/tensorflow/train_predict.py
+++ b/examples/tensorflow/train_predict.py
@@ -3,12 +3,15 @@ from __future__ import division
 from __future__ import print_function
 
 import mlflow
-from mlflow import tensorflow, tracking, pyfunc
+from mlflow import tracking, pyfunc
 import numpy as np
 import pandas as pd
+import os.path
 import shutil
 import tempfile
 import tensorflow as tf
+from tensorflow.python.saved_model import tag_constants
+import mlflow.tensorflow
 
 
 def main(argv):
@@ -36,9 +39,12 @@ def main(argv):
         try:
             saved_estimator_path = regressor.export_savedmodel(temp, receiver_fn).decode("utf-8")
             # Logging the saved model
-            tensorflow.log_saved_model(saved_model_dir=saved_estimator_path, signature_def_key="predict", artifact_path="model")
+            mlflow.tensorflow.log_model(tf_saved_model_dir=saved_estimator_path,
+                                        tf_meta_graph_tags = [tag_constants.SERVING],
+                                        tf_signature_def_key="predict",
+                                        artifact_path="model")
             # Reloading the model
-            pyfunc_model = pyfunc.load_pyfunc(saved_estimator_path)
+            pyfunc_model = pyfunc.load_pyfunc(os.path.join(mlflow.get_artifact_uri(),'model'))
             df = pd.DataFrame(data=x_test, columns=["features"] * x_train.shape[1])
             # Predicting on the loaded Python Function
             predict_df = pyfunc_model.predict(df)


### PR DESCRIPTION
Fix #849: train_predict.py present in mlflow/examples/tensorflow is corresponding to the old branch (0.7) and the code in master is not working with it.

Run log from test after api update: [tensorflow_example_run_log.txt](https://github.com/mlflow/mlflow/files/2834738/tensorflow_example_run_log.txt)
