### PR TITLE
Change git URL in README to https

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ or a Git URI::
 
     mlflow run examples/sklearn_elasticnet_wine -P alpha=0.4
 
-    mlflow run git@github.com:mlflow/mlflow-example.git -P alpha=0.4
+    mlflow run https://github.com/mlflow/mlflow-example.git -P alpha=0.4
 
 See ``examples/sklearn_elasticnet_wine`` for a sample project with an MLproject file.
 


### PR DESCRIPTION
Like in #906, the git:// URL won't work for people who do not have a GitHub SSH key, whereas a https:// URL should work for anyone.