### PR TITLE
Fix #1041 added sqlalchemy and related packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,10 @@ setup(
         'docker>=3.6.0',
         'entrypoints',
         'sqlparse',
+        'sqlalchemy==1.3.0',
+        'psycopg2',
+        'mysqlclient',
+        'pyodbc',
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
Added `sqlalchemy` and related packages ( `psycopg2`, `mysqlclient`, `pyodbc`) to setup.py.  `sqlalchemy` is pinned to 1.3.0 to match test-requirements.txt.

Note:  installation of `mysqlclient` and `pyodbc` required additional system requirements.  For example, `mysqlclient` required [system libraries for mysql](https://stackoverflow.com/questions/5178292/pip-install-mysql-python-fails-with-environmenterror-mysql-config-not-found).