### PR TITLE
[Docs] Changed output of model server

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -306,7 +306,7 @@ in MLflow saved the model as an artifact within the run.
 
       the server should respond with output similar to::
 
-          {"predictions": [6.379428821398614]}
+          [6.379428821398614]
 
     .. container:: R
 


### PR DESCRIPTION
When I run the model server the output is [value] not {"predictions": [value]} - perhaps this is something I have done but if not the docs should probably reflect this.  I haven't tested the R version so that may need updating too.