### PR TITLE
[WIP] Create separate Travis test job for Python / RST linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,13 @@ services:
 
 matrix:
   include:
+    - name: "Lint (Python and RST)"
+      python:
+        - 3.6
+      install:
+        - pip install pylint pycodestyle rstcheck
+      script:
+        - ./lint.sh
     - python: 2.7
     - python: 3.6
     - language: r
@@ -40,14 +47,6 @@ matrix:
         - npm i
         - ./lint.sh
         - npm test -- --coverage
-    - name: "Lint (Python and RST)"
-      python:
-        - 3.6
-      install:
-        - pip install pylint
-        - pip install rstcheck
-      script:
-        - ./lint.sh
 
 install:
   - sudo mkdir -p /travis-install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ services:
   - docker
 
 matrix:
+  fast_finish: true
   include:
     - name: "Lint (Python and RST)"
       python:
@@ -13,6 +14,7 @@ matrix:
         - pip install pylint pycodestyle rstcheck
       script:
         - ./lint.sh
+        - exit 1
     - python: 2.7
     - python: 3.6
     - language: r

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,14 @@ matrix:
         - npm i
         - ./lint.sh
         - npm test -- --coverage
+    - name: "Lint (Python and RST)"
+      python:
+        - 3.6
+      install:
+        - pip install pylint
+        - pip install rstcheck
+      script:
+        - ./lint.sh
 
 install:
   - sudo mkdir -p /travis-install
@@ -76,7 +84,6 @@ install:
   - wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O /travis-install/protoc.zip
   - sudo unzip /travis-install/protoc.zip -d /usr
 script:
-  - ./lint.sh
   - sudo ./test-generate-protos.sh
   - pip list
   - which mlflow

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,11 +10,9 @@ pandas<=0.23.4
 prospector[with_pyroma]==0.12.7
 pep8==1.7.1
 pyarrow==0.12.1
-pylint==1.8.2
 pyspark==2.4.0
 pytest==3.2.1
 pytest-cov==2.6.0
-rstcheck==3.2
 scikit-learn==0.20.2
 scipy==1.2.1
 tensorflow==1.12.0


### PR DESCRIPTION
This will enable failures due to lint errors to be caught more quickly because the overall build will fail as soon as the linting step fails.