### PR TITLE
rest-api.rst updates

### DIFF
--- a/docs/source/rest-api.rst
+++ b/docs/source/rest-api.rst
@@ -1,8 +1,10 @@
+
 .. _rest-api:
 
 ========
 REST API
 ========
+
 
 The MLflow REST API allows you to create, list, and get experiments and runs, and log parameters, metrics, and artifacts.
 The API is hosted under the ``/api`` route on the MLflow tracking server. For example, to list
@@ -15,10 +17,13 @@ experiments on a tracking server hosted at ``http://localhost:5000``, access
 
 ===========================
 
+
+
 .. _mlflowMlflowServicecreateExperiment:
 
 Create Experiment
 =================
+
 
 +-------------------------------------------+-------------+
 |                 Endpoint                  | HTTP Method |
@@ -30,12 +35,21 @@ Create an experiment with a name. Returns the ID of the newly created experiment
 Validates that another experiment with the same name does not already exist and fails if
 another experiment with the same name already exists.
 
+
 Throws ``RESOURCE_ALREADY_EXISTS`` if a experiment with the given name exists.
+
+
+
 
 .. _mlflowCreateExperiment:
 
 Request Structure
 -----------------
+
+
+
+
+
 
 +-------------------+------------+------------------------------------------------------------------------+
 |    Field Name     |    Type    |                              Description                               |
@@ -53,6 +67,11 @@ Request Structure
 Response Structure
 ------------------
 
+
+
+
+
+
 +---------------+-----------+---------------------------------------+
 |  Field Name   |   Type    |              Description              |
 +===============+===========+=======================================+
@@ -61,10 +80,13 @@ Response Structure
 
 ===========================
 
+
+
 .. _mlflowMlflowServicelistExperiments:
 
 List Experiments
 ================
+
 
 +-----------------------------------------+-------------+
 |                Endpoint                 | HTTP Method |
@@ -74,10 +96,18 @@ List Experiments
 
 Get a list of all experiments.
 
+
+
+
 .. _mlflowListExperiments:
 
 Request Structure
 -----------------
+
+
+
+
+
 
 +------------+-----------------------+---------------------------------------------------+
 | Field Name |         Type          |                    Description                    |
@@ -91,6 +121,11 @@ Request Structure
 Response Structure
 ------------------
 
+
+
+
+
+
 +-------------+-------------------------------------+-----------------+
 | Field Name  |                Type                 |   Description   |
 +=============+=====================================+=================+
@@ -99,10 +134,13 @@ Response Structure
 
 ===========================
 
+
+
 .. _mlflowMlflowServicegetExperiment:
 
 Get Experiment
 ==============
+
 
 +----------------------------------------+-------------+
 |                Endpoint                | HTTP Method |
@@ -111,16 +149,25 @@ Get Experiment
 +----------------------------------------+-------------+
 
 Get metadata for an experiment and a list of runs for the experiment.
+This RPC will work on deleted experiments.
+
+
+
 
 .. _mlflowGetExperiment:
 
 Request Structure
 -----------------
 
+
+
+
+
+
 +---------------+-----------+----------------------------------+
 |  Field Name   |   Type    |           Description            |
 +===============+===========+==================================+
-| experiment_id | ``INT64`` | Identifier to get an experiment. |
+| experiment_id | ``INT64`` | ID of the associated experiment. |
 |               |           | This field is required.          |
 |               |           |                                  |
 +---------------+-----------+----------------------------------+
@@ -130,20 +177,28 @@ Request Structure
 Response Structure
 ------------------
 
-+------------+----------------------------------+---------------------------------------------------------------------+
-| Field Name |               Type               |                             Description                             |
-+============+==================================+=====================================================================+
-| experiment | :ref:`mlflowexperiment`          | Returns experiment details.                                         |
-+------------+----------------------------------+---------------------------------------------------------------------+
-| runs       | An array of :ref:`mlflowruninfo` | All (max limit to be imposed) runs associated with this experiment. |
-+------------+----------------------------------+---------------------------------------------------------------------+
+
+
+
+
+
++------------+----------------------------------+----------------------------------------------------------------------------+
+| Field Name |               Type               |                                Description                                 |
++============+==================================+============================================================================+
+| experiment | :ref:`mlflowexperiment`          | Returns experiment details.                                                |
++------------+----------------------------------+----------------------------------------------------------------------------+
+| runs       | An array of :ref:`mlflowruninfo` | All (max limit to be imposed) active runs associated with this experiment. |
++------------+----------------------------------+----------------------------------------------------------------------------+
 
 ===========================
 
+
+
 .. _mlflowMlflowServicedeleteExperiment:
 
-Experiments Delete
-=========================
+Delete Experiment
+=================
+
 
 +-------------------------------------------+-------------+
 |                 Endpoint                  | HTTP Method |
@@ -154,25 +209,36 @@ Experiments Delete
 Mark an experiment and associated runs, params, metrics, ... etc for deletion.
 If the experiment uses FileStore, artifacts associated with experiment are also deleted.
 
+
+
+
 .. _mlflowDeleteExperiment:
 
 Request Structure
 -----------------
 
-+---------------+-----------+---------------------------------+
-|  Field Name   |   Type    |           Description           |
-+===============+===========+=================================+
-| experiment_id | ``INT64`` | ID of the associated experiment |
-|               |           | This field is required.         |
-|               |           |                                 |
-+---------------+-----------+---------------------------------+
+
+
+
+
+
++---------------+-----------+----------------------------------+
+|  Field Name   |   Type    |           Description            |
++===============+===========+==================================+
+| experiment_id | ``INT64`` | ID of the associated experiment. |
+|               |           | This field is required.          |
+|               |           |                                  |
++---------------+-----------+----------------------------------+
 
 ===========================
 
+
+
 .. _mlflowMlflowServicerestoreExperiment:
 
-Experiments Restore
-==========================
+Restore Experiment
+==================
+
 
 +--------------------------------------------+-------------+
 |                  Endpoint                  | HTTP Method |
@@ -186,25 +252,77 @@ artifacts associated with experiment are also restored.
 
 Throws ``RESOURCE_DOES_NOT_EXIST`` if experiment was never created or was permanently deleted.
 
+
+
+
 .. _mlflowRestoreExperiment:
 
 Request Structure
 -----------------
 
+
+
+
+
+
 +---------------+-----------+---------------------------------+
 |  Field Name   |   Type    |           Description           |
 +===============+===========+=================================+
-| experiment_id | ``INT64`` | ID of the associated experiment |
+| experiment_id | ``INT64`` | Identifier to get an experiment |
 |               |           | This field is required.         |
 |               |           |                                 |
 +---------------+-----------+---------------------------------+
 
 ===========================
 
+
+
+.. _mlflowMlflowServiceupdateExperiment:
+
+Update Experiment
+=================
+
+
++-------------------------------------------+-------------+
+|                 Endpoint                  | HTTP Method |
++===========================================+=============+
+| ``2.0/preview/mlflow/experiments/update`` | ``POST``    |
++-------------------------------------------+-------------+
+
+Updates an experiment metadata.
+
+
+
+
+.. _mlflowUpdateExperiment:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++---------------+------------+------------------------------------------------------------------------------------------+
+|  Field Name   |    Type    |                                       Description                                        |
++===============+============+==========================================================================================+
+| experiment_id | ``INT64``  | ID of the associated experiment.                                                         |
+|               |            | This field is required.                                                                  |
+|               |            |                                                                                          |
++---------------+------------+------------------------------------------------------------------------------------------+
+| new_name      | ``STRING`` | If provided, the experiment's name will be changed to this. The new name must be unique. |
++---------------+------------+------------------------------------------------------------------------------------------+
+
+===========================
+
+
+
 .. _mlflowMlflowServicecreateRun:
 
 Create Run
 ==========
+
 
 +------------------------------------+-------------+
 |              Endpoint              | HTTP Method |
@@ -216,10 +334,18 @@ Create a new run within an experiment. A run is usually a single execution of a
 machine learning or data ETL pipeline. MLflow uses runs to track :ref:`mlflowParam`,
 :ref:`mlflowMetric`, and :ref:`mlflowRunTag` associated with a single execution.
 
+
+
+
 .. _mlflowCreateRun:
 
 Request Structure
 -----------------
+
+
+
+
+
 
 +------------------+---------------------------------+------------------------------------------------------------------------------------------------+
 |    Field Name    |              Type               |                                          Description                                           |
@@ -229,25 +355,44 @@ Request Structure
 | user_id          | ``STRING``                      | ID of the user executing the run.                                                              |
 +------------------+---------------------------------+------------------------------------------------------------------------------------------------+
 | run_name         | ``STRING``                      | Human readable name for the run.                                                               |
+|                  |                                 | This field is deprecated and will be removed in MLflow 1.0. Use the ``mlflow.runName`` run tag |
+|                  |                                 | instead.                                                                                       |
 +------------------+---------------------------------+------------------------------------------------------------------------------------------------+
 | source_type      | :ref:`mlflowsourcetype`         | Originating source for the run.                                                                |
+|                  |                                 | This field is deprecated and will be removed in MLflow 1.0. Use the ``mlflow.source.type`` run |
+|                  |                                 | tag instead.                                                                                   |
 +------------------+---------------------------------+------------------------------------------------------------------------------------------------+
 | source_name      | ``STRING``                      | String descriptor for the run's source. For example, name or description of a notebook, or the |
 |                  |                                 | URL or path to a project.                                                                      |
+|                  |                                 | This field is deprecated and will be removed in MLflow 1.0. Use the ``mlflow.source.name`` run |
+|                  |                                 | tag instead.                                                                                   |
 +------------------+---------------------------------+------------------------------------------------------------------------------------------------+
 | entry_point_name | ``STRING``                      | Name of the project entry point associated with the current run, if any.                       |
+|                  |                                 | This field is deprecated and will be removed in MLflow 1.0. Use the                            |
+|                  |                                 | ``mlflow.project.entryPoint`` run tag instead.                                                 |
 +------------------+---------------------------------+------------------------------------------------------------------------------------------------+
 | start_time       | ``INT64``                       | Unix timestamp of when the run started in milliseconds.                                        |
 +------------------+---------------------------------+------------------------------------------------------------------------------------------------+
 | source_version   | ``STRING``                      | Git commit hash of the source code used to create run.                                         |
+|                  |                                 | This field is deprecated and will be removed in MLflow 1.0. Use the                            |
+|                  |                                 | ``mlflow.source.git.commit`` run tag instead.                                                  |
 +------------------+---------------------------------+------------------------------------------------------------------------------------------------+
 | tags             | An array of :ref:`mlflowruntag` | Additional metadata for run.                                                                   |
++------------------+---------------------------------+------------------------------------------------------------------------------------------------+
+| parent_run_id    | ``STRING``                      | ID of the parent run which started this run.                                                   |
+|                  |                                 | This field is deprecated and will be removed in MLflow 1.0. Use the ``mlflow.parentRunId`` run |
+|                  |                                 | tag instead.                                                                                   |
 +------------------+---------------------------------+------------------------------------------------------------------------------------------------+
 
 .. _mlflowCreateRunResponse:
 
 Response Structure
 ------------------
+
+
+
+
+
 
 +------------+------------------+------------------------+
 | Field Name |       Type       |      Description       |
@@ -257,10 +402,91 @@ Response Structure
 
 ===========================
 
+
+
+.. _mlflowMlflowServicedeleteRun:
+
+Mlflow Runs Delete
+==================
+
+
++------------------------------------+-------------+
+|              Endpoint              | HTTP Method |
++====================================+=============+
+| ``2.0/preview/mlflow/runs/delete`` | ``POST``    |
++------------------------------------+-------------+
+
+This operation will mark the run for deletion.
+
+
+
+
+.. _mlflowDeleteRun:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+-------------------------+
+| Field Name |    Type    |       Description       |
++============+============+=========================+
+| run_id     | ``STRING`` |                         |
+|            |            | This field is required. |
+|            |            |                         |
++------------+------------+-------------------------+
+
+===========================
+
+
+
+.. _mlflowMlflowServicerestoreRun:
+
+Mlflow Runs Restore
+===================
+
+
++-------------------------------------+-------------+
+|              Endpoint               | HTTP Method |
++=====================================+=============+
+| ``2.0/preview/mlflow/runs/restore`` | ``POST``    |
++-------------------------------------+-------------+
+
+Restore a deleted run.
+
+
+
+
+.. _mlflowRestoreRun:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+-------------------------+
+| Field Name |    Type    |       Description       |
++============+============+=========================+
+| run_id     | ``STRING`` |                         |
+|            |            | This field is required. |
+|            |            |                         |
++------------+------------+-------------------------+
+
+===========================
+
+
+
 .. _mlflowMlflowServicegetRun:
 
 Get Run
 =======
+
 
 +---------------------------------+-------------+
 |            Endpoint             | HTTP Method |
@@ -268,13 +494,22 @@ Get Run
 | ``2.0/preview/mlflow/runs/get`` | ``GET``     |
 +---------------------------------+-------------+
 
-Get metadata, params, tags, and metrics for a run. Only the last logged value for each metric
-is returned.
+Get metadata, params, tags, and metrics for a run. In the case where multiple metrics
+with the same key are logged for a run, return only the value with the latest timestamp.
+If there are multiple values with the latest timestamp, return the maximum of these values.
+
+
+
 
 .. _mlflowGetRun:
 
 Request Structure
 -----------------
+
+
+
+
+
 
 +------------+------------+-------------------------+
 | Field Name |    Type    |       Description       |
@@ -289,6 +524,11 @@ Request Structure
 Response Structure
 ------------------
 
+
+
+
+
+
 +------------+------------------+-----------------------------------------------------------------------+
 | Field Name |       Type       |                              Description                              |
 +============+==================+=======================================================================+
@@ -297,10 +537,13 @@ Response Structure
 
 ===========================
 
+
+
 .. _mlflowMlflowServicelogMetric:
 
 Log Metric
 ==========
+
 
 +----------------------------------------+-------------+
 |                Endpoint                | HTTP Method |
@@ -312,10 +555,18 @@ Log a metric for a run. A metric is a key-value pair (string key, float value) w
 associated timestamp. Examples include the various metrics that represent ML model accuracy.
 A metric can be logged multiple times.
 
+
+
+
 .. _mlflowLogMetric:
 
 Request Structure
 -----------------
+
+
+
+
+
 
 +------------+------------+---------------------------------------------------------------+
 | Field Name |    Type    |                          Description                          |
@@ -328,7 +579,7 @@ Request Structure
 |            |            | This field is required.                                       |
 |            |            |                                                               |
 +------------+------------+---------------------------------------------------------------+
-| value      | ``FLOAT``  | Float value of the metric being logged.                       |
+| value      | ``DOUBLE`` | Double value of the metric being logged.                      |
 |            |            | This field is required.                                       |
 |            |            |                                                               |
 +------------+------------+---------------------------------------------------------------+
@@ -339,10 +590,110 @@ Request Structure
 
 ===========================
 
+
+
+.. _mlflowMlflowServicelogBatch:
+
+Log Batch
+=========
+
+
++---------------------------------------+-------------+
+|               Endpoint                | HTTP Method |
++=======================================+=============+
+| ``2.0/preview/mlflow/runs/log-batch`` | ``POST``    |
++---------------------------------------+-------------+
+
+Log a batch of metrics, params, and/or tags for a run.
+The server will respond with an error (non-200 status code) if any data failed to be persisted.
+In case of error (due to internal server error or an invalid request), partial data may
+be written.
+
+Metrics, params, and tags may be written in interleaving fashion, but within a given entity
+type, are guaranteed to follow the order specified in the request body. That is, for an API
+request like:
+
+{
+ "run_id": "2a14ed5c6a87499199e0106c3501eab8",
+ "metrics": [
+   {"key": "mae", "value": 2.5, "timestamp": 1552550804},
+   {"key": "rmse", "value": 2.7, "timestamp": 1552550804},
+ ],
+ "params": [
+   {"key": "model_class", "value": "LogisticRegression"},
+ ]
+}
+
+The server is guaranteed to write metric "rmse" after "mae", though it may write param
+"model_class" before both metrics, after "mae", or after both metrics.
+
+The overwrite behavior for metrics, params, and tags is as follows:
+
+Metrics: metric values are never overwritten. Logging a metric (key, value, timestamp)
+appends to the set of values for the metric with the provided key.
+
+Tags: tag values may be overwritten by successive writes to the same tag key. That is, if
+multiple tag values with the same key are provided in the same API request, the last-provided
+tag value is written. Logging the same tag (key, value) is permitted - that is, logging a tag
+is idempotent.
+
+Params: once written, param values may not be changed (attempting to overwrite a param value
+will result in an error). However, logging the same param (key, value) is permitted - that is,
+logging a param is idempotent.
+
+Request Limits
+--------------
+A single JSON-serialized API request may be up to 1 MB in size and contain:
+
+- No more than 1000 metrics, params, and tags in total
+- Up to 1000 metrics
+- Up to 100 params
+- Up to 100 tags
+
+For example, a valid request might contain 900 metrics, 50 params, and 50 tags, but logging
+900 metrics, 50 params, and 51 tags would be invalid. The following limits also apply
+to metric, param, and tag keys & values:
+
+- Metric, param, and tag keys may be up to 250 characters in length
+- Param and tag values may be up to 250 characters in length
+
+
+
+
+.. _mlflowLogBatch:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+---------------------------------+---------------------------------------------------------------------------------+
+| Field Name |              Type               |                                   Description                                   |
++============+=================================+=================================================================================+
+| run_id     | ``STRING``                      | ID of the run to log under                                                      |
++------------+---------------------------------+---------------------------------------------------------------------------------+
+| metrics    | An array of :ref:`mlflowmetric` | Metrics to log. A single request can contain up to 1000 metrics, and up to 1000 |
+|            |                                 | metrics, params, and tags in total.                                             |
++------------+---------------------------------+---------------------------------------------------------------------------------+
+| params     | An array of :ref:`mlflowparam`  | Params to log. A single request can contain up to 100 params, and up to 1000    |
+|            |                                 | metrics, params, and tags in total.                                             |
++------------+---------------------------------+---------------------------------------------------------------------------------+
+| tags       | An array of :ref:`mlflowruntag` | Tags to log. A single request can contain up to 100 tags, and up to 1000        |
+|            |                                 | metrics, params, and tags in total.                                             |
++------------+---------------------------------+---------------------------------------------------------------------------------+
+
+===========================
+
+
+
 .. _mlflowMlflowServicesetTag:
 
 Set Tag
 =======
+
 
 +-------------------------------------+-------------+
 |              Endpoint               | HTTP Method |
@@ -353,33 +704,44 @@ Set Tag
 Set a tag on a run. Tags are run metadata that can be updated during a run and after
 a run completes.
 
+
+
+
 .. _mlflowSetTag:
 
 Request Structure
 -----------------
 
-+------------+------------+------------------------------------------------------------------+
-| Field Name |    Type    |                           Description                            |
-+============+============+==================================================================+
-| run_uuid   | ``STRING`` | ID of the run under which to set the tag.                        |
-|            |            | This field is required.                                          |
-|            |            |                                                                  |
-+------------+------------+------------------------------------------------------------------+
-| key        | ``STRING`` | Name of the tag. Maximum size is 255 bytes.                      |
-|            |            | This field is required.                                          |
-|            |            |                                                                  |
-+------------+------------+------------------------------------------------------------------+
-| value      | ``STRING`` | String value of the tag being logged. Maximum size if 500 bytes. |
-|            |            | This field is required.                                          |
-|            |            |                                                                  |
-+------------+------------+------------------------------------------------------------------+
+
+
+
+
+
++------------+------------+-------------------------------------------------------------------+
+| Field Name |    Type    |                            Description                            |
++============+============+===================================================================+
+| run_uuid   | ``STRING`` | ID of the run under which to set the tag.                         |
+|            |            | This field is required.                                           |
+|            |            |                                                                   |
++------------+------------+-------------------------------------------------------------------+
+| key        | ``STRING`` | Name of the tag. Maximum size is 255 bytes.                       |
+|            |            | This field is required.                                           |
+|            |            |                                                                   |
++------------+------------+-------------------------------------------------------------------+
+| value      | ``STRING`` | String value of the tag being logged. Maximum size is 5000 bytes. |
+|            |            | This field is required.                                           |
+|            |            |                                                                   |
++------------+------------+-------------------------------------------------------------------+
 
 ===========================
+
+
 
 .. _mlflowMlflowServicelogParam:
 
 Log Param
 =========
+
 
 +-------------------------------------------+-------------+
 |                 Endpoint                  | HTTP Method |
@@ -391,10 +753,18 @@ Log a param used for a run. A param is a key-value pair (string key,
 string value). Examples include hyperparameters used for ML model training and
 constant dates and values used in an ETL pipeline. A param can be logged only once for a run.
 
+
+
+
 .. _mlflowLogParam:
 
 Request Structure
 -----------------
+
+
+
+
+
 
 +------------+------------+--------------------------------------------------------------------+
 | Field Name |    Type    |                            Description                             |
@@ -407,17 +777,20 @@ Request Structure
 |            |            | This field is required.                                            |
 |            |            |                                                                    |
 +------------+------------+--------------------------------------------------------------------+
-| value      | ``STRING`` | String value of the param being logged. Maximum size if 500 bytes. |
+| value      | ``STRING`` | String value of the param being logged. Maximum size is 500 bytes. |
 |            |            | This field is required.                                            |
 |            |            |                                                                    |
 +------------+------------+--------------------------------------------------------------------+
 
 ===========================
 
+
+
 .. _mlflowMlflowServicegetMetricHistory:
 
 Get Metric History
 ==================
+
 
 +--------------------------------------------+-------------+
 |                  Endpoint                  | HTTP Method |
@@ -427,10 +800,18 @@ Get Metric History
 
 Get a list of all values for the specified metric for a given run.
 
+
+
+
 .. _mlflowGetMetricHistory:
 
 Request Structure
 -----------------
+
+
+
+
+
 
 +------------+------------+--------------------------------------------------+
 | Field Name |    Type    |                   Description                    |
@@ -449,6 +830,11 @@ Request Structure
 Response Structure
 ------------------
 
+
+
+
+
+
 +------------+---------------------------------+------------------------------------+
 | Field Name |              Type               |            Description             |
 +============+=================================+====================================+
@@ -457,10 +843,13 @@ Response Structure
 
 ===========================
 
+
+
 .. _mlflowMlflowServicesearchRuns:
 
 Search Runs
 ===========
+
 
 +------------------------------------+-------------+
 |              Endpoint              | HTTP Method |
@@ -471,23 +860,58 @@ Search Runs
 Search for runs that satisfy expressions. Search expressions can use :ref:`mlflowMetric` and
 :ref:`mlflowParam` keys.
 
+
+
+
 .. _mlflowSearchRuns:
 
 Request Structure
 -----------------
 
-+-------------------+-------------------------------------------+--------------------------------------------------------------------+
-|    Field Name     |                   Type                    |                            Description                             |
-+===================+===========================================+====================================================================+
-| experiment_ids    | An array of ``INT64``                     | List of experiment IDs to search over.                             |
-+-------------------+-------------------------------------------+--------------------------------------------------------------------+
-| anded_expressions | An array of :ref:`mlflowsearchexpression` | Expressions describing runs (AND-ed together when filtering runs). |
-+-------------------+-------------------------------------------+--------------------------------------------------------------------+
+
+
+
+
+
++-------------------+-------------------------------------------+---------------------------------------------------------------------------------------------+
+|    Field Name     |                   Type                    |                                         Description                                         |
++===================+===========================================+=============================================================================================+
+| experiment_ids    | An array of ``INT64``                     | List of experiment IDs to search over.                                                      |
++-------------------+-------------------------------------------+---------------------------------------------------------------------------------------------+
+| anded_expressions | An array of :ref:`mlflowsearchexpression` | This field is deprecated and will be removed in MLflow 1.0.                                 |
+|                   |                                           | Expressions describing runs (AND-ed together when filtering runs).                          |
+|                   |                                           | See 'filter' for a simpler on-the-wire representation of these expressions.                 |
++-------------------+-------------------------------------------+---------------------------------------------------------------------------------------------+
+| filter            | ``STRING``                                | A filter expression over params, metrics, and tags, allowing returning a subset of          |
+|                   |                                           | runs. The syntax is a subset of SQL which allows only ANDing together binary operations     |
+|                   |                                           | between a param/metric/tag and a constant.                                                  |
+|                   |                                           |                                                                                             |
+|                   |                                           | Example: ``metrics.rmse < 1 and params.model_class = 'LogisticRegression'``                 |
+|                   |                                           |                                                                                             |
+|                   |                                           | You can also select columns with spaces by using backticks or double quotes:                |
+|                   |                                           | ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``               |
+|                   |                                           |                                                                                             |
+|                   |                                           | Supported operators are =, !=, >, >=, <, <=, and LIKE.                                      |
+|                   |                                           | LIKE syntax: ``params.model_class LIKE 'Linear%'``                                          |
+|                   |                                           |                                                                                             |
+|                   |                                           | 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE  |
+|                   |                                           | error will be returned if both are specified.                                               |
+|                   |                                           | If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments |
+|                   |                                           | will be returned.                                                                           |
++-------------------+-------------------------------------------+---------------------------------------------------------------------------------------------+
+| run_view_type     | :ref:`mlflowviewtype`                     | Whether to display only active, only deleted, or all runs.                                  |
+|                   |                                           | Defaults to only active runs.                                                               |
++-------------------+-------------------------------------------+---------------------------------------------------------------------------------------------+
 
 .. _mlflowSearchRunsResponse:
 
 Response Structure
 ------------------
+
+
+
+
+
 
 +------------+------------------------------+--------------------------------------+
 | Field Name |             Type             |             Description              |
@@ -497,10 +921,13 @@ Response Structure
 
 ===========================
 
+
+
 .. _mlflowMlflowServicelistArtifacts:
 
 List Artifacts
 ==============
+
 
 +---------------------------------------+-------------+
 |               Endpoint                | HTTP Method |
@@ -511,10 +938,18 @@ List Artifacts
 List artifacts for a run. Takes an optional ``artifact_path`` prefix which if specified,
 the response contains only artifacts with the specified prefix.
 
+
+
+
 .. _mlflowListArtifacts:
 
 Request Structure
 -----------------
+
+
+
+
+
 
 +------------+------------+-----------------------------------------------------------------------------------------+
 | Field Name |    Type    |                                       Description                                       |
@@ -529,6 +964,11 @@ Request Structure
 Response Structure
 ------------------
 
+
+
+
+
+
 +------------+-----------------------------------+-------------------------------------------+
 | Field Name |               Type                |                Description                |
 +============+===================================+===========================================+
@@ -539,10 +979,13 @@ Response Structure
 
 ===========================
 
+
+
 .. _mlflowMlflowServiceupdateRun:
 
 Update Run
 ==========
+
 
 +------------------------------------+-------------+
 |              Endpoint              | HTTP Method |
@@ -552,10 +995,18 @@ Update Run
 
 Update run metadata.
 
+
+
+
 .. _mlflowUpdateRun:
 
 Request Structure
 -----------------
+
+
+
+
+
 
 +------------+------------------------+-------------------------------------------------------+
 | Field Name |          Type          |                      Description                      |
@@ -574,23 +1025,90 @@ Request Structure
 Response Structure
 ------------------
 
+
+
+
+
+
 +------------+----------------------+------------------------------+
 | Field Name |         Type         |         Description          |
 +============+======================+==============================+
 | run_info   | :ref:`mlflowruninfo` | Updated metadata of the run. |
 +------------+----------------------+------------------------------+
 
+===========================
+
+
+
+.. _mlflowMlflowServicepurgeDeletedState:
+
+Purge Deleted State
+===================
+
+
++------------------------------+-------------+
+|           Endpoint           | HTTP Method |
++==============================+=============+
+| ``2.0/preview/mlflow/purge`` | ``POST``    |
++------------------------------+-------------+
+
+Purges (permanently deletes) experiments and runs which were deleted prior to some timestamp.
+
+
+
+
+.. _mlflowPurgeDeletedState:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++-------------------+-----------+-----------------------------------------------------------------------------------------+
+|    Field Name     |   Type    |                                       Description                                       |
++===================+===========+=========================================================================================+
+| horizon_timestamp | ``INT64`` | Horizon for deleted experiments and runs. Any experiments or runs deleted prior to this |
+|                   |           | timestamp (UTC) will be permanently deleted.                                            |
+|                   |           | If this value is not provided, the server will pick the current timestamp.              |
++-------------------+-----------+-----------------------------------------------------------------------------------------+
+
 .. _RESTadd:
 
 Data Structures
 ===============
+
+
+
+.. _mlflowDoubleClause:
+
+DoubleClause
+------------
+
+
+
+
+
+
++------------+------------+------------------------------------------+
+| Field Name |    Type    |               Description                |
++============+============+==========================================+
+| comparator | ``STRING`` | OneOf (">", ">=", "==", "!=", "<=", "<") |
++------------+------------+------------------------------------------+
+| value      | ``DOUBLE`` | Float value for comparison.              |
++------------+------------+------------------------------------------+
 
 .. _mlflowExperiment:
 
 Experiment
 ----------
 
+
+
 Experiment
+
 
 +-------------------+------------+--------------------------------------------------------------------+
 |    Field Name     |    Type    |                            Description                             |
@@ -614,7 +1132,10 @@ Experiment
 FileInfo
 --------
 
+
+
 Metadata of a single artifact file or directory.
+
 
 +------------+------------+---------------------------------------------------+
 | Field Name |    Type    |                    Description                    |
@@ -631,6 +1152,11 @@ Metadata of a single artifact file or directory.
 FloatClause
 -----------
 
+
+
+
+
+
 +------------+------------+------------------------------------------+
 | Field Name |    Type    |               Description                |
 +============+============+==========================================+
@@ -644,14 +1170,17 @@ FloatClause
 Metric
 ------
 
+
+
 Metric associated with a run, represented as a key-value pair.
+
 
 +------------+------------+--------------------------------------------------+
 | Field Name |    Type    |                   Description                    |
 +============+============+==================================================+
 | key        | ``STRING`` | Key identifying this metric.                     |
 +------------+------------+--------------------------------------------------+
-| value      | ``FLOAT``  | Value associated with this metric.               |
+| value      | ``DOUBLE`` | Value associated with this metric.               |
 +------------+------------+--------------------------------------------------+
 | timestamp  | ``INT64``  | The timestamp at which this metric was recorded. |
 +------------+------------+--------------------------------------------------+
@@ -661,22 +1190,37 @@ Metric associated with a run, represented as a key-value pair.
 MetricSearchExpression
 ----------------------
 
-+------------+--------------------------+--------------------------------------------+
-| Field Name |           Type           |                Description                 |
-+============+==========================+============================================+
-| ``float``  | :ref:`mlflowfloatclause` |                                            |
-|            |                          |                                            |
-|            |                          | If ``float``, float clause for comparison. |
-+------------+--------------------------+--------------------------------------------+
-| key        | ``STRING``               | :ref:`mlflowMetric` key for search.        |
-+------------+--------------------------+--------------------------------------------+
+
+
+
+
+
++-------------------------+-------------------------------------------------------+-----------------------------------------------------------------------+
+|       Field Name        |                         Type                          |                              Description                              |
++=========================+=======================================================+=======================================================================+
+| ``float`` OR ``double`` | :ref:`mlflowfloatclause` OR :ref:`mlflowdoubleclause` |                                                                       |
+|                         |                                                       |                                                                       |
+|                         |                                                       | If ``float``, [Deprecated in 0.7.0, to be removed in future version]  |
+|                         |                                                       | Float clause for comparison. Use 'double' instead.                    |
+|                         |                                                       |                                                                       |
+|                         |                                                       |                                                                       |
+|                         |                                                       |                                                                       |
+|                         |                                                       |                                                                       |
+|                         |                                                       |                                                                       |
+|                         |                                                       | If ``double``, double clause of comparison                            |
++-------------------------+-------------------------------------------------------+-----------------------------------------------------------------------+
+| key                     | ``STRING``                                            | :ref:`mlflowMetric` key for search.                                   |
++-------------------------+-------------------------------------------------------+-----------------------------------------------------------------------+
 
 .. _mlflowParam:
 
 Param
 -----
 
+
+
 Param associated with a run.
+
 
 +------------+------------+-----------------------------------+
 | Field Name |    Type    |            Description            |
@@ -690,6 +1234,11 @@ Param associated with a run.
 
 ParameterSearchExpression
 -------------------------
+
+
+
+
+
 
 +------------+---------------------------+----------------------------------------------+
 | Field Name |           Type            |                 Description                  |
@@ -706,7 +1255,10 @@ ParameterSearchExpression
 Run
 ---
 
+
+
 A single run.
+
 
 +------------+----------------------+---------------+
 | Field Name |         Type         |  Description  |
@@ -721,7 +1273,10 @@ A single run.
 RunData
 -------
 
+
+
 Run data (metrics, params, etc).
+
 
 +------------+---------------------------------+--------------------------------------+
 | Field Name |              Type               |             Description              |
@@ -738,48 +1293,66 @@ Run data (metrics, params, etc).
 RunInfo
 -------
 
+
+
 Metadata of a single run.
 
-+------------------+-------------------------+----------------------------------------------------------------------------------+
-|    Field Name    |          Type           |                                   Description                                    |
-+==================+=========================+==================================================================================+
-| run_uuid         | ``STRING``              | Unique identifier for the run.                                                   |
-+------------------+-------------------------+----------------------------------------------------------------------------------+
-| experiment_id    | ``INT64``               | The experiment ID.                                                               |
-+------------------+-------------------------+----------------------------------------------------------------------------------+
-| name             | ``STRING``              | Human readable name that identifies this run.                                    |
-+------------------+-------------------------+----------------------------------------------------------------------------------+
-| source_type      | :ref:`mlflowsourcetype` | Source type.                                                                     |
-+------------------+-------------------------+----------------------------------------------------------------------------------+
-| source_name      | ``STRING``              | Source identifier: GitHub URL, name of notebook, name of job, etc.               |
-+------------------+-------------------------+----------------------------------------------------------------------------------+
-| user_id          | ``STRING``              | User who initiated the run.                                                      |
-+------------------+-------------------------+----------------------------------------------------------------------------------+
-| status           | :ref:`mlflowrunstatus`  | Current status of the run.                                                       |
-+------------------+-------------------------+----------------------------------------------------------------------------------+
-| start_time       | ``INT64``               | Unix timestamp of when the run started in milliseconds.                          |
-+------------------+-------------------------+----------------------------------------------------------------------------------+
-| end_time         | ``INT64``               | Unix timestamp of when the run ended in milliseconds.                            |
-+------------------+-------------------------+----------------------------------------------------------------------------------+
-| source_version   | ``STRING``              | Git commit hash of the code used for the run.                                    |
-+------------------+-------------------------+----------------------------------------------------------------------------------+
-| entry_point_name | ``STRING``              | Name of the entry point for the run.                                             |
-+------------------+-------------------------+----------------------------------------------------------------------------------+
-| artifact_uri     | ``STRING``              | URI of the directory where artifacts should be uploaded.                         |
-|                  |                         | This can be a local path (starting with "/"), or a distributed file system (DFS) |
-|                  |                         | path, like ``s3://bucket/directory`` or ``dbfs:/my/directory``.                  |
-|                  |                         | If not set, the local ``./mlruns`` directory is  chosen.                         |
-+------------------+-------------------------+----------------------------------------------------------------------------------+
+
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
+|    Field Name    |          Type           |                                          Description                                           |
++==================+=========================+================================================================================================+
+| run_uuid         | ``STRING``              | Unique identifier for the run.                                                                 |
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
+| experiment_id    | ``INT64``               | The experiment ID.                                                                             |
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
+| name             | ``STRING``              | Human readable name that identifies this run.                                                  |
+|                  |                         | This field is deprecated and will be removed in MLflow 1.0. Use the ``mlflow.runName`` run tag |
+|                  |                         | instead.                                                                                       |
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
+| source_type      | :ref:`mlflowsourcetype` | Source type.                                                                                   |
+|                  |                         | This field is deprecated and will be removed in MLflow 1.0. Use the ``mlflow.source.type`` run |
+|                  |                         | tag instead.                                                                                   |
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
+| source_name      | ``STRING``              | Source identifier: GitHub URL, name of notebook, name of job, etc.                             |
+|                  |                         | This field is deprecated and will be removed in MLflow 1.0. Use the ``mlflow.source.name`` run |
+|                  |                         | tag instead.                                                                                   |
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
+| user_id          | ``STRING``              | User who initiated the run.                                                                    |
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
+| status           | :ref:`mlflowrunstatus`  | Current status of the run.                                                                     |
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
+| start_time       | ``INT64``               | Unix timestamp of when the run started in milliseconds.                                        |
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
+| end_time         | ``INT64``               | Unix timestamp of when the run ended in milliseconds.                                          |
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
+| source_version   | ``STRING``              | Git commit hash of the code used for the run.                                                  |
+|                  |                         | This field is deprecated and will be removed in MLflow 1.0. Use the                            |
+|                  |                         | ``mlflow.source.git.commit`` run tag instead.                                                  |
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
+| entry_point_name | ``STRING``              | Name of the entry point for the run.                                                           |
+|                  |                         | This field is deprecated and will be removed in MLflow 1.0. Use the                            |
+|                  |                         | ``mlflow.project.entryPoint`` run tag instead.                                                 |
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
+| artifact_uri     | ``STRING``              | URI of the directory where artifacts should be uploaded.                                       |
+|                  |                         | This can be a local path (starting with "/"), or a distributed file system (DFS)               |
+|                  |                         | path, like ``s3://bucket/directory`` or ``dbfs:/my/directory``.                                |
+|                  |                         | If not set, the local ``./mlruns`` directory is  chosen.                                       |
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
+| lifecycle_stage  | ``STRING``              | Current life cycle stage of the experiment : OneOf("active", "deleted")                        |
++------------------+-------------------------+------------------------------------------------------------------------------------------------+
 
 .. _mlflowRunTag:
 
 RunTag
 ------
 
+
+
 Tag for a run.
 
+
 +------------+------------+----------------+
-| Field Name |    Type    | Description    |
+| Field Name |    Type    |  Description   |
 +============+============+================+
 | key        | ``STRING`` | The tag key.   |
 +------------+------------+----------------+
@@ -815,10 +1388,16 @@ automatically by MLflow:
 | ``mlflow.docker.image.id``    | ID of the Docker image used to execute this run.                                       |
 +-------------------------------+----------------------------------------------------------------------------------------+
 
+
 .. _mlflowSearchExpression:
 
 SearchExpression
 ----------------
+
+
+
+
+
 
 +-----------------------------+-------------------------------------------------------------------------------+--------------------------------------------------+
 |         Field Name          |                                     Type                                      |                   Description                    |
@@ -839,6 +1418,11 @@ SearchExpression
 StringClause
 ------------
 
+
+
+
+
+
 +------------+------------+------------------------------+
 | Field Name |    Type    |         Description          |
 +============+============+==============================+
@@ -851,6 +1435,7 @@ StringClause
 
 RunStatus
 ---------
+
 
 Status of a run.
 
@@ -873,6 +1458,7 @@ Status of a run.
 SourceType
 ----------
 
+
 Source that generated a run.
 
 +----------+------------------------------------------------------------------------+
@@ -893,6 +1479,7 @@ Source that generated a run.
 
 ViewType
 --------
+
 
 View type for ListExperiments query.
 

--- a/docs/source/rest-api.rst
+++ b/docs/source/rest-api.rst
@@ -1036,45 +1036,6 @@ Response Structure
 | run_info   | :ref:`mlflowruninfo` | Updated metadata of the run. |
 +------------+----------------------+------------------------------+
 
-===========================
-
-
-
-.. _mlflowMlflowServicepurgeDeletedState:
-
-Purge Deleted State
-===================
-
-
-+------------------------------+-------------+
-|           Endpoint           | HTTP Method |
-+==============================+=============+
-| ``2.0/preview/mlflow/purge`` | ``POST``    |
-+------------------------------+-------------+
-
-Purges (permanently deletes) experiments and runs which were deleted prior to some timestamp.
-
-
-
-
-.. _mlflowPurgeDeletedState:
-
-Request Structure
------------------
-
-
-
-
-
-
-+-------------------+-----------+-----------------------------------------------------------------------------------------+
-|    Field Name     |   Type    |                                       Description                                       |
-+===================+===========+=========================================================================================+
-| horizon_timestamp | ``INT64`` | Horizon for deleted experiments and runs. Any experiments or runs deleted prior to this |
-|                   |           | timestamp (UTC) will be permanently deleted.                                            |
-|                   |           | If this value is not provided, the server will pick the current timestamp.              |
-+-------------------+-----------+-----------------------------------------------------------------------------------------+
-
 .. _RESTadd:
 
 Data Structures


### PR DESCRIPTION
The current `rest-api.rst` file in the repo seems out of sync with the published docs (https://www.mlflow.org/docs/latest/rest-api.html), so trying to synchronize them. 