### PR TITLE
Update R batched logging API to accept dataframes

### DIFF
--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -152,7 +152,6 @@ validate_batch_input_column_names <- function(input_type, input_dataframe, expec
   stop(msg, call. = FALSE)
 }
 
-
 #' Set Tag
 #'
 #' Sets a tag on a run. Tags are run metadata that can be updated during a run and
@@ -437,6 +436,7 @@ mlflow_log_artifact <- function(path, artifact_path = NULL, run_id = NULL, clien
 
   mlflow_list_artifacts(run_id = run_id, path = artifact_path, client = client)
 }
+
 
 #' Start Run
 #'

--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -438,7 +438,6 @@ mlflow_log_artifact <- function(path, artifact_path = NULL, run_id = NULL, clien
   mlflow_list_artifacts(run_id = run_id, path = artifact_path, client = client)
 }
 
-
 #' Start Run
 #'
 #' Starts a new run. If `client` is not provided, this function infers contextual information such as

--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -116,12 +116,12 @@ mlflow_get_run <- function(run_id = NULL, client = NULL) {
 #'   data may be written.
 #' @template roxlate-client
 #' @template roxlate-run-id
-#' @param metrics A dataframe of metrics to log, containing the following columns: "key", "value", 
+#' @param metrics A dataframe of metrics to log, containing the following columns: "key", "value",
 #'  "step", "timestamp"
 #' @param params A dataframe of params to log, containing the following columns: "key", "value"
 #' @param tags A dataframe of tags to log, containing the following columns: "key", "value"
 #' @export
-mlflow_log_batch <- function(metrics = NULL, params = NULL, tags = NULL, run_id = NULL, 
+mlflow_log_batch <- function(metrics = NULL, params = NULL, tags = NULL, run_id = NULL,
                              client = NULL) {
   c(client, run_id) %<-% resolve_client_and_run_id(client, run_id)
 

--- a/mlflow/R/mlflow/R/tracking-utils.R
+++ b/mlflow/R/mlflow/R/tracking-utils.R
@@ -152,6 +152,7 @@ parse_run_data <- function(d) {
     purrr::transpose() %>%
     purrr::map(unlist) %>%
     purrr::map_at("timestamp", milliseconds_to_date) %>%
+    purrr::map_at("step", as.double) %>%
     tibble::as_tibble() %>%
     list()
 }

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -155,7 +155,7 @@ test_that("mlflow_log_batch() works", {
   )
   expect_setequal(
     metrics$timestamp,
-    purrr::map(c(200, 300), milliseconds_to_date)
+    purrr::map(c(200, 300), mlflow:::milliseconds_to_date)
   )
   metric_history <- mlflow_get_metric_history("mse")
   expect_setequal(
@@ -164,7 +164,7 @@ test_that("mlflow_log_batch() works", {
   )
   expect_setequal(
     metric_history$timestamp,
-    purrr::map(c(200, 300), milliseconds_to_date)
+    purrr::map(c(200, 300), mlflow:::milliseconds_to_date)
   )
 
   expect_setequal(

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -133,8 +133,8 @@ test_that("mlflow_log_batch() works", {
   mlflow_clear_test_dir("mlruns")
   mlflow_start_run()
   mlflow_log_batch(
-    metrics = data.frame(key = c("mse", "rmse"), value = c(21, 42),
-                         timestamp = c(100, 200)),
+    metrics = data.frame(key = c("mse", "mse", "rmse"), value = c(21, 23, 42),
+                         timestamp = c(100, 200, 300)),
     params = data.frame(key = c("l1", "optimizer"), value = c(0.01, "adam")),
     tags = data.frame(key = c("model_type", "data_year"),
                       value = c("regression", "2015"))
@@ -151,7 +151,20 @@ test_that("mlflow_log_batch() works", {
   )
   expect_setequal(
     metrics$value,
-    c(21, 42)
+    c(23, 42)
+  )
+  expect_setequal(
+    metrics$timestamp,
+    c(200, 300)
+  )
+  metric_history <- mlflow_get_metric_history("mse")
+  expect_setequal(
+    metric_history$value,
+    c(21, 23)
+  )
+  expect_setequal(
+    metric_history$timestamp,
+    c(100, 200)
   )
 
   expect_setequal(

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -155,7 +155,7 @@ test_that("mlflow_log_batch() works", {
   )
   expect_setequal(
     metrics$timestamp,
-    c(200, 300)
+    purrr::map(c(200, 300), milliseconds_to_date)
   )
   metric_history <- mlflow_get_metric_history("mse")
   expect_setequal(
@@ -164,7 +164,7 @@ test_that("mlflow_log_batch() works", {
   )
   expect_setequal(
     metric_history$timestamp,
-    c(100, 200)
+    purrr::map(c(200, 300), milliseconds_to_date)
   )
 
   expect_setequal(

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -202,16 +202,19 @@ test_that("mlflow_log_batch() works", {
 test_that("mlflow_log_batch() throws for mismatched input data columns", {
   mlflow_clear_test_dir("mlruns")
   mlflow_start_run()
+  error_text_regexp <- "*input must contain exactly the following columns*"
 
   expect_error(
     mlflow_log_batch(
       metrics = data.frame(key = c("mse"), value = c(10))
-    )
+    ),
+    regexp = error_text_regexp
   )
   expect_error(
     mlflow_log_batch(
       metrics = data.frame(bad_column = c("bad"))
-    )
+    ),
+    regexp = error_text_regexp
   )
   expect_error(
     mlflow_log_batch(
@@ -222,18 +225,21 @@ test_that("mlflow_log_batch() throws for mismatched input data columns", {
        step = c(1),
        bad_column = c("bad")
       )
-    )
+    ),
+    regexp = error_text_regexp
   )
 
   expect_error(
     mlflow_log_batch(
       params = data.frame(key = c("mse"))
-    )
+    ),
+    regexp = error_text_regexp
   )
   expect_error(
     mlflow_log_batch(
       params = data.frame(bad_column = c("bad"))
-    )
+    ),
+    regexp = error_text_regexp
   )
   expect_error(
     mlflow_log_batch(
@@ -242,18 +248,21 @@ test_that("mlflow_log_batch() throws for mismatched input data columns", {
        value = c(10),
        bad_column = c("bad")
       )
-    )
+    ),
+    regexp = error_text_regexp
   )
 
   expect_error(
     mlflow_log_batch(
       tags = data.frame(key = c("mse"))
-    )
+    ),
+    regexp = error_text_regexp
   )
   expect_error(
     mlflow_log_batch(
       tags = data.frame(bad_column = c("bad"))
-    )
+    ),
+    regexp = error_text_regexp
   )
   expect_error(
     mlflow_log_batch(
@@ -262,7 +271,8 @@ test_that("mlflow_log_batch() throws for mismatched input data columns", {
        value = c(10),
        bad_column = c("bad")
       )
-    )
+    ),
+    regexp = error_text_regexp
   )
 
   expect_error(
@@ -276,6 +286,7 @@ test_that("mlflow_log_batch() throws for mismatched input data columns", {
       tags = data.frame(
        one_more_bad_column = c("bad3")
       )
-    )
+    ),
+    regexp = error_text_regexp
   )
 })

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -133,9 +133,11 @@ test_that("mlflow_log_batch() works", {
   mlflow_clear_test_dir("mlruns")
   mlflow_start_run()
   mlflow_log_batch(
-    metrics = list(mse = 21, rmse = 42),
-    params = list(l1 = 0.01, optimizer = "adam"),
-    tags = list(model_type = "regression", data_year = "2015")
+    metrics = data.frame(key = c("mse", "rmse"), value = c(21, 42),
+                         timestamp = c(100, 200)),
+    params = data.frame(key = c("l1", "optimizer"), value = c(0.01, "adam")),
+    tags = data.frame(key = c("model_type", "data_year"),
+                      value = c("regression", "2015"))
   )
 
   run <- mlflow_get_run()
@@ -170,22 +172,5 @@ test_that("mlflow_log_batch() works", {
   expect_setequal(
     tags$value,
     c("regression", "2015")
-  )
-})
-
-test_that("mlflow_log_batch() works with timestamp", {
-  mlflow_clear_test_dir("mlruns")
-  my_time <- mlflow:::current_time()
-
-  mlflow_log_batch(
-    metrics = list(accuracy = 0.98, accuracy = 0.99),
-    timestamps = rep(my_time, 2)
-  )
-
-  metric_history <- mlflow_get_metric_history("accuracy")
-
-  expect_equal(
-    as.double(metric_history$timestamp),
-    rep(my_time, 2) / 1000
   )
 })


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Update MLflow's batched logging API to expect dataframe values for the `metric`, `parameter`, and `tags` arguments.
 
## How is this patch tested?
 
Unit tests have been updated to test the batched logging API with dataframe inputs.
 
## Release Notes

The batch logging API in R now requires metrics, parameters, and tags to be specified as dataframes.
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [X] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [X] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [X] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
