### PR TITLE
MLFLOW_EXPERIMENT_NAME env variable and --experiment-name arguments for CLI command

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -19,6 +19,7 @@ import mlflow.runs
 
 from mlflow.entities.experiment import Experiment
 from mlflow.tracking.utils import _is_local_uri
+from mlflow.utils.logging_utils import eprint
 from mlflow.utils.process import ShellCommandException
 from mlflow.utils import cli_args
 from mlflow.server import _run_server
@@ -100,19 +101,19 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, m
     local projects run from the project's root directory.
     """
     if experiment_id and experiment_name:
-        print("Specify only one of 'experiment-name' or 'experiment-id' options.", file=sys.stderr)
+        eprint("Specify only one of 'experiment-name' or 'experiment-id' options.")
         sys.exit(1)
 
     param_dict = {}
     for s in param_list:
         index = s.find("=")
         if index == -1:
-            print("Invalid format for -P parameter: '%s'. Use -P name=value." % s, file=sys.stderr)
+            eprint("Invalid format for -P parameter: '%s'. Use -P name=value." % s)
             sys.exit(1)
         name = s[:index]
         value = s[index + 1:]
         if name in param_dict:
-            print("Repeated parameter: '%s'" % name, file=sys.stderr)
+            eprint("Repeated parameter: '%s'" % name)
             sys.exit(1)
         param_dict[name] = value
     cluster_spec_arg = cluster_spec
@@ -120,7 +121,7 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, m
         try:
             cluster_spec_arg = json.loads(cluster_spec)
         except ValueError as e:
-            print("Invalid cluster spec JSON. Parse error: %s" % e)
+            eprint("Invalid cluster spec JSON. Parse error: %s" % e)
             raise
     try:
         projects.run(
@@ -183,8 +184,7 @@ def ui(backend_store_uri, default_artifact_root, host, port, gunicorn_opts):
     try:
         _run_server(backend_store_uri, default_artifact_root, host, port, 1, None, gunicorn_opts)
     except ShellCommandException:
-        print("Running the mlflow server failed. Please see the logs above for details.",
-              file=sys.stderr)
+        eprint("Running the mlflow server failed. Please see the logs above for details.")
         sys.exit(1)
 
 
@@ -245,16 +245,15 @@ def server(backend_store_uri, default_artifact_root, host, port,
         if _is_local_uri(backend_store_uri):
             default_artifact_root = backend_store_uri
         else:
-            print("Option 'default-artifact-root' is required, when backend store is not "
-                  "local file based.", file=sys.stderr)
+            eprint("Option 'default-artifact-root' is required, when backend store is not "
+                   "local file based.")
             sys.exit(1)
 
     try:
         _run_server(backend_store_uri, default_artifact_root, host, port, workers, static_prefix,
                     gunicorn_opts)
     except ShellCommandException:
-        print("Running the mlflow server failed. Please see the logs above for details.",
-              file=sys.stderr)
+        eprint("Running the mlflow server failed. Please see the logs above for details.")
         sys.exit(1)
 
 

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -49,6 +49,9 @@ def cli():
               help="A parameter for the run, of the form -P name=value. Provided parameters that "
                    "are not in the list of parameters for an entry point will be passed to the "
                    "corresponding entry point as command-line arguments in the form `--name value`")
+@click.option("--experiment-name", envvar=tracking._EXPERIMENT_NAME_ENV_VAR,
+              help="Name of the experiment under which to launch the run. If not "
+                   "specified, 'experiment-id' option will be used to launch run.")
 @click.option("--experiment-id", envvar=tracking._EXPERIMENT_ID_ENV_VAR, type=click.INT,
               help="ID of the experiment under which to launch the run. Defaults to %s" %
                    Experiment.DEFAULT_EXPERIMENT_ID)
@@ -82,8 +85,8 @@ def cli():
               help="If specified, the given run ID will be used instead of creating a new run. "
                    "Note: this argument is used internally by the MLflow project APIs "
                    "and should not be specified.")
-def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec, git_username,
-        git_password, no_conda, storage_dir, run_id):
+def run(uri, entry_point, version, param_list, experiment_name, experiment_id, mode, cluster_spec,
+        git_username, git_password, no_conda, storage_dir, run_id):
     """
     Run an MLflow project from the given URI.
 
@@ -96,6 +99,10 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
     By default, Git projects run in a new working directory with the given parameters, while
     local projects run from the project's root directory.
     """
+    if experiment_id and experiment_name:
+        print("Specify only one of 'experiment-name' or 'experiment-id' options.", file=sys.stderr)
+        sys.exit(1)
+
     param_dict = {}
     for s in param_list:
         index = s.find("=")
@@ -120,6 +127,7 @@ def run(uri, entry_point, version, param_list, experiment_id, mode, cluster_spec
             uri,
             entry_point,
             version,
+            experiment_name=experiment_name,
             experiment_id=experiment_id,
             parameters=param_dict,
             mode=mode,

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -100,7 +100,7 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, m
     By default, Git projects run in a new working directory with the given parameters, while
     local projects run from the project's root directory.
     """
-    if experiment_id and experiment_name:
+    if experiment_id is not None and experiment_name is not None:
         eprint("Specify only one of 'experiment-name' or 'experiment-id' options.")
         sys.exit(1)
 

--- a/mlflow/entities/experiment.py
+++ b/mlflow/entities/experiment.py
@@ -7,6 +7,7 @@ class Experiment(_MLflowObject):
     Experiment object.
     """
     DEFAULT_EXPERIMENT_ID = 0
+    DEFAULT_EXPERIMENT_NAME = "Default"
 
     def __init__(self, experiment_id, name, artifact_location, lifecycle_stage):
         super(Experiment, self).__init__()

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -20,7 +20,7 @@ import mlflow.tracking as tracking
 import mlflow.tracking.fluent as fluent
 from mlflow.projects.submitted_run import LocalSubmittedRun, SubmittedRun
 from mlflow.projects import _project_spec
-from mlflow.exceptions import ExecutionException
+from mlflow.exceptions import ExecutionException, MlflowException
 from mlflow.entities import RunStatus, SourceType, Param
 from mlflow.tracking.fluent import _get_experiment_id, _get_git_commit
 
@@ -49,7 +49,8 @@ _MLFLOW_DOCKER_TRACKING_DIR_PATH = "/mlflow/tmp/mlruns"
 _logger = logging.getLogger(__name__)
 
 
-def _run(uri, entry_point="main", version=None, parameters=None, experiment_id=None,
+def _run(uri, entry_point="main", version=None, parameters=None,
+         experiment_name=None, experiment_id=None,
          mode=None, cluster_spec=None, git_username=None, git_password=None, use_conda=True,
          storage_dir=None, block=True, run_id=None):
     """
@@ -59,7 +60,10 @@ def _run(uri, entry_point="main", version=None, parameters=None, experiment_id=N
     if mode == "databricks":
         mlflow.projects.databricks.before_run_validations(mlflow.get_tracking_uri(), cluster_spec)
 
-    exp_id = experiment_id or _get_experiment_id()
+    if experiment_name:
+        exp_id = tracking.MlflowClient().get_experiment_by_name(experiment_name)
+    else:
+        exp_id = experiment_id or _get_experiment_id()
     parameters = parameters or {}
     work_dir = _fetch_project(uri=uri, force_tempdir=False, version=version,
                               git_username=git_username, git_password=git_password)
@@ -129,7 +133,8 @@ def _run(uri, entry_point="main", version=None, parameters=None, experiment_id=N
                              "values: %s" % (mode, supported_modes))
 
 
-def run(uri, entry_point="main", version=None, parameters=None, experiment_id=None,
+def run(uri, entry_point="main", version=None, parameters=None,
+        experiment_name=None, experiment_id=None,
         mode=None, cluster_spec=None, git_username=None, git_password=None, use_conda=True,
         storage_dir=None, block=True, run_id=None):
     """
@@ -150,6 +155,7 @@ def run(uri, entry_point="main", version=None, parameters=None, experiment_id=No
                         using "python" to run ``.py`` files and the default shell (specified by
                         environment variable ``$SHELL``) to run ``.sh`` files.
     :param version: For Git-based projects, either a commit hash or a branch name.
+    :param experiment_name: Name of experiment under which to launch the run.
     :param experiment_id: ID of experiment under which to launch the run.
     :param mode: Execution mode of the run: "local" or "databricks". If running against Databricks,
                  will run against a Databricks workspace determined as follows: if a Databricks
@@ -181,6 +187,9 @@ def run(uri, entry_point="main", version=None, parameters=None, experiment_id=No
     :return: :py:class:`mlflow.projects.SubmittedRun` exposing information (e.g. run ID)
              about the launched run.
     """
+    if experiment_name and experiment_id:
+        raise MlflowException("Specify only one of 'experiment_name' or 'experiment_id'.")
+
     cluster_spec_dict = cluster_spec
     if (cluster_spec and type(cluster_spec) != dict
             and os.path.splitext(cluster_spec)[-1] == ".json"):
@@ -194,7 +203,8 @@ def run(uri, entry_point="main", version=None, parameters=None, experiment_id=No
                 raise
     submitted_run_obj = _run(
         uri=uri, entry_point=entry_point, version=version, parameters=parameters,
-        experiment_id=experiment_id, mode=mode, cluster_spec=cluster_spec_dict,
+        experiment_name=experiment_name, experiment_id=experiment_id,
+        mode=mode, cluster_spec=cluster_spec_dict,
         git_username=git_username, git_password=git_password, use_conda=use_conda,
         storage_dir=storage_dir, block=block, run_id=run_id)
     if block:

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -52,7 +52,7 @@ class AbstractStore:
     @abstractmethod
     def get_experiment_by_name(self, experiment_name):
         """
-        Fetches the experiment by name from backend store.
+        Fetches the experiment by name from the backend store.
         Throws an exception if experiment is not found or permanently deleted.
 
         :param experiment_name: Name of experiment

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -51,6 +51,16 @@ class AbstractStore:
         pass
 
     @abstractmethod
+    def get_experiment_by_name(self, experiment_name):
+        """
+        Fetches the experiment by name from backend store.
+        Throws an exception if experiment is not found or permanently deleted.
+
+        :param experiment_name: Name of experiment
+        :return: A single Experiment object if it exists, otherwise raises an Exception.
+        """
+
+    @abstractmethod
     def delete_experiment(self, experiment_id):
         """
         Deletes the experiment from the backend store. Deleted experiments can be restored until

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -43,10 +43,9 @@ class AbstractStore:
     def get_experiment(self, experiment_id):
         """
         Fetches the experiment by ID from the backend store.
-        Throws an exception if experiment is not found or permanently deleted.
 
         :param experiment_id: Integer id for the experiment
-        :return: A single Experiment object if it exists, otherwise raises an Exception.
+        :return: A single Experiment object if it exists, otherwise None.
         """
         pass
 

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -220,10 +220,10 @@ class FileStore(AbstractStore):
                                   databricks_pb2.RESOURCE_DOES_NOT_EXIST)
         return experiment
 
-    def get_experiment_by_name(self, name):
+    def get_experiment_by_name(self, experiment_name):
         self._check_root_dir()
         for experiment in self.list_experiments(ViewType.ALL):
-            if experiment.name == name:
+            if experiment.name == experiment_name:
                 return experiment
         return None
 

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -64,7 +64,7 @@ class FileStore(AbstractStore):
         # Create root directory if needed
         if not exists(self.root_directory):
             mkdir(self.root_directory)
-            self._create_experiment_with_id(name="Default",
+            self._create_experiment_with_id(name=Experiment.DEFAULT_EXPERIMENT_NAME,
                                             experiment_id=Experiment.DEFAULT_EXPERIMENT_ID,
                                             artifact_uri=None)
         # Create trash folder if needed

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -99,9 +99,9 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(GetExperiment, req_body)
         return Experiment.from_proto(response_proto.experiment)
 
-    def get_experiment_by_name(self, name):
+    def get_experiment_by_name(self, experiment_name):
         for experiment in self.list_experiments(ViewType.ALL):
-            if experiment.name == name:
+            if experiment.name == experiment_name:
                 return experiment
         return None
 

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -6,7 +6,7 @@ from six.moves import urllib
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.store.dbmodels.db_types import MYSQL
 from mlflow.store.dbmodels.models import Base, SqlExperiment, SqlRun, SqlMetric, SqlParam, SqlTag
-from mlflow.entities import RunStatus, SourceType
+from mlflow.entities import RunStatus, SourceType, Experiment
 from mlflow.store.abstract_store import AbstractStore
 from mlflow.entities import ViewType
 from mlflow.exceptions import MlflowException
@@ -38,11 +38,11 @@ class SqlAlchemyStore(AbstractStore):
         if len(self.list_experiments()) == 0:
             self._create_default_experiment()
 
-    # DB helper methods to allow zero values for columns with auto increments
     def _set_no_auto_for_zero_values(self):
         if self.db_type == MYSQL:
             self.session.execute("SET @@SESSION.sql_mode='NO_AUTO_VALUE_ON_ZERO';")
 
+    # DB helper methods to allow zero values for columns with auto increments
     def _unset_no_auto_for_zero_values(self):
         if self.db_type == MYSQL:
             self.session.execute("SET @@SESSION.sql_mode='';")
@@ -58,8 +58,8 @@ class SqlAlchemyStore(AbstractStore):
         """
         table = SqlExperiment.__tablename__
         default_experiment = {
-            SqlExperiment.experiment_id.name: 0,
-            SqlExperiment.name.name: 'Default',
+            SqlExperiment.experiment_id.name: Experiment.DEFAULT_EXPERIMENT_ID,
+            SqlExperiment.name.name: Experiment.DEFAULT_EXPERIMENT_NAME,
             SqlExperiment.artifact_location.name: self._get_artifact_location(0),
             SqlExperiment.lifecycle_stage.name: LifecycleStage.ACTIVE
         }
@@ -135,20 +135,23 @@ class SqlAlchemyStore(AbstractStore):
 
         return experiment.experiment_id
 
-    def _list_experiments(self, experiments, view_type=ViewType.ACTIVE_ONLY):
+    def _list_experiments(self, ids=None, names=None, view_type=ViewType.ACTIVE_ONLY):
         stages = LifecycleStage.view_type_to_stages(view_type)
         conditions = [SqlExperiment.lifecycle_stage.in_(stages)]
 
-        if len(experiments) > 0:
-            conditions.append(SqlExperiment.experiment_id.in_(experiments))
+        if ids and len(ids) > 0:
+            conditions.append(SqlExperiment.experiment_id.in_(ids))
+
+        if names and len(names) > 0:
+            conditions.append(SqlExperiment.name.in_(names))
 
         return self.session.query(SqlExperiment).filter(*conditions)
 
     def list_experiments(self, view_type=ViewType.ACTIVE_ONLY):
-        return [exp.to_mlflow_entity() for exp in self._list_experiments([], view_type)]
+        return [exp.to_mlflow_entity() for exp in self._list_experiments(view_type=view_type)]
 
     def _get_experiment(self, experiment_id, view_type):
-        experiments = self._list_experiments([experiment_id], view_type).all()
+        experiments = self._list_experiments(ids=[experiment_id], view_type=view_type).all()
         if len(experiments) == 0:
             raise MlflowException('No Experiment with id={} exists'.format(experiment_id),
                                   RESOURCE_DOES_NOT_EXIST)
@@ -160,6 +163,17 @@ class SqlAlchemyStore(AbstractStore):
 
     def get_experiment(self, experiment_id):
         return self._get_experiment(experiment_id, ViewType.ALL).to_mlflow_entity()
+
+    def get_experiment_by_name(self, experiment_name):
+        experiments = self._list_experiments(names=[experiment_name], view_type=ViewType.ALL).all()
+        if len(experiments) == 0:
+            raise MlflowException('No Experiment with name={} exists'.format(experiment_name),
+                                  RESOURCE_DOES_NOT_EXIST)
+        if len(experiments) > 1:
+            raise MlflowException('Expected only 1 experiment with name={}. Found {}.'.format(
+                experiment_name, len(experiments)), INVALID_STATE)
+
+        return experiments[0]
 
     def delete_experiment(self, experiment_id):
         experiment = self._get_experiment(experiment_id, ViewType.ACTIVE_ONLY)
@@ -348,7 +362,7 @@ class SqlAlchemyStore(AbstractStore):
         return [r for r in runs if all([does_run_match_clause(r, s) for s in search_expressions])]
 
     def _list_runs(self, experiment_id, run_view_type):
-        exp = self._list_experiments(experiments=[experiment_id], view_type=ViewType.ALL).first()
+        exp = self._list_experiments(ids=[experiment_id], view_type=ViewType.ALL).first()
         stages = set(LifecycleStage.view_type_to_stages(run_view_type))
         return [run for run in exp.runs if run.lifecycle_stage in stages]
 

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -167,8 +167,7 @@ class SqlAlchemyStore(AbstractStore):
     def get_experiment_by_name(self, experiment_name):
         experiments = self._list_experiments(names=[experiment_name], view_type=ViewType.ALL).all()
         if len(experiments) == 0:
-            raise MlflowException('No Experiment with name={} exists'.format(experiment_name),
-                                  RESOURCE_DOES_NOT_EXIST)
+            return None
         if len(experiments) > 1:
             raise MlflowException('Expected only 1 experiment with name={}. Found {}.'.format(
                 experiment_name, len(experiments)), INVALID_STATE)

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -8,7 +8,7 @@ For a higher level API for managing an "active run", use the :py:mod:`mlflow` mo
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.utils import set_tracking_uri, get_tracking_uri, _get_store, \
     _TRACKING_URI_ENV_VAR
-from mlflow.tracking.fluent import _EXPERIMENT_ID_ENV_VAR, _RUN_ID_ENV_VAR
+from mlflow.tracking.fluent import _EXPERIMENT_ID_ENV_VAR, _EXPERIMENT_NAME_ENV_VAR, _RUN_ID_ENV_VAR
 
 __all__ = [
     "MlflowClient",

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -27,6 +27,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_WEBAPP_URL, \
 from mlflow.utils.validation import _validate_run_id
 
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"
+_EXPERIMENT_NAME_ENV_VAR = "MLFLOW_EXPERIMENT_NAME"
 _RUN_ID_ENV_VAR = "MLFLOW_RUN_ID"
 _AUTODETECT_EXPERIMENT = "MLFLOW_AUTODETECT_EXPERIMENT_ID"
 _active_run_stack = []
@@ -297,9 +298,17 @@ def _get_source_type():
     return SourceType.LOCAL
 
 
+def _get_experiment_id_from_env():
+    experiment_name = env.get_env(_EXPERIMENT_NAME_ENV_VAR)
+    if experiment_name:
+        exp = MlflowClient().get_experiment_by_name(experiment_name)
+        return exp.experiment_id if exp else None
+    return env.get_env(_EXPERIMENT_ID_ENV_VAR)
+
+
 def _get_experiment_id():
     return int(_active_experiment_id or
-               env.get_env(_EXPERIMENT_ID_ENV_VAR) or
+               _get_experiment_id_from_env() or
                (env.get_env(_AUTODETECT_EXPERIMENT) and
                 is_in_databricks_notebook() and get_notebook_id()) or
                Experiment.DEFAULT_EXPERIMENT_ID)

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -120,6 +120,10 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         self.assertEqual(actual.name, name)
         self.assertEqual(actual.experiment_id, experiment_id)
 
+        actual_by_name = self.store.get_experiment_by_name(name)
+        self.assertEqual(actual_by_name.name, name)
+        self.assertEqual(actual_by_name.experiment_id, experiment_id)
+
     def test_list_experiments(self):
         testnames = ['blue', 'red', 'green']
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
 from click.testing import CliRunner
 from mock import mock
 
-from mlflow.cli import server
+from mlflow.cli import server, run
 
 
 def test_server_static_prefix_validation():
@@ -19,3 +19,28 @@ def test_server_static_prefix_validation():
         result = CliRunner().invoke(server, ["--static-prefix", "/mlflow/"])
         assert "--static-prefix should not end with a '/'." in result.output
         run_server_mock.assert_not_called()
+
+
+def test_mlflow_run():
+    with mock.patch("mlflow.cli.projects") as mock_projects:
+        result = CliRunner().invoke(run)
+        mock_projects.run.assert_not_called()
+        assert 'Missing argument "URI"' in result.output
+
+    with mock.patch("mlflow.cli.projects") as mock_projects:
+        CliRunner().invoke(run, ["project_uri"])
+        mock_projects.run.assert_called_once()
+
+    with mock.patch("mlflow.cli.projects") as mock_projects:
+        CliRunner().invoke(run, ["--experiment-id", "5", "project_uri"])
+        mock_projects.run.assert_called_once()
+
+    with mock.patch("mlflow.cli.projects") as mock_projects:
+        CliRunner().invoke(run, ["--experiment-name", "random name", "project_uri"])
+        mock_projects.run.assert_called_once()
+
+    with mock.patch("mlflow.cli.projects") as mock_projects:
+        result = CliRunner().invoke(run, ["--experiment-id", "51",
+                                          "--experiment-name", "name blah", "uri"])
+        mock_projects.run.assert_not_called()
+        assert "Specify only one of 'experiment-name' or 'experiment-id' options." in result.output

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -1,0 +1,71 @@
+import os
+import random
+
+import mlflow
+from mlflow.entities import Experiment
+from mlflow.tracking.fluent import _get_experiment_id, _get_experiment_id_from_env, \
+    _EXPERIMENT_NAME_ENV_VAR, _EXPERIMENT_ID_ENV_VAR
+from mlflow.utils.file_utils import TempDir
+
+
+class HelperEnv:
+    @classmethod
+    def assert_values(cls, exp_id, name):
+        assert os.environ.get(_EXPERIMENT_NAME_ENV_VAR) == name
+        assert os.environ.get(_EXPERIMENT_ID_ENV_VAR) == exp_id
+
+    @classmethod
+    def set_values(cls, id=None, name=None):
+        if id:
+            os.environ[_EXPERIMENT_ID_ENV_VAR] = str(id)
+        elif os.environ.get(_EXPERIMENT_ID_ENV_VAR):
+            del os.environ[_EXPERIMENT_ID_ENV_VAR]
+
+        if name:
+            os.environ[_EXPERIMENT_NAME_ENV_VAR] = str(name)
+        elif os.environ.get(_EXPERIMENT_NAME_ENV_VAR):
+            del os.environ[_EXPERIMENT_NAME_ENV_VAR]
+
+
+def test_get_experiment_id_from_env():
+    # When no env variables are set
+    HelperEnv.assert_values(None, None)
+    assert _get_experiment_id_from_env() is None
+
+    # set only ID
+    random_id = random.randint(1, 1e6)
+    HelperEnv.set_values(id=random_id)
+    HelperEnv.assert_values(str(random_id), None)
+    assert _get_experiment_id_from_env() == str(random_id)
+
+    # set only name
+    with TempDir(chdr=True):
+        name = "random experiment %d" % random.randint(1, 1e6)
+        exp_id = mlflow.create_experiment(name)
+        assert exp_id is not None
+        HelperEnv.set_values(name=name)
+        HelperEnv.assert_values(None, name)
+        assert _get_experiment_id_from_env() == exp_id
+
+    # set both: assert that name variable takes precedence
+    with TempDir(chdr=True):
+        name = "random experiment %d" % random.randint(1, 1e6)
+        exp_id = mlflow.create_experiment(name)
+        assert exp_id is not None
+        random_id = random.randint(1, 1e6)
+        HelperEnv.set_values(name=name, id=random_id)
+        HelperEnv.assert_values(str(random_id), name)
+        assert _get_experiment_id_from_env() == exp_id
+
+
+def test_get_experiment_id():
+    # When no experiment is active should return default
+    assert _get_experiment_id() == Experiment.DEFAULT_EXPERIMENT_ID
+
+    # Create a new experiment and set that as active experiment
+    with TempDir(chdr=True):
+        name = "Random experiment %d" % random.randint(1, 1e6)
+        exp_id = mlflow.create_experiment(name)
+        assert exp_id is not None
+        mlflow.set_experiment(name)
+        assert _get_experiment_id() == exp_id


### PR DESCRIPTION
- `MLFLOW_EXPERIMENT_NAME` env variable and `--experiment-name` arguments for CLI command
- `get_experiment_by_name` method for SQL store
- tests for env variables (`MLFLOW_EXPERIMENT_NAME` and `MLFLOW_EXPERIMENT_ID`)
- unit test for `mlflow run` CLI command (tested only new options)
