### PR TITLE
Fix mlflow version in Dockerfile of the docker example

### DIFF
--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM continuumio/miniconda:4.5.4
 
-RUN pip install mlflow==0.8.1 \
+RUN pip install mlflow==0.9.1 \
     && pip install azure-storage==0.36.0 \
     && pip install numpy==1.14.3 \
     && pip install pandas==0.22.0 \


### PR DESCRIPTION
## What changes are proposed in this pull request?

Upgrade Dockerfile in the docker example. Using the old version (0.8.1) to run the example via `mlflow run . -P alpha=0.5` gives me the error:
```
Traceback (most recent call last):
  File "/opt/conda/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/opt/conda/lib/python2.7/site-packages/mlflow/tracking/fluent.py", line 157, in end_run
    MlflowClient().set_terminated(_active_run_stack[-1].info.run_uuid, status)
  File "/opt/conda/lib/python2.7/site-packages/mlflow/tracking/client.py", line 213, in set_terminated
    end_time=end_time)
  File "/opt/conda/lib/python2.7/site-packages/mlflow/store/file_store.py", line 295, in update_run_info
    new_info = run_info._copy_with_overrides(run_status, end_time)
  File "/opt/conda/lib/python2.7/site-packages/mlflow/entities/run_info.py", line 67, in _copy_with_overrides
    proto = self.to_proto()
  File "/opt/conda/lib/python2.7/site-packages/mlflow/entities/run_info.py", line 151, in to_proto
    proto.experiment_id = self.experiment_id
TypeError: '0' has type str, but expected one of: int, long
```
The bug is fixed in latest version (0.9.1).
 
## How is this patch tested?
 
`cd ~/workspace/mlflow/mlflow/examples/docker`
and
`docker build -t mlflow-docker-example -f Dockerfile .` successfully.


 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [X] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
