### PR TITLE
[Runs URI][Python] changes in "models" methods

### DIFF
--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -170,6 +170,7 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see the
                       `Artifacts Documentation <https://www.mlflow.org/docs/latest/tracking.html#
                       supported-artifact-stores>`_.
+
     :return: An `H2OEstimator model object 
              <http://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/intro.html#models>`_.
     """

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -171,7 +171,7 @@ def load_model(model_uri):
                       `Artifacts Documentation <https://www.mlflow.org/docs/latest/tracking.html#
                       supported-artifact-stores>`_.
 
-    :return: An `H2OEstimator model object 
+    :return: An `H2OEstimator model object
              <http://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/intro.html#models>`_.
     """
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -15,9 +15,10 @@ import yaml
 
 import h2o
 
+import mlflow
 from mlflow import pyfunc
 from mlflow.models import Model
-import mlflow.tracking
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 
@@ -148,24 +149,31 @@ class _H2OModelWrapper:
 def _load_pyfunc(path):
     """
     Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
+
+    :param path: Local filesystem path to the MLflow Model with the ``h2o`` flavor.
     """
     return _H2OModelWrapper(_load_model(path, init=True))
 
 
-def load_model(path, run_id=None):
+def load_model(model_uri):
     """
     Load an H2O model from a local file (if ``run_id`` is ``None``) or a run.
     This function expects there is an H2O instance initialised with ``h2o.init``.
 
-    :param path: Local filesystem path or run-relative artifact path to the model saved
-                 by :py:func:`mlflow.h2o.save_model`.
-    :param run_id: Run ID. If provided, combined with ``path`` to identify the model.
+    :param model_uri: The location, in URI format, of the MLflow model, for example:
+
+                      - ``/Users/me/path/to/local/model``
+                      - ``relative/path/to/local/model``
+                      - ``s3://my_bucket/path/to/model``
+                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+
+                      For more information about supported URI schemes, see the
+                      `Artifacts Documentation <https://www.mlflow.org/docs/latest/tracking.html#
+                      supported-artifact-stores>`_.
     """
-    if run_id is not None:
-        path = mlflow.tracking.artifact_utils._get_model_log_dir(model_name=path, run_id=run_id)
-    path = os.path.abspath(path)
-    flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     # Flavor configurations for models saved in MLflow version <= 0.8.0 may not contain a
     # `data` key; in this case, we assume the model artifact path to be `model.h2o`
-    h2o_model_file_path = os.path.join(path, flavor_conf.get("data", "model.h2o"))
+    h2o_model_file_path = os.path.join(local_model_path, flavor_conf.get("data", "model.h2o"))
     return _load_model(path=h2o_model_file_path)

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -170,6 +170,8 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see the
                       `Artifacts Documentation <https://www.mlflow.org/docs/latest/tracking.html#
                       supported-artifact-stores>`_.
+    :return: An `H2OEstimator model object 
+             <http://docs.h2o.ai/h2o/latest-stable/h2o-py/docs/intro.html#models>`_.
     """
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -21,6 +21,7 @@ import tensorflow as tf
 from mlflow import pyfunc
 from mlflow.models import Model
 import mlflow.tracking
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 
@@ -171,6 +172,8 @@ class _KerasModelWrapper:
 def _load_pyfunc(model_file):
     """
     Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
+
+    :param path: Local filesystem path to the MLflow Model with the ``keras`` flavor.
     """
     if K._BACKEND == 'tensorflow':
         graph = tf.Graph()
@@ -187,23 +190,28 @@ def _load_pyfunc(model_file):
         raise Exception("Unsupported backend '%s'" % K._BACKEND)
 
 
-def load_model(path, run_id=None):
+def load_model(model_uri):
     """
     Load a Keras model from a local file (if ``run_id`` is None) or a run.
 
-    :param path: Local filesystem path or run-relative artifact path to the model saved
-                 by :py:func:`mlflow.keras.log_model`.
-    :param run_id: Run ID. If provided, combined with ``path`` to identify the model.
+    :param model_uri: The location, in URI format, of the MLflow model, for example:
+
+                      - ``/Users/me/path/to/local/model``
+                      - ``relative/path/to/local/model``
+                      - ``s3://my_bucket/path/to/model``
+                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+
+                      For more information about supported URI schemes, see the
+                      `Artifacts Documentation <https://www.mlflow.org/docs/latest/tracking.html#
+                      supported-artifact-stores>`_.
 
     >>> # Load persisted model as a Keras model or as a PyFunc, call predict() on a Pandas DataFrame
     >>> keras_model = mlflow.keras.load_model("models", run_id="96771d893a5e46159d9f3b49bf9013e2")
     >>> predictions = keras_model.predict(x_test)
     """
-    if run_id is not None:
-        path = mlflow.tracking.artifact_utils._get_model_log_dir(model_name=path, run_id=run_id)
-    path = os.path.abspath(path)
-    flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     # Flavor configurations for models saved in MLflow version <= 0.8.0 may not contain a
     # `data` key; in this case, we assume the model artifact path to be `model.h5`
-    keras_model_artifacts_path = os.path.join(path, flavor_conf.get("data", "model.h5"))
+    keras_model_artifacts_path = os.path.join(local_model_path, flavor_conf.get("data", "model.h5"))
     return _load_model(model_file=keras_model_artifacts_path)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -169,7 +169,7 @@ class _KerasModelWrapper:
         return predicted
 
 
-def _load_pyfunc(model_file):
+def _load_pyfunc(path):
     """
     Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
 
@@ -184,7 +184,7 @@ def _load_pyfunc(model_file):
         with graph.as_default():
             with sess.as_default():  # pylint:disable=not-context-manager
                 K.set_learning_phase(0)
-                m = _load_model(model_file)
+                m = _load_model(path)
         return _KerasModelWrapper(m, graph, sess)
     else:
         raise Exception("Unsupported backend '%s'" % K._BACKEND)
@@ -204,6 +204,8 @@ def load_model(model_uri):
                       For more information about supported URI schemes, see the
                       `Artifacts Documentation <https://www.mlflow.org/docs/latest/tracking.html#
                       supported-artifact-stores>`_.
+
+    :return: A Keras model instance.
 
     >>> # Load persisted model as a Keras model or as a PyFunc, call predict() on a Pandas DataFrame
     >>> keras_model = mlflow.keras.load_model("models", run_id="96771d893a5e46159d9f3b49bf9013e2")

--- a/mlflow/pyfunc/cli.py
+++ b/mlflow/pyfunc/cli.py
@@ -11,7 +11,7 @@ import pandas
 
 from mlflow.projects import _get_conda_bin_executable, _get_or_create_conda_env
 from mlflow.pyfunc import load_pyfunc, scoring_server, _load_model_env
-from mlflow.tracking.artifact_utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils import cli_args
 
 
@@ -45,58 +45,48 @@ def commands():
 
 
 @commands.command("serve")
-@cli_args.MODEL_PATH
-@cli_args.RUN_ID
+@cli_args.MODEL_URI
 @click.option("--port", "-p", default=5000, help="Server port. [default: 5000]")
 @click.option("--host", "-h", default="127.0.0.1", help="Server host. [default: 127.0.0.1]")
 @cli_args.NO_CONDA
-def serve(model_path, run_id, port, host, no_conda):
+def serve(model_uri, port, host, no_conda):
     """
     Serve a pyfunc model saved with MLflow by launching a webserver on the specified
     host and port. For information about the input data formats accepted by the webserver,
     see the following documentation:
     https://www.mlflow.org/docs/latest/models.html#pyfunc-deployment.
-
-    If a ``run_id`` is specified, ``model-path`` is treated as an artifact path within that run;
-    otherwise it is treated as a local path.
     """
-    if run_id:
-        model_path = _get_model_log_dir(model_path, run_id)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
 
-    model_env_file = _load_model_env(model_path)
+    model_env_file = _load_model_env(path=local_model_path)
     if not no_conda and model_env_file is not None:
-        conda_env_path = os.path.join(model_path, model_env_file)
+        conda_env_path = os.path.join(local_model_path, model_env_file)
         return _rerun_in_conda(conda_env_path)
 
-    app = scoring_server.init(load_pyfunc(model_path))
+    app = scoring_server.init(load_pyfunc(local_model_path))
     app.run(port=port, host=host)
 
 
 @commands.command("predict")
-@cli_args.MODEL_PATH
-@cli_args.RUN_ID
+@cli_args.MODEL_URI
 @click.option("--input-path", "-i", help="CSV containing pandas DataFrame to predict against.",
               required=True)
 @click.option("--output-path", "-o", help="File to output results to as CSV file." +
                                           " If not provided, output to stdout.")
 @cli_args.NO_CONDA
-def predict(model_path, run_id, input_path, output_path, no_conda):
+def predict(model_uri, input_path, output_path, no_conda):
     """
     Load a pandas DataFrame and runs a python_function model saved with MLflow against it.
     Return the prediction results as a CSV-formatted pandas DataFrame.
-
-    If a ``run-id`` is specified, ``model-path`` is treated as an artifact path within that run;
-    otherwise it is treated as a local path.
     """
-    if run_id:
-        model_path = _get_model_log_dir(model_path, run_id)
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
 
-    model_env_file = _load_model_env(model_path)
+    model_env_file = _load_model_env(path=local_model_path)
     if not no_conda and model_env_file is not None:
-        conda_env_path = os.path.join(model_path, model_env_file)
+        conda_env_path = os.path.join(local_model_path, model_env_file)
         return _rerun_in_conda(conda_env_path)
 
-    model = load_pyfunc(model_path)
+    model = load_pyfunc(local_model_path)
     df = pandas.read_csv(input_path)
     result = model.predict(df)
     out_stream = sys.stdout

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -308,6 +308,7 @@ def load_model(model_uri, **kwargs):
                       supported-artifact-stores>`_.
 
     :param kwargs: kwargs to pass to ``torch.load`` method.
+    :return: A PyTorch model.
 
     >>> import torch
     >>> import mlflow

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -21,13 +21,14 @@ import pandas as pd
 import torch
 import torchvision
 
+import mlflow
 import mlflow.pyfunc.utils as pyfunc_utils
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.pytorch import pickle_module as mlflow_pytorch_pickle_module
-import mlflow.tracking
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import _copy_file_or_tree
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -285,13 +286,21 @@ def _load_model(path, **kwargs):
     return torch.load(model_path, **kwargs)
 
 
-def load_model(path, run_id=None, **kwargs):
+def load_model(model_uri, **kwargs):
     """
     Load a PyTorch model from a local file (if ``run_id`` is ``None``) or a run.
 
-    :param path: Local filesystem path or run-relative artifact path to the model saved
-                 by :py:func:`mlflow.pytorch.log_model`.
-    :param run_id: Run ID. If provided, combined with ``path`` to identify the model.
+    :param model_uri: The location, in URI format, of the MLflow model, for example:
+
+                      - ``/Users/me/path/to/local/model``
+                      - ``relative/path/to/local/model``
+                      - ``s3://my_bucket/path/to/model``
+                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+
+                      For more information about supported URI schemes, see the
+                      `Artifacts Documentation <https://www.mlflow.org/docs/latest/tracking.html#
+                      supported-artifact-stores>`_.
+
     :param kwargs: kwargs to pass to ``torch.load`` method.
 
     >>> import torch
@@ -303,30 +312,31 @@ def load_model(path, run_id=None, **kwargs):
     >>> pytorch_model = mlflow.pytorch.load_model(model_path_dir, run_id)
     >>> y_pred = pytorch_model(x_new_data)
     """
-    if run_id is not None:
-        path = mlflow.tracking.artifact_utils._get_model_log_dir(model_name=path, run_id=run_id)
-    path = os.path.abspath(path)
-
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
     try:
-        pyfunc_conf = _get_flavor_configuration(model_path=path, flavor_name=pyfunc.FLAVOR_NAME)
+        pyfunc_conf = _get_flavor_configuration(
+            model_path=local_model_path, flavor_name=pyfunc.FLAVOR_NAME)
     except MlflowException:
         pyfunc_conf = {}
     code_subpath = pyfunc_conf.get(pyfunc.CODE)
     if code_subpath is not None:
-        pyfunc_utils._add_code_to_system_path(code_path=os.path.join(path, code_subpath))
+        pyfunc_utils._add_code_to_system_path(
+            code_path=os.path.join(local_model_path, code_subpath))
 
-    pytorch_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
+    pytorch_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     if torch.__version__ != pytorch_conf["pytorch_version"]:
         _logger.warning(
             "Stored model version '%s' does not match installed PyTorch version '%s'",
             pytorch_conf["pytorch_version"], torch.__version__)
-    torch_model_artifacts_path = os.path.join(path, pytorch_conf['model_data'])
+    torch_model_artifacts_path = os.path.join(local_model_path, pytorch_conf['model_data'])
     return _load_model(path=torch_model_artifacts_path, **kwargs)
 
 
 def _load_pyfunc(path, **kwargs):
     """
     Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
+
+    :param path: Local filesystem path to the MLflow Model with the ``pytorch`` flavor.
     """
     return _PyTorchWrapper(_load_model(path, **kwargs))
 

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -244,6 +244,8 @@ def load_model(model_uri):
                       `Artifacts Documentation <https://www.mlflow.org/docs/latest/tracking.html#
                       supported-artifact-stores>`_.
 
+    :return: A scikit-learn model.
+
     >>> import mlflow.sklearn
     >>> sk_model = mlflow.sklearn.load_model("sk_models", run_id="96771d893a5e46159d9f3b49bf9013e2")
     >>> #use Pandas DataFrame to make predictions

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -18,12 +18,13 @@ import copy
 
 import sklearn
 
+import mlflow
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, INTERNAL_ERROR
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
-import mlflow.tracking
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 
@@ -201,9 +202,10 @@ def _load_model_from_local_file(path):
 def _load_pyfunc(path):
     """
     Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
+
+    :param path: Local filesystem path to the MLflow Model with the ``sklearn`` flavor.
     """
-    with open(path, "rb") as f:
-        return pickle.load(f)
+    return _load_model_from_local_file(path)
 
 
 def _save_model(sk_model, output_path, serialization_format):
@@ -227,13 +229,20 @@ def _save_model(sk_model, output_path, serialization_format):
                     error_code=INTERNAL_ERROR)
 
 
-def load_model(path, run_id=None):
+def load_model(model_uri):
     """
     Load a scikit-learn model from a local file (if ``run_id`` is None) or a run.
 
-    :param path: Local filesystem path or run-relative artifact path to the model saved
-                 by :py:func:`mlflow.sklearn.save_model`.
-    :param run_id: Run ID. If provided, combined with ``path`` to identify the model.
+    :param model_uri: The location, in URI format, of the MLflow model, for example:
+
+                      - ``/Users/me/path/to/local/model``
+                      - ``relative/path/to/local/model``
+                      - ``s3://my_bucket/path/to/model``
+                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+
+                      For more information about supported URI schemes, see the
+                      `Artifacts Documentation <https://www.mlflow.org/docs/latest/tracking.html#
+                      supported-artifact-stores>`_.
 
     >>> import mlflow.sklearn
     >>> sk_model = mlflow.sklearn.load_model("sk_models", run_id="96771d893a5e46159d9f3b49bf9013e2")
@@ -241,9 +250,7 @@ def load_model(path, run_id=None):
     >>> pandas_df = ...
     >>> predictions = sk_model.predict(pandas_df)
     """
-    if run_id is not None:
-        path = mlflow.tracking.artifact_utils._get_model_log_dir(model_name=path, run_id=run_id)
-    path = os.path.abspath(path)
-    flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
-    sklearn_model_artifacts_path = os.path.join(path, flavor_conf['pickled_model'])
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    sklearn_model_artifacts_path = os.path.join(local_model_path, flavor_conf['pickled_model'])
     return _load_model_from_local_file(path=sklearn_model_artifacts_path)

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -35,6 +35,7 @@ from mlflow import pyfunc, mleap
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.utils.file_utils import TempDir
@@ -322,12 +323,20 @@ def _load_model(model_path, dfs_tmpdir=None):
     return PipelineModel.load(model_path)
 
 
-def load_model(path, run_id=None, dfs_tmpdir=None):
+def load_model(model_uri, dfs_tmpdir=None):
     """
     Load the Spark MLlib model from the path.
 
-    :param path: Local filesystem path or run-relative artifact path to the model.
-    :param run_id: Run ID. If provided, combined with ``path`` to identify the model.
+    :param model_uri: The location, in URI format, of the MLflow model, for example:
+
+                      - ``/Users/me/path/to/local/model``
+                      - ``relative/path/to/local/model``
+                      - ``s3://my_bucket/path/to/model``
+                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+
+                      For more information about supported URI schemes, see the
+                      `Artifacts Documentation <https://www.mlflow.org/docs/latest/tracking.html#
+                      supported-artifact-stores>`_.
     :param dfs_tmpdir: Temporary directory path on Distributed (Hadoop) File System (DFS) or local
                        filesystem if running in local mode. The model will be loaded from this
                        destination. Defaults to ``/tmp/mlflow``.
@@ -344,17 +353,17 @@ def load_model(path, run_id=None, dfs_tmpdir=None):
     >>>  # Make predictions on test documents.
     >>> prediction = model.transform(test)
     """
-    if run_id is not None:
-        path = mlflow.tracking.artifact_utils._get_model_log_dir(model_name=path, run_id=run_id)
-    path = os.path.abspath(path)
-    flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
-    spark_model_artifacts_path = os.path.join(path, flavor_conf['model_data'])
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    spark_model_artifacts_path = os.path.join(local_model_path, flavor_conf['model_data'])
     return _load_model(model_path=spark_model_artifacts_path, dfs_tmpdir=dfs_tmpdir)
 
 
 def _load_pyfunc(path):
     """
     Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
+
+    :param path: Local filesystem path to the MLflow Model with the ``spark`` flavor.
     """
     # NOTE: The getOrCreate() call below may change settings of the active session which we do not
     # intend to do here. In particular, setting master to local[1] can break distributed clusters.

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -23,7 +23,7 @@ from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import DIRECTORY_NOT_EMPTY
-from mlflow.tracking.artifact_utils import _download_artifact_from_uri 
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import _copy_file_or_tree
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -207,12 +207,12 @@ def load_model(model_uri, tf_sess):
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
     tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key =\
         _get_and_parse_flavor_configuration(model_path=local_model_path)
-    return _load_tensorflow_saved_model(tf_saved_model_dir=tf_saved_model_dir, tf_sess=tf_sess, 
+    return _load_tensorflow_saved_model(tf_saved_model_dir=tf_saved_model_dir, tf_sess=tf_sess,
                                         tf_meta_graph_tags=tf_meta_graph_tags,
                                         tf_signature_def_key=tf_signature_def_key)
 
 
-def _load_tensorflow_saved_model(tf_saved_model_dir, tf_sess, tf_meta_graph_tags, 
+def _load_tensorflow_saved_model(tf_saved_model_dir, tf_sess, tf_meta_graph_tags,
                                  tf_signature_def_key):
     """
     Load a specified TensorFlow model consisting of a TensorFlow meta graph and signature definition
@@ -221,12 +221,12 @@ def _load_tensorflow_saved_model(tf_saved_model_dir, tf_sess, tf_meta_graph_tags
     :param tf_saved_model_dir: The local filesystem path or run-relative artifact path to the model.
     :param tf_sess: The TensorFlow session in which to the load the metagraph.
     :param tf_meta_graph_tags: A list of tags identifying the model's metagraph within the
-                               serialized ``SavedModel`` object. For more information, see the 
-                               ``tags`` parameter of the `tf.saved_model.builder.SavedModelBuilder 
+                               serialized ``SavedModel`` object. For more information, see the
+                               ``tags`` parameter of the `tf.saved_model.builder.SavedModelBuilder
                                method <https://www.tensorflow.org/api_docs/python/tf/saved_model/
                                builder/SavedModelBuilder#add_meta_graph>`_.
     :param tf_signature_def_key: A string identifying the input/output signature associated with the
-                                 model. This is a key within the serialized ``SavedModel``'s 
+                                 model. This is a key within the serialized ``SavedModel``'s
                                  signature definition mapping. For more information, see the
                                  ``signature_def_map`` parameter of the
                                  ``tf.saved_model.builder.SavedModelBuilder`` method.
@@ -247,18 +247,18 @@ def _get_and_parse_flavor_configuration(model_path):
     """
     :param path: Local filesystem path to the MLflow Model with the ``tensorflow`` flavor.
     :return: A triple containing the following elements:
-             
+
              - ``tf_saved_model_dir``: The local filesystem path to the underlying TensorFlow
                                        SavedModel directory.
-             - ``tf_meta_graph_tags``: A list of tags identifying the TensorFlow model's metagraph 
+             - ``tf_meta_graph_tags``: A list of tags identifying the TensorFlow model's metagraph
                                        within the serialized ``SavedModel`` object.
-             - ``tf_signature_def_key``: A string identifying the input/output signature associated 
-                                         with the model. This is a key within the serialized 
+             - ``tf_signature_def_key``: A string identifying the input/output signature associated
+                                         with the model. This is a key within the serialized
                                          ``SavedModel``'s signature definition mapping.
     """
     flavor_conf = _get_flavor_configuration(model_path=model_path, flavor_name=FLAVOR_NAME)
     tf_saved_model_dir = os.path.join(model_path, flavor_conf['saved_model_dir'])
-    tf_meta_graph_tags = flavor_conf['meta_graph_tags'] 
+    tf_meta_graph_tags = flavor_conf['meta_graph_tags']
     tf_signature_def_key = flavor_conf['signature_def_key']
     return tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -23,7 +23,7 @@ from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import DIRECTORY_NOT_EMPTY
-from mlflow.tracking.artifact_utils import _get_model_log_dir
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri 
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import _copy_file_or_tree
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -165,19 +165,29 @@ def _validate_saved_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_d
     validation_tf_graph = tf.Graph()
     validation_tf_sess = tf.Session(graph=validation_tf_graph)
     with validation_tf_graph.as_default():
-        _load_model(tf_saved_model_dir=tf_saved_model_dir,
-                    tf_sess=validation_tf_sess,
-                    tf_meta_graph_tags=tf_meta_graph_tags,
-                    tf_signature_def_key=tf_signature_def_key)
+        _load_tensorflow_saved_model(tf_saved_model_dir=tf_saved_model_dir,
+                                     tf_sess=validation_tf_sess,
+                                     tf_meta_graph_tags=tf_meta_graph_tags,
+                                     tf_signature_def_key=tf_signature_def_key)
 
 
-def load_model(path, tf_sess, run_id=None):
+def load_model(model_uri, tf_sess):
     """
     Load an MLflow model that contains the TensorFlow flavor from the specified path.
 
     **This method must be called within a TensorFlow graph context.**
 
-    :param path: The local filesystem path or run-relative artifact path to the model.
+    :param model_uri: The location, in URI format, of the MLflow model, for example:
+
+                      - ``/Users/me/path/to/local/model``
+                      - ``relative/path/to/local/model``
+                      - ``s3://my_bucket/path/to/model``
+                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+
+                      For more information about supported URI schemes, see the
+                      `Artifacts Documentation <https://www.mlflow.org/docs/latest/tracking.html#
+                      supported-artifact-stores>`_.
+
     :param tf_sess: The TensorFlow session in which to the load the model.
     :return: A TensorFlow signature definition of type:
              ``tensorflow.core.protobuf.meta_graph_pb2.SignatureDef``. This defines the input and
@@ -194,17 +204,16 @@ def load_model(path, tf_sess, run_id=None):
     >>>     output_tensors = [tf_graph.get_tensor_by_name(output_signature.name)
     >>>                       for _, output_signature in signature_def.outputs.items()]
     """
-    if run_id is not None:
-        path = _get_model_log_dir(model_name=path, run_id=run_id)
-    path = os.path.abspath(path)
-    flavor_conf = _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME)
-    tf_saved_model_dir = os.path.join(path, flavor_conf['saved_model_dir'])
-    return _load_model(tf_saved_model_dir=tf_saved_model_dir, tf_sess=tf_sess,
-                       tf_meta_graph_tags=flavor_conf['meta_graph_tags'],
-                       tf_signature_def_key=flavor_conf['signature_def_key'])
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key =\
+        _get_and_parse_flavor_configuration(model_path=local_model_path)
+    return _load_tensorflow_saved_model(tf_saved_model_dir=tf_saved_model_dir, tf_sess=tf_sess, 
+                                        tf_meta_graph_tags=tf_meta_graph_tags,
+                                        tf_signature_def_key=tf_signature_def_key)
 
 
-def _load_model(tf_saved_model_dir, tf_sess, tf_meta_graph_tags, tf_signature_def_key):
+def _load_tensorflow_saved_model(tf_saved_model_dir, tf_sess, tf_meta_graph_tags, 
+                                 tf_signature_def_key):
     """
     Load a specified TensorFlow model consisting of a TensorFlow meta graph and signature definition
     from a serialized TensorFlow ``SavedModel`` collection.
@@ -212,15 +221,15 @@ def _load_model(tf_saved_model_dir, tf_sess, tf_meta_graph_tags, tf_signature_de
     :param tf_saved_model_dir: The local filesystem path or run-relative artifact path to the model.
     :param tf_sess: The TensorFlow session in which to the load the metagraph.
     :param tf_meta_graph_tags: A list of tags identifying the model's metagraph within the
-                               serialized `SavedModel` object. For more information, see the `tags`
-                               parameter of the `tf.saved_model.builder.SavedModelBuilder` method:
-                               https://www.tensorflow.org/api_docs/python/tf/saved_model/builder/
-                               SavedModelBuilder#add_meta_graph
+                               serialized ``SavedModel`` object. For more information, see the 
+                               ``tags`` parameter of the `tf.saved_model.builder.SavedModelBuilder 
+                               method <https://www.tensorflow.org/api_docs/python/tf/saved_model/
+                               builder/SavedModelBuilder#add_meta_graph>`_.
     :param tf_signature_def_key: A string identifying the input/output signature associated with the
-                                 model. This is a key within the serialized `SavedModel`'s signature
-                                 definition mapping. For more information, see the
-                                 `signature_def_map` parameter of the
-                                 `tf.saved_model.builder.SavedModelBuilder` method.
+                                 model. This is a key within the serialized ``SavedModel``'s 
+                                 signature definition mapping. For more information, see the
+                                 ``signature_def_map`` parameter of the
+                                 ``tf.saved_model.builder.SavedModelBuilder`` method.
     :return: A TensorFlow signature definition of type:
              ``tensorflow.core.protobuf.meta_graph_pb2.SignatureDef``. This defines input and
              output tensors within the specified metagraph for inference.
@@ -234,16 +243,43 @@ def _load_model(tf_saved_model_dir, tf_sess, tf_meta_graph_tags, tf_signature_de
     return meta_graph_def.signature_def[tf_signature_def_key]
 
 
+def _get_and_parse_flavor_configuration(model_path):
+    """
+    :param path: Local filesystem path to the MLflow Model with the ``tensorflow`` flavor.
+    :return: A triple containing the following elements:
+             
+             - ``tf_saved_model_dir``: The local filesystem path to the underlying TensorFlow
+                                       SavedModel directory.
+             - ``tf_meta_graph_tags``: A list of tags identifying the TensorFlow model's metagraph 
+                                       within the serialized ``SavedModel`` object.
+             - ``tf_signature_def_key``: A string identifying the input/output signature associated 
+                                         with the model. This is a key within the serialized 
+                                         ``SavedModel``'s signature definition mapping.
+    """
+    flavor_conf = _get_flavor_configuration(model_path=model_path, flavor_name=FLAVOR_NAME)
+    tf_saved_model_dir = os.path.join(model_path, flavor_conf['saved_model_dir'])
+    tf_meta_graph_tags = flavor_conf['meta_graph_tags'] 
+    tf_signature_def_key = flavor_conf['signature_def_key']
+    return tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key
+
+
 def _load_pyfunc(path):
     """
     Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``. This function loads an MLflow
     model with the TensorFlow flavor into a new TensorFlow graph and exposes it behind the
-    `pyfunc.predict` interface.
+    ``pyfunc.predict`` interface.
+
+    :param path: Local filesystem path to the MLflow Model with the ``tensorflow`` flavor.
     """
+    tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key =\
+        _get_and_parse_flavor_configuration(model_path=path)
+
     tf_graph = tf.Graph()
     tf_sess = tf.Session(graph=tf_graph)
     with tf_graph.as_default():
-        signature_def = load_model(path=path, tf_sess=tf_sess, run_id=None)
+        signature_def = _load_tensorflow_saved_model(
+            tf_saved_model_dir=tf_saved_model_dir, tf_sess=tf_sess,
+            tf_meta_graph_tags=tf_meta_graph_tags, tf_signature_def_key=tf_signature_def_key)
 
     return _TFWrapper(tf_sess=tf_sess, tf_graph=tf_graph, signature_def=signature_def)
 
@@ -251,7 +287,7 @@ def _load_pyfunc(path):
 class _TFWrapper(object):
     """
     Wrapper class that exposes a TensorFlow model for inference via a ``predict`` function such that
-    predict(data: pandas.DataFrame) -> pandas.DataFrame.
+    ``predict(data: pandas.DataFrame) -> pandas.DataFrame``.
     """
     def __init__(self, tf_sess, tf_graph, signature_def):
         """

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -487,7 +487,7 @@ def test_execution_script_run_method_scores_pandas_dfs_successfully_when_model_o
         sklearn_model, sklearn_data, model_path):
     mlflow.sklearn.save_model(sk_model=sklearn_model, path=model_path)
 
-    pyfunc_model = mlflow.pyfunc.load_pyfunc(path=model_path)
+    pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=model_path)
     pyfunc_outputs = pyfunc_model.predict(sklearn_data[0])
     assert isinstance(pyfunc_outputs, np.ndarray)
 
@@ -530,7 +530,7 @@ def test_execution_script_run_method_scores_pandas_dfs_successfully_when_model_o
 def test_execution_script_run_method_scores_pandas_dfs_successfully_when_model_outputs_pandas_dfs(
         keras_model, keras_data, model_path):
     mlflow.keras.save_model(keras_model=keras_model, path=model_path)
-    pyfunc_model = mlflow.pyfunc.load_pyfunc(path=model_path)
+    pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=model_path)
     pyfunc_outputs = pyfunc_model.predict(keras_data[0])
     assert isinstance(pyfunc_outputs, pd.DataFrame)
 

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -30,7 +30,8 @@ from mlflow.store.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.file_utils import TempDir
 
-from tests.helper_functions import set_boto_credentials, mock_s3_bucket
+from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
+from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 
 pytestmark = pytest.mark.skipif(
         (sys.version_info < (3, 0)),

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -32,7 +32,6 @@ from mlflow.utils.file_utils import TempDir
 
 from tests.helper_functions import set_boto_credentials, mock_s3_bucket
 
-
 pytestmark = pytest.mark.skipif(
         (sys.version_info < (3, 0)),
         reason="Tests require Python 3 to run!")

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -30,6 +30,8 @@ from mlflow.store.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.file_utils import TempDir
 
+from tests.helper_functions import set_boto_credentials, mock_s3_bucket
+
 
 pytestmark = pytest.mark.skipif(
         (sys.version_info < (3, 0)),
@@ -63,50 +65,6 @@ def get_azure_workspace():
     # pylint: disable=import-error
     from azureml.core import Workspace
     return Workspace.get("test_workspace")
-
-
-@pytest.fixture(scope='session', autouse=True)
-def set_boto_credentials():
-    """
-    In order to test that Azure images are built successfully for models
-    located in remote stores, we test the image build process against
-    `s3://` URIs. This method sets fake boto credentials to facilitate
-    such testing.
-    """
-    os.environ["AWS_ACCESS_KEY_ID"] = "NotARealAccessKey"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "NotARealSecretAccessKey"
-    os.environ["AWS_SESSION_TOKEN"] = "NotARealSessionToken"
-
-
-def mock_s3_bucket(bucket_name):
-    """
-    In order to test that Azure images are built successfully for models
-    located in remote stores, we test the image build process against
-    `s3://` URIs. This method creates a mock S3 bucket to facilitate such
-    testing.
-    """
-    # Import `wraps` from `six` instead of `functools` to properly set the
-    # wrapped function's `__wrapped__` attribute to the required value
-    # in Python 2
-    import boto3
-    from six import wraps
-    from moto import mock_s3
-
-    def build_mock_wrapper(fn):
-        @mock_s3
-        @wraps(fn)
-        def mock_wrapper(*args, **kwargs):
-            region_name = "us-west-2"
-            s3_client = boto3.client("s3", region_name=region_name)
-            s3_client.create_bucket(
-                Bucket=bucket_name,
-                CreateBucketConfiguration={
-                    "LocationConstraint": region_name,
-                })
-            return fn(*args, **kwargs)
-        return mock_wrapper
-
-    return build_mock_wrapper
 
 
 @pytest.fixture(scope="module")
@@ -198,14 +156,15 @@ def test_build_image_with_runs_uri_calls_expected_azure_routines(sklearn_model):
 
 
 @pytest.mark.large
-@mock_s3_bucket("test_bucket")
 @mock.patch("mlflow.azureml.mlflow_version", "0.7.0")
-def test_build_image_with_remote_uri_calls_expected_azure_routines(sklearn_model, model_path):
+def test_build_image_with_remote_uri_calls_expected_azure_routines(
+        sklearn_model, model_path, mock_s3_bucket):
     mlflow.sklearn.save_model(sk_model=sklearn_model, path=model_path)
     artifact_path = "model"
-    s3_artifact_repo = S3ArtifactRepository("s3://test_bucket")
+    artifact_root = "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
+    s3_artifact_repo = S3ArtifactRepository(artifact_root)
     s3_artifact_repo.log_artifacts(model_path, artifact_path=artifact_path)
-    model_uri = "s3://test_bucket/{artifact_path}".format(artifact_path=artifact_path)
+    model_uri = artifact_root + "/" + artifact_path
 
     with AzureMLMocks() as aml_mocks:
         workspace = get_azure_workspace()
@@ -689,14 +648,15 @@ def test_cli_build_image_with_runs_uri_calls_expected_azure_routines(sklearn_mod
 
 
 @pytest.mark.large
-@mock_s3_bucket("test_bucket")
 @mock.patch("mlflow.azureml.mlflow_version", "0.7.0")
-def test_cli_build_image_with_remote_uri_calls_expected_azure_routines(sklearn_model, model_path):
+def test_cli_build_image_with_remote_uri_calls_expected_azure_routines(
+        sklearn_model, model_path, mock_s3_bucket):
     mlflow.sklearn.save_model(sk_model=sklearn_model, path=model_path)
     artifact_path = "model"
-    s3_artifact_repo = S3ArtifactRepository("s3://test_bucket")
+    artifact_root = "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
+    s3_artifact_repo = S3ArtifactRepository(artifact_root)
     s3_artifact_repo.log_artifacts(model_path, artifact_path=artifact_path)
-    model_uri = "s3://test_bucket/{artifact_path}".format(artifact_path=artifact_path)
+    model_uri = artifact_root + "/" + artifact_path
 
     with AzureMLMocks() as aml_mocks:
         result = CliRunner(env={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}).invoke(

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -25,7 +25,6 @@ from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 
-from tests.helper_functions import pyfunc_serve_and_score_model
 from tests.helper_functions import score_model_in_sagemaker_docker_container
 
 

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -27,8 +27,6 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 
 from tests.helper_functions import pyfunc_serve_and_score_model
 from tests.helper_functions import score_model_in_sagemaker_docker_container
-from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
-from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
@@ -81,23 +79,6 @@ def test_model_save_load(h2o_iris_model, model_path):
     assert all(
             pyfunc_loaded.predict(h2o_iris_model.inference_data.as_data_frame()) ==
             h2o_model.predict(h2o_iris_model.inference_data).as_data_frame())
-
-
-@pytest.mark.large
-def test_load_model_from_remote_uri_succeeds(h2o_iris_model, model_path, mock_s3_bucket):
-    h2o_model = h2o_iris_model.model
-    mlflow.h2o.save_model(h2o_model=h2o_model, path=model_path)
-
-    artifact_root = "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
-    artifact_path = "model"
-    artifact_repo = S3ArtifactRepository(artifact_root)
-    artifact_repo.log_artifacts(model_path, artifact_path=artifact_path)
-
-    model_uri = artifact_root + "/" + artifact_path
-    h2o_model_loaded = mlflow.h2o.load_model(model_uri=model_uri)
-    assert all(
-        h2o_model_loaded.predict(h2o_iris_model.inference_data).as_data_frame() ==
-        h2o_model.predict(h2o_iris_model.inference_data).as_data_frame())
 
 
 @pytest.mark.large

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -93,10 +93,12 @@ def test_model_log(h2o_iris_model):
                 if should_start_run:
                     mlflow.start_run()
                 mlflow.h2o.log_model(h2o_model=h2o_model, artifact_path=artifact_path)
+                model_uri = "runs:/{run_id}/{artifact_path}".format(
+                    run_id=mlflow.active_run().info.run_id,
+                    artifact_path=artifact_path)
 
                 # Load model
-                h2o_model_loaded = mlflow.h2o.load_model(
-                        path=artifact_path, run_id=mlflow.active_run().info.run_id)
+                h2o_model_loaded = mlflow.h2o.load_model(model_uri=model_uri)
                 assert all(
                         h2o_model_loaded.predict(h2o_iris_model.inference_data).as_data_frame() ==
                         h2o_model.predict(h2o_iris_model.inference_data).as_data_frame())

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -8,6 +8,7 @@ import signal
 from subprocess import Popen, PIPE, STDOUT
 
 import pandas as pd
+import pytest
 
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.pyfunc
@@ -138,6 +139,30 @@ def _evaluate_scoring_proc(proc, port, data, content_type, activity_polling_time
         print("-------------------------STDOUT------------------------------")
         print(proc.stdout.read())
         print("==============================================================")
+
+
+@pytest.fixture(scope='module', autouse=True)
+def set_boto_credentials():
+    os.environ["AWS_ACCESS_KEY_ID"] = "NotARealAccessKey"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "NotARealSecretAccessKey"
+    os.environ["AWS_SESSION_TOKEN"] = "NotARealSessionToken"
+
+
+@pytest.fixture
+def mock_s3_bucket():
+    """
+    Creates a mock S3 bucket using moto
+
+    :return: The name of the mock bucket
+    """
+    import boto3
+    import moto
+
+    with moto.mock_s3():
+        bucket_name = "mock-bucket"
+        s3_client = boto3.client("s3")
+        s3_client.create_bucket(Bucket=bucket_name)
+        yield bucket_name
 
 
 class safe_edit_yaml(object):

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -65,7 +65,7 @@ def pyfunc_serve_and_score_model(
     """
     env = dict(os.environ)
     env.update(LC_ALL="en_US.UTF-8", LANG="en_US.UTF-8")
-    scoring_cmd = ['mlflow', 'pyfunc', 'serve', '-m', model_path, "-p", "0"]
+    scoring_cmd = ['mlflow', 'pyfunc', 'serve', '-m', model_uri, "-p", "0"]
     if extra_args is not None:
         scoring_cmd += extra_args
     proc = _start_scoring_proc(cmd=scoring_cmd, env=env)

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -49,9 +49,9 @@ def score_model_in_sagemaker_docker_container(
 
 
 def pyfunc_serve_and_score_model(
-        model_path, data, content_type, activity_polling_timeout_seconds=500, extra_args=None):
+        model_uri, data, content_type, activity_polling_timeout_seconds=500, extra_args=None):
     """
-    :param model_path: Path to the model to be served.
+    :param model_uri: URI to the model to be served.
     :param data: The data to send to the pyfunc server for testing. This is either a
                  Pandas dataframe or string of the format specified by `content_type`.
     :param content_type: The type of the data to send to the pyfunc server for testing. This is

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -84,7 +84,7 @@ def test_model_save_load(model, model_path, data, predicted):
 
     # pyfunc serve
     scoring_response = pyfunc_serve_and_score_model(
-        model_path=os.path.abspath(model_path),
+        model_uri=os.path.abspath(model_path),
         data=pd.DataFrame(x),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED)
     assert all(pd.read_json(scoring_response.content, orient="records").values.astype(np.float32)

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -88,14 +88,14 @@ def test_model_save_load(model, model_path, data, predicted):
                == predicted)
 
     # test spark udf
-    spark_udf_preds = score_model_as_udf(os.path.abspath(model_path),
-                                         run_id=None,
+    spark_udf_preds = score_model_as_udf(model_uri=os.path.abspath(model_path),
                                          pandas_df=pd.DataFrame(x),
                                          result_type="float")
     np.testing.assert_array_almost_equal(
         np.array(spark_udf_preds), predicted.reshape(len(spark_udf_preds)), decimal=4)
 
 
+@pytest.mark.large
 def test_model_load_from_runs_uri_succeeds(model, data, predicted):
     x, _ = data
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -178,7 +178,7 @@ def test_model_load_from_remote_uri_succeeds(
     artifact_root = "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
     artifact_path = "model"
     artifact_repo = S3ArtifactRepository(artifact_root)
-    artifact_repo.log_artifacts(sklearn_model_path, artifact_path=artifact_path)
+    artifact_repo.log_artifacts(pyfunc_model_path, artifact_path=artifact_path)
 
     model_uri = artifact_root + "/" + artifact_path
     loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=model_uri)
@@ -225,7 +225,7 @@ def test_pyfunc_model_serving_without_conda_env_activation_succeeds_with_main_sc
 
     sample_input = pd.DataFrame(iris_data[0])
     scoring_response = pyfunc_serve_and_score_model(
-            model_path=pyfunc_model_path,
+            model_uri=pyfunc_model_path,
             data=sample_input,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
             extra_args=["--no-conda"])
@@ -254,7 +254,7 @@ def test_pyfunc_model_serving_with_conda_env_activation_succeeds_with_main_scope
 
     sample_input = pd.DataFrame(iris_data[0])
     scoring_response = pyfunc_serve_and_score_model(
-            model_path=pyfunc_model_path,
+            model_uri=pyfunc_model_path,
             data=sample_input,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED)
     assert scoring_response.status_code == 200
@@ -283,7 +283,7 @@ def test_pyfunc_model_serving_without_conda_env_activation_succeeds_with_module_
 
     sample_input = pd.DataFrame(iris_data[0])
     scoring_response = pyfunc_serve_and_score_model(
-            model_path=pyfunc_model_path,
+            model_uri=pyfunc_model_path,
             data=sample_input,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
             extra_args=["--no-conda"])
@@ -315,7 +315,7 @@ def test_pyfunc_cli_predict_command_without_conda_env_activation_succeeds(
     sample_input.to_csv(input_csv_path, header=True, index=False)
     output_csv_path = os.path.join(str(tmpdir), "output.csv")
     process = Popen(['mlflow', 'pyfunc', 'predict',
-                     '--model-path', pyfunc_model_path,
+                     '--model-uri', pyfunc_model_path,
                      '-i', input_csv_path,
                      '-o', output_csv_path,
                      '--no-conda'],
@@ -349,7 +349,7 @@ def test_pyfunc_cli_predict_command_with_conda_env_activation_succeeds(
     sample_input.to_csv(input_csv_path, header=True, index=False)
     output_csv_path = os.path.join(str(tmpdir), "output.csv")
     process = Popen(['mlflow', 'pyfunc', 'predict',
-                     '--model-path', pyfunc_model_path,
+                     '--model-uri', pyfunc_model_path,
                      '-i', input_csv_path,
                      '-o', output_csv_path],
                     stderr=STDOUT,

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -135,7 +135,6 @@ def test_model_log_load(sklearn_knn_model, main_scoped_model_class, iris_data):
     sklearn_artifact_path = "sk_model"
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=sklearn_knn_model, artifact_path=sklearn_artifact_path)
-        sklearn_run_id = mlflow.active_run().info.run_id
         sklearn_model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id,
             artifact_path=sklearn_artifact_path)

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -147,7 +147,7 @@ def test_model_log_load(sklearn_knn_model, main_scoped_model_class, iris_data):
     with mlflow.start_run():
         mlflow.pyfunc.log_model(artifact_path=pyfunc_artifact_path,
                                 artifacts={
-                                    "sk_model": sklearn_model_uri, 
+                                    "sk_model": sklearn_model_uri,
                                 },
                                 python_model=main_scoped_model_class(test_predict))
         pyfunc_model_uri = "runs:/{run_id}/{artifact_path}".format(
@@ -184,7 +184,7 @@ def test_model_load_from_remote_uri_succeeds(
     pyfunc_artifact_path = "pyfunc_model"
     artifact_repo.log_artifacts(pyfunc_model_path, artifact_path=pyfunc_artifact_path)
 
-    model_uri = artifact_root + "/" + pyfunc_artifact_path 
+    model_uri = artifact_root + "/" + pyfunc_artifact_path
     loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=model_uri)
     np.testing.assert_array_equal(
             loaded_pyfunc_model.predict(model_input=iris_data[0]),

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -175,7 +175,6 @@ def test_model_load_from_remote_uri_succeeds(
                              },
                              python_model=main_scoped_model_class(test_predict))
 
-
     artifact_root = "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
     artifact_path = "model"
     artifact_repo = S3ArtifactRepository(artifact_root)

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -22,6 +22,7 @@ import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.sklearn
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
+from mlflow.store.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import get_artifact_uri as utils_get_artifact_uri, \
     _get_model_log_dir
 from mlflow.utils.environment import _mlflow_conda_env
@@ -30,6 +31,8 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 import tests
 from tests.helper_functions import pyfunc_serve_and_score_model
 from tests.helper_functions import score_model_in_sagemaker_docker_container
+from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
+from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 
 
 def get_model_class():
@@ -46,7 +49,7 @@ def get_model_class():
         def load_context(self, context):
             super(CustomSklearnModel, self).load_context(context)
             # pylint: disable=attribute-defined-outside-init
-            self.model = mlflow.sklearn.load_model(path=context.artifacts["sk_model"])
+            self.model = mlflow.sklearn.load_model(model_uri=context.artifacts["sk_model"])
 
         def predict(self, context, model_input):
             return self.predict_fn(self.model, model_input)
@@ -121,7 +124,7 @@ def test_model_save_load(sklearn_knn_model, main_scoped_model_class, iris_data, 
                              },
                              python_model=main_scoped_model_class(test_predict))
 
-    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(path=pyfunc_model_path)
+    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=pyfunc_model_path)
     np.testing.assert_array_equal(
             loaded_pyfunc_model.predict(model_input=iris_data[0]),
             test_predict(sk_model=sklearn_knn_model, model_input=iris_data[0]))
@@ -146,9 +149,40 @@ def test_model_log_load(sklearn_knn_model, main_scoped_model_class, iris_data):
                                         run_id=sklearn_run_id)
                                 },
                                 python_model=main_scoped_model_class(test_predict))
-        pyfunc_run_id = mlflow.active_run().info.run_id
+        model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id,
+            artifact_path=pyfunc_artifact_path)
 
-    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(path=pyfunc_artifact_path, run_id=pyfunc_run_id)
+    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=model_uri)
+    np.testing.assert_array_equal(
+            loaded_pyfunc_model.predict(model_input=iris_data[0]),
+            test_predict(sk_model=sklearn_knn_model, model_input=iris_data[0]))
+
+
+@pytest.mark.large
+def test_model_load_from_remote_uri_succeeds(
+        sklearn_knn_model, main_scoped_model_class, tmpdir, mock_s3_bucket, iris_data):
+    sklearn_model_path = os.path.join(str(tmpdir), "sklearn_model")
+    mlflow.sklearn.save_model(sk_model=sklearn_knn_model, path=sklearn_model_path)
+
+    def test_predict(sk_model, model_input):
+        return sk_model.predict(model_input) * 2
+
+    pyfunc_model_path = os.path.join(str(tmpdir), "pyfunc_model")
+    mlflow.pyfunc.save_model(dst_path=pyfunc_model_path,
+                             artifacts={
+                                "sk_model": sklearn_model_path
+                             },
+                             python_model=main_scoped_model_class(test_predict))
+
+
+    artifact_root = "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
+    artifact_path = "model"
+    artifact_repo = S3ArtifactRepository(artifact_root)
+    artifact_repo.log_artifacts(sklearn_model_path, artifact_path=artifact_path)
+
+    model_uri = artifact_root + "/" + artifact_path
+    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=model_uri)
     np.testing.assert_array_equal(
             loaded_pyfunc_model.predict(model_input=iris_data[0]),
             test_predict(sk_model=sklearn_knn_model, model_input=iris_data[0]))
@@ -188,7 +222,7 @@ def test_pyfunc_model_serving_without_conda_env_activation_succeeds_with_main_sc
                                 "sk_model": sklearn_model_path
                              },
                              python_model=main_scoped_model_class(test_predict))
-    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(path=pyfunc_model_path)
+    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=pyfunc_model_path)
 
     sample_input = pd.DataFrame(iris_data[0])
     scoring_response = pyfunc_serve_and_score_model(
@@ -217,7 +251,7 @@ def test_pyfunc_model_serving_with_conda_env_activation_succeeds_with_main_scope
                                 "sk_model": sklearn_model_path
                              },
                              python_model=main_scoped_model_class(test_predict))
-    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(path=pyfunc_model_path)
+    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=pyfunc_model_path)
 
     sample_input = pd.DataFrame(iris_data[0])
     scoring_response = pyfunc_serve_and_score_model(
@@ -246,7 +280,7 @@ def test_pyfunc_model_serving_without_conda_env_activation_succeeds_with_module_
                              },
                              python_model=ModuleScopedSklearnModel(test_predict),
                              code_path=[os.path.dirname(tests.__file__)])
-    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(path=pyfunc_model_path)
+    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=pyfunc_model_path)
 
     sample_input = pd.DataFrame(iris_data[0])
     scoring_response = pyfunc_serve_and_score_model(
@@ -275,7 +309,7 @@ def test_pyfunc_cli_predict_command_without_conda_env_activation_succeeds(
                                 "sk_model": sklearn_model_path
                              },
                              python_model=main_scoped_model_class(test_predict))
-    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(path=pyfunc_model_path)
+    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=pyfunc_model_path)
 
     sample_input = pd.DataFrame(iris_data[0])
     input_csv_path = os.path.join(str(tmpdir), "input with spaces.csv")
@@ -309,7 +343,7 @@ def test_pyfunc_cli_predict_command_with_conda_env_activation_succeeds(
                                 "sk_model": sklearn_model_path
                              },
                              python_model=main_scoped_model_class(test_predict))
-    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(path=pyfunc_model_path)
+    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=pyfunc_model_path)
 
     sample_input = pd.DataFrame(iris_data[0])
     input_csv_path = os.path.join(str(tmpdir), "input with spaces.csv")
@@ -469,7 +503,7 @@ def test_save_model_correctly_resolves_directory_artifact_with_nested_contents(
                              },
                              python_model=ArtifactValidationModel())
 
-    loaded_model = mlflow.pyfunc.load_pyfunc(model_path)
+    loaded_model = mlflow.pyfunc.load_pyfunc(model_uri=model_path)
     assert loaded_model.predict(iris_data[0])
 
 
@@ -596,7 +630,7 @@ def test_load_model_with_differing_cloudpickle_version_at_micro_granularity_logs
             mock.patch("cloudpickle.__version__") as cloudpickle_version_mock:
         cloudpickle_version_mock.__str__ = lambda *args, **kwargs: loader_cloudpickle_version
         warn_mock.side_effect = custom_warn
-        mlflow.pyfunc.load_pyfunc(path=model_path)
+        mlflow.pyfunc.load_pyfunc(model_uri=model_path)
 
     assert any([
         "differs from the version of CloudPickle that is currently running" in log_message and
@@ -627,7 +661,7 @@ def test_load_model_with_missing_cloudpickle_version_logs_warning(
 
     with mock.patch("mlflow.pyfunc._logger.warning") as warn_mock:
         warn_mock.side_effect = custom_warn
-        mlflow.pyfunc.load_pyfunc(path=model_path)
+        mlflow.pyfunc.load_pyfunc(model_uri=model_path)
 
     assert any([
         ("The version of CloudPickle used to save the model could not be found in the MLmodel"
@@ -654,7 +688,7 @@ def test_sagemaker_docker_model_scoring_with_default_conda_env(
                                 "sk_model": sklearn_model_path
                              },
                              python_model=main_scoped_model_class(test_predict))
-    reloaded_pyfunc = mlflow.pyfunc.load_pyfunc(path=pyfunc_model_path)
+    reloaded_pyfunc = mlflow.pyfunc.load_pyfunc(model_uri=pyfunc_model_path)
 
     inference_df = pd.DataFrame(iris_data[0])
     scoring_response = score_model_in_sagemaker_docker_container(

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -40,7 +40,7 @@ def test_scoring_server_responds_to_invalid_json_input_with_stacktrace_and_error
 
     incorrect_json_content = json.dumps({"not": "a serialized dataframe"})
     response = pyfunc_serve_and_score_model(
-            model_path=os.path.abspath(model_path),
+            model_uri=os.path.abspath(model_path),
             data=incorrect_json_content,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED)
     response_json = json.loads(response.content)
@@ -57,7 +57,7 @@ def test_scoring_server_responds_to_malformed_json_input_with_stacktrace_and_err
 
     malformed_json_content = "this is,,,, not valid json"
     response = pyfunc_serve_and_score_model(
-            model_path=os.path.abspath(model_path),
+            model_uri=os.path.abspath(model_path),
             data=malformed_json_content,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED)
     response_json = json.loads(response.content)
@@ -76,7 +76,7 @@ def test_scoring_server_responds_to_invalid_pandas_input_format_with_stacktrace_
     # format; passing a serialized Dataframe in `table` format should yield a readable error
     pandas_table_content = pd.DataFrame(sklearn_model.inference_data).to_json(orient="table")
     response = pyfunc_serve_and_score_model(
-            model_path=os.path.abspath(model_path),
+            model_uri=os.path.abspath(model_path),
             data=pandas_table_content,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED)
     response_json = json.loads(response.content)
@@ -93,7 +93,7 @@ def test_scoring_server_responds_to_incompatible_inference_dataframe_with_stackt
     incompatible_df = pd.DataFrame(np.array(range(10)))
 
     response = pyfunc_serve_and_score_model(
-            model_path=os.path.abspath(model_path),
+            model_uri=os.path.abspath(model_path),
             data=incompatible_df,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED)
     response_json = json.loads(response.content)
@@ -111,7 +111,7 @@ def test_scoring_server_responds_to_invalid_csv_input_with_stacktrace_and_error_
     # Any empty string is not valid pandas CSV
     incorrect_csv_content = ""
     response = pyfunc_serve_and_score_model(
-            model_path=os.path.abspath(model_path),
+            model_uri=os.path.abspath(model_path),
             data=incorrect_csv_content,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_CSV)
     response_json = json.loads(response.content)
@@ -128,7 +128,7 @@ def test_scoring_server_successfully_evaluates_correct_dataframes_with_pandas_re
 
     pandas_record_content = pd.DataFrame(sklearn_model.inference_data).to_json(orient="records")
     response_records_content_type = pyfunc_serve_and_score_model(
-            model_path=os.path.abspath(model_path),
+            model_uri=os.path.abspath(model_path),
             data=pandas_record_content,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_RECORDS_ORIENTED)
     assert response_records_content_type.status_code == 200
@@ -141,13 +141,13 @@ def test_scoring_server_successfully_evaluates_correct_dataframes_with_pandas_sp
 
     pandas_split_content = pd.DataFrame(sklearn_model.inference_data).to_json(orient="split")
     response_default_content_type = pyfunc_serve_and_score_model(
-            model_path=os.path.abspath(model_path),
+            model_uri=os.path.abspath(model_path),
             data=pandas_split_content,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON)
     assert response_default_content_type.status_code == 200
 
     response = pyfunc_serve_and_score_model(
-            model_path=os.path.abspath(model_path),
+            model_uri=os.path.abspath(model_path),
             data=pandas_split_content,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED)
     assert response.status_code == 200
@@ -160,7 +160,7 @@ def test_scoring_server_responds_to_invalid_content_type_request_with_unsupporte
 
     pandas_split_content = pd.DataFrame(sklearn_model.inference_data).to_json(orient="split")
     response = pyfunc_serve_and_score_model(
-            model_path=os.path.abspath(model_path),
+            model_uri=os.path.abspath(model_path),
             data=pandas_split_content,
             content_type="not_a_supported_content_type")
     assert response.status_code == 415

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -21,13 +21,13 @@ prediction = [int(1), int(2), "class1", float(0.1), 0.2]
 types = [np.int32, np.int, np.str, np.float32, np.double]
 
 
-def score_model_as_udf(model_path, run_id, pandas_df, result_type="double"):
+def score_model_as_udf(model_uri, pandas_df, result_type="double"):
     spark = pyspark.sql.SparkSession.builder\
         .config(key="spark.python.worker.reuse", value=True)\
         .master("local-cluster[2, 1, 1024]")\
         .getOrCreate()
     spark_df = spark.createDataFrame(pandas_df)
-    pyfunc_udf = spark_udf(spark, model_path, run_id, result_type=result_type)
+    pyfunc_udf = spark_udf(spark=spark, model_uri=model_uri, result_type=result_type)
     new_df = spark_df.withColumn("prediction", pyfunc_udf(*pandas_df.columns))
     return [x['prediction'] for x in new_df.collect()]
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -29,8 +29,6 @@ from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 
-from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
-from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 
 _logger = logging.getLogger(__name__)
 
@@ -40,6 +38,8 @@ _logger = logging.getLogger(__name__)
 try:
     from tests.helper_functions import pyfunc_serve_and_score_model
     from tests.helper_functions import score_model_in_sagemaker_docker_container
+    from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
+    from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 except ImportError:
     _logger.warning(
         "Failed to import test helper functions. Tests depending on these functions may fail!")

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -540,7 +540,7 @@ def test_load_pyfunc_succeeds_when_data_is_model_file_instead_of_directory(
         module_scoped_subclassed_model, model_path, data):
     """
     This test verifies that PyTorch models saved in older versions of MLflow are loaded successfully
-    by ``mlflow.pytorch.load_model``. The `data` path associated with these older models is
+    by ``mlflow.pytorch.load_model``. The ``data`` path associated with these older models is
     serialized PyTorch model file, as opposed to the current format: a directory containing a
     serialized model file and pickle module information.
     """
@@ -573,7 +573,7 @@ def test_load_model_succeeds_when_data_is_model_file_instead_of_directory(
         module_scoped_subclassed_model, model_path, data):
     """
     This test verifies that PyTorch models saved in older versions of MLflow are loaded successfully
-    by ``mlflow.pytorch.load_model``. The `data` path associated with these older models is
+    by ``mlflow.pytorch.load_model``. The ``data`` path associated with these older models is
     serialized PyTorch model file, as opposed to the current format: a directory containing a
     serialized model file and pickle module information.
     """

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -190,7 +190,7 @@ def test_log_model(sequential_model, data, sequential_predicted):
                 model_uri = "runs:/{run_id}/{artifact_path}".format(
                     run_id=mlflow.active_run().info.run_id,
                     artifact_path=artifact_path)
-                
+
                 # Load model
                 sequential_model_loaded = mlflow.pytorch.load_model(model_uri=model_uri)
 
@@ -521,8 +521,8 @@ def test_load_pyfunc_succeeds_when_data_is_model_file_instead_of_directory(
         module_scoped_subclassed_model, model_path, data):
     """
     This test verifies that PyTorch models saved in older versions of MLflow are loaded successfully
-    by ``mlflow.pytorch.load_model``. The `data` path associated with these older models is 
-    serialized PyTorch model file, as opposed to the current format: a directory containing a 
+    by ``mlflow.pytorch.load_model``. The `data` path associated with these older models is
+    serialized PyTorch model file, as opposed to the current format: a directory containing a
     serialized model file and pickle module information.
     """
     mlflow.pytorch.save_model(
@@ -554,8 +554,8 @@ def test_load_model_succeeds_when_data_is_model_file_instead_of_directory(
         module_scoped_subclassed_model, model_path, data):
     """
     This test verifies that PyTorch models saved in older versions of MLflow are loaded successfully
-    by ``mlflow.pytorch.load_model``. The `data` path associated with these older models is 
-    serialized PyTorch model file, as opposed to the current format: a directory containing a 
+    by ``mlflow.pytorch.load_model``. The `data` path associated with these older models is
+    serialized PyTorch model file, as opposed to the current format: a directory containing a
     serialized model file and pickle module information.
     """
     artifact_path = "pytorch_model"

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -387,7 +387,7 @@ def test_pyfunc_model_serving_with_module_scoped_subclassed_model_and_default_co
         code_paths=[__file__])
 
     scoring_response = pyfunc_serve_and_score_model(
-            model_path=model_path,
+            model_uri=model_path,
             data=data[0],
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
             extra_args=["--no-conda"])
@@ -410,7 +410,7 @@ def test_pyfunc_model_serving_with_main_scoped_subclassed_model_and_custom_pickl
         pickle_module=mlflow_pytorch_pickle_module)
 
     scoring_response = pyfunc_serve_and_score_model(
-            model_path=model_path,
+            model_uri=model_path,
             data=data[0],
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
             extra_args=["--no-conda"])
@@ -463,7 +463,7 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
     # Deploy the custom pyfunc model and ensure that it is able to successfully load its
     # constituent PyTorch model via `mlflow.pytorch.load_model`
     scoring_response = pyfunc_serve_and_score_model(
-            model_path=pyfunc_model_path,
+            model_uri=pyfunc_model_path,
             data=data[0],
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
             extra_args=["--no-conda"])

--- a/tests/sagemaker/mock/test_sagemaker_service_mock.py
+++ b/tests/sagemaker/mock/test_sagemaker_service_mock.py
@@ -1,9 +1,7 @@
-import os
-
 import boto3
 import pytest
 
-from tests.helper_functions import set_boto_credentials
+from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.sagemaker.mock import mock_sagemaker
 
 

--- a/tests/sagemaker/mock/test_sagemaker_service_mock.py
+++ b/tests/sagemaker/mock/test_sagemaker_service_mock.py
@@ -3,14 +3,8 @@ import os
 import boto3
 import pytest
 
+from tests.helper_functions import set_boto_credentials
 from tests.sagemaker.mock import mock_sagemaker
-
-
-@pytest.fixture(scope='session', autouse=True)
-def set_boto_credentials():
-    os.environ["AWS_ACCESS_KEY_ID"] = "NotARealAccessKey"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "NotARealSecretAccessKey"
-    os.environ["AWS_SESSION_TOKEN"] = "NotARealSessionToken"
 
 
 @pytest.fixture

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -24,6 +24,7 @@ from mlflow.protos.databricks_pb2 import ErrorCode, RESOURCE_DOES_NOT_EXIST, \
 from mlflow.store.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 
+from tests.helper_functions import set_boto_credentials
 from tests.sagemaker.mock import mock_sagemaker, Endpoint, EndpointOperation
 
 TrainedModel = namedtuple("TrainedModel", ["model_path", "run_id", "model_uri"])
@@ -46,13 +47,6 @@ def pretrained_model():
 @pytest.fixture
 def sagemaker_client():
     return boto3.client("sagemaker", region_name="us-west-2")
-
-
-@pytest.fixture(scope='session', autouse=True)
-def set_boto_credentials():
-    os.environ["AWS_ACCESS_KEY_ID"] = "NotARealAccessKey"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "NotARealSecretAccessKey"
-    os.environ["AWS_SESSION_TOKEN"] = "NotARealSessionToken"
 
 
 def get_sagemaker_backend(region_name):

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -24,7 +24,7 @@ from mlflow.protos.databricks_pb2 import ErrorCode, RESOURCE_DOES_NOT_EXIST, \
 from mlflow.store.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 
-from tests.helper_functions import set_boto_credentials
+from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.sagemaker.mock import mock_sagemaker, Endpoint, EndpointOperation
 
 TrainedModel = namedtuple("TrainedModel", ["model_path", "run_id", "model_uri"])

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -611,7 +611,6 @@ def test_deploy_in_replace_mode_with_archiving_does_not_delete_resources(
     models_before_replacement = [
             model["ModelName"] for model in sagemaker_client.list_models()["Models"]]
 
-
     model_uri = "runs:/{run_id}/{artifact_path}".format(
         run_id=pretrained_model.run_id, artifact_path=pretrained_model.model_path)
     sk_model = mlflow.sklearn.load_model(model_uri=model_uri)

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -611,8 +611,10 @@ def test_deploy_in_replace_mode_with_archiving_does_not_delete_resources(
     models_before_replacement = [
             model["ModelName"] for model in sagemaker_client.list_models()["Models"]]
 
-    sk_model = mlflow.sklearn.load_model(
-            path=pretrained_model.model_path, run_id=pretrained_model.run_id)
+
+    model_uri = "runs:/{run_id}/{artifact_path}".format(
+        run_id=pretrained_model.run_id, artifact_path=pretrained_model.model_path)
+    sk_model = mlflow.sklearn.load_model(model_uri=model_uri)
     new_artifact_path = "model"
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=sk_model, artifact_path=new_artifact_path)

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -124,7 +124,7 @@ def test_model_log(sklearn_logreg_model, model_path):
                         sklearn_logreg_model.model.predict(sklearn_logreg_model.inference_data),
                         reloaded_logreg_model.predict(sklearn_logreg_model.inference_data))
 
-                model_path = _download_artifact_from_uri(artifact_uri=model_uri) 
+                model_path = _download_artifact_from_uri(artifact_uri=model_uri)
                 model_config = Model.load(os.path.join(model_path, "MLmodel"))
                 assert pyfunc.FLAVOR_NAME in model_config.flavors
                 assert pyfunc.ENV in model_config.flavors[pyfunc.FLAVOR_NAME]

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -194,7 +194,7 @@ def test_sagemaker_docker_model_scoring_with_default_conda_env(spark_model_iris,
             data=spark_model_iris.pandas_df,
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
             flavor=mlflow.pyfunc.FLAVOR_NAME)
-    deployed_model_preds = json.loads(scoring_response.content)
+    deployed_model_preds = np.array(json.loads(scoring_response.content))
 
     np.testing.assert_array_almost_equal(
             deployed_model_preds,

--- a/tests/store/test_s3_artifact_repo.py
+++ b/tests/store/test_s3_artifact_repo.py
@@ -7,22 +7,12 @@ from moto import mock_s3
 
 from mlflow.store.artifact_repository_registry import get_artifact_repository
 
-
-@pytest.fixture(scope='session', autouse=True)
-def set_boto_credentials():
-    os.environ["AWS_ACCESS_KEY_ID"] = "NotARealAccessKey"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "NotARealSecretAccessKey"
-    os.environ["AWS_SESSION_TOKEN"] = "NotARealSessionToken"
+from tests.helper_functions import set_boto_credentials, mock_s3_bucket
 
 
 @pytest.fixture
-def s3_artifact_root():
-    with mock_s3():
-        bucket_name = "test-bucket"
-        s3_client = boto3.client("s3")
-        s3_client.create_bucket(Bucket=bucket_name)
-        yield "s3://{bucket_name}".format(bucket_name=bucket_name)
-
+def s3_artifact_root(mock_s3_bucket):
+    return "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
 
 def test_file_artifact_is_logged_and_downloaded_successfully(s3_artifact_root, tmpdir):
     file_name = "test.txt"

--- a/tests/store/test_s3_artifact_repo.py
+++ b/tests/store/test_s3_artifact_repo.py
@@ -14,6 +14,7 @@ from tests.helper_functions import set_boto_credentials, mock_s3_bucket
 def s3_artifact_root(mock_s3_bucket):
     return "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
 
+
 def test_file_artifact_is_logged_and_downloaded_successfully(s3_artifact_root, tmpdir):
     file_name = "test.txt"
     file_path = os.path.join(str(tmpdir), file_name)

--- a/tests/store/test_s3_artifact_repo.py
+++ b/tests/store/test_s3_artifact_repo.py
@@ -1,13 +1,12 @@
 import os
 import posixpath
 
-import boto3
 import pytest
-from moto import mock_s3
 
 from mlflow.store.artifact_repository_registry import get_artifact_repository
 
-from tests.helper_functions import set_boto_credentials, mock_s3_bucket
+from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
+from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 
 
 @pytest.fixture


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates Python APIs and CLIs for loading and performing inference with MLflow Models to reference Models by URIs rather than `(run_id, relative_model_path)` tuples.
 
## How is this patch tested?
 
This PR updates the existing suite of unit tests to conform to the updated APIs; it also introduces additional unit tests for performing load / inference operations on *remote* URIs (e.g., `s3://bucket_name/path/to/model`).
 
## Release Notes

Python APIs for loading and performing inference with MLflow models now reference Models by URIs, such as `runs://<mlflow_run_id>/run-relative/path/to/model` and `/local/path/to/model`, rather than `(run_id, relative_model_path)` tuples. For example, a previous call to `mlflow.pyfunc.load_pyfunc(path="model", run_id="350df159900d423da260b2cf5e5e5429")` should now be `mlflow.pyfunc.load_pyfunc("runs://350df159900d423da260b2cf5e5e5429/model")`.
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [X] CLI 
- [X] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [X] Models 
- [X] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
