### PR TITLE
Make MLflow Python entities equal each other when their properties match

### DIFF
--- a/mlflow/entities/_mlflow_object.py
+++ b/mlflow/entities/_mlflow_object.py
@@ -25,6 +25,9 @@ class _MLflowObject(object):
     def __repr__(self):
         return to_string(self)
 
+    def __eq__(self, other):
+        return type(self) == type(other) and dict(self) == dict(other)
+
 
 def to_string(obj):
     return _MLflowObjectPrinter().to_string(obj)

--- a/tests/entities/test_experiment.py
+++ b/tests/entities/test_experiment.py
@@ -37,3 +37,12 @@ class TestExperiment(unittest.TestCase):
                          lifecycle_stage=LifecycleStage.ACTIVE)
         assert str(exp) == "<Experiment: artifact_location='hi', experiment_id=0, " \
                            "lifecycle_stage='active', name='myname'>"
+
+    def test_exp_equality(self):
+        def _get_exp():
+            return Experiment(experiment_id=0, name="myname", artifact_location="hi",
+                              lifecycle_stage=LifecycleStage.ACTIVE)
+        assert _get_exp() == _get_exp()
+        assert _get_exp() != Experiment(
+            experiment_id=0, name="different-name", artifact_location="artifact/location",
+            lifecycle_stage=LifecycleStage.ACTIVE)

--- a/tests/entities/test_file_info.py
+++ b/tests/entities/test_file_info.py
@@ -27,3 +27,7 @@ class TestFileInfo(unittest.TestCase):
 
         fi3 = FileInfo.from_dictionary(as_dict)
         self._check(fi3, path, is_dir, size_in_bytes)
+
+    def test_file_info_equality(self):
+        assert FileInfo("abc", False, 123) == FileInfo("abc", False, 123)
+        assert FileInfo("def", True, 456) != FileInfo("abc", False, 123)

--- a/tests/entities/test_metric.py
+++ b/tests/entities/test_metric.py
@@ -29,3 +29,7 @@ class TestMetric(unittest.TestCase):
 
         metric3 = Metric.from_dictionary(as_dict)
         self._check(metric3, key, value, ts)
+
+    def test_metric_equality(self):
+        assert Metric("abc", 3.2, 123) == Metric("abc", 3.2, 123)
+        assert Metric("def", -3.2, 456) != Metric("abc", 3.2, 123)

--- a/tests/entities/test_param.py
+++ b/tests/entities/test_param.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mlflow.entities import Param
+from mlflow.entities import Param, RunTag
 from tests.helper_functions import random_str, random_int
 
 
@@ -31,3 +31,5 @@ class TestParam(unittest.TestCase):
         assert Param("abc", "def") == Param("abc", "def")
         assert Param("abc", "dif-val") != Param("abc", "def")
         assert Param("dif-key", "def") != Param("abc", "def")
+        # We detect type differences when field values are otherwise identical
+        assert Param(key="a", value="b") != RunTag(key="a", value="b")

--- a/tests/entities/test_param.py
+++ b/tests/entities/test_param.py
@@ -26,3 +26,8 @@ class TestParam(unittest.TestCase):
 
         param3 = Param.from_dictionary(as_dict)
         self._check(param3, key, value)
+
+    def test_param_equality(self):
+        assert Param("abc", "def") == Param("abc", "def")
+        assert Param("abc", "dif-val") != Param("abc", "def")
+        assert Param("dif-key", "def") != Param("abc", "def")

--- a/tests/entities/test_run.py
+++ b/tests/entities/test_run.py
@@ -1,4 +1,5 @@
-from mlflow.entities import Run, Metric, RunData, SourceType, RunStatus, RunInfo, LifecycleStage
+from mlflow.entities import Run, Metric, RunData, SourceType, RunStatus, RunInfo, LifecycleStage,\
+    Param, RunTag
 from tests.entities.test_run_data import TestRunData
 from tests.entities.test_run_info import TestRunInfo
 
@@ -64,3 +65,31 @@ class TestRun(TestRunInfo, TestRunData):
                    "source_name='source-name', source_type=3, source_version='version', " \
                    "start_time=0, status=4, user_id='user-id'>>"
         assert str(run1) == expected
+
+    def test_run_equality(self):
+        def _get_run_info():
+            return RunInfo(
+                run_uuid="hi", experiment_id=0, name="name", source_type=SourceType.PROJECT,
+                source_name="source-name", entry_point_name="entry-point-name",
+                user_id="user-id", status=RunStatus.FAILED, start_time=0, end_time=1,
+                source_version="version", lifecycle_stage=LifecycleStage.ACTIVE)
+
+        def _get_run_data():
+            metrics = [Metric("metric-key", i, i * 2) for i in range(5)]
+            params = [Param("param-key", "param-val-%s" % i) for i in range(5)]
+            tags = [RunTag("tag-key", "tag-val-%s" % i) for i in range(5)]
+            return RunData(metrics=metrics, params=params, tags=tags)
+        run1 = Run(_get_run_info(), _get_run_data())
+        run2 = Run(_get_run_info(), _get_run_data())
+        assert(_get_run_info() == _get_run_info())
+        assert(_get_run_data() == _get_run_data())
+        assert(run1 == run2)
+        different_run_data = RunData([], [], [])
+        different_run_info = RunInfo(
+            run_uuid="different-id", experiment_id=0, name="name", source_type=SourceType.PROJECT,
+            source_name="source-name", entry_point_name="entry-point-name",
+            user_id="user-id", status=RunStatus.FAILED, start_time=0, end_time=1,
+            source_version="version", lifecycle_stage=LifecycleStage.ACTIVE)
+        assert(different_run_info != _get_run_info())
+        assert(different_run_data != _get_run_data())
+        assert(Run(different_run_info, different_run_data) != run1)

--- a/tests/entities/test_run_tag.py
+++ b/tests/entities/test_run_tag.py
@@ -1,0 +1,6 @@
+from mlflow.entities import RunTag
+
+def test_tag_equality():
+    assert RunTag("abc", "def") == RunTag("abc", "def")
+    assert RunTag("abc", "dif-val") != RunTag("abc", "def")
+    assert RunTag("dif-key", "def") != RunTag("abc", "def")


### PR DESCRIPTION
Includes logic + tests for modified MLflow entity equality behavior - previously two entities (run/param/experiment etc) would only be equal if they were the same Python object, but this PR makes them equal if their dictionary representations are equal. Note that this is a breaking behavior change, but seems like a reasonable one - after this PR comparisons like `mlflow.tracking.MlflowClient().list_experiments() == mlflow.tracking.MlflowClient().list_experiments()` evaluate to True (same for `mlflow.get_run("some-uuid" == mlflow.get_run("some-uuid")`). This should simplify CI/CD workflows that may want to e.g. compare run parameters or tags, in addition to simplifying the unit-testing logic in #955.
