### PR TITLE
avoid warning in yml.load

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -23,7 +23,7 @@ def _mlflow_conda_env(path=None, additional_conda_deps=None, additional_pip_deps
     :return: `None` if `path` is specified. Otherwise, the a dictionary representation of the
              Conda environment.
     """
-    env = yaml.load(_conda_header,Loader=yaml.SafeLoader)
+    env = yaml.load(_conda_header, Loader=yaml.SafeLoader)
     env["dependencies"] = ["python={}".format(PYTHON_VERSION)]
     if additional_conda_deps is not None:
         env["dependencies"] += additional_conda_deps

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -23,7 +23,7 @@ def _mlflow_conda_env(path=None, additional_conda_deps=None, additional_pip_deps
     :return: `None` if `path` is specified. Otherwise, the a dictionary representation of the
              Conda environment.
     """
-    env = yaml.load(_conda_header, Loader=yaml.SafeLoader)
+    env = yaml.safe_load(_conda_header)
     env["dependencies"] = ["python={}".format(PYTHON_VERSION)]
     if additional_conda_deps is not None:
         env["dependencies"] += additional_conda_deps

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -23,7 +23,7 @@ def _mlflow_conda_env(path=None, additional_conda_deps=None, additional_pip_deps
     :return: `None` if `path` is specified. Otherwise, the a dictionary representation of the
              Conda environment.
     """
-    env = yaml.load(_conda_header)
+    env = yaml.load(_conda_header,Loader=yaml.SafeLoader)
     env["dependencies"] = ["python={}".format(PYTHON_VERSION)]
     if additional_conda_deps is not None:
         env["dependencies"] += additional_conda_deps


### PR DESCRIPTION
calling yml.load without Loader parameter is depercated for safety reason and may be obligatory in next release.
source :  https://msg.pyyaml.org/load 

to see the warning one can run the example in : mlflow/examples/sklearn_elasticnet_wine/train.py