### PR TITLE
Fix copying of project's code into docker container

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -707,7 +707,7 @@ def _build_docker_image(work_dir, project, active_run):
     dockerfile = (
         "FROM {imagename}\n"
         "LABEL Name={tag_name}\n"
-        "COPY {build_context_path}/* /mlflow/projects/code/\n"
+        "COPY {build_context_path} /mlflow/projects/code/\n"
         "WORKDIR /mlflow/projects/code/\n"
     ).format(imagename=project.docker_env.get('image'), tag_name=tag_name,
              build_context_path=_PROJECT_TAR_ARCHIVE_NAME)

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -15,6 +15,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_DOCKER_IMAGE_NAM
 
 from tests.projects.utils import TEST_DOCKER_PROJECT_DIR
 from tests.projects.utils import build_docker_example_base_image
+from tests.projects.utils import docker
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 
@@ -60,6 +61,14 @@ def test_docker_project_execution(
         assert run_tags[k] == v
     for k, v in approx_expected_tags.items():
         assert run_tags[k].startswith(v)
+    # Check if project's directory structure is copied properly into docker image.
+    client = docker.from_env()
+    project_subdirectory_exists = client.containers.run(
+        run.data.tags['mlflow.docker.image.name'],
+        'sh -c \'if [ -d "subdirectory" ]; then (echo "yes") else (echo "no") fi\'',
+        auto_remove=True
+    ).strip()
+    assert project_subdirectory_exists == 'yes'
 
 
 @pytest.mark.parametrize("tracking_uri, expected_command_segment", [

--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -1,3 +1,3 @@
-FROM continuumio/miniconda:4.5.4
+FROM continuumio/miniconda:4.5.12
 
-RUN pip install mlflow==0.8.1
+RUN pip install mlflow==0.9.0.1

--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -1,3 +1,3 @@
 FROM continuumio/miniconda:4.5.12
 
-RUN pip install mlflow==0.9.0.1
+RUN pip install mlflow==0.9.1

--- a/tests/resources/example_docker_project/subdirectory/subdirectory_file
+++ b/tests/resources/example_docker_project/subdirectory/subdirectory_file
@@ -1,0 +1,1 @@
+# Test file to check if subdirectories are copied properly into docker image.


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
This changeset fixes the copying of project's code into a docker container. Before the change, the files were copied in a wrong way, flattening the project's directory structure:

```
COPY {build_context_path}/* /mlflow/projects/code/\n
```

Now files are copied properly leaving project structure intact:

```
COPY {build_context_path} /mlflow/projects/code/\n
```
 
## How is this patch tested?
 
I've added tests to `tests/projects/test_docker_projects.py`.
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. Add the `rn/none` label, then you can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [x] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### Please add one label to the PR so it can be classified correctly in the release notes. Options:
 
* `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
* `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section
* `rn/feature` - A new user-facing feature worth mentioning in the release notes
* `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
* `rn/documentation` - A user-facing documentation change worth mentioning in the release notes