### PR TITLE
Change margin to padding for ExperimentView CSS

### DIFF
--- a/mlflow/server/js/src/components/HomePage.css
+++ b/mlflow/server/js/src/components/HomePage.css
@@ -12,14 +12,14 @@
    */
   min-width: 0px;
   flex: 1 1;
-  margin: 0 64px 0 32px;
+  padding: 0 64px 0 32px;
 }
 
 
 /* BEGIN css for when experiment list collapsed */
 .experiment-page-container {
   width: 100%;
-  margin: 0 64px 0 32px;
+  padding: 0 64px 0 32px;
 }
 .collapsed-expander-container {
   float: left;


### PR DESCRIPTION
We need to use padding so that our MLflow UI will actually fit in an iframe (otherwise it will add scrollbars to it.)
