### PR TITLE
Tag values are expected to be strings

### DIFF
--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -152,6 +152,7 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(CreateRun, req_body)
         run = Run.from_proto(response_proto.run)
         if run_name:
+            # TODO: optimization: This is making 2 calls to backend store. Include with above call.
             self.set_tag(run.info.run_uuid, RunTag(key=MLFLOW_RUN_NAME, value=run_name))
         return run
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -137,13 +137,15 @@ def start_run(run_uuid=None, experiment_id=None, source_name=None, source_versio
 
         # Polling resolved tags for run meta data : source_name, source_version,
         # entry_point_name, and source_type which is store in RunInfo for backward compatibility.
+        # TODO: Remove all 4 of the following annotated backward compatibility fixes with API
+        #  changes to create_run.
         active_run_obj = MlflowClient().create_run(
             experiment_id=exp_id_for_run,
             run_name=run_name,
-            source_name=tags.get(MLFLOW_SOURCE_NAME),
-            source_version=tags.get(MLFLOW_GIT_COMMIT),
-            entry_point_name=tags.get(MLFLOW_PROJECT_ENTRY_POINT),
-            source_type=SourceType.from_string(tags.get(MLFLOW_SOURCE_TYPE)),
+            source_name=tags.get(MLFLOW_SOURCE_NAME),  # TODO: for backward compatibility. Remove.
+            source_version=tags.get(MLFLOW_GIT_COMMIT),  # TODO: for backward compatibility. Remove.
+            entry_point_name=tags.get(MLFLOW_PROJECT_ENTRY_POINT),  # TODO: remove
+            source_type=SourceType.from_string(tags.get(MLFLOW_SOURCE_TYPE)),  # TODO: Remove
             tags=tags,
             parent_run_id=parent_run_id
         )

--- a/tests/tracking/test_context.py
+++ b/tests/tracking/test_context.py
@@ -38,7 +38,7 @@ def test_default_run_context_in_context():
 def test_default_run_context_tags(patch_script_name):
     assert DefaultRunContext().tags() == {
         MLFLOW_SOURCE_NAME: MOCK_SCRIPT_NAME,
-        MLFLOW_SOURCE_TYPE: SourceType.LOCAL
+        MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.LOCAL)
     }
 
 
@@ -86,7 +86,7 @@ def test_databricks_notebook_run_context_tags():
             patch_webapp_url as webapp_url_mock:
         assert DatabricksNotebookRunContext().tags() == {
             MLFLOW_SOURCE_NAME: notebook_path_mock.return_value,
-            MLFLOW_SOURCE_TYPE: SourceType.NOTEBOOK,
+            MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.NOTEBOOK),
             MLFLOW_DATABRICKS_NOTEBOOK_ID: notebook_id_mock.return_value,
             MLFLOW_DATABRICKS_NOTEBOOK_PATH: notebook_path_mock.return_value,
             MLFLOW_DATABRICKS_WEBAPP_URL: webapp_url_mock.return_value
@@ -104,7 +104,7 @@ def test_databricks_notebook_run_context_tags_nones():
     with patch_notebook_id, patch_notebook_path, patch_webapp_url:
         assert DatabricksNotebookRunContext().tags() == {
             MLFLOW_SOURCE_NAME: None,
-            MLFLOW_SOURCE_TYPE: SourceType.NOTEBOOK,
+            MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.NOTEBOOK),
         }
 
 

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -173,16 +173,16 @@ def test_start_run_defaults(empty_active_run_stack):
         "mlflow.tracking.context._get_source_version", return_value=mock_source_version
     )
 
-    create_run_patch = mock.patch.object(MlflowClient, "create_run")
-
     expected_tags = {
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_source_name,
-        mlflow_tags.MLFLOW_SOURCE_TYPE: mock_source_type,
+        mlflow_tags.MLFLOW_SOURCE_TYPE: "some source",
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version
     }
 
     with experiment_id_patch, databricks_notebook_patch, source_name_patch, source_type_patch, \
-            source_version_patch, create_run_patch:
+            source_version_patch, mock.patch.object(MlflowClient, "create_run"), \
+            mock.patch.object(SourceType, "to_string", return_value="some source"), \
+            mock.patch.object(SourceType, "from_string", return_value=mock_source_type):
         active_run = start_run()
         MlflowClient.create_run.assert_called_once_with(
             experiment_id=mock_experiment_id,
@@ -225,7 +225,7 @@ def test_start_run_defaults_databricks_notebook(empty_active_run_stack):
 
     expected_tags = {
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_notebook_path,
-        mlflow_tags.MLFLOW_SOURCE_TYPE: SourceType.NOTEBOOK,
+        mlflow_tags.MLFLOW_SOURCE_TYPE: "NOTEBOOK",
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version,
         mlflow_tags.MLFLOW_DATABRICKS_NOTEBOOK_ID: mock_notebook_id,
         mlflow_tags.MLFLOW_DATABRICKS_NOTEBOOK_PATH: mock_notebook_path,
@@ -265,14 +265,17 @@ def test_start_run_overrides(empty_active_run_stack):
     mock_entry_point_name = mock.Mock()
     mock_run_name = mock.Mock()
 
+    to_str_patch = mock.patch.object(SourceType, "to_string", return_value="some source type")
+    from_str_patch = mock.patch.object(SourceType, "from_string", return_value=mock_source_type)
+
     expected_tags = {
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_source_name,
-        mlflow_tags.MLFLOW_SOURCE_TYPE: mock_source_type,
+        mlflow_tags.MLFLOW_SOURCE_TYPE: "some source type",
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version,
         mlflow_tags.MLFLOW_PROJECT_ENTRY_POINT: mock_entry_point_name
     }
 
-    with databricks_notebook_patch, create_run_patch:
+    with databricks_notebook_patch, create_run_patch, to_str_patch, from_str_patch:
         active_run = start_run(
             experiment_id=mock_experiment_id, source_name=mock_source_name,
             source_version=mock_source_version, entry_point_name=mock_entry_point_name,
@@ -309,8 +312,6 @@ def test_start_run_overrides_databricks_notebook(empty_active_run_stack):
         "mlflow.utils.databricks_utils.get_webapp_url", return_value=mock_webapp_url
     )
 
-    create_run_patch = mock.patch.object(MlflowClient, "create_run")
-
     mock_experiment_id = mock.Mock()
     mock_source_name = mock.Mock()
     mock_source_type = mock.Mock()
@@ -320,7 +321,7 @@ def test_start_run_overrides_databricks_notebook(empty_active_run_stack):
 
     expected_tags = {
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_source_name,
-        mlflow_tags.MLFLOW_SOURCE_TYPE: mock_source_type,
+        mlflow_tags.MLFLOW_SOURCE_TYPE: "overridden notebook",
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version,
         mlflow_tags.MLFLOW_PROJECT_ENTRY_POINT: mock_entry_point_name,
         mlflow_tags.MLFLOW_DATABRICKS_NOTEBOOK_ID: mock_notebook_id,
@@ -328,8 +329,10 @@ def test_start_run_overrides_databricks_notebook(empty_active_run_stack):
         mlflow_tags.MLFLOW_DATABRICKS_WEBAPP_URL: mock_webapp_url
     }
 
-    with databricks_notebook_patch, create_run_patch, notebook_id_patch, notebook_path_patch, \
-            webapp_url_patch:
+    with databricks_notebook_patch, notebook_id_patch, notebook_path_patch, webapp_url_patch, \
+            mock.patch.object(MlflowClient, "create_run"), \
+            mock.patch.object(SourceType, "to_string", return_value="overridden notebook"), \
+            mock.patch.object(SourceType, "from_string", return_value=mock_source_type):
         active_run = start_run(
             experiment_id=mock_experiment_id, source_name=mock_source_name,
             source_version=mock_source_version, entry_point_name=mock_entry_point_name,
@@ -357,8 +360,6 @@ def test_start_run_with_parent():
         "mlflow.tracking.fluent.is_in_databricks_notebook", return_value=False
     )
 
-    create_run_patch = mock.patch.object(MlflowClient, "create_run")
-
     mock_experiment_id = mock.Mock()
     mock_source_name = mock.Mock()
     mock_source_type = mock.Mock()
@@ -368,12 +369,15 @@ def test_start_run_with_parent():
 
     expected_tags = {
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_source_name,
-        mlflow_tags.MLFLOW_SOURCE_TYPE: mock_source_type,
+        mlflow_tags.MLFLOW_SOURCE_TYPE: "type_1248",
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version,
         mlflow_tags.MLFLOW_PROJECT_ENTRY_POINT: mock_entry_point_name
     }
 
-    with databricks_notebook_patch, create_run_patch, active_run_stack_patch:
+    with databricks_notebook_patch, active_run_stack_patch, \
+            mock.patch.object(MlflowClient, "create_run"), \
+            mock.patch.object(SourceType, "to_string", return_value="type_1248"), \
+            mock.patch.object(SourceType, "from_string", return_value=mock_source_type):
         active_run = start_run(
             experiment_id=mock_experiment_id, source_name=mock_source_name,
             source_version=mock_source_version, entry_point_name=mock_entry_point_name,


### PR DESCRIPTION
- Fixing context providers to ensure that string values are passed for "source type". Since `SourceType` is an enum, converting to/from string involves calling class methods to preserver backward compatibility of types displayed in UI and ensuring that `RestStore` can hydrate protobufs appropriately. Fixed tests to reflect this change.

- Also making tag resolution order and precedence explicit over multiple context providers.