### PR TITLE
Allow filtering experiments by a specific view type in Python list-experiments API

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -116,9 +116,12 @@ class MlflowClient(object):
         """:return: List of :py:class:`mlflow.entities.RunInfo`"""
         return self.store.list_run_infos(experiment_id, run_view_type)
 
-    def list_experiments(self):
-        """:return: List of :py:class:`mlflow.entities.Experiment`"""
-        return self.store.list_experiments()
+    def list_experiments(self, view_type=None):
+        """
+        :return: List of :py:class:`mlflow.entities.Experiment`
+        """
+        final_view_type = ViewType.ACTIVE_ONLY if view_type is None else view_type
+        return self.store.list_experiments(view_type=final_view_type)
 
     def get_experiment(self, experiment_id):
         """

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -15,7 +15,7 @@ import time
 import tempfile
 
 import mlflow.experiments
-from mlflow.entities import RunStatus, Metric, Param, RunTag
+from mlflow.entities import RunStatus, Metric, Param, RunTag, ViewType
 from mlflow.protos.service_pb2 import LOCAL as SOURCE_TYPE_LOCAL
 from mlflow.server import app, BACKEND_STORE_URI_ENV_VAR, ARTIFACT_ROOT_ENV_VAR
 from mlflow.tracking import MlflowClient
@@ -186,6 +186,14 @@ def test_create_get_list_experiment(mlflow_client):
 
     experiments = mlflow_client.list_experiments()
     assert set([e.name for e in experiments]) == {'My Experiment', 'Default'}
+    mlflow_client.delete_experiment(experiment_id)
+    assert set([e.name for e in mlflow_client.list_experiments()]) == {'Default'}
+    assert set([e.name for e in mlflow_client.list_experiments(ViewType.ACTIVE_ONLY)]) ==\
+        {'Default'}
+    assert set([e.name for e in mlflow_client.list_experiments(ViewType.DELETED_ONLY)]) ==\
+        {'My Experiment'}
+    assert set([e.name for e in mlflow_client.list_experiments(ViewType.ALL)]) == \
+        {'My Experiment', 'Default'}
 
 
 def test_delete_restore_experiment(mlflow_client):


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
The current `MlflowClient.list_experiments` API only allows listing active experiments. This PR adds an optional `view_type` argument to MlflowClient's `list_experiments` method in Python to enable viewing deleted experiments or all experiments. R already supports specifying a view type. Java does not, but we can add Java support later on.

## How is this patch tested?
 
Unit and integration tests for the new `view_type` argument.

## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Adds an optional `view_type` argument to MlflowClient's `list_experiments` method in Python to enable viewing a) only active experiments, b) only deleted experiments or c) all experiments. The previous behavior was to return only active experiments.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
