### PR TITLE
Validate URIs before starting tracking server 

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -192,14 +192,18 @@ def _set_and_validate_uris(backend_store_uri, default_artifact_root):
 
     try:
         _get_store(backend_store_uri)
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-except
+        # We need a broad exception here to catch exceptions in optional
+        # dependencies like SQLAlchemy
         eprint("Error related to option backend_store_uri '{}': {}".format(
             backend_store_uri, e))
         sys.exit(1)
     try:
         artifact_repo = get_artifact_repository(default_artifact_root)
         artifact_repo.list_artifacts(default_artifact_root)
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-except
+        # We need a broad exception here to catch exceptions in optional
+        # dependencies like boto3 or google-cloud-storage.
         eprint("Error related to option default-artifact-root '{}': {}".format(
             default_artifact_root, e))
         sys.exit(1)

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -197,7 +197,7 @@ def _run_tracking_server(backend_store_uri, default_artifact_root, host, port, w
         sys.exit(1)
     try:
         artifact_repo = get_artifact_repository(default_artifact_root)
-        artifact_repo.list_artifacts(default_artifact_root)
+        artifact_repo.list_artifacts()
     except Exception as e:  # pylint: disable=broad-except
         # We need a broad exception here to catch exceptions in optional
         # dependencies like azure-storage or google-cloud-storage.

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -145,25 +145,35 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, m
         sys.exit(1)
 
 
+def _server_options(function):
+    function = click.option("--backend-store-uri", "--file-store", metavar="PATH",
+                            default=DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
+                            help="URI or path for backend store implementation. Acceptable backend"
+                                 "store are SQLAlchemy compatible implementation or local storage."
+                                 " Supports various SQLAlchemy compatible database like SQLite,"
+                                 " MySQL, PostgreSQL. As an example MySQL backed store can be"
+                                 " configured using connection string."
+                                 "'mysql://<user_name>:<password>@<host>:<port>/<database_name>' "
+                                 "By default file based backed store"
+                                 " will be used. (default: ./mlruns).")(function)
+    function = click.option("--default-artifact-root", metavar="URI", default=None,
+                            help="Local or S3 URI to store artifacts, for new experiments. "
+                                 "Note that this flag does not impact already-created experiments. "
+                                 "Default: " + DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)(function)
+    function = click.option("--host", "-h", metavar="HOST", default="127.0.0.1",
+                            help="The network address to listen on (default: 127.0.0.1). "
+                                 "Use 0.0.0.0 to bind to all addresses if you want to"
+                                 " access the tracking server from other machines.")(function)
+    function = click.option("--port", "-p", default=5000,
+                            help="The port to listen on (default: 5000).")(function)
+    function = click.option("--gunicorn-opts", default=None,
+                            help="Additional command line options forwarded to gunicorn"
+                                 " processes.")(function)
+    return function
+
+
 @cli.command()
-@click.option("--backend-store-uri", "--file-store", metavar="PATH",
-              default=DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
-              help="URI or path for backend store implementation. Acceptable backend store "
-                   "are SQLAlchemy compatible implementation or local storage. "
-                   "Example 'sqlite:///path/to/file.db'. "
-                   "By default file backed store will be used. (default: ./mlruns).")
-@click.option("--default-artifact-root", metavar="URI", default=None,
-              help="Path to local directory to store artifacts, for new experiments. "
-                   "Note that this flag does not impact already-created experiments. "
-                   "Default: " + DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
-@click.option("--host", "-h", metavar="HOST", default="127.0.0.1",
-              help="The network address to listen on (default: 127.0.0.1). "
-                   "Use 0.0.0.0 to bind to all addresses if you want to access the UI from "
-                   "other machines.")
-@click.option("--port", "-p", default=5000,
-              help="The port to listen on (default: 5000).")
-@click.option("--gunicorn-opts", default=None,
-              help="Additional command line options forwarded to gunicorn processes.")
+@_server_options
 def ui(backend_store_uri, default_artifact_root, host, port, gunicorn_opts):
     """
     Launch the MLflow tracking UI.
@@ -203,27 +213,11 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 
 
 @cli.command()
-@click.option("--backend-store-uri", "--file-store", metavar="PATH",
-              default=DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
-              help="URI or path for backend store implementation. Acceptable backend store "
-                   "are SQLAlchemy compatible implementation or local storage. Supports "
-                   "various SQLAlchemy compatible database like SQLite, MySQL, PostgreSQL. As an "
-                   "example MySQL backed store can be configured using connection string. "
-                   "'mysql://<user_name>:<password>@<host>:<port>/<database_name>' "
-                   "By default file based backed store will be used. (default: ./mlruns).")
-@click.option("--default-artifact-root", metavar="URI", default=None,
-              help="Local or S3 URI to store artifacts, for new experiments. "
-                   "Note that this flag does not impact already-created experiments. "
-                   "Default: Within file store")
-@click.option("--host", "-h", metavar="HOST", default="127.0.0.1",
-              help="The network address to listen on (default: 127.0.0.1). "
-                   "Use 0.0.0.0 to bind to all addresses if you want to access the tracking "
-                   "server from other machines.")
-@click.option("--port", "-p", default=5000,
-              help="The port to listen on (default: 5000).")
+@_server_options
 @click.option("--workers", "-w", default=4,
               help="Number of gunicorn worker processes to handle requests (default: 4).")
-@click.option("--static-prefix", default=None, callback=_validate_static_prefix,
+@click.option("--static-prefix", default=None,
+              callback=_validate_static_prefix,
               help="A prefix which will be prepended to the path of all static paths.")
 @click.option("--gunicorn-opts", default=None,
               help="Additional command line options forwarded to gunicorn processes.")

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -149,11 +149,11 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, m
 def _server_options(function):
     function = click.option("--backend-store-uri", "--file-store", metavar="PATH",
                             default=DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
-                            help="URI or path for backend store implementation. Acceptable backend"
-                                 "store are SQLAlchemy compatible implementation or local storage."
-                                 " Supports various SQLAlchemy compatible database like SQLite,"
-                                 " MySQL, PostgreSQL. As an example MySQL backed store can be"
-                                 " configured using connection string."
+                            help="URI or path for backend store implementation. Acceptable backend "
+                                 "store are SQLAlchemy compatible implementation or local storage. "
+                                 "Supports various SQLAlchemy compatible database like SQLite, "
+                                 "MySQL, PostgreSQL. As an example MySQL backed store can be "
+                                 "configured using connection string. "
                                  "'mysql://<user_name>:<password>@<host>:<port>/<database_name>' "
                                  "By default file based backed store"
                                  " will be used. (default: ./mlruns).")(function)
@@ -163,13 +163,13 @@ def _server_options(function):
                                  "Default: " + DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)(function)
     function = click.option("--host", "-h", metavar="HOST", default="127.0.0.1",
                             help="The network address to listen on (default: 127.0.0.1). "
-                                 "Use 0.0.0.0 to bind to all addresses if you want to"
-                                 " access the tracking server from other machines.")(function)
+                                 "Use 0.0.0.0 to bind to all addresses if you want to "
+                                 "access the tracking server from other machines.")(function)
     function = click.option("--port", "-p", default=5000,
                             help="The port to listen on (default: 5000).")(function)
     function = click.option("--gunicorn-opts", default=None,
-                            help="Additional command line options forwarded to gunicorn"
-                                 " processes.")(function)
+                            help="Additional command line options forwarded to gunicorn "
+                                 "processes.")(function)
     return function
 
 

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -45,7 +45,7 @@ def serve():
     return send_from_directory(STATIC_DIR, 'index.html')
 
 
-def _run_server(file_store_path, default_artifact_root, host, port, workers, static_prefix,
+def _run_server(backend_store_uri, default_artifact_root, host, port, workers, static_prefix,
                 gunicorn_opts):
     """
     Run the MLflow server, wrapping it in gunicorn
@@ -54,8 +54,8 @@ def _run_server(file_store_path, default_artifact_root, host, port, workers, sta
     :return: None
     """
     env_map = {}
-    if file_store_path:
-        env_map[BACKEND_STORE_URI_ENV_VAR] = file_store_path
+    if backend_store_uri:
+        env_map[BACKEND_STORE_URI_ENV_VAR] = backend_store_uri
     if default_artifact_root:
         env_map[ARTIFACT_ROOT_ENV_VAR] = default_artifact_root
     if static_prefix:

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -39,7 +39,7 @@ def _get_store():
             _store = FileStore(store_dir, artifact_root)
         else:
             raise MlflowException("Unexpected URI type '{}' for backend store. "
-                                  "Expext local file or database type.".format(store_dir))
+                                  "Expect local file or database type.".format(store_dir))
     return _store
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,13 +15,13 @@ def test_server_uri_validation():
         result = CliRunner().invoke(server,
                                     ["--backend-store-uri", "postgres://user:pwd@host:5432/mydb",
                                      "--default-artifact-root", "./mlruns"])
-        assert result.output.startswith("Error related to option backend_store_uri")
+        assert result.output.startswith("Error related to option backend-store-uri")
         run_server_mock.assert_not_called()
     with mock.patch("mlflow.cli._run_server") as run_server_mock:
         result = CliRunner().invoke(server,
                                     ["--backend-store-uri", "sqlite://invalid-sqlite-url",
                                      "--default-artifact-root", "./mlruns"])
-        assert result.output.startswith("Error related to option backend_store_uri")
+        assert result.output.startswith("Error related to option backend-store-uri")
         run_server_mock.assert_not_called()
 
     with mock.patch("mlflow.cli._run_server") as run_server_mock:


### PR DESCRIPTION
The incorrect command below silently passes:
```
mlflow ---backend-store-uri=postgres://... --default-artifact-root=gs://...
```

If the backend store URI is incorrect, the home page shows the error page.
If the backend store URI is correct and there are problems with default-artifact-root, clicking on a link to a 'run' page displays the error page.
![image](https://user-images.githubusercontent.com/21269549/55351338-f489dc00-54b5-11e9-9fbe-1f8c2808bc7c.png)

Even though it's stated that users should install additional dependencies if using the backend store URI or google cloud, configuration bugs are common and hard to catch. The current error page does not make it easy to debug such issues.

With these changes, `mlflow server` will fail before running the server and show an error message which is easier to debug.

![image](https://user-images.githubusercontent.com/21269549/55351464-59453680-54b6-11e9-89d8-ba2fcae22519.png)

A passing example:
![image](https://user-images.githubusercontent.com/21269549/55351704-ebe5d580-54b6-11e9-8cfe-6cc4afc381ee.png)

## Other notes
- Server() exits if backend_store_uri is not a local uri, but ui() does not. I'm not sure which is the expected behavior.

