### PR TITLE
Improve documentation of getRun() APIs to specify information about metric selection.

### DIFF
--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -446,8 +446,9 @@ verbose compared to the Fluent API.
 Get Run
 =======
 
-Gets metadata, params, tags, and metrics for a run. For each metric, only
-the maximum value logged at the maximum timestamp is returned.
+Gets metadata, params, tags, and metrics for a run. In the case where multiple metrics with the same
+key are logged for the run, returns only the value with the latest timestamp. If there are multiple
+values with the latest timestamp, returns the maximum of these values.
 
 .. code:: r
 

--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -446,8 +446,8 @@ verbose compared to the Fluent API.
 Get Run
 =======
 
-Gets metadata, params, tags, and metrics for a run. Only last logged value
-for each metric is returned.
+Gets metadata, params, tags, and metrics for a run. For each metric, only
+the maximum value logged at the maximum timestamp is returned.
 
 .. code:: r
 

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -282,7 +282,7 @@ mlflow_client_restore_experiment <- function(client, experiment_id) {
 
 #' Get Run
 #'
-#' Gets metadata, params, tags, and metrics for a run. For each metric, only the maximum value 
+#' Gets metadata, params, tags, and metrics for a run. For each metric, only the maximum value
 #' logged at the maximum timestamp is returned.
 #'
 #' @template roxlate-run-id

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -282,7 +282,8 @@ mlflow_client_restore_experiment <- function(client, experiment_id) {
 
 #' Get Run
 #'
-#' Gets metadata, params, tags, and metrics for a run. Only last logged value for each metric is returned.
+#' Gets metadata, params, tags, and metrics for a run. For each metric, only the maximum value 
+#' logged at the maximum timestamp is returned.
 #'
 #' @template roxlate-run-id
 #' @template roxlate-client

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -282,8 +282,9 @@ mlflow_client_restore_experiment <- function(client, experiment_id) {
 
 #' Get Run
 #'
-#' Gets metadata, params, tags, and metrics for a run. For each metric, only the maximum value
-#' logged at the maximum timestamp is returned.
+#' Gets metadata, params, tags, and metrics for a run. In the case where multiple metrics with the
+#' same key are logged for the run, returns only the value with the latest timestamp. If there are
+#' multiple values with the latest timestamp, returns the maximum of these values.
 #'
 #' @template roxlate-run-id
 #' @template roxlate-client

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -45,7 +45,11 @@ public class MlflowClient {
     this. artifactRepositoryFactory = new ArtifactRepositoryFactory(hostCredsProvider);
   }
 
-  /** @return run associated with the id. */
+  /**
+   * Gets metadata, params, tags, and metrics for a run. For each metric, only the maximum
+   * value logged at the maximum timestamp is returned.
+   * @return {@link org.mlflow.api.proto.Service#Run} associated with the id.
+   */
   public Run getRun(String runUuid) {
     URIBuilder builder = newURIBuilder("runs/get").setParameter("run_uuid", runUuid);
     return mapper.toGetRunResponse(httpCaller.get(builder.toString())).getRun();

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -50,7 +50,7 @@ public class MlflowClient {
    * same key are logged for the run, returns only the value with the latest timestamp. If there are
    * multiple values with the latest timestamp, returns the maximum of these values.
    *
-   * @return {@link org.mlflow.api.proto.Service#Run} associated with the id.
+   * @return Run associated with the id.
    */
   public Run getRun(String runUuid) {
     URIBuilder builder = newURIBuilder("runs/get").setParameter("run_uuid", runUuid);

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -46,8 +46,10 @@ public class MlflowClient {
   }
 
   /**
-   * Gets metadata, params, tags, and metrics for a run. For each metric, only the maximum
-   * value logged at the maximum timestamp is returned.
+   * Gets metadata, params, tags, and metrics for a run. In the case where multiple metrics with the
+   * same key are logged for the run, returns only the value with the latest timestamp. If there are
+   * multiple values with the latest timestamp, returns the maximum of these values.
+   *
    * @return {@link org.mlflow.api.proto.Service#Run} associated with the id.
    */
   public Run getRun(String runUuid) {

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -102,7 +102,7 @@ class AbstractStore:
         """
         Fetch the run from backend store. The resulting :py:class:`Run <mlflow.entities.Run>`
         contains a collection of run metadata - :py:class:`RunInfo <mlflow.entities.RunInfo>`,
-        as well as a collection of run parameters, tags and metrics -
+        as well as a collection of run parameters, tags, and metrics -
         :py:class`RunData <mlflow.entities.RunData>`. In the case where multiple metrics with the
         same key are logged for the run, the :py:class:`RunData <mlflow.entities.RunData>` contains
         the value at the latest timestamp for each metric. If there are multiple values with the

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -103,8 +103,10 @@ class AbstractStore:
         Fetch the run from backend store. The resulting :py:class:`Run <mlflow.entities.Run>`
         contains a collection of run metadata - :py:class:`RunInfo <mlflow.entities.RunInfo>`,
         as well as a collection of run parameters, tags and metrics -
-        :py:class`RunData <mlflow.entities.RunData>`. For each metric, only the maximum
-        value at the maximum timestamp is returned.
+        :py:class`RunData <mlflow.entities.RunData>`. In the case where multiple metrics with the
+        same key are logged for the run, the :py:class:`RunData <mlflow.entities.RunData>` contains
+        the value at the latest timestamp for each metric. If there are multiple values with the
+        latest timestamp for a given metric, the maximum of these values is returned.
 
         :param run_uuid: Unique identifier for the run.
 

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -100,12 +100,16 @@ class AbstractStore:
     @abstractmethod
     def get_run(self, run_uuid):
         """
-        Fetch the run from backend store
+        Fetch the run from backend store. The resulting :py:class:`Run <mlflow.entities.Run>`
+        contains a collection of run metadata - :py:class:`RunInfo <mlflow.entities.RunInfo>`,
+        as well as a collection of run parameters, tags and metrics -
+        :py:class`RunData <mlflow.entities.RunData>`. For each metric, only the maximum
+        value at the maximum timestamp is returned.
 
-        :param run_uuid: Unique identifier for the run
+        :param run_uuid: Unique identifier for the run.
 
-        :return: A single :py:class:`mlflow.entities.Run` object if it exists,
-            otherwise raises an exception
+        :return: A single :py:class:`mlflow.entities.Run` object, if the run exists. Otherwise,
+                 raises an exception.
         """
         pass
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -37,7 +37,7 @@ class MlflowClient(object):
         """
         Fetch the run from backend store. The resulting :py:class:`Run <mlflow.entities.Run>`
         contains a collection of run metadata - :py:class:`RunInfo <mlflow.entities.RunInfo>`,
-        as well as a collection of run parameters, tags and metrics -
+        as well as a collection of run parameters, tags, and metrics -
         :py:class`RunData <mlflow.entities.RunData>`. In the case where multiple metrics with the
         same key are logged for the run, the :py:class:`RunData <mlflow.entities.RunData>` contains
         the value at the latest timestamp for each metric. If there are multiple values with the

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -38,8 +38,10 @@ class MlflowClient(object):
         Fetch the run from backend store. The resulting :py:class:`Run <mlflow.entities.Run>`
         contains a collection of run metadata - :py:class:`RunInfo <mlflow.entities.RunInfo>`,
         as well as a collection of run parameters, tags and metrics -
-        :py:class`RunData <mlflow.entities.RunData>`. For each metric, only the maximum
-        value at the maximum timestamp is returned.
+        :py:class`RunData <mlflow.entities.RunData>`. In the case where multiple metrics with the
+        same key are logged for the run, the :py:class:`RunData <mlflow.entities.RunData>` contains
+        the value at the latest timestamp for each metric. If there are multiple values with the
+        latest timestamp for a given metric, the maximum of these values is returned.
 
         :param run_uuid: Unique identifier for the run.
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -34,7 +34,18 @@ class MlflowClient(object):
         self.store = utils._get_store(self.tracking_uri)
 
     def get_run(self, run_id):
-        """:return: :py:class:`mlflow.entities.Run` associated with the run ID."""
+        """
+        Fetch the run from backend store. The resulting :py:class:`Run <mlflow.entities.Run>`
+        contains a collection of run metadata - :py:class:`RunInfo <mlflow.entities.RunInfo>`,
+        as well as a collection of run parameters, tags and metrics -
+        :py:class`RunData <mlflow.entities.RunData>`. For each metric, only the maximum
+        value at the maximum timestamp is returned.
+
+        :param run_uuid: Unique identifier for the run.
+
+        :return: A single :py:class:`mlflow.entities.Run` object, if the run exists. Otherwise,
+                 raises an exception.
+        """
         _validate_run_id(run_id)
         return self.store.get_run(run_id)
 


### PR DESCRIPTION
This PR adds documentation for various Python, R, and Java `getRun()` APIs, specifying how metric values are selected for inclusion in the resulting run data.