### PR TITLE
Rename run_uuid in Python, Java, and REST API to run_id

### DIFF
--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -809,8 +809,6 @@ Arguments
 +--------------+-------------------------------------------------------+
 | ``end_time`` | Unix timestamp of when the run ended in milliseconds. |
 +--------------+-------------------------------------------------------+
-| ``run_id``   | Run ID.                                               |
-+--------------+-------------------------------------------------------+
 
 .. _details-16:
 
@@ -1238,7 +1236,7 @@ Performs prediction using an RFunc MLflow model from a file or data frame.
 
 .. code:: r
 
-   mlflow_rfunc_predict(model_path, run_uuid = NULL, input_path = NULL,
+   mlflow_rfunc_predict(model_path, run_id = NULL, input_path = NULL,
      output_path = NULL, data = NULL, restore = FALSE)
 
 .. _arguments-32:
@@ -1252,7 +1250,7 @@ Arguments
 | ``model_path``                | The path to the MLflow model, as a   |
 |                               | string.                              |
 +-------------------------------+--------------------------------------+
-| ``run_uuid``                  | Run ID of run to grab the model      |
+| ``run_id``                  | Run ID of run to grab the model        |
 |                               | from.                                |
 +-------------------------------+--------------------------------------+
 | ``input_path``                | Path to JSON or CSV file to be       |
@@ -1287,7 +1285,7 @@ Serves an RFunc MLflow model as a local web API.
 
 .. code:: r
 
-   mlflow_rfunc_serve(model_path, run_uuid = NULL, host = "127.0.0.1",
+   mlflow_rfunc_serve(model_path, run_id = NULL, host = "127.0.0.1",
      port = 8090, daemonized = FALSE, browse = !daemonized,
      restore = FALSE)
 
@@ -1302,7 +1300,7 @@ Arguments
 | ``model_path``                | The path to the MLflow model, as a   |
 |                               | string.                              |
 +-------------------------------+--------------------------------------+
-| ``run_uuid``                  | ID of run to grab the model from.    |
+| ``run_id``                  | ID of run to grab the model from.      |
 +-------------------------------+--------------------------------------+
 | ``host``                      | Address to use to serve model, as a  |
 |                               | string.                              |
@@ -1685,7 +1683,7 @@ block.
 
 .. code:: r
 
-   mlflow_start_run(run_uuid = NULL, experiment_id = NULL,
+   mlflow_start_run(run_id = NULL, experiment_id = NULL,
      source_name = NULL, source_version = NULL, entry_point_name = NULL,
      source_type = "LOCAL")
 
@@ -1697,14 +1695,14 @@ Arguments
 +-------------------------------+--------------------------------------+
 | Argument                      | Description                          |
 +===============================+======================================+
-| ``run_uuid``                  | If specified, get the run with the   |
+| ``run_id``                  | If specified, get the run with the     |
 |                               | specified UUID and log metrics and   |
 |                               | params under that run. The run's end |
 |                               | time is unset and its status is set  |
 |                               | to running, but the run's other      |
 |                               | attributes remain unchanged.         |
 +-------------------------------+--------------------------------------+
-| ``experiment_id``             | Used only when ``run_uuid`` is       |
+| ``experiment_id``             | Used only when ``run_id`` is         |
 |                               | unspecified. ID of the experiment    |
 |                               | under which to create the current    |
 |                               | run. If unspecified, the run is      |

--- a/examples/multistep_workflow/main.py
+++ b/examples/multistep_workflow/main.py
@@ -29,7 +29,7 @@ def _already_ran(entry_point_name, parameters, source_version, experiment_id=Non
         if run_info.entry_point_name != entry_point_name:
             continue
 
-        full_run = client.get_run(run_info.run_uuid)
+        full_run = client.get_run(run_info.run_id)
         match_failed = False
         for param_key, param_value in six.iteritems(parameters):
             run_value = full_run.params.get(param_key)
@@ -41,13 +41,13 @@ def _already_ran(entry_point_name, parameters, source_version, experiment_id=Non
 
         if run_info.status != RunStatus.FINISHED:
             eprint(("Run matched, but is not FINISHED, so skipping "
-                    "(run_id=%s, status=%s)") % (run_info.run_uuid, run_info.status))
+                    "(run_id=%s, status=%s)") % (run_info.run_id, run_info.status))
             continue
         if run_info.source_version != source_version:
             eprint(("Run matched, but has a different source version, so skipping "
                     "(found=%s, expected=%s)") % (run_info.source_version, source_version))
             continue
-        return client.get_run(run_info.run_uuid)
+        return client.get_run(run_info.run_id)
     return None
 
 

--- a/examples/remote_store/remote_server.py
+++ b/examples/remote_store/remote_server.py
@@ -17,14 +17,14 @@ if __name__ == "__main__":
     log_metric("foo", 6)
     log_metric("foo", 7)
     log_metric("random_int", random.randint(0, 100))
-    run_uuid = active_run().info.run_uuid
+    run_id = active_run().info.run_id
     # Get run metadata & data from the tracking server
     service = mlflow.tracking.MlflowClient()
-    run = service.get_run(run_uuid)
-    print("Metadata & data for run with UUID %s: %s" % (run_uuid, run))
+    run = service.get_run(run_id)
+    print("Metadata & data for run with UUID %s: %s" % (run_id, run))
     local_dir = tempfile.mkdtemp()
     message = "test artifact written during run %s within artifact URI %s\n" \
-              % (active_run().info.run_uuid, get_artifact_uri())
+              % (active_run().info.run_id, get_artifact_uri())
     try:
         file_path = os.path.join(local_dir, "some_output_file.txt")
         with open(file_path, "w") as handle:

--- a/examples/rest_api/mlflow_tracking_rest_api.py
+++ b/examples/rest_api/mlflow_tracking_rest_api.py
@@ -30,7 +30,7 @@ class MLFlowTrackingRestApi:
 		r = requests.post(url, json=payload)
 		run_id = None
 		if r.status_code == 200:
-			run_id = r.json()['run']['info']['run_uuid']
+			run_id = r.json()['run']['info']['run_id']
 		else:
 			print("Creating run failed!")
 		return run_id
@@ -47,14 +47,14 @@ class MLFlowTrackingRestApi:
 	def log_param(self, param):
 		"""Log a parameter dict for the given run."""
 		url = self.base_url + '/runs/log-parameter'
-		payload = {'run_uuid': self.run_id, 'key': param['key'], 'value': param['value']}
+		payload = {'run_id': self.run_id, 'key': param['key'], 'value': param['value']}
 		r = requests.post(url, json=payload)
 		return r.status_code
 
 	def log_metric(self, metric):
 		"""Log a metric dict for the given run."""
 		url = self.base_url + '/runs/log-metric'
-		payload = {'run_uuid': self.run_id, 'key': metric['key'], 'value': metric['value']}
+		payload = {'run_id': self.run_id, 'key': metric['key'], 'value': metric['value']}
 		r = requests.post(url, json=payload)
 		return r.status_code
 

--- a/mlflow/R/mlflow/R/model-serve.R
+++ b/mlflow/R/mlflow/R/model-serve.R
@@ -5,7 +5,7 @@
 #' Serves an RFunc MLflow model as a local web API.
 #'
 #' @param model_path The path to the MLflow model, as a string.
-#' @param run_uuid ID of run to grab the model from.
+#' @param run_id ID of run to grab the model from.
 #' @param host Address to use to serve model, as a string.
 #' @param port Port to use to serve model, as numeric.
 #' @param daemonized Makes `httpuv` server daemonized so R interactive sessions
@@ -34,7 +34,7 @@
 #' @export
 mlflow_rfunc_serve <- function(
   model_path,
-  run_uuid = NULL,
+  run_id = NULL,
   host = "127.0.0.1",
   port = 8090,
   daemonized = FALSE,
@@ -43,7 +43,7 @@ mlflow_rfunc_serve <- function(
 ) {
   mlflow_restore_or_warning(restore)
 
-  model_path <- resolve_model_path(model_path, run_uuid)
+  model_path <- resolve_model_path(model_path, run_id)
 
   httpuv_start <- if (daemonized) httpuv::startDaemonizedServer else httpuv::runServer
   serve_run(model_path, host, port, httpuv_start, browse && interactive())

--- a/mlflow/R/mlflow/R/model.R
+++ b/mlflow/R/mlflow/R/model.R
@@ -128,7 +128,7 @@ mlflow_load_model <- function(model_path, flavor = NULL, run_id = NULL) {
 #' Performs prediction using an RFunc MLflow model from a file or data frame.
 #'
 #' @param model_path The path to the MLflow model, as a string.
-#' @param run_uuid Run ID of run to grab the model from.
+#' @param run_id Run ID of run to grab the model from.
 #' @param input_path Path to 'JSON' or 'CSV' file to be used for prediction.
 #' @param output_path 'JSON' or 'CSV' file where the prediction will be written to.
 #' @param data Data frame to be scored. This can be used for testing purposes and can only
@@ -154,7 +154,7 @@ mlflow_load_model <- function(model_path, flavor = NULL, run_id = NULL) {
 #' @export
 mlflow_rfunc_predict <- function(
   model_path,
-  run_uuid = NULL,
+  run_id = NULL,
   input_path = NULL,
   output_path = NULL,
   data = NULL,
@@ -162,7 +162,7 @@ mlflow_rfunc_predict <- function(
 ) {
   mlflow_restore_or_warning(restore)
 
-  model_path <- resolve_model_path(model_path, run_uuid)
+  model_path <- resolve_model_path(model_path, run_id)
 
   if (!xor(is.null(input_path), is.null(data)))
     stop("One and only one of `input_path` or `data` must be specified.")
@@ -195,9 +195,9 @@ mlflow_rfunc_predict <- function(
   }
 }
 
-resolve_model_path <- function(model_path, run_uuid, client = mlflow_client()) {
-  if (!is.null(run_uuid)) {
-    result <- mlflow_cli("artifacts", "download", "--run-id", run_uuid, "-a", model_path,
+resolve_model_path <- function(model_path, run_id, client = mlflow_client()) {
+  if (!is.null(run_id)) {
+    result <- mlflow_cli("artifacts", "download", "--run-id", run_id, "-a", model_path,
                          echo = FALSE, client = client)
     gsub("\n", "", result$stdout)
   } else {

--- a/mlflow/R/mlflow/R/project-run.R
+++ b/mlflow/R/mlflow/R/project-run.R
@@ -53,6 +53,6 @@ mlflow_run <- function(entry_point = NULL, uri = ".", version = NULL, param_list
   args <- if (!no_conda) args else c(args, "--no-conda")
   result <- do.call(mlflow_cli, c("run", args))
   matches <- regexec(".*Run \\(ID \\'([^\\']+).*", result$stderr)
-  run_uuid <- regmatches(result$stderr, matches)[[1]][[2]]
-  invisible(run_uuid)
+  run_id <- regmatches(result$stderr, matches)[[1]][[2]]
+  invisible(run_id)
 }

--- a/mlflow/java/client/README.md
+++ b/mlflow/java/client/README.md
@@ -46,7 +46,7 @@ See [ApiClient.java](src/main/java/org/mlflow/client/ApiClient.java)
 and [Service.java domain objects](src/main/java/org/mlflow/api/proto/mlflow/Service.java).
 
 ```
-Run getRun(String runUuid)
+Run getRun(String runId)
 RunInfo createRun()
 RunInfo createRun(String experimentId)
 RunInfo createRun(String experimentId, String appName)
@@ -59,12 +59,12 @@ GetExperiment.Response getExperiment(String experimentId)
 Optional<Experiment> getExperimentByName(String experimentName)
 long createExperiment(String experimentName)
 
-void logParam(String runUuid, String key, String value)
-void logMetric(String runUuid, String key, float value)
-void setTerminated(String runUuid)
-void setTerminated(String runUuid, RunStatus status)
-void setTerminated(String runUuid, RunStatus status, long endTime)
-ListArtifacts.Response listArtifacts(String runUuid, String path)
+void logParam(String runId, String key, String value)
+void logMetric(String runId, String key, float value)
+void setTerminated(String runId)
+void setTerminated(String runId, RunStatus status)
+void setTerminated(String runId, RunStatus status, long endTime)
+ListArtifacts.Response listArtifacts(String runId, String path)
 ```
 
 ## Usage

--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
@@ -5978,7 +5978,8 @@ public final class Service {
 
     /**
      * <pre>
-     * Unique identifier for the run.
+     * [Deprecated, use run_id instead] Unique identifier for the run. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
      * <code>optional string run_uuid = 1;</code>
@@ -5986,7 +5987,8 @@ public final class Service {
     boolean hasRunUuid();
     /**
      * <pre>
-     * Unique identifier for the run.
+     * [Deprecated, use run_id instead] Unique identifier for the run. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
      * <code>optional string run_uuid = 1;</code>
@@ -5994,13 +5996,40 @@ public final class Service {
     java.lang.String getRunUuid();
     /**
      * <pre>
-     * Unique identifier for the run.
+     * [Deprecated, use run_id instead] Unique identifier for the run. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
      * <code>optional string run_uuid = 1;</code>
      */
     com.google.protobuf.ByteString
         getRunUuidBytes();
+
+    /**
+     * <pre>
+     * Unique identifier for the run.
+     * </pre>
+     *
+     * <code>optional string run_id = 15;</code>
+     */
+    boolean hasRunId();
+    /**
+     * <pre>
+     * Unique identifier for the run.
+     * </pre>
+     *
+     * <code>optional string run_id = 15;</code>
+     */
+    java.lang.String getRunId();
+    /**
+     * <pre>
+     * Unique identifier for the run.
+     * </pre>
+     *
+     * <code>optional string run_id = 15;</code>
+     */
+    com.google.protobuf.ByteString
+        getRunIdBytes();
 
     /**
      * <pre>
@@ -6333,6 +6362,7 @@ public final class Service {
     }
     private RunInfo() {
       runUuid_ = "";
+      runId_ = "";
       experimentId_ = "";
       name_ = "";
       sourceType_ = 1;
@@ -6379,13 +6409,13 @@ public final class Service {
             }
             case 18: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
+              bitField0_ |= 0x00000004;
               experimentId_ = bs;
               break;
             }
             case 26: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000004;
+              bitField0_ |= 0x00000008;
               name_ = bs;
               break;
             }
@@ -6396,20 +6426,20 @@ public final class Service {
               if (value == null) {
                 unknownFields.mergeVarintField(4, rawValue);
               } else {
-                bitField0_ |= 0x00000008;
+                bitField0_ |= 0x00000010;
                 sourceType_ = rawValue;
               }
               break;
             }
             case 42: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000010;
+              bitField0_ |= 0x00000020;
               sourceName_ = bs;
               break;
             }
             case 50: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000020;
+              bitField0_ |= 0x00000040;
               userId_ = bs;
               break;
             }
@@ -6420,43 +6450,49 @@ public final class Service {
               if (value == null) {
                 unknownFields.mergeVarintField(7, rawValue);
               } else {
-                bitField0_ |= 0x00000040;
+                bitField0_ |= 0x00000080;
                 status_ = rawValue;
               }
               break;
             }
             case 64: {
-              bitField0_ |= 0x00000080;
+              bitField0_ |= 0x00000100;
               startTime_ = input.readInt64();
               break;
             }
             case 72: {
-              bitField0_ |= 0x00000100;
+              bitField0_ |= 0x00000200;
               endTime_ = input.readInt64();
               break;
             }
             case 82: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000200;
+              bitField0_ |= 0x00000400;
               sourceVersion_ = bs;
               break;
             }
             case 90: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000400;
+              bitField0_ |= 0x00000800;
               entryPointName_ = bs;
               break;
             }
             case 106: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000800;
+              bitField0_ |= 0x00001000;
               artifactUri_ = bs;
               break;
             }
             case 114: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00001000;
+              bitField0_ |= 0x00002000;
               lifecycleStage_ = bs;
+              break;
+            }
+            case 122: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              runId_ = bs;
               break;
             }
             default: {
@@ -6496,7 +6532,8 @@ public final class Service {
     private volatile java.lang.Object runUuid_;
     /**
      * <pre>
-     * Unique identifier for the run.
+     * [Deprecated, use run_id instead] Unique identifier for the run. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
      * <code>optional string run_uuid = 1;</code>
@@ -6506,7 +6543,8 @@ public final class Service {
     }
     /**
      * <pre>
-     * Unique identifier for the run.
+     * [Deprecated, use run_id instead] Unique identifier for the run. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
      * <code>optional string run_uuid = 1;</code>
@@ -6527,7 +6565,8 @@ public final class Service {
     }
     /**
      * <pre>
-     * Unique identifier for the run.
+     * [Deprecated, use run_id instead] Unique identifier for the run. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
      * <code>optional string run_uuid = 1;</code>
@@ -6546,6 +6585,60 @@ public final class Service {
       }
     }
 
+    public static final int RUN_ID_FIELD_NUMBER = 15;
+    private volatile java.lang.Object runId_;
+    /**
+     * <pre>
+     * Unique identifier for the run.
+     * </pre>
+     *
+     * <code>optional string run_id = 15;</code>
+     */
+    public boolean hasRunId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <pre>
+     * Unique identifier for the run.
+     * </pre>
+     *
+     * <code>optional string run_id = 15;</code>
+     */
+    public java.lang.String getRunId() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Unique identifier for the run.
+     * </pre>
+     *
+     * <code>optional string run_id = 15;</code>
+     */
+    public com.google.protobuf.ByteString
+        getRunIdBytes() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     public static final int EXPERIMENT_ID_FIELD_NUMBER = 2;
     private volatile java.lang.Object experimentId_;
     /**
@@ -6556,7 +6649,7 @@ public final class Service {
      * <code>optional string experiment_id = 2;</code>
      */
     public boolean hasExperimentId() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
      * <pre>
@@ -6612,7 +6705,7 @@ public final class Service {
      * <code>optional string name = 3;</code>
      */
     public boolean hasName() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
      * <pre>
@@ -6672,7 +6765,7 @@ public final class Service {
      * <code>optional .mlflow.SourceType source_type = 4;</code>
      */
     public boolean hasSourceType() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
      * <pre>
@@ -6701,7 +6794,7 @@ public final class Service {
      * <code>optional string source_name = 5;</code>
      */
     public boolean hasSourceName() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000020) == 0x00000020);
     }
     /**
      * <pre>
@@ -6759,7 +6852,7 @@ public final class Service {
      * <code>optional string user_id = 6;</code>
      */
     public boolean hasUserId() {
-      return ((bitField0_ & 0x00000020) == 0x00000020);
+      return ((bitField0_ & 0x00000040) == 0x00000040);
     }
     /**
      * <pre>
@@ -6813,7 +6906,7 @@ public final class Service {
      * <code>optional .mlflow.RunStatus status = 7;</code>
      */
     public boolean hasStatus() {
-      return ((bitField0_ & 0x00000040) == 0x00000040);
+      return ((bitField0_ & 0x00000080) == 0x00000080);
     }
     /**
      * <pre>
@@ -6838,7 +6931,7 @@ public final class Service {
      * <code>optional int64 start_time = 8;</code>
      */
     public boolean hasStartTime() {
-      return ((bitField0_ & 0x00000080) == 0x00000080);
+      return ((bitField0_ & 0x00000100) == 0x00000100);
     }
     /**
      * <pre>
@@ -6861,7 +6954,7 @@ public final class Service {
      * <code>optional int64 end_time = 9;</code>
      */
     public boolean hasEndTime() {
-      return ((bitField0_ & 0x00000100) == 0x00000100);
+      return ((bitField0_ & 0x00000200) == 0x00000200);
     }
     /**
      * <pre>
@@ -6886,7 +6979,7 @@ public final class Service {
      * <code>optional string source_version = 10;</code>
      */
     public boolean hasSourceVersion() {
-      return ((bitField0_ & 0x00000200) == 0x00000200);
+      return ((bitField0_ & 0x00000400) == 0x00000400);
     }
     /**
      * <pre>
@@ -6946,7 +7039,7 @@ public final class Service {
      * <code>optional string entry_point_name = 11;</code>
      */
     public boolean hasEntryPointName() {
-      return ((bitField0_ & 0x00000400) == 0x00000400);
+      return ((bitField0_ & 0x00000800) == 0x00000800);
     }
     /**
      * <pre>
@@ -7007,7 +7100,7 @@ public final class Service {
      * <code>optional string artifact_uri = 13;</code>
      */
     public boolean hasArtifactUri() {
-      return ((bitField0_ & 0x00000800) == 0x00000800);
+      return ((bitField0_ & 0x00001000) == 0x00001000);
     }
     /**
      * <pre>
@@ -7067,7 +7160,7 @@ public final class Service {
      * <code>optional string lifecycle_stage = 14;</code>
      */
     public boolean hasLifecycleStage() {
-      return ((bitField0_ & 0x00001000) == 0x00001000);
+      return ((bitField0_ & 0x00002000) == 0x00002000);
     }
     /**
      * <pre>
@@ -7128,41 +7221,44 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, experimentId_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, name_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
         output.writeEnum(4, sourceType_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 5, sourceName_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 6, userId_);
       }
-      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+      if (((bitField0_ & 0x00000080) == 0x00000080)) {
         output.writeEnum(7, status_);
       }
-      if (((bitField0_ & 0x00000080) == 0x00000080)) {
+      if (((bitField0_ & 0x00000100) == 0x00000100)) {
         output.writeInt64(8, startTime_);
       }
-      if (((bitField0_ & 0x00000100) == 0x00000100)) {
+      if (((bitField0_ & 0x00000200) == 0x00000200)) {
         output.writeInt64(9, endTime_);
       }
-      if (((bitField0_ & 0x00000200) == 0x00000200)) {
+      if (((bitField0_ & 0x00000400) == 0x00000400)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 10, sourceVersion_);
       }
-      if (((bitField0_ & 0x00000400) == 0x00000400)) {
+      if (((bitField0_ & 0x00000800) == 0x00000800)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 11, entryPointName_);
       }
-      if (((bitField0_ & 0x00000800) == 0x00000800)) {
+      if (((bitField0_ & 0x00001000) == 0x00001000)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 13, artifactUri_);
       }
-      if (((bitField0_ & 0x00001000) == 0x00001000)) {
+      if (((bitField0_ & 0x00002000) == 0x00002000)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 14, lifecycleStage_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 15, runId_);
       }
       unknownFields.writeTo(output);
     }
@@ -7176,45 +7272,48 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, experimentId_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, name_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(4, sourceType_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, sourceName_);
       }
-      if (((bitField0_ & 0x00000020) == 0x00000020)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, userId_);
-      }
       if (((bitField0_ & 0x00000040) == 0x00000040)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeEnumSize(7, status_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, userId_);
       }
       if (((bitField0_ & 0x00000080) == 0x00000080)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(8, startTime_);
+          .computeEnumSize(7, status_);
       }
       if (((bitField0_ & 0x00000100) == 0x00000100)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(9, endTime_);
+          .computeInt64Size(8, startTime_);
       }
       if (((bitField0_ & 0x00000200) == 0x00000200)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(10, sourceVersion_);
+        size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(9, endTime_);
       }
       if (((bitField0_ & 0x00000400) == 0x00000400)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(11, entryPointName_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(10, sourceVersion_);
       }
       if (((bitField0_ & 0x00000800) == 0x00000800)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(13, artifactUri_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(11, entryPointName_);
       }
       if (((bitField0_ & 0x00001000) == 0x00001000)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(13, artifactUri_);
+      }
+      if (((bitField0_ & 0x00002000) == 0x00002000)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(14, lifecycleStage_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(15, runId_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -7236,6 +7335,11 @@ public final class Service {
       if (hasRunUuid()) {
         result = result && getRunUuid()
             .equals(other.getRunUuid());
+      }
+      result = result && (hasRunId() == other.hasRunId());
+      if (hasRunId()) {
+        result = result && getRunId()
+            .equals(other.getRunId());
       }
       result = result && (hasExperimentId() == other.hasExperimentId());
       if (hasExperimentId()) {
@@ -7309,6 +7413,10 @@ public final class Service {
       if (hasRunUuid()) {
         hash = (37 * hash) + RUN_UUID_FIELD_NUMBER;
         hash = (53 * hash) + getRunUuid().hashCode();
+      }
+      if (hasRunId()) {
+        hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRunId().hashCode();
       }
       if (hasExperimentId()) {
         hash = (37 * hash) + EXPERIMENT_ID_FIELD_NUMBER;
@@ -7499,30 +7607,32 @@ public final class Service {
         super.clear();
         runUuid_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        experimentId_ = "";
+        runId_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
-        name_ = "";
+        experimentId_ = "";
         bitField0_ = (bitField0_ & ~0x00000004);
-        sourceType_ = 1;
+        name_ = "";
         bitField0_ = (bitField0_ & ~0x00000008);
-        sourceName_ = "";
+        sourceType_ = 1;
         bitField0_ = (bitField0_ & ~0x00000010);
-        userId_ = "";
+        sourceName_ = "";
         bitField0_ = (bitField0_ & ~0x00000020);
-        status_ = 1;
+        userId_ = "";
         bitField0_ = (bitField0_ & ~0x00000040);
-        startTime_ = 0L;
+        status_ = 1;
         bitField0_ = (bitField0_ & ~0x00000080);
-        endTime_ = 0L;
+        startTime_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000100);
-        sourceVersion_ = "";
+        endTime_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000200);
-        entryPointName_ = "";
+        sourceVersion_ = "";
         bitField0_ = (bitField0_ & ~0x00000400);
-        artifactUri_ = "";
+        entryPointName_ = "";
         bitField0_ = (bitField0_ & ~0x00000800);
-        lifecycleStage_ = "";
+        artifactUri_ = "";
         bitField0_ = (bitField0_ & ~0x00001000);
+        lifecycleStage_ = "";
+        bitField0_ = (bitField0_ & ~0x00002000);
         return this;
       }
 
@@ -7558,49 +7668,53 @@ public final class Service {
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
         }
-        result.experimentId_ = experimentId_;
+        result.runId_ = runId_;
         if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
           to_bitField0_ |= 0x00000004;
         }
-        result.name_ = name_;
+        result.experimentId_ = experimentId_;
         if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
           to_bitField0_ |= 0x00000008;
         }
-        result.sourceType_ = sourceType_;
+        result.name_ = name_;
         if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
           to_bitField0_ |= 0x00000010;
         }
-        result.sourceName_ = sourceName_;
+        result.sourceType_ = sourceType_;
         if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
           to_bitField0_ |= 0x00000020;
         }
-        result.userId_ = userId_;
+        result.sourceName_ = sourceName_;
         if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
           to_bitField0_ |= 0x00000040;
         }
-        result.status_ = status_;
+        result.userId_ = userId_;
         if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
           to_bitField0_ |= 0x00000080;
         }
-        result.startTime_ = startTime_;
+        result.status_ = status_;
         if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
           to_bitField0_ |= 0x00000100;
         }
-        result.endTime_ = endTime_;
+        result.startTime_ = startTime_;
         if (((from_bitField0_ & 0x00000200) == 0x00000200)) {
           to_bitField0_ |= 0x00000200;
         }
-        result.sourceVersion_ = sourceVersion_;
+        result.endTime_ = endTime_;
         if (((from_bitField0_ & 0x00000400) == 0x00000400)) {
           to_bitField0_ |= 0x00000400;
         }
-        result.entryPointName_ = entryPointName_;
+        result.sourceVersion_ = sourceVersion_;
         if (((from_bitField0_ & 0x00000800) == 0x00000800)) {
           to_bitField0_ |= 0x00000800;
         }
-        result.artifactUri_ = artifactUri_;
+        result.entryPointName_ = entryPointName_;
         if (((from_bitField0_ & 0x00001000) == 0x00001000)) {
           to_bitField0_ |= 0x00001000;
+        }
+        result.artifactUri_ = artifactUri_;
+        if (((from_bitField0_ & 0x00002000) == 0x00002000)) {
+          to_bitField0_ |= 0x00002000;
         }
         result.lifecycleStage_ = lifecycleStage_;
         result.bitField0_ = to_bitField0_;
@@ -7657,13 +7771,18 @@ public final class Service {
           runUuid_ = other.runUuid_;
           onChanged();
         }
-        if (other.hasExperimentId()) {
+        if (other.hasRunId()) {
           bitField0_ |= 0x00000002;
+          runId_ = other.runId_;
+          onChanged();
+        }
+        if (other.hasExperimentId()) {
+          bitField0_ |= 0x00000004;
           experimentId_ = other.experimentId_;
           onChanged();
         }
         if (other.hasName()) {
-          bitField0_ |= 0x00000004;
+          bitField0_ |= 0x00000008;
           name_ = other.name_;
           onChanged();
         }
@@ -7671,12 +7790,12 @@ public final class Service {
           setSourceType(other.getSourceType());
         }
         if (other.hasSourceName()) {
-          bitField0_ |= 0x00000010;
+          bitField0_ |= 0x00000020;
           sourceName_ = other.sourceName_;
           onChanged();
         }
         if (other.hasUserId()) {
-          bitField0_ |= 0x00000020;
+          bitField0_ |= 0x00000040;
           userId_ = other.userId_;
           onChanged();
         }
@@ -7690,22 +7809,22 @@ public final class Service {
           setEndTime(other.getEndTime());
         }
         if (other.hasSourceVersion()) {
-          bitField0_ |= 0x00000200;
+          bitField0_ |= 0x00000400;
           sourceVersion_ = other.sourceVersion_;
           onChanged();
         }
         if (other.hasEntryPointName()) {
-          bitField0_ |= 0x00000400;
+          bitField0_ |= 0x00000800;
           entryPointName_ = other.entryPointName_;
           onChanged();
         }
         if (other.hasArtifactUri()) {
-          bitField0_ |= 0x00000800;
+          bitField0_ |= 0x00001000;
           artifactUri_ = other.artifactUri_;
           onChanged();
         }
         if (other.hasLifecycleStage()) {
-          bitField0_ |= 0x00001000;
+          bitField0_ |= 0x00002000;
           lifecycleStage_ = other.lifecycleStage_;
           onChanged();
         }
@@ -7742,7 +7861,8 @@ public final class Service {
       private java.lang.Object runUuid_ = "";
       /**
        * <pre>
-       * Unique identifier for the run.
+       * [Deprecated, use run_id instead] Unique identifier for the run. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
        * <code>optional string run_uuid = 1;</code>
@@ -7752,7 +7872,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * Unique identifier for the run.
+       * [Deprecated, use run_id instead] Unique identifier for the run. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
        * <code>optional string run_uuid = 1;</code>
@@ -7773,7 +7894,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * Unique identifier for the run.
+       * [Deprecated, use run_id instead] Unique identifier for the run. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
        * <code>optional string run_uuid = 1;</code>
@@ -7793,7 +7915,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * Unique identifier for the run.
+       * [Deprecated, use run_id instead] Unique identifier for the run. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
        * <code>optional string run_uuid = 1;</code>
@@ -7810,7 +7933,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * Unique identifier for the run.
+       * [Deprecated, use run_id instead] Unique identifier for the run. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
        * <code>optional string run_uuid = 1;</code>
@@ -7823,7 +7947,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * Unique identifier for the run.
+       * [Deprecated, use run_id instead] Unique identifier for the run. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
        * <code>optional string run_uuid = 1;</code>
@@ -7839,6 +7964,106 @@ public final class Service {
         return this;
       }
 
+      private java.lang.Object runId_ = "";
+      /**
+       * <pre>
+       * Unique identifier for the run.
+       * </pre>
+       *
+       * <code>optional string run_id = 15;</code>
+       */
+      public boolean hasRunId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <pre>
+       * Unique identifier for the run.
+       * </pre>
+       *
+       * <code>optional string run_id = 15;</code>
+       */
+      public java.lang.String getRunId() {
+        java.lang.Object ref = runId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Unique identifier for the run.
+       * </pre>
+       *
+       * <code>optional string run_id = 15;</code>
+       */
+      public com.google.protobuf.ByteString
+          getRunIdBytes() {
+        java.lang.Object ref = runId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Unique identifier for the run.
+       * </pre>
+       *
+       * <code>optional string run_id = 15;</code>
+       */
+      public Builder setRunId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Unique identifier for the run.
+       * </pre>
+       *
+       * <code>optional string run_id = 15;</code>
+       */
+      public Builder clearRunId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        runId_ = getDefaultInstance().getRunId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Unique identifier for the run.
+       * </pre>
+       *
+       * <code>optional string run_id = 15;</code>
+       */
+      public Builder setRunIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+
       private java.lang.Object experimentId_ = "";
       /**
        * <pre>
@@ -7848,7 +8073,7 @@ public final class Service {
        * <code>optional string experiment_id = 2;</code>
        */
       public boolean hasExperimentId() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
        * <pre>
@@ -7903,7 +8128,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         experimentId_ = value;
         onChanged();
         return this;
@@ -7916,7 +8141,7 @@ public final class Service {
        * <code>optional string experiment_id = 2;</code>
        */
       public Builder clearExperimentId() {
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000004);
         experimentId_ = getDefaultInstance().getExperimentId();
         onChanged();
         return this;
@@ -7933,7 +8158,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         experimentId_ = value;
         onChanged();
         return this;
@@ -7950,7 +8175,7 @@ public final class Service {
        * <code>optional string name = 3;</code>
        */
       public boolean hasName() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000008) == 0x00000008);
       }
       /**
        * <pre>
@@ -8011,7 +8236,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000004;
+  bitField0_ |= 0x00000008;
         name_ = value;
         onChanged();
         return this;
@@ -8026,7 +8251,7 @@ public final class Service {
        * <code>optional string name = 3;</code>
        */
       public Builder clearName() {
-        bitField0_ = (bitField0_ & ~0x00000004);
+        bitField0_ = (bitField0_ & ~0x00000008);
         name_ = getDefaultInstance().getName();
         onChanged();
         return this;
@@ -8045,7 +8270,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000004;
+  bitField0_ |= 0x00000008;
         name_ = value;
         onChanged();
         return this;
@@ -8062,7 +8287,7 @@ public final class Service {
        * <code>optional .mlflow.SourceType source_type = 4;</code>
        */
       public boolean hasSourceType() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000010) == 0x00000010);
       }
       /**
        * <pre>
@@ -8091,7 +8316,7 @@ public final class Service {
         if (value == null) {
           throw new NullPointerException();
         }
-        bitField0_ |= 0x00000008;
+        bitField0_ |= 0x00000010;
         sourceType_ = value.getNumber();
         onChanged();
         return this;
@@ -8106,7 +8331,7 @@ public final class Service {
        * <code>optional .mlflow.SourceType source_type = 4;</code>
        */
       public Builder clearSourceType() {
-        bitField0_ = (bitField0_ & ~0x00000008);
+        bitField0_ = (bitField0_ & ~0x00000010);
         sourceType_ = 1;
         onChanged();
         return this;
@@ -8123,7 +8348,7 @@ public final class Service {
        * <code>optional string source_name = 5;</code>
        */
       public boolean hasSourceName() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000020) == 0x00000020);
       }
       /**
        * <pre>
@@ -8184,7 +8409,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000010;
+  bitField0_ |= 0x00000020;
         sourceName_ = value;
         onChanged();
         return this;
@@ -8199,7 +8424,7 @@ public final class Service {
        * <code>optional string source_name = 5;</code>
        */
       public Builder clearSourceName() {
-        bitField0_ = (bitField0_ & ~0x00000010);
+        bitField0_ = (bitField0_ & ~0x00000020);
         sourceName_ = getDefaultInstance().getSourceName();
         onChanged();
         return this;
@@ -8218,7 +8443,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000010;
+  bitField0_ |= 0x00000020;
         sourceName_ = value;
         onChanged();
         return this;
@@ -8233,7 +8458,7 @@ public final class Service {
        * <code>optional string user_id = 6;</code>
        */
       public boolean hasUserId() {
-        return ((bitField0_ & 0x00000020) == 0x00000020);
+        return ((bitField0_ & 0x00000040) == 0x00000040);
       }
       /**
        * <pre>
@@ -8288,7 +8513,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000020;
+  bitField0_ |= 0x00000040;
         userId_ = value;
         onChanged();
         return this;
@@ -8301,7 +8526,7 @@ public final class Service {
        * <code>optional string user_id = 6;</code>
        */
       public Builder clearUserId() {
-        bitField0_ = (bitField0_ & ~0x00000020);
+        bitField0_ = (bitField0_ & ~0x00000040);
         userId_ = getDefaultInstance().getUserId();
         onChanged();
         return this;
@@ -8318,7 +8543,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000020;
+  bitField0_ |= 0x00000040;
         userId_ = value;
         onChanged();
         return this;
@@ -8333,7 +8558,7 @@ public final class Service {
        * <code>optional .mlflow.RunStatus status = 7;</code>
        */
       public boolean hasStatus() {
-        return ((bitField0_ & 0x00000040) == 0x00000040);
+        return ((bitField0_ & 0x00000080) == 0x00000080);
       }
       /**
        * <pre>
@@ -8358,7 +8583,7 @@ public final class Service {
         if (value == null) {
           throw new NullPointerException();
         }
-        bitField0_ |= 0x00000040;
+        bitField0_ |= 0x00000080;
         status_ = value.getNumber();
         onChanged();
         return this;
@@ -8371,7 +8596,7 @@ public final class Service {
        * <code>optional .mlflow.RunStatus status = 7;</code>
        */
       public Builder clearStatus() {
-        bitField0_ = (bitField0_ & ~0x00000040);
+        bitField0_ = (bitField0_ & ~0x00000080);
         status_ = 1;
         onChanged();
         return this;
@@ -8386,7 +8611,7 @@ public final class Service {
        * <code>optional int64 start_time = 8;</code>
        */
       public boolean hasStartTime() {
-        return ((bitField0_ & 0x00000080) == 0x00000080);
+        return ((bitField0_ & 0x00000100) == 0x00000100);
       }
       /**
        * <pre>
@@ -8406,7 +8631,7 @@ public final class Service {
        * <code>optional int64 start_time = 8;</code>
        */
       public Builder setStartTime(long value) {
-        bitField0_ |= 0x00000080;
+        bitField0_ |= 0x00000100;
         startTime_ = value;
         onChanged();
         return this;
@@ -8419,7 +8644,7 @@ public final class Service {
        * <code>optional int64 start_time = 8;</code>
        */
       public Builder clearStartTime() {
-        bitField0_ = (bitField0_ & ~0x00000080);
+        bitField0_ = (bitField0_ & ~0x00000100);
         startTime_ = 0L;
         onChanged();
         return this;
@@ -8434,7 +8659,7 @@ public final class Service {
        * <code>optional int64 end_time = 9;</code>
        */
       public boolean hasEndTime() {
-        return ((bitField0_ & 0x00000100) == 0x00000100);
+        return ((bitField0_ & 0x00000200) == 0x00000200);
       }
       /**
        * <pre>
@@ -8454,7 +8679,7 @@ public final class Service {
        * <code>optional int64 end_time = 9;</code>
        */
       public Builder setEndTime(long value) {
-        bitField0_ |= 0x00000100;
+        bitField0_ |= 0x00000200;
         endTime_ = value;
         onChanged();
         return this;
@@ -8467,7 +8692,7 @@ public final class Service {
        * <code>optional int64 end_time = 9;</code>
        */
       public Builder clearEndTime() {
-        bitField0_ = (bitField0_ & ~0x00000100);
+        bitField0_ = (bitField0_ & ~0x00000200);
         endTime_ = 0L;
         onChanged();
         return this;
@@ -8484,7 +8709,7 @@ public final class Service {
        * <code>optional string source_version = 10;</code>
        */
       public boolean hasSourceVersion() {
-        return ((bitField0_ & 0x00000200) == 0x00000200);
+        return ((bitField0_ & 0x00000400) == 0x00000400);
       }
       /**
        * <pre>
@@ -8545,7 +8770,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000200;
+  bitField0_ |= 0x00000400;
         sourceVersion_ = value;
         onChanged();
         return this;
@@ -8560,7 +8785,7 @@ public final class Service {
        * <code>optional string source_version = 10;</code>
        */
       public Builder clearSourceVersion() {
-        bitField0_ = (bitField0_ & ~0x00000200);
+        bitField0_ = (bitField0_ & ~0x00000400);
         sourceVersion_ = getDefaultInstance().getSourceVersion();
         onChanged();
         return this;
@@ -8579,7 +8804,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000200;
+  bitField0_ |= 0x00000400;
         sourceVersion_ = value;
         onChanged();
         return this;
@@ -8596,7 +8821,7 @@ public final class Service {
        * <code>optional string entry_point_name = 11;</code>
        */
       public boolean hasEntryPointName() {
-        return ((bitField0_ & 0x00000400) == 0x00000400);
+        return ((bitField0_ & 0x00000800) == 0x00000800);
       }
       /**
        * <pre>
@@ -8657,7 +8882,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000400;
+  bitField0_ |= 0x00000800;
         entryPointName_ = value;
         onChanged();
         return this;
@@ -8672,7 +8897,7 @@ public final class Service {
        * <code>optional string entry_point_name = 11;</code>
        */
       public Builder clearEntryPointName() {
-        bitField0_ = (bitField0_ & ~0x00000400);
+        bitField0_ = (bitField0_ & ~0x00000800);
         entryPointName_ = getDefaultInstance().getEntryPointName();
         onChanged();
         return this;
@@ -8691,7 +8916,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000400;
+  bitField0_ |= 0x00000800;
         entryPointName_ = value;
         onChanged();
         return this;
@@ -8709,7 +8934,7 @@ public final class Service {
        * <code>optional string artifact_uri = 13;</code>
        */
       public boolean hasArtifactUri() {
-        return ((bitField0_ & 0x00000800) == 0x00000800);
+        return ((bitField0_ & 0x00001000) == 0x00001000);
       }
       /**
        * <pre>
@@ -8773,7 +8998,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000800;
+  bitField0_ |= 0x00001000;
         artifactUri_ = value;
         onChanged();
         return this;
@@ -8789,7 +9014,7 @@ public final class Service {
        * <code>optional string artifact_uri = 13;</code>
        */
       public Builder clearArtifactUri() {
-        bitField0_ = (bitField0_ & ~0x00000800);
+        bitField0_ = (bitField0_ & ~0x00001000);
         artifactUri_ = getDefaultInstance().getArtifactUri();
         onChanged();
         return this;
@@ -8809,7 +9034,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000800;
+  bitField0_ |= 0x00001000;
         artifactUri_ = value;
         onChanged();
         return this;
@@ -8824,7 +9049,7 @@ public final class Service {
        * <code>optional string lifecycle_stage = 14;</code>
        */
       public boolean hasLifecycleStage() {
-        return ((bitField0_ & 0x00001000) == 0x00001000);
+        return ((bitField0_ & 0x00002000) == 0x00002000);
       }
       /**
        * <pre>
@@ -8879,7 +9104,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00001000;
+  bitField0_ |= 0x00002000;
         lifecycleStage_ = value;
         onChanged();
         return this;
@@ -8892,7 +9117,7 @@ public final class Service {
        * <code>optional string lifecycle_stage = 14;</code>
        */
       public Builder clearLifecycleStage() {
-        bitField0_ = (bitField0_ & ~0x00001000);
+        bitField0_ = (bitField0_ & ~0x00002000);
         lifecycleStage_ = getDefaultInstance().getLifecycleStage();
         onChanged();
         return this;
@@ -8909,7 +9134,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00001000;
+  bitField0_ |= 0x00002000;
         lifecycleStage_ = value;
         onChanged();
         return this;
@@ -22036,29 +22261,58 @@ public final class Service {
 
     /**
      * <pre>
-     * ID of the run to update.
+     * [Deprecated, use run_id instead] ID of the run to update.. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     boolean hasRunUuid();
     /**
      * <pre>
-     * ID of the run to update.
+     * [Deprecated, use run_id instead] ID of the run to update.. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     java.lang.String getRunUuid();
     /**
      * <pre>
-     * ID of the run to update.
+     * [Deprecated, use run_id instead] ID of the run to update.. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     com.google.protobuf.ByteString
         getRunUuidBytes();
+
+    /**
+     * <pre>
+     * ID of the run to update. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    boolean hasRunId();
+    /**
+     * <pre>
+     * ID of the run to update. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    java.lang.String getRunId();
+    /**
+     * <pre>
+     * ID of the run to update. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    com.google.protobuf.ByteString
+        getRunIdBytes();
 
     /**
      * <pre>
@@ -22108,6 +22362,7 @@ public final class Service {
     }
     private UpdateRun() {
       runUuid_ = "";
+      runId_ = "";
       status_ = 1;
       endTime_ = 0L;
     }
@@ -22149,14 +22404,20 @@ public final class Service {
               if (value == null) {
                 unknownFields.mergeVarintField(2, rawValue);
               } else {
-                bitField0_ |= 0x00000002;
+                bitField0_ |= 0x00000004;
                 status_ = rawValue;
               }
               break;
             }
             case 24: {
-              bitField0_ |= 0x00000004;
+              bitField0_ |= 0x00000008;
               endTime_ = input.readInt64();
+              break;
+            }
+            case 34: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              runId_ = bs;
               break;
             }
             default: {
@@ -22873,20 +23134,22 @@ public final class Service {
     private volatile java.lang.Object runUuid_;
     /**
      * <pre>
-     * ID of the run to update.
+     * [Deprecated, use run_id instead] ID of the run to update.. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public boolean hasRunUuid() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
      * <pre>
-     * ID of the run to update.
+     * [Deprecated, use run_id instead] ID of the run to update.. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public java.lang.String getRunUuid() {
       java.lang.Object ref = runUuid_;
@@ -22904,10 +23167,11 @@ public final class Service {
     }
     /**
      * <pre>
-     * ID of the run to update.
+     * [Deprecated, use run_id instead] ID of the run to update.. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public com.google.protobuf.ByteString
         getRunUuidBytes() {
@@ -22917,6 +23181,60 @@ public final class Service {
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         runUuid_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int RUN_ID_FIELD_NUMBER = 4;
+    private volatile java.lang.Object runId_;
+    /**
+     * <pre>
+     * ID of the run to update. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    public boolean hasRunId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <pre>
+     * ID of the run to update. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    public java.lang.String getRunId() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * ID of the run to update. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    public com.google.protobuf.ByteString
+        getRunIdBytes() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runId_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -22933,7 +23251,7 @@ public final class Service {
      * <code>optional .mlflow.RunStatus status = 2;</code>
      */
     public boolean hasStatus() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
      * <pre>
@@ -22958,7 +23276,7 @@ public final class Service {
      * <code>optional int64 end_time = 3;</code>
      */
     public boolean hasEndTime() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
      * <pre>
@@ -22988,11 +23306,14 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         output.writeEnum(2, status_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeInt64(3, endTime_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, runId_);
       }
       unknownFields.writeTo(output);
     }
@@ -23006,13 +23327,16 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.CodedOutputStream
           .computeEnumSize(2, status_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(3, endTime_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, runId_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -23034,6 +23358,11 @@ public final class Service {
       if (hasRunUuid()) {
         result = result && getRunUuid()
             .equals(other.getRunUuid());
+      }
+      result = result && (hasRunId() == other.hasRunId());
+      if (hasRunId()) {
+        result = result && getRunId()
+            .equals(other.getRunId());
       }
       result = result && (hasStatus() == other.hasStatus());
       if (hasStatus()) {
@@ -23058,6 +23387,10 @@ public final class Service {
       if (hasRunUuid()) {
         hash = (37 * hash) + RUN_UUID_FIELD_NUMBER;
         hash = (53 * hash) + getRunUuid().hashCode();
+      }
+      if (hasRunId()) {
+        hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRunId().hashCode();
       }
       if (hasStatus()) {
         hash = (37 * hash) + STATUS_FIELD_NUMBER;
@@ -23203,10 +23536,12 @@ public final class Service {
         super.clear();
         runUuid_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        status_ = 1;
+        runId_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
-        endTime_ = 0L;
+        status_ = 1;
         bitField0_ = (bitField0_ & ~0x00000004);
+        endTime_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -23242,9 +23577,13 @@ public final class Service {
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
         }
-        result.status_ = status_;
+        result.runId_ = runId_;
         if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
           to_bitField0_ |= 0x00000004;
+        }
+        result.status_ = status_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
         }
         result.endTime_ = endTime_;
         result.bitField0_ = to_bitField0_;
@@ -23301,6 +23640,11 @@ public final class Service {
           runUuid_ = other.runUuid_;
           onChanged();
         }
+        if (other.hasRunId()) {
+          bitField0_ |= 0x00000002;
+          runId_ = other.runId_;
+          onChanged();
+        }
         if (other.hasStatus()) {
           setStatus(other.getStatus());
         }
@@ -23340,20 +23684,22 @@ public final class Service {
       private java.lang.Object runUuid_ = "";
       /**
        * <pre>
-       * ID of the run to update.
+       * [Deprecated, use run_id instead] ID of the run to update.. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public boolean hasRunUuid() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
        * <pre>
-       * ID of the run to update.
+       * [Deprecated, use run_id instead] ID of the run to update.. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public java.lang.String getRunUuid() {
         java.lang.Object ref = runUuid_;
@@ -23371,10 +23717,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run to update.
+       * [Deprecated, use run_id instead] ID of the run to update.. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public com.google.protobuf.ByteString
           getRunUuidBytes() {
@@ -23391,10 +23738,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run to update.
+       * [Deprecated, use run_id instead] ID of the run to update.. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder setRunUuid(
           java.lang.String value) {
@@ -23408,10 +23756,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run to update.
+       * [Deprecated, use run_id instead] ID of the run to update.. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder clearRunUuid() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -23421,10 +23770,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run to update.
+       * [Deprecated, use run_id instead] ID of the run to update.. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder setRunUuidBytes(
           com.google.protobuf.ByteString value) {
@@ -23433,6 +23783,106 @@ public final class Service {
   }
   bitField0_ |= 0x00000001;
         runUuid_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object runId_ = "";
+      /**
+       * <pre>
+       * ID of the run to update. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public boolean hasRunId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <pre>
+       * ID of the run to update. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public java.lang.String getRunId() {
+        java.lang.Object ref = runId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run to update. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public com.google.protobuf.ByteString
+          getRunIdBytes() {
+        java.lang.Object ref = runId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run to update. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public Builder setRunId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run to update. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public Builder clearRunId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        runId_ = getDefaultInstance().getRunId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run to update. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public Builder setRunIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
         onChanged();
         return this;
       }
@@ -23446,7 +23896,7 @@ public final class Service {
        * <code>optional .mlflow.RunStatus status = 2;</code>
        */
       public boolean hasStatus() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
        * <pre>
@@ -23471,7 +23921,7 @@ public final class Service {
         if (value == null) {
           throw new NullPointerException();
         }
-        bitField0_ |= 0x00000002;
+        bitField0_ |= 0x00000004;
         status_ = value.getNumber();
         onChanged();
         return this;
@@ -23484,7 +23934,7 @@ public final class Service {
        * <code>optional .mlflow.RunStatus status = 2;</code>
        */
       public Builder clearStatus() {
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000004);
         status_ = 1;
         onChanged();
         return this;
@@ -23499,7 +23949,7 @@ public final class Service {
        * <code>optional int64 end_time = 3;</code>
        */
       public boolean hasEndTime() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000008) == 0x00000008);
       }
       /**
        * <pre>
@@ -23519,7 +23969,7 @@ public final class Service {
        * <code>optional int64 end_time = 3;</code>
        */
       public Builder setEndTime(long value) {
-        bitField0_ |= 0x00000004;
+        bitField0_ |= 0x00000008;
         endTime_ = value;
         onChanged();
         return this;
@@ -23532,7 +23982,7 @@ public final class Service {
        * <code>optional int64 end_time = 3;</code>
        */
       public Builder clearEndTime() {
-        bitField0_ = (bitField0_ & ~0x00000004);
+        bitField0_ = (bitField0_ & ~0x00000008);
         endTime_ = 0L;
         onChanged();
         return this;
@@ -25586,29 +26036,58 @@ public final class Service {
 
     /**
      * <pre>
-     * ID of the run under which to log the metric.
+     * [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     boolean hasRunUuid();
     /**
      * <pre>
-     * ID of the run under which to log the metric.
+     * [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     java.lang.String getRunUuid();
     /**
      * <pre>
-     * ID of the run under which to log the metric.
+     * [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     com.google.protobuf.ByteString
         getRunUuidBytes();
+
+    /**
+     * <pre>
+     * ID of the run under which to log the metric. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 6;</code>
+     */
+    boolean hasRunId();
+    /**
+     * <pre>
+     * ID of the run under which to log the metric. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 6;</code>
+     */
+    java.lang.String getRunId();
+    /**
+     * <pre>
+     * ID of the run under which to log the metric. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 6;</code>
+     */
+    com.google.protobuf.ByteString
+        getRunIdBytes();
 
     /**
      * <pre>
@@ -25701,6 +26180,7 @@ public final class Service {
     }
     private LogMetric() {
       runUuid_ = "";
+      runId_ = "";
       key_ = "";
       value_ = 0D;
       timestamp_ = 0L;
@@ -25739,23 +26219,29 @@ public final class Service {
             }
             case 18: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
+              bitField0_ |= 0x00000004;
               key_ = bs;
               break;
             }
             case 25: {
-              bitField0_ |= 0x00000004;
+              bitField0_ |= 0x00000008;
               value_ = input.readDouble();
               break;
             }
             case 32: {
-              bitField0_ |= 0x00000008;
+              bitField0_ |= 0x00000010;
               timestamp_ = input.readInt64();
               break;
             }
             case 40: {
-              bitField0_ |= 0x00000010;
+              bitField0_ |= 0x00000020;
               step_ = input.readInt64();
+              break;
+            }
+            case 50: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              runId_ = bs;
               break;
             }
             default: {
@@ -26207,20 +26693,22 @@ public final class Service {
     private volatile java.lang.Object runUuid_;
     /**
      * <pre>
-     * ID of the run under which to log the metric.
+     * [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public boolean hasRunUuid() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
      * <pre>
-     * ID of the run under which to log the metric.
+     * [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public java.lang.String getRunUuid() {
       java.lang.Object ref = runUuid_;
@@ -26238,10 +26726,11 @@ public final class Service {
     }
     /**
      * <pre>
-     * ID of the run under which to log the metric.
+     * [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public com.google.protobuf.ByteString
         getRunUuidBytes() {
@@ -26251,6 +26740,60 @@ public final class Service {
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         runUuid_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int RUN_ID_FIELD_NUMBER = 6;
+    private volatile java.lang.Object runId_;
+    /**
+     * <pre>
+     * ID of the run under which to log the metric. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 6;</code>
+     */
+    public boolean hasRunId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <pre>
+     * ID of the run under which to log the metric. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 6;</code>
+     */
+    public java.lang.String getRunId() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * ID of the run under which to log the metric. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 6;</code>
+     */
+    public com.google.protobuf.ByteString
+        getRunIdBytes() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runId_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -26267,7 +26810,7 @@ public final class Service {
      * <code>optional string key = 2 [(.validate_required) = true];</code>
      */
     public boolean hasKey() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
      * <pre>
@@ -26321,7 +26864,7 @@ public final class Service {
      * <code>optional double value = 3 [(.validate_required) = true];</code>
      */
     public boolean hasValue() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
      * <pre>
@@ -26344,7 +26887,7 @@ public final class Service {
      * <code>optional int64 timestamp = 4 [(.validate_required) = true];</code>
      */
     public boolean hasTimestamp() {
-      return ((bitField0_ & 0x00000008) == 0x00000008);
+      return ((bitField0_ & 0x00000010) == 0x00000010);
     }
     /**
      * <pre>
@@ -26367,7 +26910,7 @@ public final class Service {
      * <code>optional int64 step = 5 [default = 0];</code>
      */
     public boolean hasStep() {
-      return ((bitField0_ & 0x00000010) == 0x00000010);
+      return ((bitField0_ & 0x00000020) == 0x00000020);
     }
     /**
      * <pre>
@@ -26397,17 +26940,20 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, key_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
         output.writeDouble(3, value_);
       }
-      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
         output.writeInt64(4, timestamp_);
       }
-      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
         output.writeInt64(5, step_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 6, runId_);
       }
       unknownFields.writeTo(output);
     }
@@ -26421,20 +26967,23 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, key_);
-      }
       if (((bitField0_ & 0x00000004) == 0x00000004)) {
-        size += com.google.protobuf.CodedOutputStream
-          .computeDoubleSize(3, value_);
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, key_);
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.CodedOutputStream
-          .computeInt64Size(4, timestamp_);
+          .computeDoubleSize(3, value_);
       }
       if (((bitField0_ & 0x00000010) == 0x00000010)) {
         size += com.google.protobuf.CodedOutputStream
+          .computeInt64Size(4, timestamp_);
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += com.google.protobuf.CodedOutputStream
           .computeInt64Size(5, step_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, runId_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -26456,6 +27005,11 @@ public final class Service {
       if (hasRunUuid()) {
         result = result && getRunUuid()
             .equals(other.getRunUuid());
+      }
+      result = result && (hasRunId() == other.hasRunId());
+      if (hasRunId()) {
+        result = result && getRunId()
+            .equals(other.getRunId());
       }
       result = result && (hasKey() == other.hasKey());
       if (hasKey()) {
@@ -26493,6 +27047,10 @@ public final class Service {
       if (hasRunUuid()) {
         hash = (37 * hash) + RUN_UUID_FIELD_NUMBER;
         hash = (53 * hash) + getRunUuid().hashCode();
+      }
+      if (hasRunId()) {
+        hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRunId().hashCode();
       }
       if (hasKey()) {
         hash = (37 * hash) + KEY_FIELD_NUMBER;
@@ -26648,14 +27206,16 @@ public final class Service {
         super.clear();
         runUuid_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        key_ = "";
+        runId_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
-        value_ = 0D;
+        key_ = "";
         bitField0_ = (bitField0_ & ~0x00000004);
-        timestamp_ = 0L;
+        value_ = 0D;
         bitField0_ = (bitField0_ & ~0x00000008);
-        step_ = 0L;
+        timestamp_ = 0L;
         bitField0_ = (bitField0_ & ~0x00000010);
+        step_ = 0L;
+        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
 
@@ -26691,17 +27251,21 @@ public final class Service {
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
         }
-        result.key_ = key_;
+        result.runId_ = runId_;
         if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
           to_bitField0_ |= 0x00000004;
         }
-        result.value_ = value_;
+        result.key_ = key_;
         if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
           to_bitField0_ |= 0x00000008;
         }
-        result.timestamp_ = timestamp_;
+        result.value_ = value_;
         if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
           to_bitField0_ |= 0x00000010;
+        }
+        result.timestamp_ = timestamp_;
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000020;
         }
         result.step_ = step_;
         result.bitField0_ = to_bitField0_;
@@ -26758,8 +27322,13 @@ public final class Service {
           runUuid_ = other.runUuid_;
           onChanged();
         }
-        if (other.hasKey()) {
+        if (other.hasRunId()) {
           bitField0_ |= 0x00000002;
+          runId_ = other.runId_;
+          onChanged();
+        }
+        if (other.hasKey()) {
+          bitField0_ |= 0x00000004;
           key_ = other.key_;
           onChanged();
         }
@@ -26805,20 +27374,22 @@ public final class Service {
       private java.lang.Object runUuid_ = "";
       /**
        * <pre>
-       * ID of the run under which to log the metric.
+       * [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public boolean hasRunUuid() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
        * <pre>
-       * ID of the run under which to log the metric.
+       * [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public java.lang.String getRunUuid() {
         java.lang.Object ref = runUuid_;
@@ -26836,10 +27407,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run under which to log the metric.
+       * [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public com.google.protobuf.ByteString
           getRunUuidBytes() {
@@ -26856,10 +27428,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run under which to log the metric.
+       * [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder setRunUuid(
           java.lang.String value) {
@@ -26873,10 +27446,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run under which to log the metric.
+       * [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder clearRunUuid() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -26886,10 +27460,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run under which to log the metric.
+       * [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder setRunUuidBytes(
           com.google.protobuf.ByteString value) {
@@ -26898,6 +27473,106 @@ public final class Service {
   }
   bitField0_ |= 0x00000001;
         runUuid_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object runId_ = "";
+      /**
+       * <pre>
+       * ID of the run under which to log the metric. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 6;</code>
+       */
+      public boolean hasRunId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the metric. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 6;</code>
+       */
+      public java.lang.String getRunId() {
+        java.lang.Object ref = runId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the metric. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 6;</code>
+       */
+      public com.google.protobuf.ByteString
+          getRunIdBytes() {
+        java.lang.Object ref = runId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the metric. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 6;</code>
+       */
+      public Builder setRunId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the metric. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 6;</code>
+       */
+      public Builder clearRunId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        runId_ = getDefaultInstance().getRunId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the metric. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 6;</code>
+       */
+      public Builder setRunIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
         onChanged();
         return this;
       }
@@ -26911,7 +27586,7 @@ public final class Service {
        * <code>optional string key = 2 [(.validate_required) = true];</code>
        */
       public boolean hasKey() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
        * <pre>
@@ -26966,7 +27641,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         key_ = value;
         onChanged();
         return this;
@@ -26979,7 +27654,7 @@ public final class Service {
        * <code>optional string key = 2 [(.validate_required) = true];</code>
        */
       public Builder clearKey() {
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000004);
         key_ = getDefaultInstance().getKey();
         onChanged();
         return this;
@@ -26996,7 +27671,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         key_ = value;
         onChanged();
         return this;
@@ -27011,7 +27686,7 @@ public final class Service {
        * <code>optional double value = 3 [(.validate_required) = true];</code>
        */
       public boolean hasValue() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000008) == 0x00000008);
       }
       /**
        * <pre>
@@ -27031,7 +27706,7 @@ public final class Service {
        * <code>optional double value = 3 [(.validate_required) = true];</code>
        */
       public Builder setValue(double value) {
-        bitField0_ |= 0x00000004;
+        bitField0_ |= 0x00000008;
         value_ = value;
         onChanged();
         return this;
@@ -27044,7 +27719,7 @@ public final class Service {
        * <code>optional double value = 3 [(.validate_required) = true];</code>
        */
       public Builder clearValue() {
-        bitField0_ = (bitField0_ & ~0x00000004);
+        bitField0_ = (bitField0_ & ~0x00000008);
         value_ = 0D;
         onChanged();
         return this;
@@ -27059,7 +27734,7 @@ public final class Service {
        * <code>optional int64 timestamp = 4 [(.validate_required) = true];</code>
        */
       public boolean hasTimestamp() {
-        return ((bitField0_ & 0x00000008) == 0x00000008);
+        return ((bitField0_ & 0x00000010) == 0x00000010);
       }
       /**
        * <pre>
@@ -27079,7 +27754,7 @@ public final class Service {
        * <code>optional int64 timestamp = 4 [(.validate_required) = true];</code>
        */
       public Builder setTimestamp(long value) {
-        bitField0_ |= 0x00000008;
+        bitField0_ |= 0x00000010;
         timestamp_ = value;
         onChanged();
         return this;
@@ -27092,7 +27767,7 @@ public final class Service {
        * <code>optional int64 timestamp = 4 [(.validate_required) = true];</code>
        */
       public Builder clearTimestamp() {
-        bitField0_ = (bitField0_ & ~0x00000008);
+        bitField0_ = (bitField0_ & ~0x00000010);
         timestamp_ = 0L;
         onChanged();
         return this;
@@ -27107,7 +27782,7 @@ public final class Service {
        * <code>optional int64 step = 5 [default = 0];</code>
        */
       public boolean hasStep() {
-        return ((bitField0_ & 0x00000010) == 0x00000010);
+        return ((bitField0_ & 0x00000020) == 0x00000020);
       }
       /**
        * <pre>
@@ -27127,7 +27802,7 @@ public final class Service {
        * <code>optional int64 step = 5 [default = 0];</code>
        */
       public Builder setStep(long value) {
-        bitField0_ |= 0x00000010;
+        bitField0_ |= 0x00000020;
         step_ = value;
         onChanged();
         return this;
@@ -27140,7 +27815,7 @@ public final class Service {
        * <code>optional int64 step = 5 [default = 0];</code>
        */
       public Builder clearStep() {
-        bitField0_ = (bitField0_ & ~0x00000010);
+        bitField0_ = (bitField0_ & ~0x00000020);
         step_ = 0L;
         onChanged();
         return this;
@@ -27204,29 +27879,58 @@ public final class Service {
 
     /**
      * <pre>
-     * ID of the run under which to log the param.
+     * [Deprecated, use run_id instead] ID of the run under which to log the param. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     boolean hasRunUuid();
     /**
      * <pre>
-     * ID of the run under which to log the param.
+     * [Deprecated, use run_id instead] ID of the run under which to log the param. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     java.lang.String getRunUuid();
     /**
      * <pre>
-     * ID of the run under which to log the param.
+     * [Deprecated, use run_id instead] ID of the run under which to log the param. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     com.google.protobuf.ByteString
         getRunUuidBytes();
+
+    /**
+     * <pre>
+     * ID of the run under which to log the param. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    boolean hasRunId();
+    /**
+     * <pre>
+     * ID of the run under which to log the param. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    java.lang.String getRunId();
+    /**
+     * <pre>
+     * ID of the run under which to log the param. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    com.google.protobuf.ByteString
+        getRunIdBytes();
 
     /**
      * <pre>
@@ -27294,6 +27998,7 @@ public final class Service {
     }
     private LogParam() {
       runUuid_ = "";
+      runId_ = "";
       key_ = "";
       value_ = "";
     }
@@ -27330,14 +28035,20 @@ public final class Service {
             }
             case 18: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
+              bitField0_ |= 0x00000004;
               key_ = bs;
               break;
             }
             case 26: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000004;
+              bitField0_ |= 0x00000008;
               value_ = bs;
+              break;
+            }
+            case 34: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              runId_ = bs;
               break;
             }
             default: {
@@ -27789,20 +28500,22 @@ public final class Service {
     private volatile java.lang.Object runUuid_;
     /**
      * <pre>
-     * ID of the run under which to log the param.
+     * [Deprecated, use run_id instead] ID of the run under which to log the param. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public boolean hasRunUuid() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
      * <pre>
-     * ID of the run under which to log the param.
+     * [Deprecated, use run_id instead] ID of the run under which to log the param. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public java.lang.String getRunUuid() {
       java.lang.Object ref = runUuid_;
@@ -27820,10 +28533,11 @@ public final class Service {
     }
     /**
      * <pre>
-     * ID of the run under which to log the param.
+     * [Deprecated, use run_id instead] ID of the run under which to log the param. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public com.google.protobuf.ByteString
         getRunUuidBytes() {
@@ -27833,6 +28547,60 @@ public final class Service {
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         runUuid_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int RUN_ID_FIELD_NUMBER = 4;
+    private volatile java.lang.Object runId_;
+    /**
+     * <pre>
+     * ID of the run under which to log the param. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    public boolean hasRunId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <pre>
+     * ID of the run under which to log the param. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    public java.lang.String getRunId() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * ID of the run under which to log the param. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    public com.google.protobuf.ByteString
+        getRunIdBytes() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runId_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -27849,7 +28617,7 @@ public final class Service {
      * <code>optional string key = 2 [(.validate_required) = true];</code>
      */
     public boolean hasKey() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
      * <pre>
@@ -27903,7 +28671,7 @@ public final class Service {
      * <code>optional string value = 3 [(.validate_required) = true];</code>
      */
     public boolean hasValue() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
      * <pre>
@@ -27964,11 +28732,14 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, key_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, value_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, runId_);
       }
       unknownFields.writeTo(output);
     }
@@ -27982,11 +28753,14 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, key_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, value_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, runId_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -28008,6 +28782,11 @@ public final class Service {
       if (hasRunUuid()) {
         result = result && getRunUuid()
             .equals(other.getRunUuid());
+      }
+      result = result && (hasRunId() == other.hasRunId());
+      if (hasRunId()) {
+        result = result && getRunId()
+            .equals(other.getRunId());
       }
       result = result && (hasKey() == other.hasKey());
       if (hasKey()) {
@@ -28033,6 +28812,10 @@ public final class Service {
       if (hasRunUuid()) {
         hash = (37 * hash) + RUN_UUID_FIELD_NUMBER;
         hash = (53 * hash) + getRunUuid().hashCode();
+      }
+      if (hasRunId()) {
+        hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRunId().hashCode();
       }
       if (hasKey()) {
         hash = (37 * hash) + KEY_FIELD_NUMBER;
@@ -28177,10 +28960,12 @@ public final class Service {
         super.clear();
         runUuid_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        key_ = "";
+        runId_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
-        value_ = "";
+        key_ = "";
         bitField0_ = (bitField0_ & ~0x00000004);
+        value_ = "";
+        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -28216,9 +29001,13 @@ public final class Service {
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
         }
-        result.key_ = key_;
+        result.runId_ = runId_;
         if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
           to_bitField0_ |= 0x00000004;
+        }
+        result.key_ = key_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
         }
         result.value_ = value_;
         result.bitField0_ = to_bitField0_;
@@ -28275,13 +29064,18 @@ public final class Service {
           runUuid_ = other.runUuid_;
           onChanged();
         }
-        if (other.hasKey()) {
+        if (other.hasRunId()) {
           bitField0_ |= 0x00000002;
+          runId_ = other.runId_;
+          onChanged();
+        }
+        if (other.hasKey()) {
+          bitField0_ |= 0x00000004;
           key_ = other.key_;
           onChanged();
         }
         if (other.hasValue()) {
-          bitField0_ |= 0x00000004;
+          bitField0_ |= 0x00000008;
           value_ = other.value_;
           onChanged();
         }
@@ -28318,20 +29112,22 @@ public final class Service {
       private java.lang.Object runUuid_ = "";
       /**
        * <pre>
-       * ID of the run under which to log the param.
+       * [Deprecated, use run_id instead] ID of the run under which to log the param. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public boolean hasRunUuid() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
        * <pre>
-       * ID of the run under which to log the param.
+       * [Deprecated, use run_id instead] ID of the run under which to log the param. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public java.lang.String getRunUuid() {
         java.lang.Object ref = runUuid_;
@@ -28349,10 +29145,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run under which to log the param.
+       * [Deprecated, use run_id instead] ID of the run under which to log the param. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public com.google.protobuf.ByteString
           getRunUuidBytes() {
@@ -28369,10 +29166,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run under which to log the param.
+       * [Deprecated, use run_id instead] ID of the run under which to log the param. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder setRunUuid(
           java.lang.String value) {
@@ -28386,10 +29184,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run under which to log the param.
+       * [Deprecated, use run_id instead] ID of the run under which to log the param. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder clearRunUuid() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -28399,10 +29198,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run under which to log the param.
+       * [Deprecated, use run_id instead] ID of the run under which to log the param. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder setRunUuidBytes(
           com.google.protobuf.ByteString value) {
@@ -28411,6 +29211,106 @@ public final class Service {
   }
   bitField0_ |= 0x00000001;
         runUuid_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object runId_ = "";
+      /**
+       * <pre>
+       * ID of the run under which to log the param. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public boolean hasRunId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the param. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public java.lang.String getRunId() {
+        java.lang.Object ref = runId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the param. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public com.google.protobuf.ByteString
+          getRunIdBytes() {
+        java.lang.Object ref = runId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the param. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public Builder setRunId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the param. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public Builder clearRunId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        runId_ = getDefaultInstance().getRunId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the param. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public Builder setRunIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
         onChanged();
         return this;
       }
@@ -28424,7 +29324,7 @@ public final class Service {
        * <code>optional string key = 2 [(.validate_required) = true];</code>
        */
       public boolean hasKey() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
        * <pre>
@@ -28479,7 +29379,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         key_ = value;
         onChanged();
         return this;
@@ -28492,7 +29392,7 @@ public final class Service {
        * <code>optional string key = 2 [(.validate_required) = true];</code>
        */
       public Builder clearKey() {
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000004);
         key_ = getDefaultInstance().getKey();
         onChanged();
         return this;
@@ -28509,7 +29409,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         key_ = value;
         onChanged();
         return this;
@@ -28524,7 +29424,7 @@ public final class Service {
        * <code>optional string value = 3 [(.validate_required) = true];</code>
        */
       public boolean hasValue() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000008) == 0x00000008);
       }
       /**
        * <pre>
@@ -28579,7 +29479,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000004;
+  bitField0_ |= 0x00000008;
         value_ = value;
         onChanged();
         return this;
@@ -28592,7 +29492,7 @@ public final class Service {
        * <code>optional string value = 3 [(.validate_required) = true];</code>
        */
       public Builder clearValue() {
-        bitField0_ = (bitField0_ & ~0x00000004);
+        bitField0_ = (bitField0_ & ~0x00000008);
         value_ = getDefaultInstance().getValue();
         onChanged();
         return this;
@@ -28609,7 +29509,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000004;
+  bitField0_ |= 0x00000008;
         value_ = value;
         onChanged();
         return this;
@@ -28673,29 +29573,58 @@ public final class Service {
 
     /**
      * <pre>
-     * ID of the run under which to set the tag.
+     * [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     boolean hasRunUuid();
     /**
      * <pre>
-     * ID of the run under which to set the tag.
+     * [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     java.lang.String getRunUuid();
     /**
      * <pre>
-     * ID of the run under which to set the tag.
+     * [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     com.google.protobuf.ByteString
         getRunUuidBytes();
+
+    /**
+     * <pre>
+     * ID of the run under which to log the tag. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    boolean hasRunId();
+    /**
+     * <pre>
+     * ID of the run under which to log the tag. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    java.lang.String getRunId();
+    /**
+     * <pre>
+     * ID of the run under which to log the tag. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    com.google.protobuf.ByteString
+        getRunIdBytes();
 
     /**
      * <pre>
@@ -28763,6 +29692,7 @@ public final class Service {
     }
     private SetTag() {
       runUuid_ = "";
+      runId_ = "";
       key_ = "";
       value_ = "";
     }
@@ -28799,14 +29729,20 @@ public final class Service {
             }
             case 18: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
+              bitField0_ |= 0x00000004;
               key_ = bs;
               break;
             }
             case 26: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000004;
+              bitField0_ |= 0x00000008;
               value_ = bs;
+              break;
+            }
+            case 34: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              runId_ = bs;
               break;
             }
             default: {
@@ -29258,20 +30194,22 @@ public final class Service {
     private volatile java.lang.Object runUuid_;
     /**
      * <pre>
-     * ID of the run under which to set the tag.
+     * [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public boolean hasRunUuid() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
      * <pre>
-     * ID of the run under which to set the tag.
+     * [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public java.lang.String getRunUuid() {
       java.lang.Object ref = runUuid_;
@@ -29289,10 +30227,11 @@ public final class Service {
     }
     /**
      * <pre>
-     * ID of the run under which to set the tag.
+     * [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public com.google.protobuf.ByteString
         getRunUuidBytes() {
@@ -29302,6 +30241,60 @@ public final class Service {
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         runUuid_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int RUN_ID_FIELD_NUMBER = 4;
+    private volatile java.lang.Object runId_;
+    /**
+     * <pre>
+     * ID of the run under which to log the tag. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    public boolean hasRunId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <pre>
+     * ID of the run under which to log the tag. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    public java.lang.String getRunId() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * ID of the run under which to log the tag. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 4;</code>
+     */
+    public com.google.protobuf.ByteString
+        getRunIdBytes() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runId_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -29318,7 +30311,7 @@ public final class Service {
      * <code>optional string key = 2 [(.validate_required) = true];</code>
      */
     public boolean hasKey() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
      * <pre>
@@ -29372,7 +30365,7 @@ public final class Service {
      * <code>optional string value = 3 [(.validate_required) = true];</code>
      */
     public boolean hasValue() {
-      return ((bitField0_ & 0x00000004) == 0x00000004);
+      return ((bitField0_ & 0x00000008) == 0x00000008);
     }
     /**
      * <pre>
@@ -29433,11 +30426,14 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, key_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 3, value_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 4, runId_);
       }
       unknownFields.writeTo(output);
     }
@@ -29451,11 +30447,14 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, key_);
       }
-      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, value_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(4, runId_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -29477,6 +30476,11 @@ public final class Service {
       if (hasRunUuid()) {
         result = result && getRunUuid()
             .equals(other.getRunUuid());
+      }
+      result = result && (hasRunId() == other.hasRunId());
+      if (hasRunId()) {
+        result = result && getRunId()
+            .equals(other.getRunId());
       }
       result = result && (hasKey() == other.hasKey());
       if (hasKey()) {
@@ -29502,6 +30506,10 @@ public final class Service {
       if (hasRunUuid()) {
         hash = (37 * hash) + RUN_UUID_FIELD_NUMBER;
         hash = (53 * hash) + getRunUuid().hashCode();
+      }
+      if (hasRunId()) {
+        hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRunId().hashCode();
       }
       if (hasKey()) {
         hash = (37 * hash) + KEY_FIELD_NUMBER;
@@ -29646,10 +30654,12 @@ public final class Service {
         super.clear();
         runUuid_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        key_ = "";
+        runId_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
-        value_ = "";
+        key_ = "";
         bitField0_ = (bitField0_ & ~0x00000004);
+        value_ = "";
+        bitField0_ = (bitField0_ & ~0x00000008);
         return this;
       }
 
@@ -29685,9 +30695,13 @@ public final class Service {
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
         }
-        result.key_ = key_;
+        result.runId_ = runId_;
         if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
           to_bitField0_ |= 0x00000004;
+        }
+        result.key_ = key_;
+        if (((from_bitField0_ & 0x00000008) == 0x00000008)) {
+          to_bitField0_ |= 0x00000008;
         }
         result.value_ = value_;
         result.bitField0_ = to_bitField0_;
@@ -29744,13 +30758,18 @@ public final class Service {
           runUuid_ = other.runUuid_;
           onChanged();
         }
-        if (other.hasKey()) {
+        if (other.hasRunId()) {
           bitField0_ |= 0x00000002;
+          runId_ = other.runId_;
+          onChanged();
+        }
+        if (other.hasKey()) {
+          bitField0_ |= 0x00000004;
           key_ = other.key_;
           onChanged();
         }
         if (other.hasValue()) {
-          bitField0_ |= 0x00000004;
+          bitField0_ |= 0x00000008;
           value_ = other.value_;
           onChanged();
         }
@@ -29787,20 +30806,22 @@ public final class Service {
       private java.lang.Object runUuid_ = "";
       /**
        * <pre>
-       * ID of the run under which to set the tag.
+       * [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public boolean hasRunUuid() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
        * <pre>
-       * ID of the run under which to set the tag.
+       * [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public java.lang.String getRunUuid() {
         java.lang.Object ref = runUuid_;
@@ -29818,10 +30839,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run under which to set the tag.
+       * [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public com.google.protobuf.ByteString
           getRunUuidBytes() {
@@ -29838,10 +30860,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run under which to set the tag.
+       * [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder setRunUuid(
           java.lang.String value) {
@@ -29855,10 +30878,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run under which to set the tag.
+       * [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder clearRunUuid() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -29868,10 +30892,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run under which to set the tag.
+       * [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder setRunUuidBytes(
           com.google.protobuf.ByteString value) {
@@ -29880,6 +30905,106 @@ public final class Service {
   }
   bitField0_ |= 0x00000001;
         runUuid_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object runId_ = "";
+      /**
+       * <pre>
+       * ID of the run under which to log the tag. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public boolean hasRunId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the tag. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public java.lang.String getRunId() {
+        java.lang.Object ref = runId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the tag. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public com.google.protobuf.ByteString
+          getRunIdBytes() {
+        java.lang.Object ref = runId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the tag. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public Builder setRunId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the tag. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public Builder clearRunId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        runId_ = getDefaultInstance().getRunId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run under which to log the tag. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 4;</code>
+       */
+      public Builder setRunIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
         onChanged();
         return this;
       }
@@ -29893,7 +31018,7 @@ public final class Service {
        * <code>optional string key = 2 [(.validate_required) = true];</code>
        */
       public boolean hasKey() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
        * <pre>
@@ -29948,7 +31073,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         key_ = value;
         onChanged();
         return this;
@@ -29961,7 +31086,7 @@ public final class Service {
        * <code>optional string key = 2 [(.validate_required) = true];</code>
        */
       public Builder clearKey() {
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000004);
         key_ = getDefaultInstance().getKey();
         onChanged();
         return this;
@@ -29978,7 +31103,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         key_ = value;
         onChanged();
         return this;
@@ -29993,7 +31118,7 @@ public final class Service {
        * <code>optional string value = 3 [(.validate_required) = true];</code>
        */
       public boolean hasValue() {
-        return ((bitField0_ & 0x00000004) == 0x00000004);
+        return ((bitField0_ & 0x00000008) == 0x00000008);
       }
       /**
        * <pre>
@@ -30048,7 +31173,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000004;
+  bitField0_ |= 0x00000008;
         value_ = value;
         onChanged();
         return this;
@@ -30061,7 +31186,7 @@ public final class Service {
        * <code>optional string value = 3 [(.validate_required) = true];</code>
        */
       public Builder clearValue() {
-        bitField0_ = (bitField0_ & ~0x00000004);
+        bitField0_ = (bitField0_ & ~0x00000008);
         value_ = getDefaultInstance().getValue();
         onChanged();
         return this;
@@ -30078,7 +31203,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000004;
+  bitField0_ |= 0x00000008;
         value_ = value;
         onChanged();
         return this;
@@ -30142,29 +31267,58 @@ public final class Service {
 
     /**
      * <pre>
-     * ID of the run to fetch.
+     * [Deprecated, use run_id instead] ID of the run to fetch. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     boolean hasRunUuid();
     /**
      * <pre>
-     * ID of the run to fetch.
+     * [Deprecated, use run_id instead] ID of the run to fetch. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     java.lang.String getRunUuid();
     /**
      * <pre>
-     * ID of the run to fetch.
+     * [Deprecated, use run_id instead] ID of the run to fetch. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     com.google.protobuf.ByteString
         getRunUuidBytes();
+
+    /**
+     * <pre>
+     * ID of he run to fetch. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 2;</code>
+     */
+    boolean hasRunId();
+    /**
+     * <pre>
+     * ID of he run to fetch. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 2;</code>
+     */
+    java.lang.String getRunId();
+    /**
+     * <pre>
+     * ID of he run to fetch. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 2;</code>
+     */
+    com.google.protobuf.ByteString
+        getRunIdBytes();
   }
   /**
    * Protobuf type {@code mlflow.GetRun}
@@ -30180,6 +31334,7 @@ public final class Service {
     }
     private GetRun() {
       runUuid_ = "";
+      runId_ = "";
     }
 
     @java.lang.Override
@@ -30210,6 +31365,12 @@ public final class Service {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000001;
               runUuid_ = bs;
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              runId_ = bs;
               break;
             }
             default: {
@@ -30926,20 +32087,22 @@ public final class Service {
     private volatile java.lang.Object runUuid_;
     /**
      * <pre>
-     * ID of the run to fetch.
+     * [Deprecated, use run_id instead] ID of the run to fetch. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public boolean hasRunUuid() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
      * <pre>
-     * ID of the run to fetch.
+     * [Deprecated, use run_id instead] ID of the run to fetch. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public java.lang.String getRunUuid() {
       java.lang.Object ref = runUuid_;
@@ -30957,10 +32120,11 @@ public final class Service {
     }
     /**
      * <pre>
-     * ID of the run to fetch.
+     * [Deprecated, use run_id instead] ID of the run to fetch. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public com.google.protobuf.ByteString
         getRunUuidBytes() {
@@ -30970,6 +32134,60 @@ public final class Service {
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         runUuid_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int RUN_ID_FIELD_NUMBER = 2;
+    private volatile java.lang.Object runId_;
+    /**
+     * <pre>
+     * ID of he run to fetch. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 2;</code>
+     */
+    public boolean hasRunId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <pre>
+     * ID of he run to fetch. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 2;</code>
+     */
+    public java.lang.String getRunId() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * ID of he run to fetch. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 2;</code>
+     */
+    public com.google.protobuf.ByteString
+        getRunIdBytes() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runId_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -30993,6 +32211,9 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runUuid_);
       }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, runId_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -31004,6 +32225,9 @@ public final class Service {
       size = 0;
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runUuid_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, runId_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -31026,6 +32250,11 @@ public final class Service {
         result = result && getRunUuid()
             .equals(other.getRunUuid());
       }
+      result = result && (hasRunId() == other.hasRunId());
+      if (hasRunId()) {
+        result = result && getRunId()
+            .equals(other.getRunId());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -31040,6 +32269,10 @@ public final class Service {
       if (hasRunUuid()) {
         hash = (37 * hash) + RUN_UUID_FIELD_NUMBER;
         hash = (53 * hash) + getRunUuid().hashCode();
+      }
+      if (hasRunId()) {
+        hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRunId().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -31176,6 +32409,8 @@ public final class Service {
         super.clear();
         runUuid_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
+        runId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
         return this;
       }
 
@@ -31208,6 +32443,10 @@ public final class Service {
           to_bitField0_ |= 0x00000001;
         }
         result.runUuid_ = runUuid_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.runId_ = runId_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -31262,6 +32501,11 @@ public final class Service {
           runUuid_ = other.runUuid_;
           onChanged();
         }
+        if (other.hasRunId()) {
+          bitField0_ |= 0x00000002;
+          runId_ = other.runId_;
+          onChanged();
+        }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
         return this;
@@ -31295,20 +32539,22 @@ public final class Service {
       private java.lang.Object runUuid_ = "";
       /**
        * <pre>
-       * ID of the run to fetch.
+       * [Deprecated, use run_id instead] ID of the run to fetch. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public boolean hasRunUuid() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
        * <pre>
-       * ID of the run to fetch.
+       * [Deprecated, use run_id instead] ID of the run to fetch. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public java.lang.String getRunUuid() {
         java.lang.Object ref = runUuid_;
@@ -31326,10 +32572,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run to fetch.
+       * [Deprecated, use run_id instead] ID of the run to fetch. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public com.google.protobuf.ByteString
           getRunUuidBytes() {
@@ -31346,10 +32593,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run to fetch.
+       * [Deprecated, use run_id instead] ID of the run to fetch. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder setRunUuid(
           java.lang.String value) {
@@ -31363,10 +32611,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run to fetch.
+       * [Deprecated, use run_id instead] ID of the run to fetch. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder clearRunUuid() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -31376,10 +32625,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run to fetch.
+       * [Deprecated, use run_id instead] ID of the run to fetch. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder setRunUuidBytes(
           com.google.protobuf.ByteString value) {
@@ -31388,6 +32638,106 @@ public final class Service {
   }
   bitField0_ |= 0x00000001;
         runUuid_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object runId_ = "";
+      /**
+       * <pre>
+       * ID of he run to fetch. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 2;</code>
+       */
+      public boolean hasRunId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <pre>
+       * ID of he run to fetch. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 2;</code>
+       */
+      public java.lang.String getRunId() {
+        java.lang.Object ref = runId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of he run to fetch. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getRunIdBytes() {
+        java.lang.Object ref = runId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of he run to fetch. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 2;</code>
+       */
+      public Builder setRunId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of he run to fetch. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 2;</code>
+       */
+      public Builder clearRunId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        runId_ = getDefaultInstance().getRunId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of he run to fetch. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 2;</code>
+       */
+      public Builder setRunIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
         onChanged();
         return this;
       }
@@ -39797,7 +41147,8 @@ public final class Service {
 
     /**
      * <pre>
-     * ID of the run whose artifacts to list.
+     * [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
      * <code>optional string run_uuid = 1;</code>
@@ -39805,7 +41156,8 @@ public final class Service {
     boolean hasRunUuid();
     /**
      * <pre>
-     * ID of the run whose artifacts to list.
+     * [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
      * <code>optional string run_uuid = 1;</code>
@@ -39813,13 +41165,40 @@ public final class Service {
     java.lang.String getRunUuid();
     /**
      * <pre>
-     * ID of the run whose artifacts to list.
+     * [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
      * <code>optional string run_uuid = 1;</code>
      */
     com.google.protobuf.ByteString
         getRunUuidBytes();
+
+    /**
+     * <pre>
+     * ID of the run whose artifacts to list. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 3;</code>
+     */
+    boolean hasRunId();
+    /**
+     * <pre>
+     * ID of the run whose artifacts to list. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 3;</code>
+     */
+    java.lang.String getRunId();
+    /**
+     * <pre>
+     * ID of the run whose artifacts to list. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 3;</code>
+     */
+    com.google.protobuf.ByteString
+        getRunIdBytes();
 
     /**
      * <pre>
@@ -39861,6 +41240,7 @@ public final class Service {
     }
     private ListArtifacts() {
       runUuid_ = "";
+      runId_ = "";
       path_ = "";
     }
 
@@ -39896,8 +41276,14 @@ public final class Service {
             }
             case 18: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
+              bitField0_ |= 0x00000004;
               path_ = bs;
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              runId_ = bs;
               break;
             }
             default: {
@@ -41047,7 +42433,8 @@ public final class Service {
     private volatile java.lang.Object runUuid_;
     /**
      * <pre>
-     * ID of the run whose artifacts to list.
+     * [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
      * <code>optional string run_uuid = 1;</code>
@@ -41057,7 +42444,8 @@ public final class Service {
     }
     /**
      * <pre>
-     * ID of the run whose artifacts to list.
+     * [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
      * <code>optional string run_uuid = 1;</code>
@@ -41078,7 +42466,8 @@ public final class Service {
     }
     /**
      * <pre>
-     * ID of the run whose artifacts to list.
+     * [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will
+     * be removed in a future MLflow version.
      * </pre>
      *
      * <code>optional string run_uuid = 1;</code>
@@ -41097,6 +42486,60 @@ public final class Service {
       }
     }
 
+    public static final int RUN_ID_FIELD_NUMBER = 3;
+    private volatile java.lang.Object runId_;
+    /**
+     * <pre>
+     * ID of the run whose artifacts to list. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 3;</code>
+     */
+    public boolean hasRunId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <pre>
+     * ID of the run whose artifacts to list. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 3;</code>
+     */
+    public java.lang.String getRunId() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * ID of the run whose artifacts to list. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 3;</code>
+     */
+    public com.google.protobuf.ByteString
+        getRunIdBytes() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     public static final int PATH_FIELD_NUMBER = 2;
     private volatile java.lang.Object path_;
     /**
@@ -41107,7 +42550,7 @@ public final class Service {
      * <code>optional string path = 2;</code>
      */
     public boolean hasPath() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
      * <pre>
@@ -41168,8 +42611,11 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, path_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, runId_);
       }
       unknownFields.writeTo(output);
     }
@@ -41183,8 +42629,11 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, path_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, runId_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -41207,6 +42656,11 @@ public final class Service {
         result = result && getRunUuid()
             .equals(other.getRunUuid());
       }
+      result = result && (hasRunId() == other.hasRunId());
+      if (hasRunId()) {
+        result = result && getRunId()
+            .equals(other.getRunId());
+      }
       result = result && (hasPath() == other.hasPath());
       if (hasPath()) {
         result = result && getPath()
@@ -41226,6 +42680,10 @@ public final class Service {
       if (hasRunUuid()) {
         hash = (37 * hash) + RUN_UUID_FIELD_NUMBER;
         hash = (53 * hash) + getRunUuid().hashCode();
+      }
+      if (hasRunId()) {
+        hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRunId().hashCode();
       }
       if (hasPath()) {
         hash = (37 * hash) + PATH_FIELD_NUMBER;
@@ -41366,8 +42824,10 @@ public final class Service {
         super.clear();
         runUuid_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        path_ = "";
+        runId_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
+        path_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -41402,6 +42862,10 @@ public final class Service {
         result.runUuid_ = runUuid_;
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
+        }
+        result.runId_ = runId_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
         }
         result.path_ = path_;
         result.bitField0_ = to_bitField0_;
@@ -41458,8 +42922,13 @@ public final class Service {
           runUuid_ = other.runUuid_;
           onChanged();
         }
-        if (other.hasPath()) {
+        if (other.hasRunId()) {
           bitField0_ |= 0x00000002;
+          runId_ = other.runId_;
+          onChanged();
+        }
+        if (other.hasPath()) {
+          bitField0_ |= 0x00000004;
           path_ = other.path_;
           onChanged();
         }
@@ -41496,7 +42965,8 @@ public final class Service {
       private java.lang.Object runUuid_ = "";
       /**
        * <pre>
-       * ID of the run whose artifacts to list.
+       * [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
        * <code>optional string run_uuid = 1;</code>
@@ -41506,7 +42976,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run whose artifacts to list.
+       * [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
        * <code>optional string run_uuid = 1;</code>
@@ -41527,7 +42998,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run whose artifacts to list.
+       * [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
        * <code>optional string run_uuid = 1;</code>
@@ -41547,7 +43019,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run whose artifacts to list.
+       * [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
        * <code>optional string run_uuid = 1;</code>
@@ -41564,7 +43037,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run whose artifacts to list.
+       * [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
        * <code>optional string run_uuid = 1;</code>
@@ -41577,7 +43051,8 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run whose artifacts to list.
+       * [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will
+       * be removed in a future MLflow version.
        * </pre>
        *
        * <code>optional string run_uuid = 1;</code>
@@ -41593,6 +43068,106 @@ public final class Service {
         return this;
       }
 
+      private java.lang.Object runId_ = "";
+      /**
+       * <pre>
+       * ID of the run whose artifacts to list. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 3;</code>
+       */
+      public boolean hasRunId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <pre>
+       * ID of the run whose artifacts to list. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 3;</code>
+       */
+      public java.lang.String getRunId() {
+        java.lang.Object ref = runId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run whose artifacts to list. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 3;</code>
+       */
+      public com.google.protobuf.ByteString
+          getRunIdBytes() {
+        java.lang.Object ref = runId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run whose artifacts to list. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 3;</code>
+       */
+      public Builder setRunId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run whose artifacts to list. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 3;</code>
+       */
+      public Builder clearRunId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        runId_ = getDefaultInstance().getRunId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run whose artifacts to list. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 3;</code>
+       */
+      public Builder setRunIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+
       private java.lang.Object path_ = "";
       /**
        * <pre>
@@ -41602,7 +43177,7 @@ public final class Service {
        * <code>optional string path = 2;</code>
        */
       public boolean hasPath() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
        * <pre>
@@ -41657,7 +43232,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         path_ = value;
         onChanged();
         return this;
@@ -41670,7 +43245,7 @@ public final class Service {
        * <code>optional string path = 2;</code>
        */
       public Builder clearPath() {
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000004);
         path_ = getDefaultInstance().getPath();
         onChanged();
         return this;
@@ -41687,7 +43262,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         path_ = value;
         onChanged();
         return this;
@@ -42624,1301 +44199,64 @@ public final class Service {
 
   }
 
-  public interface GetArtifactOrBuilder extends
-      // @@protoc_insertion_point(interface_extends:mlflow.GetArtifact)
-      com.google.protobuf.MessageOrBuilder {
-
-    /**
-     * <pre>
-     * ID of the run from which to fetch the artifact.
-     * </pre>
-     *
-     * <code>optional string run_uuid = 1;</code>
-     */
-    boolean hasRunUuid();
-    /**
-     * <pre>
-     * ID of the run from which to fetch the artifact.
-     * </pre>
-     *
-     * <code>optional string run_uuid = 1;</code>
-     */
-    java.lang.String getRunUuid();
-    /**
-     * <pre>
-     * ID of the run from which to fetch the artifact.
-     * </pre>
-     *
-     * <code>optional string run_uuid = 1;</code>
-     */
-    com.google.protobuf.ByteString
-        getRunUuidBytes();
-
-    /**
-     * <pre>
-     * Path of the artifact to fetch (relative to the root artifact directory for the run).
-     * </pre>
-     *
-     * <code>optional string path = 2;</code>
-     */
-    boolean hasPath();
-    /**
-     * <pre>
-     * Path of the artifact to fetch (relative to the root artifact directory for the run).
-     * </pre>
-     *
-     * <code>optional string path = 2;</code>
-     */
-    java.lang.String getPath();
-    /**
-     * <pre>
-     * Path of the artifact to fetch (relative to the root artifact directory for the run).
-     * </pre>
-     *
-     * <code>optional string path = 2;</code>
-     */
-    com.google.protobuf.ByteString
-        getPathBytes();
-  }
-  /**
-   * Protobuf type {@code mlflow.GetArtifact}
-   */
-  public  static final class GetArtifact extends
-      com.google.protobuf.GeneratedMessageV3 implements
-      // @@protoc_insertion_point(message_implements:mlflow.GetArtifact)
-      GetArtifactOrBuilder {
-  private static final long serialVersionUID = 0L;
-    // Use GetArtifact.newBuilder() to construct.
-    private GetArtifact(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
-      super(builder);
-    }
-    private GetArtifact() {
-      runUuid_ = "";
-      path_ = "";
-    }
-
-    @java.lang.Override
-    public final com.google.protobuf.UnknownFieldSet
-    getUnknownFields() {
-      return this.unknownFields;
-    }
-    private GetArtifact(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      this();
-      if (extensionRegistry == null) {
-        throw new java.lang.NullPointerException();
-      }
-      int mutable_bitField0_ = 0;
-      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-          com.google.protobuf.UnknownFieldSet.newBuilder();
-      try {
-        boolean done = false;
-        while (!done) {
-          int tag = input.readTag();
-          switch (tag) {
-            case 0:
-              done = true;
-              break;
-            case 10: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000001;
-              runUuid_ = bs;
-              break;
-            }
-            case 18: {
-              com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
-              path_ = bs;
-              break;
-            }
-            default: {
-              if (!parseUnknownField(
-                  input, unknownFields, extensionRegistry, tag)) {
-                done = true;
-              }
-              break;
-            }
-          }
-        }
-      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-        throw e.setUnfinishedMessage(this);
-      } catch (java.io.IOException e) {
-        throw new com.google.protobuf.InvalidProtocolBufferException(
-            e).setUnfinishedMessage(this);
-      } finally {
-        this.unknownFields = unknownFields.build();
-        makeExtensionsImmutable();
-      }
-    }
-    public static final com.google.protobuf.Descriptors.Descriptor
-        getDescriptor() {
-      return org.mlflow.api.proto.Service.internal_static_mlflow_GetArtifact_descriptor;
-    }
-
-    @java.lang.Override
-    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-        internalGetFieldAccessorTable() {
-      return org.mlflow.api.proto.Service.internal_static_mlflow_GetArtifact_fieldAccessorTable
-          .ensureFieldAccessorsInitialized(
-              org.mlflow.api.proto.Service.GetArtifact.class, org.mlflow.api.proto.Service.GetArtifact.Builder.class);
-    }
-
-    public interface ResponseOrBuilder extends
-        // @@protoc_insertion_point(interface_extends:mlflow.GetArtifact.Response)
-        com.google.protobuf.MessageOrBuilder {
-    }
-    /**
-     * <pre>
-     * Empty because the data of the file will be streamed back in the HTTP response.
-     * The response will have an HTTP status code of 404 if the artifact path is not found.
-     * </pre>
-     *
-     * Protobuf type {@code mlflow.GetArtifact.Response}
-     */
-    public  static final class Response extends
-        com.google.protobuf.GeneratedMessageV3 implements
-        // @@protoc_insertion_point(message_implements:mlflow.GetArtifact.Response)
-        ResponseOrBuilder {
-    private static final long serialVersionUID = 0L;
-      // Use Response.newBuilder() to construct.
-      private Response(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
-        super(builder);
-      }
-      private Response() {
-      }
-
-      @java.lang.Override
-      public final com.google.protobuf.UnknownFieldSet
-      getUnknownFields() {
-        return this.unknownFields;
-      }
-      private Response(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        this();
-        if (extensionRegistry == null) {
-          throw new java.lang.NullPointerException();
-        }
-        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
-            com.google.protobuf.UnknownFieldSet.newBuilder();
-        try {
-          boolean done = false;
-          while (!done) {
-            int tag = input.readTag();
-            switch (tag) {
-              case 0:
-                done = true;
-                break;
-              default: {
-                if (!parseUnknownField(
-                    input, unknownFields, extensionRegistry, tag)) {
-                  done = true;
-                }
-                break;
-              }
-            }
-          }
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          throw e.setUnfinishedMessage(this);
-        } catch (java.io.IOException e) {
-          throw new com.google.protobuf.InvalidProtocolBufferException(
-              e).setUnfinishedMessage(this);
-        } finally {
-          this.unknownFields = unknownFields.build();
-          makeExtensionsImmutable();
-        }
-      }
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.mlflow.api.proto.Service.internal_static_mlflow_GetArtifact_Response_descriptor;
-      }
-
-      @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.mlflow.api.proto.Service.internal_static_mlflow_GetArtifact_Response_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.mlflow.api.proto.Service.GetArtifact.Response.class, org.mlflow.api.proto.Service.GetArtifact.Response.Builder.class);
-      }
-
-      private byte memoizedIsInitialized = -1;
-      @java.lang.Override
-      public final boolean isInitialized() {
-        byte isInitialized = memoizedIsInitialized;
-        if (isInitialized == 1) return true;
-        if (isInitialized == 0) return false;
-
-        memoizedIsInitialized = 1;
-        return true;
-      }
-
-      @java.lang.Override
-      public void writeTo(com.google.protobuf.CodedOutputStream output)
-                          throws java.io.IOException {
-        unknownFields.writeTo(output);
-      }
-
-      @java.lang.Override
-      public int getSerializedSize() {
-        int size = memoizedSize;
-        if (size != -1) return size;
-
-        size = 0;
-        size += unknownFields.getSerializedSize();
-        memoizedSize = size;
-        return size;
-      }
-
-      @java.lang.Override
-      public boolean equals(final java.lang.Object obj) {
-        if (obj == this) {
-         return true;
-        }
-        if (!(obj instanceof org.mlflow.api.proto.Service.GetArtifact.Response)) {
-          return super.equals(obj);
-        }
-        org.mlflow.api.proto.Service.GetArtifact.Response other = (org.mlflow.api.proto.Service.GetArtifact.Response) obj;
-
-        boolean result = true;
-        result = result && unknownFields.equals(other.unknownFields);
-        return result;
-      }
-
-      @java.lang.Override
-      public int hashCode() {
-        if (memoizedHashCode != 0) {
-          return memoizedHashCode;
-        }
-        int hash = 41;
-        hash = (19 * hash) + getDescriptor().hashCode();
-        hash = (29 * hash) + unknownFields.hashCode();
-        memoizedHashCode = hash;
-        return hash;
-      }
-
-      public static org.mlflow.api.proto.Service.GetArtifact.Response parseFrom(
-          java.nio.ByteBuffer data)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data);
-      }
-      public static org.mlflow.api.proto.Service.GetArtifact.Response parseFrom(
-          java.nio.ByteBuffer data,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data, extensionRegistry);
-      }
-      public static org.mlflow.api.proto.Service.GetArtifact.Response parseFrom(
-          com.google.protobuf.ByteString data)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data);
-      }
-      public static org.mlflow.api.proto.Service.GetArtifact.Response parseFrom(
-          com.google.protobuf.ByteString data,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data, extensionRegistry);
-      }
-      public static org.mlflow.api.proto.Service.GetArtifact.Response parseFrom(byte[] data)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data);
-      }
-      public static org.mlflow.api.proto.Service.GetArtifact.Response parseFrom(
-          byte[] data,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return PARSER.parseFrom(data, extensionRegistry);
-      }
-      public static org.mlflow.api.proto.Service.GetArtifact.Response parseFrom(java.io.InputStream input)
-          throws java.io.IOException {
-        return com.google.protobuf.GeneratedMessageV3
-            .parseWithIOException(PARSER, input);
-      }
-      public static org.mlflow.api.proto.Service.GetArtifact.Response parseFrom(
-          java.io.InputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        return com.google.protobuf.GeneratedMessageV3
-            .parseWithIOException(PARSER, input, extensionRegistry);
-      }
-      public static org.mlflow.api.proto.Service.GetArtifact.Response parseDelimitedFrom(java.io.InputStream input)
-          throws java.io.IOException {
-        return com.google.protobuf.GeneratedMessageV3
-            .parseDelimitedWithIOException(PARSER, input);
-      }
-      public static org.mlflow.api.proto.Service.GetArtifact.Response parseDelimitedFrom(
-          java.io.InputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        return com.google.protobuf.GeneratedMessageV3
-            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
-      }
-      public static org.mlflow.api.proto.Service.GetArtifact.Response parseFrom(
-          com.google.protobuf.CodedInputStream input)
-          throws java.io.IOException {
-        return com.google.protobuf.GeneratedMessageV3
-            .parseWithIOException(PARSER, input);
-      }
-      public static org.mlflow.api.proto.Service.GetArtifact.Response parseFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        return com.google.protobuf.GeneratedMessageV3
-            .parseWithIOException(PARSER, input, extensionRegistry);
-      }
-
-      @java.lang.Override
-      public Builder newBuilderForType() { return newBuilder(); }
-      public static Builder newBuilder() {
-        return DEFAULT_INSTANCE.toBuilder();
-      }
-      public static Builder newBuilder(org.mlflow.api.proto.Service.GetArtifact.Response prototype) {
-        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-      }
-      @java.lang.Override
-      public Builder toBuilder() {
-        return this == DEFAULT_INSTANCE
-            ? new Builder() : new Builder().mergeFrom(this);
-      }
-
-      @java.lang.Override
-      protected Builder newBuilderForType(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-        Builder builder = new Builder(parent);
-        return builder;
-      }
-      /**
-       * <pre>
-       * Empty because the data of the file will be streamed back in the HTTP response.
-       * The response will have an HTTP status code of 404 if the artifact path is not found.
-       * </pre>
-       *
-       * Protobuf type {@code mlflow.GetArtifact.Response}
-       */
-      public static final class Builder extends
-          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-          // @@protoc_insertion_point(builder_implements:mlflow.GetArtifact.Response)
-          org.mlflow.api.proto.Service.GetArtifact.ResponseOrBuilder {
-        public static final com.google.protobuf.Descriptors.Descriptor
-            getDescriptor() {
-          return org.mlflow.api.proto.Service.internal_static_mlflow_GetArtifact_Response_descriptor;
-        }
-
-        @java.lang.Override
-        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-            internalGetFieldAccessorTable() {
-          return org.mlflow.api.proto.Service.internal_static_mlflow_GetArtifact_Response_fieldAccessorTable
-              .ensureFieldAccessorsInitialized(
-                  org.mlflow.api.proto.Service.GetArtifact.Response.class, org.mlflow.api.proto.Service.GetArtifact.Response.Builder.class);
-        }
-
-        // Construct using org.mlflow.api.proto.Service.GetArtifact.Response.newBuilder()
-        private Builder() {
-          maybeForceBuilderInitialization();
-        }
-
-        private Builder(
-            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-          super(parent);
-          maybeForceBuilderInitialization();
-        }
-        private void maybeForceBuilderInitialization() {
-          if (com.google.protobuf.GeneratedMessageV3
-                  .alwaysUseFieldBuilders) {
-          }
-        }
-        @java.lang.Override
-        public Builder clear() {
-          super.clear();
-          return this;
-        }
-
-        @java.lang.Override
-        public com.google.protobuf.Descriptors.Descriptor
-            getDescriptorForType() {
-          return org.mlflow.api.proto.Service.internal_static_mlflow_GetArtifact_Response_descriptor;
-        }
-
-        @java.lang.Override
-        public org.mlflow.api.proto.Service.GetArtifact.Response getDefaultInstanceForType() {
-          return org.mlflow.api.proto.Service.GetArtifact.Response.getDefaultInstance();
-        }
-
-        @java.lang.Override
-        public org.mlflow.api.proto.Service.GetArtifact.Response build() {
-          org.mlflow.api.proto.Service.GetArtifact.Response result = buildPartial();
-          if (!result.isInitialized()) {
-            throw newUninitializedMessageException(result);
-          }
-          return result;
-        }
-
-        @java.lang.Override
-        public org.mlflow.api.proto.Service.GetArtifact.Response buildPartial() {
-          org.mlflow.api.proto.Service.GetArtifact.Response result = new org.mlflow.api.proto.Service.GetArtifact.Response(this);
-          onBuilt();
-          return result;
-        }
-
-        @java.lang.Override
-        public Builder clone() {
-          return (Builder) super.clone();
-        }
-        @java.lang.Override
-        public Builder setField(
-            com.google.protobuf.Descriptors.FieldDescriptor field,
-            java.lang.Object value) {
-          return (Builder) super.setField(field, value);
-        }
-        @java.lang.Override
-        public Builder clearField(
-            com.google.protobuf.Descriptors.FieldDescriptor field) {
-          return (Builder) super.clearField(field);
-        }
-        @java.lang.Override
-        public Builder clearOneof(
-            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-          return (Builder) super.clearOneof(oneof);
-        }
-        @java.lang.Override
-        public Builder setRepeatedField(
-            com.google.protobuf.Descriptors.FieldDescriptor field,
-            int index, java.lang.Object value) {
-          return (Builder) super.setRepeatedField(field, index, value);
-        }
-        @java.lang.Override
-        public Builder addRepeatedField(
-            com.google.protobuf.Descriptors.FieldDescriptor field,
-            java.lang.Object value) {
-          return (Builder) super.addRepeatedField(field, value);
-        }
-        @java.lang.Override
-        public Builder mergeFrom(com.google.protobuf.Message other) {
-          if (other instanceof org.mlflow.api.proto.Service.GetArtifact.Response) {
-            return mergeFrom((org.mlflow.api.proto.Service.GetArtifact.Response)other);
-          } else {
-            super.mergeFrom(other);
-            return this;
-          }
-        }
-
-        public Builder mergeFrom(org.mlflow.api.proto.Service.GetArtifact.Response other) {
-          if (other == org.mlflow.api.proto.Service.GetArtifact.Response.getDefaultInstance()) return this;
-          this.mergeUnknownFields(other.unknownFields);
-          onChanged();
-          return this;
-        }
-
-        @java.lang.Override
-        public final boolean isInitialized() {
-          return true;
-        }
-
-        @java.lang.Override
-        public Builder mergeFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws java.io.IOException {
-          org.mlflow.api.proto.Service.GetArtifact.Response parsedMessage = null;
-          try {
-            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-            parsedMessage = (org.mlflow.api.proto.Service.GetArtifact.Response) e.getUnfinishedMessage();
-            throw e.unwrapIOException();
-          } finally {
-            if (parsedMessage != null) {
-              mergeFrom(parsedMessage);
-            }
-          }
-          return this;
-        }
-        @java.lang.Override
-        public final Builder setUnknownFields(
-            final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.setUnknownFields(unknownFields);
-        }
-
-        @java.lang.Override
-        public final Builder mergeUnknownFields(
-            final com.google.protobuf.UnknownFieldSet unknownFields) {
-          return super.mergeUnknownFields(unknownFields);
-        }
-
-
-        // @@protoc_insertion_point(builder_scope:mlflow.GetArtifact.Response)
-      }
-
-      // @@protoc_insertion_point(class_scope:mlflow.GetArtifact.Response)
-      private static final org.mlflow.api.proto.Service.GetArtifact.Response DEFAULT_INSTANCE;
-      static {
-        DEFAULT_INSTANCE = new org.mlflow.api.proto.Service.GetArtifact.Response();
-      }
-
-      public static org.mlflow.api.proto.Service.GetArtifact.Response getDefaultInstance() {
-        return DEFAULT_INSTANCE;
-      }
-
-      @java.lang.Deprecated public static final com.google.protobuf.Parser<Response>
-          PARSER = new com.google.protobuf.AbstractParser<Response>() {
-        @java.lang.Override
-        public Response parsePartialFrom(
-            com.google.protobuf.CodedInputStream input,
-            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-            throws com.google.protobuf.InvalidProtocolBufferException {
-          return new Response(input, extensionRegistry);
-        }
-      };
-
-      public static com.google.protobuf.Parser<Response> parser() {
-        return PARSER;
-      }
-
-      @java.lang.Override
-      public com.google.protobuf.Parser<Response> getParserForType() {
-        return PARSER;
-      }
-
-      @java.lang.Override
-      public org.mlflow.api.proto.Service.GetArtifact.Response getDefaultInstanceForType() {
-        return DEFAULT_INSTANCE;
-      }
-
-    }
-
-    private int bitField0_;
-    public static final int RUN_UUID_FIELD_NUMBER = 1;
-    private volatile java.lang.Object runUuid_;
-    /**
-     * <pre>
-     * ID of the run from which to fetch the artifact.
-     * </pre>
-     *
-     * <code>optional string run_uuid = 1;</code>
-     */
-    public boolean hasRunUuid() {
-      return ((bitField0_ & 0x00000001) == 0x00000001);
-    }
-    /**
-     * <pre>
-     * ID of the run from which to fetch the artifact.
-     * </pre>
-     *
-     * <code>optional string run_uuid = 1;</code>
-     */
-    public java.lang.String getRunUuid() {
-      java.lang.Object ref = runUuid_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          runUuid_ = s;
-        }
-        return s;
-      }
-    }
-    /**
-     * <pre>
-     * ID of the run from which to fetch the artifact.
-     * </pre>
-     *
-     * <code>optional string run_uuid = 1;</code>
-     */
-    public com.google.protobuf.ByteString
-        getRunUuidBytes() {
-      java.lang.Object ref = runUuid_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        runUuid_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
-    }
-
-    public static final int PATH_FIELD_NUMBER = 2;
-    private volatile java.lang.Object path_;
-    /**
-     * <pre>
-     * Path of the artifact to fetch (relative to the root artifact directory for the run).
-     * </pre>
-     *
-     * <code>optional string path = 2;</code>
-     */
-    public boolean hasPath() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
-    }
-    /**
-     * <pre>
-     * Path of the artifact to fetch (relative to the root artifact directory for the run).
-     * </pre>
-     *
-     * <code>optional string path = 2;</code>
-     */
-    public java.lang.String getPath() {
-      java.lang.Object ref = path_;
-      if (ref instanceof java.lang.String) {
-        return (java.lang.String) ref;
-      } else {
-        com.google.protobuf.ByteString bs = 
-            (com.google.protobuf.ByteString) ref;
-        java.lang.String s = bs.toStringUtf8();
-        if (bs.isValidUtf8()) {
-          path_ = s;
-        }
-        return s;
-      }
-    }
-    /**
-     * <pre>
-     * Path of the artifact to fetch (relative to the root artifact directory for the run).
-     * </pre>
-     *
-     * <code>optional string path = 2;</code>
-     */
-    public com.google.protobuf.ByteString
-        getPathBytes() {
-      java.lang.Object ref = path_;
-      if (ref instanceof java.lang.String) {
-        com.google.protobuf.ByteString b = 
-            com.google.protobuf.ByteString.copyFromUtf8(
-                (java.lang.String) ref);
-        path_ = b;
-        return b;
-      } else {
-        return (com.google.protobuf.ByteString) ref;
-      }
-    }
-
-    private byte memoizedIsInitialized = -1;
-    @java.lang.Override
-    public final boolean isInitialized() {
-      byte isInitialized = memoizedIsInitialized;
-      if (isInitialized == 1) return true;
-      if (isInitialized == 0) return false;
-
-      memoizedIsInitialized = 1;
-      return true;
-    }
-
-    @java.lang.Override
-    public void writeTo(com.google.protobuf.CodedOutputStream output)
-                        throws java.io.IOException {
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runUuid_);
-      }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, path_);
-      }
-      unknownFields.writeTo(output);
-    }
-
-    @java.lang.Override
-    public int getSerializedSize() {
-      int size = memoizedSize;
-      if (size != -1) return size;
-
-      size = 0;
-      if (((bitField0_ & 0x00000001) == 0x00000001)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runUuid_);
-      }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
-        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, path_);
-      }
-      size += unknownFields.getSerializedSize();
-      memoizedSize = size;
-      return size;
-    }
-
-    @java.lang.Override
-    public boolean equals(final java.lang.Object obj) {
-      if (obj == this) {
-       return true;
-      }
-      if (!(obj instanceof org.mlflow.api.proto.Service.GetArtifact)) {
-        return super.equals(obj);
-      }
-      org.mlflow.api.proto.Service.GetArtifact other = (org.mlflow.api.proto.Service.GetArtifact) obj;
-
-      boolean result = true;
-      result = result && (hasRunUuid() == other.hasRunUuid());
-      if (hasRunUuid()) {
-        result = result && getRunUuid()
-            .equals(other.getRunUuid());
-      }
-      result = result && (hasPath() == other.hasPath());
-      if (hasPath()) {
-        result = result && getPath()
-            .equals(other.getPath());
-      }
-      result = result && unknownFields.equals(other.unknownFields);
-      return result;
-    }
-
-    @java.lang.Override
-    public int hashCode() {
-      if (memoizedHashCode != 0) {
-        return memoizedHashCode;
-      }
-      int hash = 41;
-      hash = (19 * hash) + getDescriptor().hashCode();
-      if (hasRunUuid()) {
-        hash = (37 * hash) + RUN_UUID_FIELD_NUMBER;
-        hash = (53 * hash) + getRunUuid().hashCode();
-      }
-      if (hasPath()) {
-        hash = (37 * hash) + PATH_FIELD_NUMBER;
-        hash = (53 * hash) + getPath().hashCode();
-      }
-      hash = (29 * hash) + unknownFields.hashCode();
-      memoizedHashCode = hash;
-      return hash;
-    }
-
-    public static org.mlflow.api.proto.Service.GetArtifact parseFrom(
-        java.nio.ByteBuffer data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static org.mlflow.api.proto.Service.GetArtifact parseFrom(
-        java.nio.ByteBuffer data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static org.mlflow.api.proto.Service.GetArtifact parseFrom(
-        com.google.protobuf.ByteString data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static org.mlflow.api.proto.Service.GetArtifact parseFrom(
-        com.google.protobuf.ByteString data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static org.mlflow.api.proto.Service.GetArtifact parseFrom(byte[] data)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data);
-    }
-    public static org.mlflow.api.proto.Service.GetArtifact parseFrom(
-        byte[] data,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws com.google.protobuf.InvalidProtocolBufferException {
-      return PARSER.parseFrom(data, extensionRegistry);
-    }
-    public static org.mlflow.api.proto.Service.GetArtifact parseFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
-    public static org.mlflow.api.proto.Service.GetArtifact parseFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
-    }
-    public static org.mlflow.api.proto.Service.GetArtifact parseDelimitedFrom(java.io.InputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input);
-    }
-    public static org.mlflow.api.proto.Service.GetArtifact parseDelimitedFrom(
-        java.io.InputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
-    }
-    public static org.mlflow.api.proto.Service.GetArtifact parseFrom(
-        com.google.protobuf.CodedInputStream input)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input);
-    }
-    public static org.mlflow.api.proto.Service.GetArtifact parseFrom(
-        com.google.protobuf.CodedInputStream input,
-        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-        throws java.io.IOException {
-      return com.google.protobuf.GeneratedMessageV3
-          .parseWithIOException(PARSER, input, extensionRegistry);
-    }
-
-    @java.lang.Override
-    public Builder newBuilderForType() { return newBuilder(); }
-    public static Builder newBuilder() {
-      return DEFAULT_INSTANCE.toBuilder();
-    }
-    public static Builder newBuilder(org.mlflow.api.proto.Service.GetArtifact prototype) {
-      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
-    }
-    @java.lang.Override
-    public Builder toBuilder() {
-      return this == DEFAULT_INSTANCE
-          ? new Builder() : new Builder().mergeFrom(this);
-    }
-
-    @java.lang.Override
-    protected Builder newBuilderForType(
-        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-      Builder builder = new Builder(parent);
-      return builder;
-    }
-    /**
-     * Protobuf type {@code mlflow.GetArtifact}
-     */
-    public static final class Builder extends
-        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
-        // @@protoc_insertion_point(builder_implements:mlflow.GetArtifact)
-        org.mlflow.api.proto.Service.GetArtifactOrBuilder {
-      public static final com.google.protobuf.Descriptors.Descriptor
-          getDescriptor() {
-        return org.mlflow.api.proto.Service.internal_static_mlflow_GetArtifact_descriptor;
-      }
-
-      @java.lang.Override
-      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-          internalGetFieldAccessorTable() {
-        return org.mlflow.api.proto.Service.internal_static_mlflow_GetArtifact_fieldAccessorTable
-            .ensureFieldAccessorsInitialized(
-                org.mlflow.api.proto.Service.GetArtifact.class, org.mlflow.api.proto.Service.GetArtifact.Builder.class);
-      }
-
-      // Construct using org.mlflow.api.proto.Service.GetArtifact.newBuilder()
-      private Builder() {
-        maybeForceBuilderInitialization();
-      }
-
-      private Builder(
-          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
-        super(parent);
-        maybeForceBuilderInitialization();
-      }
-      private void maybeForceBuilderInitialization() {
-        if (com.google.protobuf.GeneratedMessageV3
-                .alwaysUseFieldBuilders) {
-        }
-      }
-      @java.lang.Override
-      public Builder clear() {
-        super.clear();
-        runUuid_ = "";
-        bitField0_ = (bitField0_ & ~0x00000001);
-        path_ = "";
-        bitField0_ = (bitField0_ & ~0x00000002);
-        return this;
-      }
-
-      @java.lang.Override
-      public com.google.protobuf.Descriptors.Descriptor
-          getDescriptorForType() {
-        return org.mlflow.api.proto.Service.internal_static_mlflow_GetArtifact_descriptor;
-      }
-
-      @java.lang.Override
-      public org.mlflow.api.proto.Service.GetArtifact getDefaultInstanceForType() {
-        return org.mlflow.api.proto.Service.GetArtifact.getDefaultInstance();
-      }
-
-      @java.lang.Override
-      public org.mlflow.api.proto.Service.GetArtifact build() {
-        org.mlflow.api.proto.Service.GetArtifact result = buildPartial();
-        if (!result.isInitialized()) {
-          throw newUninitializedMessageException(result);
-        }
-        return result;
-      }
-
-      @java.lang.Override
-      public org.mlflow.api.proto.Service.GetArtifact buildPartial() {
-        org.mlflow.api.proto.Service.GetArtifact result = new org.mlflow.api.proto.Service.GetArtifact(this);
-        int from_bitField0_ = bitField0_;
-        int to_bitField0_ = 0;
-        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
-          to_bitField0_ |= 0x00000001;
-        }
-        result.runUuid_ = runUuid_;
-        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
-          to_bitField0_ |= 0x00000002;
-        }
-        result.path_ = path_;
-        result.bitField0_ = to_bitField0_;
-        onBuilt();
-        return result;
-      }
-
-      @java.lang.Override
-      public Builder clone() {
-        return (Builder) super.clone();
-      }
-      @java.lang.Override
-      public Builder setField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return (Builder) super.setField(field, value);
-      }
-      @java.lang.Override
-      public Builder clearField(
-          com.google.protobuf.Descriptors.FieldDescriptor field) {
-        return (Builder) super.clearField(field);
-      }
-      @java.lang.Override
-      public Builder clearOneof(
-          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
-        return (Builder) super.clearOneof(oneof);
-      }
-      @java.lang.Override
-      public Builder setRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          int index, java.lang.Object value) {
-        return (Builder) super.setRepeatedField(field, index, value);
-      }
-      @java.lang.Override
-      public Builder addRepeatedField(
-          com.google.protobuf.Descriptors.FieldDescriptor field,
-          java.lang.Object value) {
-        return (Builder) super.addRepeatedField(field, value);
-      }
-      @java.lang.Override
-      public Builder mergeFrom(com.google.protobuf.Message other) {
-        if (other instanceof org.mlflow.api.proto.Service.GetArtifact) {
-          return mergeFrom((org.mlflow.api.proto.Service.GetArtifact)other);
-        } else {
-          super.mergeFrom(other);
-          return this;
-        }
-      }
-
-      public Builder mergeFrom(org.mlflow.api.proto.Service.GetArtifact other) {
-        if (other == org.mlflow.api.proto.Service.GetArtifact.getDefaultInstance()) return this;
-        if (other.hasRunUuid()) {
-          bitField0_ |= 0x00000001;
-          runUuid_ = other.runUuid_;
-          onChanged();
-        }
-        if (other.hasPath()) {
-          bitField0_ |= 0x00000002;
-          path_ = other.path_;
-          onChanged();
-        }
-        this.mergeUnknownFields(other.unknownFields);
-        onChanged();
-        return this;
-      }
-
-      @java.lang.Override
-      public final boolean isInitialized() {
-        return true;
-      }
-
-      @java.lang.Override
-      public Builder mergeFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws java.io.IOException {
-        org.mlflow.api.proto.Service.GetArtifact parsedMessage = null;
-        try {
-          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
-        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-          parsedMessage = (org.mlflow.api.proto.Service.GetArtifact) e.getUnfinishedMessage();
-          throw e.unwrapIOException();
-        } finally {
-          if (parsedMessage != null) {
-            mergeFrom(parsedMessage);
-          }
-        }
-        return this;
-      }
-      private int bitField0_;
-
-      private java.lang.Object runUuid_ = "";
-      /**
-       * <pre>
-       * ID of the run from which to fetch the artifact.
-       * </pre>
-       *
-       * <code>optional string run_uuid = 1;</code>
-       */
-      public boolean hasRunUuid() {
-        return ((bitField0_ & 0x00000001) == 0x00000001);
-      }
-      /**
-       * <pre>
-       * ID of the run from which to fetch the artifact.
-       * </pre>
-       *
-       * <code>optional string run_uuid = 1;</code>
-       */
-      public java.lang.String getRunUuid() {
-        java.lang.Object ref = runUuid_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            runUuid_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
-      }
-      /**
-       * <pre>
-       * ID of the run from which to fetch the artifact.
-       * </pre>
-       *
-       * <code>optional string run_uuid = 1;</code>
-       */
-      public com.google.protobuf.ByteString
-          getRunUuidBytes() {
-        java.lang.Object ref = runUuid_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          runUuid_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
-      }
-      /**
-       * <pre>
-       * ID of the run from which to fetch the artifact.
-       * </pre>
-       *
-       * <code>optional string run_uuid = 1;</code>
-       */
-      public Builder setRunUuid(
-          java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        runUuid_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <pre>
-       * ID of the run from which to fetch the artifact.
-       * </pre>
-       *
-       * <code>optional string run_uuid = 1;</code>
-       */
-      public Builder clearRunUuid() {
-        bitField0_ = (bitField0_ & ~0x00000001);
-        runUuid_ = getDefaultInstance().getRunUuid();
-        onChanged();
-        return this;
-      }
-      /**
-       * <pre>
-       * ID of the run from which to fetch the artifact.
-       * </pre>
-       *
-       * <code>optional string run_uuid = 1;</code>
-       */
-      public Builder setRunUuidBytes(
-          com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000001;
-        runUuid_ = value;
-        onChanged();
-        return this;
-      }
-
-      private java.lang.Object path_ = "";
-      /**
-       * <pre>
-       * Path of the artifact to fetch (relative to the root artifact directory for the run).
-       * </pre>
-       *
-       * <code>optional string path = 2;</code>
-       */
-      public boolean hasPath() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
-      }
-      /**
-       * <pre>
-       * Path of the artifact to fetch (relative to the root artifact directory for the run).
-       * </pre>
-       *
-       * <code>optional string path = 2;</code>
-       */
-      public java.lang.String getPath() {
-        java.lang.Object ref = path_;
-        if (!(ref instanceof java.lang.String)) {
-          com.google.protobuf.ByteString bs =
-              (com.google.protobuf.ByteString) ref;
-          java.lang.String s = bs.toStringUtf8();
-          if (bs.isValidUtf8()) {
-            path_ = s;
-          }
-          return s;
-        } else {
-          return (java.lang.String) ref;
-        }
-      }
-      /**
-       * <pre>
-       * Path of the artifact to fetch (relative to the root artifact directory for the run).
-       * </pre>
-       *
-       * <code>optional string path = 2;</code>
-       */
-      public com.google.protobuf.ByteString
-          getPathBytes() {
-        java.lang.Object ref = path_;
-        if (ref instanceof String) {
-          com.google.protobuf.ByteString b = 
-              com.google.protobuf.ByteString.copyFromUtf8(
-                  (java.lang.String) ref);
-          path_ = b;
-          return b;
-        } else {
-          return (com.google.protobuf.ByteString) ref;
-        }
-      }
-      /**
-       * <pre>
-       * Path of the artifact to fetch (relative to the root artifact directory for the run).
-       * </pre>
-       *
-       * <code>optional string path = 2;</code>
-       */
-      public Builder setPath(
-          java.lang.String value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        path_ = value;
-        onChanged();
-        return this;
-      }
-      /**
-       * <pre>
-       * Path of the artifact to fetch (relative to the root artifact directory for the run).
-       * </pre>
-       *
-       * <code>optional string path = 2;</code>
-       */
-      public Builder clearPath() {
-        bitField0_ = (bitField0_ & ~0x00000002);
-        path_ = getDefaultInstance().getPath();
-        onChanged();
-        return this;
-      }
-      /**
-       * <pre>
-       * Path of the artifact to fetch (relative to the root artifact directory for the run).
-       * </pre>
-       *
-       * <code>optional string path = 2;</code>
-       */
-      public Builder setPathBytes(
-          com.google.protobuf.ByteString value) {
-        if (value == null) {
-    throw new NullPointerException();
-  }
-  bitField0_ |= 0x00000002;
-        path_ = value;
-        onChanged();
-        return this;
-      }
-      @java.lang.Override
-      public final Builder setUnknownFields(
-          final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.setUnknownFields(unknownFields);
-      }
-
-      @java.lang.Override
-      public final Builder mergeUnknownFields(
-          final com.google.protobuf.UnknownFieldSet unknownFields) {
-        return super.mergeUnknownFields(unknownFields);
-      }
-
-
-      // @@protoc_insertion_point(builder_scope:mlflow.GetArtifact)
-    }
-
-    // @@protoc_insertion_point(class_scope:mlflow.GetArtifact)
-    private static final org.mlflow.api.proto.Service.GetArtifact DEFAULT_INSTANCE;
-    static {
-      DEFAULT_INSTANCE = new org.mlflow.api.proto.Service.GetArtifact();
-    }
-
-    public static org.mlflow.api.proto.Service.GetArtifact getDefaultInstance() {
-      return DEFAULT_INSTANCE;
-    }
-
-    @java.lang.Deprecated public static final com.google.protobuf.Parser<GetArtifact>
-        PARSER = new com.google.protobuf.AbstractParser<GetArtifact>() {
-      @java.lang.Override
-      public GetArtifact parsePartialFrom(
-          com.google.protobuf.CodedInputStream input,
-          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-          throws com.google.protobuf.InvalidProtocolBufferException {
-        return new GetArtifact(input, extensionRegistry);
-      }
-    };
-
-    public static com.google.protobuf.Parser<GetArtifact> parser() {
-      return PARSER;
-    }
-
-    @java.lang.Override
-    public com.google.protobuf.Parser<GetArtifact> getParserForType() {
-      return PARSER;
-    }
-
-    @java.lang.Override
-    public org.mlflow.api.proto.Service.GetArtifact getDefaultInstanceForType() {
-      return DEFAULT_INSTANCE;
-    }
-
-  }
-
   public interface GetMetricHistoryOrBuilder extends
       // @@protoc_insertion_point(interface_extends:mlflow.GetMetricHistory)
       com.google.protobuf.MessageOrBuilder {
 
     /**
      * <pre>
-     * ID of the run from which to fetch metric values.
+     * [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field
+     * will be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     boolean hasRunUuid();
     /**
      * <pre>
-     * ID of the run from which to fetch metric values.
+     * [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field
+     * will be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     java.lang.String getRunUuid();
     /**
      * <pre>
-     * ID of the run from which to fetch metric values.
+     * [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field
+     * will be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     com.google.protobuf.ByteString
         getRunUuidBytes();
+
+    /**
+     * <pre>
+     * ID of the run from which to fetch metric values. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 3;</code>
+     */
+    boolean hasRunId();
+    /**
+     * <pre>
+     * ID of the run from which to fetch metric values. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 3;</code>
+     */
+    java.lang.String getRunId();
+    /**
+     * <pre>
+     * ID of the run from which to fetch metric values. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 3;</code>
+     */
+    com.google.protobuf.ByteString
+        getRunIdBytes();
 
     /**
      * <pre>
@@ -43960,6 +44298,7 @@ public final class Service {
     }
     private GetMetricHistory() {
       runUuid_ = "";
+      runId_ = "";
       metricKey_ = "";
     }
 
@@ -43995,8 +44334,14 @@ public final class Service {
             }
             case 18: {
               com.google.protobuf.ByteString bs = input.readBytes();
-              bitField0_ |= 0x00000002;
+              bitField0_ |= 0x00000004;
               metricKey_ = bs;
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              runId_ = bs;
               break;
             }
             default: {
@@ -44930,20 +45275,22 @@ public final class Service {
     private volatile java.lang.Object runUuid_;
     /**
      * <pre>
-     * ID of the run from which to fetch metric values.
+     * [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field
+     * will be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public boolean hasRunUuid() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
      * <pre>
-     * ID of the run from which to fetch metric values.
+     * [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field
+     * will be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public java.lang.String getRunUuid() {
       java.lang.Object ref = runUuid_;
@@ -44961,10 +45308,11 @@ public final class Service {
     }
     /**
      * <pre>
-     * ID of the run from which to fetch metric values.
+     * [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field
+     * will be removed in a future MLflow version.
      * </pre>
      *
-     * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+     * <code>optional string run_uuid = 1;</code>
      */
     public com.google.protobuf.ByteString
         getRunUuidBytes() {
@@ -44974,6 +45322,60 @@ public final class Service {
             com.google.protobuf.ByteString.copyFromUtf8(
                 (java.lang.String) ref);
         runUuid_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int RUN_ID_FIELD_NUMBER = 3;
+    private volatile java.lang.Object runId_;
+    /**
+     * <pre>
+     * ID of the run from which to fetch metric values. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 3;</code>
+     */
+    public boolean hasRunId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <pre>
+     * ID of the run from which to fetch metric values. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 3;</code>
+     */
+    public java.lang.String getRunId() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * ID of the run from which to fetch metric values. Must be provided.
+     * </pre>
+     *
+     * <code>optional string run_id = 3;</code>
+     */
+    public com.google.protobuf.ByteString
+        getRunIdBytes() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runId_ = b;
         return b;
       } else {
         return (com.google.protobuf.ByteString) ref;
@@ -44990,7 +45392,7 @@ public final class Service {
      * <code>optional string metric_key = 2 [(.validate_required) = true];</code>
      */
     public boolean hasMetricKey() {
-      return ((bitField0_ & 0x00000002) == 0x00000002);
+      return ((bitField0_ & 0x00000004) == 0x00000004);
     }
     /**
      * <pre>
@@ -45051,8 +45453,11 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, metricKey_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, runId_);
       }
       unknownFields.writeTo(output);
     }
@@ -45066,8 +45471,11 @@ public final class Service {
       if (((bitField0_ & 0x00000001) == 0x00000001)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runUuid_);
       }
-      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, metricKey_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, runId_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -45090,6 +45498,11 @@ public final class Service {
         result = result && getRunUuid()
             .equals(other.getRunUuid());
       }
+      result = result && (hasRunId() == other.hasRunId());
+      if (hasRunId()) {
+        result = result && getRunId()
+            .equals(other.getRunId());
+      }
       result = result && (hasMetricKey() == other.hasMetricKey());
       if (hasMetricKey()) {
         result = result && getMetricKey()
@@ -45109,6 +45522,10 @@ public final class Service {
       if (hasRunUuid()) {
         hash = (37 * hash) + RUN_UUID_FIELD_NUMBER;
         hash = (53 * hash) + getRunUuid().hashCode();
+      }
+      if (hasRunId()) {
+        hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRunId().hashCode();
       }
       if (hasMetricKey()) {
         hash = (37 * hash) + METRIC_KEY_FIELD_NUMBER;
@@ -45249,8 +45666,10 @@ public final class Service {
         super.clear();
         runUuid_ = "";
         bitField0_ = (bitField0_ & ~0x00000001);
-        metricKey_ = "";
+        runId_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
+        metricKey_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -45285,6 +45704,10 @@ public final class Service {
         result.runUuid_ = runUuid_;
         if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
           to_bitField0_ |= 0x00000002;
+        }
+        result.runId_ = runId_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
         }
         result.metricKey_ = metricKey_;
         result.bitField0_ = to_bitField0_;
@@ -45341,8 +45764,13 @@ public final class Service {
           runUuid_ = other.runUuid_;
           onChanged();
         }
-        if (other.hasMetricKey()) {
+        if (other.hasRunId()) {
           bitField0_ |= 0x00000002;
+          runId_ = other.runId_;
+          onChanged();
+        }
+        if (other.hasMetricKey()) {
+          bitField0_ |= 0x00000004;
           metricKey_ = other.metricKey_;
           onChanged();
         }
@@ -45379,20 +45807,22 @@ public final class Service {
       private java.lang.Object runUuid_ = "";
       /**
        * <pre>
-       * ID of the run from which to fetch metric values.
+       * [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field
+       * will be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public boolean hasRunUuid() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
        * <pre>
-       * ID of the run from which to fetch metric values.
+       * [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field
+       * will be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public java.lang.String getRunUuid() {
         java.lang.Object ref = runUuid_;
@@ -45410,10 +45840,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run from which to fetch metric values.
+       * [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field
+       * will be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public com.google.protobuf.ByteString
           getRunUuidBytes() {
@@ -45430,10 +45861,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run from which to fetch metric values.
+       * [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field
+       * will be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder setRunUuid(
           java.lang.String value) {
@@ -45447,10 +45879,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run from which to fetch metric values.
+       * [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field
+       * will be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder clearRunUuid() {
         bitField0_ = (bitField0_ & ~0x00000001);
@@ -45460,10 +45893,11 @@ public final class Service {
       }
       /**
        * <pre>
-       * ID of the run from which to fetch metric values.
+       * [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field
+       * will be removed in a future MLflow version.
        * </pre>
        *
-       * <code>optional string run_uuid = 1 [(.validate_required) = true];</code>
+       * <code>optional string run_uuid = 1;</code>
        */
       public Builder setRunUuidBytes(
           com.google.protobuf.ByteString value) {
@@ -45472,6 +45906,106 @@ public final class Service {
   }
   bitField0_ |= 0x00000001;
         runUuid_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object runId_ = "";
+      /**
+       * <pre>
+       * ID of the run from which to fetch metric values. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 3;</code>
+       */
+      public boolean hasRunId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <pre>
+       * ID of the run from which to fetch metric values. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 3;</code>
+       */
+      public java.lang.String getRunId() {
+        java.lang.Object ref = runId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run from which to fetch metric values. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 3;</code>
+       */
+      public com.google.protobuf.ByteString
+          getRunIdBytes() {
+        java.lang.Object ref = runId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run from which to fetch metric values. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 3;</code>
+       */
+      public Builder setRunId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run from which to fetch metric values. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 3;</code>
+       */
+      public Builder clearRunId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        runId_ = getDefaultInstance().getRunId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run from which to fetch metric values. Must be provided.
+       * </pre>
+       *
+       * <code>optional string run_id = 3;</code>
+       */
+      public Builder setRunIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        runId_ = value;
         onChanged();
         return this;
       }
@@ -45485,7 +46019,7 @@ public final class Service {
        * <code>optional string metric_key = 2 [(.validate_required) = true];</code>
        */
       public boolean hasMetricKey() {
-        return ((bitField0_ & 0x00000002) == 0x00000002);
+        return ((bitField0_ & 0x00000004) == 0x00000004);
       }
       /**
        * <pre>
@@ -45540,7 +46074,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         metricKey_ = value;
         onChanged();
         return this;
@@ -45553,7 +46087,7 @@ public final class Service {
        * <code>optional string metric_key = 2 [(.validate_required) = true];</code>
        */
       public Builder clearMetricKey() {
-        bitField0_ = (bitField0_ & ~0x00000002);
+        bitField0_ = (bitField0_ & ~0x00000004);
         metricKey_ = getDefaultInstance().getMetricKey();
         onChanged();
         return this;
@@ -45570,7 +46104,7 @@ public final class Service {
         if (value == null) {
     throw new NullPointerException();
   }
-  bitField0_ |= 0x00000002;
+  bitField0_ |= 0x00000004;
         metricKey_ = value;
         onChanged();
         return this;
@@ -48423,16 +48957,6 @@ public final class Service {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_mlflow_FileInfo_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_mlflow_GetArtifact_descriptor;
-  private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_mlflow_GetArtifact_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
-    internal_static_mlflow_GetArtifact_Response_descriptor;
-  private static final 
-    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
-      internal_static_mlflow_GetArtifact_Response_fieldAccessorTable;
-  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mlflow_GetMetricHistory_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -48470,176 +48994,175 @@ public final class Service {
       "Data\"g\n\007RunData\022\037\n\007metrics\030\001 \003(\0132\016.mlflo" +
       "w.Metric\022\035\n\006params\030\002 \003(\0132\r.mlflow.Param\022" +
       "\034\n\004tags\030\003 \003(\0132\016.mlflow.RunTag\"$\n\006RunTag\022" +
-      "\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"\271\002\n\007RunInfo\022" +
-      "\020\n\010run_uuid\030\001 \001(\t\022\025\n\rexperiment_id\030\002 \001(\t" +
-      "\022\014\n\004name\030\003 \001(\t\022\'\n\013source_type\030\004 \001(\0162\022.ml" +
-      "flow.SourceType\022\023\n\013source_name\030\005 \001(\t\022\017\n\007" +
-      "user_id\030\006 \001(\t\022!\n\006status\030\007 \001(\0162\021.mlflow.R" +
-      "unStatus\022\022\n\nstart_time\030\010 \001(\003\022\020\n\010end_time" +
-      "\030\t \001(\003\022\026\n\016source_version\030\n \001(\t\022\030\n\020entry_" +
-      "point_name\030\013 \001(\t\022\024\n\014artifact_uri\030\r \001(\t\022\027" +
-      "\n\017lifecycle_stage\030\016 \001(\t\"\226\001\n\nExperiment\022\025" +
-      "\n\rexperiment_id\030\001 \001(\t\022\014\n\004name\030\002 \001(\t\022\031\n\021a" +
-      "rtifact_location\030\003 \001(\t\022\027\n\017lifecycle_stag" +
-      "e\030\004 \001(\t\022\030\n\020last_update_time\030\005 \001(\003\022\025\n\rcre" +
-      "ation_time\030\006 \001(\003\"\221\001\n\020CreateExperiment\022\022\n" +
-      "\004name\030\001 \001(\tB\004\210\265\030\001\022\031\n\021artifact_location\030\002" +
-      " \001(\t\032!\n\010Response\022\025\n\rexperiment_id\030\001 \001(\t:" +
-      "+\342?(\n&com.databricks.rpc.RPC[$this.Respo" +
-      "nse]\"\230\001\n\017ListExperiments\022#\n\tview_type\030\001 " +
-      "\001(\0162\020.mlflow.ViewType\0323\n\010Response\022\'\n\013exp" +
-      "eriments\030\001 \003(\0132\022.mlflow.Experiment:+\342?(\n" +
-      "&com.databricks.rpc.RPC[$this.Response]\"" +
-      "\254\001\n\rGetExperiment\022\033\n\rexperiment_id\030\001 \001(\t" +
-      "B\004\210\265\030\001\032Q\n\010Response\022&\n\nexperiment\030\001 \001(\0132\022" +
-      ".mlflow.Experiment\022\035\n\004runs\030\002 \003(\0132\017.mlflo" +
-      "w.RunInfo:+\342?(\n&com.databricks.rpc.RPC[$" +
-      "this.Response]\"h\n\020DeleteExperiment\022\033\n\rex" +
-      "periment_id\030\001 \001(\tB\004\210\265\030\001\032\n\n\010Response:+\342?(" +
-      "\n&com.databricks.rpc.RPC[$this.Response]" +
-      "\"i\n\021RestoreExperiment\022\033\n\rexperiment_id\030\001" +
-      " \001(\tB\004\210\265\030\001\032\n\n\010Response:+\342?(\n&com.databri" +
-      "cks.rpc.RPC[$this.Response]\"z\n\020UpdateExp" +
-      "eriment\022\033\n\rexperiment_id\030\001 \001(\tB\004\210\265\030\001\022\020\n\010" +
-      "new_name\030\002 \001(\t\032\n\n\010Response:+\342?(\n&com.dat" +
-      "abricks.rpc.RPC[$this.Response]\"\321\002\n\tCrea" +
-      "teRun\022\025\n\rexperiment_id\030\001 \001(\t\022\017\n\007user_id\030" +
-      "\002 \001(\t\022\020\n\010run_name\030\003 \001(\t\022\'\n\013source_type\030\004" +
-      " \001(\0162\022.mlflow.SourceType\022\023\n\013source_name\030" +
-      "\005 \001(\t\022\030\n\020entry_point_name\030\006 \001(\t\022\022\n\nstart" +
-      "_time\030\007 \001(\003\022\026\n\016source_version\030\010 \001(\t\022\034\n\004t" +
-      "ags\030\t \003(\0132\016.mlflow.RunTag\022\025\n\rparent_run_" +
-      "id\030\n \001(\t\032$\n\010Response\022\030\n\003run\030\001 \001(\0132\013.mlfl" +
-      "ow.Run:+\342?(\n&com.databricks.rpc.RPC[$thi" +
-      "s.Response]\"\264\001\n\tUpdateRun\022\026\n\010run_uuid\030\001 " +
-      "\001(\tB\004\210\265\030\001\022!\n\006status\030\002 \001(\0162\021.mlflow.RunSt" +
-      "atus\022\020\n\010end_time\030\003 \001(\003\032-\n\010Response\022!\n\010ru" +
-      "n_info\030\001 \001(\0132\017.mlflow.RunInfo:+\342?(\n&com." +
-      "databricks.rpc.RPC[$this.Response]\"Z\n\tDe" +
-      "leteRun\022\024\n\006run_id\030\001 \001(\tB\004\210\265\030\001\032\n\n\010Respons" +
-      "e:+\342?(\n&com.databricks.rpc.RPC[$this.Res" +
-      "ponse]\"[\n\nRestoreRun\022\024\n\006run_id\030\001 \001(\tB\004\210\265" +
-      "\030\001\032\n\n\010Response:+\342?(\n&com.databricks.rpc." +
-      "RPC[$this.Response]\"\256\001\n\tLogMetric\022\026\n\010run" +
-      "_uuid\030\001 \001(\tB\004\210\265\030\001\022\021\n\003key\030\002 \001(\tB\004\210\265\030\001\022\023\n\005" +
-      "value\030\003 \001(\001B\004\210\265\030\001\022\027\n\ttimestamp\030\004 \001(\003B\004\210\265" +
-      "\030\001\022\017\n\004step\030\005 \001(\003:\0010\032\n\n\010Response:+\342?(\n&co" +
-      "m.databricks.rpc.RPC[$this.Response]\"\203\001\n" +
-      "\010LogParam\022\026\n\010run_uuid\030\001 \001(\tB\004\210\265\030\001\022\021\n\003key" +
-      "\030\002 \001(\tB\004\210\265\030\001\022\023\n\005value\030\003 \001(\tB\004\210\265\030\001\032\n\n\010Res" +
-      "ponse:+\342?(\n&com.databricks.rpc.RPC[$this" +
-      ".Response]\"\201\001\n\006SetTag\022\026\n\010run_uuid\030\001 \001(\tB" +
-      "\004\210\265\030\001\022\021\n\003key\030\002 \001(\tB\004\210\265\030\001\022\023\n\005value\030\003 \001(\tB" +
-      "\004\210\265\030\001\032\n\n\010Response:+\342?(\n&com.databricks.r" +
-      "pc.RPC[$this.Response]\"s\n\006GetRun\022\026\n\010run_" +
-      "uuid\030\001 \001(\tB\004\210\265\030\001\032$\n\010Response\022\030\n\003run\030\001 \001(" +
-      "\0132\013.mlflow.Run:+\342?(\n&com.databricks.rpc." +
-      "RPC[$this.Response]\"\212\001\n\020SearchExpression" +
-      "\0220\n\006metric\030\001 \001(\0132\036.mlflow.MetricSearchEx" +
-      "pressionH\000\0226\n\tparameter\030\002 \001(\0132!.mlflow.P" +
-      "arameterSearchExpressionH\000B\014\n\nexpression" +
-      "\"}\n\026MetricSearchExpression\022\013\n\003key\030\001 \001(\t\022" +
-      "$\n\005float\030\002 \001(\0132\023.mlflow.FloatClauseH\000\022&\n" +
-      "\006double\030\003 \001(\0132\024.mlflow.DoubleClauseH\000B\010\n" +
-      "\006clause\"Z\n\031ParameterSearchExpression\022\013\n\003" +
-      "key\030\001 \001(\t\022&\n\006string\030\002 \001(\0132\024.mlflow.Strin" +
-      "gClauseH\000B\010\n\006clause\"1\n\014StringClause\022\022\n\nc" +
-      "omparator\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"0\n\013FloatC" +
-      "lause\022\022\n\ncomparator\030\001 \001(\t\022\r\n\005value\030\002 \001(\002" +
-      "\"1\n\014DoubleClause\022\022\n\ncomparator\030\001 \001(\t\022\r\n\005" +
-      "value\030\002 \001(\001\"\216\002\n\nSearchRuns\022\026\n\016experiment" +
-      "_ids\030\001 \003(\t\0223\n\021anded_expressions\030\002 \003(\0132\030." +
-      "mlflow.SearchExpression\022\016\n\006filter\030\004 \001(\t\022" +
-      "4\n\rrun_view_type\030\003 \001(\0162\020.mlflow.ViewType" +
-      ":\013ACTIVE_ONLY\022\031\n\013max_results\030\005 \001(\005:\0041000" +
-      "\032%\n\010Response\022\031\n\004runs\030\001 \003(\0132\013.mlflow.Run:" +
-      "+\342?(\n&com.databricks.rpc.RPC[$this.Respo" +
-      "nse]\"\233\001\n\rListArtifacts\022\020\n\010run_uuid\030\001 \001(\t" +
-      "\022\014\n\004path\030\002 \001(\t\032=\n\010Response\022\020\n\010root_uri\030\001" +
-      " \001(\t\022\037\n\005files\030\002 \003(\0132\020.mlflow.FileInfo:+\342" +
-      "?(\n&com.databricks.rpc.RPC[$this.Respons" +
-      "e]\";\n\010FileInfo\022\014\n\004path\030\001 \001(\t\022\016\n\006is_dir\030\002" +
-      " \001(\010\022\021\n\tfile_size\030\003 \001(\003\"f\n\013GetArtifact\022\020" +
-      "\n\010run_uuid\030\001 \001(\t\022\014\n\004path\030\002 \001(\t\032\n\n\010Respon" +
+      "\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"\311\002\n\007RunInfo\022" +
+      "\020\n\010run_uuid\030\001 \001(\t\022\016\n\006run_id\030\017 \001(\t\022\025\n\rexp" +
+      "eriment_id\030\002 \001(\t\022\014\n\004name\030\003 \001(\t\022\'\n\013source" +
+      "_type\030\004 \001(\0162\022.mlflow.SourceType\022\023\n\013sourc" +
+      "e_name\030\005 \001(\t\022\017\n\007user_id\030\006 \001(\t\022!\n\006status\030" +
+      "\007 \001(\0162\021.mlflow.RunStatus\022\022\n\nstart_time\030\010" +
+      " \001(\003\022\020\n\010end_time\030\t \001(\003\022\026\n\016source_version" +
+      "\030\n \001(\t\022\030\n\020entry_point_name\030\013 \001(\t\022\024\n\014arti" +
+      "fact_uri\030\r \001(\t\022\027\n\017lifecycle_stage\030\016 \001(\t\"" +
+      "\226\001\n\nExperiment\022\025\n\rexperiment_id\030\001 \001(\t\022\014\n" +
+      "\004name\030\002 \001(\t\022\031\n\021artifact_location\030\003 \001(\t\022\027" +
+      "\n\017lifecycle_stage\030\004 \001(\t\022\030\n\020last_update_t" +
+      "ime\030\005 \001(\003\022\025\n\rcreation_time\030\006 \001(\003\"\221\001\n\020Cre" +
+      "ateExperiment\022\022\n\004name\030\001 \001(\tB\004\210\265\030\001\022\031\n\021art" +
+      "ifact_location\030\002 \001(\t\032!\n\010Response\022\025\n\rexpe" +
+      "riment_id\030\001 \001(\t:+\342?(\n&com.databricks.rpc" +
+      ".RPC[$this.Response]\"\230\001\n\017ListExperiments" +
+      "\022#\n\tview_type\030\001 \001(\0162\020.mlflow.ViewType\0323\n" +
+      "\010Response\022\'\n\013experiments\030\001 \003(\0132\022.mlflow." +
+      "Experiment:+\342?(\n&com.databricks.rpc.RPC[" +
+      "$this.Response]\"\254\001\n\rGetExperiment\022\033\n\rexp" +
+      "eriment_id\030\001 \001(\tB\004\210\265\030\001\032Q\n\010Response\022&\n\nex" +
+      "periment\030\001 \001(\0132\022.mlflow.Experiment\022\035\n\004ru" +
+      "ns\030\002 \003(\0132\017.mlflow.RunInfo:+\342?(\n&com.data" +
+      "bricks.rpc.RPC[$this.Response]\"h\n\020Delete" +
+      "Experiment\022\033\n\rexperiment_id\030\001 \001(\tB\004\210\265\030\001\032" +
+      "\n\n\010Response:+\342?(\n&com.databricks.rpc.RPC" +
+      "[$this.Response]\"i\n\021RestoreExperiment\022\033\n" +
+      "\rexperiment_id\030\001 \001(\tB\004\210\265\030\001\032\n\n\010Response:+" +
+      "\342?(\n&com.databricks.rpc.RPC[$this.Respon" +
+      "se]\"z\n\020UpdateExperiment\022\033\n\rexperiment_id" +
+      "\030\001 \001(\tB\004\210\265\030\001\022\020\n\010new_name\030\002 \001(\t\032\n\n\010Respon" +
       "se:+\342?(\n&com.databricks.rpc.RPC[$this.Re" +
-      "sponse]\"\236\001\n\020GetMetricHistory\022\026\n\010run_uuid" +
-      "\030\001 \001(\tB\004\210\265\030\001\022\030\n\nmetric_key\030\002 \001(\tB\004\210\265\030\001\032+" +
-      "\n\010Response\022\037\n\007metrics\030\001 \003(\0132\016.mlflow.Met" +
-      "ric:+\342?(\n&com.databricks.rpc.RPC[$this.R" +
-      "esponse]\"\261\001\n\010LogBatch\022\016\n\006run_id\030\001 \001(\t\022\037\n" +
-      "\007metrics\030\002 \003(\0132\016.mlflow.Metric\022\035\n\006params" +
-      "\030\003 \003(\0132\r.mlflow.Param\022\034\n\004tags\030\004 \003(\0132\016.ml" +
-      "flow.RunTag\032\n\n\010Response:+\342?(\n&com.databr" +
-      "icks.rpc.RPC[$this.Response]*6\n\010ViewType" +
-      "\022\017\n\013ACTIVE_ONLY\020\001\022\020\n\014DELETED_ONLY\020\002\022\007\n\003A" +
-      "LL\020\003*I\n\nSourceType\022\014\n\010NOTEBOOK\020\001\022\007\n\003JOB\020" +
-      "\002\022\013\n\007PROJECT\020\003\022\t\n\005LOCAL\020\004\022\014\n\007UNKNOWN\020\350\007*" +
-      "M\n\tRunStatus\022\013\n\007RUNNING\020\001\022\r\n\tSCHEDULED\020\002" +
-      "\022\014\n\010FINISHED\020\003\022\n\n\006FAILED\020\004\022\n\n\006KILLED\020\0052\271" +
-      "\023\n\rMlflowService\022\234\001\n\020createExperiment\022\030." +
-      "mlflow.CreateExperiment\032!.mlflow.CreateE" +
-      "xperiment.Response\"K\202\265\030G\n0\n\004POST\022\"/previ" +
-      "ew/mlflow/experiments/create\032\004\010\002\020\000\020\001*\021Cr" +
-      "eate Experiment\022\225\001\n\017listExperiments\022\027.ml" +
-      "flow.ListExperiments\032 .mlflow.ListExperi" +
-      "ments.Response\"G\202\265\030C\n-\n\003GET\022 /preview/ml" +
-      "flow/experiments/list\032\004\010\002\020\000\020\001*\020List Expe" +
-      "riments\022\214\001\n\rgetExperiment\022\025.mlflow.GetEx" +
-      "periment\032\036.mlflow.GetExperiment.Response" +
-      "\"D\202\265\030@\n,\n\003GET\022\037/preview/mlflow/experimen" +
-      "ts/get\032\004\010\002\020\000\020\001*\016Get Experiment\022\234\001\n\020delet" +
-      "eExperiment\022\030.mlflow.DeleteExperiment\032!." +
-      "mlflow.DeleteExperiment.Response\"K\202\265\030G\n0" +
-      "\n\004POST\022\"/preview/mlflow/experiments/dele" +
-      "te\032\004\010\002\020\000\020\001*\021Delete Experiment\022\241\001\n\021restor" +
-      "eExperiment\022\031.mlflow.RestoreExperiment\032\"" +
-      ".mlflow.RestoreExperiment.Response\"M\202\265\030I" +
-      "\n1\n\004POST\022#/preview/mlflow/experiments/re" +
-      "store\032\004\010\002\020\000\020\001*\022Restore Experiment\022\234\001\n\020up" +
-      "dateExperiment\022\030.mlflow.UpdateExperiment" +
-      "\032!.mlflow.UpdateExperiment.Response\"K\202\265\030" +
-      "G\n0\n\004POST\022\"/preview/mlflow/experiments/u" +
-      "pdate\032\004\010\002\020\000\020\001*\021Update Experiment\022y\n\tcrea" +
-      "teRun\022\021.mlflow.CreateRun\032\032.mlflow.Create" +
-      "Run.Response\"=\202\265\0309\n)\n\004POST\022\033/preview/mlf" +
-      "low/runs/create\032\004\010\002\020\000\020\001*\nCreate Run\022y\n\tu" +
-      "pdateRun\022\021.mlflow.UpdateRun\032\032.mlflow.Upd" +
-      "ateRun.Response\"=\202\265\0309\n)\n\004POST\022\033/preview/" +
-      "mlflow/runs/update\032\004\010\002\020\000\020\001*\nUpdate Run\022m" +
-      "\n\tdeleteRun\022\021.mlflow.DeleteRun\032\032.mlflow." +
-      "DeleteRun.Response\"1\202\265\030-\n)\n\004POST\022\033/previ" +
-      "ew/mlflow/runs/delete\032\004\010\002\020\000\020\001\022q\n\nrestore" +
-      "Run\022\022.mlflow.RestoreRun\032\033.mlflow.Restore" +
-      "Run.Response\"2\202\265\030.\n*\n\004POST\022\034/preview/mlf" +
-      "low/runs/restore\032\004\010\002\020\000\020\001\022}\n\tlogMetric\022\021." +
-      "mlflow.LogMetric\032\032.mlflow.LogMetric.Resp" +
-      "onse\"A\202\265\030=\n-\n\004POST\022\037/preview/mlflow/runs" +
-      "/log-metric\032\004\010\002\020\000\020\001*\nLog Metric\022|\n\010logPa" +
-      "ram\022\020.mlflow.LogParam\032\031.mlflow.LogParam." +
-      "Response\"C\202\265\030?\n0\n\004POST\022\"/preview/mlflow/" +
-      "runs/log-parameter\032\004\010\002\020\000\020\001*\tLog Param\022n\n" +
-      "\006setTag\022\016.mlflow.SetTag\032\027.mlflow.SetTag." +
-      "Response\";\202\265\0307\n*\n\004POST\022\034/preview/mlflow/" +
-      "runs/set-tag\032\004\010\002\020\000\020\001*\007Set Tag\022i\n\006getRun\022" +
-      "\016.mlflow.GetRun\032\027.mlflow.GetRun.Response" +
-      "\"6\202\265\0302\n%\n\003GET\022\030/preview/mlflow/runs/get\032" +
-      "\004\010\002\020\000\020\001*\007Get Run\022\247\001\n\nsearchRuns\022\022.mlflow" +
-      ".SearchRuns\032\033.mlflow.SearchRuns.Response" +
-      "\"h\202\265\030d\n)\n\004POST\022\033/preview/mlflow/runs/sea" +
-      "rch\032\004\010\002\020\000\n(\n\003GET\022\033/preview/mlflow/runs/s" +
-      "earch\032\004\010\002\020\000\020\001*\013Search Runs\022\213\001\n\rlistArtif" +
-      "acts\022\025.mlflow.ListArtifacts\032\036.mlflow.Lis" +
-      "tArtifacts.Response\"C\202\265\030?\n+\n\003GET\022\036/previ" +
-      "ew/mlflow/artifacts/list\032\004\010\002\020\000\020\001*\016List A" +
-      "rtifacts\022\235\001\n\020getMetricHistory\022\030.mlflow.G" +
-      "etMetricHistory\032!.mlflow.GetMetricHistor" +
-      "y.Response\"L\202\265\030H\n0\n\003GET\022#/preview/mlflow" +
-      "/metrics/get-history\032\004\010\002\020\000\020\001*\022Get Metric" +
-      " History\022x\n\010logBatch\022\020.mlflow.LogBatch\032\031" +
-      ".mlflow.LogBatch.Response\"?\202\265\030;\n,\n\004POST\022" +
-      "\036/preview/mlflow/runs/log-batch\032\004\010\002\020\000\020\001*" +
-      "\tLog BatchB\036\n\024org.mlflow.api.proto\220\001\001\342?\002" +
-      "\020\001"
+      "sponse]\"\321\002\n\tCreateRun\022\025\n\rexperiment_id\030\001" +
+      " \001(\t\022\017\n\007user_id\030\002 \001(\t\022\020\n\010run_name\030\003 \001(\t\022" +
+      "\'\n\013source_type\030\004 \001(\0162\022.mlflow.SourceType" +
+      "\022\023\n\013source_name\030\005 \001(\t\022\030\n\020entry_point_nam" +
+      "e\030\006 \001(\t\022\022\n\nstart_time\030\007 \001(\003\022\026\n\016source_ve" +
+      "rsion\030\010 \001(\t\022\034\n\004tags\030\t \003(\0132\016.mlflow.RunTa" +
+      "g\022\025\n\rparent_run_id\030\n \001(\t\032$\n\010Response\022\030\n\003" +
+      "run\030\001 \001(\0132\013.mlflow.Run:+\342?(\n&com.databri" +
+      "cks.rpc.RPC[$this.Response]\"\276\001\n\tUpdateRu" +
+      "n\022\020\n\010run_uuid\030\001 \001(\t\022\016\n\006run_id\030\004 \001(\t\022!\n\006s" +
+      "tatus\030\002 \001(\0162\021.mlflow.RunStatus\022\020\n\010end_ti" +
+      "me\030\003 \001(\003\032-\n\010Response\022!\n\010run_info\030\001 \001(\0132\017" +
+      ".mlflow.RunInfo:+\342?(\n&com.databricks.rpc" +
+      ".RPC[$this.Response]\"Z\n\tDeleteRun\022\024\n\006run" +
+      "_id\030\001 \001(\tB\004\210\265\030\001\032\n\n\010Response:+\342?(\n&com.da" +
+      "tabricks.rpc.RPC[$this.Response]\"[\n\nRest" +
+      "oreRun\022\024\n\006run_id\030\001 \001(\tB\004\210\265\030\001\032\n\n\010Response" +
+      ":+\342?(\n&com.databricks.rpc.RPC[$this.Resp" +
+      "onse]\"\270\001\n\tLogMetric\022\020\n\010run_uuid\030\001 \001(\t\022\016\n" +
+      "\006run_id\030\006 \001(\t\022\021\n\003key\030\002 \001(\tB\004\210\265\030\001\022\023\n\005valu" +
+      "e\030\003 \001(\001B\004\210\265\030\001\022\027\n\ttimestamp\030\004 \001(\003B\004\210\265\030\001\022\017" +
+      "\n\004step\030\005 \001(\003:\0010\032\n\n\010Response:+\342?(\n&com.da" +
+      "tabricks.rpc.RPC[$this.Response]\"\215\001\n\010Log" +
+      "Param\022\020\n\010run_uuid\030\001 \001(\t\022\016\n\006run_id\030\004 \001(\t\022" +
+      "\021\n\003key\030\002 \001(\tB\004\210\265\030\001\022\023\n\005value\030\003 \001(\tB\004\210\265\030\001\032" +
+      "\n\n\010Response:+\342?(\n&com.databricks.rpc.RPC" +
+      "[$this.Response]\"\213\001\n\006SetTag\022\020\n\010run_uuid\030" +
+      "\001 \001(\t\022\016\n\006run_id\030\004 \001(\t\022\021\n\003key\030\002 \001(\tB\004\210\265\030\001" +
+      "\022\023\n\005value\030\003 \001(\tB\004\210\265\030\001\032\n\n\010Response:+\342?(\n&" +
+      "com.databricks.rpc.RPC[$this.Response]\"}" +
+      "\n\006GetRun\022\020\n\010run_uuid\030\001 \001(\t\022\016\n\006run_id\030\002 \001" +
+      "(\t\032$\n\010Response\022\030\n\003run\030\001 \001(\0132\013.mlflow.Run" +
+      ":+\342?(\n&com.databricks.rpc.RPC[$this.Resp" +
+      "onse]\"\212\001\n\020SearchExpression\0220\n\006metric\030\001 \001" +
+      "(\0132\036.mlflow.MetricSearchExpressionH\000\0226\n\t" +
+      "parameter\030\002 \001(\0132!.mlflow.ParameterSearch" +
+      "ExpressionH\000B\014\n\nexpression\"}\n\026MetricSear" +
+      "chExpression\022\013\n\003key\030\001 \001(\t\022$\n\005float\030\002 \001(\013" +
+      "2\023.mlflow.FloatClauseH\000\022&\n\006double\030\003 \001(\0132" +
+      "\024.mlflow.DoubleClauseH\000B\010\n\006clause\"Z\n\031Par" +
+      "ameterSearchExpression\022\013\n\003key\030\001 \001(\t\022&\n\006s" +
+      "tring\030\002 \001(\0132\024.mlflow.StringClauseH\000B\010\n\006c" +
+      "lause\"1\n\014StringClause\022\022\n\ncomparator\030\001 \001(" +
+      "\t\022\r\n\005value\030\002 \001(\t\"0\n\013FloatClause\022\022\n\ncompa" +
+      "rator\030\001 \001(\t\022\r\n\005value\030\002 \001(\002\"1\n\014DoubleClau" +
+      "se\022\022\n\ncomparator\030\001 \001(\t\022\r\n\005value\030\002 \001(\001\"\216\002" +
+      "\n\nSearchRuns\022\026\n\016experiment_ids\030\001 \003(\t\0223\n\021" +
+      "anded_expressions\030\002 \003(\0132\030.mlflow.SearchE" +
+      "xpression\022\016\n\006filter\030\004 \001(\t\0224\n\rrun_view_ty" +
+      "pe\030\003 \001(\0162\020.mlflow.ViewType:\013ACTIVE_ONLY\022" +
+      "\031\n\013max_results\030\005 \001(\005:\0041000\032%\n\010Response\022\031" +
+      "\n\004runs\030\001 \003(\0132\013.mlflow.Run:+\342?(\n&com.data" +
+      "bricks.rpc.RPC[$this.Response]\"\253\001\n\rListA" +
+      "rtifacts\022\020\n\010run_uuid\030\001 \001(\t\022\016\n\006run_id\030\003 \001" +
+      "(\t\022\014\n\004path\030\002 \001(\t\032=\n\010Response\022\020\n\010root_uri" +
+      "\030\001 \001(\t\022\037\n\005files\030\002 \003(\0132\020.mlflow.FileInfo:" +
+      "+\342?(\n&com.databricks.rpc.RPC[$this.Respo" +
+      "nse]\";\n\010FileInfo\022\014\n\004path\030\001 \001(\t\022\016\n\006is_dir" +
+      "\030\002 \001(\010\022\021\n\tfile_size\030\003 \001(\003\"\250\001\n\020GetMetricH" +
+      "istory\022\020\n\010run_uuid\030\001 \001(\t\022\016\n\006run_id\030\003 \001(\t" +
+      "\022\030\n\nmetric_key\030\002 \001(\tB\004\210\265\030\001\032+\n\010Response\022\037" +
+      "\n\007metrics\030\001 \003(\0132\016.mlflow.Metric:+\342?(\n&co" +
+      "m.databricks.rpc.RPC[$this.Response]\"\261\001\n" +
+      "\010LogBatch\022\016\n\006run_id\030\001 \001(\t\022\037\n\007metrics\030\002 \003" +
+      "(\0132\016.mlflow.Metric\022\035\n\006params\030\003 \003(\0132\r.mlf" +
+      "low.Param\022\034\n\004tags\030\004 \003(\0132\016.mlflow.RunTag\032" +
+      "\n\n\010Response:+\342?(\n&com.databricks.rpc.RPC" +
+      "[$this.Response]*6\n\010ViewType\022\017\n\013ACTIVE_O" +
+      "NLY\020\001\022\020\n\014DELETED_ONLY\020\002\022\007\n\003ALL\020\003*I\n\nSour" +
+      "ceType\022\014\n\010NOTEBOOK\020\001\022\007\n\003JOB\020\002\022\013\n\007PROJECT" +
+      "\020\003\022\t\n\005LOCAL\020\004\022\014\n\007UNKNOWN\020\350\007*M\n\tRunStatus" +
+      "\022\013\n\007RUNNING\020\001\022\r\n\tSCHEDULED\020\002\022\014\n\010FINISHED" +
+      "\020\003\022\n\n\006FAILED\020\004\022\n\n\006KILLED\020\0052\271\023\n\rMlflowSer" +
+      "vice\022\234\001\n\020createExperiment\022\030.mlflow.Creat" +
+      "eExperiment\032!.mlflow.CreateExperiment.Re" +
+      "sponse\"K\202\265\030G\n0\n\004POST\022\"/preview/mlflow/ex" +
+      "periments/create\032\004\010\002\020\000\020\001*\021Create Experim" +
+      "ent\022\225\001\n\017listExperiments\022\027.mlflow.ListExp" +
+      "eriments\032 .mlflow.ListExperiments.Respon" +
+      "se\"G\202\265\030C\n-\n\003GET\022 /preview/mlflow/experim" +
+      "ents/list\032\004\010\002\020\000\020\001*\020List Experiments\022\214\001\n\r" +
+      "getExperiment\022\025.mlflow.GetExperiment\032\036.m" +
+      "lflow.GetExperiment.Response\"D\202\265\030@\n,\n\003GE" +
+      "T\022\037/preview/mlflow/experiments/get\032\004\010\002\020\000" +
+      "\020\001*\016Get Experiment\022\234\001\n\020deleteExperiment\022" +
+      "\030.mlflow.DeleteExperiment\032!.mlflow.Delet" +
+      "eExperiment.Response\"K\202\265\030G\n0\n\004POST\022\"/pre" +
+      "view/mlflow/experiments/delete\032\004\010\002\020\000\020\001*\021" +
+      "Delete Experiment\022\241\001\n\021restoreExperiment\022" +
+      "\031.mlflow.RestoreExperiment\032\".mlflow.Rest" +
+      "oreExperiment.Response\"M\202\265\030I\n1\n\004POST\022#/p" +
+      "review/mlflow/experiments/restore\032\004\010\002\020\000\020" +
+      "\001*\022Restore Experiment\022\234\001\n\020updateExperime" +
+      "nt\022\030.mlflow.UpdateExperiment\032!.mlflow.Up" +
+      "dateExperiment.Response\"K\202\265\030G\n0\n\004POST\022\"/" +
+      "preview/mlflow/experiments/update\032\004\010\002\020\000\020" +
+      "\001*\021Update Experiment\022y\n\tcreateRun\022\021.mlfl" +
+      "ow.CreateRun\032\032.mlflow.CreateRun.Response" +
+      "\"=\202\265\0309\n)\n\004POST\022\033/preview/mlflow/runs/cre" +
+      "ate\032\004\010\002\020\000\020\001*\nCreate Run\022y\n\tupdateRun\022\021.m" +
+      "lflow.UpdateRun\032\032.mlflow.UpdateRun.Respo" +
+      "nse\"=\202\265\0309\n)\n\004POST\022\033/preview/mlflow/runs/" +
+      "update\032\004\010\002\020\000\020\001*\nUpdate Run\022m\n\tdeleteRun\022" +
+      "\021.mlflow.DeleteRun\032\032.mlflow.DeleteRun.Re" +
+      "sponse\"1\202\265\030-\n)\n\004POST\022\033/preview/mlflow/ru" +
+      "ns/delete\032\004\010\002\020\000\020\001\022q\n\nrestoreRun\022\022.mlflow" +
+      ".RestoreRun\032\033.mlflow.RestoreRun.Response" +
+      "\"2\202\265\030.\n*\n\004POST\022\034/preview/mlflow/runs/res" +
+      "tore\032\004\010\002\020\000\020\001\022}\n\tlogMetric\022\021.mlflow.LogMe" +
+      "tric\032\032.mlflow.LogMetric.Response\"A\202\265\030=\n-" +
+      "\n\004POST\022\037/preview/mlflow/runs/log-metric\032" +
+      "\004\010\002\020\000\020\001*\nLog Metric\022|\n\010logParam\022\020.mlflow" +
+      ".LogParam\032\031.mlflow.LogParam.Response\"C\202\265" +
+      "\030?\n0\n\004POST\022\"/preview/mlflow/runs/log-par" +
+      "ameter\032\004\010\002\020\000\020\001*\tLog Param\022n\n\006setTag\022\016.ml" +
+      "flow.SetTag\032\027.mlflow.SetTag.Response\";\202\265" +
+      "\0307\n*\n\004POST\022\034/preview/mlflow/runs/set-tag" +
+      "\032\004\010\002\020\000\020\001*\007Set Tag\022i\n\006getRun\022\016.mlflow.Get" +
+      "Run\032\027.mlflow.GetRun.Response\"6\202\265\0302\n%\n\003GE" +
+      "T\022\030/preview/mlflow/runs/get\032\004\010\002\020\000\020\001*\007Get" +
+      " Run\022\247\001\n\nsearchRuns\022\022.mlflow.SearchRuns\032" +
+      "\033.mlflow.SearchRuns.Response\"h\202\265\030d\n)\n\004PO" +
+      "ST\022\033/preview/mlflow/runs/search\032\004\010\002\020\000\n(\n" +
+      "\003GET\022\033/preview/mlflow/runs/search\032\004\010\002\020\000\020" +
+      "\001*\013Search Runs\022\213\001\n\rlistArtifacts\022\025.mlflo" +
+      "w.ListArtifacts\032\036.mlflow.ListArtifacts.R" +
+      "esponse\"C\202\265\030?\n+\n\003GET\022\036/preview/mlflow/ar" +
+      "tifacts/list\032\004\010\002\020\000\020\001*\016List Artifacts\022\235\001\n" +
+      "\020getMetricHistory\022\030.mlflow.GetMetricHist" +
+      "ory\032!.mlflow.GetMetricHistory.Response\"L" +
+      "\202\265\030H\n0\n\003GET\022#/preview/mlflow/metrics/get" +
+      "-history\032\004\010\002\020\000\020\001*\022Get Metric History\022x\n\010" +
+      "logBatch\022\020.mlflow.LogBatch\032\031.mlflow.LogB" +
+      "atch.Response\"?\202\265\030;\n,\n\004POST\022\036/preview/ml" +
+      "flow/runs/log-batch\032\004\010\002\020\000\020\001*\tLog BatchB\036" +
+      "\n\024org.mlflow.api.proto\220\001\001\342?\002\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -48690,7 +49213,7 @@ public final class Service {
     internal_static_mlflow_RunInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_RunInfo_descriptor,
-        new java.lang.String[] { "RunUuid", "ExperimentId", "Name", "SourceType", "SourceName", "UserId", "Status", "StartTime", "EndTime", "SourceVersion", "EntryPointName", "ArtifactUri", "LifecycleStage", });
+        new java.lang.String[] { "RunUuid", "RunId", "ExperimentId", "Name", "SourceType", "SourceName", "UserId", "Status", "StartTime", "EndTime", "SourceVersion", "EntryPointName", "ArtifactUri", "LifecycleStage", });
     internal_static_mlflow_Experiment_descriptor =
       getDescriptor().getMessageTypes().get(6);
     internal_static_mlflow_Experiment_fieldAccessorTable = new
@@ -48786,7 +49309,7 @@ public final class Service {
     internal_static_mlflow_UpdateRun_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_UpdateRun_descriptor,
-        new java.lang.String[] { "RunUuid", "Status", "EndTime", });
+        new java.lang.String[] { "RunUuid", "RunId", "Status", "EndTime", });
     internal_static_mlflow_UpdateRun_Response_descriptor =
       internal_static_mlflow_UpdateRun_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_UpdateRun_Response_fieldAccessorTable = new
@@ -48822,7 +49345,7 @@ public final class Service {
     internal_static_mlflow_LogMetric_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_LogMetric_descriptor,
-        new java.lang.String[] { "RunUuid", "Key", "Value", "Timestamp", "Step", });
+        new java.lang.String[] { "RunUuid", "RunId", "Key", "Value", "Timestamp", "Step", });
     internal_static_mlflow_LogMetric_Response_descriptor =
       internal_static_mlflow_LogMetric_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_LogMetric_Response_fieldAccessorTable = new
@@ -48834,7 +49357,7 @@ public final class Service {
     internal_static_mlflow_LogParam_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_LogParam_descriptor,
-        new java.lang.String[] { "RunUuid", "Key", "Value", });
+        new java.lang.String[] { "RunUuid", "RunId", "Key", "Value", });
     internal_static_mlflow_LogParam_Response_descriptor =
       internal_static_mlflow_LogParam_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_LogParam_Response_fieldAccessorTable = new
@@ -48846,7 +49369,7 @@ public final class Service {
     internal_static_mlflow_SetTag_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_SetTag_descriptor,
-        new java.lang.String[] { "RunUuid", "Key", "Value", });
+        new java.lang.String[] { "RunUuid", "RunId", "Key", "Value", });
     internal_static_mlflow_SetTag_Response_descriptor =
       internal_static_mlflow_SetTag_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_SetTag_Response_fieldAccessorTable = new
@@ -48858,7 +49381,7 @@ public final class Service {
     internal_static_mlflow_GetRun_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetRun_descriptor,
-        new java.lang.String[] { "RunUuid", });
+        new java.lang.String[] { "RunUuid", "RunId", });
     internal_static_mlflow_GetRun_Response_descriptor =
       internal_static_mlflow_GetRun_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_GetRun_Response_fieldAccessorTable = new
@@ -48918,7 +49441,7 @@ public final class Service {
     internal_static_mlflow_ListArtifacts_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_ListArtifacts_descriptor,
-        new java.lang.String[] { "RunUuid", "Path", });
+        new java.lang.String[] { "RunUuid", "RunId", "Path", });
     internal_static_mlflow_ListArtifacts_Response_descriptor =
       internal_static_mlflow_ListArtifacts_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_ListArtifacts_Response_fieldAccessorTable = new
@@ -48931,24 +49454,12 @@ public final class Service {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_FileInfo_descriptor,
         new java.lang.String[] { "Path", "IsDir", "FileSize", });
-    internal_static_mlflow_GetArtifact_descriptor =
-      getDescriptor().getMessageTypes().get(30);
-    internal_static_mlflow_GetArtifact_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_mlflow_GetArtifact_descriptor,
-        new java.lang.String[] { "RunUuid", "Path", });
-    internal_static_mlflow_GetArtifact_Response_descriptor =
-      internal_static_mlflow_GetArtifact_descriptor.getNestedTypes().get(0);
-    internal_static_mlflow_GetArtifact_Response_fieldAccessorTable = new
-      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-        internal_static_mlflow_GetArtifact_Response_descriptor,
-        new java.lang.String[] { });
     internal_static_mlflow_GetMetricHistory_descriptor =
-      getDescriptor().getMessageTypes().get(31);
+      getDescriptor().getMessageTypes().get(30);
     internal_static_mlflow_GetMetricHistory_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetMetricHistory_descriptor,
-        new java.lang.String[] { "RunUuid", "MetricKey", });
+        new java.lang.String[] { "RunUuid", "RunId", "MetricKey", });
     internal_static_mlflow_GetMetricHistory_Response_descriptor =
       internal_static_mlflow_GetMetricHistory_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_GetMetricHistory_Response_fieldAccessorTable = new
@@ -48956,7 +49467,7 @@ public final class Service {
         internal_static_mlflow_GetMetricHistory_Response_descriptor,
         new java.lang.String[] { "Metrics", });
     internal_static_mlflow_LogBatch_descriptor =
-      getDescriptor().getMessageTypes().get(32);
+      getDescriptor().getMessageTypes().get(31);
     internal_static_mlflow_LogBatch_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_LogBatch_descriptor,

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -55,13 +55,16 @@ public class MlflowClient {
    * @return Run associated with the id.
    */
   public Run getRun(String runId) {
-    URIBuilder builder = newURIBuilder("runs/get").setParameter("run_uuid", runId);
+    URIBuilder builder = newURIBuilder("runs/get")
+      .setParameter("run_uuid", runId)
+      .setParameter("run_id", runId);
     return mapper.toGetRunResponse(httpCaller.get(builder.toString())).getRun();
   }
 
   public List<Metric> getMetricHistory(String runId, String key) {
     URIBuilder builder = newURIBuilder("metrics/get-history")
       .setParameter("run_uuid", runId)
+      .setParameter("run_id", runId)
       .setParameter("metric_key", key);
     return mapper.toGetMetricHistoryResponse(httpCaller.get(builder.toString())).getMetricsList();
   }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
@@ -35,37 +35,40 @@ class MlflowProtobufMapper {
     return print(builder);
   }
 
-  String makeLogParam(String runUuid, String key, String value) {
+  String makeLogParam(String runId, String key, String value) {
     LogParam.Builder builder = LogParam.newBuilder();
-    builder.setRunUuid(runUuid);
+    builder.setRunUuid(runId);
+    builder.setRunId(runId);
     builder.setKey(key);
     builder.setValue(value);
     return print(builder);
   }
 
-  String makeLogMetric(String runUuid, String key, double value, long timestamp) {
+  String makeLogMetric(String runId, String key, double value, long timestamp) {
     LogMetric.Builder builder = LogMetric.newBuilder();
-    builder.setRunUuid(runUuid);
+    builder.setRunUuid(runId);
+    builder.setRunId(runId);
     builder.setKey(key);
     builder.setValue(value);
     builder.setTimestamp(timestamp);
     return print(builder);
   }
 
-  String makeSetTag(String runUuid, String key, String value) {
+  String makeSetTag(String runId, String key, String value) {
     SetTag.Builder builder = SetTag.newBuilder();
-    builder.setRunUuid(runUuid);
+    builder.setRunUuid(runId);
+    builder.setRunId(runId);
     builder.setKey(key);
     builder.setValue(value);
     return print(builder);
   }
 
-  String makeLogBatch(String runUuid,
+  String makeLogBatch(String runId,
       Iterable<Metric> metrics,
       Iterable<Param> params,
       Iterable<RunTag> tags) {
     LogBatch.Builder builder = LogBatch.newBuilder();
-    builder.setRunId(runUuid);
+    builder.setRunId(runId);
     if (metrics != null) {
       builder.addAllMetrics(metrics);
     }
@@ -78,23 +81,24 @@ class MlflowProtobufMapper {
     return print(builder);
   }
 
-  String makeUpdateRun(String runUuid, RunStatus status, long endTime) {
+  String makeUpdateRun(String runId, RunStatus status, long endTime) {
     UpdateRun.Builder builder = UpdateRun.newBuilder();
-    builder.setRunUuid(runUuid);
+    builder.setRunUuid(runId);
+    builder.setRunId(runId);
     builder.setStatus(status);
     builder.setEndTime(endTime);
     return print(builder);
   }
 
-  String makeDeleteRun(String runUuid) {
+  String makeDeleteRun(String runId) {
     DeleteRun.Builder builder = DeleteRun.newBuilder();
-    builder.setRunId(runUuid);
+    builder.setRunId(runId);
     return print(builder);
   }
 
-  String makeRestoreRun(String runUuid) {
+  String makeRestoreRun(String runId) {
     RestoreRun.Builder builder = RestoreRun.newBuilder();
-    builder.setRunId(runUuid);
+    builder.setRunId(runId);
     return print(builder);
   }
 

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -305,7 +305,7 @@ public class MlflowClientTest {
     // Test logging just metrics
     {
       RunInfo runCreated = client.createRun(expId);
-      String runUuid = runCreated.getRunUuid();
+      String runUuid = runCreated.getRunId();
       logger.debug("runUuid=" + runUuid);
 
       List<Metric> metrics = new ArrayList<>(Arrays.asList(createMetric("met1", 0.081D, 10),
@@ -313,7 +313,7 @@ public class MlflowClientTest {
       client.logBatch(runUuid, metrics, null, null);
 
       Run run = client.getRun(runUuid);
-      Assert.assertEquals(run.getInfo().getRunUuid(), runUuid);
+      Assert.assertEquals(run.getInfo().getRunId(), runUuid);
 
       List<Metric> loggedMetrics = run.getData().getMetricsList();
       Assert.assertEquals(loggedMetrics.size(), 2);
@@ -324,7 +324,7 @@ public class MlflowClientTest {
     // Test logging just params
     {
       RunInfo runCreated = client.createRun(expId);
-      String runUuid = runCreated.getRunUuid();
+      String runUuid = runCreated.getRunId();
       logger.debug("runUuid=" + runUuid);
 
       Set<Param> params = new HashSet<Param>(Arrays.asList(
@@ -334,7 +334,7 @@ public class MlflowClientTest {
       client.logBatch(runUuid, null, params, null);
 
       Run run = client.getRun(runUuid);
-      Assert.assertEquals(run.getInfo().getRunUuid(), runUuid);
+      Assert.assertEquals(run.getInfo().getRunId(), runUuid);
 
       List<Param> loggedParams = run.getData().getParamsList();
       Assert.assertEquals(loggedParams.size(), 3);
@@ -346,7 +346,7 @@ public class MlflowClientTest {
     // Test logging just tags
     {
       RunInfo runCreated = client.createRun(expId);
-      String runUuid = runCreated.getRunUuid();
+      String runUuid = runCreated.getRunId();
       logger.debug("runUuid=" + runUuid);
 
       Stack<RunTag> tags = new Stack();
@@ -354,7 +354,7 @@ public class MlflowClientTest {
       client.logBatch(runUuid, null, null, tags);
 
       Run run = client.getRun(runUuid);
-      Assert.assertEquals(run.getInfo().getRunUuid(), runUuid);
+      Assert.assertEquals(run.getInfo().getRunId(), runUuid);
 
       List<RunTag> loggedTags = run.getData().getTagsList();
       Assert.assertEquals(loggedTags.size(), 1);
@@ -364,7 +364,7 @@ public class MlflowClientTest {
     // All
     {
       RunInfo runCreated = client.createRun(expId);
-      String runUuid = runCreated.getRunUuid();
+      String runUuid = runCreated.getRunId();
       logger.debug("runUuid=" + runUuid);
 
       List<Metric> metrics = new LinkedList<>(Arrays.asList(createMetric("m1", 32.23D, 12)));
@@ -376,7 +376,7 @@ public class MlflowClientTest {
       client.logBatch(runUuid, metrics, params, tags);
 
       Run run = client.getRun(runUuid);
-      Assert.assertEquals(run.getInfo().getRunUuid(), runUuid);
+      Assert.assertEquals(run.getInfo().getRunId(), runUuid);
 
       List<Metric> loggedMetrics = run.getData().getMetricsList();
       Assert.assertEquals(loggedMetrics.size(), 1);
@@ -404,7 +404,7 @@ public class MlflowClientTest {
 
     RunInfo runCreated = client.createRun(expId, sourceFile);
     Assert.assertEquals(runCreated.getLifecycleStage(), "active");
-    String deleteRunId = runCreated.getRunUuid();
+    String deleteRunId = runCreated.getRunId();
     client.deleteRun(deleteRunId);
     Assert.assertEquals(client.getRun(deleteRunId).getInfo().getLifecycleStage(), "deleted");
     client.restoreRun(deleteRunId);

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowProtobufMapperTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowProtobufMapperTest.java
@@ -23,6 +23,7 @@ public class MlflowProtobufMapperTest {
 
     Map<String, String> expectedMessage = new HashMap<>();
     expectedMessage.put("run_uuid", "my-id");
+    expectedMessage.put("run_id", "my-id");
     expectedMessage.put("key", "my-key");
     expectedMessage.put("value", "my-value");
     Assert.assertEquals(serializedMessage, expectedMessage);

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -68,7 +68,7 @@ class Model(object):
         """
         with TempDir() as tmp:
             local_path = tmp.path("model")
-            run_id = mlflow.tracking.fluent._get_or_start_run().info.run_uuid
+            run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
             mlflow_model = cls(artifact_path=artifact_path, run_id=run_id)
             flavor.save_model(path=local_path, mlflow_model=mlflow_model, **kwargs)
             mlflow.tracking.fluent.log_artifacts(local_path, artifact_path)

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -264,7 +264,7 @@ def run_databricks(remote_run, uri, entry_point, work_dir, parameters, experimen
     used to query the run's status or wait for the resulting Databricks Job run to terminate.
     """
     profile = tracking.utils.get_db_profile_from_uri(tracking.get_tracking_uri())
-    run_id = remote_run.info.run_uuid
+    run_id = remote_run.info.run_id
     db_job_runner = DatabricksJobRunner(databricks_profile=profile)
     db_run_id = db_job_runner.run_databricks(
         uri, entry_point, work_dir, parameters, experiment_id, cluster_spec, run_id)

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -212,9 +212,9 @@ service MlflowService {
     };
   }
 
-  // Get metadata, params, tags, and metrics for a run. Only the last logged value for each metric
-  // is returned.
-  //
+  // Get metadata, params, tags, and metrics for a run. In the case where multiple metrics
+  // with the same key are logged for a run, return only the value with the latest timestamp.
+  // If there are multiple values with the latest timestamp, return the maximum of these values.
   rpc getRun (GetRun) returns (GetRun.Response) {
     option (rpc) = {
       endpoints: [{
@@ -443,8 +443,12 @@ message RunTag {
 
 // Metadata of a single run.
 message RunInfo {
-  // Unique identifier for the run.
+  // [Deprecated, use run_id instead] Unique identifier for the run. This field will
+  // be removed in a future MLflow version.
   optional string run_uuid = 1;
+
+  // Unique identifier for the run.
+  optional string run_id = 15;
 
   // The experiment ID.
   optional string experiment_id = 2;
@@ -650,8 +654,12 @@ message CreateRun {
 message UpdateRun {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
-  // ID of the run to update.
-  optional string run_uuid = 1 [(validate_required) = true];
+  // [Deprecated, use run_id instead] ID of the run to update.. This field will
+  // be removed in a future MLflow version.
+  optional string run_uuid = 1;
+
+  // ID of the run to update. Must be provided.
+  optional string run_id = 4;
 
   // Updated status of the run.
   optional RunStatus status = 2;
@@ -685,8 +693,12 @@ message RestoreRun {
 message LogMetric {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
-  // ID of the run under which to log the metric.
-  optional string run_uuid = 1 [(validate_required) = true];
+  // [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will
+  // be removed in a future MLflow version.
+  optional string run_uuid = 1;
+
+  // ID of the run under which to log the metric. Must be provided.
+  optional string run_id = 6;
 
   // Name of the metric.
   optional string key = 2 [(validate_required) = true];
@@ -707,8 +719,12 @@ message LogMetric {
 message LogParam {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
-  // ID of the run under which to log the param.
-  optional string run_uuid = 1 [(validate_required) = true];
+  // [Deprecated, use run_id instead] ID of the run under which to log the param. This field will
+  // be removed in a future MLflow version.
+  optional string run_uuid = 1;
+
+  // ID of the run under which to log the param. Must be provided.
+  optional string run_id = 4;
 
   // Name of the param. Maximum size is 255 bytes.
   optional string key = 2 [(validate_required) = true];
@@ -723,8 +739,12 @@ message LogParam {
 message SetTag {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
-  // ID of the run under which to set the tag.
-  optional string run_uuid = 1 [(validate_required) = true];
+  // [Deprecated, use run_id instead] ID of the run under which to log the tag. This field will
+  // be removed in a future MLflow version.
+  optional string run_uuid = 1;
+
+  // ID of the run under which to log the tag. Must be provided.
+  optional string run_id = 4;
 
   // Name of the tag. Maximum size is 255 bytes.
   optional string key = 2 [(validate_required) = true];
@@ -739,8 +759,12 @@ message SetTag {
 message GetRun {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
-  // ID of the run to fetch.
-  optional string run_uuid = 1 [(validate_required) = true];
+  // [Deprecated, use run_id instead] ID of the run to fetch. This field will
+  // be removed in a future MLflow version.
+  optional string run_uuid = 1;
+
+  // ID of he run to fetch. Must be provided.
+  optional string run_id = 2;
 
   message Response {
     // Run metadata (name, start time, etc) and data (metrics, params, etc).
@@ -851,8 +875,12 @@ message SearchRuns {
 message ListArtifacts {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
-  // ID of the run whose artifacts to list.
+  // [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will
+  // be removed in a future MLflow version.
   optional string run_uuid = 1;
+
+  // ID of the run whose artifacts to list. Must be provided.
+  optional string run_id = 3;
 
   // Filter artifacts matching this path (a relative path from the root artifact directory).
   optional string path = 2;
@@ -878,26 +906,15 @@ message FileInfo {
   optional int64 file_size = 3;
 }
 
-message GetArtifact {
-  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
-
-  // ID of the run from which to fetch the artifact.
-  optional string run_uuid = 1;
-
-  // Path of the artifact to fetch (relative to the root artifact directory for the run).
-  optional string path = 2;
-
-  message Response {
-    // Empty because the data of the file will be streamed back in the HTTP response.
-    // The response will have an HTTP status code of 404 if the artifact path is not found.
-  }
-}
-
 message GetMetricHistory {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
-  // ID of the run from which to fetch metric values.
-  optional string run_uuid = 1 [(validate_required) = true];
+  // [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field
+  // will be removed in a future MLflow version.
+  optional string run_uuid = 1;
+
+  // ID of the run from which to fetch metric values. Must be provided.
+  optional string run_id = 3;
 
   // Name of the metric.
   optional string metric_key = 2 [(validate_required) = true];

--- a/mlflow/protos/service_pb2.py
+++ b/mlflow/protos/service_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\024org.mlflow.api.proto\220\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"H\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x04step\x18\x04 \x01(\x03:\x01\x30\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xb9\x02\n\x07RunInfo\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x16\n\x0esource_version\x18\n \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x0b \x01(\t\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\x96\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x01\n\x0fListExperiments\x12#\n\tview_type\x18\x01 \x01(\x0e\x32\x10.mlflow.ViewType\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1aQ\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12\x1d\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x10UpdateExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xd1\x02\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x10\n\x08run_name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x06 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x16\n\x0esource_version\x18\x08 \x01(\t\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x12\x15\n\rparent_run_id\x18\n \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb4\x01\n\tUpdateRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xae\x01\n\tLogMetric\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\x88\xb5\x18\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\x88\xb5\x18\x01\x12\x0f\n\x04step\x18\x05 \x01(\x03:\x01\x30\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x83\x01\n\x08LogParam\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x81\x01\n\x06SetTag\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"s\n\x06GetRun\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8a\x01\n\x10SearchExpression\x12\x30\n\x06metric\x18\x01 \x01(\x0b\x32\x1e.mlflow.MetricSearchExpressionH\x00\x12\x36\n\tparameter\x18\x02 \x01(\x0b\x32!.mlflow.ParameterSearchExpressionH\x00\x42\x0c\n\nexpression\"}\n\x16MetricSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05\x66loat\x18\x02 \x01(\x0b\x32\x13.mlflow.FloatClauseH\x00\x12&\n\x06\x64ouble\x18\x03 \x01(\x0b\x32\x14.mlflow.DoubleClauseH\x00\x42\x08\n\x06\x63lause\"Z\n\x19ParameterSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x06string\x18\x02 \x01(\x0b\x32\x14.mlflow.StringClauseH\x00\x42\x08\n\x06\x63lause\"1\n\x0cStringClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x0b\x46loatClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02\"1\n\x0c\x44oubleClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\"\x8e\x02\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\t\x12\x33\n\x11\x61nded_expressions\x18\x02 \x03(\x0b\x32\x18.mlflow.SearchExpression\x12\x0e\n\x06\x66ilter\x18\x04 \x01(\t\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x12\x19\n\x0bmax_results\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x1a%\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9b\x01\n\rListArtifacts\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"f\n\x0bGetArtifact\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9e\x01\n\x10GetMetricHistory\x12\x16\n\x08run_uuid\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb1\x01\n\x08LogBatch\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x1f\n\x07metrics\x18\x02 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x03 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x04 \x03(\x0b\x32\x0e.mlflow.RunTag\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\xb9\x13\n\rMlflowService\x12\x9c\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"K\x82\xb5\x18G\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\x95\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"G\x82\xb5\x18\x43\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\x8c\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"D\x82\xb5\x18@\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\x9c\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"K\x82\xb5\x18G\n0\n\x04POST\x12\"/preview/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\xa1\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"M\x82\xb5\x18I\n1\n\x04POST\x12#/preview/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12\x9c\x01\n\x10updateExperiment\x12\x18.mlflow.UpdateExperiment\x1a!.mlflow.UpdateExperiment.Response\"K\x82\xb5\x18G\n0\n\x04POST\x12\"/preview/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x11Update Experiment\x12y\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"=\x82\xb5\x18\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12y\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"=\x82\xb5\x18\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12m\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"1\x82\xb5\x18-\n)\n\x04POST\x12\x1b/preview/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01\x12q\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"2\x82\xb5\x18.\n*\n\x04POST\x12\x1c/preview/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01\x12}\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"A\x82\xb5\x18=\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12|\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"C\x82\xb5\x18?\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12n\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\";\x82\xb5\x18\x37\n*\n\x04POST\x12\x1c/preview/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12i\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"6\x82\xb5\x18\x32\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12\xa7\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"h\x82\xb5\x18\x64\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\x8b\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"C\x82\xb5\x18?\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\x9d\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"L\x82\xb5\x18H\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric History\x12x\n\x08logBatch\x12\x10.mlflow.LogBatch\x1a\x19.mlflow.LogBatch.Response\"?\x82\xb5\x18;\n,\n\x04POST\x12\x1e/preview/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog BatchB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"H\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x04step\x18\x04 \x01(\x03:\x01\x30\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xc9\x02\n\x07RunInfo\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x0f \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0c\n\x04name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x16\n\x0esource_version\x18\n \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x0b \x01(\t\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\x96\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x01\n\x0fListExperiments\x12#\n\tview_type\x18\x01 \x01(\x0e\x32\x10.mlflow.ViewType\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1aQ\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12\x1d\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x10UpdateExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xd1\x02\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x10\n\x08run_name\x18\x03 \x01(\t\x12\'\n\x0bsource_type\x18\x04 \x01(\x0e\x32\x12.mlflow.SourceType\x12\x13\n\x0bsource_name\x18\x05 \x01(\t\x12\x18\n\x10\x65ntry_point_name\x18\x06 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x16\n\x0esource_version\x18\x08 \x01(\t\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x12\x15\n\rparent_run_id\x18\n \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xbe\x01\n\tUpdateRun\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tLogMetric\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\x88\xb5\x18\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\x88\xb5\x18\x01\x12\x0f\n\x04step\x18\x05 \x01(\x03:\x01\x30\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8d\x01\n\x08LogParam\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8b\x01\n\x06SetTag\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\x88\xb5\x18\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"}\n\x06GetRun\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8a\x01\n\x10SearchExpression\x12\x30\n\x06metric\x18\x01 \x01(\x0b\x32\x1e.mlflow.MetricSearchExpressionH\x00\x12\x36\n\tparameter\x18\x02 \x01(\x0b\x32!.mlflow.ParameterSearchExpressionH\x00\x42\x0c\n\nexpression\"}\n\x16MetricSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12$\n\x05\x66loat\x18\x02 \x01(\x0b\x32\x13.mlflow.FloatClauseH\x00\x12&\n\x06\x64ouble\x18\x03 \x01(\x0b\x32\x14.mlflow.DoubleClauseH\x00\x42\x08\n\x06\x63lause\"Z\n\x19ParameterSearchExpression\x12\x0b\n\x03key\x18\x01 \x01(\t\x12&\n\x06string\x18\x02 \x01(\x0b\x32\x14.mlflow.StringClauseH\x00\x42\x08\n\x06\x63lause\"1\n\x0cStringClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x0b\x46loatClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x02\"1\n\x0c\x44oubleClause\x12\x12\n\ncomparator\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\"\x8e\x02\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\t\x12\x33\n\x11\x61nded_expressions\x18\x02 \x03(\x0b\x32\x18.mlflow.SearchExpression\x12\x0e\n\x06\x66ilter\x18\x04 \x01(\t\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x12\x19\n\x0bmax_results\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x1a%\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xab\x01\n\rListArtifacts\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"\xa8\x01\n\x10GetMetricHistory\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\x88\xb5\x18\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb1\x01\n\x08LogBatch\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x1f\n\x07metrics\x18\x02 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x03 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x04 \x03(\x0b\x32\x0e.mlflow.RunTag\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\xb9\x13\n\rMlflowService\x12\x9c\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"K\x82\xb5\x18G\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\x95\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"G\x82\xb5\x18\x43\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\x8c\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"D\x82\xb5\x18@\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\x9c\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"K\x82\xb5\x18G\n0\n\x04POST\x12\"/preview/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\xa1\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"M\x82\xb5\x18I\n1\n\x04POST\x12#/preview/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12\x9c\x01\n\x10updateExperiment\x12\x18.mlflow.UpdateExperiment\x1a!.mlflow.UpdateExperiment.Response\"K\x82\xb5\x18G\n0\n\x04POST\x12\"/preview/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x11Update Experiment\x12y\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"=\x82\xb5\x18\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12y\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"=\x82\xb5\x18\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12m\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"1\x82\xb5\x18-\n)\n\x04POST\x12\x1b/preview/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01\x12q\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"2\x82\xb5\x18.\n*\n\x04POST\x12\x1c/preview/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01\x12}\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"A\x82\xb5\x18=\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12|\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"C\x82\xb5\x18?\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12n\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\";\x82\xb5\x18\x37\n*\n\x04POST\x12\x1c/preview/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12i\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"6\x82\xb5\x18\x32\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12\xa7\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"h\x82\xb5\x18\x64\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\x8b\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"C\x82\xb5\x18?\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\x9d\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"L\x82\xb5\x18H\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric History\x12x\n\x08logBatch\x12\x10.mlflow.LogBatch\x1a\x19.mlflow.LogBatch.Response\"?\x82\xb5\x18;\n,\n\x04POST\x12\x1e/preview/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog BatchB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -49,8 +49,8 @@ _VIEWTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4390,
-  serialized_end=4444,
+  serialized_start=4378,
+  serialized_end=4432,
 )
 _sym_db.RegisterEnumDescriptor(_VIEWTYPE)
 
@@ -84,8 +84,8 @@ _SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4446,
-  serialized_end=4519,
+  serialized_start=4434,
+  serialized_end=4507,
 )
 _sym_db.RegisterEnumDescriptor(_SOURCETYPE)
 
@@ -119,8 +119,8 @@ _RUNSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4521,
-  serialized_end=4598,
+  serialized_start=4509,
+  serialized_end=4586,
 )
 _sym_db.RegisterEnumDescriptor(_RUNSTATUS)
 
@@ -367,84 +367,91 @@ _RUNINFO = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='experiment_id', full_name='mlflow.RunInfo.experiment_id', index=1,
+      name='run_id', full_name='mlflow.RunInfo.run_id', index=1,
+      number=15, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='experiment_id', full_name='mlflow.RunInfo.experiment_id', index=2,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='name', full_name='mlflow.RunInfo.name', index=2,
+      name='name', full_name='mlflow.RunInfo.name', index=3,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='source_type', full_name='mlflow.RunInfo.source_type', index=3,
+      name='source_type', full_name='mlflow.RunInfo.source_type', index=4,
       number=4, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=1,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='source_name', full_name='mlflow.RunInfo.source_name', index=4,
+      name='source_name', full_name='mlflow.RunInfo.source_name', index=5,
       number=5, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='user_id', full_name='mlflow.RunInfo.user_id', index=5,
+      name='user_id', full_name='mlflow.RunInfo.user_id', index=6,
       number=6, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='status', full_name='mlflow.RunInfo.status', index=6,
+      name='status', full_name='mlflow.RunInfo.status', index=7,
       number=7, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=1,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='start_time', full_name='mlflow.RunInfo.start_time', index=7,
+      name='start_time', full_name='mlflow.RunInfo.start_time', index=8,
       number=8, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='end_time', full_name='mlflow.RunInfo.end_time', index=8,
+      name='end_time', full_name='mlflow.RunInfo.end_time', index=9,
       number=9, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='source_version', full_name='mlflow.RunInfo.source_version', index=9,
+      name='source_version', full_name='mlflow.RunInfo.source_version', index=10,
       number=10, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='entry_point_name', full_name='mlflow.RunInfo.entry_point_name', index=10,
+      name='entry_point_name', full_name='mlflow.RunInfo.entry_point_name', index=11,
       number=11, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='artifact_uri', full_name='mlflow.RunInfo.artifact_uri', index=11,
+      name='artifact_uri', full_name='mlflow.RunInfo.artifact_uri', index=12,
       number=13, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='lifecycle_stage', full_name='mlflow.RunInfo.lifecycle_stage', index=12,
+      name='lifecycle_stage', full_name='mlflow.RunInfo.lifecycle_stage', index=13,
       number=14, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -463,7 +470,7 @@ _RUNINFO = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=390,
-  serialized_end=703,
+  serialized_end=719,
 )
 
 
@@ -528,8 +535,8 @@ _EXPERIMENT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=706,
-  serialized_end=856,
+  serialized_start=722,
+  serialized_end=872,
 )
 
 
@@ -559,8 +566,8 @@ _CREATEEXPERIMENT_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=926,
-  serialized_end=959,
+  serialized_start=942,
+  serialized_end=975,
 )
 
 _CREATEEXPERIMENT = _descriptor.Descriptor(
@@ -596,8 +603,8 @@ _CREATEEXPERIMENT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=859,
-  serialized_end=1004,
+  serialized_start=875,
+  serialized_end=1020,
 )
 
 
@@ -627,8 +634,8 @@ _LISTEXPERIMENTS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1063,
-  serialized_end=1114,
+  serialized_start=1079,
+  serialized_end=1130,
 )
 
 _LISTEXPERIMENTS = _descriptor.Descriptor(
@@ -657,8 +664,8 @@ _LISTEXPERIMENTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1007,
-  serialized_end=1159,
+  serialized_start=1023,
+  serialized_end=1175,
 )
 
 
@@ -695,8 +702,8 @@ _GETEXPERIMENT_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1208,
-  serialized_end=1289,
+  serialized_start=1224,
+  serialized_end=1305,
 )
 
 _GETEXPERIMENT = _descriptor.Descriptor(
@@ -725,8 +732,8 @@ _GETEXPERIMENT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1162,
-  serialized_end=1334,
+  serialized_start=1178,
+  serialized_end=1350,
 )
 
 
@@ -749,8 +756,8 @@ _DELETEEXPERIMENT_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=926,
-  serialized_end=936,
+  serialized_start=942,
+  serialized_end=952,
 )
 
 _DELETEEXPERIMENT = _descriptor.Descriptor(
@@ -779,8 +786,8 @@ _DELETEEXPERIMENT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1336,
-  serialized_end=1440,
+  serialized_start=1352,
+  serialized_end=1456,
 )
 
 
@@ -803,8 +810,8 @@ _RESTOREEXPERIMENT_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=926,
-  serialized_end=936,
+  serialized_start=942,
+  serialized_end=952,
 )
 
 _RESTOREEXPERIMENT = _descriptor.Descriptor(
@@ -833,8 +840,8 @@ _RESTOREEXPERIMENT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1442,
-  serialized_end=1547,
+  serialized_start=1458,
+  serialized_end=1563,
 )
 
 
@@ -857,8 +864,8 @@ _UPDATEEXPERIMENT_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=926,
-  serialized_end=936,
+  serialized_start=942,
+  serialized_end=952,
 )
 
 _UPDATEEXPERIMENT = _descriptor.Descriptor(
@@ -894,8 +901,8 @@ _UPDATEEXPERIMENT = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1549,
-  serialized_end=1671,
+  serialized_start=1565,
+  serialized_end=1687,
 )
 
 
@@ -925,8 +932,8 @@ _CREATERUN_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1930,
-  serialized_end=1966,
+  serialized_start=1946,
+  serialized_end=1982,
 )
 
 _CREATERUN = _descriptor.Descriptor(
@@ -1018,8 +1025,8 @@ _CREATERUN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1674,
-  serialized_end=2011,
+  serialized_start=1690,
+  serialized_end=2027,
 )
 
 
@@ -1049,8 +1056,8 @@ _UPDATERUN_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2104,
-  serialized_end=2149,
+  serialized_start=2130,
+  serialized_end=2175,
 )
 
 _UPDATERUN = _descriptor.Descriptor(
@@ -1066,16 +1073,23 @@ _UPDATERUN = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='status', full_name='mlflow.UpdateRun.status', index=1,
+      name='run_id', full_name='mlflow.UpdateRun.run_id', index=1,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='status', full_name='mlflow.UpdateRun.status', index=2,
       number=2, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=1,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='end_time', full_name='mlflow.UpdateRun.end_time', index=2,
+      name='end_time', full_name='mlflow.UpdateRun.end_time', index=3,
       number=3, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -1093,8 +1107,8 @@ _UPDATERUN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2014,
-  serialized_end=2194,
+  serialized_start=2030,
+  serialized_end=2220,
 )
 
 
@@ -1117,8 +1131,8 @@ _DELETERUN_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=926,
-  serialized_end=936,
+  serialized_start=942,
+  serialized_end=952,
 )
 
 _DELETERUN = _descriptor.Descriptor(
@@ -1147,8 +1161,8 @@ _DELETERUN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2196,
-  serialized_end=2286,
+  serialized_start=2222,
+  serialized_end=2312,
 )
 
 
@@ -1171,8 +1185,8 @@ _RESTORERUN_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=926,
-  serialized_end=936,
+  serialized_start=942,
+  serialized_end=952,
 )
 
 _RESTORERUN = _descriptor.Descriptor(
@@ -1201,8 +1215,8 @@ _RESTORERUN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2288,
-  serialized_end=2379,
+  serialized_start=2314,
+  serialized_end=2405,
 )
 
 
@@ -1225,8 +1239,8 @@ _LOGMETRIC_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=926,
-  serialized_end=936,
+  serialized_start=942,
+  serialized_end=952,
 )
 
 _LOGMETRIC = _descriptor.Descriptor(
@@ -1242,30 +1256,37 @@ _LOGMETRIC = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='key', full_name='mlflow.LogMetric.key', index=1,
+      name='run_id', full_name='mlflow.LogMetric.run_id', index=1,
+      number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='key', full_name='mlflow.LogMetric.key', index=2,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='value', full_name='mlflow.LogMetric.value', index=2,
+      name='value', full_name='mlflow.LogMetric.value', index=3,
       number=3, type=1, cpp_type=5, label=1,
       has_default_value=False, default_value=float(0),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='timestamp', full_name='mlflow.LogMetric.timestamp', index=3,
+      name='timestamp', full_name='mlflow.LogMetric.timestamp', index=4,
       number=4, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='step', full_name='mlflow.LogMetric.step', index=4,
+      name='step', full_name='mlflow.LogMetric.step', index=5,
       number=5, type=3, cpp_type=2, label=1,
       has_default_value=True, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -1283,8 +1304,8 @@ _LOGMETRIC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2382,
-  serialized_end=2556,
+  serialized_start=2408,
+  serialized_end=2592,
 )
 
 
@@ -1307,8 +1328,8 @@ _LOGPARAM_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=926,
-  serialized_end=936,
+  serialized_start=942,
+  serialized_end=952,
 )
 
 _LOGPARAM = _descriptor.Descriptor(
@@ -1324,16 +1345,23 @@ _LOGPARAM = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='key', full_name='mlflow.LogParam.key', index=1,
+      name='run_id', full_name='mlflow.LogParam.run_id', index=1,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='key', full_name='mlflow.LogParam.key', index=2,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='value', full_name='mlflow.LogParam.value', index=2,
+      name='value', full_name='mlflow.LogParam.value', index=3,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -1351,8 +1379,8 @@ _LOGPARAM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2559,
-  serialized_end=2690,
+  serialized_start=2595,
+  serialized_end=2736,
 )
 
 
@@ -1375,8 +1403,8 @@ _SETTAG_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=926,
-  serialized_end=936,
+  serialized_start=942,
+  serialized_end=952,
 )
 
 _SETTAG = _descriptor.Descriptor(
@@ -1392,16 +1420,23 @@ _SETTAG = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='key', full_name='mlflow.SetTag.key', index=1,
+      name='run_id', full_name='mlflow.SetTag.run_id', index=1,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='key', full_name='mlflow.SetTag.key', index=2,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='value', full_name='mlflow.SetTag.value', index=2,
+      name='value', full_name='mlflow.SetTag.value', index=3,
       number=3, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -1419,8 +1454,8 @@ _SETTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2693,
-  serialized_end=2822,
+  serialized_start=2739,
+  serialized_end=2878,
 )
 
 
@@ -1450,8 +1485,8 @@ _GETRUN_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1930,
-  serialized_end=1966,
+  serialized_start=1946,
+  serialized_end=1982,
 )
 
 _GETRUN = _descriptor.Descriptor(
@@ -1467,7 +1502,14 @@ _GETRUN = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='run_id', full_name='mlflow.GetRun.run_id', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -1480,8 +1522,8 @@ _GETRUN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2824,
-  serialized_end=2939,
+  serialized_start=2880,
+  serialized_end=3005,
 )
 
 
@@ -1521,8 +1563,8 @@ _SEARCHEXPRESSION = _descriptor.Descriptor(
       name='expression', full_name='mlflow.SearchExpression.expression',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=2942,
-  serialized_end=3080,
+  serialized_start=3008,
+  serialized_end=3146,
 )
 
 
@@ -1569,8 +1611,8 @@ _METRICSEARCHEXPRESSION = _descriptor.Descriptor(
       name='clause', full_name='mlflow.MetricSearchExpression.clause',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=3082,
-  serialized_end=3207,
+  serialized_start=3148,
+  serialized_end=3273,
 )
 
 
@@ -1610,8 +1652,8 @@ _PARAMETERSEARCHEXPRESSION = _descriptor.Descriptor(
       name='clause', full_name='mlflow.ParameterSearchExpression.clause',
       index=0, containing_type=None, fields=[]),
   ],
-  serialized_start=3209,
-  serialized_end=3299,
+  serialized_start=3275,
+  serialized_end=3365,
 )
 
 
@@ -1648,8 +1690,8 @@ _STRINGCLAUSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3301,
-  serialized_end=3350,
+  serialized_start=3367,
+  serialized_end=3416,
 )
 
 
@@ -1686,8 +1728,8 @@ _FLOATCLAUSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3352,
-  serialized_end=3400,
+  serialized_start=3418,
+  serialized_end=3466,
 )
 
 
@@ -1724,8 +1766,8 @@ _DOUBLECLAUSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3402,
-  serialized_end=3451,
+  serialized_start=3468,
+  serialized_end=3517,
 )
 
 
@@ -1755,8 +1797,8 @@ _SEARCHRUNS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3642,
-  serialized_end=3679,
+  serialized_start=3708,
+  serialized_end=3745,
 )
 
 _SEARCHRUNS = _descriptor.Descriptor(
@@ -1813,8 +1855,8 @@ _SEARCHRUNS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3454,
-  serialized_end=3724,
+  serialized_start=3520,
+  serialized_end=3790,
 )
 
 
@@ -1851,8 +1893,8 @@ _LISTARTIFACTS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3776,
-  serialized_end=3837,
+  serialized_start=3858,
+  serialized_end=3919,
 )
 
 _LISTARTIFACTS = _descriptor.Descriptor(
@@ -1870,7 +1912,14 @@ _LISTARTIFACTS = _descriptor.Descriptor(
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='path', full_name='mlflow.ListArtifacts.path', index=1,
+      name='run_id', full_name='mlflow.ListArtifacts.run_id', index=1,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='path', full_name='mlflow.ListArtifacts.path', index=2,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -1888,8 +1937,8 @@ _LISTARTIFACTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3727,
-  serialized_end=3882,
+  serialized_start=3793,
+  serialized_end=3964,
 )
 
 
@@ -1933,69 +1982,8 @@ _FILEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3884,
-  serialized_end=3943,
-)
-
-
-_GETARTIFACT_RESPONSE = _descriptor.Descriptor(
-  name='Response',
-  full_name='mlflow.GetArtifact.Response',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-  ],
-  extensions=[
-  ],
-  nested_types=[],
-  enum_types=[
-  ],
-  serialized_options=None,
-  is_extendable=False,
-  syntax='proto2',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=926,
-  serialized_end=936,
-)
-
-_GETARTIFACT = _descriptor.Descriptor(
-  name='GetArtifact',
-  full_name='mlflow.GetArtifact',
-  filename=None,
-  file=DESCRIPTOR,
-  containing_type=None,
-  fields=[
-    _descriptor.FieldDescriptor(
-      name='run_uuid', full_name='mlflow.GetArtifact.run_uuid', index=0,
-      number=1, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-    _descriptor.FieldDescriptor(
-      name='path', full_name='mlflow.GetArtifact.path', index=1,
-      number=2, type=9, cpp_type=9, label=1,
-      has_default_value=False, default_value=_b("").decode('utf-8'),
-      message_type=None, enum_type=None, containing_type=None,
-      is_extension=False, extension_scope=None,
-      serialized_options=None, file=DESCRIPTOR),
-  ],
-  extensions=[
-  ],
-  nested_types=[_GETARTIFACT_RESPONSE, ],
-  enum_types=[
-  ],
-  serialized_options=_b('\342?(\n&com.databricks.rpc.RPC[$this.Response]'),
-  is_extendable=False,
-  syntax='proto2',
-  extension_ranges=[],
-  oneofs=[
-  ],
-  serialized_start=3945,
-  serialized_end=4047,
+  serialized_start=3966,
+  serialized_end=4025,
 )
 
 
@@ -2025,8 +2013,8 @@ _GETMETRICHISTORY_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4120,
-  serialized_end=4163,
+  serialized_start=4108,
+  serialized_end=4151,
 )
 
 _GETMETRICHISTORY = _descriptor.Descriptor(
@@ -2042,9 +2030,16 @@ _GETMETRICHISTORY = _descriptor.Descriptor(
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
-      serialized_options=_b('\210\265\030\001'), file=DESCRIPTOR),
+      serialized_options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='metric_key', full_name='mlflow.GetMetricHistory.metric_key', index=1,
+      name='run_id', full_name='mlflow.GetMetricHistory.run_id', index=1,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='metric_key', full_name='mlflow.GetMetricHistory.metric_key', index=2,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -2062,8 +2057,8 @@ _GETMETRICHISTORY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4050,
-  serialized_end=4208,
+  serialized_start=4028,
+  serialized_end=4196,
 )
 
 
@@ -2086,8 +2081,8 @@ _LOGBATCH_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=926,
-  serialized_end=936,
+  serialized_start=942,
+  serialized_end=952,
 )
 
 _LOGBATCH = _descriptor.Descriptor(
@@ -2137,8 +2132,8 @@ _LOGBATCH = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4211,
-  serialized_end=4388,
+  serialized_start=4199,
+  serialized_end=4376,
 )
 
 _RUN.fields_by_name['info'].message_type = _RUNINFO
@@ -2198,7 +2193,6 @@ _SEARCHRUNS.fields_by_name['anded_expressions'].message_type = _SEARCHEXPRESSION
 _SEARCHRUNS.fields_by_name['run_view_type'].enum_type = _VIEWTYPE
 _LISTARTIFACTS_RESPONSE.fields_by_name['files'].message_type = _FILEINFO
 _LISTARTIFACTS_RESPONSE.containing_type = _LISTARTIFACTS
-_GETARTIFACT_RESPONSE.containing_type = _GETARTIFACT
 _GETMETRICHISTORY_RESPONSE.fields_by_name['metrics'].message_type = _METRIC
 _GETMETRICHISTORY_RESPONSE.containing_type = _GETMETRICHISTORY
 _LOGBATCH_RESPONSE.containing_type = _LOGBATCH
@@ -2235,7 +2229,6 @@ DESCRIPTOR.message_types_by_name['DoubleClause'] = _DOUBLECLAUSE
 DESCRIPTOR.message_types_by_name['SearchRuns'] = _SEARCHRUNS
 DESCRIPTOR.message_types_by_name['ListArtifacts'] = _LISTARTIFACTS
 DESCRIPTOR.message_types_by_name['FileInfo'] = _FILEINFO
-DESCRIPTOR.message_types_by_name['GetArtifact'] = _GETARTIFACT
 DESCRIPTOR.message_types_by_name['GetMetricHistory'] = _GETMETRICHISTORY
 DESCRIPTOR.message_types_by_name['LogBatch'] = _LOGBATCH
 DESCRIPTOR.enum_types_by_name['ViewType'] = _VIEWTYPE
@@ -2581,21 +2574,6 @@ FileInfo = _reflection.GeneratedProtocolMessageType('FileInfo', (_message.Messag
   ))
 _sym_db.RegisterMessage(FileInfo)
 
-GetArtifact = _reflection.GeneratedProtocolMessageType('GetArtifact', (_message.Message,), dict(
-
-  Response = _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), dict(
-    DESCRIPTOR = _GETARTIFACT_RESPONSE,
-    __module__ = 'service_pb2'
-    # @@protoc_insertion_point(class_scope:mlflow.GetArtifact.Response)
-    ))
-  ,
-  DESCRIPTOR = _GETARTIFACT,
-  __module__ = 'service_pb2'
-  # @@protoc_insertion_point(class_scope:mlflow.GetArtifact)
-  ))
-_sym_db.RegisterMessage(GetArtifact)
-_sym_db.RegisterMessage(GetArtifact.Response)
-
 GetMetricHistory = _reflection.GeneratedProtocolMessageType('GetMetricHistory', (_message.Message,), dict(
 
   Response = _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), dict(
@@ -2640,31 +2618,24 @@ _RESTOREEXPERIMENT._options = None
 _UPDATEEXPERIMENT.fields_by_name['experiment_id']._options = None
 _UPDATEEXPERIMENT._options = None
 _CREATERUN._options = None
-_UPDATERUN.fields_by_name['run_uuid']._options = None
 _UPDATERUN._options = None
 _DELETERUN.fields_by_name['run_id']._options = None
 _DELETERUN._options = None
 _RESTORERUN.fields_by_name['run_id']._options = None
 _RESTORERUN._options = None
-_LOGMETRIC.fields_by_name['run_uuid']._options = None
 _LOGMETRIC.fields_by_name['key']._options = None
 _LOGMETRIC.fields_by_name['value']._options = None
 _LOGMETRIC.fields_by_name['timestamp']._options = None
 _LOGMETRIC._options = None
-_LOGPARAM.fields_by_name['run_uuid']._options = None
 _LOGPARAM.fields_by_name['key']._options = None
 _LOGPARAM.fields_by_name['value']._options = None
 _LOGPARAM._options = None
-_SETTAG.fields_by_name['run_uuid']._options = None
 _SETTAG.fields_by_name['key']._options = None
 _SETTAG.fields_by_name['value']._options = None
 _SETTAG._options = None
-_GETRUN.fields_by_name['run_uuid']._options = None
 _GETRUN._options = None
 _SEARCHRUNS._options = None
 _LISTARTIFACTS._options = None
-_GETARTIFACT._options = None
-_GETMETRICHISTORY.fields_by_name['run_uuid']._options = None
 _GETMETRICHISTORY.fields_by_name['metric_key']._options = None
 _GETMETRICHISTORY._options = None
 _LOGBATCH._options = None
@@ -2675,8 +2646,8 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=4601,
-  serialized_end=7090,
+  serialized_start=4589,
+  serialized_end=7078,
   methods=[
   _descriptor.MethodDescriptor(
     name='createExperiment',

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -605,7 +605,7 @@ def log_model(artifact_path, loader_module=None, data_path=None, code_path=None,
     """
     with TempDir() as tmp:
         local_path = tmp.path(artifact_path)
-        run_id = active_run().info.run_uuid
+        run_id = active_run().info.run_id
         save_model(dst_path=local_path, model=Model(artifact_path=artifact_path, run_id=run_id),
                    loader_module=loader_module, data_path=data_path, code_path=code_path,
                    conda_env=conda_env, python_model=python_model, artifacts=artifacts)

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -41,7 +41,7 @@ def list_run(experiment_id, view):
     for run in runs:
         tags = {t.key: t.value for t in run.data.tags}
         run_name = tags.get(MLFLOW_RUN_NAME, "")
-        table.append([conv_longdate_to_str(run.info.start_time), run_name, run.info.run_uuid])
+        table.append([conv_longdate_to_str(run.info.start_time), run_name, run.info.run_id])
     print(tabulate(sorted(table, reverse=True), headers=["Date", "Name", "ID"]))
 
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -109,7 +109,7 @@ def log_model(spark_model, artifact_path, conda_env=None, jars=None, dfs_tmpdir=
     >>> mlflow.spark.log_model(model, "spark-model")
     """
     _validate_model(spark_model, jars)
-    run_id = mlflow.tracking.fluent._get_or_start_run().info.run_uuid
+    run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
     run_root_artifact_uri = mlflow.get_artifact_uri()
     # If the artifact URI is a local filesystem path, defer to Model.log() to persist the model,
     # since Spark may not be able to write directly to the driver's filesystem. For example,

--- a/mlflow/store/abstract_store.py
+++ b/mlflow/store/abstract_store.py
@@ -99,7 +99,7 @@ class AbstractStore:
         pass
 
     @abstractmethod
-    def get_run(self, run_uuid):
+    def get_run(self, run_id):
         """
         Fetch the run from backend store. The resulting :py:class:`Run <mlflow.entities.Run>`
         contains a collection of run metadata - :py:class:`RunInfo <mlflow.entities.RunInfo>`,
@@ -109,7 +109,7 @@ class AbstractStore:
         the value at the latest timestamp for each metric. If there are multiple values with the
         latest timestamp for a given metric, the maximum of these values is returned.
 
-        :param run_uuid: Unique identifier for the run.
+        :param run_id: Unique identifier for the run.
 
         :return: A single :py:class:`mlflow.entities.Run` object, if the run exists. Otherwise,
                  raises an exception.
@@ -117,7 +117,7 @@ class AbstractStore:
         pass
 
     @abstractmethod
-    def update_run_info(self, run_uuid, run_status, end_time):
+    def update_run_info(self, run_id, run_status, end_time):
         """
         Update the metadata of the specified run.
 
@@ -158,39 +158,39 @@ class AbstractStore:
         """
         pass
 
-    def log_metric(self, run_uuid, metric):
+    def log_metric(self, run_id, metric):
         """
         Log a metric for the specified run
 
-        :param run_uuid: String id for the run
+        :param run_id: String id for the run
         :param metric: :py:class:`mlflow.entities.Metric` instance to log
         """
-        self.log_batch(run_uuid, metrics=[metric], params=[], tags=[])
+        self.log_batch(run_id, metrics=[metric], params=[], tags=[])
 
-    def log_param(self, run_uuid, param):
+    def log_param(self, run_id, param):
         """
         Log a param for the specified run
 
-        :param run_uuid: String id for the run
+        :param run_id: String id for the run
         :param param: :py:class:`mlflow.entities.Param` instance to log
         """
-        self.log_batch(run_uuid, metrics=[], params=[param], tags=[])
+        self.log_batch(run_id, metrics=[], params=[param], tags=[])
 
-    def set_tag(self, run_uuid, tag):
+    def set_tag(self, run_id, tag):
         """
         Set a tag for the specified run
 
-        :param run_uuid: String id for the run
+        :param run_id: String id for the run
         :param tag: :py:class:`mlflow.entities.RunTag` instance to set
         """
-        self.log_batch(run_uuid, metrics=[], params=[], tags=[tag])
+        self.log_batch(run_id, metrics=[], params=[], tags=[tag])
 
     @abstractmethod
-    def get_metric_history(self, run_uuid, metric_key):
+    def get_metric_history(self, run_id, metric_key):
         """
         Return a list of metric objects corresponding to all values logged for a given metric.
 
-        :param run_uuid: Unique identifier for run
+        :param run_id: Unique identifier for run
         :param metric_key: Metric name within the run
 
         :return: A list of :py:class:`mlflow.entities.Metric` entities if logged, else empty list

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -56,7 +56,7 @@ class ArtifactRepository:
     @abstractmethod
     def list_artifacts(self, path):
         """
-        Return all the artifacts for this run_uuid directly under path. If path is a file, returns
+        Return all the artifacts for this run_id directly under path. If path is a file, returns
         an empty list. Will error if path is neither a file nor directory.
 
         :param path: Relative source path that contain desired artifacts

--- a/mlflow/store/dbmodels/models.py
+++ b/mlflow/store/dbmodels/models.py
@@ -28,50 +28,6 @@ RunStatusTypes = [
 ]
 
 
-def _create_entity(base, model):
-
-    # create dict of kwargs properties for entity and return the initialized entity
-    config = {}
-    for k in base._properties():
-        # check if its mlflow entity and build it
-        obj = getattr(model, k)
-
-        if isinstance(model, SqlRun):
-            if base is RunData:
-                # Run data contains list for metrics, params and tags
-                # so obj will be a list so we need to convert those items
-                if k == 'metrics':
-                    # only get latest recorded metrics per key
-                    metrics = {}
-                    for o in obj:
-                        existing_metric = metrics.get(o.key)
-                        if (existing_metric is None)\
-                            or ((o.step, o.timestamp, o.value) >=
-                                (existing_metric.step, existing_metric.timestamp,
-                                 existing_metric.value)):
-                            metrics[o.key] = Metric(o.key, o.value, o.timestamp, o.step)
-                    obj = list(metrics.values())
-                elif k == 'params':
-                    obj = [Param(o.key, o.value) for o in obj]
-                elif k == 'tags':
-                    obj = [RunTag(o.key, o.value) for o in obj]
-            elif base is RunInfo:
-                if k == 'source_type':
-                    obj = SourceType.from_string(obj)
-                elif k == "status":
-                    obj = RunStatus.from_string(obj)
-                elif k == "experiment_id":
-                    obj = str(obj)
-
-        # Our data model defines experiment_ids as ints, but the in-memory representation was
-        # changed to be a string in time for 1.0.
-        if isinstance(model, SqlExperiment) and k == "experiment_id":
-            obj = str(obj)
-
-        config[k] = obj
-    return base(**config)
-
-
 class SqlExperiment(Base):
     """
     DB model for :py:class:`mlflow.entities.Experiment`. These are recorded in ``experiment`` table.
@@ -114,7 +70,11 @@ class SqlExperiment(Base):
 
         :return: :py:class:`mlflow.entities.Experiment`.
         """
-        return _create_entity(Experiment, self)
+        return Experiment(
+            experiment_id=str(self.experiment_id),
+            name=self.name,
+            artifact_location=self.artifact_location,
+            lifecycle_stage=self.lifecycle_stage)
 
 
 class SqlRun(Base):
@@ -197,10 +157,39 @@ class SqlRun(Base):
 
         :return: :py:class:`mlflow.entities.Run`.
         """
-        # run has diff parameter names in __init__ than in properties_ so we do this manually
-        info = _create_entity(RunInfo, self)
-        data = _create_entity(RunData, self)
-        return Run(run_info=info, run_data=data)
+        run_info = RunInfo(
+            run_uuid=self.run_uuid,
+            run_id=self.run_uuid,
+            experiment_id=str(self.experiment_id),
+            name=self.name,
+            source_type=SourceType.from_string(self.source_type),
+            source_name=self.source_name,
+            entry_point_name=self.entry_point_name,
+            user_id=self.user_id,
+            status=RunStatus.from_string(self.status),
+            start_time=self.start_time,
+            end_time=self.end_time,
+            source_version=self.source_version,
+            lifecycle_stage=self.lifecycle_stage,
+            artifact_uri=self.artifact_uri)
+
+        # only get latest recorded metrics per key
+        all_metrics = [m.to_mlflow_entity() for m in self.metrics]
+        metrics = {}
+        for m in all_metrics:
+            existing_metric = metrics.get(m.key)
+            if (existing_metric is None)\
+                or ((m.step, m.timestamp, m.value) >=
+                    (existing_metric.step, existing_metric.timestamp,
+                        existing_metric.value)):
+                metrics[m.key] = m
+
+        run_data = RunData(
+            metrics=list(metrics.values()),
+            params=[p.to_mlflow_entity() for p in self.params],
+            tags=[t.to_mlflow_entity() for t in self.tags])
+
+        return Run(run_info=run_info, run_data=run_data)
 
 
 class SqlTag(Base):
@@ -239,7 +228,9 @@ class SqlTag(Base):
 
         :return: :py:class:`mlflow.entities.RunTag`.
         """
-        return _create_entity(RunTag, self)
+        return RunTag(
+            key=self.key,
+            value=self.value)
 
 
 class SqlMetric(Base):
@@ -285,7 +276,11 @@ class SqlMetric(Base):
 
         :return: :py:class:`mlflow.entities.Metric`.
         """
-        return _create_entity(Metric, self)
+        return Metric(
+            key=self.key,
+            value=self.value,
+            timestamp=self.timestamp,
+            step=self.step)
 
 
 class SqlParam(Base):
@@ -322,4 +317,6 @@ class SqlParam(Base):
 
         :return: :py:class:`mlflow.entities.Param`.
         """
-        return _create_entity(Param, self)
+        return Param(
+            key=self.key,
+            value=self.value)

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -117,21 +117,21 @@ class RestStore(AbstractStore):
             experiment_id=str(experiment_id), new_name=new_name))
         self._call_endpoint(UpdateExperiment, req_body)
 
-    def get_run(self, run_uuid):
+    def get_run(self, run_id):
         """
         Fetch the run from backend store
 
-        :param run_uuid: Unique identifier for the run
+        :param run_id: Unique identifier for the run
 
         :return: A single Run object if it exists, otherwise raises an Exception
         """
-        req_body = message_to_json(GetRun(run_uuid=run_uuid))
+        req_body = message_to_json(GetRun(run_uuid=run_id, run_id=run_id))
         response_proto = self._call_endpoint(GetRun, req_body)
         return Run.from_proto(response_proto.run)
 
-    def update_run_info(self, run_uuid, run_status, end_time):
+    def update_run_info(self, run_id, run_status, end_time):
         """ Updates the metadata of the specified run. """
-        req_body = message_to_json(UpdateRun(run_uuid=run_uuid, status=run_status,
+        req_body = message_to_json(UpdateRun(run_uuid=run_id, run_id=run_id, status=run_status,
                                              end_time=end_time))
         response_proto = self._call_endpoint(UpdateRun, req_body)
         return RunInfo.from_proto(response_proto.run_info)
@@ -158,51 +158,55 @@ class RestStore(AbstractStore):
         run = Run.from_proto(response_proto.run)
         if run_name:
             # TODO: optimization: This is making 2 calls to backend store. Include with above call.
-            self.set_tag(run.info.run_uuid, RunTag(key=MLFLOW_RUN_NAME, value=run_name))
+            self.set_tag(run.info.run_id, RunTag(key=MLFLOW_RUN_NAME, value=run_name))
         return run
 
-    def log_metric(self, run_uuid, metric):
+    def log_metric(self, run_id, metric):
         """
         Log a metric for the specified run
 
-        :param run_uuid: String id for the run
+        :param run_id: String id for the run
         :param metric: Metric instance to log
         """
         req_body = message_to_json(LogMetric(
-            run_uuid=run_uuid, key=metric.key, value=metric.value, timestamp=metric.timestamp,
+            run_uuid=run_id, run_id=run_id,
+            key=metric.key, value=metric.value, timestamp=metric.timestamp,
             step=metric.step))
         self._call_endpoint(LogMetric, req_body)
 
-    def log_param(self, run_uuid, param):
+    def log_param(self, run_id, param):
         """
         Log a param for the specified run
 
-        :param run_uuid: String id for the run
+        :param run_id: String id for the run
         :param param: Param instance to log
         """
-        req_body = message_to_json(LogParam(run_uuid=run_uuid, key=param.key, value=param.value))
+        req_body = message_to_json(LogParam(
+            run_uuid=run_id, run_id=run_id, key=param.key, value=param.value))
         self._call_endpoint(LogParam, req_body)
 
-    def set_tag(self, run_uuid, tag):
+    def set_tag(self, run_id, tag):
         """
         Set a tag for the specified run
 
-        :param run_uuid: String id for the run
+        :param run_id: String id for the run
         :param tag: RunTag instance to log
         """
-        req_body = message_to_json(SetTag(run_uuid=run_uuid, key=tag.key, value=tag.value))
+        req_body = message_to_json(SetTag(
+            run_uuid=run_id, run_id=run_id, key=tag.key, value=tag.value))
         self._call_endpoint(SetTag, req_body)
 
-    def get_metric_history(self, run_uuid, metric_key):
+    def get_metric_history(self, run_id, metric_key):
         """
         Return all logged values for a given metric.
 
-        :param run_uuid: Unique identifier for run
+        :param run_id: Unique identifier for run
         :param metric_key: Metric name within the run
 
         :return: A list of :py:class:`mlflow.entities.Metric` entities if logged, else empty list
         """
-        req_body = message_to_json(GetMetricHistory(run_uuid=run_uuid, metric_key=metric_key))
+        req_body = message_to_json(GetMetricHistory(
+            run_uuid=run_id, run_id=run_id, metric_key=metric_key))
         response_proto = self._call_endpoint(GetMetricHistory, req_body)
         return [Metric.from_proto(metric) for metric in response_proto.metrics]
 

--- a/mlflow/store/runs_artifact_repo.py
+++ b/mlflow/store/runs_artifact_repo.py
@@ -81,7 +81,7 @@ class RunsArtifactRepository(ArtifactRepository):
 
     def list_artifacts(self, path):
         """
-        Return all the artifacts for this run_uuid directly under path. If path is a file, returns
+        Return all the artifacts for this run_id directly under path. If path is a file, returns
         an empty list. Will error if path is neither a file nor directory.
 
         :param path: Relative source path that contain desired artifacts

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -45,7 +45,7 @@ class MlflowClient(object):
         the value at the latest timestamp for each metric. If there are multiple values with the
         latest timestamp for a given metric, the maximum of these values is returned.
 
-        :param run_uuid: Unique identifier for the run.
+        :param run_id: Unique identifier for the run.
 
         :return: A single :py:class:`mlflow.entities.Run` object, if the run exists. Otherwise,
                  raises an exception.
@@ -62,7 +62,7 @@ class MlflowClient(object):
 
         :return: A list of :py:class:`mlflow.entities.Metric` entities if logged, else empty list
         """
-        return self.store.get_metric_history(run_uuid=run_id, metric_key=key)
+        return self.store.get_metric_history(run_id=run_id, metric_key=key)
 
     def create_run(self, experiment_id, user_id=None, run_name=None, start_time=None,
                    parent_run_id=None, tags=None):

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -125,7 +125,7 @@ def test_build_image_with_run_relative_model_path_calls_expected_azure_routines(
     artifact_path = "model"
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=sklearn_model, artifact_path=artifact_path)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
 
     with AzureMLMocks() as aml_mocks:
         workspace = get_azure_workspace()
@@ -251,7 +251,7 @@ def test_build_image_includes_default_metadata_in_azure_image_and_model_tags(skl
     artifact_path = "model"
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=sklearn_model, artifact_path=artifact_path)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_config = Model.load(os.path.join(_get_model_log_dir(artifact_path, run_id), "MLmodel"))
 
     with AzureMLMocks() as aml_mocks:
@@ -562,7 +562,7 @@ def test_cli_build_image_with_run_relative_model_path_calls_expected_azure_routi
     artifact_path = "model"
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=sklearn_model, artifact_path=artifact_path)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
 
     with AzureMLMocks() as aml_mocks:
         result = CliRunner(env={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}).invoke(
@@ -595,7 +595,7 @@ def test_cli_build_image_parses_and_includes_user_specified_tags_in_azureml_imag
     artifact_path = "model"
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=sklearn_model, artifact_path=artifact_path)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
 
     with AzureMLMocks() as aml_mocks:
         result = CliRunner(env={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}).invoke(

--- a/tests/entities/test_run.py
+++ b/tests/entities/test_run.py
@@ -5,7 +5,7 @@ from tests.entities.test_run_info import TestRunInfo
 
 class TestRun(TestRunInfo, TestRunData):
     def _check_run(self, run, ri, rd_metrics, rd_params, rd_tags):
-        TestRunInfo._check(self, run.info, ri.run_uuid, ri.experiment_id, ri.name,
+        TestRunInfo._check(self, run.info, ri.run_id, ri.experiment_id, ri.name,
                            ri.source_type, ri.source_name, ri.entry_point_name,
                            ri.user_id, ri.status, ri.start_time, ri.end_time, ri.source_version,
                            ri.lifecycle_stage, ri.artifact_uri)
@@ -13,7 +13,7 @@ class TestRun(TestRunInfo, TestRunData):
 
     def test_creation_and_hydration(self):
         run_data, metrics, params, tags = TestRunData._create()
-        (run_info, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
+        (run_info, run_id, experiment_id, name, source_type, source_name, entry_point_name,
          user_id, status, start_time, end_time, source_version, lifecycle_stage,
          artifact_uri) = TestRunInfo._create()
 
@@ -21,7 +21,8 @@ class TestRun(TestRunInfo, TestRunData):
 
         self._check_run(run1, run_info, metrics, params, tags)
 
-        as_dict = {"info": {"run_uuid": run_uuid,
+        as_dict = {"info": {"run_uuid": run_id,
+                            "run_id": run_id,
                             "experiment_id": experiment_id,
                             "name": name,
                             "source_type": source_type,
@@ -47,17 +48,18 @@ class TestRun(TestRunInfo, TestRunData):
 
     def test_string_repr(self):
         run_info = RunInfo(
-            run_uuid="hi", experiment_id=0, name="name", source_type=SourceType.PROJECT,
-            source_name="source-name", entry_point_name="entry-point-name",
-            user_id="user-id", status=RunStatus.FAILED, start_time=0, end_time=1,
-            source_version="version", lifecycle_stage=LifecycleStage.ACTIVE)
+            run_uuid="hi", run_id="hi", experiment_id=0, name="name",
+            source_type=SourceType.PROJECT, source_name="source-name",
+            entry_point_name="entry-point-name", user_id="user-id", status=RunStatus.FAILED,
+            start_time=0, end_time=1, source_version="version",
+            lifecycle_stage=LifecycleStage.ACTIVE)
         metrics = [Metric(key="key-%s" % i, value=i, timestamp=0, step=i) for i in range(3)]
         run_data = RunData(metrics=metrics, params=[], tags=[])
         run1 = Run(run_info, run_data)
         expected = ("<Run: data=<RunData: metrics={'key-0': 0, 'key-1': 1, 'key-2': 2}, "
                     "params={}, tags={}>, info=<RunInfo: artifact_uri=None, end_time=1, "
                     "entry_point_name='entry-point-name', experiment_id=0, "
-                    "lifecycle_stage='active', name='name', run_uuid='hi', "
+                    "lifecycle_stage='active', name='name', run_id='hi', run_uuid='hi', "
                     "source_name='source-name', source_type=3, source_version='version', "
                     "start_time=0, status=4, user_id='user-id'>>")
         assert str(run1) == expected

--- a/tests/entities/test_run_info.py
+++ b/tests/entities/test_run_info.py
@@ -6,11 +6,12 @@ from tests.helper_functions import random_str, random_int
 
 
 class TestRunInfo(unittest.TestCase):
-    def _check(self, ri, run_uuid, experiment_id, name, source_type, source_name,
+    def _check(self, ri, run_id, experiment_id, name, source_type, source_name,
                entry_point_name, user_id, status, start_time, end_time, source_version,
                lifecycle_stage, artifact_uri):
         self.assertIsInstance(ri, RunInfo)
-        self.assertEqual(ri.run_uuid, run_uuid)
+        self.assertEqual(ri.run_uuid, run_id)
+        self.assertEqual(ri.run_id, run_id)
         self.assertEqual(ri.experiment_id, experiment_id)
         self.assertEqual(ri.name, name)
         self.assertEqual(ri.source_type, source_type)
@@ -26,7 +27,7 @@ class TestRunInfo(unittest.TestCase):
 
     @staticmethod
     def _create():
-        run_uuid = str(uuid.uuid4())
+        run_id = str(uuid.uuid4())
         experiment_id = str(random_int(10, 2000))
         name = random_str(random_int(10, 40))
         source_type = random_int(1, 4)
@@ -39,25 +40,26 @@ class TestRunInfo(unittest.TestCase):
         source_version = random_str(random_int(10, 40))
         lifecycle_stage = LifecycleStage.ACTIVE
         artifact_uri = random_str(random_int(10, 40))
-        ri = RunInfo(run_uuid=run_uuid, experiment_id=experiment_id, name=name,
+        ri = RunInfo(run_uuid=run_id, run_id=run_id, experiment_id=experiment_id, name=name,
                      source_type=source_type, source_name=source_name,
                      entry_point_name=entry_point_name, user_id=user_id,
                      status=status, start_time=start_time, end_time=end_time,
                      source_version=source_version, lifecycle_stage=lifecycle_stage,
                      artifact_uri=artifact_uri)
-        return (ri, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
+        return (ri, run_id, experiment_id, name, source_type, source_name, entry_point_name,
                 user_id, status, start_time, end_time, source_version, lifecycle_stage,
                 artifact_uri)
 
     def test_creation_and_hydration(self):
-        (ri1, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
+        (ri1, run_id, experiment_id, name, source_type, source_name, entry_point_name,
          user_id, status, start_time, end_time, source_version, lifecycle_stage,
          artifact_uri) = self._create()
-        self._check(ri1, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
+        self._check(ri1, run_id, experiment_id, name, source_type, source_name, entry_point_name,
                     user_id, status, start_time, end_time, source_version, lifecycle_stage,
                     artifact_uri)
         as_dict = {
-            "run_uuid": run_uuid,
+            "run_uuid": run_id,
+            "run_id": run_id,
             "experiment_id": experiment_id,
             "name": name,
             "source_type": source_type,
@@ -75,17 +77,17 @@ class TestRunInfo(unittest.TestCase):
 
         proto = ri1.to_proto()
         ri2 = RunInfo.from_proto(proto)
-        self._check(ri2, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
+        self._check(ri2, run_id, experiment_id, name, source_type, source_name, entry_point_name,
                     user_id, status, start_time, end_time, source_version, lifecycle_stage,
                     artifact_uri)
         ri3 = RunInfo.from_dictionary(as_dict)
-        self._check(ri3, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
+        self._check(ri3, run_id, experiment_id, name, source_type, source_name, entry_point_name,
                     user_id, status, start_time, end_time, source_version, lifecycle_stage,
                     artifact_uri)
         # Test that we can add a field to RunInfo and still deserialize it from a dictionary
         dict_copy_0 = as_dict.copy()
         dict_copy_0["my_new_field"] = "new field value"
         ri4 = RunInfo.from_dictionary(dict_copy_0)
-        self._check(ri4, run_uuid, experiment_id, name, source_type, source_name, entry_point_name,
+        self._check(ri4, run_id, experiment_id, name, source_type, source_name, entry_point_name,
                     user_id, status, start_time, end_time, source_version, lifecycle_stage,
                     artifact_uri)

--- a/tests/generate_ui_test_data.py
+++ b/tests/generate_ui_test_data.py
@@ -142,8 +142,8 @@ if __name__ == '__main__':
     loop_2_run_id = None
     with mlflow.start_run(source_name='loop-1') as run_1:
         with mlflow.start_run(source_name='loop-2', nested=True) as run_2:
-            loop_1_run_id = run_1.info.run_uuid
-            loop_2_run_id = run_2.info.run_uuid
+            loop_1_run_id = run_1.info.run_id
+            loop_2_run_id = run_2.info.run_id
     client.set_tag(loop_1_run_id, 'mlflow.parentRunId', loop_2_run_id)
 
     # Lot's of children

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -96,7 +96,7 @@ def test_model_log(h2o_iris_model):
 
                 # Load model
                 h2o_model_loaded = mlflow.h2o.load_model(
-                        path=artifact_path, run_id=mlflow.active_run().info.run_uuid)
+                        path=artifact_path, run_id=mlflow.active_run().info.run_id)
                 assert all(
                         h2o_model_loaded.predict(h2o_iris_model.inference_data).as_data_frame() ==
                         h2o_model.predict(h2o_iris_model.inference_data).as_data_frame())
@@ -168,7 +168,7 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
         mlflow.h2o.log_model(h2o_model=h2o_iris_model.model,
                              artifact_path=artifact_path,
                              conda_env=h2o_custom_env)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = _get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -202,7 +202,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
     artifact_path = "model"
     with mlflow.start_run():
         mlflow.h2o.log_model(h2o_model=h2o_iris_model.model, artifact_path=artifact_path)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = _get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -109,13 +109,13 @@ def test_model_log(tracking_uri_mock, model, data, predicted):  # pylint: disabl
             # Load model
             model_loaded = mlflow.keras.load_model(
                 "keras_model",
-                run_id=mlflow.active_run().info.run_uuid)
+                run_id=mlflow.active_run().info.run_id)
             assert all(model_loaded.predict(x) == predicted)
 
             # Loading pyfunc model
             pyfunc_loaded = mlflow.pyfunc.load_pyfunc(
                 "keras_model",
-                run_id=mlflow.active_run().info.run_uuid)
+                run_id=mlflow.active_run().info.run_id)
             assert all(pyfunc_loaded.predict(x).values == predicted)
         finally:
             mlflow.end_run()
@@ -159,7 +159,7 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(model,
     with mlflow.start_run():
         mlflow.keras.log_model(
             keras_model=model, artifact_path=artifact_path, conda_env=keras_custom_env)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = _get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -192,7 +192,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
     artifact_path = "model"
     with mlflow.start_run():
         mlflow.keras.log_model(keras_model=model, artifact_path=artifact_path, conda_env=None)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = _get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -38,16 +38,16 @@ def test_docker_project_execution(
         TEST_DOCKER_PROJECT_DIR, experiment_id=file_store.FileStore.DEFAULT_EXPERIMENT_ID,
         parameters=expected_params, entry_point="test_tracking")
     # Validate run contents in the FileStore
-    run_uuid = submitted_run.run_id
+    run_id = submitted_run.run_id
     mlflow_service = mlflow.tracking.MlflowClient()
     run_infos = mlflow_service.list_run_infos(
         experiment_id=file_store.FileStore.DEFAULT_EXPERIMENT_ID,
         run_view_type=ViewType.ACTIVE_ONLY)
     assert "file:" in run_infos[0].source_name
     assert len(run_infos) == 1
-    store_run_uuid = run_infos[0].run_uuid
-    assert run_uuid == store_run_uuid
-    run = mlflow_service.get_run(run_uuid)
+    store_run_id = run_infos[0].run_id
+    assert run_id == store_run_id
+    run = mlflow_service.get_run(run_id)
     assert run.data.params == expected_params
     assert run.data.metrics == {"some_key": 3}
     exact_expected_tags = {MLFLOW_PROJECT_ENV: "docker"}

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -199,15 +199,15 @@ def test_run_local_git_repo(local_git_repo,
     submitted_run.wait()
     validate_exit_status(submitted_run.get_status(), RunStatus.FINISHED)
     # Validate run contents in the FileStore
-    run_uuid = submitted_run.run_id
+    run_id = submitted_run.run_id
     mlflow_service = mlflow.tracking.MlflowClient()
     run_infos = mlflow_service.list_run_infos(
         experiment_id=FileStore.DEFAULT_EXPERIMENT_ID, run_view_type=ViewType.ACTIVE_ONLY)
     assert "file:" in run_infos[0].source_name
     assert len(run_infos) == 1
-    store_run_uuid = run_infos[0].run_uuid
-    assert run_uuid == store_run_uuid
-    run = mlflow_service.get_run(run_uuid)
+    store_run_id = run_infos[0].run_id
+    assert run_id == store_run_id
+    run = mlflow_service.get_run(run_id)
 
     assert run.info.status == RunStatus.FINISHED
     assert run.data.params == {"use_start_run": use_start_run}
@@ -270,15 +270,15 @@ def test_run(tmpdir, tracking_uri_mock, use_start_run):  # pylint: disable=unuse
     submitted_run.wait()
     validate_exit_status(submitted_run.get_status(), RunStatus.FINISHED)
     # Validate run contents in the FileStore
-    run_uuid = submitted_run.run_id
+    run_id = submitted_run.run_id
     mlflow_service = mlflow.tracking.MlflowClient()
 
     run_infos = mlflow_service.list_run_infos(
         experiment_id=FileStore.DEFAULT_EXPERIMENT_ID, run_view_type=ViewType.ACTIVE_ONLY)
     assert len(run_infos) == 1
-    store_run_uuid = run_infos[0].run_uuid
-    assert run_uuid == store_run_uuid
-    run = mlflow_service.get_run(run_uuid)
+    store_run_id = run_infos[0].run_id
+    assert run_id == store_run_id
+    run = mlflow_service.get_run(run_id)
 
     assert run.info.status == RunStatus.FINISHED
 
@@ -294,15 +294,15 @@ def test_run(tmpdir, tracking_uri_mock, use_start_run):  # pylint: disable=unuse
 def test_run_with_parent(tmpdir, tracking_uri_mock):  # pylint: disable=unused-argument
     """Verify that if we are in a nested run, mlflow.projects.run() will have a parent_run_id."""
     with mlflow.start_run():
-        parent_run_id = mlflow.active_run().info.run_uuid
+        parent_run_id = mlflow.active_run().info.run_id
         submitted_run = mlflow.projects.run(
             TEST_PROJECT_DIR, entry_point="test_tracking",
             parameters={"use_start_run": "1"},
             use_conda=False, experiment_id=FileStore.DEFAULT_EXPERIMENT_ID)
     assert submitted_run.run_id is not None
     validate_exit_status(submitted_run.get_status(), RunStatus.FINISHED)
-    run_uuid = submitted_run.run_id
-    run = mlflow.tracking.MlflowClient().get_run(run_uuid)
+    run_id = submitted_run.run_id
+    run = mlflow.tracking.MlflowClient().get_run(run_id)
     assert run.data.tags[MLFLOW_PARENT_RUN_ID] == parent_run_id
 
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -132,7 +132,7 @@ def test_model_log_load(sklearn_knn_model, main_scoped_model_class, iris_data):
     sklearn_artifact_path = "sk_model"
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=sklearn_knn_model, artifact_path=sklearn_artifact_path)
-        sklearn_run_id = mlflow.active_run().info.run_uuid
+        sklearn_run_id = mlflow.active_run().info.run_id
 
     def test_predict(sk_model, model_input):
         return sk_model.predict(model_input) * 2
@@ -146,7 +146,7 @@ def test_model_log_load(sklearn_knn_model, main_scoped_model_class, iris_data):
                                         run_id=sklearn_run_id)
                                 },
                                 python_model=main_scoped_model_class(test_predict))
-        pyfunc_run_id = mlflow.active_run().info.run_uuid
+        pyfunc_run_id = mlflow.active_run().info.run_id
 
     loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(path=pyfunc_artifact_path, run_id=pyfunc_run_id)
     np.testing.assert_array_equal(
@@ -362,7 +362,7 @@ def test_log_model_persists_specified_conda_env_in_mlflow_model_directory(
     sklearn_artifact_path = "sk_model"
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=sklearn_knn_model, artifact_path=sklearn_artifact_path)
-        sklearn_run_id = mlflow.active_run().info.run_uuid
+        sklearn_run_id = mlflow.active_run().info.run_id
 
     pyfunc_artifact_path = "pyfunc_model"
     with mlflow.start_run():
@@ -374,7 +374,7 @@ def test_log_model_persists_specified_conda_env_in_mlflow_model_directory(
                                 },
                                 python_model=main_scoped_model_class(predict_fn=None),
                                 conda_env=pyfunc_custom_env)
-        pyfunc_run_id = mlflow.active_run().info.run_uuid
+        pyfunc_run_id = mlflow.active_run().info.run_id
 
     pyfunc_model_path = _get_model_log_dir(pyfunc_artifact_path, pyfunc_run_id)
     pyfunc_conf = _get_flavor_configuration(
@@ -418,7 +418,7 @@ def test_log_model_without_specified_conda_env_uses_default_env_with_expected_de
     sklearn_artifact_path = "sk_model"
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=sklearn_knn_model, artifact_path=sklearn_artifact_path)
-        sklearn_run_id = mlflow.active_run().info.run_uuid
+        sklearn_run_id = mlflow.active_run().info.run_id
 
     pyfunc_artifact_path = "pyfunc_model"
     with mlflow.start_run():
@@ -429,7 +429,7 @@ def test_log_model_without_specified_conda_env_uses_default_env_with_expected_de
                                         run_id=sklearn_run_id)
                                 },
                                 python_model=main_scoped_model_class(predict_fn=None))
-        pyfunc_run_id = mlflow.active_run().info.run_uuid
+        pyfunc_run_id = mlflow.active_run().info.run_id
 
     pyfunc_model_path = _get_model_log_dir(pyfunc_artifact_path, pyfunc_run_id)
     pyfunc_conf = _get_flavor_configuration(

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -83,7 +83,7 @@ def test_model_log_load(sklearn_knn_model, iris_data, tmpdir):
                                 data_path=sk_model_path,
                                 loader_module=os.path.basename(__file__)[:-3],
                                 code_path=[__file__])
-        pyfunc_run_id = mlflow.active_run().info.run_uuid
+        pyfunc_run_id = mlflow.active_run().info.run_id
 
     pyfunc_model_path = _get_model_log_dir(pyfunc_artifact_path, pyfunc_run_id)
     model_config = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -188,7 +188,7 @@ def test_log_model(sequential_model, data, sequential_predicted):
                 mlflow.pytorch.log_model(sequential_model, artifact_path="pytorch")
 
                 # Load model
-                run_id = mlflow.active_run().info.run_uuid
+                run_id = mlflow.active_run().info.run_id
                 sequential_model_loaded = mlflow.pytorch.load_model("pytorch", run_id=run_id)
 
                 test_predictions = _predict(sequential_model_loaded, data)
@@ -279,7 +279,7 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
         mlflow.pytorch.log_model(pytorch_model=sequential_model,
                                  artifact_path=artifact_path,
                                  conda_env=pytorch_custom_env)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = tracking.artifact_utils._get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -315,7 +315,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
         mlflow.pytorch.log_model(pytorch_model=sequential_model,
                                  artifact_path=artifact_path,
                                  conda_env=None)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = tracking.artifact_utils._get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -433,7 +433,7 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
                          artifacts={
                             "pytorch_model": model_path,
                          })
-        pyfunc_run_id = mlflow.active_run().info.run_uuid
+        pyfunc_run_id = mlflow.active_run().info.run_id
 
     pyfunc_model_path = tracking.artifact_utils._get_model_log_dir(pyfunc_artifact_path,
                                                                    pyfunc_run_id)
@@ -493,7 +493,7 @@ def test_load_model_loads_torch_model_using_pickle_module_specified_at_save_time
             pytorch_model=module_scoped_subclassed_model,
             conda_env=None,
             pickle_module=custom_pickle_module)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
 
     import_module_fn = importlib.import_module
     imported_modules = []
@@ -559,7 +559,7 @@ def test_load_model_succeeds_when_data_is_model_file_instead_of_directory(
             artifact_path=artifact_path,
             pytorch_model=module_scoped_subclassed_model,
             conda_env=None)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = tracking.artifact_utils._get_model_log_dir(artifact_path, run_id)
 
     model_conf_path = os.path.join(model_path, "MLmodel")

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -35,7 +35,7 @@ def pretrained_model():
         lr = LogisticRegression()
         lr.fit(X, y)
         mlflow.sklearn.log_model(lr, model_path)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
         return TrainedModel(model_path, run_id)
 
 
@@ -517,7 +517,7 @@ def test_deploy_in_replace_mode_with_archiving_does_not_delete_resources(
     new_artifact_path = "model"
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=sk_model, artifact_path=new_artifact_path)
-        new_run_id = mlflow.active_run().info.run_uuid
+        new_run_id = mlflow.active_run().info.run_id
     mfs.deploy(app_name=app_name,
                model_path=new_artifact_path,
                run_id=new_run_id,

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -115,7 +115,7 @@ def test_model_log(sklearn_logreg_model, model_path):
                         sk_model=sklearn_logreg_model.model,
                         artifact_path=artifact_path,
                         conda_env=conda_env)
-                run_id = mlflow.active_run().info.run_uuid
+                run_id = mlflow.active_run().info.run_id
 
                 reloaded_logreg_model = mlflow.sklearn.load_model(artifact_path, run_id)
                 np.testing.assert_array_equal(
@@ -211,7 +211,7 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
         mlflow.sklearn.log_model(sk_model=sklearn_knn_model.model,
                                  artifact_path=artifact_path,
                                  conda_env=sklearn_custom_env)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = _get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -264,7 +264,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=knn_model, artifact_path=artifact_path, conda_env=None,
                                  serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = _get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -291,7 +291,7 @@ def test_model_log_uses_cloudpickle_serialization_format_by_default(sklearn_knn_
     with mlflow.start_run():
         mlflow.sklearn.log_model(
                 sk_model=sklearn_knn_model.model, artifact_path=artifact_path, conda_env=None)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = _get_model_log_dir(artifact_path, run_id)
 
     sklearn_conf = _get_flavor_configuration(

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -220,7 +220,7 @@ def test_sparkml_model_log(tmpdir, spark_model_iris):
                 cnt += 1
                 sparkm.log_model(artifact_path=artifact_path, spark_model=spark_model_iris.model,
                                  dfs_tmpdir=dfs_tmp_dir)
-                run_id = active_run().info.run_uuid
+                run_id = active_run().info.run_id
                 # test reloaded model
                 reloaded_model = sparkm.load_model(artifact_path, run_id=run_id,
                                                    dfs_tmpdir=dfs_tmp_dir)
@@ -295,7 +295,7 @@ def test_sparkml_model_log_persists_specified_conda_env_in_mlflow_model_director
                 spark_model=spark_model_iris.model,
                 artifact_path=artifact_path,
                 conda_env=spark_custom_env)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = _get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -330,7 +330,7 @@ def test_sparkml_model_log_without_specified_conda_env_uses_default_env_with_exp
     with mlflow.start_run():
         sparkm.log_model(
                 spark_model=spark_model_iris.model, artifact_path=artifact_path, conda_env=None)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = _get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -345,7 +345,7 @@ def test_sparkml_model_log_without_specified_conda_env_uses_default_env_with_exp
 def test_mleap_model_log(spark_model_iris):
     artifact_path = "model"
     with mlflow.start_run():
-        rid = active_run().info.run_uuid
+        rid = active_run().info.run_id
         sparkm.log_model(spark_model=spark_model_iris.model,
                          sample_input=spark_model_iris.spark_df,
                          artifact_path=artifact_path)

--- a/tests/store/test_abstract_store.py
+++ b/tests/store/test_abstract_store.py
@@ -25,10 +25,10 @@ class AbstractStoreTestImpl(AbstractStore):
     def rename_experiment(self, experiment_id, new_name):
         raise NotImplementedError()
 
-    def get_run(self, run_uuid):
+    def get_run(self, run_id):
         raise NotImplementedError()
 
-    def update_run_info(self, run_uuid, run_status, end_time):
+    def update_run_info(self, run_id, run_status, end_time):
         raise NotImplementedError()
 
     def create_run(self, experiment_id, user_id, run_name, source_type, source_name,
@@ -41,7 +41,7 @@ class AbstractStoreTestImpl(AbstractStore):
     def restore_run(self, run_id):
         raise NotImplementedError()
 
-    def get_metric_history(self, run_uuid, metric_key):
+    def get_metric_history(self, run_id, metric_key):
         raise NotImplementedError()
 
     def search_runs(self, experiment_ids, search_filter, run_view_type,

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -149,7 +149,7 @@ class TestRestStore(unittest.TestCase):
             metric_protos = [metric.to_proto() for metric in metrics]
             param_protos = [param.to_proto() for param in params]
             tag_protos = [tag.to_proto() for tag in tags]
-            body = message_to_json(LogBatch(run_uuid="u2", run_id="u2", metrics=metric_protos,
+            body = message_to_json(LogBatch(run_id="u2", metrics=metric_protos,
                                             params=param_protos, tags=tag_protos))
             self._verify_requests(mock_http, creds,
                                   "runs/log-batch", "POST", body)

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -113,27 +113,30 @@ class TestRestStore(unittest.TestCase):
                                                                       value=source_name),
                                                           ProtoRunTag(key='mlflow.source.type',
                                                                       value='LOCAL')]))
-                st_body = message_to_json(SetTag(run_id='', key='mlflow.runName', value=run_name))
+                st_body = message_to_json(SetTag(
+                    run_uuid='', run_id='', key='mlflow.runName', value=run_name))
                 assert mock_http.call_count == 2
                 exp_calls = [("runs/create", "POST", cr_body), ("runs/set-tag", "POST", st_body)]
                 self._verify_request_has_calls(mock_http, creds, exp_calls)
 
         with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
             store.log_param("some_uuid", Param("k1", "v1"))
-            body = message_to_json(LogParam(run_id="some_uuid", key="k1", value="v1"))
+            body = message_to_json(LogParam(
+                run_uuid="some_uuid", run_id="some_uuid", key="k1", value="v1"))
             self._verify_requests(mock_http, creds,
                                   "runs/log-parameter", "POST", body)
 
         with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
             store.set_tag("some_uuid", RunTag("t1", "abcd"*1000))
-            body = message_to_json(SetTag(run_id="some_uuid", key="t1", value="abcd"*1000))
+            body = message_to_json(SetTag(
+                run_uuid="some_uuid", run_id="some_uuid", key="t1", value="abcd"*1000))
             self._verify_requests(mock_http, creds,
                                   "runs/set-tag", "POST", body)
 
         with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
             store.log_metric("u2", Metric("m1", 0.87, 12345, 3))
-            body = message_to_json(LogMetric(run_id="u2", key="m1", value=0.87, timestamp=12345,
-                                             step=3))
+            body = message_to_json(LogMetric(
+                run_uuid="u2", run_id="u2", key="m1", value=0.87, timestamp=12345, step=3))
             self._verify_requests(mock_http, creds,
                                   "runs/log-metric", "POST", body)
 
@@ -146,7 +149,7 @@ class TestRestStore(unittest.TestCase):
             metric_protos = [metric.to_proto() for metric in metrics]
             param_protos = [param.to_proto() for param in params]
             tag_protos = [tag.to_proto() for tag in tags]
-            body = message_to_json(LogBatch(run_id="u2", metrics=metric_protos,
+            body = message_to_json(LogBatch(run_uuid="u2", run_id="u2", metrics=metric_protos,
                                             params=param_protos, tags=tag_protos))
             self._verify_requests(mock_http, creds,
                                   "runs/log-batch", "POST", body)

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -113,26 +113,26 @@ class TestRestStore(unittest.TestCase):
                                                                       value=source_name),
                                                           ProtoRunTag(key='mlflow.source.type',
                                                                       value='LOCAL')]))
-                st_body = message_to_json(SetTag(run_uuid='', key='mlflow.runName', value=run_name))
+                st_body = message_to_json(SetTag(run_id='', key='mlflow.runName', value=run_name))
                 assert mock_http.call_count == 2
                 exp_calls = [("runs/create", "POST", cr_body), ("runs/set-tag", "POST", st_body)]
                 self._verify_request_has_calls(mock_http, creds, exp_calls)
 
         with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
             store.log_param("some_uuid", Param("k1", "v1"))
-            body = message_to_json(LogParam(run_uuid="some_uuid", key="k1", value="v1"))
+            body = message_to_json(LogParam(run_id="some_uuid", key="k1", value="v1"))
             self._verify_requests(mock_http, creds,
                                   "runs/log-parameter", "POST", body)
 
         with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
             store.set_tag("some_uuid", RunTag("t1", "abcd"*1000))
-            body = message_to_json(SetTag(run_uuid="some_uuid", key="t1", value="abcd"*1000))
+            body = message_to_json(SetTag(run_id="some_uuid", key="t1", value="abcd"*1000))
             self._verify_requests(mock_http, creds,
                                   "runs/set-tag", "POST", body)
 
         with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
             store.log_metric("u2", Metric("m1", 0.87, 12345, 3))
-            body = message_to_json(LogMetric(run_uuid="u2", key="m1", value=0.87, timestamp=12345,
+            body = message_to_json(LogMetric(run_id="u2", key="m1", value=0.87, timestamp=12345,
                                              step=3))
             self._verify_requests(mock_http, creds,
                                   "runs/log-metric", "POST", body)

--- a/tests/store/test_runs_artifact_repo.py
+++ b/tests/store/test_runs_artifact_repo.py
@@ -37,7 +37,7 @@ def test_runs_artifact_repo_init():
     artifact_location = "s3://blah_bucket/"
     experiment_id = mlflow.create_experiment("expr_abc", artifact_location)
     with mlflow.start_run(experiment_id=experiment_id):
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     runs_uri = "runs:/%s/path/to/model" % run_id
     runs_repo = RunsArtifactRepository(runs_uri)
 

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -184,7 +184,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         # the runs table
         run = self._run_factory()
         with self.store.ManagedSessionMaker() as session:
-            new_tag = models.SqlTag(run_id=run.info.run_id, key='test', value='val')
+            new_tag = models.SqlTag(run_uuid=run.info.run_id, key='test', value='val')
             session.add(new_tag)
             session.commit()
             added_tags = [
@@ -202,7 +202,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         # the runs table
         run = self._run_factory()
         with self.store.ManagedSessionMaker() as session:
-            new_metric = models.SqlMetric(run_id=run.info.run_id, key='accuracy', value=0.89)
+            new_metric = models.SqlMetric(run_uuid=run.info.run_id, key='accuracy', value=0.89)
             session.add(new_metric)
             session.commit()
             metrics = session.query(models.SqlMetric).all()
@@ -220,7 +220,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         run = self._run_factory()
         with self.store.ManagedSessionMaker() as session:
             new_param = models.SqlParam(
-                run_id=run.info.run_id, key='accuracy', value='test param')
+                run_uuid=run.info.run_id, key='accuracy', value='test param')
             session.add(new_param)
             session.commit()
             params = session.query(models.SqlParam).all()
@@ -272,7 +272,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
             'experiment_id': experiment_id,
             'name': 'test run',
             'user_id': 'Anderson',
-            'run_id': 'test',
+            'run_uuid': 'test',
             'status': RunStatus.to_string(RunStatus.SCHEDULED),
             'source_type': SourceType.to_string(SourceType.LOCAL),
             'source_name': 'Python application',
@@ -403,7 +403,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         self.store.delete_run(run.info.run_id)
 
         with self.store.ManagedSessionMaker() as session:
-            actual = session.query(models.SqlRun).filter_by(run_id=run.info.run_id).first()
+            actual = session.query(models.SqlRun).filter_by(run_uuid=run.info.run_id).first()
             self.assertEqual(actual.lifecycle_stage, entities.LifecycleStage.DELETED)
 
             deleted_run = self.store.get_run(run.info.run_id)

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -47,9 +47,9 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
         return self.store.create_experiment(name=names)
 
-    def _verify_logged(self, run_uuid, metrics, params, tags):
-        run = self.store.get_run(run_uuid)
-        all_metrics = sum([self.store.get_metric_history(run_uuid, key)
+    def _verify_logged(self, run_id, metrics, params, tags):
+        run = self.store.get_run(run_id)
+        all_metrics = sum([self.store.get_metric_history(run_id, key)
                            for key in run.data.metrics], [])
         assert len(all_metrics) == len(metrics)
         logged_metrics = [(m.key, m.value, m.timestamp, m.step) for m in all_metrics]
@@ -179,12 +179,12 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
     def test_run_tag_model(self):
         # Create a run whose UUID we can reference when creating tag models.
-        # `run_uuid` is a foreign key in the tags table; therefore, in order
+        # `run_id` is a foreign key in the tags table; therefore, in order
         # to insert a tag with a given run UUID, the UUID must be present in
         # the runs table
         run = self._run_factory()
         with self.store.ManagedSessionMaker() as session:
-            new_tag = models.SqlTag(run_uuid=run.info.run_uuid, key='test', value='val')
+            new_tag = models.SqlTag(run_id=run.info.run_id, key='test', value='val')
             session.add(new_tag)
             session.commit()
             added_tags = [
@@ -197,12 +197,12 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
     def test_metric_model(self):
         # Create a run whose UUID we can reference when creating metric models.
-        # `run_uuid` is a foreign key in the tags table; therefore, in order
+        # `run_id` is a foreign key in the tags table; therefore, in order
         # to insert a metric with a given run UUID, the UUID must be present in
         # the runs table
         run = self._run_factory()
         with self.store.ManagedSessionMaker() as session:
-            new_metric = models.SqlMetric(run_uuid=run.info.run_uuid, key='accuracy', value=0.89)
+            new_metric = models.SqlMetric(run_id=run.info.run_id, key='accuracy', value=0.89)
             session.add(new_metric)
             session.commit()
             metrics = session.query(models.SqlMetric).all()
@@ -214,13 +214,13 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
     def test_param_model(self):
         # Create a run whose UUID we can reference when creating parameter models.
-        # `run_uuid` is a foreign key in the tags table; therefore, in order
+        # `run_id` is a foreign key in the tags table; therefore, in order
         # to insert a parameter with a given run UUID, the UUID must be present in
         # the runs table
         run = self._run_factory()
         with self.store.ManagedSessionMaker() as session:
             new_param = models.SqlParam(
-                run_uuid=run.info.run_uuid, key='accuracy', value='test param')
+                run_id=run.info.run_id, key='accuracy', value='test param')
             session.add(new_param)
             session.commit()
             params = session.query(models.SqlParam).all()
@@ -251,7 +251,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
             session.add_all([m1, m2, p1, p2])
 
-            run_data = models.SqlRun(run_uuid=uuid.uuid4().hex)
+            run_data = models.SqlRun(run_id=uuid.uuid4().hex)
             run_data.params.append(p1)
             run_data.params.append(p2)
             run_data.metrics.append(m1)
@@ -272,7 +272,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
             'experiment_id': experiment_id,
             'name': 'test run',
             'user_id': 'Anderson',
-            'run_uuid': 'test',
+            'run_id': 'test',
             'status': RunStatus.to_string(RunStatus.SCHEDULED),
             'source_type': SourceType.to_string(SourceType.LOCAL),
             'source_name': 'Python application',
@@ -353,7 +353,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
             name=run_name, experiment_id=experiment_id, parent_run_id=parent_run_id)
 
         created_run = self.store.create_run(**expected)
-        fetched_run = self.store.get_run(created_run.info.run_uuid)
+        fetched_run = self.store.get_run(created_run.info.run_id)
 
         for actual in [created_run, fetched_run]:
             self.assertEqual(actual.info.experiment_id, experiment_id)
@@ -373,16 +373,16 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
     def test_to_mlflow_entity_and_proto(self):
         # Create a run and log metrics, params, tags to the run
         created_run = self._run_factory()
-        run_uuid = created_run.info.run_uuid
+        run_id = created_run.info.run_id
         self.store.log_metric(
-            run_uuid=run_uuid,
+            run_id=run_id,
             metric=entities.Metric(key='my-metric', value=3.4, timestamp=0, step=0))
-        self.store.log_param(run_uuid=run_uuid, param=Param(key='my-param', value='param-val'))
-        self.store.set_tag(run_uuid=run_uuid, tag=RunTag(key='my-tag', value='tag-val'))
+        self.store.log_param(run_id=run_id, param=Param(key='my-param', value='param-val'))
+        self.store.set_tag(run_id=run_id, tag=RunTag(key='my-tag', value='tag-val'))
 
         # Verify that we can fetch the run & convert it to proto - Python protobuf bindings
         # will perform type-checking to ensure all values have the right types
-        run = self.store.get_run(run_uuid)
+        run = self.store.get_run(run_id)
         run.to_proto()
 
         # Verify attributes of the Python run entity
@@ -400,14 +400,14 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
     def test_delete_run(self):
         run = self._run_factory()
 
-        self.store.delete_run(run.info.run_uuid)
+        self.store.delete_run(run.info.run_id)
 
         with self.store.ManagedSessionMaker() as session:
-            actual = session.query(models.SqlRun).filter_by(run_uuid=run.info.run_uuid).first()
+            actual = session.query(models.SqlRun).filter_by(run_id=run.info.run_id).first()
             self.assertEqual(actual.lifecycle_stage, entities.LifecycleStage.DELETED)
 
-            deleted_run = self.store.get_run(run.info.run_uuid)
-            self.assertEqual(actual.run_uuid, deleted_run.info.run_uuid)
+            deleted_run = self.store.get_run(run.info.run_id)
+            self.assertEqual(actual.run_id, deleted_run.info.run_id)
 
     def test_log_metric(self):
         run = self._run_factory()
@@ -416,23 +416,23 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         tval = 100.0
         metric = entities.Metric(tkey, tval, int(time.time()), 0)
         metric2 = entities.Metric(tkey, tval, int(time.time()) + 2, 0)
-        self.store.log_metric(run.info.run_uuid, metric)
-        self.store.log_metric(run.info.run_uuid, metric2)
+        self.store.log_metric(run.info.run_id, metric)
+        self.store.log_metric(run.info.run_id, metric2)
 
-        run = self.store.get_run(run.info.run_uuid)
+        run = self.store.get_run(run.info.run_id)
         self.assertTrue(tkey in run.data.metrics and run.data.metrics[tkey] == tval)
 
         # SQL store _get_run method returns full history of recorded metrics.
         # Should return duplicates as well
         # MLflow RunData contains only the last reported values for metrics.
         with self.store.ManagedSessionMaker() as session:
-            sql_run_metrics = self.store._get_run(session, run.info.run_uuid).metrics
+            sql_run_metrics = self.store._get_run(session, run.info.run_id).metrics
             self.assertEqual(2, len(sql_run_metrics))
             self.assertEqual(1, len(run.data.metrics))
 
     def test_log_metric_allows_multiple_values_at_same_ts_and_run_data_uses_max_ts_value(self):
         run = self._run_factory()
-        run_uuid = run.info.run_uuid
+        run_id = run.info.run_id
         metric_name = "test-metric-1"
         # Check that we get the max of (step, timestamp, value) in that order
         tuples_to_log = [
@@ -446,13 +446,13 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
             (-1, 800, 800),
         ]
         for step, timestamp, value in reversed(tuples_to_log):
-            self.store.log_metric(run_uuid, Metric(metric_name, value, timestamp, step))
+            self.store.log_metric(run_id, Metric(metric_name, value, timestamp, step))
 
-        metric_history = self.store.get_metric_history(run_uuid, metric_name)
+        metric_history = self.store.get_metric_history(run_id, metric_name)
         logged_tuples = [(m.step, m.timestamp, m.value) for m in metric_history]
         assert set(logged_tuples) == set(tuples_to_log)
 
-        run_data = self.store.get_run(run_uuid).data
+        run_data = self.store.get_run(run_id).data
         run_metrics = run_data.metrics
         assert len(run_metrics) == 1
         assert run_metrics[metric_name] == 20
@@ -471,7 +471,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
         warnings.simplefilter("ignore")
         with self.assertRaises(MlflowException) as exception_context, warnings.catch_warnings():
-            self.store.log_metric(run.info.run_uuid, metric)
+            self.store.log_metric(run.info.run_id, metric)
             warnings.resetwarnings()
         assert exception_context.exception.error_code == ErrorCode.Name(INTERNAL_ERROR)
 
@@ -482,11 +482,11 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         tval = '100.0'
         param = entities.Param(tkey, tval)
         param2 = entities.Param('new param', 'new key')
-        self.store.log_param(run.info.run_uuid, param)
-        self.store.log_param(run.info.run_uuid, param2)
-        self.store.log_param(run.info.run_uuid, param2)
+        self.store.log_param(run.info.run_id, param)
+        self.store.log_param(run.info.run_id, param2)
+        self.store.log_param(run.info.run_id, param2)
 
-        run = self.store.get_run(run.info.run_uuid)
+        run = self.store.get_run(run.info.run_id)
         self.assertEqual(2, len(run.data.params))
         self.assertTrue(tkey in run.data.params and run.data.params[tkey] == tval)
 
@@ -497,10 +497,10 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         tval = '100.0'
         param = entities.Param(tkey, tval)
         param2 = entities.Param(tkey, 'newval')
-        self.store.log_param(run.info.run_uuid, param)
+        self.store.log_param(run.info.run_id, param)
 
         with self.assertRaises(MlflowException) as e:
-            self.store.log_param(run.info.run_uuid, param2)
+            self.store.log_param(run.info.run_id, param2)
         self.assertIn("Changing param value is not allowed. Param with key=", e.exception.message)
 
     def test_log_empty_str(self):
@@ -510,10 +510,10 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         tval = ''
         param = entities.Param(tkey, tval)
         param2 = entities.Param('new param', 'new key')
-        self.store.log_param(run.info.run_uuid, param)
-        self.store.log_param(run.info.run_uuid, param2)
+        self.store.log_param(run.info.run_id, param)
+        self.store.log_param(run.info.run_id, param2)
 
-        run = self.store.get_run(run.info.run_uuid)
+        run = self.store.get_run(run.info.run_id)
         self.assertEqual(2, len(run.data.params))
         self.assertTrue(tkey in run.data.params and run.data.params[tkey] == tval)
 
@@ -525,7 +525,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         param = entities.Param(tkey, tval)
 
         with self.assertRaises(MlflowException) as exception_context:
-            self.store.log_param(run.info.run_uuid, param)
+            self.store.log_param(run.info.run_id, param)
         assert exception_context.exception.error_code == ErrorCode.Name(INTERNAL_ERROR)
 
     def test_set_tag(self):
@@ -536,11 +536,11 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         new_val = "new val"
         tag = entities.RunTag(tkey, tval)
         new_tag = entities.RunTag(tkey, new_val)
-        self.store.set_tag(run.info.run_uuid, tag)
+        self.store.set_tag(run.info.run_id, tag)
         # Overwriting tags is allowed
-        self.store.set_tag(run.info.run_uuid, new_tag)
+        self.store.set_tag(run.info.run_id, new_tag)
 
-        run = self.store.get_run(run.info.run_uuid)
+        run = self.store.get_run(run.info.run_id)
         self.assertTrue(tkey in run.data.tags and run.data.tags[tkey] == new_val)
 
     def test_get_metric_history(self):
@@ -553,9 +553,9 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         ]
 
         for metric in expected:
-            self.store.log_metric(run.info.run_uuid, metric)
+            self.store.log_metric(run.info.run_id, metric)
 
-        actual = self.store.get_metric_history(run.info.run_uuid, key)
+        actual = self.store.get_metric_history(run.info.run_id, key)
 
         six.assertCountEqual(self,
                              [(m.key, m.value, m.timestamp) for m in expected],
@@ -563,11 +563,11 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
     def test_list_run_infos(self):
         experiment_id = self._experiment_factory('test_exp')
-        r1 = self._run_factory(config=self._get_run_configs('t1', experiment_id)).info.run_uuid
-        r2 = self._run_factory(config=self._get_run_configs('t2', experiment_id)).info.run_uuid
+        r1 = self._run_factory(config=self._get_run_configs('t1', experiment_id)).info.run_id
+        r2 = self._run_factory(config=self._get_run_configs('t2', experiment_id)).info.run_id
 
         def _runs(experiment_id, view_type):
-            return [r.run_uuid for r in self.store.list_run_infos(experiment_id, view_type)]
+            return [r.run_id for r in self.store.list_run_infos(experiment_id, view_type)]
 
         six.assertCountEqual(self, [r1, r2], _runs(experiment_id, ViewType.ALL))
         six.assertCountEqual(self, [r1, r2], _runs(experiment_id, ViewType.ACTIVE_ONLY))
@@ -593,7 +593,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         new_status = entities.RunStatus.FINISHED
         endtime = int(time.time())
 
-        actual = self.store.update_run_info(run.info.run_uuid, new_status, endtime)
+        actual = self.store.update_run_info(run.info.run_id, new_status, endtime)
 
         self.assertEqual(actual.status, new_status)
         self.assertEqual(actual.end_time, endtime)
@@ -620,57 +620,57 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         self.assertEqual(run.info.lifecycle_stage, entities.LifecycleStage.ACTIVE)
 
         with self.assertRaises(MlflowException) as e:
-            self.store.restore_run(run.info.run_uuid)
+            self.store.restore_run(run.info.run_id)
         self.assertIn("must be in 'deleted' state", e.exception.message)
 
-        self.store.delete_run(run.info.run_uuid)
+        self.store.delete_run(run.info.run_id)
         with self.assertRaises(MlflowException) as e:
-            self.store.delete_run(run.info.run_uuid)
+            self.store.delete_run(run.info.run_id)
         self.assertIn("must be in 'active' state", e.exception.message)
 
-        deleted = self.store.get_run(run.info.run_uuid)
-        self.assertEqual(deleted.info.run_uuid, run.info.run_uuid)
+        deleted = self.store.get_run(run.info.run_id)
+        self.assertEqual(deleted.info.run_id, run.info.run_id)
         self.assertEqual(deleted.info.lifecycle_stage, entities.LifecycleStage.DELETED)
 
-        self.store.restore_run(run.info.run_uuid)
+        self.store.restore_run(run.info.run_id)
         with self.assertRaises(MlflowException) as e:
-            self.store.restore_run(run.info.run_uuid)
+            self.store.restore_run(run.info.run_id)
             self.assertIn("must be in 'deleted' state", e.exception.message)
-        restored = self.store.get_run(run.info.run_uuid)
-        self.assertEqual(restored.info.run_uuid, run.info.run_uuid)
+        restored = self.store.get_run(run.info.run_id)
+        self.assertEqual(restored.info.run_id, run.info.run_id)
         self.assertEqual(restored.info.lifecycle_stage, entities.LifecycleStage.ACTIVE)
 
     def test_error_logging_to_deleted_run(self):
         exp = self._experiment_factory('error_logging')
-        run_uuid = self._run_factory(self._get_run_configs(experiment_id=exp)).info.run_uuid
+        run_id = self._run_factory(self._get_run_configs(experiment_id=exp)).info.run_id
 
-        self.store.delete_run(run_uuid)
-        self.assertEqual(self.store.get_run(run_uuid).info.lifecycle_stage,
+        self.store.delete_run(run_id)
+        self.assertEqual(self.store.get_run(run_id).info.lifecycle_stage,
                          entities.LifecycleStage.DELETED)
         with self.assertRaises(MlflowException) as e:
-            self.store.log_param(run_uuid, entities.Param("p1345", "v1"))
+            self.store.log_param(run_id, entities.Param("p1345", "v1"))
         self.assertIn("must be in 'active' state", e.exception.message)
 
         with self.assertRaises(MlflowException) as e:
-            self.store.log_metric(run_uuid, entities.Metric("m1345", 1.0, 123, 0))
+            self.store.log_metric(run_id, entities.Metric("m1345", 1.0, 123, 0))
         self.assertIn("must be in 'active' state", e.exception.message)
 
         with self.assertRaises(MlflowException) as e:
-            self.store.set_tag(run_uuid, entities.RunTag("t1345", "tv1"))
+            self.store.set_tag(run_id, entities.RunTag("t1345", "tv1"))
         self.assertIn("must be in 'active' state", e.exception.message)
 
         # restore this run and try again
-        self.store.restore_run(run_uuid)
-        self.assertEqual(self.store.get_run(run_uuid).info.lifecycle_stage,
+        self.store.restore_run(run_id)
+        self.assertEqual(self.store.get_run(run_id).info.lifecycle_stage,
                          entities.LifecycleStage.ACTIVE)
-        self.store.log_param(run_uuid, entities.Param("p1345", "v22"))
-        self.store.log_metric(run_uuid, entities.Metric("m1345", 34.0, 85, 1))  # earlier timestamp
-        self.store.set_tag(run_uuid, entities.RunTag("t1345", "tv44"))
+        self.store.log_param(run_id, entities.Param("p1345", "v22"))
+        self.store.log_metric(run_id, entities.Metric("m1345", 34.0, 85, 1))  # earlier timestamp
+        self.store.set_tag(run_id, entities.RunTag("t1345", "tv44"))
 
-        run = self.store.get_run(run_uuid)
+        run = self.store.get_run(run_id)
         self.assertEqual(run.data.params, {"p1345": "v22"})
         self.assertEqual(run.data.metrics, {"m1345": 34.0})
-        metric_history = self.store.get_metric_history(run_uuid, "m1345")
+        metric_history = self.store.get_metric_history(run_id, "m1345")
         self.assertEqual(len(metric_history), 1)
         metric_obj = metric_history[0]
         self.assertEqual(metric_obj.key, "m1345")
@@ -688,7 +688,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         search_runs.anded_expressions.extend(param_expressions or [])
         search_filter = SearchFilter(anded_expressions=search_runs.anded_expressions,
                                      filter_string=filter_string)
-        return [r.info.run_uuid
+        return [r.info.run_id
                 for r in self.store.search_runs([experiment_id], search_filter,
                                                 run_view_type, max_results)]
 
@@ -708,7 +708,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
     def test_search_vanilla(self):
         exp = self._experiment_factory('search_vanilla')
-        runs = [self._run_factory(self._get_run_configs('r_%d' % r, exp)).info.run_uuid
+        runs = [self._run_factory(self._get_run_configs('r_%d' % r, exp)).info.run_id
                 for r in range(3)]
 
         six.assertCountEqual(self, runs, self._search(exp, run_view_type=ViewType.ALL))
@@ -729,8 +729,8 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
     def test_search_params(self):
         experiment_id = self._experiment_factory('search_params')
-        r1 = self._run_factory(self._get_run_configs('r1', experiment_id)).info.run_uuid
-        r2 = self._run_factory(self._get_run_configs('r2', experiment_id)).info.run_uuid
+        r1 = self._run_factory(self._get_run_configs('r1', experiment_id)).info.run_id
+        r2 = self._run_factory(self._get_run_configs('r2', experiment_id)).info.run_id
 
         self.store.log_param(r1, entities.Param('generic_param', 'p_val'))
         self.store.log_param(r2, entities.Param('generic_param', 'p_val'))
@@ -770,8 +770,8 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
     def test_search_tags(self):
         experiment_id = self._experiment_factory('search_tags')
-        r1 = self._run_factory(self._get_run_configs('r1', experiment_id)).info.run_uuid
-        r2 = self._run_factory(self._get_run_configs('r2', experiment_id)).info.run_uuid
+        r1 = self._run_factory(self._get_run_configs('r1', experiment_id)).info.run_id
+        r2 = self._run_factory(self._get_run_configs('r2', experiment_id)).info.run_id
 
         self.store.set_tag(r1, entities.RunTag('generic_tag', 'p_val'))
         self.store.set_tag(r2, entities.RunTag('generic_tag', 'p_val'))
@@ -812,8 +812,8 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
     def test_search_metrics(self):
         experiment_id = self._experiment_factory('search_params')
-        r1 = self._run_factory(self._get_run_configs('r1', experiment_id)).info.run_uuid
-        r2 = self._run_factory(self._get_run_configs('r2', experiment_id)).info.run_uuid
+        r1 = self._run_factory(self._get_run_configs('r1', experiment_id)).info.run_id
+        r2 = self._run_factory(self._get_run_configs('r2', experiment_id)).info.run_id
 
         self.store.log_metric(r1, entities.Metric("common", 1.0, 1, 0))
         self.store.log_metric(r2, entities.Metric("common", 1.0, 1, 0))
@@ -890,8 +890,8 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
     def test_search_full(self):
         experiment_id = self._experiment_factory('search_params')
-        r1 = self._run_factory(self._get_run_configs('r1', experiment_id)).info.run_uuid
-        r2 = self._run_factory(self._get_run_configs('r2', experiment_id)).info.run_uuid
+        r1 = self._run_factory(self._get_run_configs('r1', experiment_id)).info.run_id
+        r2 = self._run_factory(self._get_run_configs('r2', experiment_id)).info.run_id
 
         self.store.log_param(r1, entities.Param('generic_param', 'p_val'))
         self.store.log_param(r2, entities.Param('generic_param', 'p_val'))
@@ -940,7 +940,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
     def test_search_with_max_results(self):
         exp = self._experiment_factory('search_with_max_results')
         runs = [self._run_factory(self._get_run_configs('r_%d' % r, exp,
-                                                        start_time=r)).info.run_uuid
+                                                        start_time=r)).info.run_id
                 for r in range(1200)]
         # reverse the ordering, since we created in increasing order of start_time
         runs.reverse()
@@ -956,26 +956,26 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
     def test_search_with_deterministic_max_results(self):
         exp = self._experiment_factory('test_search_with_deterministic_max_results')
         # Create 10 runs with the same start_time.
-        # Sort based on run_uuid
+        # Sort based on run_id
         runs = sorted([self._run_factory(self._get_run_configs('r_%d' % r, exp,
-                                                               start_time=10)).info.run_uuid
+                                                               start_time=10)).info.run_id
                        for r in range(10)])
         for n in [0, 1, 2, 4, 8, 10, 20]:
             assert(runs[:min(10, n)] == self._search(exp, max_results=n))
 
     def test_log_batch(self):
         experiment_id = self._experiment_factory('log_batch')
-        run_uuid = self._run_factory(self._get_run_configs('r1', experiment_id)).info.run_uuid
+        run_id = self._run_factory(self._get_run_configs('r1', experiment_id)).info.run_id
         metric_entities = [Metric("m1", 0.87, 12345, 0), Metric("m2", 0.49, 12345, 1)]
         param_entities = [Param("p1", "p1val"), Param("p2", "p2val")]
         tag_entities = [RunTag("t1", "t1val"), RunTag("t2", "t2val")]
         self.store.log_batch(
-            run_id=run_uuid, metrics=metric_entities, params=param_entities, tags=tag_entities)
-        run = self.store.get_run(run_uuid)
+            run_id=run_id, metrics=metric_entities, params=param_entities, tags=tag_entities)
+        run = self.store.get_run(run_id)
         assert run.data.tags == {"t1": "t1val", "t2": "t2val", MLFLOW_RUN_NAME: "r1"}
         assert run.data.params == {"p1": "p1val", "p2": "p2val"}
         metric_histories = sum(
-            [self.store.get_metric_history(run_uuid, key) for key in run.data.metrics], [])
+            [self.store.get_metric_history(run_id, key) for key in run.data.metrics], [])
         metrics = [(m.key, m.value, m.timestamp, m.step) for m in metric_histories]
         assert set(metrics) == set([("m1", 0.87, 12345, 0), ("m2", 0.49, 12345, 1)])
 
@@ -983,13 +983,13 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         # Test that log batch at the maximum allowed request size succeeds (i.e doesn't hit
         # SQL limitations, etc)
         experiment_id = self._experiment_factory('log_batch_limits')
-        run_uuid = self._run_factory(self._get_run_configs('r1', experiment_id)).info.run_uuid
+        run_id = self._run_factory(self._get_run_configs('r1', experiment_id)).info.run_id
         metric_tuples = [("m%s" % i, i, 12345, i * 2) for i in range(1000)]
         metric_entities = [Metric(*metric_tuple) for metric_tuple in metric_tuples]
-        self.store.log_batch(run_id=run_uuid, metrics=metric_entities, params=[], tags=[])
-        run = self.store.get_run(run_uuid)
+        self.store.log_batch(run_id=run_id, metrics=metric_entities, params=[], tags=[])
+        run = self.store.get_run(run_id)
         metric_histories = sum(
-            [self.store.get_metric_history(run_uuid, key) for key in run.data.metrics], [])
+            [self.store.get_metric_history(run_id, key) for key in run.data.metrics], [])
         metrics = [(m.key, m.value, m.timestamp, m.step) for m in metric_histories]
         assert set(metrics) == set(metric_tuples)
 
@@ -999,17 +999,17 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         run = self._run_factory()
         tkey = 'my-param'
         param = entities.Param(tkey, 'orig-val')
-        self.store.log_param(run.info.run_uuid, param)
+        self.store.log_param(run.info.run_id, param)
 
         overwrite_param = entities.Param(tkey, 'newval')
         tag = entities.RunTag("tag-key", "tag-val")
         metric = entities.Metric("metric-key", 3.0, 12345, 0)
         with self.assertRaises(MlflowException) as e:
-            self.store.log_batch(run.info.run_uuid, metrics=[metric], params=[overwrite_param],
+            self.store.log_batch(run.info.run_id, metrics=[metric], params=[overwrite_param],
                                  tags=[tag])
         self.assertIn("Changing param value is not allowed. Param with key=", e.exception.message)
         assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        self._verify_logged(run.info.run_uuid, metrics=[], params=[param], tags=[])
+        self._verify_logged(run.info.run_id, metrics=[], params=[param], tags=[])
 
     def test_log_batch_param_overwrite_disallowed_single_req(self):
         # Test that attempting to overwrite a param via log_batch results in an exception
@@ -1020,16 +1020,16 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
         tag = entities.RunTag("tag-key", "tag-val")
         metric = entities.Metric("metric-key", 3.0, 12345, 0)
         with self.assertRaises(MlflowException) as e:
-            self.store.log_batch(run.info.run_uuid, metrics=[metric], params=[param0, param1],
+            self.store.log_batch(run.info.run_id, metrics=[metric], params=[param0, param1],
                                  tags=[tag])
         self.assertIn("Changing param value is not allowed. Param with key=", e.exception.message)
         assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        self._verify_logged(run.info.run_uuid, metrics=[], params=[param0], tags=[])
+        self._verify_logged(run.info.run_id, metrics=[], params=[param0], tags=[])
 
     def test_log_batch_accepts_empty_payload(self):
         run = self._run_factory()
-        self.store.log_batch(run.info.run_uuid, metrics=[], params=[], tags=[])
-        self._verify_logged(run.info.run_uuid, metrics=[], params=[], tags=[])
+        self.store.log_batch(run.info.run_id, metrics=[], params=[], tags=[])
+        self._verify_logged(run.info.run_id, metrics=[], params=[], tags=[])
 
     def test_log_batch_internal_error(self):
         # Verify that internal errors during the DB save step for log_batch result in
@@ -1050,59 +1050,59 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
                 log_batch_kwargs = {"metrics": [], "params": [], "tags": []}
                 log_batch_kwargs.update(kwargs)
                 with self.assertRaises(MlflowException) as e:
-                    self.store.log_batch(run.info.run_uuid, **log_batch_kwargs)
+                    self.store.log_batch(run.info.run_id, **log_batch_kwargs)
                 self.assertIn(str(e.exception.message), "Some internal error")
 
     def test_log_batch_nonexistent_run(self):
-        nonexistent_run_uuid = uuid.uuid4().hex
+        nonexistent_run_id = uuid.uuid4().hex
         with self.assertRaises(MlflowException) as e:
-            self.store.log_batch(nonexistent_run_uuid, [], [], [])
+            self.store.log_batch(nonexistent_run_id, [], [], [])
         assert e.exception.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
-        assert "Run with id=%s not found" % nonexistent_run_uuid in e.exception.message
+        assert "Run with id=%s not found" % nonexistent_run_id in e.exception.message
 
     def test_log_batch_params_idempotency(self):
         run = self._run_factory()
         params = [Param("p-key", "p-val")]
-        self.store.log_batch(run.info.run_uuid, metrics=[], params=params, tags=[])
-        self.store.log_batch(run.info.run_uuid, metrics=[], params=params, tags=[])
-        self._verify_logged(run.info.run_uuid, metrics=[], params=params, tags=[])
+        self.store.log_batch(run.info.run_id, metrics=[], params=params, tags=[])
+        self.store.log_batch(run.info.run_id, metrics=[], params=params, tags=[])
+        self._verify_logged(run.info.run_id, metrics=[], params=params, tags=[])
 
     def test_log_batch_tags_idempotency(self):
         run = self._run_factory()
         self.store.log_batch(
-            run.info.run_uuid, metrics=[], params=[], tags=[RunTag("t-key", "t-val")])
+            run.info.run_id, metrics=[], params=[], tags=[RunTag("t-key", "t-val")])
         self.store.log_batch(
-            run.info.run_uuid, metrics=[], params=[], tags=[RunTag("t-key", "t-val")])
+            run.info.run_id, metrics=[], params=[], tags=[RunTag("t-key", "t-val")])
         self._verify_logged(
-            run.info.run_uuid, metrics=[], params=[], tags=[RunTag("t-key", "t-val")])
+            run.info.run_id, metrics=[], params=[], tags=[RunTag("t-key", "t-val")])
 
     def test_log_batch_allows_tag_overwrite(self):
         run = self._run_factory()
         self.store.log_batch(
-            run.info.run_uuid, metrics=[], params=[], tags=[RunTag("t-key", "val")])
+            run.info.run_id, metrics=[], params=[], tags=[RunTag("t-key", "val")])
         self.store.log_batch(
-            run.info.run_uuid, metrics=[], params=[], tags=[RunTag("t-key", "newval")])
+            run.info.run_id, metrics=[], params=[], tags=[RunTag("t-key", "newval")])
         self._verify_logged(
-            run.info.run_uuid, metrics=[], params=[], tags=[RunTag("t-key", "newval")])
+            run.info.run_id, metrics=[], params=[], tags=[RunTag("t-key", "newval")])
 
     def test_log_batch_allows_tag_overwrite_single_req(self):
         run = self._run_factory()
         tags = [RunTag("t-key", "val"), RunTag("t-key", "newval")]
-        self.store.log_batch(run.info.run_uuid, metrics=[], params=[], tags=tags)
-        self._verify_logged(run.info.run_uuid, metrics=[], params=[], tags=[tags[-1]])
+        self.store.log_batch(run.info.run_id, metrics=[], params=[], tags=tags)
+        self._verify_logged(run.info.run_id, metrics=[], params=[], tags=[tags[-1]])
 
     def test_log_batch_same_metric_repeated_single_req(self):
         run = self._run_factory()
         metric0 = Metric(key="metric-key", value=1, timestamp=2, step=0)
         metric1 = Metric(key="metric-key", value=2, timestamp=3, step=0)
-        self.store.log_batch(run.info.run_uuid, params=[], metrics=[metric0, metric1], tags=[])
-        self._verify_logged(run.info.run_uuid, params=[], metrics=[metric0, metric1], tags=[])
+        self.store.log_batch(run.info.run_id, params=[], metrics=[metric0, metric1], tags=[])
+        self._verify_logged(run.info.run_id, params=[], metrics=[metric0, metric1], tags=[])
 
     def test_log_batch_same_metric_repeated_multiple_reqs(self):
         run = self._run_factory()
         metric0 = Metric(key="metric-key", value=1, timestamp=2, step=0)
         metric1 = Metric(key="metric-key", value=2, timestamp=3, step=0)
-        self.store.log_batch(run.info.run_uuid, params=[], metrics=[metric0], tags=[])
-        self._verify_logged(run.info.run_uuid, params=[], metrics=[metric0], tags=[])
-        self.store.log_batch(run.info.run_uuid, params=[], metrics=[metric1], tags=[])
-        self._verify_logged(run.info.run_uuid, params=[], metrics=[metric0, metric1], tags=[])
+        self.store.log_batch(run.info.run_id, params=[], metrics=[metric0], tags=[])
+        self._verify_logged(run.info.run_id, params=[], metrics=[metric0], tags=[])
+        self.store.log_batch(run.info.run_id, params=[], metrics=[metric1], tags=[])
+        self._verify_logged(run.info.run_id, params=[], metrics=[metric0, metric1], tags=[])

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -251,7 +251,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
 
             session.add_all([m1, m2, p1, p2])
 
-            run_data = models.SqlRun(run_id=uuid.uuid4().hex)
+            run_data = models.SqlRun(run_uuid=uuid.uuid4().hex)
             run_data.params.append(p1)
             run_data.params.append(p2)
             run_data.metrics.append(m1)
@@ -407,7 +407,7 @@ class TestSqlAlchemyStoreSqliteInMemory(unittest.TestCase):
             self.assertEqual(actual.lifecycle_stage, entities.LifecycleStage.DELETED)
 
             deleted_run = self.store.get_run(run.info.run_id)
-            self.assertEqual(actual.run_id, deleted_run.info.run_id)
+            self.assertEqual(actual.run_uuid, deleted_run.info.run_id)
 
     def test_log_metric(self):
         run = self._run_factory()

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -303,7 +303,7 @@ def test_log_and_load_model_persists_and_restores_model_successfully(saved_tf_ir
                                     tf_signature_def_key=saved_tf_iris_model.signature_def_key,
                                     artifact_path=artifact_path)
 
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
 
     tf_graph = tf.Graph()
     tf_sess = tf.Session(graph=tf_graph)
@@ -369,7 +369,7 @@ def test_log_model_persists_specified_conda_env_in_mlflow_model_directory(
                                     tf_signature_def_key=saved_tf_iris_model.signature_def_key,
                                     artifact_path=artifact_path,
                                     conda_env=tf_custom_env)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = _get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -411,7 +411,7 @@ def test_log_model_without_specified_conda_env_uses_default_env_with_expected_de
                                     tf_signature_def_key=saved_tf_iris_model.signature_def_key,
                                     artifact_path=artifact_path,
                                     conda_env=None)
-        run_id = mlflow.active_run().info.run_uuid
+        run_id = mlflow.active_run().info.run_id
     model_path = _get_model_log_dir(artifact_path, run_id)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -350,7 +350,7 @@ def test_start_run_with_parent():
         mlflow_tags.MLFLOW_SOURCE_TYPE: SourceType.to_string(source_type),
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version,
         mlflow_tags.MLFLOW_PROJECT_ENTRY_POINT: mock_entry_point_name,
-        mlflow_tags.MLFLOW_PARENT_RUN_ID: parent_run.info.run_uuid
+        mlflow_tags.MLFLOW_PARENT_RUN_ID: parent_run.info.run_id
     }
 
     create_run_patch = mock.patch.object(MlflowClient, "create_run")

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -228,6 +228,7 @@ def test_create_run_all_args(mlflow_client, parent_run_id_kwarg):
 
     run = mlflow_client.get_run(run_id)
     assert run.info.run_id == run_id
+    assert run.info.run_uuid == run_id
     assert run.info.experiment_id == experiment_id
     assert run.info.user_id == create_run_kwargs["user_id"]
     assert run.info.source_type == SOURCE_TYPE_LOCAL

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -223,11 +223,11 @@ def test_create_run_all_args(mlflow_client, parent_run_id_kwarg):
     experiment_id = mlflow_client.create_experiment('Run A Lot (parent_run_id=%s)'
                                                     % (parent_run_id_kwarg))
     created_run = mlflow_client.create_run(experiment_id, **create_run_kwargs)
-    run_id = created_run.info.run_uuid
+    run_id = created_run.info.run_id
     print("Run id=%s" % run_id)
 
     run = mlflow_client.get_run(run_id)
-    assert run.info.run_uuid == run_id
+    assert run.info.run_id == run_id
     assert run.info.experiment_id == experiment_id
     assert run.info.user_id == create_run_kwargs["user_id"]
     assert run.info.source_type == SOURCE_TYPE_LOCAL
@@ -245,9 +245,9 @@ def test_create_run_all_args(mlflow_client, parent_run_id_kwarg):
 def test_create_run_defaults(mlflow_client):
     experiment_id = mlflow_client.create_experiment('Run A Little')
     created_run = mlflow_client.create_run(experiment_id)
-    run_id = created_run.info.run_uuid
+    run_id = created_run.info.run_id
     run = mlflow_client.get_run(run_id)
-    assert run.info.run_uuid == run_id
+    assert run.info.run_id == run_id
     assert run.info.experiment_id == experiment_id
     assert run.info.user_id is not None  # we should pick some default
 
@@ -255,7 +255,7 @@ def test_create_run_defaults(mlflow_client):
 def test_log_metrics_params_tags(mlflow_client, backend_store_uri):
     experiment_id = mlflow_client.create_experiment('Oh My')
     created_run = mlflow_client.create_run(experiment_id)
-    run_id = created_run.info.run_uuid
+    run_id = created_run.info.run_id
     mlflow_client.log_metric(run_id, key='metric', value=123.456, timestamp=789, step=2)
     mlflow_client.log_metric(run_id, key='stepless-metric', value=987.654, timestamp=321)
     mlflow_client.log_param(run_id, 'param', 'value')
@@ -284,7 +284,7 @@ def test_log_metrics_params_tags(mlflow_client, backend_store_uri):
 def test_log_batch(mlflow_client, backend_store_uri):
     experiment_id = mlflow_client.create_experiment('Batch em up')
     created_run = mlflow_client.create_run(experiment_id)
-    run_id = created_run.info.run_uuid
+    run_id = created_run.info.run_id
     mlflow_client.log_batch(
         run_id=run_id,
         metrics=[Metric("metric", 123.456, 789, 3)], params=[Param("param", "value")],
@@ -305,7 +305,7 @@ def test_log_batch(mlflow_client, backend_store_uri):
 def test_set_terminated_defaults(mlflow_client):
     experiment_id = mlflow_client.create_experiment('Terminator 1')
     created_run = mlflow_client.create_run(experiment_id)
-    run_id = created_run.info.run_uuid
+    run_id = created_run.info.run_id
     assert RunStatus.to_string(mlflow_client.get_run(run_id).info.status) == 'RUNNING'
     assert mlflow_client.get_run(run_id).info.end_time is None
     mlflow_client.set_terminated(run_id)
@@ -316,7 +316,7 @@ def test_set_terminated_defaults(mlflow_client):
 def test_set_terminated_status(mlflow_client):
     experiment_id = mlflow_client.create_experiment('Terminator 2')
     created_run = mlflow_client.create_run(experiment_id)
-    run_id = created_run.info.run_uuid
+    run_id = created_run.info.run_id
     assert RunStatus.to_string(mlflow_client.get_run(run_id).info.status) == 'RUNNING'
     assert mlflow_client.get_run(run_id).info.end_time is None
     mlflow_client.set_terminated(run_id, 'FAILED')
@@ -327,7 +327,7 @@ def test_set_terminated_status(mlflow_client):
 def test_artifacts(mlflow_client):
     experiment_id = mlflow_client.create_experiment('Art In Fact')
     created_run = mlflow_client.create_run(experiment_id)
-    run_id = created_run.info.run_uuid
+    run_id = created_run.info.run_id
     src_dir = tempfile.mkdtemp('test_artifacts_src')
     src_file = os.path.join(src_dir, 'my.file')
     with open(src_file, 'w') as f:

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -193,10 +193,10 @@ def test_invalid_clauses(filter_string, error_message):
 ])
 def test_bad_comparators(entity_type, bad_comparators, entity_value):
     run = Run(run_info=RunInfo(
-        run_uuid="hi", experiment_id=0, name="name", source_type=SourceType.PROJECT,
-        source_name="source-name", entry_point_name="entry-point-name",
-        user_id="user-id", status=RunStatus.FAILED, start_time=0, end_time=1,
-        source_version="version", lifecycle_stage=LifecycleStage.ACTIVE),
+        run_uuid="hi", run_id="hi", experiment_id=0, name="name",
+        source_type=SourceType.PROJECT, source_name="source-name",
+        entry_point_name="entry-point-name", user_id="user-id", status=RunStatus.FAILED,
+        start_time=0, end_time=1, source_version="version", lifecycle_stage=LifecycleStage.ACTIVE),
         run_data=RunData(metrics=[], params=[], tags=[])
     )
     for bad_comparator in bad_comparators:


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
In preparation for MLflow 1.0, we wanted to address an inconsistency in how we name `run_id` in our API. In some places, we call it `run_id` and others `run_uuid`. `run_uuid` is actually more common in our codebase, but we felt that the "uuid" portion is more of an implementation detail that users do not need to concern themselves with. As a result, this PR changes these instances to `run_id`.

We want to maintain a 1-version REST API backwards-compatibility guarantee between clients and servers. Doing this requires a few intermediate changes:

- REST APIs which took run_uuid now take both run_uuid and run_id. run_uuid is deprecated.
- Backends (ei.g., file store, sqlalchemy store) which used to handle run_uuid now accept either run_id or run_uuid (preferring the first). This allows old clients to keep operating with new servers.
- Our Python, Java, and R clients which interact with the server will set both run_id and run_uuid. This allows new clients to operate with old servers.

After MLflow 1.1, we can remove the extra properties in the clients and servers, and drop the deprecated fields from the REST API.

TODO:
  - [x] R API update (will happen in this PR)
  - JavaScript update (can happen in a subsequent PR, as JavaScript is generally coversioned with server)
 
## How is this patch tested?
 
- [x] Existing unit tests.
- [x] Forthcoming: manual tests to confirm backwards-compatibility of file store format, sqlalchemy store, and REST API compatibility of old clients/new servers and new servers/old clients.

My manual test included creating runs in both the file store and sqlalchemy store on 0.9.1. I then ran search, get_run, and create_run from a new client pointed at the old servers, and confirmed this work.

Subsequently, I upgraded my server version to this PR (including running the alembic migration over the sqlalchemy store in #1155), and confirmed that file store & sqlalchemy store could continue to search, get_run, and create_run from the _old_ client in 0.9.1. I also tried the REST API directly and confirmed that providing either `run_uuid` or `run_id` to /runs/get worked -- not entirely comprehensive, but at least confirms the process is valid end-to-end.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
run_uuid has been renamed to run_id in the Python, Java, R, and REST APIs. Where necessary, MLflow will continue to accept run_uuid until MLflow 1.1.
 
### What component(s) does this PR affect?
 
- [x] API 
- [x] REST-API
- [x] Tracking
- [x] R
- [x] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
