### PR TITLE
Python/R API fixes for 1.0

### DIFF
--- a/examples/hyperparam/search_gpyopt.py
+++ b/examples/hyperparam/search_gpyopt.py
@@ -99,7 +99,7 @@ def run(training_data, max_runs, batch_size, max_p, epochs, metric, gpy_model, g
                     "momentum": str(momentum),
                     "seed": str(seed)},
                 experiment_id=experiment_id,
-                block=False
+                synchronous=False
             )
 
             if p.wait():

--- a/examples/hyperparam/search_random.py
+++ b/examples/hyperparam/search_random.py
@@ -64,7 +64,7 @@ def run(training_data, max_runs, max_p, epochs, metric, seed, training_experimen
                     "momentum": str(momentum),
                     "seed": str(seed)},
                 experiment_id=experiment_id,
-                block=False)
+                synchronous=False)
             if p.wait():
                 training_run = tracking_client.get_run(p.run_id)
 

--- a/mlflow/R/mlflow/R/project-run.R
+++ b/mlflow/R/mlflow/R/project-run.R
@@ -9,7 +9,8 @@
 #' @param experiment_id ID of the experiment under which to launch the run.
 #' @param experiment_name Name of the experiment under which to launch the run.
 #' @param backend Execution backend to use for run.
-#' @param backend_spec Path to JSON file describing the cluster to use when launching a run on Databricks.
+#' @param backend_config Path to JSON file which will be passed to the backend. For the Databricks backend,
+#'   it should describe the cluster to use when launching a run on Databricks.
 #' @param no_conda If specified, assume that MLflow is running within a Conda environment with the necessary
 #'   dependencies for the current project instead of attempting to create a new Conda environment. Only
 #'   valid if running locally.
@@ -20,7 +21,7 @@
 #'
 #' @export
 mlflow_run <- function(entry_point = NULL, uri = ".", version = NULL, param_list = NULL,
-                       experiment_id = NULL, experiment_name = NULL, backend = NULL, backend_spec = NULL,
+                       experiment_id = NULL, experiment_name = NULL, backend = NULL, backend_config = NULL,
                        no_conda = FALSE, storage_dir = NULL) {
   if (!is.null(experiment_name) && !is.null(experiment_id)) {
     stop("Specify only one of `experiment_name` or `experiment_id`.")
@@ -41,7 +42,7 @@ mlflow_run <- function(entry_point = NULL, uri = ".", version = NULL, param_list
     mlflow_cli_param("--experiment-id", experiment_id) %>%
     mlflow_cli_param("--experiment-name", experiment_name) %>%
     mlflow_cli_param("--backend", backend) %>%
-    mlflow_cli_param("--backend-spec", backend_spec) %>%
+    mlflow_cli_param("--backend-config", backend_config) %>%
     mlflow_cli_param("--storage-dir", storage_dir) %>%
     c(param_list)
 

--- a/mlflow/R/mlflow/R/project-run.R
+++ b/mlflow/R/mlflow/R/project-run.R
@@ -8,23 +8,20 @@
 #' @param param_list A list of parameters.
 #' @param experiment_id ID of the experiment under which to launch the run.
 #' @param experiment_name Name of the experiment under which to launch the run.
-#' @param mode Execution mode to use for run.
-#' @param cluster_spec Path to JSON file describing the cluster to use when launching a run on Databricks.
-#' @param git_username Username for HTTP(S) Git authentication.
-#' @param git_password Password for HTTP(S) Git authentication.
+#' @param backend Execution backend to use for run.
+#' @param backend_spec Path to JSON file describing the cluster to use when launching a run on Databricks.
 #' @param no_conda If specified, assume that MLflow is running within a Conda environment with the necessary
 #'   dependencies for the current project instead of attempting to create a new Conda environment. Only
 #'   valid if running locally.
-#' @param storage_dir Valid only when `mode` is local. MLflow downloads artifacts from distributed URIs passed to
+#' @param storage_dir Valid only when `backend` is local. MLflow downloads artifacts from distributed URIs passed to
 #'  parameters of type `path` to subdirectories of `storage_dir`.
 #'
 #' @return The run associated with this run.
 #'
 #' @export
 mlflow_run <- function(entry_point = NULL, uri = ".", version = NULL, param_list = NULL,
-                       experiment_id = NULL, experiment_name = NULL, mode = NULL, cluster_spec = NULL,
-                       git_username = NULL, git_password = NULL, no_conda = FALSE,
-                       storage_dir = NULL) {
+                       experiment_id = NULL, experiment_name = NULL, backend = NULL, backend_spec = NULL,
+                       no_conda = FALSE, storage_dir = NULL) {
   if (!is.null(experiment_name) && !is.null(experiment_id)) {
     stop("Specify only one of `experiment_name` or `experiment_id`.")
   }
@@ -43,10 +40,8 @@ mlflow_run <- function(entry_point = NULL, uri = ".", version = NULL, param_list
     mlflow_cli_param("--version", version) %>%
     mlflow_cli_param("--experiment-id", experiment_id) %>%
     mlflow_cli_param("--experiment-name", experiment_name) %>%
-    mlflow_cli_param("--mode", mode) %>%
-    mlflow_cli_param("--cluster-spec", cluster_spec) %>%
-    mlflow_cli_param("--git-username", git_username) %>%
-    mlflow_cli_param("--git-password", git_password) %>%
+    mlflow_cli_param("--backend", backend) %>%
+    mlflow_cli_param("--backend-spec", backend_spec) %>%
     mlflow_cli_param("--storage-dir", storage_dir) %>%
     c(param_list)
 

--- a/mlflow/R/mlflow/man/mlflow_run.Rd
+++ b/mlflow/R/mlflow/man/mlflow_run.Rd
@@ -6,7 +6,7 @@
 \usage{
 mlflow_run(entry_point = NULL, uri = ".", version = NULL,
   param_list = NULL, experiment_id = NULL, experiment_name = NULL,
-  backend = NULL, backend_spec = NULL, no_conda = FALSE, storage_dir = NULL)
+  backend = NULL, backend_config = NULL, no_conda = FALSE, storage_dir = NULL)
 }
 \arguments{
 \item{entry_point}{Entry point within project, defaults to `main` if not specified.}
@@ -23,7 +23,8 @@ mlflow_run(entry_point = NULL, uri = ".", version = NULL,
 
 \item{backend}{Execution backend to use for run.}
 
-\item{backend_spec}{Path to JSON file describing the cluster to use when launching a run on Databricks.}
+\item{backend_config}{Path to JSON file which will be passed to the backend. For the Databricks backend,
+it should describe the cluster to use when launching a run on Databricks.}
 
 \item{no_conda}{If specified, assume that MLflow is running within a Conda environment with the necessary
 dependencies for the current project instead of attempting to create a new Conda environment. Only

--- a/mlflow/R/mlflow/man/mlflow_run.Rd
+++ b/mlflow/R/mlflow/man/mlflow_run.Rd
@@ -6,8 +6,7 @@
 \usage{
 mlflow_run(entry_point = NULL, uri = ".", version = NULL,
   param_list = NULL, experiment_id = NULL, experiment_name = NULL,
-  mode = NULL, cluster_spec = NULL, git_username = NULL,
-  git_password = NULL, no_conda = FALSE, storage_dir = NULL)
+  backend = NULL, backend_spec = NULL, no_conda = FALSE, storage_dir = NULL)
 }
 \arguments{
 \item{entry_point}{Entry point within project, defaults to `main` if not specified.}
@@ -22,19 +21,15 @@ mlflow_run(entry_point = NULL, uri = ".", version = NULL,
 
 \item{experiment_name}{Name of the experiment under which to launch the run.}
 
-\item{mode}{Execution mode to use for run.}
+\item{backend}{Execution backend to use for run.}
 
-\item{cluster_spec}{Path to JSON file describing the cluster to use when launching a run on Databricks.}
-
-\item{git_username}{Username for HTTP(S) Git authentication.}
-
-\item{git_password}{Password for HTTP(S) Git authentication.}
+\item{backend_spec}{Path to JSON file describing the cluster to use when launching a run on Databricks.}
 
 \item{no_conda}{If specified, assume that MLflow is running within a Conda environment with the necessary
 dependencies for the current project instead of attempting to create a new Conda environment. Only
 valid if running locally.}
 
-\item{storage_dir}{Valid only when `mode` is local. MLflow downloads artifacts from distributed URIs passed to
+\item{storage_dir}{Valid only when `backend` is local. MLflow downloads artifacts from distributed URIs passed to
 parameters of type `path` to subdirectories of `storage_dir`.}
 }
 \value{

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -27,8 +27,6 @@ For a lower level API, see the :py:mod:`mlflow.tracking` module.
 
 from mlflow.version import VERSION as __version__
 
-import os
-
 # Filter annoying Cython warnings that serve no good purpose, and so before
 # importing other modules.
 # See: https://github.com/numpy/numpy/pull/432/commits/170ed4e33d6196d7

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -18,7 +18,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils import PYTHON_VERSION, get_unique_resource_id
+from mlflow.utils import PYTHON_VERSION, experimental, get_unique_resource_id
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree, _copy_project
 from mlflow.version import VERSION as mlflow_version
 
@@ -26,6 +26,7 @@ from mlflow.version import VERSION as mlflow_version
 _logger = logging.getLogger(__name__)
 
 
+@experimental
 def build_image(model_uri, workspace, image_name=None, model_name=None,
                 mlflow_home=None, description=None, tags=None, synchronous=True):
     """

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -57,8 +57,8 @@ def cli():
 @click.option("--experiment-id", envvar=tracking._EXPERIMENT_ID_ENV_VAR, type=click.STRING,
               help="ID of the experiment under which to launch the run.")
 # TODO: Add tracking server argument once we have it working.
-@click.option("--mode", "-m", metavar="MODE",
-              help="Execution mode to use for run. Supported values: 'local' (runs project "
+@click.option("--backend", "-m", metavar="BACKEND",
+              help="Execution backend to use for run. Supported values: 'local' (runs project "
                    "locally) and 'databricks' (runs project on a Databricks cluster). "
                    "Defaults to 'local'. If running against Databricks, will run against a "
                    "Databricks workspace determined as follows: if a Databricks tracking URI "
@@ -68,26 +68,22 @@ def cli():
                    "specified by the default Databricks CLI profile. See "
                    "https://github.com/databricks/databricks-cli for more info on configuring a "
                    "Databricks CLI profile.")
-@click.option("--cluster-spec", "-c", metavar="FILE",
+@click.option("--backend-spec", "-c", metavar="FILE",
               help="Path to JSON file (must end in '.json') or JSON string describing the cluster "
                    "to use when launching a run on Databricks. See "
                    "https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster for "
                    "more info. Note that MLflow runs are currently launched against a new cluster.")
-@click.option("--git-username", metavar="USERNAME", envvar="MLFLOW_GIT_USERNAME",
-              help="Username for HTTP(S) Git authentication.")
-@click.option("--git-password", metavar="PASSWORD", envvar="MLFLOW_GIT_PASSWORD",
-              help="Password for HTTP(S) Git authentication.")
 @cli_args.NO_CONDA
 @click.option("--storage-dir", envvar="MLFLOW_TMP_DIR",
-              help="Only valid when `mode` is local."
+              help="Only valid when ``backend`` is local."
                    "MLflow downloads artifacts from distributed URIs passed to parameters of "
                    "type 'path' to subdirectories of storage_dir.")
 @click.option("--run-id", metavar="RUN_ID",
               help="If specified, the given run ID will be used instead of creating a new run. "
                    "Note: this argument is used internally by the MLflow project APIs "
                    "and should not be specified.")
-def run(uri, entry_point, version, param_list, experiment_name, experiment_id, mode, cluster_spec,
-        git_username, git_password, no_conda, storage_dir, run_id):
+def run(uri, entry_point, version, param_list, experiment_name, experiment_id, backend,
+        backend_spec, no_conda, storage_dir, run_id):
     """
     Run an MLflow project from the given URI.
 
@@ -116,10 +112,10 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, m
             eprint("Repeated parameter: '%s'" % name)
             sys.exit(1)
         param_dict[name] = value
-    cluster_spec_arg = cluster_spec
-    if cluster_spec is not None and os.path.splitext(cluster_spec)[-1] != ".json":
+    cluster_spec_arg = backend_spec
+    if backend_spec is not None and os.path.splitext(backend_spec)[-1] != ".json":
         try:
-            cluster_spec_arg = json.loads(cluster_spec)
+            cluster_spec_arg = json.loads(backend_spec)
         except ValueError as e:
             eprint("Invalid cluster spec JSON. Parse error: %s" % e)
             raise
@@ -131,13 +127,11 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, m
             experiment_name=experiment_name,
             experiment_id=experiment_id,
             parameters=param_dict,
-            mode=mode,
-            cluster_spec=cluster_spec_arg,
-            git_username=git_username,
-            git_password=git_password,
+            backend=backend,
+            backend_spec=cluster_spec_arg,
             use_conda=(not no_conda),
             storage_dir=storage_dir,
-            block=mode == "local" or mode is None,
+            synchronous=backend == "local" or backend is None,
             run_id=run_id,
         )
     except projects.ExecutionException as e:

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -68,11 +68,13 @@ def cli():
                    "specified by the default Databricks CLI profile. See "
                    "https://github.com/databricks/databricks-cli for more info on configuring a "
                    "Databricks CLI profile.")
-@click.option("--backend-spec", "-s", metavar="FILE",
-              help="Path to JSON file (must end in '.json') or JSON string describing the cluster "
-                   "to use when launching a run on Databricks. See "
-                   "https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster for "
-                   "more info. Note that MLflow runs are currently launched against a new cluster.")
+@click.option("--backend-config", "-c", metavar="FILE",
+              help="Path to JSON file (must end in '.json') or JSON string which will be passed "
+                   "as config to the backend. For the Databricks backend, this should be a "
+                   "cluster spec: see "
+                   "https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster "
+                   "for more information. Note that MLflow runs are currently launched against "
+                   "a new cluster.")
 @cli_args.NO_CONDA
 @click.option("--storage-dir", envvar="MLFLOW_TMP_DIR",
               help="Only valid when ``backend`` is local."
@@ -83,7 +85,7 @@ def cli():
                    "Note: this argument is used internally by the MLflow project APIs "
                    "and should not be specified.")
 def run(uri, entry_point, version, param_list, experiment_name, experiment_id, backend,
-        backend_spec, no_conda, storage_dir, run_id):
+        backend_config, no_conda, storage_dir, run_id):
     """
     Run an MLflow project from the given URI.
 
@@ -112,10 +114,10 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, b
             eprint("Repeated parameter: '%s'" % name)
             sys.exit(1)
         param_dict[name] = value
-    cluster_spec_arg = backend_spec
-    if backend_spec is not None and os.path.splitext(backend_spec)[-1] != ".json":
+    cluster_spec_arg = backend_config
+    if backend_config is not None and os.path.splitext(backend_config)[-1] != ".json":
         try:
-            cluster_spec_arg = json.loads(backend_spec)
+            cluster_spec_arg = json.loads(backend_config)
         except ValueError as e:
             eprint("Invalid cluster spec JSON. Parse error: %s" % e)
             raise
@@ -128,7 +130,7 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, b
             experiment_id=experiment_id,
             parameters=param_dict,
             backend=backend,
-            backend_spec=cluster_spec_arg,
+            backend_config=cluster_spec_arg,
             use_conda=(not no_conda),
             storage_dir=storage_dir,
             synchronous=backend == "local" or backend is None,

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -57,7 +57,7 @@ def cli():
 @click.option("--experiment-id", envvar=tracking._EXPERIMENT_ID_ENV_VAR, type=click.STRING,
               help="ID of the experiment under which to launch the run.")
 # TODO: Add tracking server argument once we have it working.
-@click.option("--backend", "-m", metavar="BACKEND",
+@click.option("--backend", "-b", metavar="BACKEND",
               help="Execution backend to use for run. Supported values: 'local' (runs project "
                    "locally) and 'databricks' (runs project on a Databricks cluster). "
                    "Defaults to 'local'. If running against Databricks, will run against a "
@@ -68,7 +68,7 @@ def cli():
                    "specified by the default Databricks CLI profile. See "
                    "https://github.com/databricks/databricks-cli for more info on configuring a "
                    "Databricks CLI profile.")
-@click.option("--backend-spec", "-c", metavar="FILE",
+@click.option("--backend-spec", "-s", metavar="FILE",
               help="Path to JSON file (must end in '.json') or JSON string describing the cluster "
                    "to use when launching a run on Databricks. See "
                    "https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster for "

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -19,21 +19,24 @@ from datetime import datetime
 
 import yaml
 
-
 import mlflow
 from mlflow.utils.file_utils import TempDir
 
 
 class Model(object):
-    """An MLflow Model that can support multiple model flavors."""
+    """
+    An MLflow Model that can support multiple model flavors. It is a useful class to use in
+    implementing new Model flavors.
+    """
 
-    def __init__(self, artifact_path=None, run_id=None, utc_time_created=datetime.utcnow(),
-                 flavors=None):
+    # TODO(sueann): keyword_only?
+    def __init__(self, artifact_path=None, run_id=None, utc_time_created=None, flavors=None):
         # store model id instead of run_id and path to avoid confusion when model gets exported
         if run_id:
             self.run_id = run_id
             self.artifact_path = artifact_path
-        self.utc_time_created = str(utc_time_created)
+        self.utc_time_created = \
+            str(utc_time_created if utc_time_created is not None else datetime.utcnow())
         self.flavors = flavors if flavors is not None else {}
 
     def add_flavor(self, name, **params):

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -29,7 +29,6 @@ class Model(object):
     implementing new Model flavors.
     """
 
-    # TODO(sueann): keyword_only?
     def __init__(self, artifact_path=None, run_id=None, utc_time_created=None, flavors=None):
         # store model id instead of run_id and path to avoid confusion when model gets exported
         if run_id:

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -25,8 +25,8 @@ from mlflow.utils.file_utils import TempDir
 
 class Model(object):
     """
-    An MLflow Model that can support multiple model flavors. It is a useful class to use in
-    implementing new Model flavors.
+    An MLflow Model that can support multiple model flavors. Provides APIs for implementing
+    new Model flavors.
     """
 
     def __init__(self, artifact_path=None, run_id=None, utc_time_created=None, flavors=None):
@@ -34,8 +34,7 @@ class Model(object):
         if run_id:
             self.run_id = run_id
             self.artifact_path = artifact_path
-        self.utc_time_created = \
-            str(utc_time_created if utc_time_created is not None else datetime.utcnow())
+        self.utc_time_created = str(utc_time_created or datetime.utcnow())
         self.flavors = flavors if flavors is not None else {}
 
     def add_flavor(self, name, **params):

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -70,7 +70,7 @@ def _resolve_experiment_id(experiment_name=None, experiment_id=None):
 
 
 def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
-         backend=None, cluster_spec=None, use_conda=True,
+         backend=None, backend_spec=None, use_conda=True,
          storage_dir=None, synchronous=True, run_id=None):
     """
     Helper that delegates to the project-running method corresponding to the passed-in backend.
@@ -109,7 +109,7 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
         return run_databricks(
             remote_run=active_run,
             uri=uri, entry_point=entry_point, work_dir=work_dir, parameters=parameters,
-            experiment_id=experiment_id, cluster_spec=cluster_spec)
+            experiment_id=experiment_id, cluster_spec=backend_spec)
 
     elif backend == "local" or backend is None:
         command = []
@@ -222,7 +222,7 @@ def run(uri, entry_point="main", version=None, parameters=None,
 
     submitted_run_obj = _run(
         uri=uri, experiment_id=experiment_id, entry_point=entry_point, version=version,
-        parameters=parameters, backend=backend, cluster_spec=cluster_spec_dict, use_conda=use_conda,
+        parameters=parameters, backend=backend, backend_spec=cluster_spec_dict, use_conda=use_conda,
         storage_dir=storage_dir, synchronous=synchronous, run_id=run_id)
     if synchronous:
         _wait_for(submitted_run_obj)

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -70,18 +70,17 @@ def _resolve_experiment_id(experiment_name=None, experiment_id=None):
 
 
 def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
-         mode=None, cluster_spec=None, git_username=None, git_password=None, use_conda=True,
-         storage_dir=None, block=True, run_id=None):
+         backend=None, cluster_spec=None, use_conda=True,
+         storage_dir=None, synchronous=True, run_id=None):
     """
-    Helper that delegates to the project-running method corresponding to the passed-in mode.
+    Helper that delegates to the project-running method corresponding to the passed-in backend.
     Returns a ``SubmittedRun`` corresponding to the project run.
     """
 
     parameters = parameters or {}
-    work_dir = _fetch_project(uri=uri, force_tempdir=False, version=version,
-                              git_username=git_username, git_password=git_password)
+    work_dir = _fetch_project(uri=uri, force_tempdir=False, version=version)
     project = _project_spec.load_project(work_dir)
-    _validate_execution_environment(project, mode)
+    _validate_execution_environment(project, backend)
     project.get_entry_point(entry_point)._validate_parameters(parameters)
     if run_id:
         active_run = tracking.MlflowClient().get_run(run_id)
@@ -105,14 +104,14 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
         for tag in [MLFLOW_GIT_BRANCH, LEGACY_MLFLOW_GIT_BRANCH_NAME]:
             tracking.MlflowClient().set_tag(active_run.info.run_id, tag, version)
 
-    if mode == "databricks":
+    if backend == "databricks":
         from mlflow.projects.databricks import run_databricks
         return run_databricks(
             remote_run=active_run,
             uri=uri, entry_point=entry_point, work_dir=work_dir, parameters=parameters,
             experiment_id=experiment_id, cluster_spec=cluster_spec)
 
-    elif mode == "local" or mode is None:
+    elif backend == "local" or backend is None:
         command = []
         command_separator = " "
         # If a docker_env attribute is defined in MLProject then it takes precedence over conda yaml
@@ -132,10 +131,10 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
             command_separator = " && "
             conda_env_name = _get_or_create_conda_env(project.conda_env_path)
             command += _get_conda_command(conda_env_name)
-        # In blocking mode, run the entry point command in blocking fashion, sending status updates
-        # to the tracking server when finished. Note that the run state may not be persisted to the
-        # tracking server if interrupted
-        if block:
+        # In synchronous mode, run the entry point command in a blocking fashion, sending status
+        # updates to the tracking server when finished. Note that the run state may not be
+        # persisted to the tracking server if interrupted
+        if synchronous:
             command += _get_entry_point_command(project, entry_point, parameters, storage_dir)
             command = command_separator.join(command)
             return _run_entry_point(command, work_dir, experiment_id,
@@ -145,15 +144,15 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
             work_dir=work_dir, entry_point=entry_point, parameters=parameters,
             experiment_id=experiment_id,
             use_conda=use_conda, storage_dir=storage_dir, run_id=active_run.info.run_id)
-    supported_modes = ["local", "databricks"]
+    supported_backends = ["local", "databricks"]
     raise ExecutionException("Got unsupported execution mode %s. Supported "
-                             "values: %s" % (mode, supported_modes))
+                             "values: %s" % (backend, supported_backends))
 
 
 def run(uri, entry_point="main", version=None, parameters=None,
         experiment_name=None, experiment_id=None,
-        mode=None, cluster_spec=None, git_username=None, git_password=None, use_conda=True,
-        storage_dir=None, block=True, run_id=None):
+        backend=None, backend_spec=None, use_conda=True,
+        storage_dir=None, synchronous=True, run_id=None):
     """
     Run an MLflow project. The project can be local or stored at a Git URI.
 
@@ -174,30 +173,28 @@ def run(uri, entry_point="main", version=None, parameters=None,
     :param version: For Git-based projects, either a commit hash or a branch name.
     :param experiment_name: Name of experiment under which to launch the run.
     :param experiment_id: ID of experiment under which to launch the run.
-    :param mode: Execution mode of the run: "local" or "databricks". If running against Databricks,
-                 will run against a Databricks workspace determined as follows: if a Databricks
-                 tracking URI of the form 'databricks://profile' has been set (e.g. by setting
-                 the MLFLOW_TRACKING_URI environment variable), will run against the workspace
-                 specified by <profile>. Otherwise, runs against the workspace specified by the
-                 default Databricks CLI profile.
-    :param cluster_spec: When ``mode`` is "databricks", dictionary or path to a JSON file
+    :param backend: Execution backend for the run: "local" or "databricks". If running against
+                    Databricks, will run against a Databricks workspace determined as follows: if
+                    a Databricks tracking URI of the form ``databricks://profile`` has been set
+                    (e.g. by setting the MLFLOW_TRACKING_URI environment variable), will run
+                    against the workspace specified by <profile>. Otherwise, runs against the
+                    workspace specified by the default Databricks CLI profile.
+    :param backend_spec: When ``backend`` is "databricks", dictionary or path to a JSON file
                          containing a `Databricks cluster specification
                          <https://docs.databricks.com/api/latest/jobs.html#clusterspec>`_
                          to use when launching a run.
-    :param git_username: Username for HTTP(S) authentication with Git.
-    :param git_password: Password for HTTP(S) authentication with Git.
     :param use_conda: If True (the default), create a new Conda environment for the run and
                       install project dependencies within that environment. Otherwise, run the
                       project in the current environment without installing any project
                       dependencies.
-    :param storage_dir: Used only if ``mode`` is "local". MLflow downloads artifacts from
+    :param storage_dir: Used only if ``backend`` is "local". MLflow downloads artifacts from
                         distributed URIs passed to parameters of type ``path`` to subdirectories of
                         ``storage_dir``.
-    :param block: Whether to block while waiting for a run to complete. Defaults to True.
-                  Note that if ``block`` is False and mode is "local", this method will return, but
-                  the current process will block when exiting until the local run completes.
-                  If the current process is interrupted, any asynchronous runs launched via this
-                  method will be terminated.
+    :param synchronous: Whether to block while waiting for a run to complete. Defaults to True.
+                        Note that if ``synchronous`` is False and ``backend`` is "local", this
+                        method will return, but the current process will block when exiting until
+                        the local run completes. If the current process is interrupted, any
+                        asynchronous runs launched via this method will be terminated.
     :param run_id: Note: this argument is used internally by the MLflow project APIs and should
                    not be specified. If specified, the run ID will be used instead of
                    creating a new run.
@@ -205,31 +202,29 @@ def run(uri, entry_point="main", version=None, parameters=None,
              about the launched run.
     """
 
-    cluster_spec_dict = cluster_spec
-    if (cluster_spec and type(cluster_spec) != dict
-            and os.path.splitext(cluster_spec)[-1] == ".json"):
-        with open(cluster_spec, 'r') as handle:
+    cluster_spec_dict = backend_spec
+    if (backend_spec and type(backend_spec) != dict
+            and os.path.splitext(backend_spec)[-1] == ".json"):
+        with open(backend_spec, 'r') as handle:
             try:
                 cluster_spec_dict = json.load(handle)
             except ValueError:
                 _logger.error(
                     "Error when attempting to load and parse JSON cluster spec from file %s",
-                    cluster_spec)
+                    backend_spec)
                 raise
 
-    if mode == "databricks":
-        mlflow.projects.databricks.before_run_validations(mlflow.get_tracking_uri(), cluster_spec)
+    if backend == "databricks":
+        mlflow.projects.databricks.before_run_validations(mlflow.get_tracking_uri(), backend_spec)
 
     experiment_id = _resolve_experiment_id(experiment_name=experiment_name,
                                            experiment_id=experiment_id)
 
     submitted_run_obj = _run(
         uri=uri, experiment_id=experiment_id, entry_point=entry_point, version=version,
-        parameters=parameters,
-        mode=mode, cluster_spec=cluster_spec_dict,
-        git_username=git_username, git_password=git_password, use_conda=use_conda,
-        storage_dir=storage_dir, block=block, run_id=run_id)
-    if block:
+        parameters=parameters, backend=backend, cluster_spec=cluster_spec_dict, use_conda=use_conda,
+        storage_dir=storage_dir, synchronous=synchronous, run_id=run_id)
+    if synchronous:
         _wait_for(submitted_run_obj)
     return submitted_run_obj
 
@@ -326,7 +321,7 @@ def _is_valid_branch_name(work_dir, version):
     return False
 
 
-def _fetch_project(uri, force_tempdir, version=None, git_username=None, git_password=None):
+def _fetch_project(uri, force_tempdir, version=None):
     """
     Fetch a project into a local directory, returning the path to the local project directory.
     :param force_tempdir: If True, will fetch the project into a temporary directory. Otherwise,
@@ -354,7 +349,7 @@ def _fetch_project(uri, force_tempdir, version=None, git_username=None, git_pass
             dir_util.copy_tree(src=parsed_uri, dst=dst_dir)
     else:
         assert _GIT_URI_REGEX.match(parsed_uri), "Non-local URI %s should be a Git URI" % parsed_uri
-        _fetch_git_repo(parsed_uri, version, dst_dir, git_username, git_password)
+        _fetch_git_repo(parsed_uri, version, dst_dir)
     res = os.path.abspath(os.path.join(dst_dir, subdirectory))
     if not os.path.exists(res):
         raise ExecutionException("Could not find subdirectory %s of %s" % (subdirectory, dst_dir))
@@ -382,28 +377,18 @@ def _fetch_zip_repo(uri):
     return BytesIO(response.content)
 
 
-def _fetch_git_repo(uri, version, dst_dir, git_username, git_password):
+def _fetch_git_repo(uri, version, dst_dir):
     """
     Clone the git repo at ``uri`` into ``dst_dir``, checking out commit ``version`` (or defaulting
     to the head commit of the repository's master branch if version is unspecified).
-    If ``git_username`` and ``git_password`` are specified, uses them to authenticate while fetching
-    the repo. Otherwise, assumes authentication parameters are specified by the environment,
-    e.g. by a Git credential helper.
+    Assumes authentication parameters are specified by the environment, e.g. by a Git credential
+    helper.
     """
     # We defer importing git until the last moment, because the import requires that the git
     # executable is availble on the PATH, so we only want to fail if we actually need it.
     import git
     repo = git.Repo.init(dst_dir)
     origin = repo.create_remote("origin", uri)
-    git_args = [git_username, git_password]
-    if not (all(arg is not None for arg in git_args) or all(arg is None for arg in git_args)):
-        raise ExecutionException("Either both or neither of git_username and git_password must be "
-                                 "specified.")
-    if git_username:
-        git_credentials = "url=%s\nusername=%s\npassword=%s" % (uri, git_username, git_password)
-        repo.git.config("--local", "credential.helper", "cache")
-        process.exec_cmd(cmd=["git", "credential-cache", "store"], cwd=dst_dir,
-                         cmd_stdin=git_credentials)
     origin.fetch()
     if version is not None:
         try:
@@ -623,8 +608,8 @@ def _get_conda_command(conda_env_name):
         return ["conda %s %s" % (activate_path, conda_env_name)]
 
 
-def _validate_execution_environment(project, mode):
-    if project.docker_env and mode == "databricks":
+def _validate_execution_environment(project, backend):
+    if project.docker_env and backend == "databricks":
         raise ExecutionException(
             "Running docker-based projects on Databricks is not yet supported.")
 

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -35,10 +35,10 @@ DBFS_EXPERIMENT_DIR_BASE = "mlflow-experiments"
 _logger = logging.getLogger(__name__)
 
 
-def before_run_validations(tracking_uri, cluster_spec):
+def before_run_validations(tracking_uri, backend_spec):
     """Validations to perform before running a project on Databricks."""
-    if cluster_spec is None:
-        raise ExecutionException("Cluster spec must be provided when launching MLflow project "
+    if backend_spec is None:
+        raise ExecutionException("Backend spec must be provided when launching MLflow project "
                                  "runs on Databricks.")
     if tracking.utils._is_local_uri(tracking_uri):
         raise ExecutionException(

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -35,9 +35,9 @@ DBFS_EXPERIMENT_DIR_BASE = "mlflow-experiments"
 _logger = logging.getLogger(__name__)
 
 
-def before_run_validations(tracking_uri, backend_spec):
+def before_run_validations(tracking_uri, backend_config):
     """Validations to perform before running a project on Databricks."""
-    if backend_spec is None:
+    if backend_config is None:
         raise ExecutionException("Backend spec must be provided when launching MLflow project "
                                  "runs on Databricks.")
     if tracking.utils._is_local_uri(tracking_uri):

--- a/mlflow/projects/submitted_run.py
+++ b/mlflow/projects/submitted_run.py
@@ -6,7 +6,6 @@ import logging
 
 from mlflow.entities import RunStatus
 
-
 _logger = logging.getLogger(__name__)
 
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -282,7 +282,7 @@ def load_model(model_uri, suppress_warnings=False):
                               loading process will be suppressed. If False, these warning messages
                               will be emitted.
     """
-    return load_pyfunc(path, run_id, suppress_warnings)
+    return load_pyfunc(model_uri, suppress_warnings)
 
 
 @deprecated("pyfunc.load_model")

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -206,7 +206,7 @@ from mlflow.models import Model
 from mlflow.pyfunc.model import PythonModel, PythonModelContext,\
     DEFAULT_CONDA_ENV
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils import PYTHON_VERSION, get_major_minor_py_version
+from mlflow.utils import PYTHON_VERSION, deprecated, get_major_minor_py_version
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
@@ -264,6 +264,28 @@ def _load_model_env(path):
     return _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME).get(ENV, None)
 
 
+def load_model(model_uri, suppress_warnings=False):
+    """
+    Load a model stored in Python function format.
+
+    :param model_uri: The location, in URI format, of the MLflow model, for example:
+
+                      - ``/Users/me/path/to/local/model``
+                      - ``relative/path/to/local/model``
+                      - ``s3://my_bucket/path/to/model``
+                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+
+                      For more information about supported URI schemes, see the
+                      `Artifacts Documentation <https://www.mlflow.org/docs/latest/tracking.html#
+                      supported-artifact-stores>`_.
+    :param suppress_warnings: If True, non-fatal warning messages associated with the model
+                              loading process will be suppressed. If False, these warning messages
+                              will be emitted.
+    """
+    return load_pyfunc(path, run_id, suppress_warnings)
+
+
+@deprecated("pyfunc.load_model")
 def load_pyfunc(model_uri, suppress_warnings=False):
     """
     Load a model stored in Python function format.

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -285,7 +285,7 @@ def load_model(model_uri, suppress_warnings=False):
     return load_pyfunc(model_uri, suppress_warnings)
 
 
-@deprecated("pyfunc.load_model")
+@deprecated("pyfunc.load_model", 1.0)
 def load_pyfunc(model_uri, suppress_warnings=False):
     """
     Load a model stored in Python function format.

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -119,9 +119,9 @@ def build_image(name=DEFAULT_IMAGE_NAME, mlflow_home=None):
     The image is built locally and it requires Docker to run.
 
     :param name: Docker image name.
-    :param mlflow_home: Path to a local copy of the MLflow GitHub repository. If specified, the
-                        image will install MLflow from this directory. Otherwise, it will install
-                        MLflow from pip.
+    :param mlflow_home: (Optional) Path to a local copy of the MLflow GitHub repository.
+                        If specified, the image will install MLflow from this directory.
+                        If None, it will install MLflow from pip.
     """
     with TempDir() as tmp:
         cwd = tmp.path()

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -188,7 +188,7 @@ def load_model(model_uri, tf_sess):
                       `Artifacts Documentation <https://www.mlflow.org/docs/latest/tracking.html#
                       supported-artifact-stores>`_.
 
-    :param tf_sess: The TensorFlow session in which to the load the model.
+    :param tf_sess: The TensorFlow session in which to load the model.
     :return: A TensorFlow signature definition of type:
              ``tensorflow.core.protobuf.meta_graph_pb2.SignatureDef``. This defines the input and
              output tensors for model inference.
@@ -219,7 +219,7 @@ def _load_tensorflow_saved_model(tf_saved_model_dir, tf_sess, tf_meta_graph_tags
     from a serialized TensorFlow ``SavedModel`` collection.
 
     :param tf_saved_model_dir: The local filesystem path or run-relative artifact path to the model.
-    :param tf_sess: The TensorFlow session in which to the load the metagraph.
+    :param tf_sess: The TensorFlow session in which to load the metagraph.
     :param tf_meta_graph_tags: A list of tags identifying the model's metagraph within the
                                serialized ``SavedModel`` object. For more information, see the
                                ``tags`` parameter of the `tf.saved_model.builder.SavedModelBuilder

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -4,6 +4,8 @@ import numpy as np
 import pandas as pd
 from six.moves import urllib
 
+from mlflow.utils.annotations import deprecated, experimental
+
 PYTHON_VERSION = "{major}.{minor}.{micro}".format(major=version_info.major,
                                                   minor=version_info.minor,
                                                   micro=version_info.micro)

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -1,0 +1,28 @@
+def experimental(func):
+    """
+    Decorator for marking APIs experimental in the docstring.
+
+    :param func: A function to mark
+    :returns Decorated function.
+    """
+    notice = ".. Note:: Experimental: This method may change or " + \
+             "be removed in a future release without warning.\n"
+    func.__doc__ = notice + func.__doc__
+    return func
+
+
+def deprecated(alternative=None):
+    """
+    Decorator for marking APIs deprecated in the docstring.
+
+    :param func: A function to mark
+    :returns Decorated function.
+    """
+    def deprecated_func(func):
+        notice = ".. Warning:: Deprecated: This method will be deprecated in " + \
+                 "a near future release."
+        if alternative is not None and alternative.strip():
+            notice += " Use %s instead." % alternative
+        func.__doc__ = notice + "\n" + func.__doc__
+        return func
+    return deprecated_func

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -22,7 +22,7 @@ def deprecated(alternative=None):
         notice = ".. Warning:: Deprecated: This method will be deprecated in " + \
                  "a near future release."
         if alternative is not None and alternative.strip():
-            notice += " Use %s instead." % alternative
+            notice += " Use ``%s`` instead." % alternative
         func.__doc__ = notice + "\n" + func.__doc__
         return func
     return deprecated_func

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -11,7 +11,7 @@ def experimental(func):
     return func
 
 
-def deprecated(alternative=None):
+def deprecated(alternative=None, since=None):
     """
     Decorator for marking APIs deprecated in the docstring.
 
@@ -19,7 +19,8 @@ def deprecated(alternative=None):
     :returns Decorated function.
     """
     def deprecated_func(func):
-        notice = ".. Warning:: Deprecated: This method will be deprecated in " + \
+        since_str = " since %s" % since if since else ""
+        notice = ".. Warning:: Deprecated%s: This method will be removed in " % since_str + \
                  "a near future release."
         if alternative is not None and alternative.strip():
             notice += " Use ``%s`` instead." % alternative

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -120,7 +120,7 @@ def mock_runs_get_result(succeeded):
 
 def run_databricks_project(cluster_spec, **kwargs):
     return mlflow.projects.run(
-        uri=TEST_PROJECT_DIR, backend="databricks", backend_spec=cluster_spec,
+        uri=TEST_PROJECT_DIR, backend="databricks", backend_config=cluster_spec,
         parameters={"alpha": "0.4"}, **kwargs)
 
 
@@ -176,13 +176,13 @@ def test_run_databricks_validations(
         with pytest.raises(ExecutionException):
             mlflow.projects.run(
                 TEST_PROJECT_DIR, backend="databricks", entry_point="greeter",
-                backend_spec=cluster_spec_mock)
+                backend_config=cluster_spec_mock)
         assert db_api_req_mock.call_count == 0
         db_api_req_mock.reset_mock()
         # Test bad cluster spec
         with pytest.raises(ExecutionException):
             mlflow.projects.run(TEST_PROJECT_DIR, backend="databricks", synchronous=True,
-                                backend_spec=None)
+                                backend_config=None)
         assert db_api_req_mock.call_count == 0
         db_api_req_mock.reset_mock()
         # Test that validations pass with good tracking URIs

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -165,7 +165,7 @@ def test_run_databricks_validations(
         # Test bad tracking URI
         tracking_uri_mock.return_value = tmpdir.strpath
         with pytest.raises(ExecutionException):
-            run_databricks_project(cluster_spec_mock, block=True)
+            run_databricks_project(cluster_spec_mock, synchronous=True)
         assert db_api_req_mock.call_count == 0
         db_api_req_mock.reset_mock()
         mlflow_service = mlflow.tracking.MlflowClient()
@@ -199,7 +199,7 @@ def test_run_databricks(
         # Test that MLflow gets the correct run status when performing a Databricks run
         for run_succeeded, expect_status in [(True, RunStatus.FINISHED), (False, RunStatus.FAILED)]:
             runs_get_mock.return_value = mock_runs_get_result(succeeded=run_succeeded)
-            submitted_run = run_databricks_project(cluster_spec_mock, block=False)
+            submitted_run = run_databricks_project(cluster_spec_mock, synchronous=False)
             assert submitted_run.wait() == run_succeeded
             assert submitted_run.run_id is not None
             assert runs_submit_mock.call_count == 1
@@ -227,7 +227,7 @@ def test_run_databricks_cluster_spec_json(
             "node_type_id": "i3.xlarge",
         }
         # Run project synchronously, verify that it succeeds (doesn't throw)
-        run_databricks_project(cluster_spec=cluster_spec, block=True)
+        run_databricks_project(cluster_spec=cluster_spec, synchronous=True)
         assert runs_submit_mock.call_count == 1
         runs_submit_args, _ = runs_submit_mock.call_args_list[0]
         req_body = runs_submit_args[0]
@@ -243,14 +243,14 @@ def test_run_databricks_cancel(
     # waiting for run status.
     with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
         runs_get_mock.return_value = mock_runs_get_result(succeeded=False)
-        submitted_run = run_databricks_project(cluster_spec_mock, block=False)
+        submitted_run = run_databricks_project(cluster_spec_mock, synchronous=False)
         submitted_run.cancel()
         validate_exit_status(submitted_run.get_status(), RunStatus.FAILED)
         assert runs_cancel_mock.call_count == 1
         # Test that we raise an exception when a blocking Databricks run fails
         runs_get_mock.return_value = mock_runs_get_result(succeeded=False)
         with pytest.raises(mlflow.projects.ExecutionException):
-            run_databricks_project(cluster_spec_mock, block=True)
+            run_databricks_project(cluster_spec_mock, synchronous=True)
 
 
 def test_get_tracking_uri_for_run():

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -120,7 +120,7 @@ def mock_runs_get_result(succeeded):
 
 def run_databricks_project(cluster_spec, **kwargs):
     return mlflow.projects.run(
-        uri=TEST_PROJECT_DIR, mode="databricks", cluster_spec=cluster_spec,
+        uri=TEST_PROJECT_DIR, backend="databricks", backend_spec=cluster_spec,
         parameters={"alpha": "0.4"}, **kwargs)
 
 
@@ -175,13 +175,14 @@ def test_run_databricks_validations(
         # Test misspecified parameters
         with pytest.raises(ExecutionException):
             mlflow.projects.run(
-                TEST_PROJECT_DIR, mode="databricks", entry_point="greeter",
-                cluster_spec=cluster_spec_mock)
+                TEST_PROJECT_DIR, backend="databricks", entry_point="greeter",
+                backend_spec=cluster_spec_mock)
         assert db_api_req_mock.call_count == 0
         db_api_req_mock.reset_mock()
         # Test bad cluster spec
         with pytest.raises(ExecutionException):
-            mlflow.projects.run(TEST_PROJECT_DIR, mode="databricks", block=True, cluster_spec=None)
+            mlflow.projects.run(TEST_PROJECT_DIR, backend="databricks", synchronous=True,
+                                backend_spec=None)
         assert db_api_req_mock.call_count == 0
         db_api_req_mock.reset_mock()
         # Test that validations pass with good tracking URIs

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -93,4 +93,4 @@ def test_docker_project_tracking_uri_propagation(
 def test_docker_uri_mode_validation(tracking_uri_mock):  # pylint: disable=unused-argument
     with pytest.raises(ExecutionException):
         build_docker_example_base_image()
-        mlflow.projects.run(TEST_DOCKER_PROJECT_DIR, mode="databricks")
+        mlflow.projects.run(TEST_DOCKER_PROJECT_DIR, backend="databricks")

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -82,12 +82,12 @@ def test_run_databricks_cluster_spec(tmpdir):
     with mock.patch("mlflow.projects._run") as run_mock:
         for cluster_spec_arg in [json.dumps(cluster_spec), cluster_spec_path]:
             invoke_cli_runner(
-                cli.run, [TEST_PROJECT_DIR, "-b", "databricks", "--backend-spec",
+                cli.run, [TEST_PROJECT_DIR, "-b", "databricks", "--backend-config",
                           cluster_spec_arg, "-e", "greeter", "-P", "name=hi"],
                 env={'MLFLOW_TRACKING_URI': 'databricks://profile'})
             assert run_mock.call_count == 1
             _, run_kwargs = run_mock.call_args_list[0]
-            assert run_kwargs["backend_spec"] == cluster_spec
+            assert run_kwargs["backend_config"] == cluster_spec
             run_mock.reset_mock()
         res = CliRunner().invoke(
             cli.run, [TEST_PROJECT_DIR, "-m", "databricks", "--cluster-spec",

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -82,12 +82,12 @@ def test_run_databricks_cluster_spec(tmpdir):
     with mock.patch("mlflow.projects._run") as run_mock:
         for cluster_spec_arg in [json.dumps(cluster_spec), cluster_spec_path]:
             invoke_cli_runner(
-                cli.run, [TEST_PROJECT_DIR, "-m", "databricks", "--cluster-spec",
+                cli.run, [TEST_PROJECT_DIR, "-b", "databricks", "--backend-spec",
                           cluster_spec_arg, "-e", "greeter", "-P", "name=hi"],
                 env={'MLFLOW_TRACKING_URI': 'databricks://profile'})
             assert run_mock.call_count == 1
             _, run_kwargs = run_mock.call_args_list[0]
-            assert run_kwargs["cluster_spec"] == cluster_spec
+            assert run_kwargs["backend_spec"] == cluster_spec
             run_mock.reset_mock()
         res = CliRunner().invoke(
             cli.run, [TEST_PROJECT_DIR, "-m", "databricks", "--cluster-spec",

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -282,12 +282,6 @@ def test_sparkml_model_log_invalid_args(spark_model_iris, model_path):
             spark_model=spark_model_iris.model.stages[0],
             artifact_path="model0")
         assert e.message.contains("SparkML can only save PipelineModels")
-    with pytest.raises(MlflowException) as e:
-        sparkm.log_model(
-            spark_model=spark_model_iris.model,
-            artifact_path="model1",
-            jars=["something.jar"])
-        assert e.message.contains("JAR dependencies are not implemented")
 
 
 @pytest.mark.large


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
A bunch of fixes to the python API to make them stable for 1.0:
- Create `pyfunc.load_model` method as an alias for `pyfunc.load_pyfunc`. Put up a deprecation warning.
- Fix `spark.log_model` bug w/r.t. `jars` arg
- Fix datetime arg to `projects.run`
- Remove & rename some `projects.run` parameters
- Mark `azureml.build_image` as experimental
- Some small docs changes
 
## How is this patch tested?
 
- Existing unit tests
- Built and checked docs to see that the experimental note and the deprecation warning show up. 
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Cleaned up some python and R API to make them stable for 1.0:
- Introduced `pyfunc.load_model` to be consistent with other Model modules. `pyfunc.load_pyfunc` will be deprecated in the near future.
- Fixed `spark.log_model` bug w/r.t. `jars` arg
- Removed & renamed some `projects.run` parameters for generality and consistency
- Marked `azureml.build_image` as experimental
 
### What component(s) does this PR affect?
 
- [ ] UI
- [X] CLI 
- [X] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [X] Projects 
- [ ] Artifacts 
- [X] Models 
- [ ] Scoring 
- [X] Serving
- [X] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
