### PR TITLE
Store string representation of SourceType in tags

### DIFF
--- a/mlflow/tracking/context.py
+++ b/mlflow/tracking/context.py
@@ -95,7 +95,7 @@ class DefaultRunContext(RunContextProvider):
     def tags(self):
         return {
             MLFLOW_SOURCE_NAME: _get_source_name(),
-            MLFLOW_SOURCE_TYPE: _get_source_type()
+            MLFLOW_SOURCE_TYPE: SourceType.to_string(_get_source_type())
         }
 
 
@@ -129,7 +129,7 @@ class DatabricksNotebookRunContext(RunContextProvider):
         webapp_url = databricks_utils.get_webapp_url()
         tags = {
             MLFLOW_SOURCE_NAME: notebook_path,
-            MLFLOW_SOURCE_TYPE: SourceType.NOTEBOOK
+            MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.NOTEBOOK)
         }
         if notebook_id is not None:
             tags[MLFLOW_DATABRICKS_NOTEBOOK_ID] = notebook_id

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -13,7 +13,7 @@ import time
 import logging
 
 import mlflow.tracking.utils
-from mlflow.entities import Experiment, Run, RunStatus
+from mlflow.entities import Experiment, Run, RunStatus, SourceType
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient
@@ -127,7 +127,7 @@ def start_run(run_uuid=None, experiment_id=None, source_name=None, source_versio
         if source_name is not None:
             user_specified_tags[MLFLOW_SOURCE_NAME] = source_name
         if source_type is not None:
-            user_specified_tags[MLFLOW_SOURCE_TYPE] = source_type
+            user_specified_tags[MLFLOW_SOURCE_TYPE] = SourceType.to_string(source_type)
         if source_version is not None:
             user_specified_tags[MLFLOW_GIT_COMMIT] = source_version
         if entry_point_name is not None:
@@ -141,7 +141,8 @@ def start_run(run_uuid=None, experiment_id=None, source_name=None, source_versio
             source_name=tags.get(MLFLOW_SOURCE_NAME),  # For backwards compatability
             source_version=tags.get(MLFLOW_GIT_COMMIT),  # For backwards compatability
             entry_point_name=tags.get(MLFLOW_PROJECT_ENTRY_POINT),  # For backwards compatability
-            source_type=tags.get(MLFLOW_SOURCE_TYPE),  # For backwards compatability
+            # For backwards compatability:
+            source_type=SourceType.from_string(tags.get(MLFLOW_SOURCE_TYPE)),
             tags=tags,
             parent_run_id=parent_run_id
         )

--- a/tests/tracking/test_context.py
+++ b/tests/tracking/test_context.py
@@ -38,7 +38,7 @@ def test_default_run_context_in_context():
 def test_default_run_context_tags(patch_script_name):
     assert DefaultRunContext().tags() == {
         MLFLOW_SOURCE_NAME: MOCK_SCRIPT_NAME,
-        MLFLOW_SOURCE_TYPE: SourceType.LOCAL
+        MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.LOCAL)
     }
 
 
@@ -86,7 +86,7 @@ def test_databricks_notebook_run_context_tags():
             patch_webapp_url as webapp_url_mock:
         assert DatabricksNotebookRunContext().tags() == {
             MLFLOW_SOURCE_NAME: notebook_path_mock.return_value,
-            MLFLOW_SOURCE_TYPE: SourceType.NOTEBOOK,
+            MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.NOTEBOOK),
             MLFLOW_DATABRICKS_NOTEBOOK_ID: notebook_id_mock.return_value,
             MLFLOW_DATABRICKS_NOTEBOOK_PATH: notebook_path_mock.return_value,
             MLFLOW_DATABRICKS_WEBAPP_URL: webapp_url_mock.return_value
@@ -104,7 +104,7 @@ def test_databricks_notebook_run_context_tags_nones():
     with patch_notebook_id, patch_notebook_path, patch_webapp_url:
         assert DatabricksNotebookRunContext().tags() == {
             MLFLOW_SOURCE_NAME: None,
-            MLFLOW_SOURCE_TYPE: SourceType.NOTEBOOK,
+            MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.NOTEBOOK),
         }
 
 

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -164,9 +164,8 @@ def test_start_run_defaults(empty_active_run_stack):
     source_name_patch = mock.patch(
         "mlflow.tracking.context._get_source_name", return_value=mock_source_name
     )
-    mock_source_type = mock.Mock()
     source_type_patch = mock.patch(
-        "mlflow.tracking.context._get_source_type", return_value=mock_source_type
+        "mlflow.tracking.context._get_source_type", return_value=SourceType.NOTEBOOK
     )
     mock_source_version = mock.Mock()
     source_version_patch = mock.patch(
@@ -177,7 +176,7 @@ def test_start_run_defaults(empty_active_run_stack):
 
     expected_tags = {
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_source_name,
-        mlflow_tags.MLFLOW_SOURCE_TYPE: mock_source_type,
+        mlflow_tags.MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.NOTEBOOK),
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version
     }
 
@@ -190,7 +189,7 @@ def test_start_run_defaults(empty_active_run_stack):
             source_name=mock_source_name,
             source_version=mock_source_version,
             entry_point_name=None,
-            source_type=mock_source_type,
+            source_type=SourceType.NOTEBOOK,
             tags=expected_tags,
             parent_run_id=None
         )
@@ -225,7 +224,7 @@ def test_start_run_defaults_databricks_notebook(empty_active_run_stack):
 
     expected_tags = {
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_notebook_path,
-        mlflow_tags.MLFLOW_SOURCE_TYPE: SourceType.NOTEBOOK,
+        mlflow_tags.MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.NOTEBOOK),
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version,
         mlflow_tags.MLFLOW_DATABRICKS_NOTEBOOK_ID: mock_notebook_id,
         mlflow_tags.MLFLOW_DATABRICKS_NOTEBOOK_PATH: mock_notebook_path,
@@ -260,14 +259,14 @@ def test_start_run_overrides(empty_active_run_stack):
 
     mock_experiment_id = mock.Mock()
     mock_source_name = mock.Mock()
-    mock_source_type = mock.Mock()
+    source_type = SourceType.JOB
     mock_source_version = mock.Mock()
     mock_entry_point_name = mock.Mock()
     mock_run_name = mock.Mock()
 
     expected_tags = {
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_source_name,
-        mlflow_tags.MLFLOW_SOURCE_TYPE: mock_source_type,
+        mlflow_tags.MLFLOW_SOURCE_TYPE: SourceType.to_string(source_type),
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version,
         mlflow_tags.MLFLOW_PROJECT_ENTRY_POINT: mock_entry_point_name
     }
@@ -276,7 +275,7 @@ def test_start_run_overrides(empty_active_run_stack):
         active_run = start_run(
             experiment_id=mock_experiment_id, source_name=mock_source_name,
             source_version=mock_source_version, entry_point_name=mock_entry_point_name,
-            source_type=mock_source_type, run_name=mock_run_name
+            source_type=source_type, run_name=mock_run_name
         )
         MlflowClient.create_run.assert_called_once_with(
             experiment_id=mock_experiment_id,
@@ -284,7 +283,7 @@ def test_start_run_overrides(empty_active_run_stack):
             source_name=mock_source_name,
             source_version=mock_source_version,
             entry_point_name=mock_entry_point_name,
-            source_type=mock_source_type,
+            source_type=source_type,
             tags=expected_tags,
             parent_run_id=None
         )
@@ -313,14 +312,14 @@ def test_start_run_overrides_databricks_notebook(empty_active_run_stack):
 
     mock_experiment_id = mock.Mock()
     mock_source_name = mock.Mock()
-    mock_source_type = mock.Mock()
+    source_type = SourceType.JOB
     mock_source_version = mock.Mock()
     mock_entry_point_name = mock.Mock()
     mock_run_name = mock.Mock()
 
     expected_tags = {
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_source_name,
-        mlflow_tags.MLFLOW_SOURCE_TYPE: mock_source_type,
+        mlflow_tags.MLFLOW_SOURCE_TYPE: SourceType.to_string(source_type),
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version,
         mlflow_tags.MLFLOW_PROJECT_ENTRY_POINT: mock_entry_point_name,
         mlflow_tags.MLFLOW_DATABRICKS_NOTEBOOK_ID: mock_notebook_id,
@@ -333,7 +332,7 @@ def test_start_run_overrides_databricks_notebook(empty_active_run_stack):
         active_run = start_run(
             experiment_id=mock_experiment_id, source_name=mock_source_name,
             source_version=mock_source_version, entry_point_name=mock_entry_point_name,
-            source_type=mock_source_type, run_name=mock_run_name
+            source_type=source_type, run_name=mock_run_name
         )
         MlflowClient.create_run.assert_called_once_with(
             experiment_id=mock_experiment_id,
@@ -341,7 +340,7 @@ def test_start_run_overrides_databricks_notebook(empty_active_run_stack):
             source_name=mock_source_name,
             source_version=mock_source_version,
             entry_point_name=mock_entry_point_name,
-            source_type=mock_source_type,
+            source_type=source_type,
             tags=expected_tags,
             parent_run_id=None
         )
@@ -361,14 +360,14 @@ def test_start_run_with_parent():
 
     mock_experiment_id = mock.Mock()
     mock_source_name = mock.Mock()
-    mock_source_type = mock.Mock()
+    source_type = SourceType.JOB
     mock_source_version = mock.Mock()
     mock_entry_point_name = mock.Mock()
     mock_run_name = mock.Mock()
 
     expected_tags = {
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_source_name,
-        mlflow_tags.MLFLOW_SOURCE_TYPE: mock_source_type,
+        mlflow_tags.MLFLOW_SOURCE_TYPE: SourceType.to_string(source_type),
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version,
         mlflow_tags.MLFLOW_PROJECT_ENTRY_POINT: mock_entry_point_name
     }
@@ -377,7 +376,7 @@ def test_start_run_with_parent():
         active_run = start_run(
             experiment_id=mock_experiment_id, source_name=mock_source_name,
             source_version=mock_source_version, entry_point_name=mock_entry_point_name,
-            source_type=mock_source_type, run_name=mock_run_name, nested=True
+            source_type=source_type, run_name=mock_run_name, nested=True
         )
         MlflowClient.create_run.assert_called_once_with(
             experiment_id=mock_experiment_id,
@@ -385,7 +384,7 @@ def test_start_run_with_parent():
             source_name=mock_source_name,
             source_version=mock_source_version,
             entry_point_name=mock_entry_point_name,
-            source_type=mock_source_type,
+            source_type=source_type,
             tags=expected_tags,
             parent_run_id=parent_run.info.run_uuid
         )


### PR DESCRIPTION
The changes introduced recently that store a run's `SourceType` in tags do not convert it to a string explicilty and so they are rendered as strings containing the underlying `int` of the enumeration.

This changes it so the human-readable string is used instead.