### PR TITLE
[proposal][WIP]Get or create default experiment, relax default experiment id constraint

### DIFF
--- a/mlflow/store/file_store.py
+++ b/mlflow/store/file_store.py
@@ -182,7 +182,7 @@ class FileStore(AbstractStore):
         # Get all existing experiments and find the one with largest ID.
         # len(list_all(..)) would not work when experiments are deleted.
         experiments_ids = [e.experiment_id for e in self.list_experiments(ViewType.ALL)]
-        experiment_id = max(experiments_ids) + 1 if experiments_ids else 0
+        experiment_id = max(experiments_ids) + 1 if experiments_ids else Experiment.DEFAULT_EXPERIMENT_ID
         return self._create_experiment_with_id(name, experiment_id, artifact_location)
 
     def _has_experiment(self, experiment_id):

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -303,8 +303,9 @@ def _get_or_create_experiment(experiment_name):
     exp_id = exp.experiment_id if exp else None
     if exp_id is None:
         print("INFO: '{}' does not exist. Creating a new experiment".format(experiment_name))
-        exp_id = client.create_experiment(exp)
-    return client.get_experiment(exp_id)
+        client.create_experiment(experiment_name)
+        return client.get_experiment_by_name(experiment_name)
+    return exp
 
 
 def _get_experiment_id():

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -40,19 +40,14 @@ def set_experiment(experiment_name):
 
     :param experiment_name: Name of experiment to be activated.
     """
-    client = MlflowClient()
-    experiment = client.get_experiment_by_name(experiment_name)
-    exp_id = experiment.experiment_id if experiment else None
-    if exp_id is None:  # id can be 0
-        print("INFO: '{}' does not exist. Creating a new experiment".format(experiment_name))
-        exp_id = client.create_experiment(experiment_name)
-    elif experiment.lifecycle_stage == LifecycleStage.DELETED:
+    experiment = _get_or_create_experiment(experiment_name)
+    if experiment.lifecycle_stage == LifecycleStage.DELETED:
         raise MlflowException(
             "Cannot set a deleted experiment '%s' as the active experiment."
             " You can restore the experiment, or permanently delete the "
             " experiment to create a new one." % experiment.name)
     global _active_experiment_id
-    _active_experiment_id = exp_id
+    _active_experiment_id = experiment.experiment_id
 
 
 class ActiveRun(Run):  # pylint: disable=W0223
@@ -302,8 +297,20 @@ def _get_experiment_id_from_env():
     return env.get_env(_EXPERIMENT_ID_ENV_VAR)
 
 
+def _get_or_create_experiment(experiment_name):
+    client = MlflowClient()
+    exp = client.get_experiment_by_name(experiment_name)
+    exp_id = exp.experiment_id if exp else None
+    if exp_id is None:
+        print("INFO: '{}' does not exist. Creating a new experiment".format(experiment_name))
+        exp_id = client.create_experiment(exp)
+    return client.get_experiment(exp_id)
+
+
 def _get_experiment_id():
-    return int(_active_experiment_id or
-               _get_experiment_id_from_env() or
-               (is_in_databricks_notebook() and get_notebook_id()) or
-               Experiment.DEFAULT_EXPERIMENT_ID)
+    exp_id = int(_active_experiment_id or _get_experiment_id_from_env() or
+                 (is_in_databricks_notebook() and get_notebook_id()))
+    if not exp_id:
+        exp = _get_or_create_experiment(Experiment.DEFAULT_EXPERIMENT_NAME)
+        return exp.experiment_id if exp else None
+    return exp_id


### PR DESCRIPTION
# Currently, the experiment with name "Default" and id 0, is part of the contract for all stores.
This contract is easy to miss and will run into hard to avoid errors for most user scripts

# Solution: mirror set_experiment semantics for default behavior
Rather than return experiment_id = 0, assuming "Default" experiment exists:
- check if an experiment with name "Default" exists
- if so, return the corresponding experiments id(if it was created first, it will be 0)
- else create_experiment("Default") and return that experiment's experiment_id

This approach allows rest_store and other implementations to treat all experiments the same while still supporting mlflow.start_run() without the user calling mlflow.set_experiment() beforehand

