### PR TITLE
Autodetect notebook ID when obtaining experiment ID

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -29,7 +29,8 @@ from mlflow.utils.validation import _validate_run_id
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"
 _EXPERIMENT_NAME_ENV_VAR = "MLFLOW_EXPERIMENT_NAME"
 _RUN_ID_ENV_VAR = "MLFLOW_RUN_ID"
-_AUTODETECT_EXPERIMENT = "MLFLOW_AUTODETECT_EXPERIMENT_ID"
+_AUTODETECT_EXPERIMENT_ENV_VAR = "MLFLOW_AUTODETECT_EXPERIMENT_ID"
+_AUTODETECT_EXPERIMENT_FALSE_VALUE = "false"
 _active_run_stack = []
 _active_experiment_id = None
 
@@ -309,7 +310,8 @@ def _get_experiment_id_from_env():
 def _get_experiment_id():
     return int(_active_experiment_id or
                _get_experiment_id_from_env() or
-               (env.get_env(_AUTODETECT_EXPERIMENT, True) and
+               ((env.get_env(_AUTODETECT_EXPERIMENT_ENV_VAR, "True").lower() !=
+                   _AUTODETECT_EXPERIMENT_FALSE_VALUE) and
                 is_in_databricks_notebook() and get_notebook_id()) or
                Experiment.DEFAULT_EXPERIMENT_ID)
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -29,7 +29,6 @@ from mlflow.utils.validation import _validate_run_id
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"
 _EXPERIMENT_NAME_ENV_VAR = "MLFLOW_EXPERIMENT_NAME"
 _RUN_ID_ENV_VAR = "MLFLOW_RUN_ID"
-_AUTODETECT_EXPERIMENT_ENV_VAR = "MLFLOW_AUTODETECT_EXPERIMENT_ID"
 _active_run_stack = []
 _active_experiment_id = None
 
@@ -309,8 +308,7 @@ def _get_experiment_id_from_env():
 def _get_experiment_id():
     return int(_active_experiment_id or
                _get_experiment_id_from_env() or
-               ((env.get_env(_AUTODETECT_EXPERIMENT_ENV_VAR, "True").lower() != "false") and
-                is_in_databricks_notebook() and get_notebook_id()) or
+               (is_in_databricks_notebook() and get_notebook_id()) or
                Experiment.DEFAULT_EXPERIMENT_ID)
 
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -30,7 +30,6 @@ _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"
 _EXPERIMENT_NAME_ENV_VAR = "MLFLOW_EXPERIMENT_NAME"
 _RUN_ID_ENV_VAR = "MLFLOW_RUN_ID"
 _AUTODETECT_EXPERIMENT_ENV_VAR = "MLFLOW_AUTODETECT_EXPERIMENT_ID"
-_AUTODETECT_EXPERIMENT_FALSE_VALUE = "false"
 _active_run_stack = []
 _active_experiment_id = None
 
@@ -310,8 +309,7 @@ def _get_experiment_id_from_env():
 def _get_experiment_id():
     return int(_active_experiment_id or
                _get_experiment_id_from_env() or
-               ((env.get_env(_AUTODETECT_EXPERIMENT_ENV_VAR, "True").lower() !=
-                   _AUTODETECT_EXPERIMENT_FALSE_VALUE) and
+               ((env.get_env(_AUTODETECT_EXPERIMENT_ENV_VAR, "True").lower() != "false") and
                 is_in_databricks_notebook() and get_notebook_id()) or
                Experiment.DEFAULT_EXPERIMENT_ID)
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -300,7 +300,7 @@ def _get_source_type():
 
 def _get_experiment_id_from_env():
     experiment_name = env.get_env(_EXPERIMENT_NAME_ENV_VAR)
-    if experiment_name:
+    if experiment_name is not None:
         exp = MlflowClient().get_experiment_by_name(experiment_name)
         return exp.experiment_id if exp else None
     return env.get_env(_EXPERIMENT_ID_ENV_VAR)
@@ -309,7 +309,7 @@ def _get_experiment_id_from_env():
 def _get_experiment_id():
     return int(_active_experiment_id or
                _get_experiment_id_from_env() or
-               (env.get_env(_AUTODETECT_EXPERIMENT) and
+               (env.get_env(_AUTODETECT_EXPERIMENT, True) and
                 is_in_databricks_notebook() and get_notebook_id()) or
                Experiment.DEFAULT_EXPERIMENT_ID)
 

--- a/mlflow/utils/env.py
+++ b/mlflow/utils/env.py
@@ -1,8 +1,12 @@
 import os
 
 
-def get_env(variable_name):
-    return os.environ.get(variable_name)
+def get_env(variable_name, default=None):
+    """
+    :param variable_name: The name of the environment variable to retrieve.
+    :param default: The value to return in the case that the environment variable is not defined.
+    """
+    return os.environ.get(variable_name, failobj=default)
 
 
 def unset_variable(variable_name):

--- a/mlflow/utils/env.py
+++ b/mlflow/utils/env.py
@@ -1,12 +1,8 @@
 import os
 
 
-def get_env(variable_name, default=None):
-    """
-    :param variable_name: The name of the environment variable to retrieve.
-    :param default: The value to return in the case that the environment variable is not defined.
-    """
-    return os.environ.get(variable_name, failobj=default)
+def get_env(variable_name):
+    return os.environ.get(variable_name)
 
 
 def unset_variable(variable_name):

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -1,10 +1,13 @@
+import mock
 import os
 import random
+
+import pytest
 
 import mlflow
 from mlflow.entities import Experiment
 from mlflow.tracking.fluent import _get_experiment_id, _get_experiment_id_from_env, \
-    _EXPERIMENT_NAME_ENV_VAR, _EXPERIMENT_ID_ENV_VAR
+    _EXPERIMENT_NAME_ENV_VAR, _EXPERIMENT_ID_ENV_VAR, _AUTODETECT_EXPERIMENT_ENV_VAR
 from mlflow.utils.file_utils import TempDir
 
 
@@ -25,6 +28,12 @@ class HelperEnv:
             os.environ[_EXPERIMENT_NAME_ENV_VAR] = str(name)
         elif os.environ.get(_EXPERIMENT_NAME_ENV_VAR):
             del os.environ[_EXPERIMENT_NAME_ENV_VAR]
+
+
+@pytest.fixture
+def reset_experiment_id():
+    HelperEnv.set_values()
+    mlflow.set_experiment(Experiment.DEFAULT_EXPERIMENT_NAME)
 
 
 def test_get_experiment_id_from_env():
@@ -68,4 +77,68 @@ def test_get_experiment_id():
         exp_id = mlflow.create_experiment(name)
         assert exp_id is not None
         mlflow.set_experiment(name)
+        assert _get_experiment_id() == exp_id
+
+
+def test_get_experiment_id_in_databricks_detects_notebook_id_by_default(reset_experiment_id):
+    # pylint: disable=unused-argument
+    notebook_id = 768
+
+    with mock.patch("mlflow.tracking.fluent.is_in_databricks_notebook") as notebook_detection_mock,\
+            mock.patch("mlflow.tracking.fluent.get_notebook_id") as notebook_id_mock:
+        notebook_detection_mock.side_effect = lambda *args, **kwargs: True
+        notebook_id_mock.side_effect = lambda *args, **kwargs: notebook_id
+        assert _get_experiment_id() == notebook_id
+
+
+def test_get_experiment_id_in_databricks_does_not_detect_notebook_id_if_autodetect_disabled(reset_experiment_id):
+    # pylint: disable=unused-argument
+    notebook_id = 768
+
+    try:
+        os.environ[_AUTODETECT_EXPERIMENT_ENV_VAR] = "False"
+        with mock.patch("mlflow.tracking.fluent.is_in_databricks_notebook")\
+                as notebook_detection_mock,\
+                mock.patch("mlflow.tracking.fluent.get_notebook_id") as notebook_id_mock:
+            notebook_detection_mock.side_effect = lambda *args, **kwargs: True
+            notebook_id_mock.side_effect = lambda *args, **kwargs: notebook_id
+            assert _get_experiment_id() != notebook_id
+            assert _get_experiment_id() == Experiment.DEFAULT_EXPERIMENT_ID
+    finally:
+        del os.environ[_AUTODETECT_EXPERIMENT_ENV_VAR]
+
+
+def test_get_experiment_id_in_databricks_with_active_experiment_returns_active_experiment_id(
+        reset_experiment_id):
+    # pylint: disable=unused-argument
+    with TempDir(chdr=True):
+        exp_name = "random experiment %d" % random.randint(1, 1e6)
+        exp_id = mlflow.create_experiment(exp_name)
+        mlflow.set_experiment(exp_name)
+        notebook_id = exp_id + 73
+
+    with mock.patch("mlflow.tracking.fluent.is_in_databricks_notebook") as notebook_detection_mock,\
+            mock.patch("mlflow.tracking.fluent.get_notebook_id") as notebook_id_mock:
+        notebook_detection_mock.side_effect = lambda *args, **kwargs: True
+        notebook_id_mock.side_effect = lambda *args, **kwargs: notebook_id
+
+        assert _get_experiment_id() != notebook_id
+        assert _get_experiment_id() == exp_id
+
+
+def test_get_experiment_id_in_databricks_with_experiment_defined_in_env_returns_env_experiment_id(
+        reset_experiment_id):
+    # pylint: disable=unused-argument
+    with TempDir(chdr=True):
+        exp_name = "random experiment %d" % random.randint(1, 1e6)
+        exp_id = mlflow.create_experiment(exp_name)
+        notebook_id = exp_id + 73
+        HelperEnv.set_values(id=exp_id)
+
+    with mock.patch("mlflow.tracking.fluent.is_in_databricks_notebook") as notebook_detection_mock,\
+            mock.patch("mlflow.tracking.fluent.get_notebook_id") as notebook_id_mock:
+        notebook_detection_mock.side_effect = lambda *args, **kwargs: True
+        notebook_id_mock.side_effect = lambda *args, **kwargs: notebook_id
+
+        assert _get_experiment_id() != notebook_id
         assert _get_experiment_id() == exp_id

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -92,8 +92,8 @@ def test_get_experiment_id_in_databricks_detects_notebook_id_by_default():
 
     with mock.patch("mlflow.tracking.fluent.is_in_databricks_notebook") as notebook_detection_mock,\
             mock.patch("mlflow.tracking.fluent.get_notebook_id") as notebook_id_mock:
-        notebook_detection_mock.side_effect = lambda *args, **kwargs: True
-        notebook_id_mock.side_effect = lambda *args, **kwargs: notebook_id
+        notebook_detection_mock.return_value = True
+        notebook_id_mock.return_value = notebook_id
         assert _get_experiment_id() == notebook_id
 
 
@@ -106,8 +106,8 @@ def test_get_experiment_id_in_databricks_with_active_experiment_returns_active_e
 
     with mock.patch("mlflow.tracking.fluent.is_in_databricks_notebook") as notebook_detection_mock,\
             mock.patch("mlflow.tracking.fluent.get_notebook_id") as notebook_id_mock:
-        notebook_detection_mock.side_effect = lambda *args, **kwargs: True
-        notebook_id_mock.side_effect = lambda *args, **kwargs: notebook_id
+        notebook_detection_mock.return_value = True
+        notebook_id_mock.return_value = notebook_id
 
         assert _get_experiment_id() != notebook_id
         assert _get_experiment_id() == exp_id

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -67,10 +67,9 @@ def test_get_experiment_id_from_env():
         assert _get_experiment_id_from_env() == exp_id
 
 
-def test_get_experiment_id():
-    # When no experiment is active should return default
-    assert _get_experiment_id() == Experiment.DEFAULT_EXPERIMENT_ID
-
+def test_get_experiment_id_with_active_experiment_returns_active_experiment_id(
+        reset_experiment_id):
+    # pylint: disable=unused-argument
     # Create a new experiment and set that as active experiment
     with TempDir(chdr=True):
         name = "Random experiment %d" % random.randint(1, 1e6)
@@ -78,6 +77,13 @@ def test_get_experiment_id():
         assert exp_id is not None
         mlflow.set_experiment(name)
         assert _get_experiment_id() == exp_id
+
+
+def test_get_experiment_id_with_no_active_experiments_returns_default_experiment_id(
+        reset_experiment_id):
+    # pylint: disable=unused-argument
+    assert _get_experiment_id() == Experiment.DEFAULT_EXPERIMENT_ID
+
 
 
 def test_get_experiment_id_in_databricks_detects_notebook_id_by_default(reset_experiment_id):

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -33,6 +33,11 @@ class HelperEnv:
 
 @pytest.fixture(autouse=True)
 def reset_experiment_id():
+    """
+    This fixture resets the active experiment id *after* the execution of the test case in which
+    its included
+    """
+    yield
     HelperEnv.set_values()
     mlflow.tracking.fluent._active_experiment_id = None
 

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -31,7 +31,7 @@ class HelperEnv:
             del os.environ[_EXPERIMENT_NAME_ENV_VAR]
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def reset_experiment_id():
     HelperEnv.set_values()
     mlflow.tracking.fluent._active_experiment_id = None
@@ -68,9 +68,7 @@ def test_get_experiment_id_from_env():
         assert _get_experiment_id_from_env() == exp_id
 
 
-def test_get_experiment_id_with_active_experiment_returns_active_experiment_id(
-        reset_experiment_id):
-    # pylint: disable=unused-argument
+def test_get_experiment_id_with_active_experiment_returns_active_experiment_id():
     # Create a new experiment and set that as active experiment
     with TempDir(chdr=True):
         name = "Random experiment %d" % random.randint(1, 1e6)
@@ -80,14 +78,11 @@ def test_get_experiment_id_with_active_experiment_returns_active_experiment_id(
         assert _get_experiment_id() == exp_id
 
 
-def test_get_experiment_id_with_no_active_experiments_returns_default_experiment_id(
-        reset_experiment_id):
-    # pylint: disable=unused-argument
+def test_get_experiment_id_with_no_active_experiments_returns_default_experiment_id():
     assert _get_experiment_id() == Experiment.DEFAULT_EXPERIMENT_ID
 
 
-def test_get_experiment_id_in_databricks_detects_notebook_id_by_default(reset_experiment_id):
-    # pylint: disable=unused-argument
+def test_get_experiment_id_in_databricks_detects_notebook_id_by_default():
     notebook_id = 768
 
     with mock.patch("mlflow.tracking.fluent.is_in_databricks_notebook") as notebook_detection_mock,\
@@ -97,9 +92,7 @@ def test_get_experiment_id_in_databricks_detects_notebook_id_by_default(reset_ex
         assert _get_experiment_id() == notebook_id
 
 
-def test_get_experiment_id_in_databricks_with_active_experiment_returns_active_experiment_id(
-        reset_experiment_id):
-    # pylint: disable=unused-argument
+def test_get_experiment_id_in_databricks_with_active_experiment_returns_active_experiment_id():
     with TempDir(chdr=True):
         exp_name = "random experiment %d" % random.randint(1, 1e6)
         exp_id = mlflow.create_experiment(exp_name)
@@ -115,9 +108,7 @@ def test_get_experiment_id_in_databricks_with_active_experiment_returns_active_e
         assert _get_experiment_id() == exp_id
 
 
-def test_get_experiment_id_in_databricks_with_experiment_defined_in_env_returns_env_experiment_id(
-        reset_experiment_id):
-    # pylint: disable=unused-argument
+def test_get_experiment_id_in_databricks_with_experiment_defined_in_env_returns_env_experiment_id():
     with TempDir(chdr=True):
         exp_name = "random experiment %d" % random.randint(1, 1e6)
         exp_id = mlflow.create_experiment(exp_name)

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -85,7 +85,6 @@ def test_get_experiment_id_with_no_active_experiments_returns_default_experiment
     assert _get_experiment_id() == Experiment.DEFAULT_EXPERIMENT_ID
 
 
-
 def test_get_experiment_id_in_databricks_detects_notebook_id_by_default(reset_experiment_id):
     # pylint: disable=unused-argument
     notebook_id = 768
@@ -97,7 +96,8 @@ def test_get_experiment_id_in_databricks_detects_notebook_id_by_default(reset_ex
         assert _get_experiment_id() == notebook_id
 
 
-def test_get_experiment_id_in_databricks_does_not_detect_notebook_id_if_autodetect_disabled(reset_experiment_id):
+def test_get_experiment_id_in_databricks_does_not_detect_notebook_id_if_autodetect_disabled(
+        reset_experiment_id):
     # pylint: disable=unused-argument
     notebook_id = 768
 


### PR DESCRIPTION
This PR ensures that, when attempting to obtain an experiment ID in a Databricks notebook, the notebook ID is automatically detected from the system environment.

The `mlflow.tracking.fluent._AUTODETECT_EXPERIMENT` environment variable is removed because `set_experiment()`, `_EXPERIMENT_ID_ENV_VAR `, or `_EXPERIMENT_NAME_ENV_VAR ` can be used to supersede notebook id autodetection.