### PR TITLE
Fix mlflow/examples/tensorflow/train_predict.py

### DIFF
--- a/examples/tensorflow/train_predict.py
+++ b/examples/tensorflow/train_predict.py
@@ -36,9 +36,12 @@ def main(argv):
         try:
             saved_estimator_path = regressor.export_savedmodel(temp, receiver_fn).decode("utf-8")
             # Logging the saved model
-            tensorflow.log_saved_model(saved_model_dir=saved_estimator_path, signature_def_key="predict", artifact_path="model")
+            tensorflow.log_model(tf_saved_model_dir=saved_estimator_path,
+                                 tf_meta_graph_tags=[tf.saved_model.tag_constants.SERVING],
+                                 tf_signature_def_key="predict",
+                                 artifact_path="model")
             # Reloading the model
-            pyfunc_model = pyfunc.load_pyfunc(saved_estimator_path)
+            pyfunc_model = pyfunc.load_pyfunc(mlflow.get_artifact_uri("model"))
             df = pd.DataFrame(data=x_test, columns=["features"] * x_train.shape[1])
             # Predicting on the loaded Python Function
             predict_df = pyfunc_model.predict(df)


### PR DESCRIPTION
The sample code in mlflow/examples/tensorflow/train_predict.py does not
work since it is using outdated API. This PR updates it to use latest
API (tensorflow.log_model as opposed to tensorflow.log_saved_model)

## What changes are proposed in this pull request?
Fix the sample code:
1.) Using `tensorflow.log_model` instead of `tensorflow.log_saved_model` to log the trained tensorflow model

2.) passing the `saved_estimator_path` to `pyfunc.load_pyfunc` is wrong as the `saved_estimator_path` only contains tensorflow related files (i.e. saved_model.pb and variables directory). We should pass in the mlflow model directory instead. In this case, I pass in `mlflow.get_artifact_uri("model")`

## How is this patch tested?
run `python examples/tensorflow/train_predict.py` with the output:
```
...
90     21.266378             16.6
91     25.783384             18.6
92     26.255243             22.0
93     27.795759             42.8
94     32.550938             35.1
95     23.745188             21.5
96     33.213608             36.0
97     29.410933             21.9
98     22.089586             24.1
99     36.447701             50.0
100    29.812475             26.7
101    15.286638             25.0

[102 rows x 2 columns]
```
Before the change, the run failed with:
```
Traceback (most recent call last):
  File "examples/tensorflow/train_predict.py", line 54, in <module>
    tf.app.run(main=main)
  File "/anaconda3/lib/python3.7/site-packages/tensorflow/python/platform/app.py", line 125, in run
    _sys.exit(main(argv))
  File "examples/tensorflow/train_predict.py", line 39, in main
    tensorflow.log_saved_model(saved_model_dir=saved_estimator_path, signature_def_key="predict", artifact_path="model")
AttributeError: module 'mlflow.tensorflow' has no attribute 'log_saved_model'
```
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [X] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
