### PR TITLE
Update artifact repository download methods to return absolute paths

### DIFF
--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -97,7 +97,8 @@ class ArtifactRepository:
             return local_path
 
         if dst_path is None:
-            dst_path = os.path.abspath(tempfile.mkdtemp())
+            dst_path = tempfile.mkdtemp()
+        dst_path = os.path.abspath(dst_path)
 
         if not os.path.exists(dst_path):
             raise MlflowException(

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -2,7 +2,6 @@ import os
 import pytest
 
 from mlflow.exceptions import MlflowException
-from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.store.local_artifact_repo import LocalArtifactRepository
 from mlflow.utils.file_utils import TempDir
 

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -1,101 +1,124 @@
 import os
-import unittest
+import pytest
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.store.local_artifact_repo import LocalArtifactRepository
 from mlflow.utils.file_utils import TempDir
 
+@pytest.fixture
+def local_artifact_root(tmpdir):
+    return str(tmpdir)
 
-class TestLocalArtifactRepo(unittest.TestCase):
-    def _get_contents(self, repo, dir_name):
-        return sorted([(f.path, f.is_dir, f.file_size) for f in repo.list_artifacts(dir_name)])
+@pytest.fixture
+def local_artifact_repo(local_artifact_root):
+    return LocalArtifactRepository(artifact_uri=local_artifact_root)
 
-    def test_basic_functions(self):
-        with TempDir() as test_root, TempDir() as tmp:
-            repo = get_artifact_repository(test_root.path())
-            self.assertIsInstance(repo, LocalArtifactRepository)
-            self.assertListEqual(repo.list_artifacts(), [])
-            with self.assertRaises(Exception):
-                open(repo.download_artifacts("test.txt")).read()
+def test_list_artifacts(local_artifact_repo, local_artifact_root):
+    assert len(local_artifact_repo.list_artifacts()) == 0
+   
+    artifact_rel_path = "artifact"
+    artifact_path = os.path.join(local_artifact_root, artifact_rel_path)
+    with open(artifact_path, "w") as f:
+        f.write("artifact")
+    artifacts_list = local_artifact_repo.list_artifacts()
+    assert len(artifacts_list) == 1
+    assert artifacts_list[0].path == artifact_rel_path
 
-            # Create and log a test.txt file directly
-            artifact_name = "test.txt"
-            local_file = tmp.path(artifact_name)
-            with open(local_file, "w") as f:
-                f.write("Hello world!")
-            repo.log_artifact(local_file)
-            text = open(repo.download_artifacts(artifact_name)).read()
-            self.assertEqual(text, "Hello world!")
-            # Check that it actually got written in the expected place
-            text = open(os.path.join(test_root.path(), artifact_name)).read()
-            self.assertEqual(text, "Hello world!")
 
-            # log artifact in subdir
-            repo.log_artifact(local_file, "aaa")
-            text = open(repo.download_artifacts(os.path.join("aaa", artifact_name))).read()
-            self.assertEqual(text, "Hello world!")
+def test_log_artifacts(local_artifact_repo, local_artifact_root):
+    artifact_rel_path = "test.txt"
+    artifact_text = "hello world!"
+    with TempDir() as src_dir:
+        artifact_src_path = src_dir.path(artifact_rel_path)
+        with open(artifact_src_path, "w") as f:
+            f.write(artifact_text)
+        local_artifact_repo.log_artifact(artifact_src_path)
 
-            # log a hidden artifact
-            hidden_file = tmp.path(".mystery")
-            with open(hidden_file, 'w') as f:
-                f.write("42")
-            repo.log_artifact(hidden_file, "aaa")
-            hidden_text = open(repo.download_artifacts(os.path.join("aaa", hidden_file))).read()
-            self.assertEqual(hidden_text, "42")
+    artifacts_list = local_artifact_repo.list_artifacts()
+    assert len(artifacts_list) == 1
+    assert artifacts_list[0].path == artifact_rel_path
 
-            # log artifacts in deep nested subdirs
-            nested_subdir = "bbb/ccc/ddd/eee/fghi"
-            repo.log_artifact(local_file, nested_subdir)
-            text = open(repo.download_artifacts(os.path.join(nested_subdir, artifact_name))).read()
-            self.assertEqual(text, "Hello world!")
+    artifact_dst_path = os.path.join(local_artifact_root, artifact_rel_path)
+    assert os.path.exists(artifact_dst_path)
+    assert artifact_dst_path != artifact_src_path
+    assert open(artifact_dst_path).read() == artifact_text
 
-            for bad_path in ["/", "//", "/tmp", "/bad_path", ".", "../terrible_path"]:
-                with self.assertRaises(MlflowException):
-                    repo.log_artifact(local_file, bad_path)
 
-            # Create a subdirectory for log_artifacts
-            os.mkdir(tmp.path("subdir"))
-            os.mkdir(tmp.path("subdir", "nested"))
-            with open(tmp.path("subdir", "a.txt"), "w") as f:
-                f.write("A")
-            with open(tmp.path("subdir", "b.txt"), "w") as f:
-                f.write("B")
-            with open(tmp.path("subdir", "nested", "c.txt"), "w") as f:
-                f.write("C")
-            repo.log_artifacts(tmp.path("subdir"))
-            text = open(repo.download_artifacts("a.txt")).read()
-            self.assertEqual(text, "A")
-            text = open(repo.download_artifacts("b.txt")).read()
-            self.assertEqual(text, "B")
-            text = open(repo.download_artifacts("nested/c.txt")).read()
-            self.assertEqual(text, "C")
-            infos = self._get_contents(repo, None)
-            self.assertListEqual(infos, [
-                ("a.txt", False, 1),
-                ("aaa", True, None),
-                ("b.txt", False, 1),
-                ("bbb", True, None),
-                ("nested", True, None),
-                ("test.txt", False, 12),
-            ])
+def test_download_artifacts(local_artifact_repo):
+    artifact_rel_path = "test.txt"
+    artifact_text = "hello world!"
+    with TempDir(chdr=True) as local_dir:
+        artifact_src_path = local_dir.path(artifact_rel_path)
+        with open(artifact_src_path, "w") as f:
+            f.write(artifact_text)
+        local_artifact_repo.log_artifact(artifact_src_path)
 
-            # Verify contents of subdirectories
-            self.assertListEqual(self._get_contents(repo, "nested"), [("nested/c.txt", False, 1)])
+        for dst_dir in ["dst1", local_dir.path("dst2"), None]:
+            if dst_dir is not None:
+                os.makedirs(dst_dir)
+            dst_path = local_artifact_repo.download_artifacts(
+                artifact_path=artifact_rel_path,
+                dst_path=dst_dir)
+            assert dst_path == os.path.abspath(dst_path)
+            assert open(dst_path).read() == artifact_text
 
-            infos = self._get_contents(repo, "aaa")
-            self.assertListEqual(infos, [("aaa/.mystery", False, 2), ("aaa/test.txt", False, 12)])
-            self.assertListEqual(self._get_contents(repo, "bbb"), [("bbb/ccc", True, None)])
-            self.assertListEqual(self._get_contents(repo, "bbb/ccc"), [("bbb/ccc/ddd", True, None)])
 
-            infos = self._get_contents(repo, "bbb/ccc/ddd/eee")
-            self.assertListEqual(infos, [("bbb/ccc/ddd/eee/fghi", True, None)])
+@pytest.mark.parametrize("repo_subdir_path", [
+    "aaa",
+    "aaa/bbb",
+    "aaa/bbb/ccc/ddd",
+])
+def test_artifacts_are_logged_to_and_downloaded_from_repo_subdirectory_successfully(
+    local_artifact_repo, repo_subdir_path):
+    artifact_rel_path = "test.txt"
+    artifact_text = "hello world!"
+    with TempDir(chdr=True) as local_dir:
+        artifact_src_path = local_dir.path(artifact_rel_path)
+        with open(artifact_src_path, "w") as f:
+            f.write(artifact_text)
+        local_artifact_repo.log_artifact(artifact_src_path, artifact_path=repo_subdir_path)
 
-            infos = self._get_contents(repo, "bbb/ccc/ddd/eee/fghi")
-            self.assertListEqual(infos, [("bbb/ccc/ddd/eee/fghi/test.txt", False, 12)])
+    downloaded_subdir = local_artifact_repo.download_artifacts(repo_subdir_path)
+    assert os.path.isdir(downloaded_subdir)
+    subdir_contents = os.listdir(downloaded_subdir)
+    assert len(subdir_contents) == 1
+    assert artifact_rel_path in subdir_contents
+    assert open(os.path.join(downloaded_subdir, artifact_rel_path)).read() == artifact_text
 
-            # Download a subdirectory
-            downloaded_dir = repo.download_artifacts("nested")
-            self.assertEqual(os.path.basename(downloaded_dir), "nested")
-            text = open(os.path.join(downloaded_dir, "c.txt")).read()
-            self.assertEqual(text, "C")
+    downloaded_file = local_artifact_repo.download_artifacts(
+        os.path.join(repo_subdir_path, artifact_rel_path))
+    assert open(downloaded_file).read() == artifact_text
+
+
+def test_log_artifact_throws_exception_for_invalid_artifact_paths(local_artifact_repo):
+    with TempDir() as local_dir:
+        for bad_artifact_path in ["/", "//", "/tmp", "/bad_path", ".", "../terrible_path"]:
+            with pytest.raises(MlflowException) as exc_info:
+                local_artifact_repo.log_artifact(local_dir.path(), bad_artifact_path)
+            assert "Invalid artifact path" in str(exc_info)
+
+
+def test_logging_directory_of_artifacts_produces_expected_repo_contents(local_artifact_repo):
+    with TempDir() as local_dir:
+        os.mkdir(local_dir.path("subdir"))
+        os.mkdir(local_dir.path("subdir", "nested"))
+        with open(local_dir.path("subdir", "a.txt"), "w") as f:
+            f.write("A")
+        with open(local_dir.path("subdir", "b.txt"), "w") as f:
+            f.write("B")
+        with open(local_dir.path("subdir", "nested", "c.txt"), "w") as f:
+            f.write("C")
+        local_artifact_repo.log_artifacts(local_dir.path("subdir"))
+        assert open(local_artifact_repo.download_artifacts("a.txt")).read() == "A"
+        assert open(local_artifact_repo.download_artifacts("b.txt")).read() == "B"
+        assert open(local_artifact_repo.download_artifacts("nested/c.txt")).read() == "C"
+
+
+def test_hidden_files_are_logged_correctly(local_artifact_repo):
+    with TempDir() as local_dir:
+        hidden_file = local_dir.path(".mystery")
+        with open(hidden_file, "w") as f:
+            f.write("42")
+        local_artifact_repo.log_artifact(hidden_file)
+        assert open(local_artifact_repo.download_artifacts(hidden_file)).read() == "42"

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -53,6 +53,18 @@ def test_download_artifacts(local_artifact_repo):
         with open(artifact_src_path, "w") as f:
             f.write(artifact_text)
         local_artifact_repo.log_artifact(artifact_src_path)
+        dst_path = local_artifact_repo.download_artifacts(artifact_path=artifact_rel_path)
+        assert open(dst_path).read() == artifact_text
+
+
+def test_download_artifacts_returns_absolute_paths(local_artifact_repo):
+    artifact_rel_path = "test.txt"
+    artifact_text = "hello world!"
+    with TempDir(chdr=True) as local_dir:
+        artifact_src_path = local_dir.path(artifact_rel_path)
+        with open(artifact_src_path, "w") as f:
+            f.write(artifact_text)
+        local_artifact_repo.log_artifact(artifact_src_path)
 
         for dst_dir in ["dst1", local_dir.path("dst2"), None]:
             if dst_dir is not None:
@@ -61,7 +73,6 @@ def test_download_artifacts(local_artifact_repo):
                 artifact_path=artifact_rel_path,
                 dst_path=dst_dir)
             assert dst_path == os.path.abspath(dst_path)
-            assert open(dst_path).read() == artifact_text
 
 
 @pytest.mark.parametrize("repo_subdir_path", [

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -6,13 +6,16 @@ from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.store.local_artifact_repo import LocalArtifactRepository
 from mlflow.utils.file_utils import TempDir
 
+
 @pytest.fixture
 def local_artifact_root(tmpdir):
     return str(tmpdir)
 
+
 @pytest.fixture
 def local_artifact_repo(local_artifact_root):
     return LocalArtifactRepository(artifact_uri=local_artifact_root)
+
 
 def test_list_artifacts(local_artifact_repo, local_artifact_root):
     assert len(local_artifact_repo.list_artifacts()) == 0
@@ -81,7 +84,7 @@ def test_download_artifacts_returns_absolute_paths(local_artifact_repo):
     "aaa/bbb/ccc/ddd",
 ])
 def test_artifacts_are_logged_to_and_downloaded_from_repo_subdirectory_successfully(
-    local_artifact_repo, repo_subdir_path):
+        local_artifact_repo, repo_subdir_path):
     artifact_rel_path = "test.txt"
     artifact_text = "hello world!"
     with TempDir(chdr=True) as local_dir:

--- a/tests/store/test_local_artifact_repo.py
+++ b/tests/store/test_local_artifact_repo.py
@@ -16,7 +16,7 @@ def local_artifact_repo(local_artifact_root):
 
 def test_list_artifacts(local_artifact_repo, local_artifact_root):
     assert len(local_artifact_repo.list_artifacts()) == 0
-   
+
     artifact_rel_path = "artifact"
     artifact_path = os.path.join(local_artifact_root, artifact_rel_path)
     with open(artifact_path, "w") as f:


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Update `ArtifactRepository.download_artifacts()` to always return an absolute filesystem path to the downloaded artifacts.
 
## How is this patch tested?
 
A test case was added to the suite of **local artifact repository tests**. While it seems reasonable to test each artifact repository implementation, @sueann and I agree that it's better to unify test coverage by creating a single test suite that runs against artifact repository implementations; we can prioritize this after the next release.
 
## Release Notes

Fix a bug where relative paths were returned by implementations of `ArtifactRepository.download_artifacts()`, despite the documentation clearly indicating that absolute paths are returned.
 
### Is this a user-facing change? 

- [ ] No. Add the `rn/none` label, then you can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [X] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### Please add one label to the PR so it can be classified correctly in the release notes. Options:
 
* `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
* `rn/none` - No description will be included. The PR will be mentioned just by the PR number in the "Small Bugfixes and Documentation Updates" section
* `rn/feature` - A new user-facing feature worth mentioning in the release notes
* `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
* `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
