### PR TITLE
Remove store argument from get_artifact_repository()

### DIFF
--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -17,7 +17,7 @@ from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 from mlflow.utils import PYTHON_VERSION, get_unique_resource_id
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree, _copy_project
 from mlflow.version import VERSION as mlflow_version

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -162,7 +162,7 @@ def load_model(path, run_id=None):
     :param run_id: Run ID. If provided, combined with ``path`` to identify the model.
     """
     if run_id is not None:
-        path = mlflow.tracking.utils._get_model_log_dir(model_name=path, run_id=run_id)
+        path = mlflow.tracking.artifact_utils._get_model_log_dir(model_name=path, run_id=run_id)
     path = os.path.abspath(path)
     flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
     # Flavor configurations for models saved in MLflow version <= 0.8.0 may not contain a

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -200,7 +200,7 @@ def load_model(path, run_id=None):
     >>> predictions = keras_model.predict(x_test)
     """
     if run_id is not None:
-        path = mlflow.tracking.utils._get_model_log_dir(model_name=path, run_id=run_id)
+        path = mlflow.tracking.artifact_utils._get_model_log_dir(model_name=path, run_id=run_id)
     path = os.path.abspath(path)
     flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
     # Flavor configurations for models saved in MLflow version <= 0.8.0 may not contain a

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -261,7 +261,7 @@ def _load_model_env(path, run_id=None):
     or None if none was specified at model save time
     """
     if run_id is not None:
-        path = tracking.utils._get_model_log_dir(path, run_id)
+        path = tracking.artifact_utils._get_model_log_dir(path, run_id)
     return _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME).get(ENV, None)
 
 
@@ -276,7 +276,7 @@ def load_pyfunc(path, run_id=None, suppress_warnings=False):
                               will be emitted.
     """
     if run_id is not None:
-        path = tracking.utils._get_model_log_dir(path, run_id)
+        path = tracking.artifact_utils._get_model_log_dir(path, run_id)
     conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
     model_py_version = conf.get(PY_VERSION)
     if not suppress_warnings:
@@ -373,7 +373,7 @@ def spark_udf(spark, path, run_id=None, result_type="double"):
             error_code=INVALID_PARAMETER_VALUE)
 
     if run_id:
-        path = tracking.utils._get_model_log_dir(path, run_id)
+        path = tracking.artifact_utils._get_model_log_dir(path, run_id)
 
     archive_path = SparkModelCache.add_local_model(spark, path)
 

--- a/mlflow/pyfunc/cli.py
+++ b/mlflow/pyfunc/cli.py
@@ -11,7 +11,7 @@ import pandas
 
 from mlflow.projects import _get_conda_bin_executable, _get_or_create_conda_env
 from mlflow.pyfunc import load_pyfunc, scoring_server, _load_model_env
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 from mlflow.utils import cli_args
 
 

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -16,7 +16,7 @@ import mlflow.utils
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_ALREADY_EXISTS
-from mlflow.tracking.utils import _download_artifact_from_uri
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -304,7 +304,7 @@ def load_model(path, run_id=None, **kwargs):
     >>> y_pred = pytorch_model(x_new_data)
     """
     if run_id is not None:
-        path = mlflow.tracking.utils._get_model_log_dir(model_name=path, run_id=run_id)
+        path = mlflow.tracking.artifact_utils._get_model_log_dir(model_name=path, run_id=run_id)
     path = os.path.abspath(path)
 
     try:

--- a/mlflow/rfunc/cli.py
+++ b/mlflow/rfunc/cli.py
@@ -5,7 +5,7 @@ import os
 import subprocess
 import logging
 
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 from mlflow.utils import cli_args
 
 

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -22,7 +22,7 @@ from mlflow import pyfunc, mleap
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, INVALID_PARAMETER_VALUE
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 from mlflow.utils import get_unique_resource_id
 from mlflow.utils.file_utils import TempDir, _copy_project
 from mlflow.utils.logging_utils import eprint

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -336,8 +336,7 @@ def _list_experiments():
 
 @catch_mlflow_exception
 def _get_artifact_repo(run):
-    store = _get_store()
-    return get_artifact_repository(run.info.artifact_uri, store)
+    return get_artifact_repository(run.info.artifact_uri)
 
 
 @catch_mlflow_exception

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -242,7 +242,7 @@ def load_model(path, run_id=None):
     >>> predictions = sk_model.predict(pandas_df)
     """
     if run_id is not None:
-        path = mlflow.tracking.utils._get_model_log_dir(model_name=path, run_id=run_id)
+        path = mlflow.tracking.artifact_utils._get_model_log_dir(model_name=path, run_id=run_id)
     path = os.path.abspath(path)
     flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
     sklearn_model_artifacts_path = os.path.join(path, flavor_conf['pickled_model'])

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -345,7 +345,7 @@ def load_model(path, run_id=None, dfs_tmpdir=None):
     >>> prediction = model.transform(test)
     """
     if run_id is not None:
-        path = mlflow.tracking.utils._get_model_log_dir(model_name=path, run_id=run_id)
+        path = mlflow.tracking.artifact_utils._get_model_log_dir(model_name=path, run_id=run_id)
     path = os.path.abspath(path)
     flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
     spark_model_artifacts_path = os.path.join(path, flavor_conf['model_data'])

--- a/mlflow/store/artifact_repository_registry.py
+++ b/mlflow/store/artifact_repository_registry.py
@@ -47,33 +47,26 @@ class ArtifactRepositoryRegistry:
                     stacklevel=2
                 )
 
-    def get_artifact_repository(self, artifact_uri, store=None):
+    def get_artifact_repository(self, artifact_uri):
         """Get an artifact repository from the registry based on the scheme of artifact_uri
 
         :param store_uri: The store URI. This URI is used to select which artifact repository
                           implementation to instantiate and is passed to the
                           constructor of the implementation.
-        :param store: Instance of `AbstractStore`. This is currently only used to get the host
-                      credentials when instantiating a DBFS-backed artifact repository.
 
         :return: An instance of `mlflow.store.ArtifactRepository` that fulfills the artifact URI
                  requirements.
         """
         scheme = urllib.parse.urlparse(artifact_uri).scheme
         repository = self._registry.get(scheme)
-        if scheme == "dbfs" and repository is not None:
-            if not isinstance(store, RestStore):
-                raise MlflowException('`store` must be an instance of RestStore.')
-            return repository(artifact_uri, store.get_host_creds)
-        elif repository is not None:
-            return repository(artifact_uri)
-        else:
+        if repository is None:
             raise MlflowException(
                 "Could not find a registered artifact repository for: {}. "
                 "Currently registered schemes are: {}".format(
                     artifact_uri, list(self._registry.keys())
                 )
             )
+        return repository(artifact_uri)
 
 
 _artifact_repository_registry = ArtifactRepositoryRegistry()
@@ -90,16 +83,14 @@ _artifact_repository_registry.register('hdfs', HdfsArtifactRepository)
 _artifact_repository_registry.register_entrypoints()
 
 
-def get_artifact_repository(artifact_uri, store=None):
+def get_artifact_repository(artifact_uri):
     """Get an artifact repository from the registry based on the scheme of artifact_uri
 
     :param store_uri: The store URI. This URI is used to select which artifact repository
                       implementation to instantiate and is passed to the
                       constructor of the implementation.
-    :param store: Instance of `AbstractStore`. This is currently only used to get the host
-                  credentials when instantiating a DBFS-backed artifact repository.
 
     :return: An instance of `mlflow.store.ArtifactRepository` that fulfills the artifact URI
              requirements.
     """
-    return _artifact_repository_registry.get_artifact_repository(artifact_uri, store)
+    return _artifact_repository_registry.get_artifact_repository(artifact_uri)

--- a/mlflow/store/artifact_repository_registry.py
+++ b/mlflow/store/artifact_repository_registry.py
@@ -11,7 +11,6 @@ from mlflow.store.sftp_artifact_repo import SFTPArtifactRepository
 from mlflow.store.dbfs_artifact_repo import DbfsArtifactRepository
 from mlflow.store.s3_artifact_repo import S3ArtifactRepository
 from mlflow.store.local_artifact_repo import LocalArtifactRepository
-from mlflow.store.rest_store import RestStore
 
 
 class ArtifactRepositoryRegistry:

--- a/mlflow/store/cli.py
+++ b/mlflow/store/cli.py
@@ -37,7 +37,7 @@ def log_artifact(local_file, run_id, artifact_path):
     """
     store = _get_store()
     artifact_uri = store.get_run(run_id).info.artifact_uri
-    artifact_repo = get_artifact_repository(artifact_uri, store)
+    artifact_repo = get_artifact_repository(artifact_uri)
     artifact_repo.log_artifact(local_file, artifact_path)
     _logger.info("Logged artifact from local file %s to artifact_path=%s",
                  local_file, artifact_path)
@@ -59,7 +59,7 @@ def log_artifacts(local_dir, run_id, artifact_path):
     """
     store = _get_store()
     artifact_uri = store.get_run(run_id).info.artifact_uri
-    artifact_repo = get_artifact_repository(artifact_uri, store)
+    artifact_repo = get_artifact_repository(artifact_uri)
     artifact_repo.log_artifacts(local_dir, artifact_path)
     _logger.info("Logged artifact from local dir %s to artifact_path=%s", local_dir, artifact_path)
 
@@ -77,7 +77,7 @@ def list_artifacts(run_id, artifact_path):
     artifact_path = artifact_path if artifact_path is not None else ""
     store = _get_store()
     artifact_uri = store.get_run(run_id).info.artifact_uri
-    artifact_repo = get_artifact_repository(artifact_uri, store)
+    artifact_repo = get_artifact_repository(artifact_uri)
     file_infos = artifact_repo.list_artifacts(artifact_path)
     print(_file_infos_to_json(file_infos))
 
@@ -100,6 +100,6 @@ def download_artifacts(run_id, artifact_path):
     artifact_path = artifact_path if artifact_path is not None else ""
     store = _get_store()
     artifact_uri = store.get_run(run_id).info.artifact_uri
-    artifact_repo = get_artifact_repository(artifact_uri, store)
+    artifact_repo = get_artifact_repository(artifact_uri)
     artifact_location = artifact_repo.download_artifacts(artifact_path)
     print(artifact_location)

--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -4,7 +4,7 @@ import json
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact_repo import ArtifactRepository
-from mlflow.tracking import utils
+from mlflow.tracking.utils import _get_store
 from mlflow.utils.rest_utils import http_request, http_request_safe, RESOURCE_DOES_NOT_EXIST
 from mlflow.utils.string_utils import strip_prefix
 
@@ -27,7 +27,7 @@ class DbfsArtifactRepository(ArtifactRepository):
         # TODO (sueann): we may want to pass in the databricks profile or the RestStore's
         #  get_host_creds directly instead of using _get_store, since it's possible they
         #  will be different.
-        self.get_host_creds = utils._get_store.get_host_creds
+        self.get_host_creds = _get_store().get_host_creds
         if not cleaned_artifact_uri.startswith('dbfs:/'):
             raise MlflowException('DbfsArtifactRepository URI must start with dbfs:/')
 

--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -24,8 +24,9 @@ class DbfsArtifactRepository(ArtifactRepository):
     def __init__(self, artifact_uri):
         cleaned_artifact_uri = artifact_uri.rstrip('/')
         super(DbfsArtifactRepository, self).__init__(cleaned_artifact_uri)
-        # TODO (sueann): we may want to pass in the databricks profile or the RestStore's get_host_creds directly
-        #  instead of using _get_store, since it's possible they will be different.
+        # TODO (sueann): we may want to pass in the databricks profile or the RestStore's
+        #  get_host_creds directly instead of using _get_store, since it's possible they
+        #  will be different.
         self.get_host_creds = utils._get_store.get_host_creds
         if not cleaned_artifact_uri.startswith('dbfs:/'):
             raise MlflowException('DbfsArtifactRepository URI must start with dbfs:/')

--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -24,9 +24,8 @@ class DbfsArtifactRepository(ArtifactRepository):
     def __init__(self, artifact_uri):
         cleaned_artifact_uri = artifact_uri.rstrip('/')
         super(DbfsArtifactRepository, self).__init__(cleaned_artifact_uri)
-        # TODO (sueann): we may want to pass in the databricks profile or the RestStore's
-        #  get_host_creds directly instead of using _get_store, since it's possible they
-        #  will be different.
+        # NOTE: if we ever need to support databricks profiles different from that set for
+        #  tracking, we could pass in the databricks profile name into this class.
         self.get_host_creds = utils._get_store().get_host_creds
         if not cleaned_artifact_uri.startswith('dbfs:/'):
             raise MlflowException('DbfsArtifactRepository URI must start with dbfs:/')

--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -138,5 +138,6 @@ def _get_host_creds_from_default_store():
     store = utils._get_store()
     if not isinstance(store, RestStore):
         raise MlflowException('Failed to get credentials for DBFS; they are read from the ' +
-                              'Databricks CLI credentials or _TRACKING* environment variables.')
+                              'Databricks CLI credentials or MLFLOW_TRACKING* environment ' +
+                              'variables.')
     return store.get_host_creds

--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -4,6 +4,7 @@ import json
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact_repo import ArtifactRepository
+from mlflow.tracking.utils import _get_store
 from mlflow.utils.rest_utils import http_request, http_request_safe, RESOURCE_DOES_NOT_EXIST
 from mlflow.utils.string_utils import strip_prefix
 
@@ -20,10 +21,12 @@ class DbfsArtifactRepository(ArtifactRepository):
     together with the RestStore.
     """
 
-    def __init__(self, artifact_uri, get_host_creds):
+    def __init__(self, artifact_uri):
         cleaned_artifact_uri = artifact_uri.rstrip('/')
         super(DbfsArtifactRepository, self).__init__(cleaned_artifact_uri)
-        self.get_host_creds = get_host_creds
+        # TODO (sueann): we may want to pass in the databricks profile or the RestStore's get_host_creds directly
+        #  instead of using _get_store, since it's possible they will be different.
+        self.get_host_creds = _get_store.get_host_creds
         if not cleaned_artifact_uri.startswith('dbfs:/'):
             raise MlflowException('DbfsArtifactRepository URI must start with dbfs:/')
 

--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -4,6 +4,7 @@ import json
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact_repo import ArtifactRepository
+from mlflow.store.rest_store import RestStore
 from mlflow.tracking import utils
 from mlflow.utils.rest_utils import http_request, http_request_safe, RESOURCE_DOES_NOT_EXIST
 from mlflow.utils.string_utils import strip_prefix
@@ -26,7 +27,7 @@ class DbfsArtifactRepository(ArtifactRepository):
         super(DbfsArtifactRepository, self).__init__(cleaned_artifact_uri)
         # NOTE: if we ever need to support databricks profiles different from that set for
         #  tracking, we could pass in the databricks profile name into this class.
-        self.get_host_creds = utils._get_store().get_host_creds
+        self.get_host_creds = _get_host_creds_from_default_store()
         if not cleaned_artifact_uri.startswith('dbfs:/'):
             raise MlflowException('DbfsArtifactRepository URI must start with dbfs:/')
 
@@ -131,3 +132,11 @@ class DbfsArtifactRepository(ArtifactRepository):
     def _download_file(self, remote_file_path, local_path):
         self._dbfs_download(output_path=local_path,
                             endpoint=self._get_dbfs_endpoint(remote_file_path))
+
+
+def _get_host_creds_from_default_store():
+    store = utils._get_store()
+    if not isinstance(store, RestStore):
+        raise MlflowException('Failed to get credentials for DBFS; they are read from the ' +
+                              'Databricks CLI credentials or _TRACKING* environment variables.')
+    return store.get_host_creds

--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -4,7 +4,7 @@ import json
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact_repo import ArtifactRepository
-from mlflow.tracking.utils import _get_store
+from mlflow.tracking import utils
 from mlflow.utils.rest_utils import http_request, http_request_safe, RESOURCE_DOES_NOT_EXIST
 from mlflow.utils.string_utils import strip_prefix
 
@@ -26,7 +26,7 @@ class DbfsArtifactRepository(ArtifactRepository):
         super(DbfsArtifactRepository, self).__init__(cleaned_artifact_uri)
         # TODO (sueann): we may want to pass in the databricks profile or the RestStore's get_host_creds directly
         #  instead of using _get_store, since it's possible they will be different.
-        self.get_host_creds = _get_store.get_host_creds
+        self.get_host_creds = utils._get_store.get_host_creds
         if not cleaned_artifact_uri.startswith('dbfs:/'):
             raise MlflowException('DbfsArtifactRepository URI must start with dbfs:/')
 

--- a/mlflow/store/dbfs_artifact_repo.py
+++ b/mlflow/store/dbfs_artifact_repo.py
@@ -4,7 +4,7 @@ import json
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact_repo import ArtifactRepository
-from mlflow.tracking.utils import _get_store
+from mlflow.tracking import utils
 from mlflow.utils.rest_utils import http_request, http_request_safe, RESOURCE_DOES_NOT_EXIST
 from mlflow.utils.string_utils import strip_prefix
 
@@ -27,7 +27,7 @@ class DbfsArtifactRepository(ArtifactRepository):
         # TODO (sueann): we may want to pass in the databricks profile or the RestStore's
         #  get_host_creds directly instead of using _get_store, since it's possible they
         #  will be different.
-        self.get_host_creds = _get_store().get_host_creds
+        self.get_host_creds = utils._get_store().get_host_creds
         if not cleaned_artifact_uri.startswith('dbfs:/'):
             raise MlflowException('DbfsArtifactRepository URI must start with dbfs:/')
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -23,7 +23,7 @@ from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import DIRECTORY_NOT_EMPTY
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import _copy_file_or_tree
 from mlflow.utils.model_utils import _get_flavor_configuration

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -1,0 +1,69 @@
+"""
+Utilities for dealing with artifacts in the context of a Run.
+"""
+
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.store.artifact_repository_registry import get_artifact_repository
+from mlflow.tracking.utils import _get_store
+
+
+def get_artifact_uri(run_id, artifact_path=None):
+    """
+    Get the absolute URI of the specified artifact in the specified run. If `path` is not specified,
+    the artifact root URI of the specified run will be returned; calls to ``log_artifact``
+    and ``log_artifacts`` write artifact(s) to subdirectories of the artifact root URI.
+
+    :param run_id: The ID of the run for which to obtain an absolute artifact URI.
+    :param artifact_path: The run-relative artifact path. For example,
+                          ``path/to/artifact``. If unspecified, the artifact root URI for the
+                          specified run will be returned.
+    :return: An *absolute* URI referring to the specified artifact or the specified run's artifact
+             root. For example, if an artifact path is provided and the specified run uses an
+             S3-backed  store, this may be a uri of the form
+             ``s3://<bucket_name>/path/to/artifact/root/path/to/artifact``. If an artifact path
+             is not provided and the specified run uses an S3-backed store, this may be a URI of
+             the form ``s3://<bucket_name>/path/to/artifact/root``.
+    """
+    if not run_id:
+        raise MlflowException(
+            message="A run_id must be specified in order to obtain an artifact uri!",
+            error_code=INVALID_PARAMETER_VALUE)
+
+    store = _get_store()
+    run = store.get_run(run_id)
+    if artifact_path is None:
+        return run.info.artifact_uri
+    else:
+        # Path separators may not be consistent across all artifact repositories. Therefore, when
+        # joining the run's artifact root directory with the artifact's relative path, we use the
+        # path module defined by the appropriate artifact repository
+        artifact_path_module = \
+            get_artifact_repository(run.info.artifact_uri).get_path_module()
+        return artifact_path_module.join(run.info.artifact_uri, artifact_path)
+
+
+# TODO(sueann): This method does not require a Run and its internals should be moved to
+#  data.download_uri (requires confirming that Projects will not break with this change).
+def _download_artifact_from_uri(artifact_uri, output_path=None):
+    """
+    :param artifact_uri: The *absolute* URI of the artifact to download.
+    :param output_path: The local filesystem path to which to download the artifact. If unspecified,
+                        a local output path will be created.
+    """
+    artifact_path_module = \
+        get_artifact_repository(artifact_uri).get_path_module()
+    artifact_src_dir = artifact_path_module.dirname(artifact_uri)
+    artifact_src_relative_path = artifact_path_module.basename(artifact_uri)
+    artifact_repo = get_artifact_repository(artifact_uri=artifact_src_dir)
+    return artifact_repo.download_artifacts(artifact_path=artifact_src_relative_path,
+                                            dst_path=output_path)
+
+
+def _get_model_log_dir(model_name, run_id):
+    if not run_id:
+        raise Exception("Must specify a run_id to get logging directory for a model.")
+    store = _get_store()
+    run = store.get_run(run_id)
+    artifact_repo = get_artifact_repository(run.info.artifact_uri)
+    return artifact_repo.download_artifacts(model_name)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -216,7 +216,7 @@ class MlflowClient(object):
         :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
         """
         run = self.get_run(run_id)
-        artifact_repo = get_artifact_repository(run.info.artifact_uri, self.store)
+        artifact_repo = get_artifact_repository(run.info.artifact_uri)
         artifact_repo.log_artifact(local_path, artifact_path)
 
     def log_artifacts(self, run_id, local_dir, artifact_path=None):
@@ -227,7 +227,7 @@ class MlflowClient(object):
         :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
         """
         run = self.get_run(run_id)
-        artifact_repo = get_artifact_repository(run.info.artifact_uri, self.store)
+        artifact_repo = get_artifact_repository(run.info.artifact_uri)
         artifact_repo.log_artifacts(local_dir, artifact_path)
 
     def list_artifacts(self, run_id, path=None):
@@ -241,7 +241,7 @@ class MlflowClient(object):
         """
         run = self.get_run(run_id)
         artifact_root = run.info.artifact_uri
-        artifact_repo = get_artifact_repository(artifact_root, self.store)
+        artifact_repo = get_artifact_repository(artifact_root)
         return artifact_repo.list_artifacts(path)
 
     def download_artifacts(self, run_id, path):
@@ -255,7 +255,7 @@ class MlflowClient(object):
         """
         run = self.get_run(run_id)
         artifact_root = run.info.artifact_uri
-        artifact_repo = get_artifact_repository(artifact_root, self.store)
+        artifact_repo = get_artifact_repository(artifact_root)
         return artifact_repo.download_artifacts(path)
 
     def set_terminated(self, run_id, status=None, end_time=None):

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -11,12 +11,11 @@ import atexit
 import time
 import logging
 
-import mlflow.tracking.utils
 from mlflow.entities import Run, SourceType, RunStatus, Param, RunTag, Metric
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient
-from mlflow.tracking import context
+from mlflow.tracking import artifact_utils, context
 from mlflow.utils import env
 from mlflow.utils.databricks_utils import is_in_databricks_notebook, get_notebook_id
 from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT, MLFLOW_SOURCE_TYPE, MLFLOW_SOURCE_NAME, \
@@ -290,8 +289,8 @@ def get_artifact_uri(artifact_path=None):
              is not provided and the currently active run uses an S3-backed store, this may be a
              URI of the form ``s3://<bucket_name>/path/to/artifact/root``.
     """
-    return mlflow.tracking.utils.get_artifact_uri(
-        run_id=_get_or_start_run().info.run_uuid, artifact_path=artifact_path)
+    return artifact_utils.get_artifact_uri(run_id=_get_or_start_run().info.run_uuid,
+                                           artifact_path=artifact_path)
 
 
 def _get_or_start_run():

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -266,7 +266,7 @@ _tracking_store_registry.register_entrypoints()
 
 
 def _get_store(store_uri=None, artifact_uri=None):
-
+    
     return _tracking_store_registry.get_store(store_uri, artifact_uri)
 
 

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -275,7 +275,7 @@ def _get_model_log_dir(model_name, run_id):
         raise Exception("Must specify a run_id to get logging directory for a model.")
     store = _get_store()
     run = store.get_run(run_id)
-    artifact_repo = get_artifact_repository(run.info.artifact_uri, store)
+    artifact_repo = get_artifact_repository(run.info.artifact_uri)
     return artifact_repo.download_artifacts(model_name)
 
 

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -8,9 +8,7 @@ import entrypoints
 from six.moves import urllib
 
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
-from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.store.dbmodels.db_types import DATABASE_ENGINES
 from mlflow.store.file_store import FileStore
 from mlflow.store.rest_store import RestStore
@@ -72,56 +70,6 @@ def get_tracking_uri():
         return env.get_env(_TRACKING_URI_ENV_VAR)
     else:
         return os.path.abspath(DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
-
-
-def get_artifact_uri(run_id, artifact_path=None):
-    """
-    Get the absolute URI of the specified artifact in the specified run. If `path` is not specified,
-    the artifact root URI of the specified run will be returned; calls to ``log_artifact``
-    and ``log_artifacts`` write artifact(s) to subdirectories of the artifact root URI.
-
-    :param run_id: The ID of the run for which to obtain an absolute artifact URI.
-    :param artifact_path: The run-relative artifact path. For example,
-                          ``path/to/artifact``. If unspecified, the artifact root URI for the
-                          specified run will be returned.
-    :return: An *absolute* URI referring to the specified artifact or the specified run's artifact
-             root. For example, if an artifact path is provided and the specified run uses an
-             S3-backed  store, this may be a uri of the form
-             ``s3://<bucket_name>/path/to/artifact/root/path/to/artifact``. If an artifact path
-             is not provided and the specified run uses an S3-backed store, this may be a URI of
-             the form ``s3://<bucket_name>/path/to/artifact/root``.
-    """
-    if not run_id:
-        raise MlflowException(
-                message="A run_id must be specified in order to obtain an artifact uri!",
-                error_code=INVALID_PARAMETER_VALUE)
-
-    store = _get_store()
-    run = store.get_run(run_id)
-    if artifact_path is None:
-        return run.info.artifact_uri
-    else:
-        # Path separators may not be consistent across all artifact repositories. Therefore, when
-        # joining the run's artifact root directory with the artifact's relative path, we use the
-        # path module defined by the appropriate artifact repository
-        artifact_path_module =\
-            get_artifact_repository(run.info.artifact_uri).get_path_module()
-        return artifact_path_module.join(run.info.artifact_uri, artifact_path)
-
-
-def _download_artifact_from_uri(artifact_uri, output_path=None):
-    """
-    :param artifact_uri: The *absolute* URI of the artifact to download.
-    :param output_path: The local filesystem path to which to download the artifact. If unspecified,
-                        a local output path will be created.
-    """
-    artifact_path_module =\
-        get_artifact_repository(artifact_uri).get_path_module()
-    artifact_src_dir = artifact_path_module.dirname(artifact_uri)
-    artifact_src_relative_path = artifact_path_module.basename(artifact_uri)
-    artifact_repo = get_artifact_repository(artifact_uri=artifact_src_dir)
-    return artifact_repo.download_artifacts(artifact_path=artifact_src_relative_path,
-                                            dst_path=output_path)
 
 
 def _is_local_uri(uri):
@@ -266,19 +214,11 @@ _tracking_store_registry.register_entrypoints()
 
 
 def _get_store(store_uri=None, artifact_uri=None):
-    
+
     return _tracking_store_registry.get_store(store_uri, artifact_uri)
 
 
-def _get_model_log_dir(model_name, run_id):
-    if not run_id:
-        raise Exception("Must specify a run_id to get logging directory for a model.")
-    store = _get_store()
-    run = store.get_run(run_id)
-    artifact_repo = get_artifact_repository(run.info.artifact_uri)
-    return artifact_repo.download_artifacts(model_name)
-
-
+# TODO(sueann): move to a projects utils module
 def _get_git_url_if_present(uri):
     """
     Return the path git_uri#sub_directory if the URI passed is a local path that's part of

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -109,8 +109,6 @@ def get_artifact_uri(run_id, artifact_path=None):
         return artifact_path_module.join(run.info.artifact_uri, artifact_path)
 
 
-# TODO(sueann): ideally this is deprecated in favor of data.download_uri
-#  but there may be differences in auth mechanisms between Projects and artifacts -- ???
 def _download_artifact_from_uri(artifact_uri, output_path=None):
     """
     :param artifact_uri: The *absolute* URI of the artifact to download.
@@ -241,8 +239,9 @@ class TrackingStoreRegistry:
             store_uri += ':'
 
         scheme = urllib.parse.urlparse(store_uri).scheme
-        store_builder = self._registry.get(scheme)
-        if store_builder is None:
+        try:
+            store_builder = self._registry[scheme]
+        except KeyError:
             raise MlflowException(
                 "Could not find a registered tracking store for: {}. "
                 "Currently registered schemes are: {}".format(

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -26,7 +26,7 @@ from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 from mlflow.utils.file_utils import TempDir
 
 

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -19,7 +19,7 @@ import mlflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.models import Model
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -17,7 +17,7 @@ import mlflow.keras
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.models import Model
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 from tests.helper_functions import pyfunc_serve_and_score_model

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -22,8 +22,8 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.sklearn
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
-from mlflow.tracking.artifact_utils import get_artifact_uri as utils_get_artifact_uri
-from mlflow.tracking.artifact_utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import get_artifact_uri as utils_get_artifact_uri, \
+    _get_model_log_dir
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -22,8 +22,8 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.sklearn
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
-from mlflow.tracking.utils import get_artifact_uri as utils_get_artifact_uri
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import get_artifact_uri as utils_get_artifact_uri
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -17,7 +17,7 @@ import mlflow.pyfunc.model
 import mlflow.sklearn
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 
 
 def _load_pyfunc(path):

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -274,7 +274,7 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
                                  artifact_path=artifact_path,
                                  conda_env=pytorch_custom_env)
         run_id = mlflow.active_run().info.run_uuid
-    model_path = tracking.utils._get_model_log_dir(artifact_path, run_id)
+    model_path = tracking.artifact_utils._get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -308,7 +308,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
                                  artifact_path=artifact_path,
                                  conda_env=None)
         run_id = mlflow.active_run().info.run_uuid
-    model_path = tracking.utils._get_model_log_dir(artifact_path, run_id)
+    model_path = tracking.artifact_utils._get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -423,7 +423,8 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
                          })
         pyfunc_run_id = mlflow.active_run().info.run_uuid
 
-    pyfunc_model_path = tracking.utils._get_model_log_dir(pyfunc_artifact_path, pyfunc_run_id)
+    pyfunc_model_path = tracking.artifact_utils._get_model_log_dir(pyfunc_artifact_path,
+                                                                   pyfunc_run_id)
 
     # Deploy the custom pyfunc model and ensure that it is able to successfully load its
     # constituent PyTorch model via `mlflow.pytorch.load_model`
@@ -543,7 +544,7 @@ def test_load_model_succeeds_when_data_is_model_file_instead_of_directory(
             pytorch_model=module_scoped_subclassed_model,
             conda_env=None)
         run_id = mlflow.active_run().info.run_uuid
-    model_path = tracking.utils._get_model_log_dir(artifact_path, run_id)
+    model_path = tracking.artifact_utils._get_model_log_dir(artifact_path, run_id)
 
     model_conf_path = os.path.join(model_path, "MLmodel")
     model_conf = Model.load(model_conf_path)

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -19,7 +19,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import ErrorCode, RESOURCE_DOES_NOT_EXIST, INVALID_PARAMETER_VALUE
 from mlflow.protos.databricks_pb2 import INTERNAL_ERROR
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 
 from tests.sagemaker.mock import mock_sagemaker, Endpoint, EndpointOperation
 

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -25,7 +25,7 @@ from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.models import Model
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -25,7 +25,7 @@ from mlflow import active_run, pyfunc, mleap
 from mlflow import spark as sparkm
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration

--- a/tests/store/test_artifact_repository_registry.py
+++ b/tests/store/test_artifact_repository_registry.py
@@ -4,8 +4,6 @@ from six.moves import reload_module as reload
 
 import mlflow
 from mlflow.store.artifact_repository_registry import ArtifactRepositoryRegistry
-from mlflow.store.rest_store import RestStore
-from mlflow.store.sqlalchemy_store import SqlAlchemyStore
 
 
 def test_standard_artifact_registry():
@@ -69,38 +67,6 @@ def test_plugin_registration():
     assert repository_instance == mock_plugin.return_value
 
     mock_plugin.assert_called_once_with("mock-scheme://fake-host/fake-path")
-
-
-def test_dbfs_instantiation():
-    artifact_repository_registry = ArtifactRepositoryRegistry()
-
-    mock_dbfs_constructor = mock.Mock()
-    artifact_repository_registry.register("dbfs", mock_dbfs_constructor)
-
-    mock_get_host_creds = mock.Mock()
-    rest_store = RestStore(mock_get_host_creds)
-
-    mock_dbfs_repo = artifact_repository_registry.get_artifact_repository(
-        artifact_uri="dbfs://test-path", store=rest_store
-    )
-    assert mock_dbfs_repo == mock_dbfs_constructor.return_value
-    mock_dbfs_constructor.assert_called_once_with("dbfs://test-path", mock_get_host_creds)
-
-
-def test_incorrect_dbfs_instantiation():
-    artifact_repository_registry = ArtifactRepositoryRegistry()
-
-    mock_dbfs_constructor = mock.Mock()
-    artifact_repository_registry.register("dbfs", mock_dbfs_constructor)
-
-    sql_store = SqlAlchemyStore("sqlite://", "./mlruns")
-
-    with pytest.raises(mlflow.exceptions.MlflowException, match="must be an instance of RestStore"):
-        artifact_repository_registry.get_artifact_repository(
-            artifact_uri="dbfs://test-path", store=sql_store
-        )
-
-    mock_dbfs_constructor.assert_not_called()
 
 
 def test_get_unknown_scheme():

--- a/tests/store/test_azure_blob_artifact_repo.py
+++ b/tests/store/test_azure_blob_artifact_repo.py
@@ -46,7 +46,7 @@ def test_artifact_uri_factory(mock_client):
     # We pass in the mock_client here to clear Azure environment variables, but we don't use it;
     # We do need to set up a fake access key for the code to run though
     os.environ['AZURE_STORAGE_ACCESS_KEY'] = ''
-    repo = get_artifact_repository(TEST_URI, mock.Mock())
+    repo = get_artifact_repository(TEST_URI)
     assert isinstance(repo, AzureBlobArtifactRepository)
     del os.environ['AZURE_STORAGE_ACCESS_KEY']
 

--- a/tests/store/test_dbfs_artifact_repo.py
+++ b/tests/store/test_dbfs_artifact_repo.py
@@ -7,12 +7,19 @@ import mock
 from mock import Mock
 
 from mlflow.exceptions import MlflowException
-from mlflow.store.dbfs_artifact_repo import DbfsArtifactRepository
+from mlflow.store.dbfs_artifact_repo import DbfsArtifactRepository, \
+    _get_host_creds_from_default_store
+from mlflow.store.file_store import FileStore
+from mlflow.store.rest_store import RestStore
+from mlflow.utils.rest_utils import MlflowHostCreds
 
 
 @pytest.fixture()
 def dbfs_artifact_repo():
-    return DbfsArtifactRepository('dbfs:/test/')
+    with mock.patch('mlflow.store.dbfs_artifact_repo._get_host_creds_from_default_store') \
+            as get_creds_mock:
+        get_creds_mock.return_value = lambda: MlflowHostCreds('http://host')
+        return DbfsArtifactRepository('dbfs:/test/')
 
 
 TEST_FILE_1_CONTENT = u"Hello 🍆🍔".encode("utf-8")
@@ -64,10 +71,13 @@ LIST_ARTIFACTS_SINGLE_FILE_RESPONSE = {
 
 class TestDbfsArtifactRepository(object):
     def test_init_validation_and_cleaning(self):
-        repo = DbfsArtifactRepository('dbfs:/test/')
-        assert repo.artifact_uri == 'dbfs:/test'
-        with pytest.raises(MlflowException):
-            DbfsArtifactRepository('s3://test')
+        with mock.patch('mlflow.store.dbfs_artifact_repo._get_host_creds_from_default_store') \
+                as get_creds_mock:
+            get_creds_mock.return_value = lambda: MlflowHostCreds('http://host')
+            repo = DbfsArtifactRepository('dbfs:/test/')
+            assert repo.artifact_uri == 'dbfs:/test'
+            with pytest.raises(MlflowException):
+                DbfsArtifactRepository('s3://test')
 
     @pytest.mark.parametrize("artifact_path,expected_endpoint", [
         (None, '/dbfs/test/test.txt'),
@@ -205,3 +215,16 @@ class TestDbfsArtifactRepository(object):
             _, kwargs_call_2 = chronological_download_calls[1]
             assert kwargs_call_1['endpoint'] == '/dbfs/test/dir'
             assert kwargs_call_2['endpoint'] == '/dbfs/test/a.txt'
+
+
+def test_get_host_creds_from_default_store_file_store():
+    with mock.patch('mlflow.tracking.utils._get_store') as get_store_mock:
+        get_store_mock.return_value = FileStore()
+        with pytest.raises(MlflowException):
+            _get_host_creds_from_default_store()
+
+
+def test_get_host_creds_from_default_store_rest_store():
+    with mock.patch('mlflow.tracking.utils._get_store') as get_store_mock:
+        get_store_mock.return_value = RestStore(lambda: MlflowHostCreds('http://host'))
+        assert isinstance(_get_host_creds_from_default_store()(), MlflowHostCreds)

--- a/tests/store/test_dbfs_artifact_repo.py
+++ b/tests/store/test_dbfs_artifact_repo.py
@@ -8,12 +8,11 @@ from mock import Mock
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.dbfs_artifact_repo import DbfsArtifactRepository
-from mlflow.utils.rest_utils import MlflowHostCreds
 
 
 @pytest.fixture()
 def dbfs_artifact_repo():
-    return DbfsArtifactRepository('dbfs:/test/', lambda: MlflowHostCreds('http://host'))
+    return DbfsArtifactRepository('dbfs:/test/')
 
 
 TEST_FILE_1_CONTENT = u"Hello 🍆🍔".encode("utf-8")
@@ -65,10 +64,10 @@ LIST_ARTIFACTS_SINGLE_FILE_RESPONSE = {
 
 class TestDbfsArtifactRepository(object):
     def test_init_validation_and_cleaning(self):
-        repo = DbfsArtifactRepository('dbfs:/test/', lambda: MlflowHostCreds('http://host'))
+        repo = DbfsArtifactRepository('dbfs:/test/')
         assert repo.artifact_uri == 'dbfs:/test'
         with pytest.raises(MlflowException):
-            DbfsArtifactRepository('s3://test', lambda: MlflowHostCreds('http://host'))
+            DbfsArtifactRepository('s3://test')
 
     @pytest.mark.parametrize("artifact_path,expected_endpoint", [
         (None, '/dbfs/test/test.txt'),

--- a/tests/store/test_ftp_artifact_repo.py
+++ b/tests/store/test_ftp_artifact_repo.py
@@ -1,5 +1,5 @@
 # pylint: disable=redefined-outer-name
-from mock import Mock, MagicMock
+from mock import MagicMock
 import pytest
 import os
 import ftplib
@@ -15,7 +15,7 @@ def ftp_mock():
 
 
 def test_artifact_uri_factory():
-    repo = get_artifact_repository("ftp://user:pass@test_ftp:123/some/path", Mock())
+    repo = get_artifact_repository("ftp://user:pass@test_ftp:123/some/path")
     assert isinstance(repo, FTPArtifactRepository)
 
 

--- a/tests/store/test_gcs_artifact_repo.py
+++ b/tests/store/test_gcs_artifact_repo.py
@@ -22,7 +22,7 @@ def gcs_mock():
 
 
 def test_artifact_uri_factory():
-    repo = get_artifact_repository("gs://test_bucket/some/path", mock.Mock())
+    repo = get_artifact_repository("gs://test_bucket/some/path")
     assert isinstance(repo, GCSArtifactRepository)
 
 

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -2,8 +2,6 @@ import os
 import unittest
 
 from mlflow.exceptions import MlflowException
-from mock import Mock
-
 from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.store.local_artifact_repo import LocalArtifactRepository
 from mlflow.utils.file_utils import TempDir
@@ -15,7 +13,7 @@ class TestLocalArtifactRepo(unittest.TestCase):
 
     def test_basic_functions(self):
         with TempDir() as test_root, TempDir() as tmp:
-            repo = get_artifact_repository(test_root.path(), Mock())
+            repo = get_artifact_repository(test_root.path())
             self.assertIsInstance(repo, LocalArtifactRepository)
             self.assertListEqual(repo.list_artifacts(), [])
             with self.assertRaises(Exception):

--- a/tests/store/test_s3_artifact_repo.py
+++ b/tests/store/test_s3_artifact_repo.py
@@ -1,6 +1,5 @@
 import os
 import posixpath
-from mock import Mock
 
 import boto3
 import pytest
@@ -33,7 +32,7 @@ def test_file_artifact_is_logged_and_downloaded_successfully(s3_artifact_root, t
     with open(file_path, "w") as f:
         f.write(file_text)
 
-    repo = get_artifact_repository(posixpath.join(s3_artifact_root, "some/path"), Mock())
+    repo = get_artifact_repository(posixpath.join(s3_artifact_root, "some/path"))
     repo.log_artifact(file_path)
     downloaded_text = open(repo.download_artifacts(file_name)).read()
     assert downloaded_text == file_text
@@ -51,7 +50,7 @@ def test_file_and_directories_artifacts_are_logged_and_downloaded_successfully_i
     with open(os.path.join(nested_path, "c.txt"), "w") as f:
         f.write("C")
 
-    repo = get_artifact_repository(posixpath.join(s3_artifact_root, "some/path"), Mock())
+    repo = get_artifact_repository(posixpath.join(s3_artifact_root, "some/path"))
     repo.log_artifacts(subdir_path)
 
     # Download individual files and verify correctness of their contents
@@ -89,7 +88,7 @@ def test_file_and_directories_artifacts_are_logged_and_listed_successfully_in_ba
     with open(os.path.join(nested_path, "c.txt"), "w") as f:
         f.write("C")
 
-    repo = get_artifact_repository(posixpath.join(s3_artifact_root, "some/path"), Mock())
+    repo = get_artifact_repository(posixpath.join(s3_artifact_root, "some/path"))
     repo.log_artifacts(subdir_path)
 
     root_artifacts_listing = sorted(
@@ -115,7 +114,7 @@ def test_download_directory_artifact_succeeds_when_artifact_root_is_s3_bucket_ro
     with open(os.path.join(nested_path, file_a_name), "w") as f:
         f.write(file_a_text)
 
-    repo = get_artifact_repository(s3_artifact_root, Mock())
+    repo = get_artifact_repository(s3_artifact_root)
     repo.log_artifacts(subdir_path)
 
     downloaded_dir_path = repo.download_artifacts("nested")
@@ -132,7 +131,7 @@ def test_download_file_artifact_succeeds_when_artifact_root_is_s3_bucket_root(
     with open(file_a_path, "w") as f:
         f.write(file_a_text)
 
-    repo = get_artifact_repository(s3_artifact_root, Mock())
+    repo = get_artifact_repository(s3_artifact_root)
     repo.log_artifact(file_a_path)
 
     downloaded_file_path = repo.download_artifacts(file_a_name)

--- a/tests/store/test_sftp_artifact_repo.py
+++ b/tests/store/test_sftp_artifact_repo.py
@@ -1,4 +1,4 @@
-from mock import Mock, MagicMock
+from mock import MagicMock
 import pytest
 from tempfile import NamedTemporaryFile
 import pysftp
@@ -16,9 +16,7 @@ def sftp_mock():
 def test_artifact_uri_factory():
     from paramiko.ssh_exception import SSHException
     with pytest.raises(SSHException):
-        get_artifact_repository(
-            "sftp://user:pass@test_sftp:123/some/path",
-            Mock())
+        get_artifact_repository("sftp://user:pass@test_sftp:123/some/path")
 
 
 def test_list_artifacts_empty(sftp_mock):

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -20,7 +20,7 @@ import mlflow.tensorflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow.exceptions import MlflowException
 from mlflow import pyfunc
-from mlflow.tracking.utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _get_model_log_dir
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 from tests.helper_functions import score_model_in_sagemaker_docker_container

--- a/tests/tracking/test_artifact_utils.py
+++ b/tests/tracking/test_artifact_utils.py
@@ -1,0 +1,47 @@
+import os
+
+import mlflow
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+
+
+def test_artifact_can_be_downloaded_from_absolute_uri_successfully(tmpdir):
+    artifact_file_name = "artifact.txt"
+    artifact_text = "Sample artifact text"
+    local_artifact_path = tmpdir.join(artifact_file_name).strpath
+    with open(local_artifact_path, "w") as out:
+        out.write(artifact_text)
+
+    logged_artifact_path = "artifact"
+    with mlflow.start_run():
+        mlflow.log_artifact(local_path=local_artifact_path, artifact_path=logged_artifact_path)
+        artifact_uri = mlflow.get_artifact_uri(artifact_path=logged_artifact_path)
+
+    downloaded_artifact_path = os.path.join(
+        _download_artifact_from_uri(artifact_uri), artifact_file_name)
+    assert downloaded_artifact_path != local_artifact_path
+    assert downloaded_artifact_path != logged_artifact_path
+    with open(downloaded_artifact_path, "r") as f:
+        assert f.read() == artifact_text
+
+
+def test_download_artifact_from_absolute_uri_persists_data_to_specified_output_directory(tmpdir):
+    artifact_file_name = "artifact.txt"
+    artifact_text = "Sample artifact text"
+    local_artifact_path = tmpdir.join(artifact_file_name).strpath
+    with open(local_artifact_path, "w") as out:
+        out.write(artifact_text)
+
+    logged_artifact_subdir = "logged_artifact"
+    with mlflow.start_run():
+        mlflow.log_artifact(local_path=local_artifact_path, artifact_path=logged_artifact_subdir)
+        artifact_uri = mlflow.get_artifact_uri(artifact_path=logged_artifact_subdir)
+
+    artifact_output_path = tmpdir.join("artifact_output").strpath
+    os.makedirs(artifact_output_path)
+    _download_artifact_from_uri(artifact_uri=artifact_uri, output_path=artifact_output_path)
+    assert logged_artifact_subdir in os.listdir(artifact_output_path)
+    assert artifact_file_name in os.listdir(
+        os.path.join(artifact_output_path, logged_artifact_subdir))
+    with open(os.path.join(
+            artifact_output_path, logged_artifact_subdir, artifact_file_name), "r") as f:
+        assert f.read() == artifact_text

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -435,8 +435,8 @@ def test_get_artifact_uri_with_artifact_path_unspecified_returns_artifact_root_d
 def test_get_artifact_uri_uses_currently_active_run_id():
     artifact_path = "artifact"
     with mlflow.start_run() as active_run:
-        assert mlflow.get_artifact_uri(artifact_path=artifact_path) ==\
-            tracking.utils.get_artifact_uri(
+        assert mlflow.get_artifact_uri(artifact_path=artifact_path) == \
+               mlflow.tracking.artifact_utils.get_artifact_uri(
                 run_id=active_run.info.run_uuid, artifact_path=artifact_path)
 
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -436,7 +436,7 @@ def test_get_artifact_uri_uses_currently_active_run_id():
     artifact_path = "artifact"
     with mlflow.start_run() as active_run:
         assert mlflow.get_artifact_uri(artifact_path=artifact_path) == \
-               mlflow.tracking.artifact_utils.get_artifact_uri(
+               tracking.artifact_utils.get_artifact_uri(
                 run_id=active_run.info.run_uuid, artifact_path=artifact_path)
 
 

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -10,7 +10,8 @@ from mlflow.store.rest_store import RestStore
 from mlflow.store.sqlalchemy_store import SqlAlchemyStore
 from mlflow.tracking.utils import _get_store, _TRACKING_URI_ENV_VAR, _TRACKING_USERNAME_ENV_VAR, \
     _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, _TRACKING_INSECURE_TLS_ENV_VAR, \
-    get_db_profile_from_uri, _download_artifact_from_uri, TrackingStoreRegistry
+    get_db_profile_from_uri, TrackingStoreRegistry
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 
 
 def test_get_store_file_store(tmp_wkdir):

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -11,7 +11,6 @@ from mlflow.store.sqlalchemy_store import SqlAlchemyStore
 from mlflow.tracking.utils import _get_store, _TRACKING_URI_ENV_VAR, _TRACKING_USERNAME_ENV_VAR, \
     _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, _TRACKING_INSECURE_TLS_ENV_VAR, \
     get_db_profile_from_uri, TrackingStoreRegistry
-from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 
 
 def test_get_store_file_store(tmp_wkdir):
@@ -280,46 +279,3 @@ def test_get_store_for_unregistered_scheme():
 
 def test_get_db_profile_from_uri_casing():
     assert get_db_profile_from_uri('databricks://aAbB') == 'aAbB'
-
-
-def test_artifact_can_be_downloaded_from_absolute_uri_successfully(tmpdir):
-    artifact_file_name = "artifact.txt"
-    artifact_text = "Sample artifact text"
-    local_artifact_path = tmpdir.join(artifact_file_name).strpath
-    with open(local_artifact_path, "w") as out:
-        out.write(artifact_text)
-
-    logged_artifact_path = "artifact"
-    with mlflow.start_run():
-        mlflow.log_artifact(local_path=local_artifact_path, artifact_path=logged_artifact_path)
-        artifact_uri = mlflow.get_artifact_uri(artifact_path=logged_artifact_path)
-
-    downloaded_artifact_path = os.path.join(
-        _download_artifact_from_uri(artifact_uri), artifact_file_name)
-    assert downloaded_artifact_path != local_artifact_path
-    assert downloaded_artifact_path != logged_artifact_path
-    with open(downloaded_artifact_path, "r") as f:
-        assert f.read() == artifact_text
-
-
-def test_download_artifact_from_absolute_uri_persists_data_to_specified_output_directory(tmpdir):
-    artifact_file_name = "artifact.txt"
-    artifact_text = "Sample artifact text"
-    local_artifact_path = tmpdir.join(artifact_file_name).strpath
-    with open(local_artifact_path, "w") as out:
-        out.write(artifact_text)
-
-    logged_artifact_subdir = "logged_artifact"
-    with mlflow.start_run():
-        mlflow.log_artifact(local_path=local_artifact_path, artifact_path=logged_artifact_subdir)
-        artifact_uri = mlflow.get_artifact_uri(artifact_path=logged_artifact_subdir)
-
-    artifact_output_path = tmpdir.join("artifact_output").strpath
-    os.makedirs(artifact_output_path)
-    _download_artifact_from_uri(artifact_uri=artifact_uri, output_path=artifact_output_path)
-    assert logged_artifact_subdir in os.listdir(artifact_output_path)
-    assert artifact_file_name in os.listdir(
-        os.path.join(artifact_output_path, logged_artifact_subdir))
-    with open(os.path.join(
-            artifact_output_path, logged_artifact_subdir, artifact_file_name), "r") as f:
-        assert f.read() == artifact_text


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
This PR removes the `store` parameter from `ArtifactRepositoryRegistry.get_artifact_repository()`. It does so by having `DBFSArtifactRepository` internally resolve the host credentials via `tracking.utils._get_store()`. 

This led to a circular import: `tracking.utils` (for artifact/model methods) imports `get_artifact_repository` imports `DBFSArtifactRepository` imports `tracking.utils._get_store`.  Python 2 did not like this (Python 3.5+ supports circular imports better), so moved out the artifact-related methods from `tracking.utils` to `tracking.artifact_utils`. A lot of the changes in the PR are simple refactors due to this move.
 
This change will allow Artifact Repositories to be used for downloading artifacts outside the Tracking context, e.g. in `<model-type>.load_model`. 

## How is this patch tested?
 
```
$ ./lint.sh
$ pytest
```
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. Add the `rn/none` label, then you can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Removed `store` argument from ``ArtifactRepositoryRegistry.get_artifact_store``. This is not a user-facing change, but may impact those writing ArtifactRepository plug-ins.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [X] Tracking
- [ ] Projects 
- [X] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python
