### PR TITLE
Fix base64 encoding for basic auth in R tracking client

### DIFF
--- a/mlflow/R/mlflow/R/tracking-rest.R
+++ b/mlflow/R/mlflow/R/tracking-rest.R
@@ -24,7 +24,7 @@ get_rest_config <- function(host_creds) {
   headers <- list()
   auth_header <- if (!is.na(host_creds$username) && !is.na(host_creds$password)) {
     basic_auth_str <- paste(host_creds$username, host_creds$password, sep = ":")
-    paste("Basic", base64encode(basic_auth_str), sep = " ")
+    paste("Basic", base64encode(charToRaw(basic_auth_str)), sep = " ")
   } else if (!is.na(host_creds$token)) {
     paste("Bearer", host_creds$token, sep = " ")
   } else {


### PR DESCRIPTION
This is a minor fix for R clients using https and basic authentication.

By default base64encode interprets the user/password string as a filename, which causes a weird error:

```
Error in file(what, "rb") : cannot open the connection
In addition: Warning message:
In file(what, "rb") :
  cannot open file '$USERNAME_REDACTED:$PASSWORD_REDACTED': No such file or directory
```

In order to fix it, we have to convert the string to raw bytes. 

I've tested the change locally and it works. Please let me know how I can help you to get this merged.