### PR TITLE
[WIP]Add windows support for LocalArtifactRepository and FileStore

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -630,7 +630,8 @@ def _get_docker_command(image, active_run):
                                  experiment_id=active_run.info.experiment_id)
     tracking_uri = tracking.get_tracking_uri()
     if tracking.utils._is_local_uri(tracking_uri):
-        cmd += ["-v", "%s:%s" % (tracking_uri, _MLFLOW_DOCKER_TRACKING_DIR_PATH)]
+        path = file_utils.parse_path(tracking_uri)
+        cmd += ["-v", "%s:%s" % (path, _MLFLOW_DOCKER_TRACKING_DIR_PATH)]
         env_vars[tracking._TRACKING_URI_ENV_VAR] = _MLFLOW_DOCKER_TRACKING_DIR_PATH
     if tracking.utils._is_databricks_uri(tracking_uri):
         db_profile = mlflow.tracking.utils.get_db_profile_from_uri(tracking_uri)

--- a/mlflow/store/artifact_repository_registry.py
+++ b/mlflow/store/artifact_repository_registry.py
@@ -78,6 +78,7 @@ class ArtifactRepositoryRegistry:
 _artifact_repository_registry = ArtifactRepositoryRegistry()
 
 _artifact_repository_registry.register('', LocalArtifactRepository)
+_artifact_repository_registry.register('file', LocalArtifactRepository)
 _artifact_repository_registry.register('s3', S3ArtifactRepository)
 _artifact_repository_registry.register('gs', GCSArtifactRepository)
 _artifact_repository_registry.register('wasbs', AzureBlobArtifactRepository)

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -4,6 +4,8 @@ import os
 import uuid
 import six
 
+import mlflow.tracking
+
 from mlflow.entities import Experiment, Metric, Param, Run, RunData, RunInfo, RunStatus, RunTag, \
                             ViewType
 from mlflow.entities.lifecycle_stage import LifecycleStage
@@ -25,7 +27,6 @@ from mlflow.utils.file_utils import (is_directory, list_subdirs, mkdir, exists, 
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME, MLFLOW_PARENT_RUN_ID
 
 _TRACKING_DIR_ENV_VAR = "MLFLOW_TRACKING_DIR"
-_LOCAL_FS_URI_PREFIX = "file:///" if os.sep == "/" else "file://"
 
 
 def _default_root_dir():
@@ -319,7 +320,7 @@ class FileStore(AbstractStore):
                     "%s." % experiment_id,
                     databricks_pb2.INVALID_STATE)
         run_uuid = uuid.uuid4().hex
-        artifact_uri = _LOCAL_FS_URI_PREFIX + self._get_artifact_dir(experiment_id, run_uuid)
+        artifact_uri = mlflow.tracking.utils._LOCAL_FS_URI_PREFIX + self._get_artifact_dir(experiment_id, run_uuid)
         run_info = RunInfo(run_uuid=run_uuid, experiment_id=experiment_id,
                            name="",
                            artifact_uri=artifact_uri, source_type=source_type,

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -161,7 +161,7 @@ class FileStore(AbstractStore):
         if artifact_uri:
             artifact_path = parse_path(artifact_uri)
         else:
-            artifact_path = build_path(self.artifact_root_uri, str(experiment_id))
+            artifact_path = build_path(self.root_directory, str(experiment_id))
         experiment = Experiment(experiment_id, name, artifact_path, LifecycleStage.ACTIVE)
         write_yaml(meta_dir, FileStore.META_DATA_FILE_NAME, dict(experiment))
         return experiment_id

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -23,7 +23,6 @@ from mlflow.utils.file_utils import (is_directory, list_subdirs, mkdir, exists, 
                                      write_to, append_to, make_containing_dirs, mv, get_parent_dir,
                                      list_all, parse_path, local_uri_from_path)
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME, MLFLOW_PARENT_RUN_ID
-from mlflow import tracking
 
 _TRACKING_DIR_ENV_VAR = "MLFLOW_TRACKING_DIR"
 
@@ -61,7 +60,7 @@ class FileStore(AbstractStore):
         """
         super(FileStore, self).__init__()
         self.root_directory = parse_path(root_directory or _default_root_dir())
-        self.artifact_root_uri = artifact_root_uri or local_uri_from_path(self.root_directory)
+        self.artifact_root_uri = artifact_root_uri or local_uri_from_path(parse_path(self.root_directory))
         self.trash_folder = build_path(self.root_directory, FileStore.TRASH_FOLDER_NAME)
         # Create root directory if needed
         if not exists(self.root_directory):
@@ -158,7 +157,8 @@ class FileStore(AbstractStore):
     def _create_experiment_with_id(self, name, experiment_id, artifact_uri):
         self._check_root_dir()
         meta_dir = mkdir(self.root_directory, str(experiment_id))
-        artifact_uri = artifact_uri or local_uri_from_path(build_path(self.artifact_root_uri, str(experiment_id)))
+        artifact_uri = artifact_uri or local_uri_from_path(
+            build_path(parse_path(self.artifact_root_uri), str(experiment_id)))
         experiment = Experiment(experiment_id, name, artifact_uri, LifecycleStage.ACTIVE)
         write_yaml(meta_dir, FileStore.META_DATA_FILE_NAME, dict(experiment))
         return experiment_id
@@ -319,7 +319,7 @@ class FileStore(AbstractStore):
                     "%s." % experiment_id,
                     databricks_pb2.INVALID_STATE)
         run_uuid = uuid.uuid4().hex
-        artifact_uri = tracking.utils._LOCAL_FS_URI_PREFIX + self._get_artifact_dir(experiment_id, run_uuid)
+        artifact_uri = self._get_artifact_dir(experiment_id, run_uuid)
         run_info = RunInfo(run_uuid=run_uuid, experiment_id=experiment_id,
                            name="",
                            artifact_uri=artifact_uri, source_type=source_type,

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -60,7 +60,8 @@ class FileStore(AbstractStore):
         """
         super(FileStore, self).__init__()
         self.root_directory = parse_path(root_directory or _default_root_dir())
-        self.artifact_root_uri = artifact_root_uri or local_uri_from_path(parse_path(self.root_directory))
+        self.artifact_root_uri = artifact_root_uri or local_uri_from_path(
+            parse_path(self.root_directory))
         self.trash_folder = build_path(self.root_directory, FileStore.TRASH_FOLDER_NAME)
         # Create root directory if needed
         if not exists(self.root_directory):

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -157,7 +157,10 @@ class FileStore(AbstractStore):
     def _create_experiment_with_id(self, name, experiment_id, artifact_uri):
         self._check_root_dir()
         meta_dir = mkdir(self.root_directory, str(experiment_id))
-        artifact_path = parse_path(artifact_uri) if artifact_uri else build_path(self.artifact_root_uri, str(experiment_id))
+        if artifact_uri:
+            artifact_path = parse_path(artifact_uri)
+        else:
+            artifact_path = build_path(self.artifact_root_uri, str(experiment_id))
         experiment = Experiment(experiment_id, name, artifact_path, LifecycleStage.ACTIVE)
         write_yaml(meta_dir, FileStore.META_DATA_FILE_NAME, dict(experiment))
         return experiment_id

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -4,8 +4,6 @@ import os
 import uuid
 import six
 
-import mlflow.tracking
-
 from mlflow.entities import Experiment, Metric, Param, Run, RunData, RunInfo, RunStatus, RunTag, \
                             ViewType
 from mlflow.entities.lifecycle_stage import LifecycleStage
@@ -23,7 +21,7 @@ from mlflow.utils.env import get_env
 from mlflow.utils.file_utils import (is_directory, list_subdirs, mkdir, exists, write_yaml,
                                      read_yaml, find, read_file_lines, read_file, build_path,
                                      write_to, append_to, make_containing_dirs, mv, get_parent_dir,
-                                     list_all)
+                                     list_all, parse_path)
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME, MLFLOW_PARENT_RUN_ID
 
 _TRACKING_DIR_ENV_VAR = "MLFLOW_TRACKING_DIR"
@@ -61,8 +59,8 @@ class FileStore(AbstractStore):
         Create a new FileStore with the given root directory and a given default artifact root URI.
         """
         super(FileStore, self).__init__()
-        self.root_directory = root_directory or _default_root_dir()
-        self.artifact_root_uri = artifact_root_uri or self.root_directory
+        self.root_directory = parse_path(root_directory or _default_root_dir())
+        self.artifact_root_uri = artifact_root_uri or "file://" + self.root_directory
         self.trash_folder = build_path(self.root_directory, FileStore.TRASH_FOLDER_NAME)
         # Create root directory if needed
         if not exists(self.root_directory):
@@ -159,8 +157,8 @@ class FileStore(AbstractStore):
     def _create_experiment_with_id(self, name, experiment_id, artifact_uri):
         self._check_root_dir()
         meta_dir = mkdir(self.root_directory, str(experiment_id))
-        artifact_uri = artifact_uri or build_path(self.artifact_root_uri, str(experiment_id))
-        experiment = Experiment(experiment_id, name, artifact_uri, LifecycleStage.ACTIVE)
+        artifact_path = parse_path(artifact_uri) if artifact_uri else build_path(self.artifact_root_uri, str(experiment_id))
+        experiment = Experiment(experiment_id, name, artifact_path, LifecycleStage.ACTIVE)
         write_yaml(meta_dir, FileStore.META_DATA_FILE_NAME, dict(experiment))
         return experiment_id
 
@@ -320,7 +318,7 @@ class FileStore(AbstractStore):
                     "%s." % experiment_id,
                     databricks_pb2.INVALID_STATE)
         run_uuid = uuid.uuid4().hex
-        artifact_uri = mlflow.tracking.utils._LOCAL_FS_URI_PREFIX + self._get_artifact_dir(experiment_id, run_uuid)
+        artifact_uri = self._get_artifact_dir(experiment_id, run_uuid)
         run_info = RunInfo(run_uuid=run_uuid, experiment_id=experiment_id,
                            name="",
                            artifact_uri=artifact_uri, source_type=source_type,

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -158,10 +158,8 @@ class FileStore(AbstractStore):
     def _create_experiment_with_id(self, name, experiment_id, artifact_uri):
         self._check_root_dir()
         meta_dir = mkdir(self.root_directory, str(experiment_id))
-        if artifact_uri:
-            artifact_path = parse_path(artifact_uri)
-        else:
-            artifact_path = build_path(self.root_directory, str(experiment_id))
+        artifact_path = parse_path(artifact_uri) if artifact_uri \
+            else build_path(self.root_directory, str(experiment_id))
         experiment = Experiment(experiment_id, name, artifact_path, LifecycleStage.ACTIVE)
         write_yaml(meta_dir, FileStore.META_DATA_FILE_NAME, dict(experiment))
         return experiment_id

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -21,11 +21,11 @@ from mlflow.utils.env import get_env
 from mlflow.utils.file_utils import (is_directory, list_subdirs, mkdir, exists, write_yaml,
                                      read_yaml, find, read_file_lines, read_file, build_path,
                                      write_to, append_to, make_containing_dirs, mv, get_parent_dir,
-                                     list_all, parse_path)
+                                     list_all, parse_path, local_uri_from_path)
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME, MLFLOW_PARENT_RUN_ID
+from mlflow import tracking
 
 _TRACKING_DIR_ENV_VAR = "MLFLOW_TRACKING_DIR"
-_LOCAL_FS_URI_PREFIX = "file:///" if os.sep == "/" else "file://"
 
 
 def _default_root_dir():
@@ -61,7 +61,7 @@ class FileStore(AbstractStore):
         """
         super(FileStore, self).__init__()
         self.root_directory = parse_path(root_directory or _default_root_dir())
-        self.artifact_root_uri = artifact_root_uri or "file://" + self.root_directory
+        self.artifact_root_uri = artifact_root_uri or local_uri_from_path(self.root_directory)
         self.trash_folder = build_path(self.root_directory, FileStore.TRASH_FOLDER_NAME)
         # Create root directory if needed
         if not exists(self.root_directory):
@@ -158,9 +158,8 @@ class FileStore(AbstractStore):
     def _create_experiment_with_id(self, name, experiment_id, artifact_uri):
         self._check_root_dir()
         meta_dir = mkdir(self.root_directory, str(experiment_id))
-        artifact_path = parse_path(artifact_uri) if artifact_uri \
-            else build_path(self.root_directory, str(experiment_id))
-        experiment = Experiment(experiment_id, name, artifact_path, LifecycleStage.ACTIVE)
+        artifact_uri = artifact_uri or local_uri_from_path(build_path(self.artifact_root_uri, str(experiment_id)))
+        experiment = Experiment(experiment_id, name, artifact_uri, LifecycleStage.ACTIVE)
         write_yaml(meta_dir, FileStore.META_DATA_FILE_NAME, dict(experiment))
         return experiment_id
 
@@ -320,7 +319,7 @@ class FileStore(AbstractStore):
                     "%s." % experiment_id,
                     databricks_pb2.INVALID_STATE)
         run_uuid = uuid.uuid4().hex
-        artifact_uri = _LOCAL_FS_URI_PREFIX + self._get_artifact_dir(experiment_id, run_uuid)
+        artifact_uri = tracking.utils._LOCAL_FS_URI_PREFIX + self._get_artifact_dir(experiment_id, run_uuid)
         run_info = RunInfo(run_uuid=run_uuid, experiment_id=experiment_id,
                            name="",
                            artifact_uri=artifact_uri, source_type=source_type,

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -59,11 +59,9 @@ class FileStore(AbstractStore):
         Create a new FileStore with the given root directory and a given default artifact root URI.
         """
         super(FileStore, self).__init__()
-        root_directory = root_directory or _default_root_dir()
-        if artifact_root_uri is not None:
-            self.artifact_root_uri = artifact_root_uri
-        else:
-            self.artifact_root_uri = local_uri_from_path(parse_path(root_directory))
+        self.root_directory = parse_path(root_directory or _default_root_dir())
+        self.artifact_root_uri = artifact_root_uri or local_uri_from_path(parse_path(self.root_directory))
+        self.trash_folder = build_path(self.root_directory, FileStore.TRASH_FOLDER_NAME)
         # Create root directory if needed
         if not exists(self.root_directory):
             mkdir(self.root_directory)
@@ -135,14 +133,6 @@ class FileStore(AbstractStore):
 
     def _get_deleted_experiments(self, full_path=False):
         return list_subdirs(self.trash_folder, full_path)
-
-    @property
-    def root_directory(self):
-        return parse_path(self.artifact_root_uri)
-
-    @property
-    def trash_folder(self):
-        return build_path(self.root_directory, FileStore.TRASH_FOLDER_NAME)
 
     def list_experiments(self, view_type=ViewType.ACTIVE_ONLY):
         self._check_root_dir()

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -59,9 +59,11 @@ class FileStore(AbstractStore):
         Create a new FileStore with the given root directory and a given default artifact root URI.
         """
         super(FileStore, self).__init__()
-        self.root_directory = parse_path(root_directory or _default_root_dir())
-        self.artifact_root_uri = artifact_root_uri or local_uri_from_path(parse_path(self.root_directory))
-        self.trash_folder = build_path(self.root_directory, FileStore.TRASH_FOLDER_NAME)
+        root_directory = root_directory or _default_root_dir()
+        if artifact_root_uri is not None:
+            self.artifact_root_uri = artifact_root_uri
+        else:
+            self.artifact_root_uri = local_uri_from_path(parse_path(root_directory))
         # Create root directory if needed
         if not exists(self.root_directory):
             mkdir(self.root_directory)
@@ -133,6 +135,14 @@ class FileStore(AbstractStore):
 
     def _get_deleted_experiments(self, full_path=False):
         return list_subdirs(self.trash_folder, full_path)
+
+    @property
+    def root_directory(self):
+        return parse_path(self.artifact_root_uri)
+
+    @property
+    def trash_folder(self):
+        return build_path(self.root_directory, FileStore.TRASH_FOLDER_NAME)
 
     def list_experiments(self, view_type=ViewType.ACTIVE_ONLY):
         self._check_root_dir()

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -25,6 +25,7 @@ from mlflow.utils.file_utils import (is_directory, list_subdirs, mkdir, exists, 
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME, MLFLOW_PARENT_RUN_ID
 
 _TRACKING_DIR_ENV_VAR = "MLFLOW_TRACKING_DIR"
+_LOCAL_FS_URI_PREFIX = "file:///" if os.sep == "/" else "file://"
 
 
 def _default_root_dir():
@@ -321,7 +322,7 @@ class FileStore(AbstractStore):
                     "%s." % experiment_id,
                     databricks_pb2.INVALID_STATE)
         run_uuid = uuid.uuid4().hex
-        artifact_uri = self._get_artifact_dir(experiment_id, run_uuid)
+        artifact_uri = _LOCAL_FS_URI_PREFIX + self._get_artifact_dir(experiment_id, run_uuid)
         run_info = RunInfo(run_uuid=run_uuid, experiment_id=experiment_id,
                            name="",
                            artifact_uri=artifact_uri, source_type=source_type,

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -25,6 +25,7 @@ from mlflow.utils.file_utils import (is_directory, list_subdirs, mkdir, exists, 
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME, MLFLOW_PARENT_RUN_ID
 
 _TRACKING_DIR_ENV_VAR = "MLFLOW_TRACKING_DIR"
+_LOCAL_FS_URI_PREFIX = "file:///" if os.sep == "/" else "file://"
 
 
 def _default_root_dir():
@@ -318,7 +319,7 @@ class FileStore(AbstractStore):
                     "%s." % experiment_id,
                     databricks_pb2.INVALID_STATE)
         run_uuid = uuid.uuid4().hex
-        artifact_uri = self._get_artifact_dir(experiment_id, run_uuid)
+        artifact_uri = _LOCAL_FS_URI_PREFIX + self._get_artifact_dir(experiment_id, run_uuid)
         run_info = RunInfo(run_uuid=run_uuid, experiment_id=experiment_id,
                            name="",
                            artifact_uri=artifact_uri, source_type=source_type,

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -1,7 +1,7 @@
 import distutils.dir_util as dir_util
 import shutil
 
-import mlflow.tracking
+from six.moves import urllib
 
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import mkdir, list_all, get_file_info, parse_path
@@ -12,13 +12,7 @@ class LocalArtifactRepository(ArtifactRepository):
     """Stores artifacts as files in a local directory."""
     def __init__(self, *args, **kwargs):
         super(LocalArtifactRepository, self).__init__(*args, **kwargs)
-
-        if mlflow.tracking.utils._is_local_uri(self.artifact_uri):
-            mkdir(parse_path(self.artifact_location))
-
-    @property
-    def artifact_location(self):
-        return parse_path(self.artifact_uri)
+        self.artifact_dir = parse_path(self.artifact_uri)
 
     def get_path_module(self):
         import os
@@ -28,29 +22,29 @@ class LocalArtifactRepository(ArtifactRepository):
         if artifact_path and path_not_unique(artifact_path):
             raise Exception("Invalid artifact path: '%s'. %s" % (artifact_path,
                                                                  bad_path_message(artifact_path)))
-        artifact_location = self.get_path_module().join(self.artifact_location, artifact_path) \
-            if artifact_path else self.artifact_location
+        artifact_dir = self.get_path_module().join(self.artifact_dir, artifact_path) \
+            if artifact_path else self.artifact_dir
 
-        if not self.get_path_module().exists(artifact_location):
-            mkdir(artifact_location)
-        shutil.copy(local_file, artifact_location)
+        if not self.get_path_module().exists(artifact_dir):
+            mkdir(artifact_dir)
+        shutil.copy(local_file, artifact_dir)
 
     def log_artifacts(self, local_dir, artifact_path=None):
         if artifact_path and path_not_unique(artifact_path):
             raise Exception("Invalid artifact path: '%s'. %s" % (artifact_path,
                                                                  bad_path_message(artifact_path)))
-        artifact_location = self.get_path_module().join(self.artifact_location, artifact_path) \
-            if artifact_path else self.artifact_location
-        if not self.get_path_module().exists(artifact_location):
-            mkdir(artifact_location)
-        dir_util.copy_tree(src=local_dir, dst=artifact_location)
+        artifact_dir = self.get_path_module().join(self.artifact_dir, artifact_path) \
+            if artifact_path else self.artifact_dir
+        if not self.get_path_module().exists(artifact_dir):
+            mkdir(artifact_dir)
+        dir_util.copy_tree(src=local_dir, dst=artifact_dir)
 
     def list_artifacts(self, path=None):
-        list_dir = self.get_path_module().join(self.artifact_location, path) \
-            if path else self.artifact_location
+        list_dir = self.get_path_module().join(self.artifact_dir, path) \
+            if path else self.artifact_dir
         if self.get_path_module().isdir(list_dir):
             artifact_files = list_all(list_dir, full_path=True)
-            infos = [get_file_info(f, self.get_path_module().relpath(f, self.artifact_location))
+            infos = [get_file_info(f, self.get_path_module().relpath(f, self.artifact_dir))
                      for f in artifact_files]
             return sorted(infos, key=lambda f: f.path)
         else:
@@ -58,4 +52,4 @@ class LocalArtifactRepository(ArtifactRepository):
 
     def _download_file(self, remote_file_path, local_path):
         shutil.copyfile(
-            self.get_path_module().join(self.artifact_location, remote_file_path), local_path)
+            self.get_path_module().join(self.artifact_dir, remote_file_path), local_path)

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -40,10 +40,8 @@ class LocalArtifactRepository(ArtifactRepository):
         dir_util.copy_tree(src=local_dir, dst=artifact_dir)
 
     def list_artifacts(self, path=None):
-        if path:
-            list_dir = self.get_path_module().join(self.artifact_dir, path)
-        else:
-            list_dir = self.artifact_dir
+        list_dir = self.get_path_module().join(self.artifact_dir, path) \
+            if path else self.artifact_dir
         if self.get_path_module().isdir(list_dir):
             artifact_files = list_all(list_dir, full_path=True)
             infos = [get_file_info(f, self.get_path_module().relpath(f, self.artifact_dir))

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -4,7 +4,7 @@ import shutil
 from six.moves import urllib
 
 from mlflow.store.artifact_repo import ArtifactRepository
-from mlflow.utils.file_utils import mkdir, list_all, get_file_info
+from mlflow.utils.file_utils import mkdir, list_all, get_file_info, parse_path
 from mlflow.utils.validation import path_not_unique, bad_path_message
 
 
@@ -12,10 +12,7 @@ class LocalArtifactRepository(ArtifactRepository):
     """Stores artifacts as files in a local directory."""
     def __init__(self, *args, **kwargs):
         super(LocalArtifactRepository, self).__init__(*args, **kwargs)
-
-        parsed_url = urllib.parse.urlparse(self.artifact_uri)
-        #  If path is "", use the netloc instead, this handles the case of windows and file:// as prefix
-        self.artifact_dir = parsed_url.path if parsed_url.path else parsed_url.netloc
+        self.artifact_dir = parse_path(self.artifact_uri)
 
     def get_path_module(self):
         import os

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -1,4 +1,5 @@
 import distutils.dir_util as dir_util
+import os
 import shutil
 
 from six.moves import urllib
@@ -12,9 +13,12 @@ class LocalArtifactRepository(ArtifactRepository):
     """Stores artifacts as files in a local directory."""
     def __init__(self, *args, **kwargs):
         super(LocalArtifactRepository, self).__init__(*args, **kwargs)
-        scheme = urllib.parse.urlparse(self.artifact_uri).scheme
-        if scheme != "":
-            self.artifact_dir = self.artifact_uri[len(scheme + "://"):]
+
+        parsed_url = urllib.parse.urlparse(self.artifact_uri)
+        if parsed_url.scheme != "":
+            #  Windows paths are not registered as url paths.
+            #  file:(//)DRIVE://file\path\file.txt" is parsed with "file\path\file.txt" as netloc
+            self.artifact_dir = parsed_url.path if os.sep == "/" else parsed_url.netloc
         else:
             self.artifact_dir = self.artifact_uri
 

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -16,9 +16,8 @@ class LocalArtifactRepository(ArtifactRepository):
 
         parsed_url = urllib.parse.urlparse(self.artifact_uri)
         if parsed_url.scheme != "":
-            #  Windows paths are not registered as url paths.
-            #  file:(//)DRIVE://file\path\file.txt" is parsed with "file\path\file.txt" as netloc
-            self.artifact_dir = parsed_url.path if os.sep == "/" else parsed_url.netloc
+            #  If path is "", use the netloc instead, this handles the case of windows and file:// as prefix
+            self.artifact_dir = parsed_url.path if parsed_url.path else  parsed_url.netloc
         else:
             self.artifact_dir = self.artifact_uri
 

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -1,5 +1,4 @@
 import distutils.dir_util as dir_util
-import os
 import shutil
 
 from six.moves import urllib
@@ -15,11 +14,8 @@ class LocalArtifactRepository(ArtifactRepository):
         super(LocalArtifactRepository, self).__init__(*args, **kwargs)
 
         parsed_url = urllib.parse.urlparse(self.artifact_uri)
-        if parsed_url.scheme != "":
-            #  If path is "", use the netloc instead, this handles the case of windows and file:// as prefix
-            self.artifact_dir = parsed_url.path if parsed_url.path else  parsed_url.netloc
-        else:
-            self.artifact_dir = self.artifact_uri
+        #  If path is "", use the netloc instead, this handles the case of windows and file:// as prefix
+        self.artifact_dir = parsed_url.path if parsed_url.path else parsed_url.netloc
 
     def get_path_module(self):
         import os

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -1,6 +1,8 @@
 import distutils.dir_util as dir_util
 import shutil
 
+from six.moves import urllib
+
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import mkdir, list_all, get_file_info
 from mlflow.utils.validation import path_not_unique, bad_path_message
@@ -8,6 +10,13 @@ from mlflow.utils.validation import path_not_unique, bad_path_message
 
 class LocalArtifactRepository(ArtifactRepository):
     """Stores artifacts as files in a local directory."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        scheme = urllib.parse.urlparse(self.artifact_uri).scheme
+        if scheme != "":
+            self.artifact_dir = self.artifact_uri[len(scheme + "://"):]
+        else:
+            self.artifact_dir = self.artifact_uri
 
     def get_path_module(self):
         import os
@@ -17,8 +26,9 @@ class LocalArtifactRepository(ArtifactRepository):
         if artifact_path and path_not_unique(artifact_path):
             raise Exception("Invalid artifact path: '%s'. %s" % (artifact_path,
                                                                  bad_path_message(artifact_path)))
-        artifact_dir = self.get_path_module().join(self.artifact_uri, artifact_path) \
-            if artifact_path else self.artifact_uri
+        artifact_dir = self.get_path_module().join(self.artifact_dir, artifact_path) \
+            if artifact_path else self.artifact_dir
+
         if not self.get_path_module().exists(artifact_dir):
             mkdir(artifact_dir)
         shutil.copy(local_file, artifact_dir)
@@ -27,18 +37,17 @@ class LocalArtifactRepository(ArtifactRepository):
         if artifact_path and path_not_unique(artifact_path):
             raise Exception("Invalid artifact path: '%s'. %s" % (artifact_path,
                                                                  bad_path_message(artifact_path)))
-        artifact_dir = self.get_path_module().join(self.artifact_uri, artifact_path) \
-            if artifact_path else self.artifact_uri
+        artifact_dir = self.get_path_module().join(self.artifact_dir, artifact_path) \
+            if artifact_path else self.artifact_dir
         if not self.get_path_module().exists(artifact_dir):
             mkdir(artifact_dir)
         dir_util.copy_tree(src=local_dir, dst=artifact_dir)
 
     def list_artifacts(self, path=None):
-        artifact_dir = self.artifact_uri
-        list_dir = self.get_path_module().join(artifact_dir, path) if path else artifact_dir
+        list_dir = self.get_path_module().join(self.artifact_dir, path) if path else artifact_dir
         if self.get_path_module().isdir(list_dir):
             artifact_files = list_all(list_dir, full_path=True)
-            infos = [get_file_info(f, self.get_path_module().relpath(f, artifact_dir))
+            infos = [get_file_info(f, self.get_path_module().relpath(f, self.artifact_dir))
                      for f in artifact_files]
             return sorted(infos, key=lambda f: f.path)
         else:
@@ -46,4 +55,4 @@ class LocalArtifactRepository(ArtifactRepository):
 
     def _download_file(self, remote_file_path, local_path):
         shutil.copyfile(
-            self.get_path_module().join(self.artifact_uri, remote_file_path), local_path)
+            self.get_path_module().join(self.artifact_dir, remote_file_path), local_path)

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -11,7 +11,7 @@ from mlflow.utils.validation import path_not_unique, bad_path_message
 class LocalArtifactRepository(ArtifactRepository):
     """Stores artifacts as files in a local directory."""
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super(LocalArtifactRepository, self).__init__(*args, **kwargs)
         scheme = urllib.parse.urlparse(self.artifact_uri).scheme
         if scheme != "":
             self.artifact_dir = self.artifact_uri[len(scheme + "://"):]

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -1,8 +1,6 @@
 import distutils.dir_util as dir_util
 import shutil
 
-from six.moves import urllib
-
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import mkdir, list_all, get_file_info, parse_path
 from mlflow.utils.validation import path_not_unique, bad_path_message

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -1,7 +1,7 @@
 import distutils.dir_util as dir_util
 import shutil
 
-from six.moves import urllib
+import mlflow.tracking
 
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import mkdir, list_all, get_file_info, parse_path
@@ -12,7 +12,13 @@ class LocalArtifactRepository(ArtifactRepository):
     """Stores artifacts as files in a local directory."""
     def __init__(self, *args, **kwargs):
         super(LocalArtifactRepository, self).__init__(*args, **kwargs)
-        self.artifact_dir = parse_path(self.artifact_uri)
+
+        if mlflow.tracking.utils._is_local_uri(self.artifact_uri):
+            mkdir(parse_path(self.artifact_location))
+
+    @property
+    def artifact_location(self):
+        return parse_path(self.artifact_uri)
 
     def get_path_module(self):
         import os
@@ -22,29 +28,29 @@ class LocalArtifactRepository(ArtifactRepository):
         if artifact_path and path_not_unique(artifact_path):
             raise Exception("Invalid artifact path: '%s'. %s" % (artifact_path,
                                                                  bad_path_message(artifact_path)))
-        artifact_dir = self.get_path_module().join(self.artifact_dir, artifact_path) \
-            if artifact_path else self.artifact_dir
+        artifact_location = self.get_path_module().join(self.artifact_location, artifact_path) \
+            if artifact_path else self.artifact_location
 
-        if not self.get_path_module().exists(artifact_dir):
-            mkdir(artifact_dir)
-        shutil.copy(local_file, artifact_dir)
+        if not self.get_path_module().exists(artifact_location):
+            mkdir(artifact_location)
+        shutil.copy(local_file, artifact_location)
 
     def log_artifacts(self, local_dir, artifact_path=None):
         if artifact_path and path_not_unique(artifact_path):
             raise Exception("Invalid artifact path: '%s'. %s" % (artifact_path,
                                                                  bad_path_message(artifact_path)))
-        artifact_dir = self.get_path_module().join(self.artifact_dir, artifact_path) \
-            if artifact_path else self.artifact_dir
-        if not self.get_path_module().exists(artifact_dir):
-            mkdir(artifact_dir)
-        dir_util.copy_tree(src=local_dir, dst=artifact_dir)
+        artifact_location = self.get_path_module().join(self.artifact_location, artifact_path) \
+            if artifact_path else self.artifact_location
+        if not self.get_path_module().exists(artifact_location):
+            mkdir(artifact_location)
+        dir_util.copy_tree(src=local_dir, dst=artifact_location)
 
     def list_artifacts(self, path=None):
-        list_dir = self.get_path_module().join(self.artifact_dir, path) \
-            if path else self.artifact_dir
+        list_dir = self.get_path_module().join(self.artifact_location, path) \
+            if path else self.artifact_location
         if self.get_path_module().isdir(list_dir):
             artifact_files = list_all(list_dir, full_path=True)
-            infos = [get_file_info(f, self.get_path_module().relpath(f, self.artifact_dir))
+            infos = [get_file_info(f, self.get_path_module().relpath(f, self.artifact_location))
                      for f in artifact_files]
             return sorted(infos, key=lambda f: f.path)
         else:
@@ -52,4 +58,4 @@ class LocalArtifactRepository(ArtifactRepository):
 
     def _download_file(self, remote_file_path, local_path):
         shutil.copyfile(
-            self.get_path_module().join(self.artifact_dir, remote_file_path), local_path)
+            self.get_path_module().join(self.artifact_location, remote_file_path), local_path)

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -1,6 +1,8 @@
 import distutils.dir_util as dir_util
 import shutil
 
+from six.moves import urllib
+
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import mkdir, list_all, get_file_info, parse_path
 from mlflow.utils.validation import path_not_unique, bad_path_message

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -44,7 +44,7 @@ class LocalArtifactRepository(ArtifactRepository):
         dir_util.copy_tree(src=local_dir, dst=artifact_dir)
 
     def list_artifacts(self, path=None):
-        list_dir = self.get_path_module().join(self.artifact_dir, path) if path else artifact_dir
+        list_dir = self.get_path_module().join(self.artifact_dir, path) if path else self.artifact_dir
         if self.get_path_module().isdir(list_dir):
             artifact_files = list_all(list_dir, full_path=True)
             infos = [get_file_info(f, self.get_path_module().relpath(f, self.artifact_dir))

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -1,8 +1,6 @@
 import distutils.dir_util as dir_util
 import shutil
 
-from six.moves import urllib
-
 from mlflow.store.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import mkdir, list_all, get_file_info, parse_path
 from mlflow.utils.validation import path_not_unique, bad_path_message
@@ -40,7 +38,10 @@ class LocalArtifactRepository(ArtifactRepository):
         dir_util.copy_tree(src=local_dir, dst=artifact_dir)
 
     def list_artifacts(self, path=None):
-        list_dir = self.get_path_module().join(self.artifact_dir, path) if path else self.artifact_dir
+        if path:
+            list_dir = self.get_path_module().join(self.artifact_dir, path)
+        else:
+            list_dir = self.artifact_dir
         if self.get_path_module().isdir(list_dir):
             artifact_files = list_all(list_dir, full_path=True)
             infos = [get_file_info(f, self.get_path_module().relpath(f, self.artifact_dir))

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -13,7 +13,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_ALREADY_EXISTS, \
     INVALID_STATE, RESOURCE_DOES_NOT_EXIST, INTERNAL_ERROR
 from mlflow.tracking.utils import _is_local_uri
-from mlflow.utils.file_utils import build_path, mkdir
+from mlflow.utils.file_utils import build_path, mkdir, parse_path
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_RUN_NAME
 from mlflow.utils.validation import _validate_batch_log_limits, _validate_batch_log_data,\
     _validate_run_id
@@ -60,7 +60,7 @@ class SqlAlchemyStore(AbstractStore):
         self.ManagedSessionMaker = self._get_managed_session_maker(SessionMaker)
 
         if _is_local_uri(default_artifact_root):
-            mkdir(default_artifact_root)
+            mkdir(parse_path(default_artifact_root))
 
         if len(self.list_experiments()) == 0:
             with self.ManagedSessionMaker() as session:

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -12,8 +12,7 @@ from mlflow.entities import ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_ALREADY_EXISTS, \
     INVALID_STATE, RESOURCE_DOES_NOT_EXIST, INTERNAL_ERROR
-from mlflow.tracking.utils import _is_local_uri
-from mlflow.utils.file_utils import build_path, mkdir, parse_path
+from mlflow.utils.file_utils import build_path
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_RUN_NAME
 from mlflow.utils.validation import _validate_batch_log_limits, _validate_batch_log_data,\
     _validate_run_id
@@ -58,9 +57,6 @@ class SqlAlchemyStore(AbstractStore):
         Base.metadata.bind = self.engine
         SessionMaker = sqlalchemy.orm.sessionmaker(bind=self.engine)
         self.ManagedSessionMaker = self._get_managed_session_maker(SessionMaker)
-
-        if _is_local_uri(default_artifact_root):
-            mkdir(parse_path(default_artifact_root))
 
         if len(self.list_experiments()) == 0:
             with self.ManagedSessionMaker() as session:

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -12,7 +12,8 @@ from mlflow.entities import ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_ALREADY_EXISTS, \
     INVALID_STATE, RESOURCE_DOES_NOT_EXIST, INTERNAL_ERROR
-from mlflow.utils.file_utils import build_path
+from mlflow.tracking.utils import _is_local_uri
+from mlflow.utils.file_utils import build_path, mkdir, parse_path
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_RUN_NAME
 from mlflow.utils.validation import _validate_batch_log_limits, _validate_batch_log_data,\
     _validate_run_id
@@ -57,6 +58,9 @@ class SqlAlchemyStore(AbstractStore):
         Base.metadata.bind = self.engine
         SessionMaker = sqlalchemy.orm.sessionmaker(bind=self.engine)
         self.ManagedSessionMaker = self._get_managed_session_maker(SessionMaker)
+
+        if _is_local_uri(default_artifact_root):
+            mkdir(parse_path(default_artifact_root))
 
         if len(self.list_experiments()) == 0:
             with self.ManagedSessionMaker() as session:

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -19,7 +19,6 @@ from mlflow.utils.databricks_utils import get_databricks_host_creds
 
 
 _TRACKING_URI_ENV_VAR = "MLFLOW_TRACKING_URI"
-# The extra / is removed from the prefix to avoid corrupting windows paths
 _LOCAL_FS_URI_PREFIX = "file:///"
 _REMOTE_URI_PREFIX = "http://"
 

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -70,10 +70,9 @@ def get_tracking_uri():
         return _tracking_uri
     elif env.get_env(_TRACKING_URI_ENV_VAR) is not None:
         return env.get_env(_TRACKING_URI_ENV_VAR)
-    elif os.sep != "/":
-        return _LOCAL_FS_URI_PREFIX + os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
     else:
-        return os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
+        # If linux based path, remove extra /
+        return _LOCAL_FS_URI_PREFIX + os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)[int(os.sep == "/"):]
 
 
 def get_artifact_uri(run_id, artifact_path=None):

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -71,9 +71,10 @@ def get_tracking_uri():
     elif env.get_env(_TRACKING_URI_ENV_VAR) is not None:
         return env.get_env(_TRACKING_URI_ENV_VAR)
     else:
-        path = os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
-        # The Nones below are filling in missing values of the uri, no partial value method was found
-        return urllib.parse.urlunparse(("file", None, path, None, None, None))
+        prefix = _LOCAL_FS_URI_PREFIX
+        if os.sep != "/":
+            prefix = prefix[:-1]
+        return prefix + os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
 
 
 def get_artifact_uri(run_id, artifact_path=None):
@@ -146,11 +147,6 @@ def _is_databricks_uri(uri):
 
 def _get_file_store(store_uri, **_):
     path = urllib.parse.urlparse(store_uri).path if store_uri else None
-
-    if not os.path.exists(path) and path[0] == "/":
-        # Parse out starting / for windows paths, urlparse prepends / to paths
-        path = path[1:]
-
     return FileStore(path, path)
 
 

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -71,9 +71,8 @@ def get_tracking_uri():
     elif env.get_env(_TRACKING_URI_ENV_VAR) is not None:
         return env.get_env(_TRACKING_URI_ENV_VAR)
     else:
-        prefix = _LOCAL_FS_URI_PREFIX
-        if os.sep != "/":
-            prefix = prefix[:-1]
+        prefix = _LOCAL_FS_URI_PREFIX if os.sep == "/" else "file://"
+        # The extra / is removed from the prefix to avoid corrupting windows paths
         return prefix + os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
 
 

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -20,7 +20,7 @@ from mlflow.utils.databricks_utils import get_databricks_host_creds
 
 _TRACKING_URI_ENV_VAR = "MLFLOW_TRACKING_URI"
 # The extra / is removed from the prefix to avoid corrupting windows paths
-_LOCAL_FS_URI_PREFIX = "file:///" if os.sep == "/" else "file://"
+_LOCAL_FS_URI_PREFIX = "file://"
 _REMOTE_URI_PREFIX = "http://"
 
 # Extra environment variables which take precedence for setting the basic/bearer

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -14,7 +14,7 @@ from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.store.dbmodels.db_types import DATABASE_ENGINES
 from mlflow.store.file_store import FileStore
 from mlflow.store.rest_store import RestStore
-from mlflow.utils import env, rest_utils
+from mlflow.utils import env, rest_utils, file_utils
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 
 
@@ -145,8 +145,7 @@ def _is_databricks_uri(uri):
 
 
 def _get_file_store(store_uri, **_):
-    path = urllib.parse.urlparse(store_uri).path if store_uri else None
-    return FileStore(path, path)
+    return FileStore(file_utils.parse_path(store_uri), store_uri)
 
 
 def _is_database_uri(uri):

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -71,7 +71,9 @@ def get_tracking_uri():
     elif env.get_env(_TRACKING_URI_ENV_VAR) is not None:
         return env.get_env(_TRACKING_URI_ENV_VAR)
     else:
-        return os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
+        path = os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
+        # The Nones below are filling in missing values of the uri, no partial value method was found
+        return urllib.parse.urlunparse(("file", None, path, None, None, None))
 
 
 def get_artifact_uri(run_id, artifact_path=None):
@@ -144,6 +146,11 @@ def _is_databricks_uri(uri):
 
 def _get_file_store(store_uri, **_):
     path = urllib.parse.urlparse(store_uri).path if store_uri else None
+
+    if not os.path.exists(path) and path[0] == "/":
+        # Parse out starting / for windows paths, urlparse prepends / to paths
+        path = path[1:]
+
     return FileStore(path, path)
 
 

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -20,7 +20,7 @@ from mlflow.utils.databricks_utils import get_databricks_host_creds
 
 _TRACKING_URI_ENV_VAR = "MLFLOW_TRACKING_URI"
 # The extra / is removed from the prefix to avoid corrupting windows paths
-_LOCAL_FS_URI_PREFIX = "file://"
+_LOCAL_FS_URI_PREFIX = "file:///"
 _REMOTE_URI_PREFIX = "http://"
 
 # Extra environment variables which take precedence for setting the basic/bearer
@@ -71,8 +71,10 @@ def get_tracking_uri():
         return _tracking_uri
     elif env.get_env(_TRACKING_URI_ENV_VAR) is not None:
         return env.get_env(_TRACKING_URI_ENV_VAR)
-    else:
+    elif os.sep != "/":
         return _LOCAL_FS_URI_PREFIX + os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
+    else:
+        return os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
 
 
 def get_artifact_uri(run_id, artifact_path=None):

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -19,7 +19,8 @@ from mlflow.utils.databricks_utils import get_databricks_host_creds
 
 
 _TRACKING_URI_ENV_VAR = "MLFLOW_TRACKING_URI"
-_LOCAL_FS_URI_PREFIX = "file:///"
+# The extra / is removed from the prefix to avoid corrupting windows paths
+_LOCAL_FS_URI_PREFIX = "file:///" if os.sep == "/" else "file://"
 _REMOTE_URI_PREFIX = "http://"
 
 # Extra environment variables which take precedence for setting the basic/bearer
@@ -71,9 +72,7 @@ def get_tracking_uri():
     elif env.get_env(_TRACKING_URI_ENV_VAR) is not None:
         return env.get_env(_TRACKING_URI_ENV_VAR)
     else:
-        prefix = _LOCAL_FS_URI_PREFIX if os.sep == "/" else "file://"
-        # The extra / is removed from the prefix to avoid corrupting windows paths
-        return prefix + os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
+        return _LOCAL_FS_URI_PREFIX + os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
 
 
 def get_artifact_uri(run_id, artifact_path=None):

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -70,9 +70,10 @@ def get_tracking_uri():
         return _tracking_uri
     elif env.get_env(_TRACKING_URI_ENV_VAR) is not None:
         return env.get_env(_TRACKING_URI_ENV_VAR)
+    elif os.sep == "/":
+        return os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
     else:
-        # If linux based path, remove extra /
-        return _LOCAL_FS_URI_PREFIX + os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)[int(os.sep == "/"):]
+        return _LOCAL_FS_URI_PREFIX + os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
 
 
 def get_artifact_uri(run_id, artifact_path=None):

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -4,12 +4,12 @@ import os
 import shutil
 import tarfile
 import tempfile
-from six.moves import urllib
 
 import yaml
 
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MissingConfigException
+from mlflow.tracking.utils import _LOCAL_FS_URI_PREFIX
 
 ENCODING = "utf-8"
 
@@ -346,8 +346,12 @@ def get_parent_dir(path):
 
 
 def parse_path(uri):
-    if not uri.startwith(_LOCAL_FS_URI_PREFIX:
-        raise Exception("Unsupported uri: %s, does not start with %s" % (uri, _LOCAL_FS_URI_PREFIX)
+    if not uri.startswith(_LOCAL_FS_URI_PREFIX):
+        raise Exception("Unsupported uri: %s, does not start with %s" % (uri, _LOCAL_FS_URI_PREFIX))
 
-    prefix_length = len(_LOCAL_FS_URI_PREFIX) - int(os.sep == "/")  # Keep / for linux abs paths
-    return  uri[prefix_length:]
+    fs_prefix_with_localhost = uri.startswith(_LOCAL_FS_URI_PREFIX[:-1] + "localhost/")
+    backslash_count = int(os.sep == "/")  # Keep / for linux abs paths
+    if uri.startswith(fs_prefix_with_localhost):
+        return uri[fs_prefix_with_localhost - backslash_count:]
+
+    return uri[_LOCAL_FS_URI_PREFIX - backslash_count:]

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -346,8 +346,8 @@ def get_parent_dir(path):
 
 
 def parse_path(uri):
-    parsed_url = urllib.parse.urlparse(uri)
-    if os.sep != "/":
-        if parsed_url.path.startswith("/"):
-            return os.path.join(parsed_url.netloc, parsed_url.path[1:])
-    return os.path.join(parsed_url.netloc, parsed_url.path)
+    if not uri.startwith(_LOCAL_FS_URI_PREFIX:
+        raise Exception("Unsupported uri: %s, does not start with %s" % (uri, _LOCAL_FS_URI_PREFIX)
+
+    prefix_length = len(_LOCAL_FS_URI_PREFIX) - int(os.sep == "/")  # Keep / for linux abs paths
+    return  uri[prefix_length:]

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -347,7 +347,7 @@ def get_parent_dir(path):
 
 def parse_path(uri):
     relative_path_uri_prefix = "file:"
-    backslash_count = int(os.sep == "/")  # Keep / for linux abs paths
+    backslash_count = 1 if os.sep == "/" else 0  # Keep / for linux abs paths
     fs_prefix_with_localhost = tracking.utils._LOCAL_FS_URI_PREFIX[:-1] + "localhost/"
     if uri.startswith(fs_prefix_with_localhost):
         return uri[fs_prefix_with_localhost - backslash_count:]
@@ -365,5 +365,5 @@ def parse_path(uri):
 
 def local_uri_from_path(path):
     path = os.path.abspath(path)
-    prefix = tracking.utils._LOCAL_FS_URI_PREFIX[:-1] if os.sep == "/" else tracking.utils._LOCAL_FS_URI_PREFIX
+    prefix = "file://" if os.sep == "/" else tracking.utils._LOCAL_FS_URI_PREFIX
     return prefix + path

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import tarfile
 import tempfile
+from six.moves import urllib
 
 import yaml
 
@@ -342,3 +343,11 @@ def _copy_file_or_tree(src, dst, dst_dir=None):
 
 def get_parent_dir(path):
     return os.path.abspath(os.path.join(path, os.pardir))
+
+
+def parse_path(uri):
+    parsed_url = urllib.parse.urlparse(uri)
+    if os.sep != "/":
+        if parsed_url.path.startswith("/"):
+            return os.path.join(parsed_url.netloc, parsed_url.path[1:])
+    return os.path.join(parsed_url.netloc, parsed_url.path)

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -350,17 +350,18 @@ def parse_path(uri):
     backslash_count = 1 if os.sep == "/" else 0  # Keep / for linux abs paths
     fs_prefix_with_localhost = mlflow.tracking.utils._LOCAL_FS_URI_PREFIX[:-1] + "localhost/"
     if uri.startswith(fs_prefix_with_localhost):
-        return uri[fs_prefix_with_localhost - backslash_count:]
+        path = uri[fs_prefix_with_localhost - backslash_count:]
     elif uri.startswith(mlflow.tracking.utils._LOCAL_FS_URI_PREFIX):
-        return uri[len(mlflow.tracking.utils._LOCAL_FS_URI_PREFIX) - backslash_count:]
+        path = uri[len(mlflow.tracking.utils._LOCAL_FS_URI_PREFIX) - backslash_count:]
     elif uri.startswith(relative_path_uri_prefix):
-        return uri[len(relative_path_uri_prefix):]
+        path = uri[len(relative_path_uri_prefix):]
     else:
         try:
-            return os.path.abspath(uri)
+            path = os.path.normpath(uri)
         except Exception:
             raise Exception("Unsupported uri: %s, use a uri for an absolute path with prefix %s." %
                             (uri, mlflow.tracking.utils._LOCAL_FS_URI_PREFIX))
+    return path.replace("\\", "/")
 
 
 def local_uri_from_path(path):

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -9,7 +9,7 @@ import yaml
 
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MissingConfigException
-from mlflow import tracking
+import mlflow.tracking
 
 ENCODING = "utf-8"
 
@@ -348,11 +348,11 @@ def get_parent_dir(path):
 def parse_path(uri):
     relative_path_uri_prefix = "file:"
     backslash_count = 1 if os.sep == "/" else 0  # Keep / for linux abs paths
-    fs_prefix_with_localhost = tracking.utils._LOCAL_FS_URI_PREFIX[:-1] + "localhost/"
+    fs_prefix_with_localhost = mlflow.tracking.utils._LOCAL_FS_URI_PREFIX[:-1] + "localhost/"
     if uri.startswith(fs_prefix_with_localhost):
         return uri[fs_prefix_with_localhost - backslash_count:]
-    elif uri.startswith(tracking.utils._LOCAL_FS_URI_PREFIX):
-        return uri[len(tracking.utils._LOCAL_FS_URI_PREFIX) - backslash_count:]
+    elif uri.startswith(mlflow.tracking.utils._LOCAL_FS_URI_PREFIX):
+        return uri[len(mlflow.tracking.utils._LOCAL_FS_URI_PREFIX) - backslash_count:]
     elif uri.startswith(relative_path_uri_prefix):
         return uri[len(relative_path_uri_prefix):]
     else:
@@ -360,10 +360,10 @@ def parse_path(uri):
             return os.path.abspath(uri)
         except Exception:
             raise Exception("Unsupported uri: %s, use a uri for an absolute path with prefix %s." %
-                            (uri, tracking.utils._LOCAL_FS_URI_PREFIX))
+                            (uri, mlflow.tracking.utils._LOCAL_FS_URI_PREFIX))
 
 
 def local_uri_from_path(path):
     path = os.path.abspath(path)
-    prefix = "file://" if os.sep == "/" else tracking.utils._LOCAL_FS_URI_PREFIX
+    prefix = "file://" if os.sep == "/" else mlflow.tracking.utils._LOCAL_FS_URI_PREFIX
     return prefix + path

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -346,19 +346,19 @@ def get_parent_dir(path):
 
 
 def parse_path(uri):
-    relative_path_prefix = "file:"
+    relative_path_uri_prefix = "file:"
     backslash_count = int(os.sep == "/")  # Keep / for linux abs paths
     fs_prefix_with_localhost = tracking.utils._LOCAL_FS_URI_PREFIX[:-1] + "localhost/"
     if uri.startswith(fs_prefix_with_localhost):
         return uri[fs_prefix_with_localhost - backslash_count:]
     elif uri.startswith(tracking.utils._LOCAL_FS_URI_PREFIX):
         return uri[len(tracking.utils._LOCAL_FS_URI_PREFIX) - backslash_count:]
-    elif uri.startswith(relative_path_prefix):
-        return uri[len(relative_path_prefix):]
+    elif uri.startswith(relative_path_uri_prefix):
+        return uri[len(relative_path_uri_prefix):]
     elif os.sep == "/":
         return uri
     else:
-        raise Exception("Unsupported uri: %s, please pass a uri with prefix %s." %
+        raise Exception("Unsupported uri: %s, use a uri for an absolute path with prefix %s." %
                         (uri, tracking.utils._LOCAL_FS_URI_PREFIX))
 
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -355,14 +355,15 @@ def parse_path(uri):
         return uri[len(tracking.utils._LOCAL_FS_URI_PREFIX) - backslash_count:]
     elif uri.startswith(relative_path_uri_prefix):
         return uri[len(relative_path_uri_prefix):]
-    elif os.sep == "/":
-        return uri
     else:
-        raise Exception("Unsupported uri: %s, use a uri for an absolute path with prefix %s." %
-                        (uri, tracking.utils._LOCAL_FS_URI_PREFIX))
+        try:
+            return os.path.abspath(uri)
+        except Exception:
+            raise Exception("Unsupported uri: %s, use a uri for an absolute path with prefix %s." %
+                            (uri, tracking.utils._LOCAL_FS_URI_PREFIX))
 
 
 def local_uri_from_path(path):
     path = os.path.abspath(path)
-    prefix = tracking.utils._LOCAL_FS_URI_PREFIX[1:] if os.sep == "/" else tracking.utils._LOCAL_FS_URI_PREFIX
+    prefix = tracking.utils._LOCAL_FS_URI_PREFIX[:-1] if os.sep == "/" else tracking.utils._LOCAL_FS_URI_PREFIX
     return prefix + path

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -17,7 +17,7 @@ _RUN_ID_REGEX = re.compile(r"^[a-zA-Z0-9][\w\-]{0,255}$")
 
 _BAD_CHARACTERS_MESSAGE = (
     "Names may only contain alphanumerics, underscores (_), dashes (-), periods (.),"
-    " spaces ( ), and slashes (/ or \)."
+    " spaces ( ), and slashes (/ or \\)."
 )
 
 MAX_PARAMS_TAGS_PER_BATCH = 100

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -17,7 +17,7 @@ _RUN_ID_REGEX = re.compile(r"^[a-zA-Z0-9][\w\-]{0,255}$")
 
 _BAD_CHARACTERS_MESSAGE = (
     "Names may only contain alphanumerics, underscores (_), dashes (-), periods (.),"
-    " spaces ( ), and slashes (/ or \\)."
+    " spaces ( ), and both back and forward slash."
 )
 
 MAX_PARAMS_TAGS_PER_BATCH = 100

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -10,14 +10,14 @@ import numpy as np
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
-_VALID_PARAM_AND_METRIC_NAMES = re.compile(r"^[/\w.\- ]*$")
+_VALID_PARAM_AND_METRIC_NAMES = re.compile(r"^[/\\\w.\- ]*$")
 
 # Regex for valid run IDs: must be an alphanumeric string of length 1 to 256.
 _RUN_ID_REGEX = re.compile(r"^[a-zA-Z0-9][\w\-]{0,255}$")
 
 _BAD_CHARACTERS_MESSAGE = (
     "Names may only contain alphanumerics, underscores (_), dashes (-), periods (.),"
-    " spaces ( ), and slashes (/)."
+    " spaces ( ), and slashes (/ or \)."
 )
 
 MAX_PARAMS_TAGS_PER_BATCH = 100

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -46,7 +46,7 @@ def build_docker_example_base_image():
 @pytest.fixture()
 def tracking_uri_mock(tmpdir):
     try:
-        mlflow.set_tracking_uri(os.path.join(tmpdir.strpath, 'mlruns'))
+        mlflow.set_tracking_uri("file://" + os.path.join(tmpdir.strpath, 'mlruns'))
         yield tmpdir
     finally:
         mlflow.set_tracking_uri(None)

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -5,6 +5,7 @@ import docker
 import pytest
 
 import mlflow
+import mlflow.tracking
 from mlflow.entities import RunStatus
 from mlflow.projects import _project_spec
 
@@ -46,7 +47,8 @@ def build_docker_example_base_image():
 @pytest.fixture()
 def tracking_uri_mock(tmpdir):
     try:
-        mlflow.set_tracking_uri(os.path.join(tmpdir.strpath, 'mlruns'))
+        prefix = mlflow.tracking.utils._LOCAL_FS_URI_PREFIX if os.sep != "/" else ""
+        mlflow.set_tracking_uri(prefix + os.path.join(tmpdir.strpath, 'mlruns'))
         yield tmpdir
     finally:
         mlflow.set_tracking_uri(None)

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -46,7 +46,7 @@ def build_docker_example_base_image():
 @pytest.fixture()
 def tracking_uri_mock(tmpdir):
     try:
-        mlflow.set_tracking_uri("file://" + os.path.join(tmpdir.strpath, 'mlruns'))
+        mlflow.set_tracking_uri(os.path.join(tmpdir.strpath, 'mlruns'))
         yield tmpdir
     finally:
         mlflow.set_tracking_uri(None)

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -49,8 +49,8 @@ def build_docker_example_base_image():
 def tracking_uri_mock(tmpdir):
     try:
         path = os.path.abspath(os.path.join(tmpdir.strpath, 'mlruns'))
-        tracking_uri = path if os.sep == "/" else _LOCAL_FS_URI_PREFIX + path
-        mlflow.set_tracking_uri(tracking_uri)
+        path = path[1:] if path.startswith("/") else path # Remove prefix / from linux abs paths
+        mlflow.set_tracking_uri(_LOCAL_FS_URI_PREFIX + path)
         yield tmpdir
     finally:
         mlflow.set_tracking_uri(None)

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -5,9 +5,10 @@ import docker
 import pytest
 
 import mlflow
-import mlflow.tracking
+
 from mlflow.entities import RunStatus
 from mlflow.projects import _project_spec
+from mlflow.tracking.utils import _LOCAL_FS_URI_PREFIX
 
 
 TEST_DIR = "tests"
@@ -47,7 +48,7 @@ def build_docker_example_base_image():
 @pytest.fixture()
 def tracking_uri_mock(tmpdir):
     try:
-        prefix = mlflow.tracking.utils._LOCAL_FS_URI_PREFIX if os.sep != "/" else ""
+        prefix = _LOCAL_FS_URI_PREFIX if os.sep != "/" else ""
         mlflow.set_tracking_uri(prefix + os.path.join(tmpdir.strpath, 'mlruns'))
         yield tmpdir
     finally:

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -48,8 +48,9 @@ def build_docker_example_base_image():
 @pytest.fixture()
 def tracking_uri_mock(tmpdir):
     try:
-        prefix = _LOCAL_FS_URI_PREFIX if os.sep != "/" else ""
-        mlflow.set_tracking_uri(prefix + os.path.join(tmpdir.strpath, 'mlruns'))
+        path = os.path.abspath(os.path.join(tmpdir.strpath, 'mlruns'))
+        path = path[1:] if path.startswith("/") else path # Remove prefix / from linux abs paths
+        mlflow.set_tracking_uri(_LOCAL_FS_URI_PREFIX + path)
         yield tmpdir
     finally:
         mlflow.set_tracking_uri(None)

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -49,7 +49,7 @@ def build_docker_example_base_image():
 def tracking_uri_mock(tmpdir):
     try:
         path = os.path.abspath(os.path.join(tmpdir.strpath, 'mlruns'))
-        path = path[1:] if path.startswith("/") else path # Remove prefix / from linux abs paths
+        path = path[1:] if path.startswith("/") else path  # Remove prefix / from linux abs paths
         mlflow.set_tracking_uri(_LOCAL_FS_URI_PREFIX + path)
         yield tmpdir
     finally:

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -49,8 +49,8 @@ def build_docker_example_base_image():
 def tracking_uri_mock(tmpdir):
     try:
         path = os.path.abspath(os.path.join(tmpdir.strpath, 'mlruns'))
-        path = path[1:] if path.startswith("/") else path # Remove prefix / from linux abs paths
-        mlflow.set_tracking_uri(_LOCAL_FS_URI_PREFIX + path)
+        tracking_uri = path if os.sep == "/" else _LOCAL_FS_URI_PREFIX + path
+        mlflow.set_tracking_uri(tracking_uri)
         yield tmpdir
     finally:
         mlflow.set_tracking_uri(None)

--- a/tests/store/test_azure_blob_artifact_repo.py
+++ b/tests/store/test_azure_blob_artifact_repo.py
@@ -1,8 +1,15 @@
-import os
+import logging
 import mock
+import os
 import pytest
 
-from azure.storage.blob import Blob, BlobPrefix, BlobProperties, BlockBlobService
+_logger = logging.getLogger(__name__)
+
+try:
+    from azure.storage.blob import Blob, BlobPrefix, BlobProperties, BlockBlobService
+except ImportError:
+    _logger.warning("Failed to import azure, related tests will fail")
+
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact_repository_registry import get_artifact_repository

--- a/tests/store/test_azure_blob_artifact_repo.py
+++ b/tests/store/test_azure_blob_artifact_repo.py
@@ -1,15 +1,8 @@
-import logging
-import mock
 import os
+import mock
 import pytest
 
-_logger = logging.getLogger(__name__)
-
-try:
-    from azure.storage.blob import Blob, BlobPrefix, BlobProperties, BlockBlobService
-except ImportError:
-    _logger.warning("Failed to import azure, related tests will fail")
-
+from azure.storage.blob import Blob, BlobPrefix, BlobProperties, BlockBlobService
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact_repository_registry import get_artifact_repository

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -3,6 +3,7 @@
 import os
 import shutil
 import six
+import tempfile
 import time
 import unittest
 import uuid
@@ -21,7 +22,7 @@ from tests.helper_functions import random_int, random_str
 
 
 class TestFileStore(unittest.TestCase):
-    ROOT_LOCATION = "/tmp"
+    ROOT_LOCATION = tempfile.gettempdir()
 
     def setUp(self):
         self._create_root(TestFileStore.ROOT_LOCATION)

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -399,7 +399,7 @@ class TestFileStore(unittest.TestCase):
             fs, experiment_id, "tags.p_b = 'ABC'"))
 
     def test_weird_param_names(self):
-        WEIRD_PARAM_NAME = "this is/a weird/but valid param"
+        WEIRD_PARAM_NAME = os.path.normpath("this is/a weird/but valid param")
         fs = FileStore(self.test_root)
         run_uuid = self.exp_data[0]["runs"][0]
         fs.log_param(run_uuid, Param(WEIRD_PARAM_NAME, "Value"))
@@ -423,7 +423,7 @@ class TestFileStore(unittest.TestCase):
         assert param.value == ""
 
     def test_weird_metric_names(self):
-        WEIRD_METRIC_NAME = "this is/a weird/but valid metric"
+        WEIRD_METRIC_NAME = os.path.normpath("this is/a weird/but valid metric")
         fs = FileStore(self.test_root)
         run_uuid = self.exp_data[0]["runs"][0]
         fs.log_metric(run_uuid, Metric(WEIRD_METRIC_NAME, 10, 1234))
@@ -436,7 +436,7 @@ class TestFileStore(unittest.TestCase):
         assert metric.timestamp == 1234
 
     def test_weird_tag_names(self):
-        WEIRD_TAG_NAME = "this is/a weird/but valid tag"
+        WEIRD_TAG_NAME = os.path.norm_path("this is/a weird/but valid tag")
         fs = FileStore(self.test_root)
         run_uuid = self.exp_data[0]["runs"][0]
         fs.set_tag(run_uuid, RunTag(WEIRD_TAG_NAME, "Muhahaha!"))

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -436,7 +436,7 @@ class TestFileStore(unittest.TestCase):
         assert metric.timestamp == 1234
 
     def test_weird_tag_names(self):
-        WEIRD_TAG_NAME = os.path.norm_path("this is/a weird/but valid tag")
+        WEIRD_TAG_NAME = os.path.normpath("this is/a weird/but valid tag")
         fs = FileStore(self.test_root)
         run_uuid = self.exp_data[0]["runs"][0]
         fs.set_tag(run_uuid, RunTag(WEIRD_TAG_NAME, "Muhahaha!"))

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import sys
 
 from mock import Mock
 
@@ -16,6 +17,9 @@ class TestLocalArtifactRepo(object):
 
     @pytest.mark.parametrize("prefix", [mlflow.tracking.utils._LOCAL_FS_URI_PREFIX, "file:", ""])
     def test_basic_functions(self, prefix):
+        if prefix == "" and not os.sep == "/":
+            pytest.skip("skipping direct path as artifact_uri, not supported on windows")
+
         with TempDir() as test_root, TempDir() as tmp:
             repo = get_artifact_repository(prefix + test_root.path(), Mock())
             assert isinstance(repo, LocalArtifactRepository)

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -3,10 +3,10 @@ import pytest
 from mock import Mock
 
 
+from mlflow import tracking
 from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.store.local_artifact_repo import LocalArtifactRepository
 from mlflow.utils.file_utils import TempDir
-from mlflow.tracking.utils import _LOCAL_FS_URI_PREFIX
 
 
 class TestLocalArtifactRepo(object):
@@ -14,7 +14,7 @@ class TestLocalArtifactRepo(object):
         return sorted([(f.path, f.is_dir, f.file_size) for f in repo.list_artifacts(dir_name)])
 
     @pytest.mark.parametrize(
-        "prefix", [_LOCAL_FS_URI_PREFIX[:-1], "file:", ""])
+        "prefix", [tracking.utils._LOCAL_FS_URI_PREFIX[:-1], "file:", ""])
     def test_basic_functions(self, prefix):
         if prefix == "" and not os.sep == "/":
             pytest.skip("skipping direct path as artifact_uri, not supported on windows")

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -14,7 +14,7 @@ class TestLocalArtifactRepo(object):
         return sorted([(f.path, f.is_dir, f.file_size) for f in repo.list_artifacts(dir_name)])
 
     @pytest.mark.parametrize(
-        "prefix", [tracking.utils._LOCAL_FS_URI_PREFIX[:-1], "file:", ""])
+        "prefix", [tracking.utils._LOCAL_FS_URI_PREFIX, "file:", ""])
     def test_basic_functions(self, prefix):
         if prefix == "" and not os.sep == "/":
             pytest.skip("skipping direct path as artifact_uri, not supported on windows")

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -3,6 +3,8 @@ import unittest
 
 from mock import Mock
 
+import mlflow.tracking
+
 from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.store.local_artifact_repo import LocalArtifactRepository
 from mlflow.utils.file_utils import TempDir
@@ -14,7 +16,7 @@ class TestLocalArtifactRepo(unittest.TestCase):
 
     def test_basic_functions(self):
         with TempDir() as test_root, TempDir() as tmp:
-            repo = get_artifact_repository("file://" + test_root.path(), Mock())
+            repo = get_artifact_repository(mlflow.tracking.utils._LOCAL_FS_URI_PREFIX + test_root.path(), Mock())
             self.assertIsInstance(repo, LocalArtifactRepository)
             self.assertListEqual(repo.list_artifacts(), [])
             with self.assertRaises(Exception):

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -2,11 +2,11 @@ import os
 import pytest
 from mock import Mock
 
-import mlflow.tracking
 
 from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.store.local_artifact_repo import LocalArtifactRepository
 from mlflow.utils.file_utils import TempDir
+from mlflow.tracking.utils import _LOCAL_FS_URI_PREFIX
 
 
 class TestLocalArtifactRepo(object):
@@ -14,7 +14,7 @@ class TestLocalArtifactRepo(object):
         return sorted([(f.path, f.is_dir, f.file_size) for f in repo.list_artifacts(dir_name)])
 
     @pytest.mark.parametrize(
-        "prefix", [mlflow.tracking.utils._LOCAL_FS_URI_PREFIX[:-1], "file:", ""])
+        "prefix", [_LOCAL_FS_URI_PREFIX[:-1], "file:", ""])
     def test_basic_functions(self, prefix):
         if prefix == "" and not os.sep == "/":
             pytest.skip("skipping direct path as artifact_uri, not supported on windows")

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -15,7 +15,7 @@ class TestLocalArtifactRepo(object):
     def _get_contents(self, repo, dir_name):
         return sorted([(f.path, f.is_dir, f.file_size) for f in repo.list_artifacts(dir_name)])
 
-    @pytest.mark.parametrize("prefix", [mlflow.tracking.utils._LOCAL_FS_URI_PREFIX, "file:", ""])
+    @pytest.mark.parametrize("prefix", [mlflow.tracking.utils._LOCAL_FS_URI_PREFIX[:-1], "file:", ""])
     def test_basic_functions(self, prefix):
         if prefix == "" and not os.sep == "/":
             pytest.skip("skipping direct path as artifact_uri, not supported on windows")

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -1,7 +1,5 @@
 import os
 import pytest
-import sys
-
 from mock import Mock
 
 import mlflow.tracking
@@ -15,7 +13,8 @@ class TestLocalArtifactRepo(object):
     def _get_contents(self, repo, dir_name):
         return sorted([(f.path, f.is_dir, f.file_size) for f in repo.list_artifacts(dir_name)])
 
-    @pytest.mark.parametrize("prefix", [mlflow.tracking.utils._LOCAL_FS_URI_PREFIX[:-1], "file:", ""])
+    @pytest.mark.parametrize(
+        "prefix", [mlflow.tracking.utils._LOCAL_FS_URI_PREFIX[:-1], "file:", ""])
     def test_basic_functions(self, prefix):
         if prefix == "" and not os.sep == "/":
             pytest.skip("skipping direct path as artifact_uri, not supported on windows")
@@ -89,7 +88,8 @@ class TestLocalArtifactRepo(object):
             ]
 
             # Verify contents of subdirectories
-            assert self._get_contents(repo, "nested") == [(os.path.normpath("nested/c.txt"), False, 1)]
+            path = os.path.normpath("nested/c.txt")
+            assert self._get_contents(repo, "nested") == [(path, False, 1)]
 
             infos = self._get_contents(repo, "aaa")
             assert infos == [

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -10,9 +10,8 @@ import attrdict
 import mock
 import pytest
 
-from six.moves import urllib
-
 import mlflow
+
 from mlflow import tracking
 from mlflow.entities import RunStatus, LifecycleStage, Metric, Param, RunTag, ViewType
 from mlflow.exceptions import MlflowException
@@ -324,7 +323,6 @@ def test_log_artifact(tracking_uri_mock):
     for parent_dir in artifact_parent_dirs:
         with start_run():
             artifact_uri = mlflow.get_artifact_uri()
-            parsed_url = urllib.parse.urlparse(artifact_uri)
             run_artifact_dir = parse_path(artifact_uri)
 
             mlflow.log_artifact(path0, parent_dir)

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -414,8 +414,8 @@ def test_start_deleted_run():
     with mlflow.start_run() as active_run:
         run_id = active_run.info.run_uuid
     tracking.MlflowClient().delete_run(run_id)
-    with pytest.raises(MlflowException):
-        with mlflow.start_run(run_id=run_id):
+    with pytest.raises(MlflowException, matches='because it is in the deleted state.'):
+        with mlflow.start_run(run_uuid=run_id):
             pass
     assert mlflow.active_run() is None
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -414,8 +414,8 @@ def test_start_deleted_run():
     with mlflow.start_run() as active_run:
         run_id = active_run.info.run_uuid
     tracking.MlflowClient().delete_run(run_id)
-    with pytest.raises(MlflowException, matches='because it is in the deleted state.'):
-        with mlflow.start_run(run_uuid=run_id):
+    with pytest.raises(MlflowException):
+        with mlflow.start_run(run_id=run_id):
             pass
     assert mlflow.active_run() is None
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -408,8 +408,8 @@ def test_start_deleted_run():
     with mlflow.start_run() as active_run:
         run_id = active_run.info.run_uuid
     tracking.MlflowClient().delete_run(run_id)
-    with pytest.raises(MlflowException):
-        with mlflow.start_run(run_id=run_id):
+    with pytest.raises(MlflowException, matches='because it is in the deleted state.'):
+        with mlflow.start_run(run_uuid=run_id):
             pass
     assert mlflow.active_run() is None
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -320,8 +320,9 @@ def test_log_artifact(tracking_uri_mock):
     for parent_dir in artifact_parent_dirs:
         with start_run():
             artifact_uri = mlflow.get_artifact_uri()
-            scheme = urllib.parse.urlparse(artifact_uri).scheme
-            run_artifact_dir = artifact_uri[len(scheme + "://"):] if scheme != "" else artifact_uri
+            parsed_url = urllib.parse.urlparse(artifact_uri)
+            run_artifact_dir = parse_url.path if parsed_url.path else parsed_url.netloc
+
             mlflow.log_artifact(path0, parent_dir)
         expected_dir = os.path.join(run_artifact_dir, parent_dir) \
             if parent_dir is not None else run_artifact_dir
@@ -332,8 +333,9 @@ def test_log_artifact(tracking_uri_mock):
     for parent_dir in artifact_parent_dirs:
         with start_run():
             artifact_uri = mlflow.get_artifact_uri()
-            run_artifact_dir = mlflow.get_artifact_uri()
-            run_artifact_dir = artifact_uri[len(scheme + "://"):] if scheme != "" else artifact_uri
+            parsed_url = urllib.parse.urlparse(artifact_uri)
+            run_artifact_dir = parse_url.path if parsed_url.path else parsed_url.netloc
+
             mlflow.log_artifacts(artifact_src_dir, parent_dir)
         # Check that the logged artifacts match
         expected_artifact_output_dir = os.path.join(run_artifact_dir, parent_dir) \
@@ -350,6 +352,7 @@ def test_uri_types():
     assert utils._is_local_uri("mlruns")
     assert utils._is_local_uri("./mlruns")
     assert utils._is_local_uri("file:///foo/mlruns")
+    assert utils._is_local_uri("file:/foo/mlruns")
     assert not utils._is_local_uri("https://whatever")
     assert not utils._is_local_uri("http://whatever")
     assert not utils._is_local_uri("databricks")

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -4,15 +4,17 @@ import pytest
 from mlflow.exceptions import MlflowException
 from mlflow.entities import Metric, Param, RunTag
 from mlflow.protos.databricks_pb2 import ErrorCode, INVALID_PARAMETER_VALUE
+import os
+
 from mlflow.utils.validation import _validate_metric_name, _validate_param_name, \
                                     _validate_tag_name, _validate_run_id, \
                                     _validate_batch_log_data, _validate_batch_log_limits
 
 GOOD_METRIC_OR_PARAM_NAMES = [
-    "a", "Ab-5_", "a/b/c", "a.b.c", ".a", "b.", "a..a/._./o_O/.e.", "a b/c d",
+    "a", "Ab-5_", os.path.normpath("a/b/c"), "a.b.c", ".a", "b.", os.path.normpath("a..a/._./o_O/.e."), os.path.normpath("a b/c d"),
 ]
 BAD_METRIC_OR_PARAM_NAMES = [
-    "", ".", "/", "..", "//", "a//b", "a/./b", "/a", "a/", ":", "\\", "./", "/./",
+    "", ".", "/", "..", "//", "a//b", "a/./b", "/a", "a/", ":", "./", "/./",
 ]
 
 

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -11,10 +11,11 @@ from mlflow.utils.validation import _validate_metric_name, _validate_param_name,
                                     _validate_batch_log_data, _validate_batch_log_limits
 
 GOOD_METRIC_OR_PARAM_NAMES = [
-    "a", "Ab-5_", os.path.normpath("a/b/c"), "a.b.c", ".a", "b.", os.path.normpath("a..a/._./o_O/.e."), os.path.normpath("a b/c d"),
+    "a", "Ab-5_", os.path.normpath("a/b/c"), "a.b.c", ".a",
+    "b.", os.path.normpath("a..a/._./o_O/.e."), os.path.normpath("a b/c d")
 ]
 BAD_METRIC_OR_PARAM_NAMES = [
-    "", ".", "/", "..", "//", "a//b", "a/./b", "/a", "a/", ":", "./", "/./",
+    "", ".", "/", "..", "//", "a//b", "a/./b", "/a", "a/", ":", "./", "/./"
 ]
 
 


### PR DESCRIPTION
# This PR adds windows support for all fluent.py APIs.

## Solution overview
The solution utilizes the already supported store scheme: file, adds a file scheme for artifact repositories, updates tests to use os.path.normpath(it may be worth introducing the convention of os.path.join([list of path components])) instead of using os.path.normpath or non windows compatible: nested/files/are/here.

### Reasoning behind altered file prefix
The local file system prefix adds an extra /. This forward slash becomes the beginning of the path for linux FS, however, this is not compatible with windows since the os separator is not /, we omit the extra forward slash in utils.py accordingly.

## Issues and fixes that came up during the PR
### six.moves.urllib was previously used for parsing the uris.
Windows paths do not parse perfectly however(urls use / to separate netloc and path), so we strip out the prefix instead of relying on six.moves.urllib.parse.urlparse to keep the functionality consistent across OSs.

### Wrapped some imports in try catches to avoid top level pytest failures
Some minor top level test failures were wrapped in try catches to reduce errors from unrelated test files breaking pytest for that directory. 

### Windows drive was being checked as a scheme. scheme C is not supported for uri C://somewhere.txt.
The initial errors with windows were related to C:// not being a registered store. A previous solution checked if the uri did not have a registered scheme, if it did not, os.path.exists(path) was used to determine if it was a local path or not, if it was a local path, file://(/)path was returned as the store uri or artifact uri accordingly.

### artifact_uri was used as a path, file://(/) prefix broke the assumption
In LocalArtifactRepository, self.artifact_uri was assumed to be a valid local file path, this assumption was removed and self.artifact_dir is now assumed to be the local file path. This allows us to use file scheme while maintaining the original behavior.