### PR TITLE
Fix documentation of Saving and Serving Models in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,9 +72,9 @@ MLflow artifacts and then load them again for serving. There is an example train
     Score: 0.666
     Model saved in run <run-id>
 
-    $ mlflow sklearn serve -r <run-id> -m model
+    $ mlflow pyfunc serve -r <run-id> -m model
 
-    $ curl -d '[{"x": 1}, {"x": -1}]' -H 'Content-Type: application/json' -X POST localhost:5000/invocations
+    $ curl -d '{"columns":[0],"index":[0,1],"data":[[1],[-1]]}' -H 'Content-Type: application/json'  localhost:5000/invocations
 
 
 


### PR DESCRIPTION
Documentation in the README.rst of section Saving and Serving Models is outdated and broken.

1.) `mlflow sklearn` has been removed from CLI since versin 0.8.0 and user should be using `mflow pyfunc` instead.
2.) `curl -d '[{"x": 1}, {"x": -1}]'` for testing inference server does not work

Fix for 1.): should be `mlflow pyfunc`
Fix for 2.): should be `curl -d '{"columns":[0],"index":[0,1],"data":[[1],[-1]]}'`

## What changes are proposed in this pull request?
 
Update the documentation for `Saving and Serving Models` in README.rst
 
## How is this patch tested?
 
`cd ~/workspace/mlflow/mlflow`
`python examples/sklearn_logistic_regression/train.py`
` mlflow pyfunc serve -r 8fc62972f0c74803b0234091ce33731b -m model`

`curl -d '{"columns":[0],"index":[0],"data":[[1]]}' -H 'Content-Type: application/json'  localhost:5000/invocations`

`Output: [1]`

## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [X] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
