### PR TITLE
Added support for CLI to `mlflow download` object from Google Cloud

### DIFF
--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -5,14 +5,17 @@ import re
 
 import boto3
 import click
+from google.cloud import storage
 from six.moves import urllib
 
 from mlflow.utils import process
 
 DBFS_PREFIX = "dbfs:/"
 S3_PREFIX = "s3://"
+GC_PREFIX = "gc://"
 DBFS_REGEX = re.compile("^%s" % re.escape(DBFS_PREFIX))
 S3_REGEX = re.compile("^%s" % re.escape(S3_PREFIX))
+GC_REGEX = re.compile("^%s" % re.escape(GC_PREFIX))
 
 
 class DownloadException(Exception):
@@ -28,6 +31,23 @@ def _fetch_s3(uri, local_path):
     print("=== Downloading S3 object %s to local path %s ===" % (uri, os.path.abspath(local_path)))
     (bucket, s3_path) = parse_s3_uri(uri)
     boto3.client('s3').download_file(bucket, s3_path, local_path)
+
+
+def _fetch_gc(uri, local_path):
+    print("=== Downloading GCP object %s to local path %s ===" % (uri, os.path.abspath(local_path)))
+    (bucket, gc_path) = parse_gc_uri(uri)
+    storage.Client().bucket(bucket).get_blob(gc_path).download_to_filename(local_path)
+
+
+def parse_gc_uri(uri):
+    """Parse a GC URI, returning (bucket, path)"""
+    parsed = urllib.parse.urlparse(uri)
+    if parsed.scheme != "gc":
+        raise Exception("Not an GC URI: %s" % uri)
+    path = parsed.path
+    if path.startswith('/'):
+        path = path[1:]
+    return parsed.netloc, path
 
 
 def parse_s3_uri(uri):
@@ -51,9 +71,11 @@ def download_uri(uri, output_path):
         _fetch_dbfs(uri, output_path)
     elif S3_REGEX.match(uri):
         _fetch_s3(uri, output_path)
+    elif GC_REGEX.match(uri):
+        _fetch_gc(uri, output_path)
     else:
-        raise DownloadException("`uri` must be a DBFS (%s) or S3 (%s) URI, got "
-                                "%s" % (DBFS_PREFIX, S3_PREFIX, uri))
+        raise DownloadException("`uri` must be a DBFS (%s), S3 (%s), or GC (%s) URI, got "
+                                "%s" % (DBFS_PREFIX, S3_PREFIX, GC_PREFIX, uri))
 
 
 @click.command("download")
@@ -62,7 +84,7 @@ def download_uri(uri, output_path):
               help="Output path into which to download the artifact.")
 def download(uri, output_path):
     """
-    Download the artifact at the specified DBFS or S3 URI into the specified local output path, or
+    Download the artifact at the specified DBFS, S3, or GC URI into the specified local output path, or
     the current directory if no output path is specified.
     """
     if output_path is None:

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -29,13 +29,15 @@ def load_project():
 def test_is_uri():
     assert is_uri("s3://some/s3/path")
     assert is_uri("dbfs:/some/dbfs/path")
+    assert is_uri("gc:/some/gc/path")
     assert is_uri("file://some/local/path")
     assert not is_uri("/tmp/some/local/path")
 
 
 def test_download_uri():
     # Verify downloading from DBFS & S3 urls calls the corresponding helper functions
-    prefix_to_mock = {"dbfs:/": "mlflow.data._fetch_dbfs", "s3://": "mlflow.data._fetch_s3"}
+    prefix_to_mock = {"dbfs:/": "mlflow.data._fetch_dbfs",
+                      "s3://": "mlflow.data._fetch_s3", "gc://": "mlflow.data._fetch_gc"}
     for prefix, fn_name in prefix_to_mock.items():
         with mock.patch(fn_name) as mocked_fn, temp_directory() as dst_dir:
             download_uri(uri=os.path.join(prefix, "some/path"),


### PR DESCRIPTION
Modified data.py to add support for downloading objects from GCP buckets.  Can use CLI to `mlflow download gc://<bucket-name>/<object-path>`