### PR TITLE
Fix log_parameter -> log_param in mleap doc

### DIFF
--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -61,8 +61,8 @@ def log_model(spark_model, sample_input, artifact_path):
     >>> pipeline = Pipeline(stages=[tokenizer, hashingTF, lr])
     >>> model = pipeline.fit(training)
     >>> #log parameters
-    >>> mlflow.log_parameter("max_iter", 10)
-    >>> mlflow.log_parameter("reg_param", 0.001)
+    >>> mlflow.log_param("max_iter", 10)
+    >>> mlflow.log_param("reg_param", 0.001)
     >>> #log the Spark MLlib model in MLeap format
     >>> mlflow.mleap.log_model(model, test_df, "mleap-model")
     """


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fix MLeap example to call `mlflow.log_param` instead of nonexistent `mlflow.log_parameter`
 
## How is this patch tested?
 
N/A
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. Add the `rn/none` label, then you can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [X] Examples 
- [X] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python
