### PR TITLE
Use pandas-split format as default for JSON requests to pyfunc scoring server

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -458,16 +458,12 @@ The local REST API server accepts the following data formats as inputs:
 
 * JSON-serialized pandas DataFrames in the ``split`` orientation. For example,
   ``data = pandas_df.to_json(orient='split')``. This format is specified using a ``Content-Type``
-  request header value of ``application/json; format=pandas-split``. Starting in MLflow 0.9.0,
-  this will be the default format if ``Content-Type`` is ``application/json`` (i.e, with no format
-  specification).
+  request header value of ``application/json`` or ``application/json; format=pandas-split``.
 
 * JSON-serialized pandas DataFrames in the ``records`` orientation. *We do not recommend using
-  this format because it is not guaranteed to preserve column ordering.* Currently, this format is
-  specified using a ``Content-Type`` request header value of  ``application/json; format=pandas-records``
-  or ``application/json``. Starting in MLflow 0.9.0, ``application/json`` will refer to the
-  ``split`` format instead. For forwards compatibility, we recommend using the ``split`` format
-  or specifying the ``application/json; format=pandas-records`` content type.
+  this format because it is not guaranteed to preserve column ordering.* This format is
+  specified using a ``Content-Type`` request header value of
+  ``application/json; format=pandas-records``.
 
 * CSV-serialized pandas DataFrames. For example, ``data = pandas_df.to_csv()``. This format is
   specified using a ``Content-Type`` request header value of ``text/csv``.

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -121,12 +121,6 @@ def test_scoring_server_successfully_evaluates_correct_dataframes_with_pandas_re
     mlflow.sklearn.save_model(sk_model=sklearn_model.model, path=model_path)
 
     pandas_record_content = pd.DataFrame(sklearn_model.inference_data).to_json(orient="records")
-    response_default_content_type = pyfunc_serve_and_score_model(
-            model_path=os.path.abspath(model_path),
-            data=pandas_record_content,
-            content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON)
-    assert response_default_content_type.status_code == 200
-
     response_records_content_type = pyfunc_serve_and_score_model(
             model_path=os.path.abspath(model_path),
             data=pandas_record_content,
@@ -139,6 +133,12 @@ def test_scoring_server_successfully_evaluates_correct_dataframes_with_pandas_sp
     mlflow.sklearn.save_model(sk_model=sklearn_model.model, path=model_path)
 
     pandas_split_content = pd.DataFrame(sklearn_model.inference_data).to_json(orient="split")
+    response_default_content_type = pyfunc_serve_and_score_model(
+            model_path=os.path.abspath(model_path),
+            data=pandas_split_content,
+            content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON)
+    assert response_default_content_type.status_code == 200
+
     response = pyfunc_serve_and_score_model(
             model_path=os.path.abspath(model_path),
             data=pandas_split_content,


### PR DESCRIPTION
This PR modifies the pyfunc scoring server to interpret requests with the `application/json` content type as containing json-serialized pandas dataframes in the `split` format, rather than the `records` format. 

It also updates documentation and tests accordingly.