### PR TITLE
[Runs URI] Add RunsArtifactRepository

### DIFF
--- a/mlflow/store/artifact_repository_registry.py
+++ b/mlflow/store/artifact_repository_registry.py
@@ -3,14 +3,15 @@ import warnings
 from six.moves import urllib
 
 from mlflow.exceptions import MlflowException
-from mlflow.store.gcs_artifact_repo import GCSArtifactRepository
 from mlflow.store.azure_blob_artifact_repo import AzureBlobArtifactRepository
-from mlflow.store.ftp_artifact_repo import FTPArtifactRepository
-from mlflow.store.hdfs_artifact_repo import HdfsArtifactRepository
-from mlflow.store.sftp_artifact_repo import SFTPArtifactRepository
 from mlflow.store.dbfs_artifact_repo import DbfsArtifactRepository
-from mlflow.store.s3_artifact_repo import S3ArtifactRepository
+from mlflow.store.ftp_artifact_repo import FTPArtifactRepository
+from mlflow.store.gcs_artifact_repo import GCSArtifactRepository
+from mlflow.store.hdfs_artifact_repo import HdfsArtifactRepository
 from mlflow.store.local_artifact_repo import LocalArtifactRepository
+from mlflow.store.runs_artifact_repo import RunsArtifactRepository
+from mlflow.store.s3_artifact_repo import S3ArtifactRepository
+from mlflow.store.sftp_artifact_repo import SFTPArtifactRepository
 
 
 class ArtifactRepositoryRegistry:
@@ -78,6 +79,7 @@ _artifact_repository_registry.register('ftp', FTPArtifactRepository)
 _artifact_repository_registry.register('sftp', SFTPArtifactRepository)
 _artifact_repository_registry.register('dbfs', DbfsArtifactRepository)
 _artifact_repository_registry.register('hdfs', HdfsArtifactRepository)
+_artifact_repository_registry.register('runs', RunsArtifactRepository)
 
 _artifact_repository_registry.register_entrypoints()
 

--- a/mlflow/store/runs_artifact_repo.py
+++ b/mlflow/store/runs_artifact_repo.py
@@ -1,0 +1,96 @@
+from six.moves import urllib
+
+from mlflow.exceptions import MlflowException
+from mlflow.store.artifact_repo import ArtifactRepository
+
+
+class RunsArtifactRepository(ArtifactRepository):
+    """
+    Handles artifacts associated with a Run via URIs of the form
+      `runs:/<run_id>/run-relative/path/to/artifact`.
+    It is a light wrapper that resolves the artifact path to an absolute URI then instantiates
+    and uses the artifact repository for that URI.
+
+    The relative path part of ``artifact_uri`` is expected to be in posixpath format, so Windows
+    users should take special care when constructing the URI.
+    """
+
+    def __init__(self, artifact_uri):
+        from mlflow.tracking.artifact_utils import get_artifact_uri
+        from mlflow.store.artifact_repository_registry import get_artifact_repository
+        (run_id, artifact_path) = RunsArtifactRepository.parse_runs_uri(artifact_uri)
+        uri = get_artifact_uri(run_id, artifact_path)
+        assert urllib.parse.urlparse(uri).scheme != "runs"  # avoid an infinite loop
+        super(RunsArtifactRepository, self).__init__(artifact_uri)
+        self.repo = get_artifact_repository(uri)
+
+    @staticmethod
+    def parse_runs_uri(run_uri):
+        parsed = urllib.parse.urlparse(run_uri)
+        if parsed.scheme != "runs":
+            raise MlflowException("Not a proper runs:/ URI: %s" % run_uri)
+        # hostname = parsed.netloc  # TODO: support later
+
+        path = parsed.path
+        if not path.startswith('/') or len(path) <= 1:
+            raise MlflowException("Not a proper runs:/ URI: %s" % run_uri)
+        path = path[1:]
+
+        path_parts = path.split('/')
+        run_id = path_parts[0]
+        if run_id == '':
+            raise MlflowException("Not a proper runs:/ URI: %s" % run_uri)
+
+        artifact_path = '/'.join(path_parts[1:]) if len(path_parts) > 1 else None
+        artifact_path = artifact_path if artifact_path != '' else None
+
+        return run_id, artifact_path
+
+    def get_path_module(self):
+        import posixpath
+        return posixpath
+
+    def log_artifact(self, local_file, artifact_path=None):
+        """
+        Log a local file as an artifact, optionally taking an ``artifact_path`` to place it in
+        within the run's artifacts. Run artifacts can be organized into directories, so you can
+        place the artifact in a directory this way.
+
+        :param local_file: Path to artifact to log
+        :param artifact_path: Directory within the run's artifact directory in which to log the
+                              artifact
+        """
+        self.repo.log_artifact(local_file, artifact_path)
+
+    def log_artifacts(self, local_dir, artifact_path=None):
+        """
+        Log the files in the specified local directory as artifacts, optionally taking
+        an ``artifact_path`` to place them in within the run's artifacts.
+
+        :param local_dir: Directory of local artifacts to log
+        :param artifact_path: Directory within the run's artifact directory in which to log the
+                              artifacts
+        """
+        self.repo.log_artifacts(local_dir, artifact_path)
+
+    def list_artifacts(self, path):
+        """
+        Return all the artifacts for this run_uuid directly under path. If path is a file, returns
+        an empty list. Will error if path is neither a file nor directory.
+
+        :param path: Relative source path that contain desired artifacts
+
+        :return: List of artifacts as FileInfo listed directly under path.
+        """
+        self.repo.list_artifacts(path)
+
+    def _download_file(self, remote_file_path, local_path):
+        """
+        Download the file at the specified relative remote path and saves
+        it at the specified local path.
+
+        :param remote_file_path: Source path to the remote file, relative to the root
+                                 directory of the artifact repository.
+        :param local_path: The path to which to save the downloaded file.
+        """
+        self.repo._download_file(remote_file_path, local_path)

--- a/mlflow/store/runs_artifact_repo.py
+++ b/mlflow/store/runs_artifact_repo.py
@@ -28,18 +28,24 @@ class RunsArtifactRepository(ArtifactRepository):
     def parse_runs_uri(run_uri):
         parsed = urllib.parse.urlparse(run_uri)
         if parsed.scheme != "runs":
-            raise MlflowException("Not a proper runs:/ URI: %s" % run_uri)
+            raise MlflowException(
+                "Not a proper runs:/ URI: %s. " % run_uri +
+                "Runs URIs must be of the form 'runs:/<run_id>/run-relative/path/to/artifact'")
         # hostname = parsed.netloc  # TODO: support later
 
         path = parsed.path
         if not path.startswith('/') or len(path) <= 1:
-            raise MlflowException("Not a proper runs:/ URI: %s" % run_uri)
+            raise MlflowException(
+                "Not a proper runs:/ URI: %s. " % run_uri +
+                "Runs URIs must be of the form 'runs:/<run_id>/run-relative/path/to/artifact'")
         path = path[1:]
 
         path_parts = path.split('/')
         run_id = path_parts[0]
         if run_id == '':
-            raise MlflowException("Not a proper runs:/ URI: %s" % run_uri)
+            raise MlflowException(
+                "Not a proper runs:/ URI: %s. " % run_uri +
+                "Runs URIs must be of the form 'runs:/<run_id>/run-relative/path/to/artifact'")
 
         artifact_path = '/'.join(path_parts[1:]) if len(path_parts) > 1 else None
         artifact_path = artifact_path if artifact_path != '' else None

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -2,12 +2,15 @@
 Utilities for dealing with artifacts in the context of a Run.
 """
 
+from six.moves import urllib
+
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.tracking.utils import _get_store
 
 
+# TODO(sueann): maybe move to RunsArtifactRepository so the circular dependency is clear?
 def get_artifact_uri(run_id, artifact_path=None):
     """
     Get the absolute URI of the specified artifact in the specified run. If `path` is not specified,
@@ -32,6 +35,7 @@ def get_artifact_uri(run_id, artifact_path=None):
 
     store = _get_store()
     run = store.get_run(run_id)
+    assert urllib.parse.urlparse(run.info.artifact_uri).scheme != "runs"  # avoid an infinite loop
     if artifact_path is None:
         return run.info.artifact_uri
     else:
@@ -43,7 +47,7 @@ def get_artifact_uri(run_id, artifact_path=None):
         return artifact_path_module.join(run.info.artifact_uri, artifact_path)
 
 
-# TODO(sueann): This method does not require a Run and its internals should be moved to
+# TODO: This method does not require a Run and its internals should be moved to
 #  data.download_uri (requires confirming that Projects will not break with this change).
 def _download_artifact_from_uri(artifact_uri, output_path=None):
     """

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -10,7 +10,6 @@ from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.tracking.utils import _get_store
 
 
-# TODO(sueann): maybe move to RunsArtifactRepository so the circular dependency is clear?
 def get_artifact_uri(run_id, artifact_path=None):
     """
     Get the absolute URI of the specified artifact in the specified run. If `path` is not specified,
@@ -35,6 +34,7 @@ def get_artifact_uri(run_id, artifact_path=None):
 
     store = _get_store()
     run = store.get_run(run_id)
+    # Maybe move this method to RunsArtifactRepository so the circular dependency is clearer.
     assert urllib.parse.urlparse(run.info.artifact_uri).scheme != "runs"  # avoid an infinite loop
     if artifact_path is None:
         return run.info.artifact_uri

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -12,7 +12,7 @@ from mlflow.store import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.tracking import utils
 from mlflow.utils.search_utils import SearchFilter
 from mlflow.utils.validation import _validate_param_name, _validate_tag_name, _validate_run_id, \
-    _validate_experiment_name, _validate_metric
+    _validate_experiment_artifact_location, _validate_experiment_name, _validate_metric
 from mlflow.entities import Param, Metric, RunStatus, RunTag, ViewType, SourceType
 from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.utils.mlflow_tags import MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, MLFLOW_PARENT_RUN_ID, \
@@ -133,6 +133,7 @@ class MlflowClient(object):
         :return: Integer ID of the created experiment.
         """
         _validate_experiment_name(name)
+        _validate_experiment_artifact_location(artifact_location)
         return self.store.create_experiment(
             name=name,
             artifact_location=artifact_location,

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -188,3 +188,10 @@ def _validate_experiment_name(experiment_name):
     if not isinstance(experiment_name, str):
         raise MlflowException("Invalid experiment name: %s. Expects a string." % experiment_name,
                               error_code=INVALID_PARAMETER_VALUE)
+
+
+def _validate_experiment_artifact_location(artifact_location):
+    if artifact_location is not None and artifact_location.startswith("runs:"):
+        raise MlflowException("Artifact location cannot be a runs:/ URI. Given: '%s'"
+                              % artifact_location,
+                              error_code=INVALID_PARAMETER_VALUE)

--- a/tests/store/test_runs_artifact_repo.py
+++ b/tests/store/test_runs_artifact_repo.py
@@ -32,7 +32,8 @@ def test_parse_runs_uri_invalid_input(uri):
         RunsArtifactRepository.parse_runs_uri(uri)
 
 
-def test_runs_artifact_repo_init(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_runs_artifact_repo_init():
     artifact_location = "s3://blah_bucket/"
     experiment_id = mlflow.create_experiment("expr_abc", artifact_location)
     with mlflow.start_run(experiment_id=experiment_id):

--- a/tests/store/test_runs_artifact_repo.py
+++ b/tests/store/test_runs_artifact_repo.py
@@ -1,8 +1,11 @@
-import mock
 import pytest
 
+import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.store.runs_artifact_repo import RunsArtifactRepository
+from mlflow.store.s3_artifact_repo import S3ArtifactRepository
+
+from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 
 @pytest.mark.parametrize("uri, expected_run_id, expected_artifact_path", [
@@ -29,19 +32,15 @@ def test_parse_runs_uri_invalid_input(uri):
         RunsArtifactRepository.parse_runs_uri(uri)
 
 
-# We should add an integration test for this code path.
-# This test at least makes sure there are no silly mistakes and the code run in testing
-def test_runs_artifact_repo_gets_correct_internal_repo():
-    runs_uri = 'runs:/1234abcdf1394asdfwer33/path/to/model'
-    absolute_uri = 's3://blah_bucket/cool'
+def test_runs_artifact_repo_init(tracking_uri_mock):
+    artifact_location = "s3://blah_bucket/"
+    experiment_id = mlflow.create_experiment("expr_abc", artifact_location)
+    with mlflow.start_run(experiment_id=experiment_id):
+        run_id = mlflow.active_run().info.run_uuid
+    runs_uri = "runs:/%s/path/to/model" % run_id
+    runs_repo = RunsArtifactRepository(runs_uri)
 
-    with mock.patch('mlflow.store.artifact_repository_registry.get_artifact_repository') \
-        as get_artifact_repo_mock, \
-            mock.patch('mlflow.tracking.artifact_utils.get_artifact_uri') as get_artifact_uri_mock:
-        get_artifact_uri_mock.return_value = absolute_uri
-
-        runs_repo = RunsArtifactRepository(runs_uri)
-
-        assert runs_repo.artifact_uri == runs_uri
-        assert get_artifact_repo_mock.call_count == 1
-        assert get_artifact_repo_mock.call_args_list[0][0][0] == absolute_uri
+    assert runs_repo.artifact_uri == runs_uri
+    assert isinstance(runs_repo.repo, S3ArtifactRepository)
+    expected_absolute_uri = "%s%s/artifacts/path/to/model" % (artifact_location, run_id)
+    assert runs_repo.repo.artifact_uri == expected_absolute_uri

--- a/tests/store/test_runs_artifact_repo.py
+++ b/tests/store/test_runs_artifact_repo.py
@@ -1,0 +1,47 @@
+import mock
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.store.runs_artifact_repo import RunsArtifactRepository
+
+
+@pytest.mark.parametrize("uri, expected_run_id, expected_artifact_path", [
+    ('runs:/1234abcdf1394asdfwer33/path/to/model', '1234abcdf1394asdfwer33', 'path/to/model'),
+    ('runs:/1234abcdf1394asdfwer33/path/to/model/', '1234abcdf1394asdfwer33', 'path/to/model/'),
+    ('runs:/1234abcdf1394asdfwer33', '1234abcdf1394asdfwer33', None),
+    ('runs:/1234abcdf1394asdfwer33/', '1234abcdf1394asdfwer33', None),
+    ('runs:///1234abcdf1394asdfwer33/', '1234abcdf1394asdfwer33', None),
+])
+def test_parse_runs_uri_valid_input(uri, expected_run_id, expected_artifact_path):
+    (run_id, artifact_path) = RunsArtifactRepository.parse_runs_uri(uri)
+    assert run_id == expected_run_id
+    assert artifact_path == expected_artifact_path
+
+
+@pytest.mark.parametrize("uri", [
+    'notruns:/1234abcdf1394asdfwer33/',  # wrong scheme
+    'runs:/',                            # no run id
+    'runs:1234abcdf1394asdfwer33/',      # missing slash
+    'runs://1234abcdf1394asdfwer33/',    # hostnames are not yet supported
+])
+def test_parse_runs_uri_invalid_input(uri):
+    with pytest.raises(MlflowException):
+        RunsArtifactRepository.parse_runs_uri(uri)
+
+
+# We should add an integration test for this code path.
+# This test at least makes sure there are no silly mistakes and the code run in testing
+def test_runs_artifact_repo_gets_correct_internal_repo():
+    runs_uri = 'runs:/1234abcdf1394asdfwer33/path/to/model'
+    absolute_uri = 's3://blah_bucket/cool'
+
+    with mock.patch('mlflow.store.artifact_repository_registry.get_artifact_repository') \
+        as get_artifact_repo_mock, \
+            mock.patch('mlflow.tracking.artifact_utils.get_artifact_uri') as get_artifact_uri_mock:
+        get_artifact_uri_mock.return_value = absolute_uri
+
+        runs_repo = RunsArtifactRepository(runs_uri)
+
+        assert runs_repo.artifact_uri == runs_uri
+        assert get_artifact_repo_mock.call_count == 1
+        get_artifact_repo_mock.call_args_list[0][0][0] == absolute_uri

--- a/tests/store/test_runs_artifact_repo.py
+++ b/tests/store/test_runs_artifact_repo.py
@@ -44,4 +44,4 @@ def test_runs_artifact_repo_gets_correct_internal_repo():
 
         assert runs_repo.artifact_uri == runs_uri
         assert get_artifact_repo_mock.call_count == 1
-        get_artifact_repo_mock.call_args_list[0][0][0] == absolute_uri
+        assert get_artifact_repo_mock.call_args_list[0][0][0] == absolute_uri

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -5,8 +5,8 @@ from mlflow.exceptions import MlflowException
 from mlflow.entities import Metric, Param, RunTag
 from mlflow.protos.databricks_pb2 import ErrorCode, INVALID_PARAMETER_VALUE
 from mlflow.utils.validation import _validate_metric_name, _validate_param_name, \
-                                    _validate_tag_name, _validate_run_id, \
-                                    _validate_batch_log_data, _validate_batch_log_limits
+    _validate_tag_name, _validate_run_id, _validate_batch_log_data, \
+    _validate_batch_log_limits, _validate_experiment_artifact_location
 
 GOOD_METRIC_OR_PARAM_NAMES = [
     "a", "Ab-5_", "a/b/c", "a.b.c", ".a", "b.", "a..a/._./o_O/.e.", "a b/c d",
@@ -112,3 +112,10 @@ def test_validate_batch_log_data():
     _validate_batch_log_data(
         metrics=[Metric("metric-key", 1.0, 0, 0)], params=[Param("param-key", "param-val")],
         tags=[RunTag("tag-key", "tag-val")])
+
+
+def test_validate_experiment_artifact_location():
+    _validate_experiment_artifact_location('abcde')
+    _validate_experiment_artifact_location(None)
+    with pytest.raises(MlflowException):
+        _validate_experiment_artifact_location('runs:/blah/bleh/blergh')


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Introduces `RunsArtifactRepository` to handle artifact URIs of the form `runs:/<run_id>/path/to/artifact` to represent artifacts associated with a run. After this change, we will deprecate `run_id` args where they are optional (e.g. `load_model`). 
 
## How is this patch tested?

```
pytest tests/store/test_runs_artifact_repo.py
pytest tests/utils/test_validation.py
```
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. Add the `rn/none` label, then you can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

This particular PR is not user-facing but it is a basis for PRs to come that will change APIs specifying `(run_id, artifact_path)` outside of MLflow Tracking to accept a single parameter `artifact_uri`. The change will allow a uniform treatment of artifact locations, and enable referring to artifacts in relation to a Run in more tricky settings such as specifying artifact dependencies for a project.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [X] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### Please add one label to the PR so it can be classified correctly in the release notes. Options:
 
* `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
* `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section
* `rn/feature` - A new user-facing feature worth mentioning in the release notes
* `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
* `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
