### PR TITLE
Move S3 and boto fixtures into helper functions

### DIFF
--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -30,7 +30,8 @@ from mlflow.store.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.file_utils import TempDir
 
-from tests.helper_functions import set_boto_credentials, mock_s3_bucket
+from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
+from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 
 pytestmark = pytest.mark.skipif(
         (sys.version_info < (3, 0)),

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -32,7 +32,6 @@ from mlflow.utils.file_utils import TempDir
 
 from tests.helper_functions import set_boto_credentials, mock_s3_bucket
 
-
 pytestmark = pytest.mark.skipif(
         (sys.version_info < (3, 0)),
         reason="Tests require Python 3 to run!")

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -30,6 +30,8 @@ from mlflow.store.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.file_utils import TempDir
 
+from tests.helper_functions import set_boto_credentials, mock_s3_bucket
+
 
 pytestmark = pytest.mark.skipif(
         (sys.version_info < (3, 0)),
@@ -63,50 +65,6 @@ def get_azure_workspace():
     # pylint: disable=import-error
     from azureml.core import Workspace
     return Workspace.get("test_workspace")
-
-
-@pytest.fixture(scope='session', autouse=True)
-def set_boto_credentials():
-    """
-    In order to test that Azure images are built successfully for models
-    located in remote stores, we test the image build process against
-    `s3://` URIs. This method sets fake boto credentials to facilitate
-    such testing.
-    """
-    os.environ["AWS_ACCESS_KEY_ID"] = "NotARealAccessKey"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "NotARealSecretAccessKey"
-    os.environ["AWS_SESSION_TOKEN"] = "NotARealSessionToken"
-
-
-def mock_s3_bucket(bucket_name):
-    """
-    In order to test that Azure images are built successfully for models
-    located in remote stores, we test the image build process against
-    `s3://` URIs. This method creates a mock S3 bucket to facilitate such
-    testing.
-    """
-    # Import `wraps` from `six` instead of `functools` to properly set the
-    # wrapped function's `__wrapped__` attribute to the required value
-    # in Python 2
-    import boto3
-    from six import wraps
-    from moto import mock_s3
-
-    def build_mock_wrapper(fn):
-        @mock_s3
-        @wraps(fn)
-        def mock_wrapper(*args, **kwargs):
-            region_name = "us-west-2"
-            s3_client = boto3.client("s3", region_name=region_name)
-            s3_client.create_bucket(
-                Bucket=bucket_name,
-                CreateBucketConfiguration={
-                    "LocationConstraint": region_name,
-                })
-            return fn(*args, **kwargs)
-        return mock_wrapper
-
-    return build_mock_wrapper
 
 
 @pytest.fixture(scope="module")
@@ -198,14 +156,15 @@ def test_build_image_with_runs_uri_calls_expected_azure_routines(sklearn_model):
 
 
 @pytest.mark.large
-@mock_s3_bucket("test_bucket")
 @mock.patch("mlflow.azureml.mlflow_version", "0.7.0")
-def test_build_image_with_remote_uri_calls_expected_azure_routines(sklearn_model, model_path):
+def test_build_image_with_remote_uri_calls_expected_azure_routines(
+        sklearn_model, model_path, mock_s3_bucket):
     mlflow.sklearn.save_model(sk_model=sklearn_model, path=model_path)
     artifact_path = "model"
-    s3_artifact_repo = S3ArtifactRepository("s3://test_bucket")
+    artifact_root = "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
+    s3_artifact_repo = S3ArtifactRepository(artifact_root)
     s3_artifact_repo.log_artifacts(model_path, artifact_path=artifact_path)
-    model_uri = "s3://test_bucket/{artifact_path}".format(artifact_path=artifact_path)
+    model_uri = artifact_root + "/" + artifact_path
 
     with AzureMLMocks() as aml_mocks:
         workspace = get_azure_workspace()
@@ -689,14 +648,15 @@ def test_cli_build_image_with_runs_uri_calls_expected_azure_routines(sklearn_mod
 
 
 @pytest.mark.large
-@mock_s3_bucket("test_bucket")
 @mock.patch("mlflow.azureml.mlflow_version", "0.7.0")
-def test_cli_build_image_with_remote_uri_calls_expected_azure_routines(sklearn_model, model_path):
+def test_cli_build_image_with_remote_uri_calls_expected_azure_routines(
+        sklearn_model, model_path, mock_s3_bucket):
     mlflow.sklearn.save_model(sk_model=sklearn_model, path=model_path)
     artifact_path = "model"
-    s3_artifact_repo = S3ArtifactRepository("s3://test_bucket")
+    artifact_root = "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
+    s3_artifact_repo = S3ArtifactRepository(artifact_root)
     s3_artifact_repo.log_artifacts(model_path, artifact_path=artifact_path)
-    model_uri = "s3://test_bucket/{artifact_path}".format(artifact_path=artifact_path)
+    model_uri = artifact_root + "/" + artifact_path
 
     with AzureMLMocks() as aml_mocks:
         result = CliRunner(env={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}).invoke(

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -8,6 +8,7 @@ import signal
 from subprocess import Popen, PIPE, STDOUT
 
 import pandas as pd
+import pytest
 
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.pyfunc
@@ -138,6 +139,30 @@ def _evaluate_scoring_proc(proc, port, data, content_type, activity_polling_time
         print("-------------------------STDOUT------------------------------")
         print(proc.stdout.read())
         print("==============================================================")
+
+
+@pytest.fixture(scope='module', autouse=True)
+def set_boto_credentials():
+    os.environ["AWS_ACCESS_KEY_ID"] = "NotARealAccessKey"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "NotARealSecretAccessKey"
+    os.environ["AWS_SESSION_TOKEN"] = "NotARealSessionToken"
+
+
+@pytest.fixture
+def mock_s3_bucket():
+    """
+    Creates a mock S3 bucket using moto
+
+    :return: The name of the mock bucket
+    """
+    import boto3
+    import moto
+
+    with moto.mock_s3():
+        bucket_name = "mock-bucket"
+        s3_client = boto3.client("s3")
+        s3_client.create_bucket(Bucket=bucket_name)
+        yield bucket_name
 
 
 class safe_edit_yaml(object):

--- a/tests/sagemaker/mock/test_sagemaker_service_mock.py
+++ b/tests/sagemaker/mock/test_sagemaker_service_mock.py
@@ -1,9 +1,7 @@
-import os
-
 import boto3
 import pytest
 
-from tests.helper_functions import set_boto_credentials
+from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.sagemaker.mock import mock_sagemaker
 
 

--- a/tests/sagemaker/mock/test_sagemaker_service_mock.py
+++ b/tests/sagemaker/mock/test_sagemaker_service_mock.py
@@ -3,14 +3,8 @@ import os
 import boto3
 import pytest
 
+from tests.helper_functions import set_boto_credentials
 from tests.sagemaker.mock import mock_sagemaker
-
-
-@pytest.fixture(scope='session', autouse=True)
-def set_boto_credentials():
-    os.environ["AWS_ACCESS_KEY_ID"] = "NotARealAccessKey"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "NotARealSecretAccessKey"
-    os.environ["AWS_SESSION_TOKEN"] = "NotARealSessionToken"
 
 
 @pytest.fixture

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -24,6 +24,7 @@ from mlflow.protos.databricks_pb2 import ErrorCode, RESOURCE_DOES_NOT_EXIST, \
 from mlflow.store.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 
+from tests.helper_functions import set_boto_credentials
 from tests.sagemaker.mock import mock_sagemaker, Endpoint, EndpointOperation
 
 TrainedModel = namedtuple("TrainedModel", ["model_path", "run_id", "model_uri"])
@@ -46,13 +47,6 @@ def pretrained_model():
 @pytest.fixture
 def sagemaker_client():
     return boto3.client("sagemaker", region_name="us-west-2")
-
-
-@pytest.fixture(scope='session', autouse=True)
-def set_boto_credentials():
-    os.environ["AWS_ACCESS_KEY_ID"] = "NotARealAccessKey"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "NotARealSecretAccessKey"
-    os.environ["AWS_SESSION_TOKEN"] = "NotARealSessionToken"
 
 
 def get_sagemaker_backend(region_name):

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -24,7 +24,7 @@ from mlflow.protos.databricks_pb2 import ErrorCode, RESOURCE_DOES_NOT_EXIST, \
 from mlflow.store.s3_artifact_repo import S3ArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 
-from tests.helper_functions import set_boto_credentials
+from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.sagemaker.mock import mock_sagemaker, Endpoint, EndpointOperation
 
 TrainedModel = namedtuple("TrainedModel", ["model_path", "run_id", "model_uri"])

--- a/tests/store/test_s3_artifact_repo.py
+++ b/tests/store/test_s3_artifact_repo.py
@@ -7,22 +7,12 @@ from moto import mock_s3
 
 from mlflow.store.artifact_repository_registry import get_artifact_repository
 
-
-@pytest.fixture(scope='session', autouse=True)
-def set_boto_credentials():
-    os.environ["AWS_ACCESS_KEY_ID"] = "NotARealAccessKey"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "NotARealSecretAccessKey"
-    os.environ["AWS_SESSION_TOKEN"] = "NotARealSessionToken"
+from tests.helper_functions import set_boto_credentials, mock_s3_bucket
 
 
 @pytest.fixture
-def s3_artifact_root():
-    with mock_s3():
-        bucket_name = "test-bucket"
-        s3_client = boto3.client("s3")
-        s3_client.create_bucket(Bucket=bucket_name)
-        yield "s3://{bucket_name}".format(bucket_name=bucket_name)
-
+def s3_artifact_root(mock_s3_bucket):
+    return "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
 
 def test_file_artifact_is_logged_and_downloaded_successfully(s3_artifact_root, tmpdir):
     file_name = "test.txt"

--- a/tests/store/test_s3_artifact_repo.py
+++ b/tests/store/test_s3_artifact_repo.py
@@ -14,6 +14,7 @@ from tests.helper_functions import set_boto_credentials, mock_s3_bucket
 def s3_artifact_root(mock_s3_bucket):
     return "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
 
+
 def test_file_artifact_is_logged_and_downloaded_successfully(s3_artifact_root, tmpdir):
     file_name = "test.txt"
     file_path = os.path.join(str(tmpdir), file_name)

--- a/tests/store/test_s3_artifact_repo.py
+++ b/tests/store/test_s3_artifact_repo.py
@@ -1,13 +1,12 @@
 import os
 import posixpath
 
-import boto3
 import pytest
-from moto import mock_s3
 
 from mlflow.store.artifact_repository_registry import get_artifact_repository
 
-from tests.helper_functions import set_boto_credentials, mock_s3_bucket
+from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
+from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 
 
 @pytest.fixture


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
De-dupe boto credentials fixtures and mock S3 buckets by defining appropriate methods in `tests.helper_functions`.
 
## How is this patch tested?
 
This patch is tested by confirming that existing unit tests pass.
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
