### PR TITLE
Add Python and Java client APIs for GetMetricHistory REST API

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -59,6 +59,13 @@ public class MlflowClient {
     return mapper.toGetRunResponse(httpCaller.get(builder.toString())).getRun();
   }
 
+  public List<Metric> getMetricHistory(String runUuid, String key) {
+    URIBuilder builder = newURIBuilder("metrics/get-history")
+      .setParameter("run_uuid", runUuid)
+      .setParameter("metric_key", key);
+    return mapper.toGetMetricHistoryResponse(httpCaller.get(builder.toString())).getMetricsList();
+  }
+
   /**
    * Creates a new run under the default experiment with no application name.
    * @return RunInfo created by the server

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
@@ -126,6 +126,12 @@ class MlflowProtobufMapper {
     return builder.build();
   }
 
+  GetMetricHistory.Response toGetMetricHistoryResponse(String json) {
+    GetMetricHistory.Response.Builder builder = GetMetricHistory.Response.newBuilder();
+    merge(json, builder);
+    return builder.build();
+  }
+
   CreateRun.Response toCreateRunResponse(String json) {
     CreateRun.Response.Builder builder = CreateRun.Response.newBuilder();
     merge(json, builder);

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -137,6 +137,8 @@ public class MlflowClientTest {
     // Log metrics
     client.logMetric(runId, "accuracy_score", ACCURACY_SCORE);
     client.logMetric(runId, "zero_one_loss", ZERO_ONE_LOSS);
+    client.logMetric(runId, "logged_multiple_times", 2.0);
+    client.logMetric(runId, "logged_multiple_times", -1.0);
 
     // Log tag
     client.setTag(runId, "user_email", USER_EMAIL);
@@ -274,10 +276,15 @@ public class MlflowClientTest {
     assertParam(params, "max_depth", MAX_DEPTH);
 
     List<Metric> metrics = run.getData().getMetricsList();
-    Assert.assertEquals(metrics.size(), 2);
+    Assert.assertEquals(metrics.size(), 3);
     assertMetric(metrics, "accuracy_score", ACCURACY_SCORE);
     assertMetric(metrics, "zero_one_loss", ZERO_ONE_LOSS);
+    assertMetric(metrics, "logged_multiple_times", -1.0);
     assert(metrics.get(0).getTimestamp() > 0) : metrics.get(0).getTimestamp();
+
+    List<Metric> metricHistory = client.getMetricHistory(runId, "logged_multiple_times");
+    assertMetricHistory(metricHistory, "logged_multiple_times", Arrays.asList(2.0, -1.0),
+      Arrays.asList(0L, 0L));
 
     List<RunTag> tags = run.getData().getTagsList();
     Assert.assertEquals(tags.size(), 1);

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
@@ -28,6 +28,17 @@ public class TestUtils {
     Assert.assertTrue(metrics.stream().filter(e -> e.getKey().equals(key) && equals(e.getValue(), value)).findFirst().isPresent());
   }
 
+  public static void assertMetricHistory(List<Metric> history, String key, List<Double> values, List<Long> steps) {
+    Assert.assertEquals(history.size(), values.size());
+    Assert.assertEquals(history.size(), steps.size());
+    for (int i = 0; i < history.size(); i++) {
+      Metric metric = history.get(i);
+      Assert.assertEquals(metric.getKey(), key);
+      Assert.assertTrue(equals(metric.getValue(), values.get(i)));
+      Assert.assertTrue(equals(metric.getStep(), steps.get(i)));
+    }
+  }
+
   public static void assertTag(List<RunTag> tags, String key, String value) {
     Assert.assertTrue(tags.stream().filter(e -> e.getKey().equals(key) && e.getValue().equals(value)).findFirst().isPresent());
   }

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -53,6 +53,17 @@ class MlflowClient(object):
         _validate_run_id(run_id)
         return self.store.get_run(run_id)
 
+    def get_metric_history(self, run_id, key):
+        """
+        Return a list of metric objects corresponding to all values logged for a given metric.
+
+        :param run_id: Unique identifier for run
+        :param key: Metric name within the run
+
+        :return: A list of :py:class:`mlflow.entities.Metric` entities if logged, else empty list
+        """
+        return self.store.get_metric_history(run_uuid=run_id, metric_key=key)
+
     def create_run(self, experiment_id, user_id=None, run_name=None, start_time=None,
                    parent_run_id=None, tags=None):
         """

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -265,16 +265,14 @@ def test_log_metrics_params_tags(mlflow_client, backend_store_uri):
     assert run.data.metrics.get('stepless-metric') == 987.654
     assert run.data.params.get('param') == 'value'
     assert run.data.tags.get('taggity') == 'do-dah'
-    # TODO(sid): replace this with mlflow_client.get_metric_history
-    store = _tracking_store_registry.get_store(backend_store_uri)
-    metric_history0 = store.get_metric_history(run_id, "metric")
+    metric_history0 = mlflow_client.get_metric_history(run_id, "metric")
     assert len(metric_history0) == 1
     metric0 = metric_history0[0]
     assert metric0.key == "metric"
     assert metric0.value == 123.456
     assert metric0.timestamp == 789
     assert metric0.step == 2
-    metric_history1 = store.get_metric_history(run_id, "stepless-metric")
+    metric_history1 = mlflow_client.get_metric_history(run_id, "stepless-metric")
     assert len(metric_history1) == 1
     metric1 = metric_history1[0]
     assert metric1.key == "stepless-metric"
@@ -295,9 +293,7 @@ def test_log_batch(mlflow_client, backend_store_uri):
     assert run.data.metrics.get('metric') == 123.456
     assert run.data.params.get('param') == 'value'
     assert run.data.tags.get('taggity') == 'do-dah'
-    # TODO(sid): replace this with mlflow_client.get_metric_history
-    store = _tracking_store_registry.get_store(backend_store_uri)
-    metric_history = store.get_metric_history(run_id, "metric")
+    metric_history = mlflow_client.get_metric_history(run_id, "metric")
     assert len(metric_history) == 1
     metric = metric_history[0]
     assert metric.key == "metric"

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -164,18 +164,17 @@ def test_log_batch(tracking_uri_mock, tmpdir):
         run_uuid = active_run.info.run_uuid
         mlflow.tracking.MlflowClient().log_batch(run_id=run_uuid, metrics=metrics, params=params,
                                                  tags=tags)
-    finished_run = tracking.MlflowClient().get_run(run_uuid)
+    client = tracking.MlflowClient()
+    finished_run = client.get_run(run_uuid)
     # Validate metrics
     assert len(finished_run.data.metrics) == 2
     for key, value in finished_run.data.metrics.items():
         assert expected_metrics[key] == value
-    # TODO: use client get_metric_history API here instead once it exists
-    fs = FileStore(os.path.join(tmpdir.strpath, "mlruns"))
-    metric_history0 = fs.get_metric_history(run_uuid, "metric-key0")
+    metric_history0 = client.get_metric_history(run_uuid, "metric-key0")
     assert set([(m.value, m.timestamp, m.step) for m in metric_history0]) == set([
         (1.0, t, 0),
     ])
-    metric_history1 = fs.get_metric_history(run_uuid, "metric-key1")
+    metric_history1 = client.get_metric_history(run_uuid, "metric-key1")
     assert set([(m.value, m.timestamp, m.step) for m in metric_history1]) == set([
         (4.0, t, 1),
     ])
@@ -206,15 +205,14 @@ def test_log_metric(tracking_uri_mock, tmpdir):
     expected_pairs = {"name_1": 30, "name_2": -3, "nested/nested/name": 40}
     for key, value in finished_run.data.metrics.items():
         assert expected_pairs[key] == value
-    # TODO: use client get_metric_history API here instead once it exists
-    fs = FileStore(os.path.join(tmpdir.strpath, "mlruns"))
-    metric_history_name1 = fs.get_metric_history(run_uuid, "name_1")
+    client = tracking.MlflowClient()
+    metric_history_name1 = client.get_metric_history(run_uuid, "name_1")
     assert set([(m.value, m.timestamp, m.step) for m in metric_history_name1]) == set([
         (25, 300, 0),
         (30, 302, 5),
         (40, 303, -2),
     ])
-    metric_history_name2 = fs.get_metric_history(run_uuid, "name_2")
+    metric_history_name2 = client.get_metric_history(run_uuid, "name_2")
     assert set([(m.value, m.timestamp, m.step) for m in metric_history_name2]) == set([
         (-3, 301, 0),
     ])


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Adds Python and Java client APIs corresponding to the GetMetricHistory REST API. In Python, adds a new `get_metric_history` method to `mlflow.tracking.MlflowClient`, and in Java, adds a new `getMetricHistory` method to `org.mlflow.tracking.MlflowClient`.

I also surveyed our examples to see if any hacked around the lack of a `get_metric_history` API, but none do.

## How is this patch tested?
 
Unit tests in Python and java
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. Add the `rn/none` label, then you can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Adds Python and Java client APIs corresponding to the GetMetricHistory REST API. In Python, adds a new `get_metric_history` method to `mlflow.tracking.MlflowClient`, and in Java, adds a new `getMetricHistory` method to `org.mlflow.tracking.MlflowClient`.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [x] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [x] Java
- [x] Python

### Please add one label to the PR so it can be classified correctly in the release notes. Options:
 
* `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
* `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section
* `rn/feature` - A new user-facing feature worth mentioning in the release notes
* `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
* `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
