### PR TITLE
Remove pyarrow as an explicit dependency of MLflow

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         'docker>=3.6.0',
         'entrypoints',
         'sqlparse',
-        'pyarrow>=0.12.0'
     ],
     entry_points='''
         [console_scripts]


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Removes Pyarrow as an explicit dependency of MLflow. Pyarrow is primarily used for Spark UDF functionality - since PySpark isn't bundled with MLflow, it doesn't make sense for pyarrow to be.

## How is this patch tested?
 
Existing tests
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. Add the `rn/none` label, then you can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### Please add one label to the PR so it can be classified correctly in the release notes. Options:
 
* `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
* `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section
* `rn/feature` - A new user-facing feature worth mentioning in the release notes
* `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
* `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
