### PR TITLE
Support GCS in Download Utilities

### DIFF
--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 import os
 import re
 
-import boto3
 import click
 from six.moves import urllib
 
@@ -11,8 +10,10 @@ from mlflow.utils import process
 
 DBFS_PREFIX = "dbfs:/"
 S3_PREFIX = "s3://"
+GS_PREFIX = "gs://"
 DBFS_REGEX = re.compile("^%s" % re.escape(DBFS_PREFIX))
 S3_REGEX = re.compile("^%s" % re.escape(S3_PREFIX))
+GS_REGEX = re.compile("^%s" % re.escape(GS_PREFIX))
 
 
 class DownloadException(Exception):
@@ -25,9 +26,17 @@ def _fetch_dbfs(uri, local_path):
 
 
 def _fetch_s3(uri, local_path):
+    import boto3
     print("=== Downloading S3 object %s to local path %s ===" % (uri, os.path.abspath(local_path)))
     (bucket, s3_path) = parse_s3_uri(uri)
     boto3.client('s3').download_file(bucket, s3_path, local_path)
+
+
+def _fetch_gs(uri, local_path):
+    from google.cloud import storage
+    print("=== Downloading GCS file %s to local path %s ===" % (uri, os.path.abspath(local_path)))
+    (bucket, gs_path) = parse_gs_uri(uri)
+    storage.Client().get_bucket(bucket).get_blob(gs_path).download_to_filename(local_path)
 
 
 def parse_s3_uri(uri):
@@ -35,6 +44,17 @@ def parse_s3_uri(uri):
     parsed = urllib.parse.urlparse(uri)
     if parsed.scheme != "s3":
         raise Exception("Not an S3 URI: %s" % uri)
+    path = parsed.path
+    if path.startswith('/'):
+        path = path[1:]
+    return parsed.netloc, path
+
+
+def parse_gs_uri(uri):
+    """Parse an GCS URI, returning (bucket, path)"""
+    parsed = urllib.parse.urlparse(uri)
+    if parsed.scheme != "gs":
+        raise Exception("Not a GCS URI: %s" % uri)
     path = parsed.path
     if path.startswith('/'):
         path = path[1:]
@@ -51,9 +71,11 @@ def download_uri(uri, output_path):
         _fetch_dbfs(uri, output_path)
     elif S3_REGEX.match(uri):
         _fetch_s3(uri, output_path)
+    elif GS_REGEX.match(uri):
+        _fetch_gs(uri, output_path)
     else:
-        raise DownloadException("`uri` must be a DBFS (%s) or S3 (%s) URI, got "
-                                "%s" % (DBFS_PREFIX, S3_PREFIX, uri))
+        raise DownloadException("`uri` must be a DBFS (%s), S3 (%s), or GCS (%s) URI, got "
+                                "%s" % (DBFS_PREFIX, S3_PREFIX, GS_PREFIX, uri))
 
 
 @click.command("download")

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -84,7 +84,7 @@ def download_uri(uri, output_path):
               help="Output path into which to download the artifact.")
 def download(uri, output_path):
     """
-    Download the artifact at the specified DBFS or S3 URI into the specified local output path, or
+    Download the artifact at the specified DBFS, S3, or GCS URI into the specified local output path, or
     the current directory if no output path is specified.
     """
     if output_path is None:

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -84,8 +84,8 @@ def download_uri(uri, output_path):
               help="Output path into which to download the artifact.")
 def download(uri, output_path):
     """
-    Download the artifact at the specified DBFS, S3, or GCS URI into the specified local output path, or
-    the current directory if no output path is specified.
+    Download the artifact at the specified DBFS, S3, or GCS URI into the specified local output
+    path, or the current directory if no output path is specified.
     """
     if output_path is None:
         output_path = os.path.basename(uri)

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -28,6 +28,7 @@ def load_project():
 
 def test_is_uri():
     assert is_uri("s3://some/s3/path")
+    assert is_uri("gs://some/gs/path")
     assert is_uri("dbfs:/some/dbfs/path")
     assert is_uri("file://some/local/path")
     assert not is_uri("/tmp/some/local/path")
@@ -35,7 +36,9 @@ def test_is_uri():
 
 def test_download_uri():
     # Verify downloading from DBFS & S3 urls calls the corresponding helper functions
-    prefix_to_mock = {"dbfs:/": "mlflow.data._fetch_dbfs", "s3://": "mlflow.data._fetch_s3"}
+    prefix_to_mock = {"dbfs:/": "mlflow.data._fetch_dbfs",
+                      "s3://": "mlflow.data._fetch_s3",
+                      "gs://": "mlflow.data._fetch_gs"}
     for prefix, fn_name in prefix_to_mock.items():
         with mock.patch(fn_name) as mocked_fn, temp_directory() as dst_dir:
             download_uri(uri=os.path.join(prefix, "some/path"),

--- a/tests/projects/test_entry_point.py
+++ b/tests/projects/test_entry_point.py
@@ -76,7 +76,7 @@ def test_path_parameter():
                 user_parameters={"path": os.path.join(dst_dir, "some/nonexistent/file")},
                 storage_dir=dst_dir)
         # Verify that we do call `download_uri` when passing a URI to a parameter of type "path"
-        for i, prefix in enumerate(["dbfs:/", "s3://"]):
+        for i, prefix in enumerate(["dbfs:/", "s3://", "gs://"]):
             with TempDir() as tmp:
                 dst_dir = tmp.path()
                 params, _ = entry_point.compute_parameters(


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Adds the ability to handle `gs://bucket/path` files in download utilities. This expands functionality to GCS for `mlflow download` as well as for parameters of type `path` in `MLProject` files.

Solves for one of a few sources that are supported as artifact stores but not as download sources. (see #1134)

This PR also moves the imports in `mlflow/data.py` for both `google.cloud.storage` and `boto3` into each source's respective `_fetch_*` helper function. This should prevent a user who wants to utilize just one of these dependencies from having to install the other for the sake of access to this module.
 
## How is this patch tested?
 
Added tests for `gs://...` URIs to `tests/data/test_data.py` and `test_path_parameter` in `tests/projects/test_entry_point.py`. It may be worth adding additional tests to `test_path_params` in that latter file, as well.

I additionally confirmed expected behavior with a toy MLProject that read a GCS file as a `path` parameter and printed its local tmp file path.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. Add the `rn/none` label, then you can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
**Changes to CLI**: `mlflow download` will now handle URIs in the form `gs://bucket/path`.

**Change to Projects**: Project parameters of type `path` will now handle URIs in the form `gs://bucket/path`. 
 
### What component(s) does this PR affect?
 
- [ ] UI
- [x] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [x] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python
