### PR TITLE
Resolve bug in sqlalchemy backed handler.py server

### DIFF
--- a/mlflow/store/dbmodels/models.py
+++ b/mlflow/store/dbmodels/models.py
@@ -60,6 +60,8 @@ def _create_entity(base, model):
                     obj = SourceType.from_string(obj)
                 elif k == "status":
                     obj = RunStatus.from_string(obj)
+            if k == "experiment_id" and isinstance(obj, int):
+                obj = str(obj)
 
         # Our data model defines experiment_ids as ints, but the in-memory representation was
         # changed to be a string in time for 1.0.

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -1091,3 +1091,10 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         self._verify_logged(run.info.run_uuid, params=[], metrics=[metric0], tags=[])
         self.store.log_batch(run.info.run_uuid, params=[], metrics=[metric1], tags=[])
         self._verify_logged(run.info.run_uuid, params=[], metrics=[metric0, metric1], tags=[])
+
+    def test_create_run_to_proto(self):
+        experiment_id = self._experiment_factory('test_create_run')
+        for exp_id in [experiment_id, int(experiment_id)]:
+            expected = self._get_run_configs(experiment_id=int(experiment_id))
+            actual = self.store.create_run(**expected)
+            actual.to_proto()


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Resolve bug in serializing SqlAlchemy returned Run when experiment_id is passed as int to store.


Please fill in changes proposed in this fix)
 
## How is this patch tested?
Both string and int experiment_ids are passed to create_run, the resulting runs are then serialized to_proto.

 
(Details)
 
## Release Notes
 
### Is this a user-facing change? 

- [ X] No. Add the `rn/none` label, then you can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
https://github.com/mlflow/mlflow/pull/1067 introduced a bug for servers backed by SqlAlchemy that receive int experiment_id as input. The tests were updated to the new inputs and therefore did not cover this code path. A test for this code path was added.

### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ X] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ X] Python

### Please add one label to the PR so it can be classified correctly in the release notes. Options:
 
* `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

@smurching  noticed the bug. The PR was done quickly to avoid conflicts with Spark Summit if they exist