### PR TITLE
.travis.yml: The 'sudo' tag is now deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: true
 language: python
 
 services:
@@ -9,7 +8,6 @@ matrix:
     - python: 2.7
     - python: 3.6
     - language: r
-      dist: trusty
       cache: packages
       before_install:
         - export NOT_CRAN=true


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo: false__ in your __.travis.yml__, we recommend removing that configuration_"

Also, do not hard-code __Trusty__ because it reaches its end-of-life this month.
https://wiki.ubuntu.com/Releases