### PR TITLE
Stabilizing methods in Python Models modules

### DIFF
--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -16,10 +16,12 @@ from six import reraise
 import mlflow
 from mlflow.models import Model
 from mlflow.exceptions import MlflowException
+from mlflow.utils import keyword_only
 
 FLAVOR_NAME = "mleap"
 
 
+@keyword_only
 def log_model(spark_model, sample_input, artifact_path):
     """
     Log a Spark MLLib model in MLeap format as an MLflow artifact
@@ -64,12 +66,14 @@ def log_model(spark_model, sample_input, artifact_path):
     >>> mlflow.log_param("max_iter", 10)
     >>> mlflow.log_param("reg_param", 0.001)
     >>> #log the Spark MLlib model in MLeap format
-    >>> mlflow.mleap.log_model(model, test_df, "mleap-model")
+    >>> mlflow.mleap.log_model(spark_model=model, sample_input=test_df,
+    >>>                        artifact_path="mleap-model")
     """
     return Model.log(artifact_path=artifact_path, flavor=mlflow.mleap,
                      spark_model=spark_model, sample_input=sample_input)
 
 
+@keyword_only
 def save_model(spark_model, sample_input, path, mlflow_model=Model()):
     """
     Save a Spark MLlib PipelineModel in MLeap format at a local path.
@@ -94,7 +98,8 @@ def save_model(spark_model, sample_input, path, mlflow_model=Model()):
     >>> model_save_dir = ...
     >>> sample_input_df = ...
     >>> #save the spark MLlib model in MLeap flavor
-    >>> mlflow.mleap.save_model(spark_model, sample_input_df, model_save_dir)
+    >>> mlflow.mleap.save_model(spark_model=spark_model, sample_input_df=sample_input_df,
+    >>>                         path=model_save_dir)
     """
     add_to_model(mlflow_model, path, spark_model, sample_input)
     mlflow_model.save(os.path.join(path, "MLmodel"))

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -90,21 +90,13 @@ def save_model(spark_model, sample_input, path, mlflow_model=Model()):
                          required by MLeap for data schema inference.
     :param path: Local path where the model is to be saved.
     :param mlflow_model: :py:mod:`mlflow.models.Model` to which this flavor is being added.
-
-    >>> import mlflow
-    >>> import mlflow.mleap
-    >>> #set values as appropriate
-    >>> spark_model = ...
-    >>> model_save_dir = ...
-    >>> sample_input_df = ...
-    >>> #save the spark MLlib model in MLeap flavor
-    >>> mlflow.mleap.save_model(spark_model=spark_model, sample_input_df=sample_input_df,
-    >>>                         path=model_save_dir)
     """
-    add_to_model(mlflow_model, path, spark_model, sample_input)
+    add_to_model(mlflow_model=mlflow_model, path=path, spark_model=spark_model,
+                 sample_input=sample_input)
     mlflow_model.save(os.path.join(path, "MLmodel"))
 
 
+@keyword_only
 def add_to_model(mlflow_model, path, spark_model, sample_input):
     """
     Add the MLeap flavor to an existing MLflow model.
@@ -115,16 +107,6 @@ def add_to_model(mlflow_model, path, spark_model, sample_input):
                         cannot contain any custom transformers.
     :param sample_input: Sample PySpark DataFrame input that the model can evaluate. This is
                          required by MLeap for data schema inference.
-
-    >>> import mlflow
-    >>> import mlflow.mleap
-    >>> #set values
-    >>> mlflow_model = ...
-    >>> spark_model = ...
-    >>> model_path_dir = ...
-    >>> sample_input_df =
-    >>> #add MLeap flavor to our MLflow model
-    >>> mlflow.mleap.add_to_model(mlflow_model,model_path_dir, sample_input_df)
     """
     from pyspark.ml.pipeline import PipelineModel
     from pyspark.sql import DataFrame

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -221,7 +221,8 @@ def _save_model_metadata(dst_dir, spark_model, mlflow_model, sample_input, conda
     "sparkml").
     """
     if sample_input is not None:
-        mleap.add_to_model(mlflow_model, dst_dir, spark_model, sample_input)
+        mleap.add_to_model(mlflow_model=mlflow_model, path=dst_dir, spark_model=spark_model,
+                           sample_input=sample_input)
 
     pyspark_version = pyspark.version.__version__
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -24,6 +24,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import DIRECTORY_NOT_EMPTY
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.utils import keyword_only
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import _copy_file_or_tree
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -42,6 +43,7 @@ DEFAULT_CONDA_ENV = _mlflow_conda_env(
 _logger = logging.getLogger(__name__)
 
 
+@keyword_only
 def log_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, artifact_path,
               conda_env=None):
     """
@@ -86,6 +88,7 @@ def log_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, arti
                      tf_signature_def_key=tf_signature_def_key, conda_env=conda_env)
 
 
+@keyword_only
 def save_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, path,
                mlflow_model=Model(), conda_env=None):
     """

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 from six.moves import urllib
 
-from mlflow.utils.annotations import deprecated, experimental
+from mlflow.utils.annotations import deprecated, experimental, keyword_only
 
 PYTHON_VERSION = "{major}.{minor}.{micro}".format(major=version_info.major,
                                                   minor=version_info.minor,

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -34,15 +34,13 @@ def deprecated(alternative=None, since=None):
 
 def keyword_only(func):
     """
-    A decorator that forces keyword arguments in the wrapped method
-    and saves actual input keyword arguments in `_input_kwargs`.
+    A decorator that forces keyword arguments in the wrapped method.
     """
     @wraps(func)
     def wrapper(*args, **kwargs):
         if len(args) > 0:
             raise TypeError("Method %s only accepts keyword arguments." % func.__name__)
-        self._input_kwargs = kwargs
-        return func(self, **kwargs)
+        return func(**kwargs)
     notice = ".. Note:: This method only accepts keyword arguments.\n"
     wrapper.__doc__ = notice + wrapper.__doc__
     return wrapper

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -44,4 +44,3 @@ def keyword_only(func):
     notice = ".. Note:: This method only accepts keyword arguments.\n"
     wrapper.__doc__ = notice + wrapper.__doc__
     return wrapper
-

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -39,8 +39,8 @@ def keyword_only(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         if len(args) > 0:
-            raise TypeError("Method %s only accepts keyword arguments." % func.__name__)
+            raise TypeError("Method %s only takes keyword arguments." % func.__name__)
         return func(**kwargs)
-    notice = ".. Note:: This method only accepts keyword arguments.\n"
+    notice = ".. Note:: This method requires all argument be specified by keyword.\n"
     wrapper.__doc__ = notice + wrapper.__doc__
     return wrapper

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -1,3 +1,6 @@
+from functools import wraps
+
+
 def experimental(func):
     """
     Decorator for marking APIs experimental in the docstring.
@@ -27,3 +30,20 @@ def deprecated(alternative=None, since=None):
         func.__doc__ = notice + "\n" + func.__doc__
         return func
     return deprecated_func
+
+
+def keyword_only(func):
+    """
+    A decorator that forces keyword arguments in the wrapped method
+    and saves actual input keyword arguments in `_input_kwargs`.
+    """
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if len(args) > 0:
+            raise TypeError("Method %s only accepts keyword arguments." % func.__name__)
+        self._input_kwargs = kwargs
+        return func(self, **kwargs)
+    notice = ".. Note:: This method only accepts keyword arguments.\n"
+    wrapper.__doc__ = notice + wrapper.__doc__
+    return wrapper
+

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -324,6 +324,16 @@ def test_load_model_loads_artifacts_from_specified_model_directory(saved_tf_iris
         signature_def = mlflow.tensorflow.load_model(model_uri=model_path, tf_sess=tf_sess)
 
 
+def test_log_model_with_non_keyword_args_fails(saved_tf_iris_model):
+    artifact_path = "model"
+    with mlflow.start_run():
+        with pytest.raises(TypeError):
+            mlflow.tensorflow.log_model(saved_tf_iris_model.path,
+                                        saved_tf_iris_model.meta_graph_tags,
+                                        saved_tf_iris_model.signature_def_key,
+                                        artifact_path)
+
+
 @pytest.mark.large
 def test_log_and_load_model_persists_and_restores_model_successfully(saved_tf_iris_model):
     artifact_path = "model"


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
To make the methods in Models modules stable in MLflow 1.0, we want to future-proof them against any potential changes in the underlying frameworks (e.g. sklearn, spark, tensorflow). To do so, here we propose to make some methods take in keyword arguments only, by introducing a `keyword_only` decorator that enforces such. 

The change is breaking for any current usages of the APIs, so here we recommend changing only the TensorFlow APIs which may need to change in the near future:
```
def log_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, artifact_path, conda_env=None)
def save_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, path, mlflow_model=Model(), conda_env=None)
```

Alternatively, we could not put any restrictions and create new modules (e.g. `tensorflow2`) in the future as needed. 

If we go with the `keyword_only` decorator route, the following also may merit the decorator if we think the requirement for a `sample_df` in `mleap` will change in the future:
```
mlflow.mleap.log_model(spark_model, sample_input, artifact_path)
mlflow.mleap.save_model(spark_model, sample_input, path, mlflow_model=Model())
```
but the current PR does not mark them as so.

## How is this patch tested?
 
Existing & new unit tests
```
pytest --large tests/tensorflow/test_tensorflow_model_export.py
```

## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
We now require the arguments of ``save_model`` and ``log_model`` methods in the ``tensorflow`` and ``mleap`` modules to be keyword arguments. This is to future-proof their usages against API changes involving the TensorFlow model specification.
 
### What component(s) does this PR affect?
 
- [X] API 
- [X] Models 
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
