### PR TITLE
Remove deprecated RunInfo properties from start_run

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -11,15 +11,14 @@ import atexit
 import time
 import logging
 
-from mlflow.entities import Run, SourceType, RunStatus, Param, RunTag, Metric
+from mlflow.entities import Run, RunStatus, Param, RunTag, Metric
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.exceptions import MlflowException
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking import artifact_utils, context
 from mlflow.utils import env
 from mlflow.utils.databricks_utils import is_in_databricks_notebook, get_notebook_id
-from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT, MLFLOW_SOURCE_TYPE, MLFLOW_SOURCE_NAME, \
-    MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_PARENT_RUN_ID, MLFLOW_RUN_NAME
+from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_RUN_NAME
 from mlflow.utils.validation import _validate_run_id
 
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -69,8 +69,7 @@ class ActiveRun(Run):  # pylint: disable=W0223
         return exc_type is None
 
 
-def start_run(run_id=None, experiment_id=None, source_name=None, source_version=None,
-              entry_point_name=None, source_type=None, run_name=None, nested=False):
+def start_run(run_id=None, experiment_id=None, run_name=None, nested=False):
     """
     Start a new MLflow run, setting it as the active run under which metrics and parameters
     will be logged. The return value can be used as a context manager within a ``with`` block;
@@ -89,14 +88,8 @@ def start_run(run_id=None, experiment_id=None, source_name=None, source_version=
                           is unspecified, will look for valid experiment in the following order:
                           activated using ``set_experiment``, ``MLFLOW_EXPERIMENT_ID`` env variable,
                           or the default experiment.
-    :param source_name: Name of the source file or URI of the project to be associated with the run.
-                        If none provided defaults to the current file.
-    :param source_version: Optional Git commit hash to associate with the run.
-    :param entry_point_name: Optional name of the entry point for the current run.
-    :param source_type: Integer :py:class:`mlflow.entities.SourceType` describing the type
-                        of the run ("local", "project", etc.). Defaults to
-                        :py:class:`mlflow.entities.SourceType.LOCAL` ("local").
-    :param run_name: Name of new run. Used only when ``run_id`` is unspecified.
+    :param run_name: Name of new run (set a mlflow.runName tag).
+                     Used only when ``run_id`` is unspecified.
     :param nested: Parameter which must be set to ``True`` to create nested runs.
     :return: :py:class:`mlflow.ActiveRun` object that acts as a context manager wrapping
              the run's state.
@@ -126,14 +119,6 @@ def start_run(run_id=None, experiment_id=None, source_name=None, source_version=
         user_specified_tags = {}
         if parent_run_id is not None:
             user_specified_tags[MLFLOW_PARENT_RUN_ID] = parent_run_id
-        if source_name is not None:
-            user_specified_tags[MLFLOW_SOURCE_NAME] = source_name
-        if source_type is not None:
-            user_specified_tags[MLFLOW_SOURCE_TYPE] = SourceType.to_string(source_type)
-        if source_version is not None:
-            user_specified_tags[MLFLOW_GIT_COMMIT] = source_version
-        if entry_point_name is not None:
-            user_specified_tags[MLFLOW_PROJECT_ENTRY_POINT] = entry_point_name
         if run_name is not None:
             user_specified_tags[MLFLOW_RUN_NAME] = run_name
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -87,7 +87,7 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False):
                           is unspecified, will look for valid experiment in the following order:
                           activated using ``set_experiment``, ``MLFLOW_EXPERIMENT_ID`` env variable,
                           or the default experiment.
-    :param run_name: Name of new run (set a mlflow.runName tag).
+    :param run_name: Name of new run (stored as a ``mlflow.runName`` tag).
                      Used only when ``run_id`` is unspecified.
     :param nested: Parameter which must be set to ``True`` to create nested runs.
     :return: :py:class:`mlflow.ActiveRun` object that acts as a context manager wrapping

--- a/tests/generate_ui_test_data.py
+++ b/tests/generate_ui_test_data.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
     client = MlflowClient()
     # Simple run
     for l1, alpha in itertools.product([0, 0.25, 0.5, 0.75, 1], [0, 0.5, 1]):
-        with mlflow.start_run(source_name='ipython', source_version=SOURCE_VERSIONS[0]):
+        with mlflow.start_run(run_name='ipython', source_version=SOURCE_VERSIONS[0]):
             parameters = {
                 'l1': str(l1),
                 'alpha': str(alpha),
@@ -56,7 +56,7 @@ if __name__ == '__main__':
             log_metrics(metrics)
 
     # Big parameter values
-    with mlflow.start_run(source_name='ipython', source_version=SOURCE_VERSIONS[1]):
+    with mlflow.start_run(run_name='ipython', source_version=SOURCE_VERSIONS[1]):
         parameters = {
             'this is a pretty long parameter name': 'NA10921-test_file_2018-08-10.txt',
         }
@@ -67,7 +67,7 @@ if __name__ == '__main__':
         log_metrics(metrics)
 
     # Nested runs.
-    with mlflow.start_run(source_name='multirun.py'):
+    with mlflow.start_run(run_name='multirun.py'):
         l1 = 0.5
         alpha = 0.5
         parameters = {
@@ -82,7 +82,7 @@ if __name__ == '__main__':
         log_params(parameters)
         log_metrics(metrics)
 
-        with mlflow.start_run(source_name='child_params.py', nested=True):
+        with mlflow.start_run(run_name='child_params.py', nested=True):
             parameters = {
                 'lot': str(rand()),
                 'of': str(rand()),
@@ -103,7 +103,7 @@ if __name__ == '__main__':
             log_params(parameters)
             mlflow.log_metric('test_metric', 1)
 
-        with mlflow.start_run(source_name='child_metrics.py', nested=True):
+        with mlflow.start_run(run_name='child_metrics.py', nested=True):
             metrics = {
                 'lot': [rand()],
                 'of': [rand()],
@@ -123,61 +123,61 @@ if __name__ == '__main__':
             }
             log_metrics(metrics)
 
-        with mlflow.start_run(source_name='sort_child.py', nested=True):
+        with mlflow.start_run(run_name='sort_child.py', nested=True):
             mlflow.log_metric('test_metric', 1)
             mlflow.log_param('test_param', 1)
 
-        with mlflow.start_run(source_name='sort_child.py', nested=True):
+        with mlflow.start_run(run_name='sort_child.py', nested=True):
             mlflow.log_metric('test_metric', 2)
             mlflow.log_param('test_param', 2)
 
     # Grandchildren
-    with mlflow.start_run(source_name='parent'):
-        with mlflow.start_run(source_name='child', nested=True):
-            with mlflow.start_run(source_name='grandchild', nested=True):
+    with mlflow.start_run(run_name='parent'):
+        with mlflow.start_run(run_name='child', nested=True):
+            with mlflow.start_run(run_name='grandchild', nested=True):
                 pass
 
     # Loop
     loop_1_run_id = None
     loop_2_run_id = None
-    with mlflow.start_run(source_name='loop-1') as run_1:
-        with mlflow.start_run(source_name='loop-2', nested=True) as run_2:
+    with mlflow.start_run(run_name='loop-1') as run_1:
+        with mlflow.start_run(run_name='loop-2', nested=True) as run_2:
             loop_1_run_id = run_1.info.run_id
             loop_2_run_id = run_2.info.run_id
     client.set_tag(loop_1_run_id, 'mlflow.parentRunId', loop_2_run_id)
 
     # Lot's of children
-    with mlflow.start_run(source_name='parent-with-lots-of-children'):
+    with mlflow.start_run(run_name='parent-with-lots-of-children'):
         for i in range(100):
-            with mlflow.start_run(source_name='child-{}'.format(i), nested=True):
+            with mlflow.start_run(run_name='child-{}'.format(i), nested=True):
                 pass
     mlflow.set_experiment("my-empty-experiment")
     mlflow.set_experiment("runs-but-no-metrics-params")
     for i in range(100):
-        with mlflow.start_run(source_name="empty-run-{}".format(i)):
+        with mlflow.start_run(run_name="empty-run-{}".format(i)):
             pass
     if args.large:
         mlflow.set_experiment("med-size-experiment")
         # Experiment with a mix of nested runs & non-nested runs
         for i in range(3):
-            with mlflow.start_run(source_name='parent-with-children-{}'.format(i)):
+            with mlflow.start_run(run_name='parent-with-children-{}'.format(i)):
                 params = {rand_str(): rand_str() for _ in range(5)}
                 metrics = {rand_str(): [rand()] for _ in range(5)}
                 log_params(params)
                 log_metrics(metrics)
                 for j in range(10):
-                    with mlflow.start_run(source_name='child-{}'.format(j), nested=True):
+                    with mlflow.start_run(run_name='child-{}'.format(j), nested=True):
                         params = {rand_str(): rand_str() for _ in range(30)}
                         metrics = {rand_str(): [rand()] for idx in range(30)}
                         log_params(params)
                         log_metrics(metrics)
             for j in range(10):
-                with mlflow.start_run(source_name='unnested-{}-{}'.format(i, j)):
+                with mlflow.start_run(run_name='unnested-{}-{}'.format(i, j)):
                     params = {rand_str(): rand_str() for _ in range(5)}
                     metrics = {rand_str(): [rand()] for _ in range(5)}
         mlflow.set_experiment("hitting-metric-param-limits")
         for i in range(50):
-            with mlflow.start_run(source_name="big-run-{}".format(i)):
+            with mlflow.start_run(run_name="big-run-{}".format(i)):
                 params = {str(j) + "a" * 250: "b" * 1000 for j in range(100)}
                 metrics = {str(j) + "a" * 250: [rand()] for j in range(100)}
                 log_metrics(metrics)

--- a/tests/generate_ui_test_data.py
+++ b/tests/generate_ui_test_data.py
@@ -11,12 +11,6 @@ from random import random as rand
 
 from mlflow.tracking import MlflowClient
 
-SOURCE_VERSIONS = [
-    'f7581541a524f4879794e724a9653eaca2bef1d7',
-    '53de5661eb457efa3cb996aa592656c41a888c1d',
-    'ccc76efe9ceb633710bbd7acf408bebe0095eb10'
-]
-
 
 def log_metrics(metrics):
     for k, values in metrics.items():
@@ -42,7 +36,7 @@ if __name__ == '__main__':
     client = MlflowClient()
     # Simple run
     for l1, alpha in itertools.product([0, 0.25, 0.5, 0.75, 1], [0, 0.5, 1]):
-        with mlflow.start_run(run_name='ipython', source_version=SOURCE_VERSIONS[0]):
+        with mlflow.start_run(run_name='ipython'):
             parameters = {
                 'l1': str(l1),
                 'alpha': str(alpha),
@@ -56,7 +50,7 @@ if __name__ == '__main__':
             log_metrics(metrics)
 
     # Big parameter values
-    with mlflow.start_run(run_name='ipython', source_version=SOURCE_VERSIONS[1]):
+    with mlflow.start_run(run_name='ipython'):
         parameters = {
             'this is a pretty long parameter name': 'NA10921-test_file_2018-08-10.txt',
         }


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Although it's totally valid to take these properties and convert them into tags, we think that users do not typically want to override them, so don't need to make this part of the stable public API in 1.0.

Note that we kept run_name -- we propose that this is useful to set from the get-go and deserves to remain part of the fluent API. This is the same as the R API.
 
## How is this patch tested?
 
- [x] Existing unit tests.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Mostly in #1188, but we also removed `source_name`, `source_version`, `source_type`, and `entry_point_name` from start_run in the fluent API. 

### What component(s) does this PR affect?
 
- [x] Tracking
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
