### PR TITLE
Provide default implementations of AbstractStore log methods

### DIFF
--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -115,6 +115,7 @@ class AbstractStore:
         """
         pass
 
+    @abstractmethod
     def update_run_info(self, run_uuid, run_status, end_time):
         """
         Update the metadata of the specified run.
@@ -123,6 +124,7 @@ class AbstractStore:
         """
         pass
 
+    @abstractmethod
     def create_run(self, experiment_id, user_id, run_name, source_type, source_name,
                    entry_point_name, start_time, source_version, tags, parent_run_id):
         """
@@ -210,6 +212,7 @@ class AbstractStore:
         """
         pass
 
+    @abstractmethod
     def list_run_infos(self, experiment_id, run_view_type):
         """
         Return run information for runs which belong to the experiment_id

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -162,7 +162,7 @@ class AbstractStore:
         :param run_uuid: String id for the run
         :param metric: :py:class:`mlflow.entities.Metric` instance to log
         """
-        pass
+        self.log_batch(run_uuid, metrics=[metric], params=[], tags=[])
 
     def log_param(self, run_uuid, param):
         """
@@ -171,7 +171,7 @@ class AbstractStore:
         :param run_uuid: String id for the run
         :param param: :py:class:`mlflow.entities.Param` instance to log
         """
-        pass
+        self.log_batch(run_uuid, metrics=[], params=[param], tags=[])
 
     def set_tag(self, run_uuid, tag):
         """
@@ -180,7 +180,7 @@ class AbstractStore:
         :param run_uuid: String id for the run
         :param tag: :py:class:`mlflow.entities.RunTag` instance to set
         """
-        pass
+        self.log_batch(run_uuid, metrics=[], params=[], tags=[tag])
 
     @abstractmethod
     def get_metric_history(self, run_uuid, metric_key):

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -212,7 +212,6 @@ class AbstractStore:
         """
         pass
 
-    @abstractmethod
     def list_run_infos(self, experiment_id, run_view_type):
         """
         Return run information for runs which belong to the experiment_id

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -224,17 +224,6 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(SearchRuns, req_body)
         return [Run.from_proto(proto_run) for proto_run in response_proto.runs]
 
-    def list_run_infos(self, experiment_id, run_view_type):
-        """
-        Return run information for runs which belong to the experiment_id
-
-        :param experiment_id: The experiment id which to search.
-
-        :return: A list of RunInfo objects that satisfy the search expressions
-        """
-        runs = self.search_runs([experiment_id], None, run_view_type)
-        return [run.info for run in runs]
-
     def delete_run(self, run_id):
         req_body = message_to_json(DeleteRun(run_id=run_id))
         self._call_endpoint(DeleteRun, req_body)

--- a/tests/store/test_abstract_store.py
+++ b/tests/store/test_abstract_store.py
@@ -101,3 +101,15 @@ def test_set_tag():
         store.log_batch.assert_called_once_with(
             run_id, metrics=[], params=[], tags=[tag]
         )
+
+
+def test_list_run_infos():
+    experiment_id = mock.Mock()
+    view_type = mock.Mock()
+    run_infos = [mock.Mock(), mock.Mock()]
+    runs = [mock.Mock(info=info) for info in run_infos]
+
+    with mock.patch.object(AbstractStoreTestImpl, "search_runs", return_value=runs):
+        store = AbstractStoreTestImpl()
+        assert store.list_run_infos(experiment_id, view_type) == run_infos
+        store.search_runs.assert_called_once_with([experiment_id], None, view_type)

--- a/tests/store/test_abstract_store.py
+++ b/tests/store/test_abstract_store.py
@@ -49,9 +49,6 @@ class ConcreteStore(AbstractStore):
     def log_batch(self, run_id, metrics, params, tags):
         raise NotImplementedError()
 
-    def list_experiments(self, *args, **kwargs):
-        raise NotImplementedError()
-
 
 def test_log_metric():
     run_id = mock.Mock()

--- a/tests/store/test_abstract_store.py
+++ b/tests/store/test_abstract_store.py
@@ -35,7 +35,7 @@ def test_log_metric(mock_abstract_methods):
     )
 
 
-def test_log_param():
+def test_log_param(mock_abstract_methods):
     run_id = mock.Mock()
     param = mock.Mock()
 
@@ -46,7 +46,7 @@ def test_log_param():
     )
 
 
-def test_set_tag():
+def test_set_tag(mock_abstract_methods):
     run_id = mock.Mock()
     tag = mock.Mock()
 

--- a/tests/store/test_abstract_store.py
+++ b/tests/store/test_abstract_store.py
@@ -19,7 +19,6 @@ def mock_abstract_methods():
         mock.patch.object(AbstractStore, "restore_run"), \
         mock.patch.object(AbstractStore, "get_metric_history"), \
         mock.patch.object(AbstractStore, "search_runs"), \
-        mock.patch.object(AbstractStore, "list_run_infos"), \
             mock.patch.object(AbstractStore, "log_batch"):
         yield
 

--- a/tests/store/test_abstract_store.py
+++ b/tests/store/test_abstract_store.py
@@ -63,7 +63,7 @@ def test_get_experiment_by_name():
 def test_get_experiment_by_name_missing():
     with mock.patch.object(AbstractStoreTestImpl, "list_experiments", return_value=[]):
         store = AbstractStoreTestImpl()
-        store.get_experiment_by_name("my experiment") is None
+        assert store.get_experiment_by_name("my experiment") is None
         store.list_experiments.assert_called_once_with(ViewType.ALL)
 
 

--- a/tests/store/test_abstract_store.py
+++ b/tests/store/test_abstract_store.py
@@ -1,51 +1,56 @@
 import mock
 
 from mlflow.store.abstract_store import AbstractStore
+from mlflow.entities import ViewType
 
 
 class ConcreteStore(AbstractStore):
 
+    def list_experiments(self, view_type=ViewType.ACTIVE_ONLY):
+        raise NotImplementedError()
+
+    def create_experiment(self, name, artifact_location):
+        raise NotImplementedError()
+
+    def get_experiment(self, experiment_id):
+        raise NotImplementedError()
+
+    def delete_experiment(self, experiment_id):
+        raise NotImplementedError()
+
+    def restore_experiment(self, experiment_id):
+        raise NotImplementedError()
+
+    def rename_experiment(self, experiment_id, new_name):
+        raise NotImplementedError()
+
+    def get_run(self, run_uuid):
+        raise NotImplementedError()
+
+    def update_run_info(self, run_uuid, run_status, end_time):
+        raise NotImplementedError()
+
+    def create_run(self, experiment_id, user_id, run_name, source_type, source_name,
+                   entry_point_name, start_time, source_version, tags, parent_run_id):
+        raise NotImplementedError()
+
+    def delete_run(self, run_id):
+        raise NotImplementedError()
+
+    def restore_run(self, run_id):
+        raise NotImplementedError()
+
+    def get_metric_history(self, run_uuid, metric_key):
+        raise NotImplementedError()
+
+    def search_runs(self, experiment_ids, search_filter, run_view_type):
+        raise NotImplementedError()
+
+    def log_batch(self, run_id, metrics, params, tags):
+        raise NotImplementedError()
+
     def list_experiments(self, *args, **kwargs):
-        pass
-
-    def create_experiment(self, *args, **kwargs):
-        pass
-
-    def get_experiment(self, *args, **kwargs):
-        pass
-
-    def delete_experiment(self, *args, **kwargs):
-        pass
-
-    def restore_experiment(self, *args, **kwargs):
-        pass
-
-    def rename_experiment(self, *args, **kwargs):
-        pass
-
-    def get_run(self, *args, **kwargs):
-        pass
-
-    def update_run_info(self, *args, **kwargs):
-        pass
-
-    def create_run(self, *args, **kwargs):
-        pass
-
-    def delete_run(self, *args, **kwargs):
-        pass
-
-    def restore_run(self, *args, **kwargs):
-        pass
-
-    def get_metric_history(self, *args, **kwargs):
-        pass
-
-    def search_runs(self, *args, **kwargs):
-        pass
-
-    def log_batch(self, *args, **kwargs):
-        pass
+        raise NotImplementedError()
 
 
 def test_log_metric():

--- a/tests/store/test_abstract_store.py
+++ b/tests/store/test_abstract_store.py
@@ -1,0 +1,36 @@
+import mock
+
+from mlflow.store.abstract_store import AbstractStore
+
+
+def test_log_metric():
+
+    run_id = mock.Mock()
+    metric = mock.Mock()
+
+    with mock.patch.object(AbstractStore, 'log_batch'):
+        store = AbstractStore()
+        store.log_metric(run_id, metric)
+        store.log_batch.assert_called_once_with(run_id, metrics=[metric], params=[], tags=[])
+
+
+def test_log_param():
+
+    run_id = mock.Mock()
+    param = mock.Mock()
+
+    with mock.patch.object(AbstractStore, 'log_batch'):
+        store = AbstractStore()
+        store.log_param(run_id, param)
+        store.log_batch.assert_called_once_with(run_id, metrics=[], params=[param], tags=[])
+
+
+def test_set_tag():
+
+    run_id = mock.Mock()
+    tag = mock.Mock()
+
+    with mock.patch.object(AbstractStore, 'log_batch'):
+        store = AbstractStore()
+        store.set_tag(run_id, tag)
+        store.log_batch.assert_called_once_with(run_id, metrics=[], params=[], tags=[tag])

--- a/tests/store/test_abstract_store.py
+++ b/tests/store/test_abstract_store.py
@@ -1,36 +1,57 @@
 import mock
+import pytest
 
 from mlflow.store.abstract_store import AbstractStore
 
 
-def test_log_metric():
+@pytest.fixture
+def mock_abstract_methods():
+    with mock.patch.object(AbstractStore, "list_experiments"), \
+        mock.patch.object(AbstractStore, "create_experiment"), \
+        mock.patch.object(AbstractStore, "get_experiment"), \
+        mock.patch.object(AbstractStore, "delete_experiment"), \
+        mock.patch.object(AbstractStore, "restore_experiment"), \
+        mock.patch.object(AbstractStore, "rename_experiment"), \
+        mock.patch.object(AbstractStore, "get_run"), \
+        mock.patch.object(AbstractStore, "update_run_info"), \
+        mock.patch.object(AbstractStore, "create_run"), \
+        mock.patch.object(AbstractStore, "delete_run"), \
+        mock.patch.object(AbstractStore, "restore_run"), \
+        mock.patch.object(AbstractStore, "get_metric_history"), \
+        mock.patch.object(AbstractStore, "search_runs"), \
+        mock.patch.object(AbstractStore, "list_run_infos"), \
+            mock.patch.object(AbstractStore, "log_batch"):
+        yield
 
+
+def test_log_metric(mock_abstract_methods):
     run_id = mock.Mock()
     metric = mock.Mock()
 
-    with mock.patch.object(AbstractStore, 'log_batch'):
-        store = AbstractStore()
-        store.log_metric(run_id, metric)
-        store.log_batch.assert_called_once_with(run_id, metrics=[metric], params=[], tags=[])
+    store = AbstractStore()
+    store.log_metric(run_id, metric)
+    store.log_batch.assert_called_once_with(
+        run_id, metrics=[metric], params=[], tags=[]
+    )
 
 
 def test_log_param():
-
     run_id = mock.Mock()
     param = mock.Mock()
 
-    with mock.patch.object(AbstractStore, 'log_batch'):
-        store = AbstractStore()
-        store.log_param(run_id, param)
-        store.log_batch.assert_called_once_with(run_id, metrics=[], params=[param], tags=[])
+    store = AbstractStore()
+    store.log_param(run_id, param)
+    store.log_batch.assert_called_once_with(
+        run_id, metrics=[], params=[param], tags=[]
+    )
 
 
 def test_set_tag():
-
     run_id = mock.Mock()
     tag = mock.Mock()
 
-    with mock.patch.object(AbstractStore, 'log_batch'):
-        store = AbstractStore()
-        store.set_tag(run_id, tag)
-        store.log_batch.assert_called_once_with(run_id, metrics=[], params=[], tags=[tag])
+    store = AbstractStore()
+    store.set_tag(run_id, tag)
+    store.log_batch.assert_called_once_with(
+        run_id, metrics=[], params=[], tags=[tag]
+    )

--- a/tests/store/test_abstract_store.py
+++ b/tests/store/test_abstract_store.py
@@ -1,56 +1,84 @@
 import mock
-import pytest
 
 from mlflow.store.abstract_store import AbstractStore
 
 
-@pytest.fixture
-def mock_abstract_methods():
-    with mock.patch.object(AbstractStore, "list_experiments"), \
-        mock.patch.object(AbstractStore, "create_experiment"), \
-        mock.patch.object(AbstractStore, "get_experiment"), \
-        mock.patch.object(AbstractStore, "delete_experiment"), \
-        mock.patch.object(AbstractStore, "restore_experiment"), \
-        mock.patch.object(AbstractStore, "rename_experiment"), \
-        mock.patch.object(AbstractStore, "get_run"), \
-        mock.patch.object(AbstractStore, "update_run_info"), \
-        mock.patch.object(AbstractStore, "create_run"), \
-        mock.patch.object(AbstractStore, "delete_run"), \
-        mock.patch.object(AbstractStore, "restore_run"), \
-        mock.patch.object(AbstractStore, "get_metric_history"), \
-        mock.patch.object(AbstractStore, "search_runs"), \
-            mock.patch.object(AbstractStore, "log_batch"):
-        yield
+class ConcreteStore(AbstractStore):
+
+    def list_experiments(self, *args, **kwargs):
+        pass
+
+    def create_experiment(self, *args, **kwargs):
+        pass
+
+    def get_experiment(self, *args, **kwargs):
+        pass
+
+    def delete_experiment(self, *args, **kwargs):
+        pass
+
+    def restore_experiment(self, *args, **kwargs):
+        pass
+
+    def rename_experiment(self, *args, **kwargs):
+        pass
+
+    def get_run(self, *args, **kwargs):
+        pass
+
+    def update_run_info(self, *args, **kwargs):
+        pass
+
+    def create_run(self, *args, **kwargs):
+        pass
+
+    def delete_run(self, *args, **kwargs):
+        pass
+
+    def restore_run(self, *args, **kwargs):
+        pass
+
+    def get_metric_history(self, *args, **kwargs):
+        pass
+
+    def search_runs(self, *args, **kwargs):
+        pass
+
+    def log_batch(self, *args, **kwargs):
+        pass
 
 
-def test_log_metric(mock_abstract_methods):  # pylint: disable=unused-argument
+def test_log_metric():
     run_id = mock.Mock()
     metric = mock.Mock()
 
-    store = AbstractStore()
-    store.log_metric(run_id, metric)
-    store.log_batch.assert_called_once_with(
-        run_id, metrics=[metric], params=[], tags=[]
-    )
+    with mock.patch.object(ConcreteStore, "log_batch"):
+        store = ConcreteStore()
+        store.log_metric(run_id, metric)
+        store.log_batch.assert_called_once_with(
+            run_id, metrics=[metric], params=[], tags=[]
+        )
 
 
-def test_log_param(mock_abstract_methods):  # pylint: disable=unused-argument
+def test_log_param():
     run_id = mock.Mock()
     param = mock.Mock()
 
-    store = AbstractStore()
-    store.log_param(run_id, param)
-    store.log_batch.assert_called_once_with(
-        run_id, metrics=[], params=[param], tags=[]
-    )
+    with mock.patch.object(ConcreteStore, "log_batch"):
+        store = ConcreteStore()
+        store.log_param(run_id, param)
+        store.log_batch.assert_called_once_with(
+            run_id, metrics=[], params=[param], tags=[]
+        )
 
 
-def test_set_tag(mock_abstract_methods):  # pylint: disable=unused-argument
+def test_set_tag():
     run_id = mock.Mock()
     tag = mock.Mock()
 
-    store = AbstractStore()
-    store.set_tag(run_id, tag)
-    store.log_batch.assert_called_once_with(
-        run_id, metrics=[], params=[], tags=[tag]
-    )
+    with mock.patch.object(ConcreteStore, "log_batch"):
+        store = ConcreteStore()
+        store.set_tag(run_id, tag)
+        store.log_batch.assert_called_once_with(
+            run_id, metrics=[], params=[], tags=[tag]
+        )

--- a/tests/store/test_abstract_store.py
+++ b/tests/store/test_abstract_store.py
@@ -50,6 +50,23 @@ class AbstractStoreTestImpl(AbstractStore):
         raise NotImplementedError()
 
 
+def test_get_experiment_by_name():
+    experiments = [mock.Mock(), mock.Mock(), mock.Mock()]
+    # Configure name after mock creation as name is a reserved argument to Mock()
+    experiments[1].configure_mock(name="my experiment")
+    with mock.patch.object(AbstractStoreTestImpl, "list_experiments", return_value=experiments):
+        store = AbstractStoreTestImpl()
+        assert store.get_experiment_by_name("my experiment") == experiments[1]
+        store.list_experiments.assert_called_once_with(ViewType.ALL)
+
+
+def test_get_experiment_by_name_missing():
+    with mock.patch.object(AbstractStoreTestImpl, "list_experiments", return_value=[]):
+        store = AbstractStoreTestImpl()
+        store.get_experiment_by_name("my experiment") is None
+        store.list_experiments.assert_called_once_with(ViewType.ALL)
+
+
 def test_log_metric():
     run_id = mock.Mock()
     metric = mock.Mock()

--- a/tests/store/test_abstract_store.py
+++ b/tests/store/test_abstract_store.py
@@ -23,7 +23,7 @@ def mock_abstract_methods():
         yield
 
 
-def test_log_metric(mock_abstract_methods):
+def test_log_metric(mock_abstract_methods):  # pylint: disable=unused-argument
     run_id = mock.Mock()
     metric = mock.Mock()
 
@@ -34,7 +34,7 @@ def test_log_metric(mock_abstract_methods):
     )
 
 
-def test_log_param(mock_abstract_methods):
+def test_log_param(mock_abstract_methods):  # pylint: disable=unused-argument
     run_id = mock.Mock()
     param = mock.Mock()
 
@@ -45,7 +45,7 @@ def test_log_param(mock_abstract_methods):
     )
 
 
-def test_set_tag(mock_abstract_methods):
+def test_set_tag(mock_abstract_methods):  # pylint: disable=unused-argument
     run_id = mock.Mock()
     tag = mock.Mock()
 

--- a/tests/store/test_abstract_store.py
+++ b/tests/store/test_abstract_store.py
@@ -4,7 +4,7 @@ from mlflow.store.abstract_store import AbstractStore
 from mlflow.entities import ViewType
 
 
-class ConcreteStore(AbstractStore):
+class AbstractStoreTestImpl(AbstractStore):
 
     def list_experiments(self, view_type=ViewType.ACTIVE_ONLY):
         raise NotImplementedError()
@@ -54,8 +54,8 @@ def test_log_metric():
     run_id = mock.Mock()
     metric = mock.Mock()
 
-    with mock.patch.object(ConcreteStore, "log_batch"):
-        store = ConcreteStore()
+    with mock.patch.object(AbstractStoreTestImpl, "log_batch"):
+        store = AbstractStoreTestImpl()
         store.log_metric(run_id, metric)
         store.log_batch.assert_called_once_with(
             run_id, metrics=[metric], params=[], tags=[]
@@ -66,8 +66,8 @@ def test_log_param():
     run_id = mock.Mock()
     param = mock.Mock()
 
-    with mock.patch.object(ConcreteStore, "log_batch"):
-        store = ConcreteStore()
+    with mock.patch.object(AbstractStoreTestImpl, "log_batch"):
+        store = AbstractStoreTestImpl()
         store.log_param(run_id, param)
         store.log_batch.assert_called_once_with(
             run_id, metrics=[], params=[param], tags=[]
@@ -78,8 +78,8 @@ def test_set_tag():
     run_id = mock.Mock()
     tag = mock.Mock()
 
-    with mock.patch.object(ConcreteStore, "log_batch"):
-        store = ConcreteStore()
+    with mock.patch.object(AbstractStoreTestImpl, "log_batch"):
+        store = AbstractStoreTestImpl()
         store.set_tag(run_id, tag)
         store.log_batch.assert_called_once_with(
             run_id, metrics=[], params=[], tags=[tag]


### PR DESCRIPTION
The abstract store has methods for logging individual metrics, params and tags, however since these are not marked as abstract methods they're not currently required to be implemented in tracking store implementations.

This change provides default implementations of `log_metric`, `log_param` and `set_tag` that proxy calls to the more general `log_batch` added by @smurching in #950.

Following this change, as long as stores implement `log_batch`, the above methods need not be provided.