### PR TITLE
Revert "Fix mlflow was not loaded from conda env in current. (#1037)"

### DIFF
--- a/mlflow/pyfunc/cli.py
+++ b/mlflow/pyfunc/cli.py
@@ -24,8 +24,8 @@ def _rerun_in_conda(conda_env_path):
     activate_path = _get_conda_bin_executable("activate")
     commands = []
     commands.append("source {} {}".format(activate_path, conda_env_name))
-    safe_argv = [shlex_quote(arg) for arg in sys.argv[1:]]
-    commands.append("mlflow " + " ".join(safe_argv) + " --no-conda")
+    safe_argv = [shlex_quote(arg) for arg in sys.argv]
+    commands.append(" ".join(safe_argv) + " --no-conda")
     commandline = " && ".join(commands)
     _logger.info("=== Running command '%s'", commandline)
     child = subprocess.Popen(["bash", "-c", commandline], close_fds=True)


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
This reverts commit e0fb2bf4876db8a5db9cd96c1288dd128e40dfd6 from #1037, which contains a useful fix for Conda users but unfortunately broke tests - we'll try to re-merge the PR such that it doesn't break tests after this revert.
 
## How is this patch tested?
 
Existing tests
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. Add the `rn/none` label, then you can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [x] Models 
- [x] Scoring 
- [x] Serving
- [ ] R
- [ ] Java
- [ ] Python

### Please add one label to the PR so it can be classified correctly in the release notes. Options:
 
* `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
* `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section
* `rn/feature` - A new user-facing feature worth mentioning in the release notes
* `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
* `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
