### PR TITLE
Add flag and message for run purging

### DIFF
--- a/mlflow/server/js/config-overrides.js
+++ b/mlflow/server/js/config-overrides.js
@@ -41,7 +41,10 @@ module.exports = {
     config = rewireDefinePlugin(config, env, {
       'process.env': {
         'HIDE_HEADER': process.env.HIDE_HEADER ? JSON.stringify('true') : JSON.stringify('false'),
-        'HIDE_EXPERIMENT_LIST': process.env.HIDE_EXPERIMENT_LIST ? JSON.stringify('true') : JSON.stringify('false')
+        'HIDE_EXPERIMENT_LIST':
+          process.env.HIDE_EXPERIMENT_LIST ? JSON.stringify('true') : JSON.stringify('false'),
+        'SHOW_GDPR_PURGING_MESSAGES':
+          process.env.SHOW_GDPR_PURGING_MESSAGES ? JSON.stringify('true') : JSON.stringify('false')
       }
     });
     return config;

--- a/mlflow/server/js/src/components/modals/ConfirmModal.js
+++ b/mlflow/server/js/src/components/modals/ConfirmModal.js
@@ -33,10 +33,7 @@ export class ConfirmModal extends Component {
     handleSubmit: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
-    helpText: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.element,
-    ]).isRequired,
+    helpText: PropTypes.node.isRequired,
     confirmButtonText: PropTypes.string.isRequired,
   };
 

--- a/mlflow/server/js/src/components/modals/ConfirmModal.js
+++ b/mlflow/server/js/src/components/modals/ConfirmModal.js
@@ -73,9 +73,9 @@ export class ConfirmModal extends Component {
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <p style={{ marginBottom: '10px' }}>
+          <div style={{ marginBottom: '10px' }}>
             {this.props.helpText}
-          </p>
+          </div>
         </Modal.Body>
         <Modal.Footer>
           <Button

--- a/mlflow/server/js/src/components/modals/ConfirmModal.js
+++ b/mlflow/server/js/src/components/modals/ConfirmModal.js
@@ -33,7 +33,10 @@ export class ConfirmModal extends Component {
     handleSubmit: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
-    helpText: PropTypes.string.isRequired,
+    helpText: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
+    ]).isRequired,
     confirmButtonText: PropTypes.string.isRequired,
   };
 

--- a/mlflow/server/js/src/components/modals/DeleteRunModal.js
+++ b/mlflow/server/js/src/components/modals/DeleteRunModal.js
@@ -36,7 +36,22 @@ class DeleteRunModal extends Component {
         onClose={this.props.onClose}
         handleSubmit={this.handleSubmit}
         title={`Delete Experiment ${Utils.pluralize("Run", number)}`}
-        helpText={`${number} experiment ${Utils.pluralize('run', number)} will be deleted.`}
+        helpText={
+          <div>
+            <p>
+              <b>{number} experiment {Utils.pluralize('run', number)} will be deleted.</b>
+            </p>
+            {
+              process.env.SHOW_GDPR_PURGING_MESSAGES === 'true' ?
+              <p>
+                Deleted runs are restorable for 30 days, after which they are purged along with
+                associated metrics, params and tags.
+                <br />
+                Artifacts are not automatically purged and must be manually deleted.
+              </p> : ""
+            }
+          </div>
+        }
         confirmButtonText={"Delete"}
       />
     );


### PR DESCRIPTION
This PR adds additional messaging around purging behavior to the delete run confirmation modal. The messaging is gated by a new `SHOW_GDPR_PURGING_MESSAGES` flag.

**Old**:

![Screen Shot 2019-03-18 at 12 46 47 PM](https://user-images.githubusercontent.com/39497902/54558841-ec8d5080-497b-11e9-901f-7dabb93c3a33.png)

**New (without additional messaging)**:
![Screen Shot 2019-03-18 at 12 45 40 PM](https://user-images.githubusercontent.com/39497902/54558765-c5cf1a00-497b-11e9-996e-c6f5f88071e8.png)

**New (with additional messaging)**:
![Screen Shot 2019-03-18 at 11 21 07 AM](https://user-images.githubusercontent.com/39497902/54558616-6cff8180-497b-11e9-95ab-d564d16365c8.png)