### PR TITLE
Do not raise if error_code is missing. Avoid dropping response body o…

### DIFF
--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -38,7 +38,7 @@ class RestException(MlflowException):
     """Exception thrown on non 200-level responses from the REST API"""
     def __init__(self, json):
         error_code = json.get('error_code', INTERNAL_ERROR)
-        message = "Response body: '%s'" % (json)
+        message = error_code
         if 'message' in json:
             message = "%s: %s" % (error_code, json['message'])
         super(RestException, self).__init__(message, error_code=error_code)

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -37,7 +37,7 @@ class MlflowException(Exception):
 class RestException(MlflowException):
     """Exception thrown on non 200-level responses from the REST API"""
     def __init__(self, json):
-        error_code = json['error_code']
+        error_code = json.get('error_code')
         message = error_code
         if 'message' in json:
             message = "%s: %s" % (error_code, json['message'])

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -37,8 +37,8 @@ class MlflowException(Exception):
 class RestException(MlflowException):
     """Exception thrown on non 200-level responses from the REST API"""
     def __init__(self, json):
-        error_code = json.get('error_code')
-        message = error_code
+        error_code = json.get('error_code', INTERNAL_ERROR)
+        message = "Response body: '%s'" % (json)
         if 'message' in json:
             message = "%s: %s" % (error_code, json['message'])
         super(RestException, self).__init__(message, error_code=error_code)

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -87,6 +87,7 @@ def _get_safe_port():
     sock.close()
     return port
 
+
 # Root directory for all stores (backend or artifact stores) created during this suite
 SUITE_ROOT_DIR = tempfile.mkdtemp("test_rest_tracking")
 # Root directory for all artifact stores created during this suite

--- a/tests/utils/test_exception.py
+++ b/tests/utils/test_exception.py
@@ -11,17 +11,6 @@ def test_rest_exception_default_error_code():
     assert "something important." in str(exc)
 
 
-def test_rest_exception_without_message():
-    exc = RestException({"my_property": "something important."})
-    assert "something important." in str(exc)
-
-
-def test_rest_exception_error_code_and_no_message():
-    exc = RestException({"error_code": 2, "messages": "something important."})
-    assert "something important." in str(exc)
-    assert "2" in str(exc)
-
-
 def test_rest_exception_error_code_is_not_none():
     error_string = "something important."
     exc = RestException({"message": error_string})

--- a/tests/utils/test_exception.py
+++ b/tests/utils/test_exception.py
@@ -1,6 +1,11 @@
-from mlflow.exceptions import ExecutionException
+from mlflow.exceptions import ExecutionException, RestException
 
 
 def test_execution_exception_string_repr():
     exc = ExecutionException("Uh oh")
     assert str(exc) == "Uh oh"
+
+
+def test_rest_exception_default_error_code():
+    exc = RestException({"message": "something important."})
+    assert "something important." in str(exc)

--- a/tests/utils/test_exception.py
+++ b/tests/utils/test_exception.py
@@ -9,3 +9,14 @@ def test_execution_exception_string_repr():
 def test_rest_exception_default_error_code():
     exc = RestException({"message": "something important."})
     assert "something important." in str(exc)
+
+
+def test_rest_exception_without_message():
+    exc = RestException({"my_property": "something important."})
+    assert "something important." in str(exc)
+
+
+def test_rest_exception_error_code_and_no_message():
+    exc = RestException({"error_code": 2, "messages": "something important."})
+    assert "something important." in str(exc)
+    assert "2" in str(exc)

--- a/tests/utils/test_exception.py
+++ b/tests/utils/test_exception.py
@@ -20,3 +20,10 @@ def test_rest_exception_error_code_and_no_message():
     exc = RestException({"error_code": 2, "messages": "something important."})
     assert "something important." in str(exc)
     assert "2" in str(exc)
+
+
+def test_rest_exception_error_code_is_not_none():
+    error_string = "something important."
+    exc = RestException({"message": error_string})
+    assert "None" not in error_string
+    assert "None" not in str(exc)


### PR DESCRIPTION
If error_code is missing in the exception response, an KeyError: 'error_code' is raised. This drops the error message completely.

## What changes are proposed in this pull request?
Use get instead of accessing the key directly for error_code in response json. This avoids a KeyError for a missing "error_code" key in new server implementations. It may be worth introducing a specific default, for now the PR proposes InternalError as the default error_code which is the current default.
 
 
## How is this patch tested?

A test, using the new class omitting the "error_code" top level property was added.
 
(Details)
 
## Release Notes
 
### Is this a user-facing change? 

- [X ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [X ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
