### PR TITLE
Search: Handling periods in param or metric name

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -86,7 +86,7 @@ class SearchFilter(object):
     @classmethod
     def _get_identifier(cls, identifier):
         try:
-            entity_type, key = identifier.split(sep=".", maxsplit=1)
+            entity_type, key = identifier.split(".", 1)
         except ValueError:
             raise MlflowException("Invalid filter string '%s'. Filter comparison is expected as "
                                   "'metric.<key> <comparator> <value>' or"

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -86,7 +86,7 @@ class SearchFilter(object):
     @classmethod
     def _get_identifier(cls, identifier):
         try:
-            entity_type, key = identifier.split(".")
+            entity_type, key = identifier.split(sep=".", maxsplit=1)
         except ValueError:
             raise MlflowException("Invalid filter string '%s'. Filter comparison is expected as "
                                   "'metric.<key> <comparator> <value>' or"

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -84,6 +84,14 @@ def test_anded_expression_2():
                                  'key': 'model',
                                  'type': 'parameter',
                                  'value': "LR"}]),
+    ('metrics."accuracy.2.0" > 5', [{'comparator': '>',
+                                     'key': 'accuracy.2.0',
+                                     'type': 'metric',
+                                     'value': '5'}]),
+    ('params."p.a.r.a.m" != "a"', [{'comparator': '!=',
+                                    'key': 'p.a.r.a.m',
+                                    'type': 'parameter',
+                                    'value': 'a'}]),
 ])
 def test_filter(filter_string, parsed_filter):
     assert SearchFilter(filter_string=filter_string)._parse() == parsed_filter
@@ -113,7 +121,6 @@ def test_correct_quote_trimming(filter_string, parsed_filter):
     ("param`.A > 0.1", "Invalid clause(s) in filter string"),
     ("`dummy.A > 0.1", "Invalid clause(s) in filter string"),
     ("dummy`.A > 0.1", "Invalid clause(s) in filter string"),
-    ("metrics.crazy.name > 0.1", "Invalid filter string"),
 ])
 def test_error_filter(filter_string, error_message):
     with pytest.raises(MlflowException) as e:


### PR DESCRIPTION
Allowing searching on metric/param name with periods in them

```
metric."real.accuracy" > 0.1
```