### PR TITLE
Move user to tag

### DIFF
--- a/docs/source/rest-api.rst
+++ b/docs/source/rest-api.rst
@@ -353,6 +353,8 @@ Request Structure
 | experiment_id    | ``INT64``                       | ID of the associated experiment.                                                               |
 +------------------+---------------------------------+------------------------------------------------------------------------------------------------+
 | user_id          | ``STRING``                      | ID of the user executing the run.                                                              |
+|                  |                                 | This field is deprecated and will be removed in a later MLflow version. Use the                |
+|                  |                                 | ``mlflow.user`` run tag instead.                                                               |
 +------------------+---------------------------------+------------------------------------------------------------------------------------------------+
 | run_name         | ``STRING``                      | Human readable name for the run.                                                               |
 |                  |                                 | This field is deprecated and will be removed in MLflow 1.0. Use the ``mlflow.runName`` run tag |
@@ -1279,6 +1281,8 @@ Metadata of a single run.
 |                  |                         | tag instead.                                                                                   |
 +------------------+-------------------------+------------------------------------------------------------------------------------------------+
 | user_id          | ``STRING``              | User who initiated the run.                                                                    |
+|                  |                         | This field is deprecated and will be removed in a later MLflow version. Use the                |
+|                  |                         | ``mlflow.user`` run tag instead.                                                               |
 +------------------+-------------------------+------------------------------------------------------------------------------------------------+
 | status           | :ref:`mlflowrunstatus`  | Current status of the run.                                                                     |
 +------------------+-------------------------+------------------------------------------------------------------------------------------------+

--- a/examples/rest_api/mlflow_tracking_rest_api.py
+++ b/examples/rest_api/mlflow_tracking_rest_api.py
@@ -26,6 +26,7 @@ class MLFlowTrackingRestApi:
 	def create_run(self):
 		"""Create a new run for tracking."""
 		url = self.base_url + '/runs/create'
+		# user_id is deprecated and will be removed from the API in a future release  
 		payload = {'experiment_id': self.experiment_id, 'start_time': int(time.time() * 1000), 'user_id': _get_user_id()}
 		r = requests.post(url, json=payload)
 		run_id = None

--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -26,18 +26,18 @@ mlflow_log_metric <- function(key, value, timestamp = NULL, run_id = NULL, clien
   invisible(value)
 }
 
-
-
-
-mlflow_create_run <- function(user_id = NULL, start_time = NULL, tags = NULL,
-                              experiment_id = NULL, client) {
+mlflow_create_run <- function(start_time = NULL, tags = NULL, experiment_id = NULL, client) {
   experiment_id <- resolve_experiment_id(experiment_id)
+
+  # Read user_id from tags
+  # user_id is deprecated and will be removed from a future release
+  user_id <- tags[[MLFLOW_TAGS$MLFLOW_USER]] %||% "unknown"
+
   tags <- if (!is.null(tags)) tags %>%
     purrr::imap(~ list(key = .y, value = .x)) %>%
     unname()
 
   start_time <- start_time %||% current_time()
-  user_id <- user_id %||% mlflow_user()
 
   response <- mlflow_rest(
     "runs", "create",
@@ -310,7 +310,6 @@ mlflow_set_terminated <- function(status, end_time, run_id, client) {
   mlflow_get_run(client = client, run_id = response$run_info$run_uuid)
 }
 
-
 #' Download Artifacts
 #'
 #' Download an artifact file or directory from a run to a local directory if applicable,
@@ -340,7 +339,6 @@ mlflow_download_artifacts <- function(path, run_id = NULL, client = NULL) {
   )
   gsub("\n", "", result$stdout)
 }
-
 
 # ' Download Artifacts from URI.
 mlflow_download_artifacts_from_uri <- function(artifact_uri, client = mlflow_client()) {
@@ -444,12 +442,11 @@ mlflow_log_artifact <- function(path, artifact_path = NULL, run_id = NULL, clien
   mlflow_list_artifacts(run_id = run_id, path = artifact_path, client = client)
 }
 
-
 #' Start Run
 #'
 #' Starts a new run. If `client` is not provided, this function infers contextual information such as
 #'   source name and version, and also registers the created run as the active run. If `client` is provided,
-#'   no inference is done, and additional arguments such as `user_id` and `start_time` can be provided.
+#'   no inference is done, and additional arguments such as `start_time` can be provided.
 #'
 #' @param run_id If specified, get the run with the specified UUID and log metrics
 #'   and params under that run. The run's end time is unset and its status is set to
@@ -462,7 +459,6 @@ mlflow_log_artifact <- function(path, artifact_path = NULL, run_id = NULL, clien
 #' @param source_version Optional Git commit hash to associate with the run.
 #' @param entry_point_name Optional name of the entry point for to the current run.
 #' @param source_type Integer enum value describing the type of the run  ("local", "project", etc.).
-#' @param user_id User ID or LDAP for the user executing the run. Only used when `client` is specified.
 #' @param start_time Unix timestamp of when the run started in milliseconds. Only used when `client` is specified.
 #' @param tags Additional metadata for run in key-value pairs. Only used when `client` is specified.
 #' @template roxlate-client
@@ -475,21 +471,19 @@ mlflow_log_artifact <- function(path, artifact_path = NULL, run_id = NULL, clien
 #' }
 #'
 #' @export
-mlflow_start_run <- function(run_id = NULL, experiment_id = NULL, user_id = NULL,
-                             start_time = NULL, tags = NULL, client = NULL) {
+mlflow_start_run <- function(run_id = NULL, experiment_id = NULL, start_time = NULL, tags = NULL, client = NULL) {
 
   # When `client` is provided, this function acts as a wrapper for `runs/create` and does not register
   #  an active run.
   if (!is.null(client)) {
     if (!is.null(run_id)) stop("`run_id` should not be specified when `client` is specified.", call. = FALSE)
-    run <- mlflow_create_run(client = client, user_id = user_id, start_time = start_time,
+    run <- mlflow_create_run(client = client, start_time = start_time,
                              tags = tags, experiment_id = experiment_id)
     return(run)
   }
 
   # Fluent mode, check to see if extraneous params passed.
 
-  if (!is.null(user_id)) stop("`user_id` should only be specified when `client` is specified.", call. = FALSE)
   if (!is.null(start_time)) stop("`start_time` should only be specified when `client` is specified.", call. = FALSE)
   if (!is.null(tags)) stop("`tags` should only be specified when `client` is specified.", call. = FALSE)
 
@@ -524,13 +518,13 @@ mlflow_start_run <- function(run_id = NULL, experiment_id = NULL, user_id = NULL
   run
 }
 
-
 mlflow_get_run_context <- function(client, ...) {
   UseMethod("mlflow_get_run_context")
 }
 
 mlflow_get_run_context.default <- function(client, experiment_id, ...) {
   tags <- list()
+  tags[[MLFLOW_TAGS$MLFLOW_USER]] <- mlflow_user()
   tags[[MLFLOW_TAGS$MLFLOW_SOURCE_NAME]] <- get_source_name()
   tags[[MLFLOW_TAGS$MLFLOW_SOURCE_VERSION]] <- get_source_version()
   tags[[MLFLOW_TAGS$MLFLOW_SOURCE_TYPE]] <- MLFLOW_SOURCE_TYPE$LOCAL
@@ -580,6 +574,7 @@ mlflow_end_run <- function(status = c("FINISHED", "SCHEDULED", "FAILED", "KILLED
 }
 
 MLFLOW_TAGS <- list(
+  MLFLOW_USER = "mlflow.user",
   MLFLOW_SOURCE_NAME = "mlflow.source.name",
   MLFLOW_SOURCE_VERSION = "mlflow.source.version",
   MLFLOW_SOURCE_TYPE = "mlflow.source.type"

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -6,8 +6,7 @@ test_that("mlflow_start_run()/mlflow_get_run() work properly", {
   run <- mlflow_start_run(
     client = client,
     experiment_id = "0",
-    user_id = "user1",
-    tags = list(foo = "bar", foz = "baz")
+    tags = list(foo = "bar", foz = "baz", mlflow.user = "user1")
   )
 
   run <- mlflow_get_run(client = client, run$run_uuid)
@@ -16,7 +15,11 @@ test_that("mlflow_start_run()/mlflow_get_run() work properly", {
 
   expect_true(
     all(purrr::transpose(run$tags[[1]]) %in%
-          list(list(key = "foz", value = "baz"), list(key = "foo", value = "bar"))
+      list(
+        list(key = "foz", value = "baz"),
+        list(key = "foo", value = "bar"),
+        list(key = "mlflow.user", value = "user1")
+      )
     )
   )
 })
@@ -71,7 +74,6 @@ test_that("logging functionality", {
   expect_identical(metric_history$value, c(24, 25))
   expect_true(all(difftime(metric_history$timestamp, run_start_time) >= 0))
   expect_true(all(difftime(metric_history$timestamp, run_end_time) <= 0))
-
 
   expect_error(
     mlflow_get_run(),

--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
@@ -6060,6 +6060,8 @@ public final class Service {
     /**
      * <pre>
      * User who initiated the run.
+     * This field is deprecated, and will be removed in a future MLflow release.
+     * Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 6;</code>
@@ -6068,6 +6070,8 @@ public final class Service {
     /**
      * <pre>
      * User who initiated the run.
+     * This field is deprecated, and will be removed in a future MLflow release.
+     * Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 6;</code>
@@ -6076,6 +6080,8 @@ public final class Service {
     /**
      * <pre>
      * User who initiated the run.
+     * This field is deprecated, and will be removed in a future MLflow release.
+     * Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 6;</code>
@@ -6508,6 +6514,8 @@ public final class Service {
     /**
      * <pre>
      * User who initiated the run.
+     * This field is deprecated, and will be removed in a future MLflow release.
+     * Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 6;</code>
@@ -6518,6 +6526,8 @@ public final class Service {
     /**
      * <pre>
      * User who initiated the run.
+     * This field is deprecated, and will be removed in a future MLflow release.
+     * Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 6;</code>
@@ -6539,6 +6549,8 @@ public final class Service {
     /**
      * <pre>
      * User who initiated the run.
+     * This field is deprecated, and will be removed in a future MLflow release.
+     * Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 6;</code>
@@ -7581,6 +7593,8 @@ public final class Service {
       /**
        * <pre>
        * User who initiated the run.
+       * This field is deprecated, and will be removed in a future MLflow release.
+       * Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 6;</code>
@@ -7591,6 +7605,8 @@ public final class Service {
       /**
        * <pre>
        * User who initiated the run.
+       * This field is deprecated, and will be removed in a future MLflow release.
+       * Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 6;</code>
@@ -7612,6 +7628,8 @@ public final class Service {
       /**
        * <pre>
        * User who initiated the run.
+       * This field is deprecated, and will be removed in a future MLflow release.
+       * Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 6;</code>
@@ -7632,6 +7650,8 @@ public final class Service {
       /**
        * <pre>
        * User who initiated the run.
+       * This field is deprecated, and will be removed in a future MLflow release.
+       * Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 6;</code>
@@ -7649,6 +7669,8 @@ public final class Service {
       /**
        * <pre>
        * User who initiated the run.
+       * This field is deprecated, and will be removed in a future MLflow release.
+       * Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 6;</code>
@@ -7662,6 +7684,8 @@ public final class Service {
       /**
        * <pre>
        * User who initiated the run.
+       * This field is deprecated, and will be removed in a future MLflow release.
+       * Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 6;</code>
@@ -17727,6 +17751,8 @@ public final class Service {
     /**
      * <pre>
      * ID of the user executing the run.
+     * This field is deprecated, and will be removed in a future MLflow release.
+     * Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 2;</code>
@@ -17735,6 +17761,8 @@ public final class Service {
     /**
      * <pre>
      * ID of the user executing the run.
+     * This field is deprecated, and will be removed in a future MLflow release.
+     * Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 2;</code>
@@ -17743,6 +17771,8 @@ public final class Service {
     /**
      * <pre>
      * ID of the user executing the run.
+     * This field is deprecated, and will be removed in a future MLflow release.
+     * Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 2;</code>
@@ -18652,6 +18682,8 @@ public final class Service {
     /**
      * <pre>
      * ID of the user executing the run.
+     * This field is deprecated, and will be removed in a future MLflow release.
+     * Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 2;</code>
@@ -18662,6 +18694,8 @@ public final class Service {
     /**
      * <pre>
      * ID of the user executing the run.
+     * This field is deprecated, and will be removed in a future MLflow release.
+     * Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 2;</code>
@@ -18683,6 +18717,8 @@ public final class Service {
     /**
      * <pre>
      * ID of the user executing the run.
+     * This field is deprecated, and will be removed in a future MLflow release.
+     * Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 2;</code>
@@ -19306,6 +19342,8 @@ public final class Service {
       /**
        * <pre>
        * ID of the user executing the run.
+       * This field is deprecated, and will be removed in a future MLflow release.
+       * Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 2;</code>
@@ -19316,6 +19354,8 @@ public final class Service {
       /**
        * <pre>
        * ID of the user executing the run.
+       * This field is deprecated, and will be removed in a future MLflow release.
+       * Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 2;</code>
@@ -19337,6 +19377,8 @@ public final class Service {
       /**
        * <pre>
        * ID of the user executing the run.
+       * This field is deprecated, and will be removed in a future MLflow release.
+       * Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 2;</code>
@@ -19357,6 +19399,8 @@ public final class Service {
       /**
        * <pre>
        * ID of the user executing the run.
+       * This field is deprecated, and will be removed in a future MLflow release.
+       * Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 2;</code>
@@ -19374,6 +19418,8 @@ public final class Service {
       /**
        * <pre>
        * ID of the user executing the run.
+       * This field is deprecated, and will be removed in a future MLflow release.
+       * Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 2;</code>
@@ -19387,6 +19433,8 @@ public final class Service {
       /**
        * <pre>
        * ID of the user executing the run.
+       * This field is deprecated, and will be removed in a future MLflow release.
+       * Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 2;</code>

--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
@@ -6060,8 +6060,8 @@ public final class Service {
     /**
      * <pre>
      * User who initiated the run.
-     * This field is deprecated, and will be removed in a future MLflow release.
-     * Use 'mlflow.user' tag instead.
+     * This field is deprecated as of MLflow 1.0, and will be removed in a future
+     * MLflow release. Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 6;</code>
@@ -6070,8 +6070,8 @@ public final class Service {
     /**
      * <pre>
      * User who initiated the run.
-     * This field is deprecated, and will be removed in a future MLflow release.
-     * Use 'mlflow.user' tag instead.
+     * This field is deprecated as of MLflow 1.0, and will be removed in a future
+     * MLflow release. Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 6;</code>
@@ -6080,8 +6080,8 @@ public final class Service {
     /**
      * <pre>
      * User who initiated the run.
-     * This field is deprecated, and will be removed in a future MLflow release.
-     * Use 'mlflow.user' tag instead.
+     * This field is deprecated as of MLflow 1.0, and will be removed in a future
+     * MLflow release. Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 6;</code>
@@ -6514,8 +6514,8 @@ public final class Service {
     /**
      * <pre>
      * User who initiated the run.
-     * This field is deprecated, and will be removed in a future MLflow release.
-     * Use 'mlflow.user' tag instead.
+     * This field is deprecated as of MLflow 1.0, and will be removed in a future
+     * MLflow release. Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 6;</code>
@@ -6526,8 +6526,8 @@ public final class Service {
     /**
      * <pre>
      * User who initiated the run.
-     * This field is deprecated, and will be removed in a future MLflow release.
-     * Use 'mlflow.user' tag instead.
+     * This field is deprecated as of MLflow 1.0, and will be removed in a future
+     * MLflow release. Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 6;</code>
@@ -6549,8 +6549,8 @@ public final class Service {
     /**
      * <pre>
      * User who initiated the run.
-     * This field is deprecated, and will be removed in a future MLflow release.
-     * Use 'mlflow.user' tag instead.
+     * This field is deprecated as of MLflow 1.0, and will be removed in a future
+     * MLflow release. Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 6;</code>
@@ -7593,8 +7593,8 @@ public final class Service {
       /**
        * <pre>
        * User who initiated the run.
-       * This field is deprecated, and will be removed in a future MLflow release.
-       * Use 'mlflow.user' tag instead.
+       * This field is deprecated as of MLflow 1.0, and will be removed in a future
+       * MLflow release. Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 6;</code>
@@ -7605,8 +7605,8 @@ public final class Service {
       /**
        * <pre>
        * User who initiated the run.
-       * This field is deprecated, and will be removed in a future MLflow release.
-       * Use 'mlflow.user' tag instead.
+       * This field is deprecated as of MLflow 1.0, and will be removed in a future
+       * MLflow release. Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 6;</code>
@@ -7628,8 +7628,8 @@ public final class Service {
       /**
        * <pre>
        * User who initiated the run.
-       * This field is deprecated, and will be removed in a future MLflow release.
-       * Use 'mlflow.user' tag instead.
+       * This field is deprecated as of MLflow 1.0, and will be removed in a future
+       * MLflow release. Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 6;</code>
@@ -7650,8 +7650,8 @@ public final class Service {
       /**
        * <pre>
        * User who initiated the run.
-       * This field is deprecated, and will be removed in a future MLflow release.
-       * Use 'mlflow.user' tag instead.
+       * This field is deprecated as of MLflow 1.0, and will be removed in a future
+       * MLflow release. Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 6;</code>
@@ -7669,8 +7669,8 @@ public final class Service {
       /**
        * <pre>
        * User who initiated the run.
-       * This field is deprecated, and will be removed in a future MLflow release.
-       * Use 'mlflow.user' tag instead.
+       * This field is deprecated as of MLflow 1.0, and will be removed in a future
+       * MLflow release. Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 6;</code>
@@ -7684,8 +7684,8 @@ public final class Service {
       /**
        * <pre>
        * User who initiated the run.
-       * This field is deprecated, and will be removed in a future MLflow release.
-       * Use 'mlflow.user' tag instead.
+       * This field is deprecated as of MLflow 1.0, and will be removed in a future
+       * MLflow release. Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 6;</code>
@@ -17751,8 +17751,8 @@ public final class Service {
     /**
      * <pre>
      * ID of the user executing the run.
-     * This field is deprecated, and will be removed in a future MLflow release.
-     * Use 'mlflow.user' tag instead.
+     * This field is deprecated as of MLflow 1.0, and will be removed in a future
+     * MLflow release. Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 2;</code>
@@ -17761,8 +17761,8 @@ public final class Service {
     /**
      * <pre>
      * ID of the user executing the run.
-     * This field is deprecated, and will be removed in a future MLflow release.
-     * Use 'mlflow.user' tag instead.
+     * This field is deprecated as of MLflow 1.0, and will be removed in a future
+     * MLflow release. Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 2;</code>
@@ -17771,8 +17771,8 @@ public final class Service {
     /**
      * <pre>
      * ID of the user executing the run.
-     * This field is deprecated, and will be removed in a future MLflow release.
-     * Use 'mlflow.user' tag instead.
+     * This field is deprecated as of MLflow 1.0, and will be removed in a future
+     * MLflow release. Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 2;</code>
@@ -18682,8 +18682,8 @@ public final class Service {
     /**
      * <pre>
      * ID of the user executing the run.
-     * This field is deprecated, and will be removed in a future MLflow release.
-     * Use 'mlflow.user' tag instead.
+     * This field is deprecated as of MLflow 1.0, and will be removed in a future
+     * MLflow release. Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 2;</code>
@@ -18694,8 +18694,8 @@ public final class Service {
     /**
      * <pre>
      * ID of the user executing the run.
-     * This field is deprecated, and will be removed in a future MLflow release.
-     * Use 'mlflow.user' tag instead.
+     * This field is deprecated as of MLflow 1.0, and will be removed in a future
+     * MLflow release. Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 2;</code>
@@ -18717,8 +18717,8 @@ public final class Service {
     /**
      * <pre>
      * ID of the user executing the run.
-     * This field is deprecated, and will be removed in a future MLflow release.
-     * Use 'mlflow.user' tag instead.
+     * This field is deprecated as of MLflow 1.0, and will be removed in a future
+     * MLflow release. Use 'mlflow.user' tag instead.
      * </pre>
      *
      * <code>optional string user_id = 2;</code>
@@ -19342,8 +19342,8 @@ public final class Service {
       /**
        * <pre>
        * ID of the user executing the run.
-       * This field is deprecated, and will be removed in a future MLflow release.
-       * Use 'mlflow.user' tag instead.
+       * This field is deprecated as of MLflow 1.0, and will be removed in a future
+       * MLflow release. Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 2;</code>
@@ -19354,8 +19354,8 @@ public final class Service {
       /**
        * <pre>
        * ID of the user executing the run.
-       * This field is deprecated, and will be removed in a future MLflow release.
-       * Use 'mlflow.user' tag instead.
+       * This field is deprecated as of MLflow 1.0, and will be removed in a future
+       * MLflow release. Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 2;</code>
@@ -19377,8 +19377,8 @@ public final class Service {
       /**
        * <pre>
        * ID of the user executing the run.
-       * This field is deprecated, and will be removed in a future MLflow release.
-       * Use 'mlflow.user' tag instead.
+       * This field is deprecated as of MLflow 1.0, and will be removed in a future
+       * MLflow release. Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 2;</code>
@@ -19399,8 +19399,8 @@ public final class Service {
       /**
        * <pre>
        * ID of the user executing the run.
-       * This field is deprecated, and will be removed in a future MLflow release.
-       * Use 'mlflow.user' tag instead.
+       * This field is deprecated as of MLflow 1.0, and will be removed in a future
+       * MLflow release. Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 2;</code>
@@ -19418,8 +19418,8 @@ public final class Service {
       /**
        * <pre>
        * ID of the user executing the run.
-       * This field is deprecated, and will be removed in a future MLflow release.
-       * Use 'mlflow.user' tag instead.
+       * This field is deprecated as of MLflow 1.0, and will be removed in a future
+       * MLflow release. Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 2;</code>
@@ -19433,8 +19433,8 @@ public final class Service {
       /**
        * <pre>
        * ID of the user executing the run.
-       * This field is deprecated, and will be removed in a future MLflow release.
-       * Use 'mlflow.user' tag instead.
+       * This field is deprecated as of MLflow 1.0, and will be removed in a future
+       * MLflow release. Use 'mlflow.user' tag instead.
        * </pre>
        *
        * <code>optional string user_id = 2;</code>

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -84,6 +84,8 @@ public class MlflowClient {
     CreateRun.Builder request = CreateRun.newBuilder();
     request.setExperimentId(experimentId);
     request.setStartTime(System.currentTimeMillis());
+    // userId is deprecated and will be removed in a future release.
+    // It should be set as the `mlflow.user` tag instead.
     String username = System.getProperty("user.name");
     if (username != null) {
       request.setUserId(System.getProperty("user.name"));
@@ -431,7 +433,6 @@ public class MlflowClient {
   public void logArtifacts(String runId, File localDir) {
     getArtifactRepository(runId).logArtifacts(localDir);
   }
-
 
   /**
    * Uploads all files within the given local director an artifactPath within the run's root

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -86,12 +86,7 @@ public class MlflowClient {
     request.setStartTime(System.currentTimeMillis());
     String username = System.getProperty("user.name");
     if (username != null) {
-      RunTag.Builder tag = RunTag.newBuilder();
-      tag.setKey("mlflow.user");
-      tag.setValue(username);
-      request.addTags(tag.build());
-      // userId is deprecated and will be removed in a future MLflow release
-      request.setUserId(username);
+      request.setUserId(System.getProperty("user.name"));
     }
     return createRun(request.build());
   }
@@ -436,6 +431,7 @@ public class MlflowClient {
   public void logArtifacts(String runId, File localDir) {
     getArtifactRepository(runId).logArtifacts(localDir);
   }
+
 
   /**
    * Uploads all files within the given local director an artifactPath within the run's root

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -86,7 +86,12 @@ public class MlflowClient {
     request.setStartTime(System.currentTimeMillis());
     String username = System.getProperty("user.name");
     if (username != null) {
-      request.setUserId(System.getProperty("user.name"));
+      RunTag.Builder tag = RunTag.newBuilder();
+      tag.setKey("mlflow.user");
+      tag.setValue(username);
+      request.addTags(tag.build());
+      // userId is deprecated and will be removed in a future MLflow release
+      request.setUserId(username);
     }
     return createRun(request.build());
   }
@@ -431,7 +436,6 @@ public class MlflowClient {
   public void logArtifacts(String runId, File localDir) {
     getArtifactRepository(runId).logArtifacts(localDir);
   }
-
 
   /**
    * Uploads all files within the given local director an artifactPath within the run's root

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -19,6 +19,7 @@ import docker
 
 import mlflow.tracking as tracking
 import mlflow.tracking.fluent as fluent
+import mlflow.tracking.context as context
 from mlflow.projects.submitted_run import LocalSubmittedRun, SubmittedRun
 from mlflow.projects import _project_spec
 from mlflow.exceptions import ExecutionException, MlflowException
@@ -28,8 +29,8 @@ from mlflow.tracking.context import _get_git_commit
 import mlflow.projects.databricks
 from mlflow.utils import process
 from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_DOCKER_IMAGE_NAME, \
-    MLFLOW_DOCKER_IMAGE_ID, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, MLFLOW_GIT_COMMIT, \
-    MLFLOW_GIT_REPO_URL, MLFLOW_GIT_BRANCH, LEGACY_MLFLOW_GIT_REPO_URL, \
+    MLFLOW_DOCKER_IMAGE_ID, MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, \
+    MLFLOW_GIT_COMMIT, MLFLOW_GIT_REPO_URL, MLFLOW_GIT_BRANCH, LEGACY_MLFLOW_GIT_REPO_URL, \
     LEGACY_MLFLOW_GIT_BRANCH_NAME, MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_PARENT_RUN_ID
 from mlflow.utils import databricks_utils, file_utils
 
@@ -573,6 +574,7 @@ def _create_run(uri, experiment_id, work_dir, entry_point):
         parent_run_id = None
 
     tags = {
+        MLFLOW_USER: context._get_user(),
         MLFLOW_SOURCE_NAME: source_name,
         MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.PROJECT),
         MLFLOW_PROJECT_ENTRY_POINT: entry_point

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -454,8 +454,8 @@ message RunInfo {
   optional string experiment_id = 2;
 
   // User who initiated the run.
-  // This field is deprecated, and will be removed in a future MLflow release.
-  // Use 'mlflow.user' tag instead.
+  // This field is deprecated as of MLflow 1.0, and will be removed in a future
+  // MLflow release. Use 'mlflow.user' tag instead.
   optional string user_id = 6;
 
   // Current status of the run.
@@ -583,8 +583,8 @@ message CreateRun {
   optional string experiment_id = 1;
 
   // ID of the user executing the run.
-  // This field is deprecated, and will be removed in a future MLflow release.
-  // Use 'mlflow.user' tag instead.
+  // This field is deprecated as of MLflow 1.0, and will be removed in a future
+  // MLflow release. Use 'mlflow.user' tag instead.
   optional string user_id = 2;
 
   // Unix timestamp of when the run started in milliseconds.

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -454,6 +454,8 @@ message RunInfo {
   optional string experiment_id = 2;
 
   // User who initiated the run.
+  // This field is deprecated, and will be removed in a future MLflow release.
+  // Use 'mlflow.user' tag instead.
   optional string user_id = 6;
 
   // Current status of the run.
@@ -581,6 +583,8 @@ message CreateRun {
   optional string experiment_id = 1;
 
   // ID of the user executing the run.
+  // This field is deprecated, and will be removed in a future MLflow release.
+  // Use 'mlflow.user' tag instead.
   optional string user_id = 2;
 
   // Unix timestamp of when the run started in milliseconds.
@@ -632,7 +636,6 @@ message RestoreRun {
 
   message Response {}
 }
-
 
 message LogMetric {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";

--- a/mlflow/tracking/context.py
+++ b/mlflow/tracking/context.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import getpass
 import logging
 import warnings
 from abc import ABCMeta, abstractmethod
@@ -28,8 +29,7 @@ _DEFAULT_USER = "unknown"
 def _get_user():
     """Get the current computer username."""
     try:
-        import pwd
-        return pwd.getpwuid(os.getuid())[0]
+        return getpass.getuser()
     except ImportError:
         return _DEFAULT_USER
 

--- a/mlflow/tracking/context.py
+++ b/mlflow/tracking/context.py
@@ -9,6 +9,7 @@ import entrypoints
 from mlflow.entities import SourceType
 from mlflow.utils import databricks_utils
 from mlflow.utils.mlflow_tags import (
+    MLFLOW_USER,
     MLFLOW_SOURCE_TYPE,
     MLFLOW_SOURCE_NAME,
     MLFLOW_GIT_COMMIT,
@@ -19,6 +20,18 @@ from mlflow.utils.mlflow_tags import (
 
 
 _logger = logging.getLogger(__name__)
+
+
+_DEFAULT_USER = "unknown"
+
+
+def _get_user():
+    """Get the current computer username."""
+    try:
+        import pwd
+        return pwd.getpwuid(os.getuid())[0]
+    except ImportError:
+        return _DEFAULT_USER
 
 
 def _get_main_file():
@@ -92,6 +105,7 @@ class DefaultRunContext(RunContextProvider):
 
     def tags(self):
         return {
+            MLFLOW_USER: _get_user(),
             MLFLOW_SOURCE_NAME: _get_source_name(),
             MLFLOW_SOURCE_TYPE: SourceType.to_string(_get_source_type())
         }

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -6,6 +6,7 @@ See the REST API documentation for information on the meaning of these tags.
 
 MLFLOW_RUN_NAME = "mlflow.runName"
 MLFLOW_PARENT_RUN_ID = "mlflow.parentRunId"
+MLFLOW_USER = "mlflow.user"
 MLFLOW_SOURCE_TYPE = "mlflow.source.type"
 MLFLOW_SOURCE_NAME = "mlflow.source.name"
 MLFLOW_GIT_COMMIT = "mlflow.source.git.commit"

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -13,13 +13,22 @@ from mlflow.entities import RunStatus, ViewType, Experiment, SourceType
 from mlflow.exceptions import ExecutionException, MlflowException
 from mlflow.store.file_store import FileStore
 from mlflow.utils import env
-from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, \
-    MLFLOW_GIT_BRANCH, MLFLOW_GIT_REPO_URL, LEGACY_MLFLOW_GIT_BRANCH_NAME, \
+from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_USER, MLFLOW_SOURCE_NAME, \
+    MLFLOW_SOURCE_TYPE, MLFLOW_GIT_BRANCH, MLFLOW_GIT_REPO_URL, LEGACY_MLFLOW_GIT_BRANCH_NAME, \
     LEGACY_MLFLOW_GIT_REPO_URL, MLFLOW_PROJECT_ENTRY_POINT
 
 from tests.projects.utils import TEST_PROJECT_DIR, TEST_PROJECT_NAME, GIT_PROJECT_URI, \
     validate_exit_status, assert_dirs_equal
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
+
+
+MOCK_USER = "janebloggs"
+
+
+@pytest.fixture
+def patch_user():
+    with mock.patch("mlflow.tracking.context._get_user", return_value=MOCK_USER):
+        yield
 
 
 def _build_uri(base_uri, subdirectory):
@@ -176,7 +185,8 @@ def test_is_valid_branch_name(local_git_repo):
 
 @pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
 @pytest.mark.parametrize("version", [None, "master", "git-commit"])
-def test_run_local_git_repo(local_git_repo,
+def test_run_local_git_repo(patch_user,
+                            local_git_repo,
                             local_git_repo_uri,
                             tracking_uri_mock,  # pylint: disable=unused-argument
                             use_start_run,
@@ -213,6 +223,7 @@ def test_run_local_git_repo(local_git_repo,
     assert run.data.metrics == {"some_key": 3}
 
     tags = run.data.tags
+    assert tags[MLFLOW_USER] == MOCK_USER
     assert "file:" in tags[MLFLOW_SOURCE_NAME]
     assert tags[MLFLOW_SOURCE_TYPE] == SourceType.to_string(SourceType.PROJECT)
     assert tags[MLFLOW_PROJECT_ENTRY_POINT] == "test_tracking"
@@ -256,7 +267,10 @@ def test_invalid_version_local_git_repo(local_git_repo_uri,
 
 
 @pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
-def test_run(tmpdir, tracking_uri_mock, use_start_run):  # pylint: disable=unused-argument
+def test_run(tmpdir,
+             patch_user,
+             tracking_uri_mock,  # pylint: disable=unused-argument
+             use_start_run):
     submitted_run = mlflow.projects.run(
         TEST_PROJECT_DIR, entry_point="test_tracking",
         parameters={"use_start_run": use_start_run},
@@ -285,6 +299,7 @@ def test_run(tmpdir, tracking_uri_mock, use_start_run):  # pylint: disable=unuse
     assert run.data.metrics == {"some_key": 3}
 
     tags = run.data.tags
+    assert tags[MLFLOW_USER] == MOCK_USER
     assert "file:" in tags[MLFLOW_SOURCE_NAME]
     assert tags[MLFLOW_SOURCE_TYPE] == SourceType.to_string(SourceType.PROJECT)
     assert tags[MLFLOW_PROJECT_ENTRY_POINT] == "test_tracking"

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -185,7 +185,7 @@ def test_is_valid_branch_name(local_git_repo):
 
 @pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
 @pytest.mark.parametrize("version", [None, "master", "git-commit"])
-def test_run_local_git_repo(patch_user,
+def test_run_local_git_repo(patch_user,  # pylint: disable=unused-argument
                             local_git_repo,
                             local_git_repo_uri,
                             tracking_uri_mock,  # pylint: disable=unused-argument
@@ -267,8 +267,8 @@ def test_invalid_version_local_git_repo(local_git_repo_uri,
 
 
 @pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
-def test_run(tmpdir,
-             patch_user,
+def test_run(tmpdir,  # pylint: disable=unused-argument
+             patch_user,  # pylint: disable=unused-argument
              tracking_uri_mock,  # pylint: disable=unused-argument
              use_start_run):
     submitted_run = mlflow.projects.run(

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -81,12 +81,6 @@ class TestRestStore(unittest.TestCase):
     def _verify_requests(self, http_request, host_creds, endpoint, method, json_body):
         http_request.assert_called_with(**(self._args(host_creds, endpoint, method, json_body)))
 
-    def _verify_request_has_calls(self, http_request, host_creds, call_args):
-        http_request.assert_has_calls(calls=[mock.call(**(self._args(host_creds, endpoint, method,
-                                                                     json_body)))
-                                             for endpoint, method, json_body in call_args],
-                                      any_order=True)
-
     @mock.patch('requests.request')
     def test_requestor(self, request):
         response = mock.MagicMock
@@ -120,9 +114,20 @@ class TestRestStore(unittest.TestCase):
                                                                       value='LOCAL'),
                                                           ProtoRunTag(key='mlflow.user',
                                                                       value=user_name)]))
+                expected_kwargs = self._args(creds, "runs/create", "POST", cr_body)
+
                 assert mock_http.call_count == 1
-                exp_calls = [("runs/create", "POST", cr_body)]
-                self._verify_request_has_calls(mock_http, creds, exp_calls)
+                actual_kwargs = mock_http.call_args[1]
+
+                # Test the passed tag values separately from the rest of the request
+                # Tag order is inconsistent on Python 2 and 3, but the order does not matter
+                expected_tags = expected_kwargs['json'].pop('tags')
+                actual_tags = actual_kwargs['json'].pop('tags')
+                assert (
+                    sorted(expected_tags, key=lambda t: t['key']) ==
+                    sorted(actual_tags, key=lambda t: t['key'])
+                )
+                assert expected_kwargs == actual_kwargs
 
         with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
             store.log_param("some_uuid", Param("k1", "v1"))

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -114,12 +114,12 @@ class TestRestStore(unittest.TestCase):
             with mlflow.start_run(experiment_id="43"):
                 cr_body = message_to_json(CreateRun(experiment_id="43",
                                                     user_id=user_name, start_time=13579000,
-                                                    tags=[ProtoRunTag(key='mlflow.user',
-                                                                      value=user_name),
-                                                          ProtoRunTag(key='mlflow.source.name',
+                                                    tags=[ProtoRunTag(key='mlflow.source.name',
                                                                       value=source_name),
                                                           ProtoRunTag(key='mlflow.source.type',
-                                                                      value='LOCAL')]))
+                                                                      value='LOCAL'),
+                                                          ProtoRunTag(key='mlflow.user',
+                                                                      value=user_name)]))
                 assert mock_http.call_count == 1
                 exp_calls = [("runs/create", "POST", cr_body)]
                 self._verify_request_has_calls(mock_http, creds, exp_calls)

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -108,13 +108,15 @@ class TestRestStore(unittest.TestCase):
         )
         with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http, \
                 mock.patch('mlflow.tracking.utils._get_store', return_value=store), \
-                mock.patch('mlflow.tracking.client._get_user_id', return_value=user_name), \
+                mock.patch('mlflow.tracking.context._get_user', return_value=user_name), \
                 mock.patch('time.time', return_value=13579), \
                 source_name_patch, source_type_patch:
             with mlflow.start_run(experiment_id="43"):
                 cr_body = message_to_json(CreateRun(experiment_id="43",
                                                     user_id=user_name, start_time=13579000,
-                                                    tags=[ProtoRunTag(key='mlflow.source.name',
+                                                    tags=[ProtoRunTag(key='mlflow.user',
+                                                                      value=user_name),
+                                                          ProtoRunTag(key='mlflow.source.name',
                                                                       value=source_name),
                                                           ProtoRunTag(key='mlflow.source.type',
                                                                       value='LOCAL')]))

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -160,6 +160,10 @@ def test_start_run_defaults(empty_active_run_stack):
     databricks_notebook_patch = mock.patch(
         "mlflow.tracking.fluent.is_in_databricks_notebook", return_value=False
     )
+    mock_user = mock.Mock()
+    user_patch = mock.patch(
+        "mlflow.tracking.context._get_user", return_value=mock_user
+    )
     mock_source_name = mock.Mock()
     source_name_patch = mock.patch(
         "mlflow.tracking.context._get_source_name", return_value=mock_source_name
@@ -173,6 +177,7 @@ def test_start_run_defaults(empty_active_run_stack):
     )
 
     expected_tags = {
+        mlflow_tags.MLFLOW_USER: mock_user,
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_source_name,
         mlflow_tags.MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.NOTEBOOK),
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version
@@ -180,8 +185,8 @@ def test_start_run_defaults(empty_active_run_stack):
 
     create_run_patch = mock.patch.object(MlflowClient, "create_run")
 
-    with experiment_id_patch, databricks_notebook_patch, source_name_patch, source_type_patch, \
-            source_version_patch, create_run_patch:
+    with experiment_id_patch, databricks_notebook_patch, user_patch, source_name_patch, \
+            source_type_patch, source_version_patch, create_run_patch:
         active_run = start_run()
         MlflowClient.create_run.assert_called_once_with(
             experiment_id=mock_experiment_id,
@@ -198,6 +203,10 @@ def test_start_run_defaults_databricks_notebook(empty_active_run_stack):
     )
     databricks_notebook_patch = mock.patch(
         "mlflow.utils.databricks_utils.is_in_databricks_notebook", return_value=True
+    )
+    mock_user = mock.Mock()
+    user_patch = mock.patch(
+        "mlflow.tracking.context._get_user", return_value=mock_user
     )
     mock_source_version = mock.Mock()
     source_version_patch = mock.patch(
@@ -217,6 +226,7 @@ def test_start_run_defaults_databricks_notebook(empty_active_run_stack):
     )
 
     expected_tags = {
+        mlflow_tags.MLFLOW_USER: mock_user,
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_notebook_path,
         mlflow_tags.MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.NOTEBOOK),
         mlflow_tags.MLFLOW_GIT_COMMIT: mock_source_version,
@@ -227,7 +237,7 @@ def test_start_run_defaults_databricks_notebook(empty_active_run_stack):
 
     create_run_patch = mock.patch.object(MlflowClient, "create_run")
 
-    with experiment_id_patch, databricks_notebook_patch, source_version_patch, \
+    with experiment_id_patch, databricks_notebook_patch, user_patch, source_version_patch, \
             notebook_id_patch, notebook_path_patch, webapp_url_patch, create_run_patch:
         active_run = start_run()
         MlflowClient.create_run.assert_called_once_with(
@@ -249,11 +259,16 @@ def test_start_run_with_parent():
     databricks_notebook_patch = mock.patch(
         "mlflow.tracking.fluent.is_in_databricks_notebook", return_value=False
     )
+    mock_user = mock.Mock()
+    user_patch = mock.patch(
+        "mlflow.tracking.context._get_user", return_value=mock_user
+    )
     source_name_patch = mock.patch(
         "mlflow.tracking.context._get_source_name", return_value=mock_source_name
     )
 
     expected_tags = {
+        mlflow_tags.MLFLOW_USER: mock_user,
         mlflow_tags.MLFLOW_SOURCE_NAME: mock_source_name,
         mlflow_tags.MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.LOCAL),
         mlflow_tags.MLFLOW_PARENT_RUN_ID: parent_run.info.run_id
@@ -261,7 +276,8 @@ def test_start_run_with_parent():
 
     create_run_patch = mock.patch.object(MlflowClient, "create_run")
 
-    with databricks_notebook_patch, active_run_stack_patch, create_run_patch, source_name_patch:
+    with databricks_notebook_patch, active_run_stack_patch, create_run_patch, user_patch, \
+            source_name_patch:
         active_run = start_run(
             experiment_id=mock_experiment_id, nested=True
         )

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -4,7 +4,7 @@ and ensures we can use the tracking API to communicate with it.
 """
 
 import mock
-from subprocess import Popen, PIPE, STDOUT
+from subprocess import Popen
 import os
 import sys
 import pytest
@@ -16,8 +16,7 @@ import tempfile
 
 import mlflow.experiments
 from mlflow.entities import RunStatus, Metric, Param, RunTag, ViewType
-from mlflow.protos.service_pb2 import LOCAL as SOURCE_TYPE_LOCAL
-from mlflow.server import app, BACKEND_STORE_URI_ENV_VAR, ARTIFACT_ROOT_ENV_VAR
+from mlflow.server import BACKEND_STORE_URI_ENV_VAR, ARTIFACT_ROOT_ENV_VAR
 from mlflow.tracking import MlflowClient
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME, MLFLOW_PARENT_RUN_ID, MLFLOW_SOURCE_TYPE, \
     MLFLOW_SOURCE_NAME, MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_GIT_COMMIT

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -18,8 +18,8 @@ import mlflow.experiments
 from mlflow.entities import RunStatus, Metric, Param, RunTag, ViewType
 from mlflow.server import BACKEND_STORE_URI_ENV_VAR, ARTIFACT_ROOT_ENV_VAR
 from mlflow.tracking import MlflowClient
-from mlflow.utils.mlflow_tags import MLFLOW_RUN_NAME, MLFLOW_PARENT_RUN_ID, MLFLOW_SOURCE_TYPE, \
-    MLFLOW_SOURCE_NAME, MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_GIT_COMMIT
+from mlflow.utils.mlflow_tags import MLFLOW_USER, MLFLOW_RUN_NAME, MLFLOW_PARENT_RUN_ID, \
+    MLFLOW_SOURCE_TYPE, MLFLOW_SOURCE_NAME, MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_GIT_COMMIT
 from mlflow.utils.file_utils import path_to_local_file_uri, local_file_uri_to_path
 from tests.integration.utils import invoke_cli_runner
 
@@ -237,13 +237,14 @@ def test_rename_experiment_cli(mlflow_client, cli_env):
 
 @pytest.mark.parametrize("parent_run_id_kwarg", [None, "my-parent-id"])
 def test_create_run_all_args(mlflow_client, parent_run_id_kwarg):
+    user = "username"
     source_name = "Hello"
     entry_point = "entry"
     source_version = "abc"
     create_run_kwargs = {
-        "user_id": "123",
         "start_time": 456,
         "tags": {
+            MLFLOW_USER: user,
             MLFLOW_SOURCE_TYPE: "LOCAL",
             MLFLOW_SOURCE_NAME: source_name,
             MLFLOW_PROJECT_ENTRY_POINT: entry_point,
@@ -263,10 +264,11 @@ def test_create_run_all_args(mlflow_client, parent_run_id_kwarg):
     assert run.info.run_id == run_id
     assert run.info.run_uuid == run_id
     assert run.info.experiment_id == experiment_id
-    assert run.info.user_id == create_run_kwargs["user_id"]
+    assert run.info.user_id == user
     assert run.info.start_time == create_run_kwargs["start_time"]
     for tag in create_run_kwargs["tags"]:
         assert tag in run.data.tags
+    assert run.data.tags.get(MLFLOW_USER) == user
     assert run.data.tags.get(MLFLOW_RUN_NAME) == "my name"
     assert run.data.tags.get(MLFLOW_PARENT_RUN_ID) == parent_run_id_kwarg or "7"
     assert mlflow_client.list_run_infos(experiment_id) == [run.info]
@@ -279,7 +281,7 @@ def test_create_run_defaults(mlflow_client):
     run = mlflow_client.get_run(run_id)
     assert run.info.run_id == run_id
     assert run.info.experiment_id == experiment_id
-    assert run.info.user_id is not None  # we should pick some default
+    assert run.info.user_id == "unknown"
 
 
 def test_log_metrics_params_tags(mlflow_client, backend_store_uri):

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -18,7 +18,8 @@ from mlflow.protos.databricks_pb2 import ErrorCode, INVALID_PARAMETER_VALUE
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.fluent import start_run, end_run
 from mlflow.utils.file_utils import local_file_uri_to_path
-from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE
+from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_USER, MLFLOW_SOURCE_NAME, \
+    MLFLOW_SOURCE_TYPE
 
 from tests.projects.utils import tracking_uri_mock
 
@@ -185,7 +186,7 @@ def test_log_batch(tracking_uri_mock, tmpdir):
     expected_metrics = {"metric-key0": 1.0, "metric-key1": 4.0}
     expected_params = {"param-key0": "param-val0", "param-key1": "param-val1"}
     exact_expected_tags = {"tag-key0": "tag-val0", "tag-key1": "tag-val1"}
-    approx_expected_tags = set([MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE])
+    approx_expected_tags = set([MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE])
 
     t = int(time.time())
     sorted_expected_metrics = sorted(expected_metrics.items(), key=lambda kv: kv[0])
@@ -278,7 +279,7 @@ def get_store_mock(tmpdir):
 
 def test_set_tags(tracking_uri_mock):
     exact_expected_tags = {"name_1": "c", "name_2": "b", "nested/nested/name": "5"}
-    approx_expected_tags = set([MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE])
+    approx_expected_tags = set([MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE])
     with start_run() as active_run:
         run_id = active_run.info.run_id
         mlflow.set_tags(exact_expected_tags)


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Following #1188 and further discussion with @aarondav, this PR migrates storage of the user who started a run to tags.

In particular:

* The tag `mlflow.user` has been added and is set on creation of a run.
* The user_id field on runs has been marked as deprecated and subject to removal in a future release, as was done previously for source_name, source_type etc.
* user_id has been removed as an argument from the Python and R create_run methods (it was not exposed on the Java client createRun method).
* Clients continue to pass the user_id attribute, which is read from tags on run creation, for the duration of the deprecation period.
* Documentation has been updated to reflect that user_id is deprecated.

I've also changed the logic for detecting system username from `pwd.getpwuid(os.getuid())[0]` to the standard library helper [`getpass.getuser`](https://github.com/python/cpython/blob/3.7/Lib/getpass.py#L154), which should support Windows systems in most cases.
 
## How is this patch tested?
 
These changes affect a number of existing unit and integration tests, which have been updated to the change as appropriate.
 
## Release Notes

* The run field user_id has been deprecated in favour of the new tag `mlflow.user`.
* user_id has been removed as an argument from the create_run methods of the Python and R clients.
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
I've selected 'no' as the Python fluent interface and Java client interfaces are unchanged, and it seems likely as users would not often be using the `user_id` argument to `mlflow_start_run` in the R client.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [x] API 
- [x] REST-API 
- [ ] Examples 
- [x] Docs
- [x] Tracking
- [x] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [x] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes