### PR TITLE
experiment name validator

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -10,7 +10,7 @@ from six import iteritems
 
 from mlflow.tracking import utils
 from mlflow.utils.validation import _validate_metric_name, _validate_param_name, \
-                                    _validate_tag_name, _validate_run_id
+    _validate_tag_name, _validate_run_id, _validate_experiment_name
 from mlflow.entities import Param, Metric, RunStatus, RunTag, ViewType, SourceType
 from mlflow.store.artifact_repo import ArtifactRepository
 
@@ -96,6 +96,7 @@ class MlflowClient(object):
                                   If not provided, the server picks an appropriate default.
         :return: Integer ID of the created experiment.
         """
+        _validate_experiment_name(name)
         return self.store.create_experiment(
             name=name,
             artifact_location=artifact_location,

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -68,3 +68,13 @@ def _validate_experiment_id(exp_id):
     except ValueError:
         raise MlflowException("Invalid experiment ID: '%s'" % exp_id,
                               error_code=INVALID_PARAMETER_VALUE)
+
+
+def _validate_experiment_name(experiment_name):
+    """Check that `experiment_name` is a valid string and raise an exception if it isn't."""
+    if experiment_name == "" or experiment_name is None:
+        raise MlflowException("Invalid experiment name: '%s'" % experiment_name,
+                              error_code=INVALID_PARAMETER_VALUE)
+    if not isinstance(experiment_name, str):
+        raise MlflowException("Invalid experiment name: %s. Expects a string." % experiment_name,
+                              error_code=INVALID_PARAMETER_VALUE)

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -44,6 +44,25 @@ def test_create_experiment_with_duplicate_name(tracking_uri_mock):
         mlflow.create_experiment(name)
 
 
+def test_create_experiments_with_bad_names():
+    # None for name
+    with pytest.raises(MlflowException) as e:
+        mlflow.create_experiment(None)
+        assert e.message.contains("Invalid experiment name: 'None'")
+
+    # empty string name
+    with pytest.raises(MlflowException) as e:
+        mlflow.create_experiment("")
+        assert e.message.contains("Invalid experiment name: ''")
+
+
+@pytest.mark.parametrize("name", [123, 0, -1.2, [], ["A"], {1: 2}])
+def test_create_experiments_with_bad_name_types(name):
+    with pytest.raises(MlflowException) as e:
+        mlflow.create_experiment(name)
+        assert e.message.contains("Invalid experiment name: %s. Expects a string." % name)
+
+
 def test_set_experiment(tracking_uri_mock, reset_active_experiment):
     with pytest.raises(TypeError):
         mlflow.set_experiment()


### PR DESCRIPTION
Validate that experiment name is legit (not null, not empty, and string type)

Credits to this [blog on MLflow](https://blog.octo.com/prise-en-main-de-mlflow-un-outil-pour-tracer-les-resultats-de-vos-experiences) for highlighting this bug.