### PR TITLE
Don't create SqlAlchemyStore on every request

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -32,7 +32,7 @@ def _get_store():
         artifact_root = os.environ.get(ARTIFACT_ROOT_ENV_VAR, None)
         if _is_database_uri(store_dir):
             from mlflow.store.sqlalchemy_store import SqlAlchemyStore
-            return SqlAlchemyStore(store_dir, artifact_root)
+            _store = SqlAlchemyStore(store_dir, artifact_root)
         elif _is_local_uri(store_dir):
             from mlflow.store.file_store import FileStore
             _store = FileStore(store_dir, artifact_root)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fixes #1197
Basically make SqlAlchemyStore a singleton, so that we can use it in later requests.
 
## How is this patch tested?
Tried it on my local server; not sure if it makes sense to write a unit test for it as the change is pretty straightforward.
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [x] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes