### PR TITLE
Proposed waitress introduction as windows webserver

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -141,6 +141,25 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, b
         sys.exit(1)
 
 
+def _validate_server_args(static_prefix=None, gunicorn_opts=None, workers=None, waitress_opts=None):
+    server_kwargs = {'static_prefix': static_prefix}
+    if sys.platform == "win32":
+        if gunicorn_opts is not None:
+            raise NotImplementedError("waitress replaces gunicorn on Windows, cannot specify --gunicorn-opts")
+        server_kwargs.update({
+            'waitress_opts': waitress_opts
+        })
+    else:
+        if waitress_opts is not None:
+            raise NotImplementedError(
+                "gunicorn replaces waitress on non-Windows platforms, cannot specify --waitress-opts")
+        server_kwargs.update({
+            'workers': workers if workers else 1,
+            'gunicorn_opts': gunicorn_opts
+        })
+    return server_kwargs
+
+
 @cli.command()
 @click.option("--backend-store-uri", metavar="PATH",
               default=DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
@@ -162,6 +181,7 @@ def ui(backend_store_uri, default_artifact_root, port):
 
     The UI will be visible at http://localhost:5000 by default.
     """
+
     # Ensure that both backend_store_uri and default_artifact_uri are set correctly.
     if not backend_store_uri:
         backend_store_uri = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
@@ -181,7 +201,7 @@ def ui(backend_store_uri, default_artifact_root, port):
 
     # TODO: We eventually want to disable the write path in this version of the server.
     try:
-        _run_server(backend_store_uri, default_artifact_root, "127.0.0.1", port, 1, None, [])
+        _run_server(backend_store_uri, default_artifact_root, "127.0.0.1", port, None, 1)
     except ShellCommandException:
         eprint("Running the mlflow server failed. Please see the logs above for details.")
         sys.exit(1)
@@ -221,8 +241,10 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
               help="A prefix which will be prepended to the path of all static paths.")
 @click.option("--gunicorn-opts", default=None,
               help="Additional command line options forwarded to gunicorn processes.")
+@click.option("--waitress-opts", default=None,
+              help="Additional command line options for waitress-serve.")
 def server(backend_store_uri, default_artifact_root, host, port,
-           workers, static_prefix, gunicorn_opts):
+           workers, static_prefix, gunicorn_opts, waitress_opts):
     """
     Run the MLflow tracking server.
 
@@ -230,6 +252,9 @@ def server(backend_store_uri, default_artifact_root, host, port,
     the local machine. To let the server accept connections from other machines, you will need to
     pass --host 0.0.0.0 to listen on all network interfaces (or a specific interface address).
     """
+
+    _validate_server_args(static_prefix=static_prefix, gunicorn_opts=gunicorn_opts,
+                          workers=workers, waitress_opts=waitress_opts)
 
     # Ensure that both backend_store_uri and default_artifact_uri are set correctly.
     if not backend_store_uri:
@@ -251,8 +276,8 @@ def server(backend_store_uri, default_artifact_root, host, port,
         sys.exit(1)
 
     try:
-        _run_server(backend_store_uri, default_artifact_root, host, port, workers, static_prefix,
-                    gunicorn_opts)
+        _run_server(backend_store_uri, default_artifact_root, host, port,
+                    static_prefix, workers, gunicorn_opts, waitress_opts)
     except ShellCommandException:
         eprint("Running the mlflow server failed. Please see the logs above for details.")
         sys.exit(1)

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -141,23 +141,14 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, b
         sys.exit(1)
 
 
-def _validate_server_args(static_prefix=None, gunicorn_opts=None, workers=None, waitress_opts=None):
-    server_kwargs = {'static_prefix': static_prefix}
+def _validate_server_args(gunicorn_opts=None, workers=None, waitress_opts=None):
     if sys.platform == "win32":
-        if gunicorn_opts is not None:
-            raise NotImplementedError("waitress replaces gunicorn on Windows, cannot specify --gunicorn-opts")
-        server_kwargs.update({
-            'waitress_opts': waitress_opts
-        })
+        if gunicorn_opts is not None or workers is not None:
+            raise NotImplementedError("waitress replaces gunicorn on Windows, cannot specify --gunicorn-opts or --workers")
     else:
         if waitress_opts is not None:
             raise NotImplementedError(
                 "gunicorn replaces waitress on non-Windows platforms, cannot specify --waitress-opts")
-        server_kwargs.update({
-            'workers': workers if workers else 1,
-            'gunicorn_opts': gunicorn_opts
-        })
-    return server_kwargs
 
 
 @cli.command()
@@ -253,8 +244,7 @@ def server(backend_store_uri, default_artifact_root, host, port,
     pass --host 0.0.0.0 to listen on all network interfaces (or a specific interface address).
     """
 
-    _validate_server_args(static_prefix=static_prefix, gunicorn_opts=gunicorn_opts,
-                          workers=workers, waitress_opts=waitress_opts)
+    _validate_server_args(gunicorn_opts=gunicorn_opts, workers=workers, waitress_opts=waitress_opts)
 
     # Ensure that both backend_store_uri and default_artifact_uri are set correctly.
     if not backend_store_uri:

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -144,11 +144,14 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, b
 def _validate_server_args(gunicorn_opts=None, workers=None, waitress_opts=None):
     if sys.platform == "win32":
         if gunicorn_opts is not None or workers is not None:
-            raise NotImplementedError("waitress replaces gunicorn on Windows, cannot specify --gunicorn-opts or --workers")
+            raise NotImplementedError(
+                "waitress replaces gunicorn on Windows, "
+                "cannot specify --gunicorn-opts or --workers")
     else:
         if waitress_opts is not None:
             raise NotImplementedError(
-                "gunicorn replaces waitress on non-Windows platforms, cannot specify --waitress-opts")
+                "gunicorn replaces waitress on non-Windows platforms, "
+                "cannot specify --waitress-opts")
 
 
 @cli.command()

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -23,7 +23,7 @@ class PyFuncBackend(FlavorBackend):
 
     def __init__(self, config, workers=1, no_conda=False, install_mlflow=False, **kwargs):
         super(PyFuncBackend, self).__init__(config=config, **kwargs)
-        self._nworkers = workers
+        self._nworkers = workers or 1
         self._no_conda = no_conda
         self._install_mlflow = install_mlflow
 
@@ -45,11 +45,11 @@ class PyFuncBackend(FlavorBackend):
                        'content_type={content_type}, '
                        'json_format={json_format})"'
                        ).format(
-                         model_uri=repr(local_uri),
-                         input_path=repr(input_path),
-                         output_path=repr(output_path),
-                         content_type=repr(content_type),
-                         json_format=repr(json_format))
+                model_uri=repr(local_uri),
+                input_path=repr(input_path),
+                output_path=repr(output_path),
+                content_type=repr(content_type),
+                json_format=repr(json_format))
             return _execute_in_conda_env(conda_env_path, command, self._install_mlflow)
         else:
             scoring_server._predict(local_uri, input_path, output_path, content_type,
@@ -65,9 +65,9 @@ class PyFuncBackend(FlavorBackend):
         local_uri = path_to_local_file_uri(local_path)
         command = ("gunicorn --timeout 60 -b {host}:{port} -w {nworkers} "
                    "mlflow.pyfunc.scoring_server.wsgi:app").format(
-                     host=host,
-                     port=port,
-                     nworkers=self._nworkers)
+            host=host,
+            port=port,
+            nworkers=self._nworkers)
         command_env = os.environ.copy()
         command_env[scoring_server._SERVER_MODEL_PATH] = local_uri
         if not self._no_conda and ENV in self._config:

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -86,5 +86,5 @@ def _run_server(file_store_path, default_artifact_root, host, port, static_prefi
     if sys.platform == 'win32':
         full_command = _build_waitress_command(waitress_opts, host, port)
     else:
-        full_command = _build_gunicorn_command(gunicorn_opts, host, port, workers)
+        full_command = _build_gunicorn_command(gunicorn_opts, host, port, workers or 4)
     exec_cmd(full_command, env=env_map, stream_output=True)

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -1,5 +1,6 @@
 import os
 import shlex
+import sys
 
 from flask import Flask, send_from_directory
 
@@ -48,10 +49,27 @@ def serve():
     return send_from_directory(STATIC_DIR, 'index.html')
 
 
-def _run_server(file_store_path, default_artifact_root, host, port, workers, static_prefix,
-                gunicorn_opts):
+def _build_waitress_command(waitress_opts, host, port):
+    opts = shlex.split(waitress_opts) if waitress_opts else []
+    return ['waitress-serve'] + \
+        opts + [
+            "--host=%s" % host,
+            "--port=%s" % port,
+            "--ident=mlflow",
+            "mlflow.server:app"
+    ]
+
+
+def _build_gunicorn_command(gunicorn_opts, host, port, workers):
+    bind_address = "%s:%s" % (host, port)
+    opts = shlex.split(gunicorn_opts) if gunicorn_opts else []
+    return ["gunicorn"] + opts + ["-b", bind_address, "-w", "%s" % workers, "mlflow.server:app"]
+
+
+def _run_server(file_store_path, default_artifact_root, host, port, static_prefix=None,
+                workers=None, gunicorn_opts=None, waitress_opts=None):
     """
-    Run the MLflow server, wrapping it in gunicorn
+    Run the MLflow server, wrapping it in gunicorn or waitress on windows
     :param static_prefix: If set, the index.html asset will be served from the path static_prefix.
                           If left None, the index.html asset will be served from the root path.
     :return: None
@@ -63,7 +81,10 @@ def _run_server(file_store_path, default_artifact_root, host, port, workers, sta
         env_map[ARTIFACT_ROOT_ENV_VAR] = default_artifact_root
     if static_prefix:
         env_map[STATIC_PREFIX_ENV_VAR] = static_prefix
-    bind_address = "%s:%s" % (host, port)
-    opts = shlex.split(gunicorn_opts) if gunicorn_opts else []
-    exec_cmd(["gunicorn"] + opts + ["-b", bind_address, "-w", "%s" % workers, "mlflow.server:app"],
-             env=env_map, stream_output=True)
+
+    # TODO: eventually may want waitress on non-win32
+    if sys.platform == 'win32':
+        full_command = _build_waitress_command(waitress_opts, host, port)
+    else:
+        full_command = _build_gunicorn_command(gunicorn_opts, host, port, workers)
+    exec_cmd(full_command, env=env_map, stream_output=True)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -41,6 +41,9 @@ _tracking_store_registry.register('file', _get_file_store)
 for scheme in DATABASE_ENGINES:
     _tracking_store_registry.register(scheme, _get_sqlalchemy_store)
 
+_tracking_store_registry.register_entrypoints()
+
+
 
 def _get_store(backend_store_uri=None, default_artifact_root=None):
     from mlflow.server import BACKEND_STORE_URI_ENV_VAR, ARTIFACT_ROOT_ENV_VAR

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -41,9 +41,6 @@ _tracking_store_registry.register('file', _get_file_store)
 for scheme in DATABASE_ENGINES:
     _tracking_store_registry.register(scheme, _get_sqlalchemy_store)
 
-_tracking_store_registry.register_entrypoints()
-
-
 
 def _get_store(backend_store_uri=None, default_artifact_root=None):
     from mlflow.server import BACKEND_STORE_URI_ENV_VAR, ARTIFACT_ROOT_ENV_VAR

--- a/mlflow/server/js/package-lock.json
+++ b/mlflow/server/js/package-lock.json
@@ -5803,12 +5803,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5823,17 +5825,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5950,7 +5955,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5962,6 +5968,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5976,6 +5983,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5983,12 +5991,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -6007,6 +6017,7 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6087,7 +6098,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6099,6 +6111,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -6220,6 +6233,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -38,5 +38,5 @@ HOST = click.option("--host", "-h", metavar="HOST", default="127.0.0.1",
                          "server from other machines.")
 PORT = click.option("--port", "-p", default=5000,
                     help="The port to listen on (default: 5000).")
-WORKERS = click.option("--workers", "-w", default=4,
+WORKERS = click.option("--workers", "-w", default=None,  # We use None to disambiguate manually selecting "4"
                        help="Number of gunicorn worker processes to handle requests (default: 4).")

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -38,5 +38,7 @@ HOST = click.option("--host", "-h", metavar="HOST", default="127.0.0.1",
                          "server from other machines.")
 PORT = click.option("--port", "-p", default=5000,
                     help="The port to listen on (default: 5000).")
-WORKERS = click.option("--workers", "-w", default=None,  # We use None to disambiguate manually selecting "4"
+
+# We use None to disambiguate manually selecting "4"
+WORKERS = click.option("--workers", "-w", default=None,
                        help="Number of gunicorn worker processes to handle requests (default: 4).")

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import imp
 import os
+import sys
 from setuptools import setup, find_packages
 
 version = imp.load_source(
@@ -33,7 +34,7 @@ setup(
         'databricks-cli>=0.8.0',
         'requests>=2.17.3',
         'six>=1.10.0',
-        'gunicorn',
+        'waitress' if sys.platform == 'win32' else 'gunicorn',
         'Flask',
         'numpy',
         'pandas',


### PR DESCRIPTION
The main purpose of this PR is to introduce mlflow ui functionality on windows. I added on the server CLI command as well, but am unsure of the implications until we get the Windows FileStore support in. 

At the moment I opted not to replace gunicorn in all code paths after both reviewing the gunicorn-related commit history (there appear to have been customer use cases driving some of them) and kept the changes platform-dependent (ie assuming no one is interested in waitress on non-win32 platforms), but am happy to revisit that if there's interest.

Current status:
mlflow ui works inside waitress-serve (pretty much a drop-in replacement). mlflow server needs @eedeleon's windows support change to get filestore working locally.

Requires:
1. ~CLI syntax/signature feedback from interested parties~
2. ~#996 for some basic automated validation~ We've decided to add some basic selenium testing in a followup PR, screenshots attached here for manual validation

Manual validation:
1. Followed dev instructions for npm run build
2. mlflow (pip install -e .) ui/server <- works
3. underlying waitress-serve command <- works

![image](https://user-images.githubusercontent.com/16749003/59886821-a38bd480-938e-11e9-9250-44f147da735d.png)

