### PR TITLE
Add HTTP header with MLflow version in Java client

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -1,5 +1,7 @@
 package org.mlflow.tracking;
 
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
 import org.apache.http.client.utils.URIBuilder;
 
 import org.mlflow.api.proto.Service.*;
@@ -8,12 +10,14 @@ import org.mlflow.artifacts.ArtifactRepositoryFactory;
 import org.mlflow.tracking.creds.*;
 
 import java.io.File;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.lang.Iterable;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 /**

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -1,7 +1,5 @@
 package org.mlflow.tracking;
 
-import com.google.common.base.Supplier;
-import com.google.common.base.Suppliers;
 import org.apache.http.client.utils.URIBuilder;
 
 import org.mlflow.api.proto.Service.*;
@@ -10,14 +8,12 @@ import org.mlflow.artifacts.ArtifactRepositoryFactory;
 import org.mlflow.tracking.creds.*;
 
 import java.io.File;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.lang.Iterable;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.stream.Collectors;
 
 /**

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClientVersion.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClientVersion.java
@@ -8,6 +8,8 @@ import com.google.common.base.Suppliers;
 
 /** Returns the version of the MLflow project this client was compiled against. */
 public class MlflowClientVersion {
+  // To avoid extra disk IO during class loading (static initialization), we lazily read the
+  // pom.properties file on first access and then cache the result to avoid future IO.
   private static Supplier<String> clientVersionSupplier = Suppliers.memoize(() -> {
     try {
       Properties p = new Properties();

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClientVersion.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClientVersion.java
@@ -1,0 +1,32 @@
+package org.mlflow.tracking;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+
+/** Returns the version of the MLflow project this client was compiled against. */
+public class MlflowClientVersion {
+  private static Supplier<String> clientVersionSupplier = Suppliers.memoize(() -> {
+    try {
+      Properties p = new Properties();
+      InputStream is = MlflowClientVersion.class.getResourceAsStream(
+        "/META-INF/maven/org.mlflow/mlflow-client/pom.properties");
+      if (is == null) {
+        return "";
+      }
+      p.load(is);
+      return p.getProperty("version", "");
+    } catch (Exception e) {
+      return "";
+    }
+  });
+
+  private MlflowClientVersion() {}
+
+  /** @return MLflow client version (e.g., 0.9.1) or an empty string if detection fails. */
+  public static String getClientVersion() {
+    return clientVersionSupplier.get();
+  }
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
@@ -114,6 +114,13 @@ class MlflowHttpCaller {
     } else if (token != null) {
       request.addHeader("Authorization", "Bearer " + token);
     }
+
+    String userAgent = "mlflow-java-client";
+    String clientVersion = MlflowClientVersion.getClientVersion();
+    if (!clientVersion.isEmpty()) {
+      userAgent += "/" + clientVersion;
+    }
+    request.addHeader("User-Agent", userAgent);
   }
 
   private boolean isError(int statusCode) {


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Similar to #1131, this adds a header like "mlflow-java-client/0.9.1" as a User-Agent header to requests sent by the MLflow Java client.

This one is harder to test in isolation because the mechanism relies on the embedding of the META-INF in the shaded package jar, and is not available in unit tests. I manually tested this out and observed that the header is set, and will write have an end-to-end integration test to confirm that the client knows its own version.