### PR TITLE
Refactor for "get_experiment_by_name" and sphinx markup in docs.

### DIFF
--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -45,19 +45,24 @@ class AbstractStore:
         Fetches the experiment by ID from the backend store.
 
         :param experiment_id: Integer id for the experiment
-        :return: A single Experiment object if it exists, otherwise None.
+        :return: A single :py:class:`mlflow.entities.Experiment` object if it exists,
+        otherwise raises an exception.
         """
         pass
 
-    @abstractmethod
     def get_experiment_by_name(self, experiment_name):
         """
         Fetches the experiment by name from the backend store.
-        Throws an exception if experiment is not found or permanently deleted.
+        This is a base implementation using ``list_experiments``, derived classes may have
+        some specialized implementations.
 
         :param experiment_name: Name of experiment
-        :return: A single Experiment object if it exists, otherwise raises an Exception.
+        :return: A single :py:class:`mlflow.entities.Experiment` object if it exists.
         """
+        for experiment in self.list_experiments(ViewType.ALL):
+            if experiment.name == experiment_name:
+                return experiment
+        return None
 
     @abstractmethod
     def delete_experiment(self, experiment_id):
@@ -93,14 +98,15 @@ class AbstractStore:
         Fetches the run from backend store
 
         :param run_uuid: Unique identifier for the run
-        :return: A single Run object if it exists, otherwise raises an Exception
+        :return: A single :py:class:`mlflow.entities.Run` object if it exists,
+        otherwise raises an exception
         """
         pass
 
     def update_run_info(self, run_uuid, run_status, end_time):
         """
         Updates the metadata of the specified run.
-        :return: RunInfo describing the updated run.
+        :return: :py:class:`mlflow.entities.RunInfo` describing the updated run.
         """
         pass
 
@@ -137,7 +143,7 @@ class AbstractStore:
         """
         Logs a metric for the specified run
         :param run_uuid: String id for the run
-        :param metric: Metric instance to log
+        :param metric: :py:class:`mlflow.entities.Metric` instance to log
         """
         pass
 
@@ -145,7 +151,7 @@ class AbstractStore:
         """
         Logs a param for the specified run
         :param run_uuid: String id for the run
-        :param param: Param instance to log
+        :param param: :py:class:`mlflow.entities.Param` instance to log
         """
         pass
 
@@ -153,7 +159,7 @@ class AbstractStore:
         """
         Sets a tag for the specified run
         :param run_uuid: String id for the run
-        :param tag: RunTag instance to set
+        :param tag: :py:class:`mlflow.entities.RunTag` instance to set
         """
         pass
 
@@ -202,7 +208,8 @@ class AbstractStore:
         :param experiment_ids: List of experiment ids to scope the search
         :param search_expression: list of search expressions
 
-        :return: A list of Run objects that satisfy the search expressions
+        :return: A list of :py:class:`mlflow.entities.Run` objects that satisfy the search
+        expressions
         """
         pass
 
@@ -213,6 +220,7 @@ class AbstractStore:
 
         :param experiment_id: The experiment id which to search.
 
-        :return: A list of RunInfo objects that satisfy the search expressions
+        :return: A list of :py:class:`mlflow.entities.RunInfo` objects that satisfy the
+        search expressions
         """
         pass

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -5,7 +5,7 @@ from mlflow.entities import ViewType
 
 class AbstractStore:
     """
-    Abstract class for Backend Storage
+    Abstract class for Backend Storage.
     This class will define API interface for front ends to connect with various types of backends
     """
 
@@ -23,6 +23,7 @@ class AbstractStore:
         """
 
         :param view_type: Qualify requested type of experiments.
+
         :return: a list of Experiment objects stored in store for requested view.
         """
         pass
@@ -35,6 +36,7 @@ class AbstractStore:
 
         :param name: Desired name for an experiment
         :param artifact_location: Base location for artifacts in runs. May be None.
+
         :return: experiment_id (integer) for the newly created experiment if successful, else None
         """
         pass
@@ -45,8 +47,10 @@ class AbstractStore:
         Fetches the experiment by ID from the backend store.
 
         :param experiment_id: Integer id for the experiment
+
         :return: A single :py:class:`mlflow.entities.Experiment` object if it exists,
-        otherwise raises an exception.
+            otherwise raises an exception.
+
         """
         pass
 
@@ -57,6 +61,7 @@ class AbstractStore:
         some specialized implementations.
 
         :param experiment_name: Name of experiment
+
         :return: A single :py:class:`mlflow.entities.Experiment` object if it exists.
         """
         for experiment in self.list_experiments(ViewType.ALL):
@@ -98,14 +103,16 @@ class AbstractStore:
         Fetches the run from backend store
 
         :param run_uuid: Unique identifier for the run
+
         :return: A single :py:class:`mlflow.entities.Run` object if it exists,
-        otherwise raises an exception
+            otherwise raises an exception
         """
         pass
 
     def update_run_info(self, run_uuid, run_status, end_time):
         """
         Updates the metadata of the specified run.
+
         :return: :py:class:`mlflow.entities.RunInfo` describing the updated run.
         """
         pass
@@ -119,6 +126,7 @@ class AbstractStore:
         :param experiment_id: ID of the experiment for this run
         :param user_id: ID of the user launching this run
         :param source_type: Enum (integer) describing the source of the run
+
         :return: The created Run object
         """
         pass
@@ -209,7 +217,7 @@ class AbstractStore:
         :param search_expression: list of search expressions
 
         :return: A list of :py:class:`mlflow.entities.Run` objects that satisfy the search
-        expressions
+            expressions
         """
         pass
 
@@ -221,6 +229,6 @@ class AbstractStore:
         :param experiment_id: The experiment id which to search.
 
         :return: A list of :py:class:`mlflow.entities.RunInfo` objects that satisfy the
-        search expressions
+            search expressions
         """
         pass

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -220,13 +220,6 @@ class FileStore(AbstractStore):
                                   databricks_pb2.RESOURCE_DOES_NOT_EXIST)
         return experiment
 
-    def get_experiment_by_name(self, experiment_name):
-        self._check_root_dir()
-        for experiment in self.list_experiments(ViewType.ALL):
-            if experiment.name == experiment_name:
-                return experiment
-        return None
-
     def delete_experiment(self, experiment_id):
         experiment_dir = self._get_experiment_path(experiment_id, ViewType.ACTIVE_ONLY)
         if experiment_dir is None:

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -93,17 +93,12 @@ class RestStore(AbstractStore):
         Fetches the experiment from the backend store.
 
         :param experiment_id: Integer id for the experiment
-        :return: A single Experiment object if it exists, otherwise raises an Exception.
+        :return: A single :py:class:`mlflow.entities.Experiment` object if it exists,
+        otherwise raises an Exception.
         """
         req_body = message_to_json(GetExperiment(experiment_id=experiment_id))
         response_proto = self._call_endpoint(GetExperiment, req_body)
         return Experiment.from_proto(response_proto.experiment)
-
-    def get_experiment_by_name(self, experiment_name):
-        for experiment in self.list_experiments(ViewType.ALL):
-            if experiment.name == experiment_name:
-                return experiment
-        return None
 
     def delete_experiment(self, experiment_id):
         req_body = message_to_json(DeleteExperiment(experiment_id=experiment_id))

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -165,9 +165,13 @@ class SqlAlchemyStore(AbstractStore):
         return self._get_experiment(experiment_id, ViewType.ALL).to_mlflow_entity()
 
     def get_experiment_by_name(self, experiment_name):
+        """
+        Specialized implementation for SQL backed store.
+        """
         experiments = self._list_experiments(names=[experiment_name], view_type=ViewType.ALL).all()
         if len(experiments) == 0:
             return None
+
         if len(experiments) > 1:
             raise MlflowException('Expected only 1 experiment with name={}. Found {}.'.format(
                 experiment_name, len(experiments)), INVALID_STATE)


### PR DESCRIPTION
addressing comments in PR #889

- Basic implementation of `get_experiment_by_name` to base class, SQL has a specialized implementation.
- Added sphinx markup for `AbstractStore` for pydocs

