### PR TITLE
[Easy][Runs URI] Fix RunsArtifactRepository.list_artifacts

### DIFF
--- a/mlflow/store/runs_artifact_repo.py
+++ b/mlflow/store/runs_artifact_repo.py
@@ -88,7 +88,7 @@ class RunsArtifactRepository(ArtifactRepository):
 
         :return: List of artifacts as FileInfo listed directly under path.
         """
-        self.repo.list_artifacts(path)
+        return self.repo.list_artifacts(path)
 
     def _download_file(self, remote_file_path, local_path):
         """


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Have `RunsArtifactRepository.list_artifacts` actually return the artifacts. 

This was found as I was testing the changes in https://github.com/mlflow/mlflow/pull/1174. We should really have unit/integration tests specifically for `RunsArtifactRepository` but skipping for now since the codepath will be covered by other modules (e.g. the sagemaker tests mentioned above) and I'd like to get this in quickly to unblock the API changes to come.

 
## How is this patch tested?
 
Actually found it as I was testing the changes in https://github.com/mlflow/mlflow/pull/1174 with 
```
pytest tests/sagemaker/test_deployment.py
```
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. Add the `rn/none` label, then you can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Fixes a bug in https://github.com/mlflow/mlflow/pull/1169, so can be listed under the Runs URI breaking change.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [X] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [X] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### Please add one label to the PR so it can be classified correctly in the release notes. Options:
 
* `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
* `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section
* `rn/feature` - A new user-facing feature worth mentioning in the release notes
* `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
* `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
