### PR TITLE
lint.sh: Upgrade from pep8 to flake8

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -5,7 +5,7 @@ set -e
 FWDIR="$(cd "`dirname $0`"; pwd)"
 cd "$FWDIR"
 
-flake8 --max-line-length=100 --exclude mlflow/protos,mlflow/server/js -- mlflow tests
+flake8 --max-line-length=100 --exclude mlflow/protos,mlflow/server/js .
 pylint --msg-template="{path} ({line},{column}): [{msg_id} {symbol}] {msg}" --rcfile="$FWDIR/pylintrc" -- mlflow tests
 
 rstcheck README.rst

--- a/lint.sh
+++ b/lint.sh
@@ -5,7 +5,7 @@ set -e
 FWDIR="$(cd "`dirname $0`"; pwd)"
 cd "$FWDIR"
 
-pycodestyle --max-line-length=100 --exclude mlflow/protos,mlflow/server/js -- mlflow tests
+flake8 --max-line-length=100 --exclude mlflow/protos,mlflow/server/js -- mlflow tests
 pylint --msg-template="{path} ({line},{column}): [{msg_id} {symbol}] {msg}" --rcfile="$FWDIR/pylintrc" -- mlflow tests
 
 rstcheck README.rst

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,11 +4,11 @@ google-cloud-storage==1.14.0
 h2o==3.22.1.4
 botocore<=1.12.84
 boto3<=1.9.84
+flake8>=3.7.7
 mock==2.0.0
 moto==1.3.7
 pandas<=0.23.4
 prospector[with_pyroma]==0.12.7
-pep8==1.7.1
 pyarrow==0.12.1
 pylint==1.8.2
 pyspark==2.4.0


### PR DESCRIPTION
pep8 is a backleveled version of pycodestyle.  flake8 is a superset of the current pycodestyle that adds other tests as well.