### PR TITLE
[WIP] More unit tests for search file- and sql-backed store

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -15,9 +15,8 @@ class SearchFilter(object):
     _ALTERNATE_PARAM_IDENTIFIERS = set(["param", "params"])
     VALID_KEY_TYPE = set([_METRIC_IDENTIFIER] + list(_ALTERNATE_METRIC_IDENTIFIERS)
                          + [_PARAM_IDENTIFIER] + list(_ALTERNATE_PARAM_IDENTIFIERS))
-    VALUE_TYPES = set([TokenType.Literal.String.Single,
-                       TokenType.Literal.Number.Integer,
-                       TokenType.Literal.Number.Float])
+    STRING_VALUE_TYPES = set([TokenType.Literal.String.Single])
+    NUMERIC_VALUE_TYPES = set([TokenType.Literal.Number.Integer, TokenType.Literal.Number.Float])
 
     def __init__(self, search_runs=None):
         self._filter_string = search_runs.filter if search_runs else None
@@ -74,8 +73,10 @@ class SearchFilter(object):
     def _process_token(cls, token):
         if token.ttype == TokenType.Operator.Comparison:
             return {"comparator": token.value}
-        elif token.ttype in cls.VALUE_TYPES:
+        elif token.ttype in cls.NUMERIC_VALUE_TYPES:
             return {"value": token.value}
+        elif token.ttype in cls.STRING_VALUE_TYPES:
+            return {"value": token.value.strip("'")}  # strip quotes
         else:
             return {}
 

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -850,7 +850,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
         expr = self._metric_expression("common", "<=", 0.75)
         six.assertCountEqual(self, [], self._search(experiment_id, metrics_expressions=[expr]))
-        six.assertCountEqual(self, [], self._search(experiment_id,filter="metrics.common <= 0.75"))
+        six.assertCountEqual(self, [], self._search(experiment_id, filter="metrics.common <= 0.75"))
 
         # tests for same metric name across runs with different values and timestamps
         expr = self._metric_expression("measure_a", ">", 0.0)
@@ -903,7 +903,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         # there is a recorded metric this threshold but not last timestamp
         expr = self._metric_expression("m_b", ">", 5.0)
         six.assertCountEqual(self, [], self._search(experiment_id, metrics_expressions=[expr]))
-        six.assertCountEqual(self, [], self._search(experiment_id,filter="metrics.m_b>5.0"))
+        six.assertCountEqual(self, [], self._search(experiment_id, filter="metrics.m_b>5.0"))
 
         # metrics matches last reported timestamp for 'm_b'
         expr = self._metric_expression("m_b", "=", 4.0)


### PR DESCRIPTION
Using filter-string approach. Replicating all existing `anded_expression` tests to `filter` string approach to ensure identical behavior for stores.

## NOTE:
This test needs changes in #1042 to make some of this tests pass.