### PR TITLE
Keras test: decrease decimal comparison precision

### DIFF
--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -92,7 +92,7 @@ def test_model_save_load(model, model_path, data, predicted):
                                          pandas_df=pd.DataFrame(x),
                                          result_type="float")
     np.testing.assert_array_almost_equal(
-        np.array(spark_udf_preds), predicted.reshape(len(spark_udf_preds)), decimal=6)
+        np.array(spark_udf_preds), predicted.reshape(len(spark_udf_preds)), decimal=4)
 
 
 def test_model_log(tracking_uri_mock, model, data, predicted):  # pylint: disable=unused-argument


### PR DESCRIPTION
The `test_keras_model_export#test_model_save_load` test fails frequently due to minor precision mismatches, producing test errors of the following form:

```
E       AssertionError: 
E       Arrays are not almost equal to 6 decimals
E       
E       Mismatch: 0.667%
E       Max absolute difference: 4.2949673e+09
E       Max relative difference: 1.08981123e-07
E        x: array([-2.548077e+16, -2.406746e+16, -2.351782e+16, -2.351549e+16,
E              -2.532320e+16, -2.791077e+16, -2.382944e+16, -2.524394e+16,
E              -2.233832e+16, -2.438104e+16, -2.697239e+16, -2.484954e+16,...
E        y: array([-2.548077e+16, -2.406746e+16, -2.351782e+16, -2.351549e+16,
E              -2.532320e+16, -2.791077e+16, -2.382944e+16, -2.524394e+16,
E              -2.233832e+16, -2.438104e+16, -2.697239e+16, -2.484954e+16,...
tests/keras/test_keras_model_export.py:95: AssertionError
```

This PR decreases the precision of the array comparison operation used in the test to match the precision used in `test_keras_model_export#test_sagemaker_docker_model_scoring_with_default_conda_env`, which doesn't seem to produce intermittent failures.