### PR TITLE
Default conda environments: Install CloudPickle from pip

### DIFF
--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -25,10 +25,10 @@ from mlflow.utils.file_utils import TempDir, _copy_file_or_tree
 # `mlflow.pyfunc.save_model()` and `mlflow.pyfunc.log_model()` when a user-defined subclass of
 # ``PythonModel`` is provided.
 DEFAULT_CONDA_ENV = _mlflow_conda_env(
-    additional_conda_deps=[
+    additional_conda_deps=None,
+    additional_pip_deps=[
         "cloudpickle=={}".format(cloudpickle.__version__),
     ],
-    additional_pip_deps=None,
     additional_conda_channels=None,
 )
 

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -119,7 +119,7 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
         conda_env = copy.deepcopy(DEFAULT_CONDA_ENV)
         if serialization_format == SERIALIZATION_FORMAT_CLOUDPICKLE:
             import cloudpickle
-            conda_env["dependencies"].append("cloudpickle=={}".format(cloudpickle.__version__))
+            conda_env["dependencies"].append({"pip": ["cloudpickle=={}".format(cloudpickle.__version__)]})
     elif not isinstance(conda_env, dict):
         with open(conda_env, "r") as f:
             conda_env = yaml.safe_load(f)

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -119,7 +119,8 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=Model(),
         conda_env = copy.deepcopy(DEFAULT_CONDA_ENV)
         if serialization_format == SERIALIZATION_FORMAT_CLOUDPICKLE:
             import cloudpickle
-            conda_env["dependencies"].append({"pip": ["cloudpickle=={}".format(cloudpickle.__version__)]})
+            conda_env["dependencies"].append(
+                {"pip": ["cloudpickle=={}".format(cloudpickle.__version__)]})
     elif not isinstance(conda_env, dict):
         with open(conda_env, "r") as f:
             conda_env = yaml.safe_load(f)

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -307,8 +307,11 @@ def test_model_save_with_cloudpickle_format_adds_cloudpickle_to_conda_environmen
     assert os.path.exists(saved_conda_env_path)
     with open(saved_conda_env_path, "r") as f:
         saved_conda_env_parsed = yaml.safe_load(f)
-    assert any([
-        "cloudpickle" in dependency for dependency in saved_conda_env_parsed["dependencies"]])
+
+    pip_deps = [dependency for dependency in saved_conda_env_parsed["dependencies"]
+                if type(dependency) == dict and "pip" in dependency]
+    assert len(pip_deps) == 1
+    assert any(["cloudpickle" in pip_dep for pip_dep in pip_deps[0]["pip"]])
 
 
 def test_model_save_without_cloudpickle_format_does_not_add_cloudpickle_to_conda_environment(


### PR DESCRIPTION
We've had several test failures and user errors occur because updates to Conda packages tend to lag behind updates to PyPI package. As a result, when a user / test suite installs the latest version of a package from PyPI, our default conda environments for models often reference dependency versions that do not yet exist on Conda.

~~This PR modifies the default conda environments to install most major dependencies from PyPI instead of Conda, hopefully ameliorating this issue.~~

As a small step toward ameliorating this issue, this PR modifies default conda environments to install the `CloudPickle` library from PyPI instead of Conda, since updates to this library often hit PyPI before Conda.