### PR TITLE
Documentation for backend and artifact stores

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -255,9 +255,9 @@ An MLflow tracking server has two properties related to how data is stored: a ba
 an artifact store.
 
 The *backend store* (exposed as ``--backend-store-uri``) is where the *server* stores run and
-experiment metadata. For backward compatibility, ``--file-store`` option is an alias to this
-option. This can be a local path *file store* specified as ``./path_to_store`` or
-``file://path_to_store``, or a SQL connection string for a *database backed store*. For the
+experiment metadata. For backwards compatibility, ``--file-store`` is an alias for this option.
+This can be a local path *file store* specified as ``./path_to_store`` or
+``file:/path_to_store``, or a SQL connection string for a *database-backed store*. For the
 latter, the argument must be a SQL connection string specified as
 ``db_type://<user_name>:<password>@<host>:<port>/<database_name>``. Supported database types are
 ``mysql``, ``mssql``, ``sqlite``, and ``postgresql``.

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -251,10 +251,9 @@ You run an MLflow tracking server using ``mlflow server``.  An example configura
 Storage
 -------
 
-An MLflow tracking server has two components for storage: a **backend store** and an
-**artifact store**.
+An MLflow tracking server has two components for storage: a *backend store* and an *artifact store*.
 
-The **backend store** is where MLflow Tracking Server stores experiment and run metadata as well as
+The backend store is where MLflow Tracking Server stores experiment and run metadata as well as
 params, metrics, and tags for runs. MLflow supports two types of backend stores: *file store* and
 *database-backed store*.
 
@@ -271,7 +270,7 @@ persistent (that is, non-ephemeral) file system location.
 .. note::
   For backwards compatibility, ``--file-store`` is an alias for this option.
 
-The **artifact store** is a location suitable for large data (such as an S3 bucket or shared NFS
+The artifact store is a location suitable for large data (such as an S3 bucket or shared NFS
 file system) and is where clients log their artifact output (for example, models).
 ``artifact_location`` is a property recorded on :py:class:`mlflow.entities.Experiment` for
 default location to store artifacts for all runs in this experiment. Additional, ``artifact_uri``

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -264,9 +264,9 @@ for a *database-backed store*. For the latter, the argument must be a SQL connec
 specified as ``db_type://<user_name>:<password>@<host>:<port>/<database_name>``. Supported
 database types are ``mysql``, ``mssql``, ``sqlite``, and ``postgresql``.
 
-By default this is set to the local ``./mlruns`` directory (the same as when running ``mlflow run``
-locally), but when running a server, make sure that this points to a persistent (that is,
-non-ephemeral) file system location.
+By default ``--backend-store-uri`` is set to the local ``./mlruns`` directory (the same as when
+running ``mlflow run`` locally), but when running a server, make sure that this points to a
+persistent (that is, non-ephemeral) file system location.
 
 .. note::
   For backwards compatibility, ``--file-store`` is an alias for this option.

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -251,26 +251,37 @@ You run an MLflow tracking server using ``mlflow server``.  An example configura
 Storage
 -------
 
-An MLflow tracking server has two properties related to how data is stored: a backend store and
-an artifact store.
+An MLflow tracking server has two components for storage: a **backend store** and an
+**artifact store**.
 
-The *backend store* (exposed as ``--backend-store-uri``) is where the *server* stores run and
-experiment metadata. For backwards compatibility, ``--file-store`` is an alias for this option.
-This can be a local path *file store* specified as ``./path_to_store`` or
-``file:/path_to_store``, or a SQL connection string for a *database-backed store*. For the
-latter, the argument must be a SQL connection string specified as
-``db_type://<user_name>:<password>@<host>:<port>/<database_name>``. Supported database types are
-``mysql``, ``mssql``, ``sqlite``, and ``postgresql``.
+The **backend store** is where MLflow Tracking Server stores experiment and run metadata as well as
+params, metrics, and tags for runs. MLflow supports two types of backend stores: *file store* and
+*database-backed store*.
+
+Use ``--backend-store-uri`` to configure type of backend store. This can be a local path *file
+store* specified as ``./path_to_store`` or ``file:/path_to_store``, or a SQL connection string
+for a *database-backed store*. For the latter, the argument must be a SQL connection string
+specified as ``db_type://<user_name>:<password>@<host>:<port>/<database_name>``. Supported
+database types are ``mysql``, ``mssql``, ``sqlite``, and ``postgresql``.
+
 By default this is set to the local ``./mlruns`` directory (the same as when running ``mlflow run``
 locally), but when running a server, make sure that this points to a persistent (that is,
 non-ephemeral) file system location.
 
-The *artifact store* is a location suitable for large data (such as an S3 bucket or shared NFS file system)
-and is where *clients* log their artifact output (for example, models). The artifact store is a property
-of an experiment, but the ``--default-artifact-root`` flag sets the artifact root URI for
-newly-created experiments that do not specify one.
-Once you create an experiment, ``--default-artifact-root`` is no longer relevant to it.
-It defaults to the local ``./mlruns`` directory.
+.. note::
+  For backwards compatibility, ``--file-store`` is an alias for this option.
+
+The **artifact store** is a location suitable for large data (such as an S3 bucket or shared NFS
+file system) and is where clients log their artifact output (for example, models).
+``artifact_location`` is a property recorded on :py:class:`mlflow.entities.Experiment` for
+default location to store artifacts for all runs in this experiment. Additional, ``artifact_uri``
+is a property on :py:class:`mlflow.entities.RunInfo` to indicate location where all artifacts for
+this run are stored.
+
+Use ``--default-artifact-root`` (defaults to local ``./mlruns`` directory) to configure default
+location to server's artifact store. This will be used as artifact location for newly-created
+experiments that do not specify one. Once you create an experiment, ``--default-artifact-root``
+is no longer relevant to that experiment.
 
 To allow the server and clients to access the artifact location, you should configure your cloud
 provider credentials as normal. For example, for S3, you can set the ``AWS_ACCESS_KEY_ID``
@@ -288,7 +299,8 @@ See `Set up AWS Credentials and Region for Development <https://docs.aws.amazon.
 Supported Artifact Stores
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In addition to local file paths, MLflow supports the following storage systems as artifact stores: Amazon S3, Azure Blob Storage, Google Cloud Storage, SFTP server, and NFS.
+In addition to local file paths, MLflow supports the following storage systems as artifact
+stores: Amazon S3, Azure Blob Storage, Google Cloud Storage, SFTP server, and NFS.
 
 Amazon S3
 ^^^^^^^^^

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -250,7 +250,8 @@ You run an MLflow tracking server using ``mlflow server``.  An example configura
 Storage
 -------
 
-An MLflow tracking server has two properties related to how data is stored: file store and artifact store.
+An MLflow tracking server has two properties related to how data is stored: backend store and
+artifact store.
 
 The *backend store* (exposed as ``--backend-store-uri``) is where the *server* stores run and
 experiment metadata. For backward compatibility, ``--file-store`` option is an alias to this
@@ -259,8 +260,9 @@ option. This can be a local path **file store** specified as ``./path_to_store``
 latter, argument is expected to be a SQL connection string specified as
 ``db_type://<user_name>:<password>@<host>:<port>/<database_name>``. Supported database types are
 ``mysql``, ``mssql``, ``sqlite``, and ``postgresql``.
-It defaults to the local ``./mlruns`` directory (the same as when running ``mlflow run`` locally), but when
-running a server, make sure that this points to a persistent (that is, non-ephemeral) file system location.
+By default this is set to the local ``./mlruns`` directory (the same as when running ``mlflow run``
+locally), but when running a server, make sure that this points to a persistent (that is,
+non-ephemeral) file system location.
 
 The *artifact store* is a location suitable for large data (such as an S3 bucket or shared NFS file system)
 and is where *clients* log their artifact output (for example, models). The artifact store is a property

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -250,14 +250,14 @@ You run an MLflow tracking server using ``mlflow server``.  An example configura
 Storage
 -------
 
-An MLflow tracking server has two properties related to how data is stored: backend store and
-artifact store.
+An MLflow tracking server has two properties related to how data is stored: a backend store and
+an artifact store.
 
 The *backend store* (exposed as ``--backend-store-uri``) is where the *server* stores run and
 experiment metadata. For backward compatibility, ``--file-store`` option is an alias to this
-option. This can be a local path **file store** specified as ``./path_to_store`` or
-``file://path_to_store``, or a SQL connection string for a *Database backed store*. For the
-latter, argument is expected to be a SQL connection string specified as
+option. This can be a local path *file store* specified as ``./path_to_store`` or
+``file://path_to_store``, or a SQL connection string for a *database backed store*. For the
+latter, the argument must be a SQL connection string specified as
 ``db_type://<user_name>:<password>@<host>:<port>/<database_name>``. Supported database types are
 ``mysql``, ``mssql``, ``sqlite``, and ``postgresql``.
 By default this is set to the local ``./mlruns`` directory (the same as when running ``mlflow run``

--- a/mlflow/store/__init__.py
+++ b/mlflow/store/__init__.py
@@ -1,7 +1,7 @@
 """
 An MLflow tracking server has two properties related to how data is stored: *backend store* to
-record ML experiments, runs, parameters, metrics. ... etc and *artifact store* to store run
-artifacts like models, plots, images. ... etc.
+record ML experiments, runs, parameters, metrics, etc., and *artifact store* to store run
+artifacts like models, plots, images, etc.
 
 Several constants are used by multiple backend store implementations.
 """

--- a/mlflow/store/__init__.py
+++ b/mlflow/store/__init__.py
@@ -1,5 +1,9 @@
 """
-Constants shared by several backend store implementations.
+An MLflow tracking server has two properties related to how data is stored: *backend store* to
+record ML experiments, runs, parameters, metrics. ... etc and *artifact store* to store run
+artifacts like models, plots, images. ... etc.
+
+Several constants are used by multiple backend store implementations.
 """
 
 # Path to default location for backend when using local FileStore or ArtifactStore.

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -31,7 +31,7 @@ class AbstractStore:
     @abstractmethod
     def create_experiment(self, name, artifact_location):
         """
-        Creates a new experiment.
+        Create a new experiment.
         If an experiment with the given name already exists, throws exception.
 
         :param name: Desired name for an experiment
@@ -44,7 +44,7 @@ class AbstractStore:
     @abstractmethod
     def get_experiment(self, experiment_id):
         """
-        Fetches the experiment by ID from the backend store.
+        Fetch the experiment by ID from the backend store.
 
         :param experiment_id: Integer id for the experiment
 
@@ -56,7 +56,7 @@ class AbstractStore:
 
     def get_experiment_by_name(self, experiment_name):
         """
-        Fetches the experiment by name from the backend store.
+        Fetch the experiment by name from the backend store.
         This is a base implementation using ``list_experiments``, derived classes may have
         some specialized implementations.
 
@@ -72,7 +72,7 @@ class AbstractStore:
     @abstractmethod
     def delete_experiment(self, experiment_id):
         """
-        Deletes the experiment from the backend store. Deleted experiments can be restored until
+        Delete the experiment from the backend store. Deleted experiments can be restored until
         permanently deleted.
 
         :param experiment_id: Integer id for the experiment
@@ -100,7 +100,7 @@ class AbstractStore:
     @abstractmethod
     def get_run(self, run_uuid):
         """
-        Fetches the run from backend store
+        Fetch the run from backend store
 
         :param run_uuid: Unique identifier for the run
 
@@ -111,7 +111,7 @@ class AbstractStore:
 
     def update_run_info(self, run_uuid, run_status, end_time):
         """
-        Updates the metadata of the specified run.
+        Update the metadata of the specified run.
 
         :return: :py:class:`mlflow.entities.RunInfo` describing the updated run.
         """
@@ -120,7 +120,7 @@ class AbstractStore:
     def create_run(self, experiment_id, user_id, run_name, source_type, source_name,
                    entry_point_name, start_time, source_version, tags, parent_run_id):
         """
-        Creates a run under the specified experiment ID, setting the run's status to "RUNNING"
+        Create a run under the specified experiment ID, setting the run's status to "RUNNING"
         and the start time to the current time.
 
         :param experiment_id: ID of the experiment for this run
@@ -134,7 +134,7 @@ class AbstractStore:
     @abstractmethod
     def delete_run(self, run_id):
         """
-        Deletes a run.
+        Delete a run.
 
         :param run_id
         """
@@ -143,7 +143,7 @@ class AbstractStore:
     @abstractmethod
     def restore_run(self, run_id):
         """
-        Restores a run.
+        Restore a run.
 
         :param run_id
         """
@@ -151,7 +151,7 @@ class AbstractStore:
 
     def log_metric(self, run_uuid, metric):
         """
-        Logs a metric for the specified run
+        Log a metric for the specified run
 
         :param run_uuid: String id for the run
         :param metric: :py:class:`mlflow.entities.Metric` instance to log
@@ -160,7 +160,7 @@ class AbstractStore:
 
     def log_param(self, run_uuid, param):
         """
-        Logs a param for the specified run
+        Log a param for the specified run
 
         :param run_uuid: String id for the run
         :param param: :py:class:`mlflow.entities.Param` instance to log
@@ -169,7 +169,7 @@ class AbstractStore:
 
     def set_tag(self, run_uuid, tag):
         """
-        Sets a tag for the specified run
+        Set a tag for the specified run
 
         :param run_uuid: String id for the run
         :param tag: :py:class:`mlflow.entities.RunTag` instance to set
@@ -179,7 +179,7 @@ class AbstractStore:
     @abstractmethod
     def get_metric_history(self, run_uuid, metric_key):
         """
-        Returns all logged value for a given metric.
+        Return all logged value for a given metric.
 
         :param run_uuid: Unique identifier for run
         :param metric_key: Metric name within the run
@@ -191,7 +191,7 @@ class AbstractStore:
     @abstractmethod
     def search_runs(self, experiment_ids, search_filter, run_view_type):
         """
-        Returns runs that match the given list of search expressions within the experiments.
+        Return runs that match the given list of search expressions within the experiments.
         Given multiple search expressions, all these expressions are ANDed together for search.
 
         :param experiment_ids: List of experiment ids to scope the search
@@ -206,7 +206,7 @@ class AbstractStore:
 
     def list_run_infos(self, experiment_id, run_view_type):
         """
-        Returns run information for runs which belong to the experiment_id
+        Return run information for runs which belong to the experiment_id
 
         :param experiment_id: The experiment id which to search.
 
@@ -219,7 +219,7 @@ class AbstractStore:
     @abstractmethod
     def log_batch(self, run_id, metrics, params, tags):
         """
-        Logs multiple metrics, params, and tags for the specified run
+        Log multiple metrics, params, and tags for the specified run
 
         :param run_id: String id for the run
         :param metrics: List of :py:class:`mlflow.entities.Metric` instances to log

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -6,7 +6,7 @@ from mlflow.entities import ViewType
 class AbstractStore:
     """
     Abstract class for Backend Storage.
-    This class will define API interface for front ends to connect with various types of backends
+    This class defines the API interface for front ends to connect with various types of backends.
     """
 
     __metaclass__ = ABCMeta
@@ -37,7 +37,7 @@ class AbstractStore:
         :param name: Desired name for an experiment
         :param artifact_location: Base location for artifacts in runs. May be None.
 
-        :return: experiment_id (integer) for the newly created experiment if successful, else None
+        :return: experiment_id (integer) for the newly created experiment if successful, else None.
         """
         pass
 
@@ -179,7 +179,7 @@ class AbstractStore:
     @abstractmethod
     def get_metric_history(self, run_uuid, metric_key):
         """
-        Return all logged value for a given metric.
+        Return all logged values for a given metric.
 
         :param run_uuid: Unique identifier for run
         :param metric_key: Metric name within the run
@@ -196,8 +196,8 @@ class AbstractStore:
 
         :param experiment_ids: List of experiment ids to scope the search
         :param search_filter: :py:class`mlflow.utils.search_utils.SearchFilter` object to encode
-            search expression or filter string.
-        :param run_view_type: ACTIVE, DELETED, or ALL runs.
+            search expression or filter string
+        :param run_view_type: ACTIVE, DELETED, or ALL runs
 
         :return: A list of :py:class:`mlflow.entities.Run` objects that satisfy the search
             expressions
@@ -208,7 +208,7 @@ class AbstractStore:
         """
         Return run information for runs which belong to the experiment_id
 
-        :param experiment_id: The experiment id which to search.
+        :param experiment_id: The experiment id which to search
 
         :return: A list of :py:class:`mlflow.entities.RunInfo` objects that satisfy the
             search expressions
@@ -226,8 +226,6 @@ class AbstractStore:
         :param params: List of :py:class:`mlflow.entities.Param` instances to log
         :param tags: List of :py:class:`mlflow.entities.RunTag` instances to log
 
-        :return: Tuple (failed_metrics, failed_params, failed_tags) where each element of
-                 the tuple is a list of of :py:class:`mlflow.protos.service_pb2.BatchLogFailure`
-                 protos describing metrics/params/tags that failed to be logged & why.
+        :return: None.
         """
         pass

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -135,7 +135,8 @@ class AbstractStore:
     def delete_run(self, run_id):
         """
         Deletes a run.
-        :param run_id:
+
+        :param run_id
         """
         pass
 
@@ -143,13 +144,15 @@ class AbstractStore:
     def restore_run(self, run_id):
         """
         Restores a run.
-        :param run_id:
+
+        :param run_id
         """
         pass
 
     def log_metric(self, run_uuid, metric):
         """
         Logs a metric for the specified run
+
         :param run_uuid: String id for the run
         :param metric: :py:class:`mlflow.entities.Metric` instance to log
         """
@@ -158,6 +161,7 @@ class AbstractStore:
     def log_param(self, run_uuid, param):
         """
         Logs a param for the specified run
+
         :param run_uuid: String id for the run
         :param param: :py:class:`mlflow.entities.Param` instance to log
         """
@@ -166,6 +170,7 @@ class AbstractStore:
     def set_tag(self, run_uuid, tag):
         """
         Sets a tag for the specified run
+
         :param run_uuid: String id for the run
         :param tag: :py:class:`mlflow.entities.RunTag` instance to set
         """
@@ -215,11 +220,13 @@ class AbstractStore:
     def log_batch(self, run_id, metrics, params, tags):
         """
         Logs multiple metrics, params, and tags for the specified run
+
         :param run_id: String id for the run
         :param metrics: List of :py:class:`mlflow.entities.Metric` instances to log
         :param params: List of :py:class:`mlflow.entities.Param` instances to log
         :param tags: List of :py:class:`mlflow.entities.RunTag` instances to log
-        :returns Tuple (failed_metrics, failed_params, failed_tags) where each element of
+
+        :return: Tuple (failed_metrics, failed_params, failed_tags) where each element of
                  the tuple is a list of of :py:class:`mlflow.protos.service_pb2.BatchLogFailure`
                  protos describing metrics/params/tags that failed to be logged & why.
         """

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -9,8 +9,8 @@ from mlflow.utils.file_utils import build_path
 
 class ArtifactRepository:
     """
-    Defines how to upload (log) and download potentially large artifacts from different
-    storage backends.
+    Abstract artifact repo that defines how to upload (log) and download potentially large
+    artifacts from different storage backends.
     """
 
     __metaclass__ = ABCMeta
@@ -32,6 +32,7 @@ class ArtifactRepository:
         Logs a local file as an artifact, optionally taking an ``artifact_path`` to place it in
         within the run's artifacts. Run artifacts can be organized into directories, so you can
         place the artifact in a directory this way.
+
         :param local_file: Path to artifact to log
         :param artifact_path: Directory within the run's artifact directory in which to log the
                               artifact
@@ -43,6 +44,7 @@ class ArtifactRepository:
         """
         Logs the files in the specified local directory as artifacts, optionally taking
         an ``artifact_path`` to place them in within the run's artifacts.
+
         :param local_dir: Directory of local artifacts to log
         :param artifact_path: Directory within the run's artifact directory in which to log the
                               artifacts
@@ -56,6 +58,7 @@ class ArtifactRepository:
         an empty list. Will error if path is neither a file nor directory.
 
         :param path: Relative source path that contain desired artifacts
+
         :return: List of artifacts as FileInfo listed directly under path.
         """
         pass
@@ -65,11 +68,13 @@ class ArtifactRepository:
         Download an artifact file or directory to a local directory if applicable, and return a
         local path for it.
         The caller is responsible for managing the lifecycle of the downloaded artifacts.
+
         :param path: Relative source path to the desired artifacts.
         :param dst_path: Absolute path of the local filesystem destination directory to which to
                          download the specified artifacts. This directory must already exist. If
                          unspecified, the artifacts will be downloaded to a new, uniquely-named
                          directory on the local filesystem.
+
         :return: Absolute path of the local filesystem location containing the downloaded artifacts.
         """
         # TODO: Probably need to add a more efficient method to stream just a single artifact

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -29,7 +29,7 @@ class ArtifactRepository:
     @abstractmethod
     def log_artifact(self, local_file, artifact_path=None):
         """
-        Logs a local file as an artifact, optionally taking an ``artifact_path`` to place it in
+        Log a local file as an artifact, optionally taking an ``artifact_path`` to place it in
         within the run's artifacts. Run artifacts can be organized into directories, so you can
         place the artifact in a directory this way.
 
@@ -42,7 +42,7 @@ class ArtifactRepository:
     @abstractmethod
     def log_artifacts(self, local_dir, artifact_path=None):
         """
-        Logs the files in the specified local directory as artifacts, optionally taking
+        Log the files in the specified local directory as artifacts, optionally taking
         an ``artifact_path`` to place them in within the run's artifacts.
 
         :param local_dir: Directory of local artifacts to log
@@ -115,7 +115,7 @@ class ArtifactRepository:
     @abstractmethod
     def _download_file(self, remote_file_path, local_path):
         """
-        Downloads the file at the specified relative remote path and saves
+        Download the file at the specified relative remote path and saves
         it at the specified local path.
 
         :param remote_file_path: Source path to the remote file, relative to the root

--- a/mlflow/store/cli.py
+++ b/mlflow/store/cli.py
@@ -31,7 +31,7 @@ def commands():
                    "run's artifact directory.")
 def log_artifact(local_file, run_id, artifact_path):
     """
-    Logs a local file as an artifact of a run, optionally within a run-specific
+    Log a local file as an artifact of a run, optionally within a run-specific
     artifact path. Run artifacts can be organized into directories, so you can
     place the artifact in a directory this way.
     """
@@ -53,7 +53,7 @@ def log_artifact(local_file, run_id, artifact_path):
                    "run's artifact directory.")
 def log_artifacts(local_dir, run_id, artifact_path):
     """
-    Logs the files within a local directory as an artifact of a run, optionally
+    Log the files within a local directory as an artifact of a run, optionally
     within a run-specific artifact path. Run artifacts can be organized into
     directories, so you can place the artifact in a directory this way.
     """

--- a/mlflow/store/dbmodels/models.py
+++ b/mlflow/store/dbmodels/models.py
@@ -62,12 +62,30 @@ def _create_entity(base, model):
 
 
 class SqlExperiment(Base):
+    """
+    DB model for :py:class:`mlflow.entities.Experiment`. These are recorded in ``experiment`` table.
+    """
     __tablename__ = 'experiments'
 
     experiment_id = Column(Integer, autoincrement=True)
+    """
+    Experiment ID: `Integer`. *Primary Key* for ``experiment`` table.
+    """
     name = Column(String(256), unique=True, nullable=False)
+    """
+    Experiment name: `String` (limit 256 characters). Defined as *Unique* and *Non null* in
+                     table schema.
+    """
     artifact_location = Column(String(256), nullable=True)
+    """
+    Default artifact location for this experiment: `String` (limit 256 characters). Defined as
+                                                    *Non null* in table schema.
+    """
     lifecycle_stage = Column(String(32), default=LifecycleStage.ACTIVE)
+    """
+    Lifecycle Stage of experiment: `String` (limit 32 characters).
+                                    Can be either ``active`` (default) or ``deleted``.
+    """
 
     __table_args__ = (
         CheckConstraint(
@@ -80,26 +98,79 @@ class SqlExperiment(Base):
         return '<SqlExperiment ({}, {})>'.format(self.experiment_id, self.name)
 
     def to_mlflow_entity(self):
+        """
+        Convert DB model to corresponding MLflow entity.
+
+        :return: :py:class:`mlflow.entities.Experiment`.
+        """
         return _create_entity(Experiment, self)
 
 
 class SqlRun(Base):
+    """
+    DB model for :py:class:`mlflow.entities.Run`. These are recorded in ``runs`` table.
+    """
     __tablename__ = 'runs'
 
     run_uuid = Column(String(32), nullable=False)
+    """
+    Run UUID: `String` (limit 32 characters). *Primary Key* for ``runs`` table.
+    """
     name = Column(String(250))
+    """
+    Run name: `String` (limit 250 characters).
+    """
     source_type = Column(String(20), default=SourceType.to_string(SourceType.LOCAL))
+    """
+    Source Type: `String` (limit 20 characters). Can be one of ``NOTEBOOK``, ``JOB``, ``PROJECT``,
+                 ``LOCAL`` (default), or ``UNKNOWN``.
+    """
     source_name = Column(String(500))
+    """
+    Name of source recording the run: `String` (limit 500 characters).
+    """
     entry_point_name = Column(String(50))
+    """
+    Entry-point name that launched the run run: `String` (limit 50 characters).
+    """
     user_id = Column(String(256), nullable=True, default=None)
+    """
+    User ID: `String` (limit 256 characters). Defaults to ``null``.
+    """
     status = Column(String(20), default=RunStatus.to_string(RunStatus.SCHEDULED))
+    """
+    Run Status: `String` (limit 20 characters). Can be one of ``RUNNING``, ``SCHEDULED`` (default),
+                ``FINISHED``, ``FAILED``.
+    """
     start_time = Column(BigInteger, default=int(time.time()))
+    """
+    Run start time: `BigInteger`. Defaults to current system time.
+    """
     end_time = Column(BigInteger, nullable=True, default=None)
+    """
+    Run end time: `BigInteger`.
+    """
     source_version = Column(String(50))
+    """
+    Source version: `String` (limit 50 characters).
+    """
     lifecycle_stage = Column(String(20), default=LifecycleStage.ACTIVE)
+    """
+    Lifecycle Stage of run: `String` (limit 32 characters).
+                            Can be either ``active`` (default) or ``deleted``.
+    """
     artifact_uri = Column(String(200), default=None)
+    """
+    Default artifact location for this run: `String` (limit 200 characters).
+    """
     experiment_id = Column(Integer, ForeignKey('experiments.experiment_id'))
+    """
+    Experiment ID to which this run belongs to: *Foreign Key* into ``experiment`` table.
+    """
     experiment = relationship('SqlExperiment', backref=backref('runs', cascade='all'))
+    """
+    SQLAlchemy relationship (many:one) with :py:class:`mlflow.store.dbmodels.models.SqlExperiment`.
+    """
 
     __table_args__ = (
         CheckConstraint(source_type.in_(SourceTypes), name='source_type'),
@@ -110,6 +181,11 @@ class SqlRun(Base):
     )
 
     def to_mlflow_entity(self):
+        """
+        Convert DB model to corresponding MLflow entity.
+
+        :return: :py:class:`mlflow.entities.Run`.
+        """
         # run has diff parameter names in __init__ than in properties_ so we do this manually
         info = _create_entity(RunInfo, self)
         data = _create_entity(RunData, self)
@@ -117,12 +193,27 @@ class SqlRun(Base):
 
 
 class SqlTag(Base):
+    """
+    DB model for :py:class:`mlflow.entities.RunTag`. These are recorded in ``tags`` table.
+    """
     __tablename__ = 'tags'
 
     key = Column(String(250))
+    """
+    Tag key: `String` (limit 250 characters). *Primary Key* for ``tags`` table.
+    """
     value = Column(String(250), nullable=True)
+    """
+    Value associated with tag: `String` (limit 250 characters). Could be *null*.
+    """
     run_uuid = Column(String(32), ForeignKey('runs.run_uuid'))
+    """
+    Run UUID to which this tag belongs to: *Foreign Key* into ``runs`` table.
+    """
     run = relationship('SqlRun', backref=backref('tags', cascade='all'))
+    """
+    SQLAlchemy relationship (many:one) with :py:class:`mlflow.store.dbmodels.models.SqlRun`.
+    """
 
     __table_args__ = (
         PrimaryKeyConstraint('key', 'run_uuid', name='tag_pk'),
@@ -132,6 +223,11 @@ class SqlTag(Base):
         return '<SqlRunTag({}, {})>'.format(self.key, self.value)
 
     def to_mlflow_entity(self):
+        """
+        Convert DB model to corresponding MLflow entity.
+
+        :return: :py:class:`mlflow.entities.RunTag`.
+        """
         return _create_entity(RunTag, self)
 
 
@@ -139,10 +235,27 @@ class SqlMetric(Base):
     __tablename__ = 'metrics'
 
     key = Column(String(250))
+    """
+    Metric key: `String` (limit 250 characters). Part of *Primary Key* for ``metrics`` table.
+    """
     value = Column(Float, nullable=False)
+    """
+    Metric value: `Float`. Defined as *Non-null* in schema.
+    """
     timestamp = Column(BigInteger, default=lambda: int(time.time()))
+    """
+    Timestamp recorded for this metric entry: `BigInteger`. Part of *Primary Key* for
+                                               ``metrics`` table.
+    """
     run_uuid = Column(String(32), ForeignKey('runs.run_uuid'))
+    """
+    Run UUID to which this metric belongs to: Part of *Primary Key* for ``metrics`` table.
+                                              *Foreign Key* into ``runs`` table.
+    """
     run = relationship('SqlRun', backref=backref('metrics', cascade='all'))
+    """
+    SQLAlchemy relationship (many:one) with :py:class:`mlflow.store.dbmodels.models.SqlRun`.
+    """
 
     __table_args__ = (
         PrimaryKeyConstraint('key', 'timestamp', 'run_uuid', name='metric_pk'),
@@ -152,6 +265,11 @@ class SqlMetric(Base):
         return '<SqlMetric({}, {}, {})>'.format(self.key, self.value, self.timestamp)
 
     def to_mlflow_entity(self):
+        """
+        Convert DB model to corresponding MLflow entity.
+
+        :return: :py:class:`mlflow.entities.Metric`.
+        """
         return _create_entity(Metric, self)
 
 
@@ -159,9 +277,22 @@ class SqlParam(Base):
     __tablename__ = 'params'
 
     key = Column(String(250))
+    """
+    Param key: `String` (limit 250 characters). Part of *Primary Key* for ``params`` table.
+    """
     value = Column(String(250), nullable=False)
+    """
+    Param value: `String` (limit 250 characters). Defined as *Non-null* in schema.
+    """
     run_uuid = Column(String(32), ForeignKey('runs.run_uuid'))
+    """
+    Run UUID to which this metric belongs to: Part of *Primary Key* for ``params`` table.
+                                              *Foreign Key* into ``runs`` table.
+    """
     run = relationship('SqlRun', backref=backref('params', cascade='all'))
+    """
+    SQLAlchemy relationship (many:one) with :py:class:`mlflow.store.dbmodels.models.SqlRun`.
+    """
 
     __table_args__ = (
         PrimaryKeyConstraint('key', 'run_uuid', name='param_pk'),
@@ -171,4 +302,9 @@ class SqlParam(Base):
         return '<SqlParam({}, {})>'.format(self.key, self.value)
 
     def to_mlflow_entity(self):
+        """
+        Convert DB model to corresponding MLflow entity.
+
+        :return: :py:class:`mlflow.entities.Param`.
+        """
         return _create_entity(Param, self)

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -209,7 +209,8 @@ class FileStore(AbstractStore):
 
     def get_experiment(self, experiment_id):
         """
-        Fetches the experiment. This will search for active as well as deleted experiments.
+        Fetch the experiment.
+        Note: This API will search for active as well as deleted experiments.
 
         :param experiment_id: Integer id for the experiment
         :return: A single Experiment object if it exists, otherwise raises an Exception.
@@ -347,7 +348,7 @@ class FileStore(AbstractStore):
 
     def get_run(self, run_uuid):
         """
-        Will get both active and deleted runs.
+        Note: Will get both active and deleted runs.
         """
         _validate_run_id(run_uuid)
         run_info = self._get_run_info(run_uuid)
@@ -361,7 +362,7 @@ class FileStore(AbstractStore):
 
     def _get_run_info(self, run_uuid):
         """
-        Will get both active and deleted runs.
+        Note: Will get both active and deleted runs.
         """
         exp_id, run_dir = self._find_run_root(run_uuid)
         if run_dir is None:

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -39,6 +39,7 @@ _METHOD_TO_INFO = _api_method_to_info()
 class RestStore(AbstractStore):
     """
     Client for a remote tracking server accessed via REST API calls
+
     :param get_host_creds: Method to be invoked prior to every REST request to get the
       :py:class:`mlflow.rest_utils.MlflowHostCreds` for the request. Note that this
       is a function so that we can obtain fresh credentials in the case of expiry.
@@ -82,6 +83,7 @@ class RestStore(AbstractStore):
         If an experiment with the given name already exists, throws exception.
 
         :param name: Desired name for an experiment
+
         :return: experiment_id (integer) for the newly created experiment if successful, else None
         """
         req_body = message_to_json(CreateExperiment(
@@ -94,6 +96,7 @@ class RestStore(AbstractStore):
         Fetches the experiment from the backend store.
 
         :param experiment_id: Integer id for the experiment
+
         :return: A single :py:class:`mlflow.entities.Experiment` object if it exists,
         otherwise raises an Exception.
         """
@@ -119,6 +122,7 @@ class RestStore(AbstractStore):
         Fetches the run from backend store
 
         :param run_uuid: Unique identifier for the run
+
         :return: A single Run object if it exists, otherwise raises an Exception
         """
         req_body = message_to_json(GetRun(run_uuid=run_uuid))
@@ -141,6 +145,7 @@ class RestStore(AbstractStore):
         :param experiment_id: ID of the experiment for this run
         :param user_id: ID of the user launching this run
         :param source_type: Enum (integer) describing the source of the run
+
         :return: The created Run object
         """
         tag_protos = [tag.to_proto() for tag in tags]
@@ -158,6 +163,7 @@ class RestStore(AbstractStore):
     def log_metric(self, run_uuid, metric):
         """
         Logs a metric for the specified run
+
         :param run_uuid: String id for the run
         :param metric: Metric instance to log
         """
@@ -168,6 +174,7 @@ class RestStore(AbstractStore):
     def log_param(self, run_uuid, param):
         """
         Logs a param for the specified run
+
         :param run_uuid: String id for the run
         :param param: Param instance to log
         """
@@ -177,6 +184,7 @@ class RestStore(AbstractStore):
     def set_tag(self, run_uuid, tag):
         """
         Sets a tag for the specified run
+
         :param run_uuid: String id for the run
         :param tag: RunTag instance to log
         """

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -193,7 +193,7 @@ class RestStore(AbstractStore):
 
     def get_metric_history(self, run_uuid, metric_key):
         """
-        Return all logged value for a given metric.
+        Return all logged values for a given metric.
 
         :param run_uuid: Unique identifier for run
         :param metric_key: Metric name within the run

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -22,7 +22,7 @@ def _get_path(endpoint_path):
 
 
 def _api_method_to_info():
-    """ Returns a dictionary mapping each API method to a tuple (path, HTTP method)"""
+    """ Return a dictionary mapping each API method to a tuple (path, HTTP method)"""
     service_methods = MlflowService.DESCRIPTOR.methods
     res = {}
     for service_method in service_methods:
@@ -79,7 +79,7 @@ class RestStore(AbstractStore):
 
     def create_experiment(self, name, artifact_location=None):
         """
-        Creates a new experiment.
+        Create a new experiment.
         If an experiment with the given name already exists, throws exception.
 
         :param name: Desired name for an experiment
@@ -93,7 +93,7 @@ class RestStore(AbstractStore):
 
     def get_experiment(self, experiment_id):
         """
-        Fetches the experiment from the backend store.
+        Fetch the experiment from the backend store.
 
         :param experiment_id: Integer id for the experiment
 
@@ -119,7 +119,7 @@ class RestStore(AbstractStore):
 
     def get_run(self, run_uuid):
         """
-        Fetches the run from backend store
+        Fetch the run from backend store
 
         :param run_uuid: Unique identifier for the run
 
@@ -139,7 +139,7 @@ class RestStore(AbstractStore):
     def create_run(self, experiment_id, user_id, run_name, source_type, source_name,
                    entry_point_name, start_time, source_version, tags, parent_run_id):
         """
-        Creates a run under the specified experiment ID, setting the run's status to "RUNNING"
+        Create a run under the specified experiment ID, setting the run's status to "RUNNING"
         and the start time to the current time.
 
         :param experiment_id: ID of the experiment for this run
@@ -162,7 +162,7 @@ class RestStore(AbstractStore):
 
     def log_metric(self, run_uuid, metric):
         """
-        Logs a metric for the specified run
+        Log a metric for the specified run
 
         :param run_uuid: String id for the run
         :param metric: Metric instance to log
@@ -173,7 +173,7 @@ class RestStore(AbstractStore):
 
     def log_param(self, run_uuid, param):
         """
-        Logs a param for the specified run
+        Log a param for the specified run
 
         :param run_uuid: String id for the run
         :param param: Param instance to log
@@ -183,7 +183,7 @@ class RestStore(AbstractStore):
 
     def set_tag(self, run_uuid, tag):
         """
-        Sets a tag for the specified run
+        Set a tag for the specified run
 
         :param run_uuid: String id for the run
         :param tag: RunTag instance to log
@@ -193,7 +193,7 @@ class RestStore(AbstractStore):
 
     def get_metric_history(self, run_uuid, metric_key):
         """
-        Returns all logged value for a given metric.
+        Return all logged value for a given metric.
 
         :param run_uuid: Unique identifier for run
         :param metric_key: Metric name within the run
@@ -206,7 +206,7 @@ class RestStore(AbstractStore):
 
     def search_runs(self, experiment_ids, search_filter, run_view_type):
         """
-        Returns runs that match the given list of search expressions within the experiments.
+        Return runs that match the given list of search expressions within the experiments.
         Given multiple search expressions, all these expressions are ANDed together for search.
 
         :param experiment_ids: List of experiment ids to scope the search
@@ -226,7 +226,7 @@ class RestStore(AbstractStore):
 
     def list_run_infos(self, experiment_id, run_view_type):
         """
-        Returns run information for runs which belong to the experiment_id
+        Return run information for runs which belong to the experiment_id
 
         :param experiment_id: The experiment id which to search.
 

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -40,7 +40,7 @@ class SqlAlchemyStore(AbstractStore):
         """
         Create a database backed store.
 
-        :param db_uri: SQL connection string used by SQLAlchemy Engine to connect to database.
+        :param db_uri: SQL connection string used by SQLAlchemy Engine to connect to the database.
                        Argument is expected to be in the format:
                        ``db_type://<user_name>:<password>@<host>:<port>/<database_name>`
                        Supported database types are ``mysql``, ``mssql``, ``sqlite``,

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -40,7 +40,7 @@ class SqlAlchemyStore(AbstractStore):
         """
         Create a database backed store.
 
-        :param db_uri: SQL connection string used by SQLAlchemy Engine to connected to database.
+        :param db_uri: SQL connection string used by SQLAlchemy Engine to connect to database.
                        Argument is expected to be in the format:
                        ``db_type://<user_name>:<password>@<host>:<port>/<database_name>`
                        Supported database types are ``mysql``, ``mssql``, ``sqlite``,

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -31,23 +31,22 @@ class SqlAlchemyStore(AbstractStore):
 
     Run artifacts are stored in a separate location using artifact stores conforming to
     :py:class:`mlflow.store.artifact_repo.ArtifactRepository`. Default artifact locations for
-    user experiments are stored in database along with meta data for with
-    :py:class:`mlflow.store.dbmodels.models.SqlExperiment`. Each run artifact location is recorded
-    in :py:class:`mlflow.store.dbmodels.models.SqlRun` and stored in backend DB.
+    user experiments are stored in the database along with metadata/ Each run artifact location
+    is recorded in :py:class:`mlflow.store.dbmodels.models.SqlRun` and stored in the backend DB.
     """
     ARTIFACTS_FOLDER_NAME = "artifacts"
 
     def __init__(self, db_uri, default_artifact_root):
         """
-        Creates a database backed store.
+        Create a database backed store.
 
         :param db_uri: SQL connection string used by SQLAlchemy Engine to connected to database.
                        Argument is expected to in this format:
                        ``db_type://<user_name>:<password>@<host>:<port>/<database_name>`
                        Supported database types are ``mysql``, ``mssql``, ``sqlite``,
                        and ``postgresql``.
-        :param default_artifact_root: Path/URI to location suitable for large data (such as an S3
-                                      bucket, DBFS path, or shared NFS file system).
+        :param default_artifact_root: Path/URI to location suitable for large data (such as a blob
+                                      store object, DBFS path, or shared NFS file system).
         """
         super(SqlAlchemyStore, self).__init__()
         self.db_uri = db_uri

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -31,7 +31,7 @@ class SqlAlchemyStore(AbstractStore):
 
     Run artifacts are stored in a separate location using artifact stores conforming to
     :py:class:`mlflow.store.artifact_repo.ArtifactRepository`. Default artifact locations for
-    user experiments are stored in the database along with metadata/ Each run artifact location
+    user experiments are stored in the database along with metadata. Each run artifact location
     is recorded in :py:class:`mlflow.store.dbmodels.models.SqlRun` and stored in the backend DB.
     """
     ARTIFACTS_FOLDER_NAME = "artifacts"
@@ -41,7 +41,7 @@ class SqlAlchemyStore(AbstractStore):
         Create a database backed store.
 
         :param db_uri: SQL connection string used by SQLAlchemy Engine to connected to database.
-                       Argument is expected to in this format:
+                       Argument is expected to be in the format:
                        ``db_type://<user_name>:<password>@<host>:<port>/<database_name>`
                        Supported database types are ``mysql``, ``mssql``, ``sqlite``,
                        and ``postgresql``.


### PR DESCRIPTION
- Additional documentation for new SqlAlchemyStore
- DB models entities, table schemas and how these models relate to MLflow entities.