### PR TITLE
Resolve cloudpickle version in setup.py with test-requirements.txt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     package_data={"mlflow": js_files + sagmaker_server_files},
     install_requires=[
         'click>=7.0',
-        'cloudpickle==0.6.1',
+        'cloudpickle>=0.6.1',
         'databricks-cli>=0.8.0',
         'requests>=2.17.3',
         'six>=1.10.0',
@@ -45,7 +45,6 @@ setup(
         'querystring_parser',
         'simplejson',
         'mleap>=0.8.1',
-        'cloudpickle',
         'docker>=3.6.0',
         'entrypoints',
         'sqlparse',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     package_data={"mlflow": js_files + sagmaker_server_files},
     install_requires=[
         'click>=7.0',
-        'cloudpickle>=0.6.1',
+        'cloudpickle',
         'databricks-cli>=0.8.0',
         'requests>=2.17.3',
         'six>=1.10.0',


### PR DESCRIPTION
If you install dependencies according to `test-requirement.txt`, the main package can't be built properly due to the cloudpickle version discrepancy. Updating `setup.py` to be compatible with `test-requirement.txt`.