### PR TITLE
[mlflow/R] Update databricks utils to use current notebook as default experiment.

### DIFF
--- a/mlflow/R/mlflow/R/databricks-utils.R
+++ b/mlflow/R/mlflow/R/databricks-utils.R
@@ -92,7 +92,7 @@ get_databricks_config <- function(profile) {
 }
 
 mlflow_get_run_context.mlflow_databricks_client <- function(client, source_name, source_version,
-                                                            source_type, ...) {
+                                                            source_type, experiment_id, ...) {
   if (exists(".databricks_internals")) {
     notebook_info <- do.call(".get_notebook_info", list(), envir = .databricks_internals)
     if (!is.na(notebook_info$id) && !is.na(notebook_info$path)) {
@@ -106,6 +106,7 @@ mlflow_get_run_context.mlflow_databricks_client <- function(client, source_name,
         source_type =  MLFLOW_SOURCE_TYPE$NOTEBOOK,
         source_name = notebook_info$path,
         tags = tags,
+        experiment_id = experiment_id %||% notebook_info$id,
         ...
       )
     } else {

--- a/mlflow/R/mlflow/R/tracking-fluent.R
+++ b/mlflow/R/mlflow/R/tracking-fluent.R
@@ -76,9 +76,8 @@ mlflow_start_run <- function(run_uuid = NULL, experiment_id = NULL, source_name 
     client <- mlflow_client()
     mlflow_client_get_run(client, existing_run_uuid)
   } else {
-    experiment_id <- experiment_id
-                     %||% mlflow_get_active_experiment_id()
-                     %||% Sys.getenv("MLFLOW_EXPERIMENT_ID", unset = NULL)
+    experiment_id <- experiment_id %||% mlflow_get_active_experiment_id()
+    experiment_id <- experiment_id %||% Sys.getenv("MLFLOW_EXPERIMENT_ID", unset = NULL)
     client <- mlflow_client()
     args <- mlflow_get_run_context(
       client,

--- a/mlflow/R/mlflow/R/tracking-fluent.R
+++ b/mlflow/R/mlflow/R/tracking-fluent.R
@@ -77,7 +77,8 @@ mlflow_start_run <- function(run_uuid = NULL, experiment_id = NULL, source_name 
     mlflow_client_get_run(client, existing_run_uuid)
   } else {
     experiment_id <- experiment_id %||% mlflow_get_active_experiment_id()
-    experiment_id <- experiment_id %||% Sys.getenv("MLFLOW_EXPERIMENT_ID", unset = NULL)
+    experiment_id <- experiment_id %||% Sys.getenv("MLFLOW_EXPERIMENT_ID", unset = NA)
+    experiment_id <- if(is.na(experiment_id)) NULL else experiment_id
     client <- mlflow_client()
     args <- mlflow_get_run_context(
       client,

--- a/mlflow/R/mlflow/R/tracking-fluent.R
+++ b/mlflow/R/mlflow/R/tracking-fluent.R
@@ -98,10 +98,12 @@ mlflow_get_run_context <- function(client, ...) {
   UseMethod("mlflow_get_run_context")
 }
 
-mlflow_get_run_context.default <- function(client, source_name, source_version, ...) {
+mlflow_get_run_context.default <- function(client, source_name, source_version, experiment_id,
+                                           ...) {
   list(client = client,
        source_name = source_name %||% get_source_name(),
        source_version = source_version %||% get_source_version(),
+       experiment_id = experiment_id %||% 0,
        ...)
 }
 

--- a/mlflow/R/mlflow/R/tracking-fluent.R
+++ b/mlflow/R/mlflow/R/tracking-fluent.R
@@ -78,7 +78,7 @@ mlflow_start_run <- function(run_uuid = NULL, experiment_id = NULL, source_name 
   } else {
     experiment_id <- experiment_id %||% mlflow_get_active_experiment_id()
     experiment_id <- experiment_id %||% Sys.getenv("MLFLOW_EXPERIMENT_ID", unset = NA)
-    experiment_id <- if(is.na(experiment_id)) NULL else experiment_id
+    experiment_id <- if (is.na(experiment_id)) NULL else experiment_id
     client <- mlflow_client()
     args <- mlflow_get_run_context(
       client,

--- a/mlflow/R/mlflow/R/tracking-fluent.R
+++ b/mlflow/R/mlflow/R/tracking-fluent.R
@@ -76,9 +76,9 @@ mlflow_start_run <- function(run_uuid = NULL, experiment_id = NULL, source_name 
     client <- mlflow_client()
     mlflow_client_get_run(client, existing_run_uuid)
   } else {
-    experiment_id <- as.integer(
-      experiment_id %||% mlflow_get_active_experiment_id() %||% Sys.getenv("MLFLOW_EXPERIMENT_ID", unset = "0")
-    )
+    experiment_id <- experiment_id
+                     %||% mlflow_get_active_experiment_id()
+                     %||% Sys.getenv("MLFLOW_EXPERIMENT_ID", unset = NULL)
     client <- mlflow_client()
     args <- mlflow_get_run_context(
       client,


### PR DESCRIPTION
When running in db notebook, use the notebook as default mlflow experiment. 