### PR TITLE
Java support for logging metrics with x-coordinates

### DIFF
--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -10,7 +10,8 @@
 #' @template roxlate-run-id
 #' @template roxlate-client
 #' @export
-mlflow_log_metric <- function(key, value, timestamp = NULL, run_id = NULL, client = NULL) {
+mlflow_log_metric <- function(key, value, timestamp = NULL, step = NULL, run_id = NULL,
+                              client = NULL) {
   c(client, run_id) %<-% resolve_client_and_run_id(client, run_id)
   key <- cast_string(key)
   value <- cast_scalar_double(value)

--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -10,8 +10,7 @@
 #' @template roxlate-run-id
 #' @template roxlate-client
 #' @export
-mlflow_log_metric <- function(key, value, timestamp = NULL, step = NULL, run_id = NULL,
-                              client = NULL) {
+mlflow_log_metric <- function(key, value, timestamp = NULL, run_id = NULL, client = NULL) {
   c(client, run_id) %<-% resolve_client_and_run_id(client, run_id)
   key <- cast_string(key)
   value <- cast_scalar_double(value)

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -48,9 +48,8 @@ public class MlflowClient {
   }
 
   /**
-   * Gets metadata, params, tags, and metrics for a run. In the case where multiple metrics with the
-   * same key are logged for the run, returns only the value with the latest timestamp. If there are
-   * multiple values with the latest timestamp, returns the maximum of these values.
+   * Gets metadata, params, tags, and metrics for a run. A single value is returned for each metric
+   * key: the most recently logged metric value at the largest step.
    *
    * @return Run associated with the id.
    */
@@ -253,7 +252,16 @@ public class MlflowClient {
    * */
   public void logMetric(String runId, String key, double value) {
     sendPost("runs/log-metric", mapper.makeLogMetric(runId, key, value,
-      System.currentTimeMillis()));
+      System.currentTimeMillis(), 0));
+  }
+
+  /**
+   * Logs a new metric against the given run, as a key-value pair.
+   * New values for the same metric may be recorded over time, and are marked with a timestamp.
+   * */
+  public void logMetric(String runId, String key, double value, long step) {
+    sendPost("runs/log-metric", mapper.makeLogMetric(runId, key, value,
+      System.currentTimeMillis(), step));
   }
 
   /**

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -251,17 +251,15 @@ public class MlflowClient {
    * New values for the same metric may be recorded over time, and are marked with a timestamp.
    * */
   public void logMetric(String runId, String key, double value) {
-    sendPost("runs/log-metric", mapper.makeLogMetric(runId, key, value,
-      System.currentTimeMillis(), 0));
+    logMetric(runId, key, value, System.currentTimeMillis(), 0);
   }
 
   /**
    * Logs a new metric against the given run, as a key-value pair.
    * New values for the same metric may be recorded over time, and are marked with a timestamp.
    * */
-  public void logMetric(String runId, String key, double value, long step) {
-    sendPost("runs/log-metric", mapper.makeLogMetric(runId, key, value,
-      System.currentTimeMillis(), step));
+  public void logMetric(String runId, String key, double value, long timestamp, long step) {
+    sendPost("runs/log-metric", mapper.makeLogMetric(runId, key, value, timestamp, step));
   }
 
   /**

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -247,17 +247,28 @@ public class MlflowClient {
   }
 
   /**
-   * Logs a new metric against the given run, as a key-value pair.
-   * New values for the same metric may be recorded over time, and are marked with a timestamp.
-   * */
+   * Logs a new metric against the given run, as a key-value pair. Metrics are recorded
+   * against two axes: timestamp and step. This method uses the number of milliseconds
+   * since the Unix epoch for the timestamp, and it uses the default step of zero.
+   *
+   * @param runId the id of the run in which to record the metric
+   * @param key the key identifying the metric for which to record the specified value
+   * @param value the value of the metric
+   */
   public void logMetric(String runId, String key, double value) {
     logMetric(runId, key, value, System.currentTimeMillis(), 0);
   }
 
   /**
-   * Logs a new metric against the given run, as a key-value pair.
-   * New values for the same metric may be recorded over time, and are marked with a timestamp.
-   * */
+   * Logs a new metric against the given run, as a key-value pair. Metrics are recorded
+   * against two axes: timestamp and step.
+   *
+   * @param runId the id of the run in which to record the metric
+   * @param key the key identifying the metric for which to record the specified value
+   * @param value the value of the metric
+   * @param timestamp the timestamp at which to record the metric value
+   * @param step the step at which to record the metric value
+   */
   public void logMetric(String runId, String key, double value, long timestamp, long step) {
     sendPost("runs/log-metric", mapper.makeLogMetric(runId, key, value, timestamp, step));
   }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
@@ -44,13 +44,14 @@ class MlflowProtobufMapper {
     return print(builder);
   }
 
-  String makeLogMetric(String runId, String key, double value, long timestamp) {
+  String makeLogMetric(String runId, String key, double value, long timestamp, long step) {
     LogMetric.Builder builder = LogMetric.newBuilder();
     builder.setRunUuid(runId);
     builder.setRunId(runId);
     builder.setKey(key);
     builder.setValue(value);
     builder.setTimestamp(timestamp);
+    builder.setStep(step);
     return print(builder);
   }
 

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -320,8 +320,9 @@ public class MlflowClientTest {
       String runUuid = runCreated.getRunId();
       logger.debug("runUuid=" + runUuid);
 
-      List<Metric> metrics = new ArrayList<>(Arrays.asList(createMetric("met1", 0.081D, 10),
-        createMetric("metric2", 82.3D, 100)));
+      List<Metric> metrics = new ArrayList<>(Arrays.asList(createMetric("met1", 0.081D, 10, 0),
+        createMetric("metric2", 82.3D, 100, 73), createMetric("metric3", 1.0D, 1000, 1),
+        createMetric("metric3", 2.0D, 2000, 3), createMetric("metric3", 3.0D, 0, -2)));
       client.logBatch(runUuid, metrics, null, null);
 
       Run run = client.getRun(runUuid);
@@ -329,8 +330,9 @@ public class MlflowClientTest {
 
       List<Metric> loggedMetrics = run.getData().getMetricsList();
       Assert.assertEquals(loggedMetrics.size(), 2);
-      assertMetric(loggedMetrics, "met1", 0.081D);
-      assertMetric(loggedMetrics, "metric2", 82.3D);
+      assertMetric(loggedMetrics, "met1", 0.081D, 10, 0);
+      assertMetric(loggedMetrics, "metric2", 82.3D, 100, 73);
+      assertMetric(loggedMetrics, "metric3", 2.0D, 2000, 3);
     }
 
     // Test logging just params
@@ -379,7 +381,7 @@ public class MlflowClientTest {
       String runUuid = runCreated.getRunId();
       logger.debug("runUuid=" + runUuid);
 
-      List<Metric> metrics = new LinkedList<>(Arrays.asList(createMetric("m1", 32.23D, 12)));
+      List<Metric> metrics = new LinkedList<>(Arrays.asList(createMetric("m1", 32.23D, 12, 0)));
       Vector<Param> params = new Vector<>(Arrays.asList(createParam("p1", "param1"),
         createParam("p2", "another param")));
       Set<RunTag> tags = new HashSet<>(Arrays.asList(createTag("t1", "t1"),

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -137,8 +137,12 @@ public class MlflowClientTest {
     // Log metrics
     client.logMetric(runId, "accuracy_score", ACCURACY_SCORE);
     client.logMetric(runId, "zero_one_loss", ZERO_ONE_LOSS);
-    client.logMetric(runId, "logged_multiple_times", 2.0);
-    client.logMetric(runId, "logged_multiple_times", -1.0);
+    client.logMetric(runId, "multi_log_default_step_ts", 2.0);
+    client.logMetric(runId, "multi_log_default_step_ts", -1.0);
+    client.logMetric(runId, "multi_log_specified_step_ts", 1.0, -1000, 1);
+    client.logMetric(runId, "multi_log_specified_step_ts", 2.0, 2000, -5);
+    client.logMetric(runId, "multi_log_specified_step_ts", -3.0, 3000, 4);
+    client.logMetric(runId, "multi_log_specified_step_ts", 4.0, 2999, 4);
 
     // Log tag
     client.setTag(runId, "user_email", USER_EMAIL);
@@ -280,15 +284,23 @@ public class MlflowClientTest {
     assertParam(params, "max_depth", MAX_DEPTH);
 
     List<Metric> metrics = run.getData().getMetricsList();
-    Assert.assertEquals(metrics.size(), 3);
+    Assert.assertEquals(metrics.size(), 4);
     assertMetric(metrics, "accuracy_score", ACCURACY_SCORE);
     assertMetric(metrics, "zero_one_loss", ZERO_ONE_LOSS);
-    assertMetric(metrics, "logged_multiple_times", -1.0);
+    assertMetric(metrics, "multi_log_default_step_ts", -1.0);
+    assertMetric(metrics, "multi_log_specified_step_ts", -3.0);
     assert(metrics.get(0).getTimestamp() > 0) : metrics.get(0).getTimestamp();
 
-    List<Metric> metricHistory = client.getMetricHistory(runId, "logged_multiple_times");
-    assertMetricHistory(metricHistory, "logged_multiple_times", Arrays.asList(2.0, -1.0),
-      Arrays.asList(0L, 0L));
+    List<Metric> multiDefaultMetricHistory = client.getMetricHistory(
+      runId, "multi_log_default_step_ts");
+    assertMetricHistory(multiDefaultMetricHistory, "multi_log_default_step_ts",
+      Arrays.asList(2.0, -1.0), Arrays.asList(0L, 0L));
+
+    List<Metric> multiSpecifiedMetricHistory = client.getMetricHistory(
+      runId, "multi_log_specified_step_ts");
+    assertMetricHistory(multiSpecifiedMetricHistory, "multi_log_specified_step_ts",
+      Arrays.asList(1.0, 2.0, -3.0, 4.0), Arrays.asList(-1000L, 2000L, 3000L, 2999L),
+      Arrays.asList(1L, -5L, 4L, 4L));
 
     List<RunTag> tags = run.getData().getTagsList();
     Assert.assertEquals(tags.size(), 1);

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -329,7 +329,7 @@ public class MlflowClientTest {
       Assert.assertEquals(run.getInfo().getRunId(), runUuid);
 
       List<Metric> loggedMetrics = run.getData().getMetricsList();
-      Assert.assertEquals(loggedMetrics.size(), 2);
+      Assert.assertEquals(loggedMetrics.size(), 3);
       assertMetric(loggedMetrics, "met1", 0.081D, 10, 0);
       assertMetric(loggedMetrics, "metric2", 82.3D, 100, 73);
       assertMetric(loggedMetrics, "metric3", 2.0D, 2000, 3);

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
@@ -30,7 +30,6 @@ public class TestUtils {
   }
 
   public static void assertMetric(List<Metric> metrics, String key, double value, long timestamp, long step) {
-    assertMetric(metrics, key, value);
     Assert.assertTrue(metrics.stream().filter(
       e -> e.getKey().equals(key) && equals(e.getValue(), value) && equals(e.getTimestamp(), timestamp)
       && equals(e.getStep(), step)).findFirst().isPresent());

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
@@ -29,11 +29,10 @@ public class TestUtils {
     Assert.assertTrue(metrics.stream().filter(e -> e.getKey().equals(key) && equals(e.getValue(), value)).findFirst().isPresent());
   }
 
-  public static void assertMetric(List<Metric> metrics, String key, double value, long runStart, long runEnd) {
-    Assert.assertTrue(metrics.stream().filter(e -> e.getKey().equals(key) &&
-      equals(e.getValue(), value) && e.getTimestamp() >= runStart &&
-      e.getTimestamp() <= runEnd
-    ).findFirst().isPresent());
+  public static void assertMetric(List<Metric> metrics, String key, double value, long timestamp, long step) {
+    assertMetric(metrics, key, value);
+    Assert.assertTrue(metrics.stream().filter(
+      e -> equals(e.getTimestamp(), timestamp) && equals(e.getStep(), step)).findFirst().isPresent());
   }
 
   public static void assertMetricHistory(List<Metric> history, String key, List<Double> values, List<Long> steps) {
@@ -65,9 +64,10 @@ public class TestUtils {
     return "JavaTestExp_" + UUID.randomUUID().toString();
   }
 
-  public static Metric createMetric(String name, double value, long timestamp) {
+  public static Metric createMetric(String name, double value, long timestamp, long step) {
     Metric.Builder builder = Metric.newBuilder();
     builder.setKey(name).setValue(value).setTimestamp(timestamp);
+    builder.setKey(name).setValue(value).setStep(step);
     return builder.build();
   }
 

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
@@ -32,7 +32,8 @@ public class TestUtils {
   public static void assertMetric(List<Metric> metrics, String key, double value, long timestamp, long step) {
     assertMetric(metrics, key, value);
     Assert.assertTrue(metrics.stream().filter(
-      e -> equals(e.getTimestamp(), timestamp) && equals(e.getStep(), step)).findFirst().isPresent());
+      e -> e.getKey().equals(key) && equals(e.getValue(), value) && equals(e.getTimestamp(), timestamp)
+      && equals(e.getStep(), step)).findFirst().isPresent());
   }
 
   public static void assertMetricHistory(List<Metric> history, String key, List<Double> values, List<Long> steps) {

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
@@ -47,6 +47,13 @@ public class TestUtils {
     }
   }
 
+  public static void assertMetricHistory(List<Metric> history, String key, List<Double> values, List<Long> timestamps, List<Long> steps) {
+    assertMetricHistory(history, key, values, steps);
+    for(int i = 0; i < history.size(); ++i) {
+      Assert.assertTrue(equals(history.get(i).getTimestamp(), timestamps.get(i)));
+    }
+  }
+
   public static void assertTag(List<RunTag> tags, String key, String value) {
     Assert.assertTrue(tags.stream().filter(e -> e.getKey().equals(key) && e.getValue().equals(value)).findFirst().isPresent());
   }

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -42,8 +42,7 @@ class MlflowClient(object):
         as well as a collection of run parameters, tags, and metrics -
         :py:class`RunData <mlflow.entities.RunData>`. In the case where multiple metrics with the
         same key are logged for the run, the :py:class:`RunData <mlflow.entities.RunData>` contains
-        the value at the latest timestamp for each metric. If there are multiple values with the
-        latest timestamp for a given metric, the maximum of these values is returned.
+        the most recently logged value at the largest step for each metric.
 
         :param run_id: Unique identifier for the run.
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
This PR introduces an additional `logMetric()` model to MLflow's Java client APIs allowing users to specify the `step` and `timestamp` at which to record each metric value.
 
## How is this patch tested?
 
The PR expands existing unit tests to verify behavioral correctness of the new `logMetric()` API.
 
## Release Notes

Introduces Java client support for logging metrics against a `step` axis.
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [X] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [X] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
