### PR TITLE
Validate backend store URI before starting tracking server

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -183,11 +183,9 @@ def ui(backend_store_uri, default_artifact_root, host, port, gunicorn_opts):
             default_artifact_root = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 
     try:
-        _get_store(backend_store_uri)
+        _get_store(backend_store_uri, default_artifact_root)
     except Exception as e:  # pylint: disable=broad-except
-        # We need a broad exception here to catch exceptions in optional
-        # dependencies like SQLAlchemy
-        _logger.error("Error related to option --backend-store-uri")
+        _logger.error("Error initializing backend store")
         _logger.exception(e)
         sys.exit(1)
 
@@ -260,11 +258,9 @@ def server(backend_store_uri, default_artifact_root, host, port,
             sys.exit(1)
 
     try:
-        _get_store(backend_store_uri)
+        _get_store(backend_store_uri, default_artifact_root)
     except Exception as e:  # pylint: disable=broad-except
-        # We need a broad exception here to catch exceptions in optional
-        # dependencies like SQLAlchemy
-        _logger.error("Error related to option --backend-store-uri")
+        _logger.error("Error initializing backend store")
         _logger.exception(e)
         sys.exit(1)
 

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -260,7 +260,6 @@ def server(backend_store_uri, default_artifact_root, host, port,
             sys.exit(1)
 
     try:
-        _logger.error(backend_store_uri) ####### DEBUG
         _get_store(backend_store_uri)
     except Exception as e:  # pylint: disable=broad-except
         # We need a broad exception here to catch exceptions in optional

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -260,6 +260,7 @@ def server(backend_store_uri, default_artifact_root, host, port,
             sys.exit(1)
 
     try:
+        _logger.error(backend_store_uri) ####### DEBUG
         _get_store(backend_store_uri)
     except Exception as e:  # pylint: disable=broad-except
         # We need a broad exception here to catch exceptions in optional

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -19,7 +19,7 @@ import mlflow.runs
 import mlflow.store.db.utils
 import mlflow.db
 
-from mlflow.tracking.utils import _is_local_uri
+from mlflow.tracking.utils import _is_local_uri, _get_store
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.process import ShellCommandException
 from mlflow.utils import cli_args
@@ -181,6 +181,15 @@ def ui(backend_store_uri, default_artifact_root, host, port, gunicorn_opts):
         else:
             default_artifact_root = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 
+    try:
+        _get_store(backend_store_uri)
+    except Exception as e:  # pylint: disable=broad-except
+        # We need a broad exception here to catch exceptions in optional
+        # dependencies like SQLAlchemy
+        _logger.error("Error related to option --backend-store-uri")
+        _logger.exception(e)
+        sys.exit(1)
+
     # TODO: We eventually want to disable the write path in this version of the server.
     try:
         _run_server(backend_store_uri, default_artifact_root, host, port, 1, None, gunicorn_opts)
@@ -248,6 +257,15 @@ def server(backend_store_uri, default_artifact_root, host, port,
             eprint("Option 'default-artifact-root' is required, when backend store is not "
                    "local file based.")
             sys.exit(1)
+
+    try:
+        _get_store(backend_store_uri)
+    except Exception as e:  # pylint: disable=broad-except
+        # We need a broad exception here to catch exceptions in optional
+        # dependencies like SQLAlchemy
+        _logger.error("Error related to option --backend-store-uri")
+        _logger.exception(e)
+        sys.exit(1)
 
     try:
         _run_server(backend_store_uri, default_artifact_root, host, port, workers, static_prefix,

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -19,11 +19,12 @@ import mlflow.runs
 import mlflow.store.db.utils
 import mlflow.db
 
-from mlflow.tracking.utils import _is_local_uri, _get_store
+from mlflow.tracking.utils import _is_local_uri
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.process import ShellCommandException
 from mlflow.utils import cli_args
 from mlflow.server import _run_server
+from mlflow.server.handlers import _get_store
 from mlflow.store import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 from mlflow import tracking
 import mlflow.store.cli

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -23,19 +23,12 @@ from mlflow.utils.validation import _validate_batch_log_api_req
 
 _store = None
 
-import logging ###### DEBUG
-
-_logger = logging.getLogger(__name__)  ####### DEBUG
-
-
 
 def _get_store(backend_store_uri=None):
     from mlflow.server import BACKEND_STORE_URI_ENV_VAR, ARTIFACT_ROOT_ENV_VAR
-    _logger.error(backend_store_uri)  ######## DEBUG
     global _store
     if _store is None:
         store_dir = backend_store_uri or os.environ.get(BACKEND_STORE_URI_ENV_VAR, None)
-        _logger.error(store_dir) ####### DEBUG
         artifact_root = os.environ.get(ARTIFACT_ROOT_ENV_VAR, None)
         if _is_database_uri(store_dir):
             from mlflow.store.sqlalchemy_store import SqlAlchemyStore

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -23,12 +23,19 @@ from mlflow.utils.validation import _validate_batch_log_api_req
 
 _store = None
 
+import logging ###### DEBUG
 
-def _get_store():
+_logger = logging.getLogger(__name__)  ####### DEBUG
+
+
+
+def _get_store(backend_store_uri=None):
     from mlflow.server import BACKEND_STORE_URI_ENV_VAR, ARTIFACT_ROOT_ENV_VAR
+    _logger.error(backend_store_uri)  ######## DEBUG
     global _store
     if _store is None:
-        store_dir = os.environ.get(BACKEND_STORE_URI_ENV_VAR, None)
+        store_dir = backend_store_uri or os.environ.get(BACKEND_STORE_URI_ENV_VAR, None)
+        _logger.error(store_dir) ####### DEBUG
         artifact_root = os.environ.get(ARTIFACT_ROOT_ENV_VAR, None)
         if _is_database_uri(store_dir):
             from mlflow.store.sqlalchemy_store import SqlAlchemyStore

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -24,12 +24,12 @@ from mlflow.utils.validation import _validate_batch_log_api_req
 _store = None
 
 
-def _get_store(backend_store_uri=None):
+def _get_store(backend_store_uri=None, default_artifact_root=None):
     from mlflow.server import BACKEND_STORE_URI_ENV_VAR, ARTIFACT_ROOT_ENV_VAR
     global _store
     if _store is None:
         store_dir = backend_store_uri or os.environ.get(BACKEND_STORE_URI_ENV_VAR, None)
-        artifact_root = os.environ.get(ARTIFACT_ROOT_ENV_VAR, None)
+        artifact_root = default_artifact_root or os.environ.get(ARTIFACT_ROOT_ENV_VAR, None)
         if _is_database_uri(store_dir):
             from mlflow.store.sqlalchemy_store import SqlAlchemyStore
             _store = SqlAlchemyStore(store_dir, artifact_root)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,25 @@ def test_server_static_prefix_validation():
         run_server_mock.assert_not_called()
 
 
+def test_server_uri_validation():
+    with mock.patch("mlflow.cli._run_server") as run_server_mock:
+        result = CliRunner().invoke(server, ["--backend-store-uri", "sqlite://"])
+        assert result.output.startswith("Option 'default-artifact-root' is required")
+        run_server_mock.assert_not_called()
+
+    with mock.patch("mlflow.cli._run_server") as run_server_mock:
+        # SQLAlchemy expects postgresql:// not postgres://
+        result = CliRunner().invoke(server,
+                                    ["--backend-store-uri", "postgres://user:pwd@host:5432/mydb",
+                                     "--default-artifact-root", "./mlruns"])
+        run_server_mock.assert_not_called()
+    with mock.patch("mlflow.cli._run_server") as run_server_mock:
+        result = CliRunner().invoke(server,
+                                    ["--backend-store-uri", "sqlite://invalid-sqlite-url",
+                                     "--default-artifact-root", "./mlruns"])
+        run_server_mock.assert_not_called()
+
+
 def test_mlflow_run():
     with mock.patch("mlflow.cli.projects") as mock_projects:
         result = CliRunner().invoke(run)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,10 @@
 from click.testing import CliRunner
 from mock import mock
+import pytest
 
-from mlflow.cli import server, run
+from mlflow.cli import run, server, ui
 from mlflow.server import handlers
+
 
 def test_server_static_prefix_validation():
     with mock.patch("mlflow.cli._run_server") as run_server_mock:
@@ -28,11 +30,12 @@ def test_server_default_artifact_root_validation():
         run_server_mock.assert_not_called()
 
 
-def test_server_uri_validation():
+@pytest.mark.parametrize("command", [server, ui])
+def test_tracking_uri_validation(command):
     handlers._store = None
     with mock.patch("mlflow.cli._run_server") as run_server_mock:
         # SQLAlchemy expects postgresql:// not postgres://
-        CliRunner().invoke(server,
+        CliRunner().invoke(command,
                            ["--backend-store-uri", "postgres://user:pwd@host:5432/mydb",
                             "--default-artifact-root", "./mlruns"])
         run_server_mock.assert_not_called()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,7 +2,7 @@ from click.testing import CliRunner
 from mock import mock
 
 from mlflow.cli import server, run
-
+from mlflow.server import handlers
 
 def test_server_static_prefix_validation():
     with mock.patch("mlflow.cli._run_server") as run_server_mock:
@@ -21,22 +21,20 @@ def test_server_static_prefix_validation():
         run_server_mock.assert_not_called()
 
 
-def test_server_uri_validation():
+def test_server_default_artifact_root_validation():
     with mock.patch("mlflow.cli._run_server") as run_server_mock:
         result = CliRunner().invoke(server, ["--backend-store-uri", "sqlite://"])
         assert result.output.startswith("Option 'default-artifact-root' is required")
         run_server_mock.assert_not_called()
 
+
+def test_server_uri_validation():
+    handlers._store = None
     with mock.patch("mlflow.cli._run_server") as run_server_mock:
         # SQLAlchemy expects postgresql:// not postgres://
-        result = CliRunner().invoke(server,
-                                    ["--backend-store-uri", "postgres://user:pwd@host:5432/mydb",
-                                     "--default-artifact-root", "./mlruns"])
-        run_server_mock.assert_not_called()
-    with mock.patch("mlflow.cli._run_server") as run_server_mock:
-        result = CliRunner().invoke(server,
-                                    ["--backend-store-uri", "sqlite://invalid-sqlite-url",
-                                     "--default-artifact-root", "./mlruns"])
+        CliRunner().invoke(server,
+                           ["--backend-store-uri", "postgres://user:pwd@host:5432/mydb",
+                            "--default-artifact-root", "./mlruns"])
         run_server_mock.assert_not_called()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ def test_server_static_prefix_validation():
 
 def test_server_default_artifact_root_validation():
     with mock.patch("mlflow.cli._run_server") as run_server_mock:
-        result = CliRunner().invoke(server, ["--backend-store-uri", "sqlite://"])
+        result = CliRunner().invoke(server, ["--backend-store-uri", "postgresql://"])
         assert result.output.startswith("Option 'default-artifact-root' is required")
         run_server_mock.assert_not_called()
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
A command like `mlflow ---backend-store-uri=invalidscheme://...` silently fails. A user would see a generic error page after opening the tracking server in a web browser. This PR makes sure that invalid backend store URIs cause the command to fail early, allowing users to correct typos and other errors

This is a rewrite of #1073. See that for more details
 
## How is this patch tested?
 
Tests were written in `test_cli.py` to check that the invalid command exits early.

Also manually tested failure & success cases for running `mlflow server ...`.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?

- [x] CLI 

### How should the PR be classified in the release notes? Choose one:
 
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
