### PR TITLE
Update master post 0.9.1 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,30 @@
 Changelog
 =========
 
+0.9.1 (2019-04-21)
+------------------
+MLflow 0.9.1 is a patch release on top of 0.9.0 containing mostly bug fixes and internal improvements. We have also included a one breaking API change in preparation for additions in MLflow 1.0 and later. This release also includes significant improvements to the Search API.
+
+Breaking changes:
+
+- [Tracking] Generalized experiment_id to string (from a long) to be more permissive of different ID types in different backend stores. While breaking for the REST API, this change is backwards compatible for python and R clients. (#1067, #1034 @eedeleon)
+
+More features and improvements:
+
+- [Search][API] Moving search filters into a query string based syntax, with Java client, python client, and UI support. This also improves quote, period, and special character handling in query strings and adds the ability to search on tags in filter string. (#1042, #1055, #1063, #1068, #1099, #1106 @mparkhe; #1025 @andrewmchen; #1060 @smurching)
+- [Tracking] Limits and validations to batch-logging APIs in OSS server (#958 @smurching)
+- [Tracking][Java] Java client API for batch-logging (#1081 @mparkhe)
+- [Tracking] Improved consistency of handling multiple metric values per timestamp across tracking stores (#972, #999 @dbczumar)
+
+Bug fixes and documentation updates:
+
+- [Tracking][Python] Reintroduces the parent_run_id argument to MlflowClient.create_run. This API is planned for removal in MLflow 1.0 (#1137 @smurching)
+- [Tracking][Python] Provide default implementations of AbstractStore log methods (#1051 @acroz)
+- [R] (Released on CRAN as MLflow 0.9.0.1) Small bug fixes with R (#1123 @smurching; #1045, #1017, #1019, #1039, #1048, #1098,  #1101, #1107, #1108, #1119 @tomasatdatabricks)
+
+Small bug fixes and doc updates (#1024, #1029 @bayethiernodiop; #1075 @avflor; #968, #1010, #1070, #1091, #1092 @smurching; #1004, #1085 @dbczumar; #1033, #1046 @sueann; #1053 @tomasatdatabricks; #987 @hanyucui; #935, #941 @jimthompson5802; #963 @amilbourne; #1016 @andrewmchen; #991 @jaroslawk; #1007 @mparkhe)
+
+
 0.9.0.1 (2019-04-09)
 --------------------
 Bugfix release (PyPI only) with the following changes:
@@ -36,7 +60,7 @@ More features and improvements:
 
 - [UI] Add a button for downloading artifacts (#967, @mateiz)
 - [CLI] Add CLI commands for runs: now you can ``list``, ``delete``, ``restore``, and ``describe`` runs through the CLI (#720, @DorIndivo)
-- [CLI] The ``run`` command now can take ``--experiment-name`` as an argument, as an alternative to the ``--experiment-id`` argument. You can also choose to set the ``_EXPERIMENT_NAME_ENV_VAR`` environment variable instead of passing in the value explicitly. (#889, #894, @mparke)
+- [CLI] The ``run`` command now can take ``--experiment-name`` as an argument, as an alternative to the ``--experiment-id`` argument. You can also choose to set the ``_EXPERIMENT_NAME_ENV_VAR`` environment variable instead of passing in the value explicitly. (#889, #894, @mparkhe)
 - [Examples] Add Image classification example with Keras. (#743, @tomasatdatabricks )
 - [Artifacts] Add ``get_artifact_uri()`` and ``_download_artifact_from_uri`` convenience functions (#779)
 - [Artifacts] Allow writing Spark models directly to the target artifact store when possible (#808, @smurching)
@@ -46,7 +70,7 @@ More features and improvements:
 - [Runs][R] Allow client to infer context info when creating new run in fluent API (#958, @tomasatdatabricks)
 - [Runs][UI] Support Git Commit hyperlink for Gitlab and Bitbucket. Previously the clickable hyperlink was generated only for Github pages. (#901)
 - [Search][API] Allow param value to have any content, not just alphanumeric characters, ``.``, and ``-`` (#788, @mparkhe)
-- [Search][API] Support "filter" string in the ``SearchRuns`` API. Corresponding UI improvements are planned for the future (#905, @mparke)
+- [Search][API] Support "filter" string in the ``SearchRuns`` API. Corresponding UI improvements are planned for the future (#905, @mparkhe)
 - [Logging] Basic support for LogBatch. NOTE: The feature is currently experimental and the behavior is expected to change in the near future. (#950, #951, #955, #1001, @smurching)
 
 

--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mlflow
 Type: Package
 Title: Interface to 'MLflow'
-Version: 0.9.1
+Version: 0.9.2
 Authors@R: c(
   person("Matei", "Zaharia", email = "matei@databricks.com", role = c("aut", "cre")),
   person("Javier", "Luraschi", email = "javier@rstudio.com", role = c("aut")),

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -3,12 +3,28 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.mlflow</groupId>
   <artifactId>mlflow-parent</artifactId>
-  <version>0.9.1</version>
+  <version>0.9.2</version>
   <packaging>pom</packaging>
   <name>MLflow Parent POM</name>
   <url>http://mlflow.org</url>
 
   <description>Open source platform for the machine learning lifecycle</description>
+
+  <repositories>
+    <repository>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
+    </repository>
+  </repositories>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>google-maven-central</id>
+      <name>Google Maven Central</name>
+      <url>https://maven-central.storage-download.googleapis.com/repos/central/data</url>
+    </pluginRepository>
+  </pluginRepositories>
 
   <!-- The following sections (licenses, developers, scm, and distributionManagement) are needed to
        publish pom-only packages to Maven -->

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,4 +1,4 @@
 # Copyright 2018 Databricks, Inc.
 
 
-VERSION = '0.9.1.dev0'
+VERSION = '0.9.2.dev0'


### PR DESCRIPTION
Updating CHANGELOG.rst from branch-0.9.1, bumping version number, and adding Google Maven Central mirror usage. 

## What changes are proposed in this pull request?

This change updating CHANGELOG.rst from branch-0.9.1, bumps version number, and adds Google Maven Central mirror usage. It also has small typo fixes in CHANGELOG.rst.
 
## How is this patch tested?
 
Automated Travis tests.
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. Add the `rn/none` label, then you can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### Please add one label to the PR so it can be classified correctly in the release notes. Options:
 
* `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
* `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section
* `rn/feature` - A new user-facing feature worth mentioning in the release notes
* `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
* `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
