### PR TITLE
[DOCS] Fix pytorch pickle module docs

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -59,6 +59,9 @@ _logger = logging.getLogger(__name__)
 def log_model(pytorch_model, artifact_path, conda_env=None, code_paths=None,
               pickle_module=mlflow_pytorch_pickle_module, **kwargs):
     """
+    log_model(pytorch_model, artifact_path, conda_env=None, code_paths=None,\
+              pickle_module=mlflow.pytorch.pickle_module, **kwargs)
+
     Log a PyTorch model as an MLflow artifact for the current run.
 
     :param pytorch_model: PyTorch model to be saved. Must accept a single ``torch.FloatTensor`` as
@@ -146,6 +149,9 @@ def log_model(pytorch_model, artifact_path, conda_env=None, code_paths=None,
 def save_model(pytorch_model, path, conda_env=None, mlflow_model=Model(), code_paths=None,
                pickle_module=mlflow_pytorch_pickle_module, **kwargs):
     """
+    save_model(pytorch_model, path, conda_env=None, mlflow_model=mlflow.models.Model(),\
+               code_paths=None, pickle_module=mlflow.pytorch.pickle_module, **kwargs)
+
     Save a PyTorch model to a path on the local file system.
 
     :param pytorch_model: PyTorch model to be saved. Must accept a single ``torch.FloatTensor`` as


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Overrides the Sphinx autogenerated docstring for the `mlflow.pytorch.log_model` and `mlflow.pytorch.save_model` methods to reference `mlflow.pytorch.pickle_module` by name rather than path (fixes the docstring issue seen here: https://mlflow.org/docs/latest/python_api/mlflow.pytorch.html#mlflow.pytorch.save_model).
 
## How is this patch tested?
 
This patch has been tested by manually generating the docs with Sphinx and verifying that the docstring contains the correct set of parameters *without* displaying the system path to `mlflow.pytorch.pickle_module`.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Fix the Sphinx autogenerated docstring for the `mlflow.pytorch.log_model` and `mlflow.pytorch.save_model` methods to reference `mlflow.pytorch.pickle_module` by name rather than path.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [X] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
