### PR TITLE
Remove --file-store CLI argument from 'mlflow server' and 'mlflow ui'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,9 +45,9 @@ Start it with::
     mlflow ui
 
 **Note:** Running ``mlflow ui`` from within a clone of MLflow is not recommended - doing so will
-run the dev UI from source. We recommend running the UI from a different working directory, using the
-``--file-store`` option to specify which log directory to run against. Alternatively, see instructions
-for running the dev UI in the `contributor guide <CONTRIBUTING.rst>`_.
+run the dev UI from source. We recommend running the UI from a different working directory,
+specifying a backend store via the ``--backend-store-uri`` option. Alternatively, see
+instructions for running the dev UI in the `contributor guide <CONTRIBUTING.rst>`_.
 
 
 Running a Project from a URI

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -275,8 +275,6 @@ By default ``--backend-store-uri`` is set to the local ``./mlruns`` directory (t
 running ``mlflow run`` locally), but when running a server, make sure that this points to a
 persistent (that is, non-ephemeral) file system location.
 
-.. note::
-  For backwards compatibility, ``--file-store`` is an alias for this option.
 
 The artifact store is a location suitable for large data (such as an S3 bucket or shared NFS
 file system) and is where clients log their artifact output (for example, models).

--- a/mlflow/R/mlflow/R/tracking-server.R
+++ b/mlflow/R/mlflow/R/tracking-server.R
@@ -58,7 +58,7 @@ mlflow_server <- function(file_store = "mlruns", default_artifact_root = NULL,
   file_store <- fs::path_abs(file_store)
 
   args <- mlflow_cli_param(list(), "--port", port) %>%
-    mlflow_cli_param("--file-store", file_store) %>%
+    mlflow_cli_param("--backend-store-uri", file_store) %>%
     mlflow_cli_param("--default-artifact-root", default_artifact_root) %>%
     mlflow_cli_param("--host", host) %>%
     mlflow_cli_param("--port", port) %>%

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -144,12 +144,13 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, m
 
 
 @cli.command()
-@click.option("--backend-store-uri", "--file-store", metavar="PATH",
+@click.option("--backend-store-uri", metavar="PATH",
               default=DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
-              help="URI or path for backend store implementation. Acceptable backend store "
-                   "are SQLAlchemy compatible implementation or local storage. "
-                   "Example 'sqlite:///path/to/file.db'. "
-                   "By default file backed store will be used. (default: ./mlruns).")
+              help="URI to which to persist experiment and run data. Acceptable URIs are "
+                   "SQLAlchemy-compatible database connection strings "
+                   "(e.g. 'sqlite:///path/to/file.db') or local filesystem URIs "
+                   "(e.g. 'file:///absolute/path/to/directory'). By default, data will be logged "
+                   "to the ./mlruns directory.")
 @click.option("--default-artifact-root", metavar="URI", default=None,
               help="Path to local directory to store artifacts, for new experiments. "
                    "Note that this flag does not impact already-created experiments. "
@@ -201,14 +202,13 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 
 
 @cli.command()
-@click.option("--backend-store-uri", "--file-store", metavar="PATH",
+@click.option("--backend-store-uri", metavar="PATH",
               default=DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH,
-              help="URI or path for backend store implementation. Acceptable backend store "
-                   "are SQLAlchemy compatible implementation or local storage. Supports "
-                   "various SQLAlchemy compatible database like SQLite, MySQL, PostgreSQL. As an "
-                   "example MySQL backed store can be configured using connection string. "
-                   "'mysql://<user_name>:<password>@<host>:<port>/<database_name>' "
-                   "By default file based backed store will be used. (default: ./mlruns).")
+              help="URI to which to persist experiment and run data. Acceptable URIs are "
+                   "SQLAlchemy-compatible database connection strings "
+                   "(e.g. 'sqlite:///path/to/file.db') or local filesystem URIs "
+                   "(e.g. 'file:///absolute/path/to/directory'). By default, data will be logged "
+                   "to the ./mlruns directory.")
 @click.option("--default-artifact-root", metavar="URI", default=None,
               help="Local or S3 URI to store artifacts, for new experiments. "
                    "Note that this flag does not impact already-created experiments. "

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/TestClientProvider.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/TestClientProvider.java
@@ -84,7 +84,7 @@ public class TestClientProvider {
     int freePort = getFreePort();
     String bindAddress = "127.0.0.1";
     pb.command("mlflow", "server", "--host", bindAddress, "--port", "" + freePort,
-      "--file-store", tempDir.resolve("mlruns").toString(), "--workers", "1");
+      "--backend-store-uri", tempDir.resolve("mlruns").toString(), "--workers", "1");
     serverProcess = pb.start();
 
     // NB: We cannot use pb.inheritIO() because that interacts poorly with the Maven


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Removes the --file-store CLI argument to `mlflow server` and `mlflow ui`. Note that users can directly substitute `--backend-store-uri` for `--file-store` and still specify local filesystem paths, but the docs  use `file:///` URIs, which should work across platforms & so seem like a better practice to encourage. Shout out to @dbczumar for noticing this in https://github.com/mlflow/mlflow/pull/1155
 
## How is this patch tested?
 
Existing tests (for example, Java tests actually run a server via the CLI). Also manually ran `mlflow server` and `mlflow ui` to verify they still work with the `--backend-store-uri` option. Finally, did a `git grep "file-store"` to verify the option is no longer used anywhere.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Removes the `--file-store` option from the `mlflow server` and `mlflow ui` CLI commands. Users should update their CLI commands to use the `--backend-store-uri` option instead. For example,
`mlflow server --file-store /my/local/path` becomes `mlflow server --backend-store-uri file:///my/local/path`
 
### What component(s) does this PR affect?
 
- [ ] UI
- [x] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
