### PR TITLE
Fix test dependencies

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -25,7 +25,7 @@ torchvision
 pysftp
 keras
 attrdict==2.0.0
-azureml-sdk==1.0.15.1; python_version >= "3.0"
+azureml-sdk; python_version >= "3.0"
 cloudpickle
 pytest-localserver
 sqlalchemy

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -25,7 +25,7 @@ torchvision
 pysftp
 keras
 attrdict==2.0.0
-azureml-sdk; python_version >= "3.0"
+azureml-sdk==1.0.15.1; python_version >= "3.0"
 cloudpickle
 pytest-localserver
 sqlalchemy

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -19,7 +19,7 @@ rstcheck==3.2
 # library on Anaconda catches up to pip
 scikit-learn==0.20.0
 scipy
-tensorflow
+tensorflow==1.12.0
 torch
 torchvision
 pysftp

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -29,5 +29,6 @@ azureml-sdk; python_version >= "3.0"
 cloudpickle
 pytest-localserver
 sqlalchemy
+cryptography==2.5.0
 # test plugin
 tests/resources/mlflow-test-plugin/


### PR DESCRIPTION
Currently, tests are failing in CI because the latest version of tensorflow on PyPI (1.13.1) is ahead of that on Anaconda (1.12.0).

This is because the Keras tests dump out a model which bakes in the version of tensorflow installed as a conda dependency. However, as tensorflow is installed from PyPI when testing, this results in an unsatisfiable dependency being written out with the serialised model. When the Keras tests
re-read the generated model, we attempt to create a new conda environment with tensorflow==1.13.1 as a conda dependency, which crashes.

It should probably be reconsidered whether relevant test dependencies should just be installed from conda in the future, or alternatively if we should create a default environment using pip depedencies rather than conda dependances in `mlflow.keras` (and `mlflow.tensorflow` and other model types as appropriate).

For the moment, though, this version issue is causing tests to fail (see at least PRs #926 and #930), so I suggest pinning the tensorflow version as in this PR to facilitate other development.