### PR TITLE
File Store: When reading run data, return maximum metric value at maximum timestamp

### DIFF
--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -413,13 +413,13 @@ class FileStore(AbstractStore):
         if len(metric_data) == 0:
             raise ValueError("Metric '%s' is malformed. No data found." % metric_name)
         max_timestamp, max_value = metric_data[0]
-        for timestamp, value in metric_data:
+        for timestamp, value in metric_data[1:]:
             if timestamp > max_timestamp:
                 max_timestamp = timestamp
                 max_value = value
             elif timestamp == max_timestamp:
                 max_value = max(max_value, value)
-        return Metric(metric_name, float(timestamp_relative_max_value), int(max_timestamp))
+        return Metric(metric_name, float(max_value), int(max_timestamp))
 
     def get_all_metrics(self, run_uuid):
         _validate_run_id(run_uuid)

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -413,7 +413,7 @@ class FileStore(AbstractStore):
             metric_data.append((int(metric_timestamp), float(metric_value)))
         if len(metric_data) == 0:
             raise ValueError("Metric '%s' is malformed. No data found." % metric_name)
-        # Python performs element-wise comparsion of equal-length tuples, ordering them
+        # Python performs element-wise comparison of equal-length tuples, ordering them
         # based on their first differing element. Therefore, we use max() operator to find the
         # largest value at the largest timestamp. For more information, see
         # https://docs.python.org/3/reference/expressions.html#value-comparisons

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -413,7 +413,11 @@ class FileStore(AbstractStore):
             metric_data.append((int(metric_timestamp), float(metric_value)))
         if len(metric_data) == 0:
             raise ValueError("Metric '%s' is malformed. No data found." % metric_name)
-        max_timestamp, max_value = sorted(metric_data)[-1]
+        # Python performs element-wise comparsion of equal-length tuples, ordering them
+        # based on their first differing element. Therefore, we use max() operator to find the
+        # largest value at the largest timestamp. For more information, see
+        # https://docs.python.org/3/reference/expressions.html#value-comparisons
+        max_timestamp, max_value = max(metric_data)
         return Metric(metric_name, max_value, max_timestamp)
 
     def get_all_metrics(self, run_uuid):

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -412,9 +412,13 @@ class FileStore(AbstractStore):
         ]
         if len(metric_data) == 0:
             raise ValueError("Metric '%s' is malformed. No data found." % metric_name)
-        max_timestamp = max(metric_datum[0] for metric_datum in metric_data)
-        timestamp_relative_max_value = max(
-            metric_datum[1] for metric_datum in metric_data if metric_datum[0] == max_timestamp)
+        max_timestamp, max_value = metric_data[0]
+        for timestamp, value in metric_data:
+            if timestamp > max_timestamp:
+                max_timestamp = timestamp
+                max_value = value
+            elif timestamp == max_timestamp:
+                max_value = max(max_value, value)
         return Metric(metric_name, float(timestamp_relative_max_value), int(max_timestamp))
 
     def get_all_metrics(self, run_uuid):

--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -407,19 +407,14 @@ class FileStore(AbstractStore):
     @staticmethod
     def _get_metric_from_file(parent_path, metric_name):
         _validate_metric_name(metric_name)
-        metric_data = [
-           line.strip().split(" ") for line in read_file_lines(parent_path, metric_name)
-        ]
+        metric_data = []
+        for line in read_file_lines(parent_path, metric_name):
+            metric_timestamp, metric_value = line.split()
+            metric_data.append((int(metric_timestamp), float(metric_value)))
         if len(metric_data) == 0:
             raise ValueError("Metric '%s' is malformed. No data found." % metric_name)
-        max_timestamp, max_value = metric_data[0]
-        for timestamp, value in metric_data[1:]:
-            if timestamp > max_timestamp:
-                max_timestamp = timestamp
-                max_value = value
-            elif timestamp == max_timestamp:
-                max_value = max(max_value, value)
-        return Metric(metric_name, float(max_value), int(max_timestamp))
+        max_timestamp, max_value = sorted(metric_data)[-1]
+        return Metric(metric_name, max_value, max_timestamp)
 
     def get_all_metrics(self, run_uuid):
         _validate_run_id(run_uuid)

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -285,22 +285,32 @@ class TestFileStore(unittest.TestCase):
                 dict_run_info['lifecycle_stage'] = LifecycleStage.ACTIVE
                 self.assertEqual(dict_run_info, dict(run_info))
 
-    def test_log_metric_allows_multiple_values_at_same_timestamp_and_run_data_uses_max_value(self):
+    def test_log_metric_allows_multiple_values_at_same_ts_and_run_data_uses_max_ts_and_value(self):
         fs = FileStore(self.test_root)
         run_uuid = self._create_run(fs).info.run_uuid
 
         metric_name = "test-metric-1"
-        timestamp = int(time.time())
-        metric1 = Metric(metric_name, 100.0, timestamp)
-        metric2 = Metric(metric_name, 2.02, timestamp)
+        timestamp_low = 1000
+        timestamp_high = 2000
+        value_range = map(float, range(-10, 10))
 
-        fs.log_metric(run_uuid, metric1)
-        fs.log_metric(run_uuid, metric2)
+        logged_values = []
+        for timestamp in [timestamp_high, timestamp_low]:
+            for value in reversed(value_range):
+                self.store.log_metric(run.info.run_uuid, Metric(metric_name, value, timestamp))
+                logged_values.append(value)
 
-        run_metrics = fs.get_run(run_uuid).data.metrics
+        six.assertCountEqual(
+            self,
+            [metric.value for metric in
+             self.store.get_metric_history(run.info.run_uuid, metric_name)],
+            logged_values)
+
+        run_metrics = self.store.get_run(run.info.run_uuid).data.metrics
         assert len(run_metrics) == 1
         assert run_metrics[0].key == metric_name
-        assert run_metrics[0].value == 100.0
+        assert run_metrics[0].value == max(value_range)
+        assert run_metrics[0].timestamp == timestamp_high
 
     def test_get_all_metrics(self):
         def get_expected_metric_timestamp_and_value(metric_entries):

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -314,12 +314,6 @@ class TestFileStore(unittest.TestCase):
         assert run_metrics[0].timestamp == timestamp_high
 
     def test_get_all_metrics(self):
-        def get_expected_metric_timestamp_and_value(metric_entries):
-            expected_timestamp = max(entry[0] for entry in metric_entries)
-            expected_value = max(
-                entry[1] for entry in metric_entries if entry[0] == expected_timestamp)
-            return expected_timestamp, expected_value
-
         fs = FileStore(self.test_root)
         for exp_id in self.experiments:
             runs = self.exp_data[exp_id]["runs"]
@@ -329,8 +323,7 @@ class TestFileStore(unittest.TestCase):
                 metrics_dict = run_info.pop("metrics")
                 for metric in metrics:
                     # just the last recorded value
-                    expected_timestamp, expected_value = get_expected_metric_timestamp_and_value(
-                        metrics_dict[metric.key])
+                    expected_timestamp, expected_value = max(metrics_dict[metric.key])
                     self.assertEqual(metric.timestamp, expected_timestamp)
                     self.assertEqual(metric.value, expected_value)
 

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -285,7 +285,7 @@ class TestFileStore(unittest.TestCase):
                 dict_run_info['lifecycle_stage'] = LifecycleStage.ACTIVE
                 self.assertEqual(dict_run_info, dict(run_info))
 
-    def test_log_metric_allows_multiple_values_at_same_timestamp_and_read_returns_max_value(self):
+    def test_log_metric_allows_multiple_values_at_same_timestamp_and_run_data_uses_max_value(self):
         fs = FileStore(self.test_root)
         run_uuid = self._create_run(fs).info.run_uuid
         

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 import shutil
+import six
 import time
 import unittest
 import uuid
@@ -297,16 +298,16 @@ class TestFileStore(unittest.TestCase):
         logged_values = []
         for timestamp in [timestamp_high, timestamp_low]:
             for value in reversed(value_range):
-                self.store.log_metric(run.info.run_uuid, Metric(metric_name, value, timestamp))
+                fs.log_metric(run_uuid, Metric(metric_name, value, timestamp))
                 logged_values.append(value)
 
         six.assertCountEqual(
             self,
             [metric.value for metric in
-             self.store.get_metric_history(run.info.run_uuid, metric_name)],
+            fs.get_metric_history(run_uuid, metric_name)],
             logged_values)
 
-        run_metrics = self.store.get_run(run.info.run_uuid).data.metrics
+        run_metrics = fs.get_run(run_uuid).data.metrics
         assert len(run_metrics) == 1
         assert run_metrics[0].key == metric_name
         assert run_metrics[0].value == max(value_range)

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -292,8 +292,8 @@ class TestFileStore(unittest.TestCase):
 
         metric_name = "test-metric-1"
         timestamp_values_mapping = {
-            1000: map(float, range(-20, 20)),
-            2000: map(float, range(-10, 10)),
+            1000: [float(i) for i in range(-20, 20)],
+            2000: [float(i) for i in range(-10, 10)],
         }
 
         logged_values = []

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -291,7 +291,6 @@ class TestFileStore(unittest.TestCase):
         run_uuid = self._create_run(fs).info.run_uuid
 
         metric_name = "test-metric-1"
-
         timestamp_values_mapping = {
             1000: map(float, range(-20, 20)),
             2000: map(float, range(-10, 10)),

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -292,7 +292,7 @@ class TestFileStore(unittest.TestCase):
         metric_name = "test-metric-1"
         timestamp = int(time.time())
         metric1 = Metric(metric_name, 100.0, timestamp)
-        metric2 = Metric(metric_name, 1.02, timestamp)
+        metric2 = Metric(metric_name, 2.02, timestamp)
 
         fs.log_metric(run_uuid, metric1)
         fs.log_metric(run_uuid, metric2)

--- a/tests/store/test_file_store.py
+++ b/tests/store/test_file_store.py
@@ -288,7 +288,7 @@ class TestFileStore(unittest.TestCase):
     def test_log_metric_allows_multiple_values_at_same_timestamp_and_run_data_uses_max_value(self):
         fs = FileStore(self.test_root)
         run_uuid = self._create_run(fs).info.run_uuid
-        
+
         metric_name = "test-metric-1"
         timestamp = int(time.time())
         metric1 = Metric(metric_name, 100.0, timestamp)
@@ -300,7 +300,7 @@ class TestFileStore(unittest.TestCase):
         run_metrics = fs.get_run(run_uuid).data.metrics
         assert len(run_metrics) == 1
         assert run_metrics[0].key == metric_name
-        assert run_metrics[0].value == 100.0 
+        assert run_metrics[0].value == 100.0
 
     def test_get_all_metrics(self):
         def get_expected_metric_timestamp_and_value(metric_entries):

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -208,9 +208,12 @@ def test_log_metrics(tracking_uri_mock):
     with active_run:
         mlflow.log_metrics(expected_metrics)
     finished_run = tracking.MlflowClient().get_run(run_uuid)
-    assert len(finished_run.data.metrics) == len(expected_metrics)
+    # Validate metric key/values match what we expect, and that all metrics have the same timestamp
+    common_timestamp = finished_run.data.metrics[0].timestamp
+    assert len(finished_run.data.metrics) == 3
     for metric in finished_run.data.metrics:
         assert expected_metrics[metric.key] == metric.value
+        assert metric.timestamp == common_timestamp
 
 
 @pytest.fixture

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -206,16 +206,11 @@ def test_log_metrics(tracking_uri_mock):
     run_uuid = active_run.info.run_uuid
     expected_metrics = {"name_1": 30, "name_2": -3, "nested/nested/name": 40}
     with active_run:
-        mlflow.log_metric("name_1", 25)
-        mlflow.log_metric("nested/nested/name", 45)
         mlflow.log_metrics(expected_metrics)
     finished_run = tracking.MlflowClient().get_run(run_uuid)
-    # Validate metric key/values match what we expect, and that all metrics have the same timestamp
-    common_timestamp = finished_run.data.metrics[0].timestamp
-    assert len(finished_run.data.metrics) == 3
+    assert len(finished_run.data.metrics) == len(expected_metrics)
     for metric in finished_run.data.metrics:
         assert expected_metrics[metric.key] == metric.value
-        assert metric.timestamp == common_timestamp
 
 
 @pytest.fixture

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -210,7 +210,7 @@ def test_log_metrics(tracking_uri_mock):
     finished_run = tracking.MlflowClient().get_run(run_uuid)
     # Validate metric key/values match what we expect, and that all metrics have the same timestamp
     common_timestamp = finished_run.data.metrics[0].timestamp
-    assert len(finished_run.data.metrics) == 3
+    assert len(finished_run.data.metrics) == len(expected_metrics)
     for metric in finished_run.data.metrics:
         assert expected_metrics[metric.key] == metric.value
         assert metric.timestamp == common_timestamp


### PR DESCRIPTION
This PR updates file store metric insertion logic to handle the case where multiple metric values are logged for the same timestamp in a manner that's consistent with other stores. When reading metrics, the maximum value at the maximum timestamp is selected for each metric.