### PR TITLE
Rename dst_path parameter in pyfunc save_model to path

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -331,7 +331,7 @@ instance of this model with ``n = 5`` in MLflow Model format. Finally, it loads 
     # Construct and save the model
     model_path = "add_n_model"
     add5_model = AddN(n=5)
-    mlflow.pyfunc.save_model(dst_path=model_path, python_model=add5_model)
+    mlflow.pyfunc.save_model(path=model_path, python_model=add5_model)
 
     # Load the model in `python_function` format
     loaded_model = mlflow.pyfunc.load_pyfunc(model_path)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -431,7 +431,7 @@ def spark_udf(spark, model_uri, result_type="double"):
     return pandas_udf(predict, result_type)
 
 
-def save_model(dst_path, loader_module=None, data_path=None, code_path=None, conda_env=None,
+def save_model(path, loader_module=None, data_path=None, code_path=None, conda_env=None,
                model=Model(), python_model=None, artifacts=None):
     """
     Create a custom Pyfunc model, incorporating custom inference logic and data dependencies.
@@ -534,11 +534,11 @@ def save_model(dst_path, loader_module=None, data_path=None, code_path=None, con
 
     if first_argument_set_specified:
         return _save_model_with_loader_module_and_data_path(
-                path=dst_path, loader_module=loader_module, data_path=data_path,
+                path=path, loader_module=loader_module, data_path=data_path,
                 code_paths=code_path, conda_env=conda_env, mlflow_model=model)
     elif second_argument_set_specified:
         return mlflow.pyfunc.model._save_model_with_class_artifacts_params(
-            path=dst_path, python_model=python_model, artifacts=artifacts, conda_env=conda_env,
+            path=path, python_model=python_model, artifacts=artifacts, conda_env=conda_env,
             code_paths=code_path, mlflow_model=model)
 
 
@@ -619,7 +619,7 @@ def log_model(artifact_path, loader_module=None, data_path=None, code_path=None,
     with TempDir() as tmp:
         local_path = tmp.path(artifact_path)
         run_id = active_run().info.run_id
-        save_model(dst_path=local_path, model=Model(artifact_path=artifact_path, run_id=run_id),
+        save_model(path=local_path, model=Model(artifact_path=artifact_path, run_id=run_id),
                    loader_module=loader_module, data_path=data_path, code_path=code_path,
                    conda_env=conda_env, python_model=python_model, artifacts=artifacts)
         log_artifacts(local_path, artifact_path)
@@ -670,38 +670,6 @@ def _save_model_with_loader_module_and_data_path(path, loader_module, data_path=
         mlflow_model, loader_module=loader_module, code=code, data=data, env=env)
     mlflow_model.save(os.path.join(path, 'MLmodel'))
     return mlflow_model
-
-
-def get_module_loader_src(src_path, dst_path):
-    """
-    Generate Python source of the model loader.
-
-    Model loader contains ``load_pyfunc`` method with no parameters. It hardcodes model
-    loading of the given model into a Python source. This is done so that the exported model has no
-    unnecessary dependencies on MLflow or any other configuration file format or parsing library.
-
-    :param src_path: Current path to the model.
-    :param dst_path: Relative or absolute path where the model will be stored in the deployment
-                     environment.
-    :return: Python source code of the model loader as string.
-
-    """
-    conf_path = os.path.join(src_path, "MLmodel")
-    model = Model.load(conf_path)
-    if FLAVOR_NAME not in model.flavors:
-        raise Exception("Format '{format}' not found not in {path}.".format(format=FLAVOR_NAME,
-                                                                            path=conf_path))
-    conf = model.flavors[FLAVOR_NAME]
-    update_path = ""
-    if CODE in conf and conf[CODE]:
-        src_code_path = os.path.join(src_path, conf[CODE])
-        dst_code_path = os.path.join(dst_path, conf[CODE])
-        code_path = ["os.path.abspath('%s')" % x for x in [dst_code_path] +
-                     mlflow.pyfunc.utils._get_code_dirs(src_code_path, dst_code_path)]
-        update_path = "sys.path = {} + sys.path; ".format("[%s]" % ",".join(code_path))
-
-    data_path = os.path.join(dst_path, conf[DATA]) if (DATA in conf) else dst_path
-    return loader_template.format(update_path=update_path, main=conf[MAIN], data_path=data_path)
 
 
 loader_template = """

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -443,7 +443,7 @@ def save_model(path, loader_module=None, data_path=None, code_path=None, conda_e
     parameters for the second workflow: ``python_model``, ``artifacts``, cannot be
     specified together.
 
-    :param dst_path: The path to which to save the Python model.
+    :param path: The path to which to save the Python model.
     :param loader_module: The name of the Python module that will be used to load the model
                           from ``data_path``. This module must define a method with the prototype
                           ``_load_pyfunc(data_path)``. If not *None*, this module and its

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -118,7 +118,7 @@ def test_model_save_load(sklearn_knn_model, main_scoped_model_class, iris_data, 
         return sk_model.predict(model_input) * 2
 
     pyfunc_model_path = os.path.join(str(tmpdir), "pyfunc_model")
-    mlflow.pyfunc.save_model(dst_path=pyfunc_model_path,
+    mlflow.pyfunc.save_model(path=pyfunc_model_path,
                              artifacts={
                                 "sk_model": sklearn_model_path
                              },
@@ -174,7 +174,7 @@ def test_model_load_from_remote_uri_succeeds(
         return sk_model.predict(model_input) * 2
 
     pyfunc_model_path = os.path.join(str(tmpdir), "pyfunc_model")
-    mlflow.pyfunc.save_model(dst_path=pyfunc_model_path,
+    mlflow.pyfunc.save_model(path=pyfunc_model_path,
                              artifacts={
                                 "sk_model": sklearn_model_path
                              },
@@ -219,7 +219,7 @@ def test_pyfunc_model_serving_without_conda_env_activation_succeeds_with_main_sc
         return sk_model.predict(model_input) * 2
 
     pyfunc_model_path = os.path.join(str(tmpdir), "pyfunc_model")
-    mlflow.pyfunc.save_model(dst_path=pyfunc_model_path,
+    mlflow.pyfunc.save_model(path=pyfunc_model_path,
                              artifacts={
                                 "sk_model": sklearn_model_path
                              },
@@ -248,7 +248,7 @@ def test_pyfunc_model_serving_with_conda_env_activation_succeeds_with_main_scope
         return sk_model.predict(model_input) * 2
 
     pyfunc_model_path = os.path.join(str(tmpdir), "pyfunc_model")
-    mlflow.pyfunc.save_model(dst_path=pyfunc_model_path,
+    mlflow.pyfunc.save_model(path=pyfunc_model_path,
                              artifacts={
                                 "sk_model": sklearn_model_path
                              },
@@ -276,7 +276,7 @@ def test_pyfunc_model_serving_without_conda_env_activation_succeeds_with_module_
         return sk_model.predict(model_input) * 2
 
     pyfunc_model_path = os.path.join(str(tmpdir), "pyfunc_model")
-    mlflow.pyfunc.save_model(dst_path=pyfunc_model_path,
+    mlflow.pyfunc.save_model(path=pyfunc_model_path,
                              artifacts={
                                 "sk_model": sklearn_model_path
                              },
@@ -306,7 +306,7 @@ def test_pyfunc_cli_predict_command_without_conda_env_activation_succeeds(
         return sk_model.predict(model_input) * 2
 
     pyfunc_model_path = os.path.join(str(tmpdir), "pyfunc_model")
-    mlflow.pyfunc.save_model(dst_path=pyfunc_model_path,
+    mlflow.pyfunc.save_model(path=pyfunc_model_path,
                              artifacts={
                                 "sk_model": sklearn_model_path
                              },
@@ -340,7 +340,7 @@ def test_pyfunc_cli_predict_command_with_conda_env_activation_succeeds(
         return sk_model.predict(model_input) * 2
 
     pyfunc_model_path = os.path.join(str(tmpdir), "pyfunc_model")
-    mlflow.pyfunc.save_model(dst_path=pyfunc_model_path,
+    mlflow.pyfunc.save_model(path=pyfunc_model_path,
                              artifacts={
                                 "sk_model": sklearn_model_path
                              },
@@ -372,7 +372,7 @@ def test_save_model_persists_specified_conda_env_in_mlflow_model_directory(
                               serialization_format=mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE)
 
     pyfunc_model_path = os.path.join(str(tmpdir), "pyfunc_model")
-    mlflow.pyfunc.save_model(dst_path=pyfunc_model_path,
+    mlflow.pyfunc.save_model(path=pyfunc_model_path,
                              artifacts={
                                 "sk_model": sklearn_model_path
                              },
@@ -433,7 +433,7 @@ def test_save_model_without_specified_conda_env_uses_default_env_with_expected_d
     mlflow.sklearn.save_model(sk_model=sklearn_logreg_model, path=sklearn_model_path)
 
     pyfunc_model_path = os.path.join(str(tmpdir), "pyfunc_model")
-    mlflow.pyfunc.save_model(dst_path=pyfunc_model_path,
+    mlflow.pyfunc.save_model(path=pyfunc_model_path,
                              artifacts={
                                 "sk_model": sklearn_model_path
                              },
@@ -499,7 +499,7 @@ def test_save_model_correctly_resolves_directory_artifact_with_nested_contents(
                 with open(expected_file_path, "r") as f:
                     return (f.read() == nested_file_text)
 
-    mlflow.pyfunc.save_model(dst_path=model_path,
+    mlflow.pyfunc.save_model(path=model_path,
                              artifacts={
                                  "testdir": directory_artifact_path
                              },
@@ -511,7 +511,7 @@ def test_save_model_correctly_resolves_directory_artifact_with_nested_contents(
 
 @pytest.mark.large
 def test_save_model_with_no_artifacts_does_not_produce_artifacts_dir(model_path):
-    mlflow.pyfunc.save_model(dst_path=model_path,
+    mlflow.pyfunc.save_model(path=model_path,
                              python_model=ModuleScopedSklearnModel(predict_fn=None),
                              artifacts=None)
 
@@ -525,12 +525,12 @@ def test_save_model_with_no_artifacts_does_not_produce_artifacts_dir(model_path)
 @pytest.mark.large
 def test_save_model_with_python_model_argument_of_invalid_type_raises_exeption(tmpdir):
     with pytest.raises(MlflowException) as exc_info:
-        mlflow.pyfunc.save_model(dst_path=os.path.join(str(tmpdir), "model1"),
+        mlflow.pyfunc.save_model(path=os.path.join(str(tmpdir), "model1"),
                                  python_model="not the right type")
     assert "python_model` must be a subclass of `PythonModel`" in str(exc_info)
 
     with pytest.raises(MlflowException) as exc_info:
-        mlflow.pyfunc.save_model(dst_path=os.path.join(str(tmpdir), "model2"),
+        mlflow.pyfunc.save_model(path=os.path.join(str(tmpdir), "model2"),
                                  python_model="not the right type")
     assert "python_model` must be a subclass of `PythonModel`" in str(exc_info)
 
@@ -538,7 +538,7 @@ def test_save_model_with_python_model_argument_of_invalid_type_raises_exeption(t
 @pytest.mark.large
 def test_save_model_with_unsupported_argument_combinations_throws_exception(model_path):
     with pytest.raises(MlflowException) as exc_info:
-        mlflow.pyfunc.save_model(dst_path=model_path,
+        mlflow.pyfunc.save_model(path=model_path,
                                  artifacts={
                                     "artifact": "/path/to/artifact",
                                  },
@@ -548,7 +548,7 @@ def test_save_model_with_unsupported_argument_combinations_throws_exception(mode
     python_model = ModuleScopedSklearnModel(predict_fn=None)
     loader_module = __name__
     with pytest.raises(MlflowException) as exc_info:
-        mlflow.pyfunc.save_model(dst_path=model_path,
+        mlflow.pyfunc.save_model(path=model_path,
                                  python_model=python_model,
                                  loader_module=loader_module)
     assert "The following sets of parameters cannot be specified together" in str(exc_info)
@@ -556,7 +556,7 @@ def test_save_model_with_unsupported_argument_combinations_throws_exception(mode
     assert str(loader_module) in str(exc_info)
 
     with pytest.raises(MlflowException) as exc_info:
-        mlflow.pyfunc.save_model(dst_path=model_path,
+        mlflow.pyfunc.save_model(path=model_path,
                                  python_model=python_model,
                                  data_path="/path/to/data",
                                  artifacts={
@@ -565,7 +565,7 @@ def test_save_model_with_unsupported_argument_combinations_throws_exception(mode
     assert "The following sets of parameters cannot be specified together" in str(exc_info)
 
     with pytest.raises(MlflowException) as exc_info:
-        mlflow.pyfunc.save_model(dst_path=model_path,
+        mlflow.pyfunc.save_model(path=model_path,
                                  python_model=None,
                                  loader_module=None)
     assert "Either `loader_module` or `python_model` must be specified" in str(exc_info)
@@ -614,7 +614,7 @@ def test_load_model_with_differing_cloudpickle_version_at_micro_granularity_logs
         def predict(self, context, model_input):
             return model_input
 
-    mlflow.pyfunc.save_model(dst_path=model_path, python_model=TestModel())
+    mlflow.pyfunc.save_model(path=model_path, python_model=TestModel())
     saver_cloudpickle_version = "0.5.8"
     model_config_path = os.path.join(model_path, "MLmodel")
     model_config = Model.load(model_config_path)
@@ -649,7 +649,7 @@ def test_load_model_with_missing_cloudpickle_version_logs_warning(
         def predict(self, context, model_input):
             return model_input
 
-    mlflow.pyfunc.save_model(dst_path=model_path, python_model=TestModel())
+    mlflow.pyfunc.save_model(path=model_path, python_model=TestModel())
     model_config_path = os.path.join(model_path, "MLmodel")
     model_config = Model.load(model_config_path)
     del model_config.flavors[mlflow.pyfunc.FLAVOR_NAME][
@@ -685,7 +685,7 @@ def test_sagemaker_docker_model_scoring_with_default_conda_env(
         return sk_model.predict(model_input) * 2
 
     pyfunc_model_path = os.path.join(str(tmpdir), "pyfunc_model")
-    mlflow.pyfunc.save_model(dst_path=pyfunc_model_path,
+    mlflow.pyfunc.save_model(path=pyfunc_model_path,
                              artifacts={
                                 "sk_model": sklearn_model_path
                              },

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -56,7 +56,7 @@ def test_model_save_load(sklearn_knn_model, iris_data, tmpdir, model_path):
         pickle.dump(sklearn_knn_model, f)
 
     model_config = Model(run_id="test", artifact_path="testtest")
-    mlflow.pyfunc.save_model(dst_path=model_path,
+    mlflow.pyfunc.save_model(path=model_path,
                              data_path=sk_model_path,
                              loader_module=os.path.basename(__file__)[:-3],
                              code_path=[__file__],
@@ -97,7 +97,7 @@ def test_model_log_load(sklearn_knn_model, iris_data, tmpdir):
 @pytest.mark.large
 def test_save_model_with_unsupported_argument_combinations_throws_exception(model_path):
     with pytest.raises(MlflowException) as exc_info:
-        mlflow.pyfunc.save_model(dst_path=model_path,
+        mlflow.pyfunc.save_model(path=model_path,
                                  data_path="/path/to/data")
     assert "Either `loader_module` or `python_model` must be specified" in str(exc_info)
 

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -68,7 +68,7 @@ def model_path(tmpdir):
 @pytest.mark.large
 def test_spark_udf(spark, model_path):
     mlflow.pyfunc.save_model(
-        dst_path=model_path,
+        path=model_path,
         loader_module=__name__,
         code_path=[os.path.dirname(tests.__file__)],
     )
@@ -111,7 +111,7 @@ def test_spark_udf(spark, model_path):
 @pytest.mark.large
 def test_model_cache(spark, model_path):
     mlflow.pyfunc.save_model(
-        dst_path=model_path,
+        path=model_path,
         loader_module=__name__,
         code_path=[os.path.dirname(tests.__file__)],
     )


### PR DESCRIPTION
## What changes are proposed in this pull request?

This makes pyfunc consistent with all other save_models.

Also removes unused `get_module_loader_src` method.
 
## How is this patch tested?
 
- [x] Unit tests
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
`pyfunc.save_model` has the `dst_path` parameter renamed to `path`.
 
### What component(s) does this PR affect?
 
- [x] Models 
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
