### PR TITLE
Add support for searching on tags in MLflow UI

### DIFF
--- a/mlflow/server/js/src/Actions.js
+++ b/mlflow/server/js/src/Actions.js
@@ -77,11 +77,11 @@ export const restoreRunApi = (runUuid, id = getUUID()) => {
 };
 
 export const SEARCH_RUNS_API = 'SEARCH_RUNS_API';
-export const searchRunsApi = (experimentIds, andedExpressions, runViewType, id = getUUID()) => {
+export const searchRunsApi = (experimentIds, filterString, runViewType, id = getUUID()) => {
   return {
     type: SEARCH_RUNS_API,
     payload: wrapDeferred(MlflowService.searchRuns, {
-      experiment_ids: experimentIds, anded_expressions: andedExpressions, run_view_type: runViewType
+      experiment_ids: experimentIds, filter: filterString, run_view_type: runViewType
     }),
     meta: { id: id },
   };

--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -85,10 +85,12 @@ class ExperimentPage extends Component {
         lastExperimentId: props.experimentId,
         lifecycleFilter: LIFECYCLE_FILTER.ACTIVE,
       };
+      const filterString = newState.persistedState.searchInput;
+      SearchUtils.validateSearchInput(filterString);
       props.dispatch(getExperimentApi(props.experimentId, newState.getExperimentRequestId));
       props.dispatch(searchRunsApi(
         [props.experimentId],
-        SearchUtils.parseSearchInput(newState.persistedState.searchInput),
+        filterString,
         lifecycleFilterToRunViewType(newState.lifecycleFilter),
         newState.searchRunsRequestId));
       return newState;
@@ -97,7 +99,7 @@ class ExperimentPage extends Component {
   }
 
   onSearch(paramKeyFilterString, metricKeyFilterString, searchInput, lifecycleFilterInput) {
-    const andedExpressions = SearchUtils.parseSearchInput(searchInput);
+    SearchUtils.validateSearchInput(searchInput);
     this.setState({
       persistedState: new ExperimentPagePersistedState({
         paramKeyFilterString,
@@ -107,7 +109,7 @@ class ExperimentPage extends Component {
       lifecycleFilter: lifecycleFilterInput,
     });
     const searchRunsRequestId = this.props.dispatchSearchRuns(
-      this.props.experimentId, andedExpressions, lifecycleFilterInput);
+      this.props.experimentId, searchInput, lifecycleFilterInput);
     this.setState({ searchRunsRequestId });
   }
 

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -310,7 +310,10 @@ class ExperimentView extends Component {
                   <label className="filter-label">Search Runs:</label>
                   <div className="filter-wrapper">
                     <input type="text"
-                           placeholder={'metrics.rmse < 1 and params.model = "tree"'}
+                           placeholder={
+                             'metrics.rmse < 1 and params.model = "tree" and ' +
+                             'tags.mlflow.parentRunId = "abc"'
+                           }
                            value={this.state.searchInput}
                            onChange={this.onSearchInput}
                     />

--- a/mlflow/server/js/src/utils/SearchUtils.test.js
+++ b/mlflow/server/js/src/utils/SearchUtils.test.js
@@ -1,0 +1,45 @@
+import { SearchUtils } from './SearchUtils';
+
+test("validateSearchInput", () => {
+  const goodComparators = {
+    'metrics': ['<', '>', '<=', '>=', '=', '!='],
+    'params': ['=', '!='],
+    'tags': ['=', '!=']
+  };
+  const goodValues = {
+    'metrics': '0.123456789',
+    'params': '"1.0"',
+    'tags': '"abc"',
+  };
+  const goodKeys = {
+    'metrics': 'rmse',
+    'params': 'alpha',
+    'tags': 'mlflow.parentRunId',
+  };
+  const badComparators = {
+    'metrics': ['~', '~=', '=~'],
+    'params': ['>', '<', '>=', '<='],
+    'tags': ['>', '<', '>=', '<='],
+  };
+  ['metrics', 'params', 'tags'].forEach((entityType) => {
+    const key = goodKeys[entityType];
+    const value = goodValues[entityType];
+    // Test searches with valid comparators for the current entity type
+    goodComparators[entityType].forEach((goodComparator) => {
+      SearchUtils.validateSearchInput(`${entityType}.${key} ${goodComparator} ${value}`);
+    });
+    // Test searches with invalid comparators for the current entity type
+    badComparators[entityType].forEach((badComparator) => {
+      expect(() => {
+        SearchUtils.validateSearchInput(`${entityType}.${key} ${badComparator} ${value}`);
+      }).toThrow('The search input should be like');
+    });
+  });
+  // Test searching over a combination of entity types
+  SearchUtils.validateSearchInput('metrics.rmse < 0.1 and tags.mlflow.parentRunId = "abc"');
+  SearchUtils.validateSearchInput('metrics.rmse < 0.1 and ' +
+    'tags.mlflow.parentRunId = "abc" and params.alpha = "0.1"');
+  expect(() => {
+    SearchUtils.validateSearchInput('metrics.rmse < 0.1 and tags.mlflow.parentRunId ~= "abc"');
+  }).toThrow('The search input should be like');
+});


### PR DESCRIPTION
Adds support for searching on tags in the MLflow UI by:
* Switching the UI to use the new `filter` string field in the `SearchRuns` proto, which allows searching over tags (support added in #1060)
* Relaxing validations to allow for searching on tags

Adds JS unit tests for the updated validation.

### Screenshots
It's now possible to e.g. search over tags, e.g. to identify child runs of a parent run:
![image](https://user-images.githubusercontent.com/2358483/55304654-4b81a980-5401-11e9-9608-f225967af751.png)

Or to find runs of MLflow projects with docker environments:
![image](https://user-images.githubusercontent.com/2358483/55304715-b7fca880-5401-11e9-8a24-a670207a0775.png)

