### PR TITLE
Apply maximum runs limit in the Search UI

### DIFF
--- a/mlflow/server/js/src/Actions.js
+++ b/mlflow/server/js/src/Actions.js
@@ -1,6 +1,8 @@
 import { MlflowService } from './sdk/MlflowService';
 import ErrorCodes from './sdk/ErrorCodes';
 
+export const SEARCH_MAX_RESULTS = 1000;
+
 export const isPendingApi = (action) => {
   return action.type.endsWith("_PENDING");
 };
@@ -81,7 +83,10 @@ export const searchRunsApi = (experimentIds, filter, runViewType, id = getUUID()
   return {
     type: SEARCH_RUNS_API,
     payload: wrapDeferred(MlflowService.searchRuns, {
-      experiment_ids: experimentIds, filter: filter, run_view_type: runViewType
+      experiment_ids: experimentIds,
+      filter: filter,
+      run_view_type: runViewType,
+      max_results: SEARCH_MAX_RESULTS + 1,
     }),
     meta: { id: id },
   };

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -401,7 +401,7 @@ export class ExperimentView extends Component {
           <div className="ExperimentView-run-buttons">
             <span className="run-count">
               {runInfos.length > SEARCH_MAX_RESULTS ?
-                'Showing the latest 1000 matching runs' :
+                `Showing the latest ${SEARCH_MAX_RESULTS} matching runs` :
                 `${runInfos.length} matching ${runInfos.length === 1 ? 'run' : 'runs'}`
               }
             </span>

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -25,6 +25,7 @@ import { Icon, Popover } from 'antd';
 
 import Utils from '../utils/Utils';
 import {Spinner} from "./Spinner";
+import {SEARCH_MAX_RESULTS} from "../Actions";
 
 export const DEFAULT_EXPANDED_VALUE = false;
 
@@ -399,7 +400,10 @@ export class ExperimentView extends Component {
           </form>
           <div className="ExperimentView-run-buttons">
             <span className="run-count">
-              {runInfos.length} matching {runInfos.length === 1 ? 'run' : 'runs'}
+              {runInfos.length > SEARCH_MAX_RESULTS ?
+                'Showing the latest 1000 matching runs' :
+                `${runInfos.length} matching ${runInfos.length === 1 ? 'run' : 'runs'}`
+              }
             </span>
             <Button className="btn-primary" disabled={compareDisabled} onClick={this.onCompare}>
               Compare

--- a/mlflow/server/js/src/components/ExperimentView.test.js
+++ b/mlflow/server/js/src/components/ExperimentView.test.js
@@ -5,7 +5,7 @@ import Fixtures from "../test-utils/Fixtures";
 import {LIFECYCLE_FILTER} from "./ExperimentPage";
 import KeyFilter from "../utils/KeyFilter";
 import {addApiToState, addExperimentToState, createPendingApi, emptyState} from "../test-utils/ReduxStoreFixtures";
-import {getUUID} from "../Actions";
+import {getUUID, SEARCH_MAX_RESULTS} from "../Actions";
 import {Spinner} from "./Spinner";
 
 let onSearchSpy;
@@ -78,4 +78,16 @@ test("mapStateToProps doesn't blow up if the searchRunsApi is pending", () => {
     paramsList: [],
     tagsList: [],
   });
+});
+
+test(`Says that the SEARCH_RUNS_LIMIT is hit when more than ${SEARCH_MAX_RESULTS} runs are returned`, () => {
+  const wrapper = getExperimentViewMock();
+  wrapper.setProps({ runInfos: Array(SEARCH_MAX_RESULTS + 1) });
+  expect(wrapper.find('.run-count').text()).toEqual(`Showing the latest ${SEARCH_MAX_RESULTS} matching runs`);
+});
+
+test(`Doesn't say the SEARCH_RUNS_LIMIT is hit when <= than ${SEARCH_MAX_RESULTS} runs are returned`, () => {
+  const wrapper = getExperimentViewMock();
+  wrapper.setProps({ runInfos: Array(SEARCH_MAX_RESULTS) });
+  expect(wrapper.find('.run-count').text()).toEqual(`${SEARCH_MAX_RESULTS} matching runs`);
 });

--- a/mlflow/server/js/src/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/components/ExperimentViewUtil.js
@@ -3,6 +3,7 @@ import Utils from "../utils/Utils";
 import { Link } from 'react-router-dom';
 import Routes from '../Routes';
 import { DEFAULT_EXPANDED_VALUE } from './ExperimentView';
+import { SEARCH_MAX_RESULTS } from '../Actions';
 
 export default class ExperimentViewUtil {
   /** Returns checkbox cell for a row. */
@@ -400,7 +401,7 @@ export default class ExperimentViewUtil {
         }
       }
     });
-    return mergedRows;
+    return mergedRows.slice(0, SEARCH_MAX_RESULTS);
   }
 
   static getRows({ runInfos, sortState, paramsList, metricsList, tagsList, runsExpanded, getRow }) {


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
In this PR, we apply a limit of 1000 runs to be returned in the experiment view. For users who would like to see more runs, they should go ahead and provide a search query in the UI to filter down the results or use the search API directly.
 
## How is this patch tested?
 
Added two unit tests for the runs limit message and did manual testing.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. Add the `rn/none` label, then you can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
The experiment view in the UI will now return a maximum of 1000 runs. This is a holdover feature until we implement proper pagination in the UI.
 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### Please add one label to the PR so it can be classified correctly in the release notes. Options:
 
* `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
* `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section
* `rn/feature` - A new user-facing feature worth mentioning in the release notes
* `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
* `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
