### PR TITLE
[PR template] Turn PR labels into checkboxes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
  
 ### Is this a user-facing change? 
 
-- [ ] No. Add the `rn/none` label, then you can skip the rest of this section.
+- [ ] No. You can skip the rest of this section.
 - [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
  
 (Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
@@ -33,10 +33,10 @@
 - [ ] Java
 - [ ] Python
 
-### Please add one label to the PR so it can be classified correctly in the release notes. Options:
+### How should the PR be classified in the release notes? Choose one:
  
-* `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
-* `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section
-* `rn/feature` - A new user-facing feature worth mentioning in the release notes
-* `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
-* `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
+- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
+- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
+- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
+- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
+- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Since the permission scheme for PR labels is not clear, let's turn them into checkboxes in the PR template and the reviewer can apply the corresponding label.
 
## How is this patch tested?
 
View the rendered markdown.
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. Add the `rn/none` label, then you can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### Please add one label to the PR so it can be classified correctly in the release notes. Options:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
