### PR TITLE
Add a button for downloading artifacts

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -101,10 +101,12 @@ def get_artifact_handler():
     run = _get_store().get_run(request_dict['run_uuid'])
     filename = os.path.abspath(_get_artifact_repo(run).download_artifacts(request_dict['path']))
     extension = os.path.splitext(filename)[-1].replace(".", "")
+    # Always send artifacts as attachments to prevent the browser from displaying them on our web
+    # server's domain, which might enable XSS.
     if extension in _TEXT_EXTENSIONS:
-        return send_file(filename, mimetype='text/plain')
+        return send_file(filename, mimetype='text/plain', as_attachment=True)
     else:
-        return send_file(filename)
+        return send_file(filename, as_attachment=True)
 
 
 def _not_implemented():

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -81,5 +81,13 @@
       "lcov"
     ]
   },
-  "proxy": "http://localhost:5000"
+  "proxy": {
+    "/ajax-api": {
+      "target": "http://localhost:5000"
+    },
+    "/get-artifact": {
+      "target": "http://localhost:5000",
+      "ws": true
+    }
+  }
 }

--- a/mlflow/server/js/src/components/ArtifactView.css
+++ b/mlflow/server/js/src/components/ArtifactView.css
@@ -5,7 +5,20 @@
   padding-top: 8px;
 }
 
+.artifact-info-link {
+  float: right;
+  width: 39px;
+  height: 40px;
+  padding-top: 4px;
+  font-size: 21px;
+}
+
+.artifact-info-path {
+  margin-right: 48px;
+}
+
 .artifact-info-size {
+  margin-right: 45px;
 }
 
 .view-button {

--- a/mlflow/server/js/src/components/ArtifactView.css
+++ b/mlflow/server/js/src/components/ArtifactView.css
@@ -7,9 +7,9 @@
 
 .artifact-info-link {
   float: right;
-  width: 39px;
+  width: 38px;
   height: 40px;
-  padding-top: 4px;
+  padding-top: 5px;
   font-size: 21px;
 }
 

--- a/mlflow/server/js/src/components/ArtifactView.js
+++ b/mlflow/server/js/src/components/ArtifactView.js
@@ -10,7 +10,7 @@ import { ArtifactNode as ArtifactUtils, ArtifactNode } from '../utils/ArtifactUt
 import { decorators, Treebeard } from 'react-treebeard';
 import bytes from 'bytes';
 import './ArtifactView.css';
-import ShowArtifactPage from './artifact-view-components/ShowArtifactPage';
+import ShowArtifactPage, {getSrc} from './artifact-view-components/ShowArtifactPage';
 import spinner from '../static/mlflow-spinner.png';
 
 class ArtifactView extends Component {
@@ -53,11 +53,22 @@ class ArtifactView extends Component {
               <div className="artifact-info">
                 {this.state.activeNodeId ?
                   (<div>
-                    <div>
+                    <div className="artifact-info-link">
+                      <a href={getSrc(this.state.activeNodeId, this.props.runUuid)}
+                         target="_blank"
+                         title="Open in New Tab">
+                        <i className="fas fa-external-link-alt"/>
+                      </a>
+                    </div>
+                    <div className="artifact-info-path">
                       <label>Full Path:</label> {this.getRealPath()}
                     </div>
-                    <div className="artifact-info-size"><label>Size:</label> {this.getSize()}</div>
-                  </div>) :
+                    <div className="artifact-info-size">
+                      <label>Size:</label> {this.getSize()}
+                    </div>
+                  </div>
+                  )
+                  :
                   null
                 }
               </div>

--- a/mlflow/server/js/src/components/ArtifactView.js
+++ b/mlflow/server/js/src/components/ArtifactView.js
@@ -56,8 +56,8 @@ class ArtifactView extends Component {
                     <div className="artifact-info-link">
                       <a href={getSrc(this.state.activeNodeId, this.props.runUuid)}
                          target="_blank"
-                         title="Open in New Tab">
-                        <i className="fas fa-external-link-alt"/>
+                         title="Download artifact">
+                        <i className="fas fa-download"/>
                       </a>
                     </div>
                     <div className="artifact-info-path">

--- a/mlflow/server/js/src/components/ArtifactView.js
+++ b/mlflow/server/js/src/components/ArtifactView.js
@@ -20,6 +20,7 @@ class ArtifactView extends Component {
     this.getTreebeardData = this.getTreebeardData.bind(this);
     this.getRealPath = this.getRealPath.bind(this);
     this.shouldShowTreebeard = this.shouldShowTreebeard.bind(this);
+    this.activeNodeIsDirectory = this.activeNodeIsDirectory.bind(this);
   }
   static propTypes = {
     runUuid: PropTypes.string.isRequired,
@@ -52,14 +53,18 @@ class ArtifactView extends Component {
             <div className="artifact-right">
               <div className="artifact-info">
                 {this.state.activeNodeId ?
-                  (<div>
-                    <div className="artifact-info-link">
-                      <a href={getSrc(this.state.activeNodeId, this.props.runUuid)}
-                         target="_blank"
-                         title="Download artifact">
-                        <i className="fas fa-download"/>
-                      </a>
-                    </div>
+                  <div>
+                    {!this.activeNodeIsDirectory() ?
+                      <div className="artifact-info-link">
+                        <a href={getSrc(this.state.activeNodeId, this.props.runUuid)}
+                           target="_blank"
+                           title="Download artifact">
+                          <i className="fas fa-download"/>
+                        </a>
+                      </div>
+                      :
+                      null
+                    }
                     <div className="artifact-info-path">
                       <label>Full Path:</label> {this.getRealPath()}
                     </div>
@@ -67,7 +72,6 @@ class ArtifactView extends Component {
                       <label>Size:</label> {this.getSize()}
                     </div>
                   </div>
-                  )
                   :
                   null
                 }
@@ -76,7 +80,8 @@ class ArtifactView extends Component {
             </div>
             <div className="artifact-center">
             </div>
-          </div> :
+          </div>
+          :
           <div className="empty-artifact-outer-container">
             <div className="empty-artifact-container">
               <div>
@@ -94,6 +99,7 @@ class ArtifactView extends Component {
       </div>
     );
   }
+
   onToggleTreebeard(dataNode, toggled) {
     const { id, loading } = dataNode;
     const newRequestedNodeIds = new Set(this.state.requestedNodeIds);
@@ -177,6 +183,16 @@ class ArtifactView extends Component {
       return bytes(parseInt(size, 10));
     }
     return bytes(0);
+  }
+
+  activeNodeIsDirectory() {
+    if (this.state.activeNodeId) {
+      const node = ArtifactUtils.findChild(this.props.artifactNode, this.state.activeNodeId);
+      return node.fileInfo.is_dir;
+    } else {
+      // No node is highlighted so we're displaying the root, which is a directory.
+      return true;
+    }
   }
 }
 


### PR DESCRIPTION
This makes it possible to download .html files, images, etc and view them locally. It looks like this:

![screen shot 2019-03-07 at 7 24 25 pm](https://user-images.githubusercontent.com/228859/54005533-ae3b9a00-410e-11e9-92c8-451e2224d63c.png)

I also updated `package.json` to have it treat /get-artifact as a web server, because otherwise it tried to redirect all paths that return MIME type HTML to /index.html (this is the default behavior for the React proxy).