### PR TITLE
Pin test dependency versions

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,34 +1,32 @@
 # Test reqs
-azure-storage
-google-cloud-storage
-h2o
+azure-storage==0.36.0
+google-cloud-storage==1.14.0
+h2o==3.22.1.4
 botocore<=1.12.84
 boto3<=1.9.84
 mock==2.0.0
-moto
+moto==1.3.7
 pandas<=0.23.4
 prospector[with_pyroma]==0.12.7
 pep8==1.7.1
-pyarrow
+pyarrow==0.12.1
 pylint==1.8.2
-pyspark
+pyspark==2.4.0
 pytest==3.2.1
 pytest-cov==2.6.0
 rstcheck==3.2
-# TODO: Stop pinning the version of scikit-learn when the latest version of the
-# library on Anaconda catches up to pip
-scikit-learn==0.20.0
-scipy
+scikit-learn==0.20.2
+scipy==1.2.1
 tensorflow==1.12.0
-torch
-torchvision
-pysftp
-keras
+torch==1.0.1
+torchvision==0.2.2
+pysftp==0.2.9
+keras==2.2.4
 attrdict==2.0.0
-azureml-sdk; python_version >= "3.0"
-cloudpickle
-pytest-localserver
-sqlalchemy
+azureml-sdk==1.0.17; python_version >= "3.0"
+cloudpickle==0.8.0
+pytest-localserver==0.5.0
+sqlalchemy==1.3.0
 cryptography==2.5.0
 # test plugin
 tests/resources/mlflow-test-plugin/


### PR DESCRIPTION
We've had several test failures occur because updates to Conda packages tend to lag behind updates to PyPI package. As a result, when a test suite installs the latest version of a package from PyPI, our default conda environments for models often reference dependency versions that do not yet exist on Conda. Additionally, dependency upgrades have caused errors in test infrastructure (e.g, mocks) in the past.

This PR attempts to address these common test failures by pinning test dependency versions.