### PR TITLE
MLflow UI: Make RunView job logs link open in new window/tab

### DIFF
--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -264,7 +264,7 @@ class RunView extends Component {
             <div className="run-info">
               <span className="metadata-header">Job Output: </span>
               <span className="metadata-info">
-                <a href={tags['mlflow.databricks.runURL'].value}>Logs</a>
+                <a href={tags['mlflow.databricks.runURL'].value} target="_blank">Logs</a>
               </span>
             </div>
             : null


### PR DESCRIPTION
The MLflow run view contains a link to job output associated with a run, when applicable. This PR makes the link open in a new window/tab using `target=_blank`.