### PR TITLE
Fix bug when deserializing integer experiment ID for runs in SQLAlchemyStore

### DIFF
--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -35,7 +35,7 @@ def create(experiment_name, artifact_location):
     """
     store = _get_store()
     exp_id = store.create_experiment(experiment_name, artifact_location)
-    print("Created experiment '%s' with id %d" % (experiment_name, exp_id))
+    print("Created experiment '%s' with id %s" % (experiment_name, exp_id))
 
 
 @commands.command("list")

--- a/mlflow/store/dbmodels/models.py
+++ b/mlflow/store/dbmodels/models.py
@@ -60,6 +60,8 @@ def _create_entity(base, model):
                     obj = SourceType.from_string(obj)
                 elif k == "status":
                     obj = RunStatus.from_string(obj)
+                elif k == "experiment_id":
+                    obj = str(obj)
 
         # Our data model defines experiment_ids as ints, but the in-memory representation was
         # changed to be a string in time for 1.0.

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -383,7 +383,7 @@ class SqlAlchemyStore(AbstractStore):
                 # we would be unable to determine the cause of failure for the first session's
                 # "commit" operation.
                 session.commit()
-            except sqlalchemy.exc.IntegrityError as e:
+            except sqlalchemy.exc.IntegrityError:
                 # Roll back the current session to make it usable for further transactions. In the
                 # event of an error during "commit", a rollback is required in order to continue
                 # using the session. In this case, we re-use the session because the SqlRun, `run`,

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -184,6 +184,7 @@ class SqlAlchemyStore(AbstractStore):
                 raise MlflowException('Experiment(name={}) already exists. '
                                       'Error: {}'.format(name, str(e)), RESOURCE_ALREADY_EXISTS)
 
+            session.flush()
             return str(experiment.experiment_id)
 
     def _list_experiments(self, session, ids=None, names=None, view_type=ViewType.ACTIVE_ONLY):
@@ -277,13 +278,14 @@ class SqlAlchemyStore(AbstractStore):
                          start_time=start_time, end_time=None,
                          source_version=source_version, lifecycle_stage=LifecycleStage.ACTIVE)
 
+            tags_dict = {}
             for tag in tags:
-                run.tags.append(SqlTag(key=tag.key, value=tag.value))
+                tags_dict[tag.key] = tag.value
             if parent_run_id:
-                run.tags.append(SqlTag(key=MLFLOW_PARENT_RUN_ID, value=parent_run_id))
+                tags_dict[MLFLOW_PARENT_RUN_ID] = parent_run_id
             if run_name:
-                run.tags.append(SqlTag(key=MLFLOW_RUN_NAME, value=run_name))
-
+                tags_dict[MLFLOW_RUN_NAME] = run_name
+            run.tags = [SqlTag(key=key, value=value) for key, value in tags_dict.items()]
             self._save_to_db(objs=run, session=session)
 
             return run.to_mlflow_entity()
@@ -381,7 +383,7 @@ class SqlAlchemyStore(AbstractStore):
                 # we would be unable to determine the cause of failure for the first session's
                 # "commit" operation.
                 session.commit()
-            except sqlalchemy.exc.IntegrityError:
+            except sqlalchemy.exc.IntegrityError as e:
                 # Roll back the current session to make it usable for further transactions. In the
                 # event of an error during "commit", a rollback is required in order to continue
                 # using the session. In this case, we re-use the session because the SqlRun, `run`,

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -352,40 +352,51 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         expected = self._get_run_configs(
             name=run_name, experiment_id=experiment_id, parent_run_id=parent_run_id)
 
-        actual = self.store.create_run(**expected)
+        created_run = self.store.create_run(**expected)
+        fetched_run = self.store.get_run(created_run.info.run_uuid)
 
-        self.assertEqual(actual.info.experiment_id, experiment_id)
-        self.assertEqual(actual.info.user_id, expected["user_id"])
-        self.assertEqual(actual.info.name, run_name)
-        self.assertEqual(actual.info.source_type, expected["source_type"])
-        self.assertEqual(actual.info.source_name, expected["source_name"])
-        self.assertEqual(actual.info.source_version, expected["source_version"])
-        self.assertEqual(actual.info.entry_point_name, expected["entry_point_name"])
-        self.assertEqual(actual.info.start_time, expected["start_time"])
+        for actual in [created_run, fetched_run]:
+            self.assertEqual(actual.info.experiment_id, experiment_id)
+            self.assertEqual(actual.info.user_id, expected["user_id"])
+            self.assertEqual(actual.info.name, run_name)
+            self.assertEqual(actual.info.source_type, expected["source_type"])
+            self.assertEqual(actual.info.source_name, expected["source_name"])
+            self.assertEqual(actual.info.source_version, expected["source_version"])
+            self.assertEqual(actual.info.entry_point_name, expected["entry_point_name"])
+            self.assertEqual(actual.info.start_time, expected["start_time"])
 
-        # Run creation should add two additional tags containing the run name and parent run id.
-        # Check for the existence of these two tags
-        self.assertEqual(
-            actual.data.tags, {MLFLOW_PARENT_RUN_ID: parent_run_id, MLFLOW_RUN_NAME: run_name})
+            # Run creation should add two additional tags containing the run name and parent run id.
+            # Check for the existence of these two tags
+            self.assertEqual(
+                actual.data.tags, {MLFLOW_PARENT_RUN_ID: parent_run_id, MLFLOW_RUN_NAME: run_name})
 
-    def test_to_mlflow_entity(self):
-        # Create a run and obtain an MLflow Run entity associated with the new run
-        run = self._run_factory()
+    def test_to_mlflow_entity_and_proto(self):
+        # Create a run and log metrics, params, tags to the run
+        created_run = self._run_factory()
+        run_uuid = created_run.info.run_uuid
+        self.store.log_metric(
+            run_uuid=run_uuid,
+            metric=entities.Metric(key='my-metric', value=3.4, timestamp=0, step=0))
+        self.store.log_param(run_uuid=run_uuid, param=Param(key='my-param', value='param-val'))
+        self.store.set_tag(run_uuid=run_uuid, tag=RunTag(key='my-tag', value='tag-val'))
 
+        # Verify that we can fetch the run & convert it to proto - Python protobuf bindings
+        # will perform type-checking to ensure all values have the right types
+        run = self.store.get_run(run_uuid)
+        run.to_proto()
+
+        # Verify attributes of the Python run entity
         self.assertIsInstance(run.info, entities.RunInfo)
         self.assertIsInstance(run.data, entities.RunData)
 
-        for key, metric in run.data.metrics.items():
-            self.assertEqual(metric.key, key)
-            self.assertIsInstance(metric, entities.Metric)
+        self.assertEqual(run.data.metrics, {"my-metric": 3.4})
+        self.assertEqual(run.data.params, {"my-param": "param-val"})
+        self.assertEqual(run.data.tags["my-tag"], "tag-val")
 
-        for param_key, param_val in run.data.params:
-            self.assertIsInstance(param_key, str)
-            self.assertIsInstance(param_val, str)
+        # Get the parent experiment of the run, verify it can be converted to protobuf
+        exp = self.store.get_experiment(run.info.experiment_id)
+        exp.to_proto()
 
-        for tag_key, tag_val in run.data.tags.items():
-            self.assertIsInstance(tag_key, str)
-            self.assertIsInstance(tag_val, str)
 
     def test_delete_run(self):
         run = self._run_factory()
@@ -474,6 +485,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         param2 = entities.Param('new param', 'new key')
         self.store.log_param(run.info.run_uuid, param)
         self.store.log_param(run.info.run_uuid, param2)
+        self.store.log_param(run.info.run_uuid, param2)
 
         run = self.store.get_run(run.info.run_uuid)
         self.assertEqual(2, len(run.data.params))
@@ -522,11 +534,15 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
         tkey = 'test tag'
         tval = 'a boogie'
+        new_val = "new val"
         tag = entities.RunTag(tkey, tval)
+        new_tag = entities.RunTag(tkey, new_val)
         self.store.set_tag(run.info.run_uuid, tag)
+        # Overwriting tags is allowed
+        self.store.set_tag(run.info.run_uuid, new_tag)
 
         run = self.store.get_run(run.info.run_uuid)
-        self.assertTrue(tkey in run.data.tags and run.data.tags[tkey] == tval)
+        self.assertTrue(tkey in run.data.tags and run.data.tags[tkey] == new_val)
 
     def test_get_metric_history(self):
         run = self._run_factory()

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -397,7 +397,6 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         exp = self.store.get_experiment(run.info.experiment_id)
         exp.to_proto()
 
-
     def test_delete_run(self):
         run = self._run_factory()
 

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -164,7 +164,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
             self.assertEqual(len(result), 1)
 
         experiment_id = self.store.create_experiment(name='test exp')
-
+        self.assertEqual(experiment_id, "1")
         with self.store.ManagedSessionMaker() as session:
             result = session.query(models.SqlExperiment).all()
             self.assertEqual(len(result), 2)

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -25,7 +25,14 @@ from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME, MLFLOW_PARENT_RUN_ID, MLFL
 
 
 LOCALHOST = '127.0.0.1'
+server_root_dir = tempfile.mkdtemp("test_rest_tracking")
+artifact_root_dir = tempfile.mkdtemp(suffix="artifacts", dir=server_root_dir)
+BACKEND_URIS = [
+    "sqlite:////%s/test-database.db" % server_root_dir,  # SQLAlchemyStore
+    os.path.join(server_root_dir, "file_store_root"),  # FileStore
+]
 
+BACKEND_URI_TO_SERVER_URL = {}
 
 def _await_server_up_or_die(port, timeout=60):
     """Waits until the local flask server is listening on the given port."""
@@ -73,7 +80,6 @@ def _init_server(backend_uri):
     print("Lauenching tracking server against backend  URI %s, res %s" % (backend_uri, res))
     return res, process
 
-
 def _get_safe_port():
     """Returns an ephemeral port that is very likely to be free to bind to."""
     sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -82,41 +88,31 @@ def _get_safe_port():
     sock.close()
     return port
 
-server_root_dir = tempfile.mkdtemp("test_rest_tracking")
-artifact_root_dir = tempfile.mkdtemp(suffix="artifacts", dir=server_root_dir)
-BACKEND_URIS = [
-    "sqlite:////%s/test-database.db" % server_root_dir,  # SQLAlchemyStore
-    os.path.join(server_root_dir, "file_store_root"),  # FileStore
-]
-SERVER_URLS = []
-SERVER_PROCS = []
-BACKEND_URI_TO_SERVER_URL = {}
-for uri in BACKEND_URIS:
-    server_url, process = _init_server(backend_uri=uri)
-    SERVER_PROCS.append(process)
-    SERVER_URLS.append(server_url)
-    BACKEND_URI_TO_SERVER_URL[uri] = server_url
-
-
-def pytest_generate_tests(metafunc):
-    """
-    Dynamically pass the list of generated
-    """
-    if 'backend_store_uri' in metafunc.fixturenames:
-        metafunc.parametrize('backend_store_uri', BACKEND_URIS)
-
 @pytest.fixture(scope="module", autouse=True)
 def server_urls():
     """
     Clean up all servers created for testing in `pytest_generate_tests`
     """
+    server_procs = []
+    global BACKEND_URI_TO_SERVER_URL
+    for uri in BACKEND_URIS:
+        server_url, process = _init_server(backend_uri=uri)
+        BACKEND_URI_TO_SERVER_URL[server_url] = uri
+        server_procs.append(process)
     yield
-    for server_url, process in zip(SERVER_URLS, SERVER_PROCS):
-        print("Terminating server at %s..." % (server_url))
+    for i, process in enumerate(server_procs):
+        print("Terminating server (%s of %s)..." % (i, len(server_procs)))
         process.terminate()
         _await_server_down_or_die(process)
     shutil.rmtree(server_root_dir)
 
+
+def pytest_generate_tests(metafunc):
+    """
+    Automatically parametrize each each fixture/test with the list of backend store URIs
+    """
+    if 'backend_store_uri' in metafunc.fixturenames:
+        metafunc.parametrize('backend_store_uri', BACKEND_URIS)
 
 @pytest.fixture()
 def tracking_server_uri(backend_store_uri):

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -12,7 +12,6 @@ import shutil
 import time
 import tempfile
 
-from click.testing import CliRunner
 
 import mlflow.experiments
 from mlflow.entities import RunStatus, Metric, Param, RunTag
@@ -22,7 +21,7 @@ from mlflow.tracking import MlflowClient
 from mlflow.tracking.utils import _tracking_store_registry
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME, MLFLOW_PARENT_RUN_ID, MLFLOW_SOURCE_TYPE, \
     MLFLOW_SOURCE_NAME, MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_GIT_COMMIT
-
+from tests.integration.utils import invoke_cli_runner
 
 LOCALHOST = '127.0.0.1'
 
@@ -170,12 +169,12 @@ def test_delete_restore_experiment(mlflow_client):
 
 def test_delete_restore_experiment_cli(mlflow_client, cli_env):
     experiment_name = "DeleteriousCLI"
-    CliRunner(env=cli_env).invoke(mlflow.experiments.commands, ['create', experiment_name])
+    invoke_cli_runner(mlflow.experiments.commands, ['create', experiment_name], env=cli_env)
     experiment_id = mlflow_client.get_experiment_by_name(experiment_name).experiment_id
     assert mlflow_client.get_experiment(experiment_id).lifecycle_stage == 'active'
-    CliRunner(env=cli_env).invoke(mlflow.experiments.commands, ['delete', str(experiment_id)])
+    invoke_cli_runner(mlflow.experiments.commands, ['delete', str(experiment_id)], env=cli_env)
     assert mlflow_client.get_experiment(experiment_id).lifecycle_stage == 'deleted'
-    CliRunner(env=cli_env).invoke(mlflow.experiments.commands, ['restore', str(experiment_id)])
+    invoke_cli_runner(mlflow.experiments.commands, ['restore', str(experiment_id)], env=cli_env)
     assert mlflow_client.get_experiment(experiment_id).lifecycle_stage == 'active'
 
 
@@ -190,12 +189,12 @@ def test_rename_experiment_cli(mlflow_client, cli_env):
     bad_experiment_name = "CLIBadName"
     good_experiment_name = "CLIGoodName"
 
-    CliRunner(env=cli_env).invoke(mlflow.experiments.commands, ['create', bad_experiment_name])
+    invoke_cli_runner(mlflow.experiments.commands, ['create', bad_experiment_name], env=cli_env)
     experiment_id = mlflow_client.get_experiment_by_name(bad_experiment_name).experiment_id
     assert mlflow_client.get_experiment(experiment_id).name == bad_experiment_name
-    CliRunner(env=cli_env).invoke(
+    invoke_cli_runner(
             mlflow.experiments.commands,
-            ['rename', str(experiment_id), good_experiment_name])
+            ['rename', str(experiment_id), good_experiment_name], env=cli_env)
     assert mlflow_client.get_experiment(experiment_id).name == good_experiment_name
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fixes a bug (#1165, #1166) where we'd fail to cast the integer experiment ID returned by the database to a string when deserializing runs in SQLAlchemyStore. This caused failures during ensuing attempts to serialize the run from the DB back to protobuf.

Also fixes a couple of small bugs discovered through the addition of E2E REST tests for the SQLAlchemyStore - namely:
* `SQLAlchemyStore.create_experiment` incorrectly returning an experiment ID of `None` 
* `SQLAlchemyStore.create_run` breaking in cases where both `parent_run_id` and its corresponding tag are passed.
* `mlflow experiments create` CLI broken (experiment creation succeeds, but printing the ID of created experiment fails) against remote tracking servers because experiment IDs are returned as strings instead of ints.
 
## How is this patch tested?
 
* Adds tests for conversion to protobuf in SQLAlchemyStore
* Extends existing end-to-end server tests in test_rest_tracking to also run against the SQLAlchemyStore (in addition to the FileStore)
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. Add the `rn/none` label, then you can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Fixes a bug in deserializing runs along read path REST APIs in the SQLAlchemyStore. In particular, this PR fixes the SQLAlchemyStore's logic for handling GetRun, UpdateRun, GetExperiment, SearchRuns API requests.

### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### Please add one label to the PR so it can be classified correctly in the release notes. Options:
 
* `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
* `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section
* `rn/feature` - A new user-facing feature worth mentioning in the release notes
* `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
* `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
