### PR TITLE
support digit parameter to control number of digits returned by predict in R

### DIFF
--- a/mlflow/R/mlflow/R/model-serve.R
+++ b/mlflow/R/mlflow/R/model-serve.R
@@ -13,6 +13,7 @@
 #'   `httpuv::stopDaemonizedServer()` with the handle returned from this call.
 #' @param browse Launch browser with serving landing page?
 #' @param restore Should \code{mlflow_restore_snapshot()} be called before serving?
+#' @param digits number of significant digits to be returned on api call, defaults to jsonlite's digit = 4.
 #'
 #' @examples
 #' \dontrun{
@@ -39,14 +40,15 @@ mlflow_rfunc_serve <- function(
   port = 8090,
   daemonized = FALSE,
   browse = !daemonized,
-  restore = FALSE
+  restore = FALSE,
+  digits = 4
 ) {
   mlflow_restore_or_warning(restore)
 
   model_path <- resolve_model_path(model_path, run_id)
 
   httpuv_start <- if (daemonized) httpuv::startDaemonizedServer else httpuv::runServer
-  serve_run(model_path, host, port, httpuv_start, browse && interactive())
+  serve_run(model_path, host, port, httpuv_start, browse && interactive(), digits)
 }
 
 serve_content_type <- function(file_path) {
@@ -126,7 +128,7 @@ serve_empty_page <- function(req, sess, model) {
   )
 }
 
-serve_handlers <- function(host, port) {
+serve_handlers <- function(host, port, digits) {
   handlers <- list(
     "^/swagger.json" = function(req, model) {
       list(
@@ -160,7 +162,7 @@ serve_handlers <- function(host, port) {
           "Content-Type" = paste0(serve_content_type("json"), "; charset=UTF-8")
         ),
         body = charToRaw(enc2utf8(
-          jsonlite::toJSON(list(predictions = results), auto_unbox = TRUE)
+          jsonlite::toJSON(list(predictions = results), auto_unbox = TRUE, digits = digits )
         ))
       )
     },
@@ -188,14 +190,14 @@ message_serve_start <- function(host, port, model) {
 }
 
 #' @importFrom utils browseURL
-serve_run <- function(model_path, host, port, start, browse) {
+serve_run <- function(model_path, host, port, start, browse, digits) {
   model <- mlflow_load_model(model_path)
 
   message_serve_start(host, port, model)
 
   if (browse) browseURL(paste0("http://", host, ":", port))
 
-  handlers <- serve_handlers(host, port)
+  handlers <- serve_handlers(host, port, digits)
 
   start(host, port, list(
     onHeaders = function(req) {


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Models deployed using mlflow::mlflow_rfunc_serve() returns 4 decimal places for numeric predictions. Users should be able to pass number of desired decimal places for numeric predictions when using R as deployment environment.
 
## How is this patch tested?
 
(Details)
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [*] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [*] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [*] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
