### PR TITLE
PR template including a release notes section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,11 +8,14 @@
  
 ## Release Notes
  
-### Is this a user-facing change? If so, please give a 1-2 sentence description for MLflow users.
+### Is this a user-facing change? 
+
+[ ] No. Add the `rn/none` label, then you can skip the rest of this section.
+[ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
  
 (Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
  
-### What component(s) does this PR touch?
+### What component(s) does this PR affect?
  
 - [ ] UI
 - [ ] CLI 
@@ -30,7 +33,7 @@
 - [ ] Java
 - [ ] Python
 
-### Please add a label to the PR so it can be classified correctly in the release notes. Options:
+### Please add one label to the PR so it can be classified correctly in the release notes. Options:
  
 * `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
 * `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,39 @@
+## What changes are proposed in this pull request?
+ 
+(Please fill in changes proposed in this fix)
+ 
+## How is this patch tested?
+ 
+(Details)
+ 
+## Release Notes
+ 
+### Is this a user-facing change? If so, please give a 1-2 sentence description for MLflow users.
+ 
+(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
+ 
+### What component(s) does this PR touch?
+ 
+- [ ] UI
+- [ ] CLI 
+- [ ] API 
+- [ ] REST-API 
+- [ ] Examples 
+- [ ] Docs
+- [ ] Tracking
+- [ ] Projects 
+- [ ] Artifacts 
+- [ ] Models 
+- [ ] Scoring 
+- [ ] Serving
+- [ ] R
+- [ ] Java
+- [ ] Python
+
+### Please add a label to the PR so it can be classified correctly in the release notes. Options:
+ 
+* `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
+* `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section
+* `rn/feature` - A new user-facing feature worth mentioning in the release notes
+* `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
+* `rn/documentation` - A user-facing documentation change worth mentioning in the release notes


### PR DESCRIPTION
Here is a proposal for a PR template to help with the release notes construction. See https://github.com/mlflow/mlflow/blob/master/CHANGELOG.rst for reference on whether this template is going to be useful in constructing it... :-) 