### PR TITLE
Return the prediction from the Python server as an object

### DIFF
--- a/mlflow/pyfunc/scoring_server.py
+++ b/mlflow/pyfunc/scoring_server.py
@@ -161,7 +161,7 @@ def init(model):
                     error_code=BAD_REQUEST)
 
         predictions = get_jsonable_obj(raw_predictions, pandas_orient="records")
-        result = json.dumps(predictions, cls=NumpyEncoder)
+        result = json.dumps({"predictions": predictions}, cls=NumpyEncoder)
         return flask.Response(response=result, status=200, mimetype='application/json')
 
     return app

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -83,8 +83,11 @@ def test_model_save_load(model, model_path, data, predicted):
         model_path=os.path.abspath(model_path),
         data=pd.DataFrame(x),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED)
-    assert all(pd.read_json(scoring_response.content, orient="records").values.astype(np.float32)
-               == predicted)
+    assert all(
+        pd.DataFrame(
+            json.loads(scoring_response.content)["predictions"]
+        ).values.astype(np.float32) == predicted
+    )
 
     # test spark udf
     spark_udf_preds = score_model_as_udf(os.path.abspath(model_path),

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -193,8 +193,10 @@ def test_pyfunc_model_serving_without_conda_env_activation_succeeds_with_main_sc
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
             extra_args=["--no-conda"])
     assert scoring_response.status_code == 200
+    response_json = json.loads(scoring_response.text)
+    assert response_json["predictions"]
     np.testing.assert_array_equal(
-        np.array(json.loads(scoring_response.text)),
+        np.array(response_json["predictions"]),
         loaded_pyfunc_model.predict(sample_input))
 
 
@@ -220,8 +222,10 @@ def test_pyfunc_model_serving_with_conda_env_activation_succeeds_with_main_scope
             data=sample_input,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED)
     assert scoring_response.status_code == 200
+    response_json = json.loads(scoring_response.text)
+    assert response_json["predictions"]
     np.testing.assert_array_equal(
-        np.array(json.loads(scoring_response.text)),
+        np.array(response_json["predictions"]),
         loaded_pyfunc_model.predict(sample_input))
 
 
@@ -249,8 +253,10 @@ def test_pyfunc_model_serving_without_conda_env_activation_succeeds_with_module_
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
             extra_args=["--no-conda"])
     assert scoring_response.status_code == 200
+    response_json = json.loads(scoring_response.text)
+    assert response_json["predictions"]
     np.testing.assert_array_equal(
-        np.array(json.loads(scoring_response.text)),
+        np.array(response_json["predictions"]),
         loaded_pyfunc_model.predict(sample_input))
 
 
@@ -640,7 +646,7 @@ def test_sagemaker_docker_model_scoring_with_default_conda_env(
             data=inference_df,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
             flavor=mlflow.pyfunc.FLAVOR_NAME)
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
+    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content)["predictions"])
 
     pandas.testing.assert_frame_equal(
         deployed_model_preds,

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -126,6 +126,8 @@ def test_scoring_server_successfully_evaluates_correct_dataframes_with_pandas_re
             data=pandas_record_content,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_RECORDS_ORIENTED)
     assert response_records_content_type.status_code == 200
+    response_json = json.loads(response_records_content_type.content)
+    assert response_json["predictions"]
 
 
 def test_scoring_server_successfully_evaluates_correct_dataframes_with_pandas_split_orientation(

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -361,7 +361,7 @@ def test_pyfunc_model_serving_with_module_scoped_subclassed_model_and_default_co
             extra_args=["--no-conda"])
     assert scoring_response.status_code == 200
 
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
+    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content)["predictions"])
     np.testing.assert_array_almost_equal(
         deployed_model_preds.values[:, 0],
         _predict(model=module_scoped_subclassed_model, data=data),
@@ -383,7 +383,7 @@ def test_pyfunc_model_serving_with_main_scoped_subclassed_model_and_custom_pickl
             extra_args=["--no-conda"])
     assert scoring_response.status_code == 200
 
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
+    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content)["predictions"])
     np.testing.assert_array_almost_equal(
         deployed_model_preds.values[:, 0],
         _predict(model=main_scoped_subclassed_model, data=data),
@@ -434,7 +434,7 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
             extra_args=["--no-conda"])
     assert scoring_response.status_code == 200
 
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
+    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content)["predictions"])
     np.testing.assert_array_almost_equal(
         deployed_model_preds.values[:, 0],
         _predict(model=module_scoped_subclassed_model, data=data),

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -162,7 +162,7 @@ def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
             flavor=mlflow.pyfunc.FLAVOR_NAME)
     np.testing.assert_array_almost_equal(
             spark_model_iris.predictions,
-            np.array(json.loads(scoring_response_1.content)),
+            np.array(json.loads(scoring_response_1.content)["predictions"]),
             decimal=4)
     # 2. score and compare mleap deployed in Sagemaker docker container
     scoring_response_2 = score_model_in_sagemaker_docker_container(


### PR DESCRIPTION
Instead of returning [p1, p2, p3], return {"predictions": [p1, p2, p3]}
This is in keeping with what the R server does.

This PR is a possible fix for #963