### PR TITLE
[CLI] clean-ups for 1.0

### DIFF
--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -344,7 +344,7 @@ mlflow_download_artifacts <- function(path, run_id = NULL, client = NULL) {
 
 # ' Download Artifacts from URI.
 mlflow_download_artifacts_from_uri <- function(artifact_uri, client = mlflow_client()) {
-  result <- mlflow_cli("artifacts", "download-from-uri", "-a", artifact_uri, echo = FALSE,
+  result <- mlflow_cli("artifacts", "download", "-u", artifact_uri, echo = FALSE,
                        client = client)
   gsub("\n", "", result$stdout)
 }

--- a/mlflow/azureml/cli.py
+++ b/mlflow/azureml/cli.py
@@ -22,7 +22,6 @@ def commands():
     pass
 
 
-@experimental
 @commands.command("build-image")
 @cli_args.MODEL_URI
 @click.option("--workspace-name", "-w", required=True,
@@ -45,6 +44,7 @@ def commands():
                     " key-value pairs, to associate with the Azure Container Image and the Azure"
                     " Model that are created. These tags will be added to a set of default tags"
                     " that include the model path, the model run id (if specified), and more."))
+@experimental
 def build_image(model_uri, workspace_name, subscription_id, image_name, model_name,
                 mlflow_home, description, tags):
     """

--- a/mlflow/azureml/cli.py
+++ b/mlflow/azureml/cli.py
@@ -8,7 +8,7 @@ import json
 import click
 
 import mlflow.azureml
-from mlflow.utils import cli_args
+from mlflow.utils import cli_args, experimental
 
 
 @click.group("azureml")
@@ -22,6 +22,7 @@ def commands():
     pass
 
 
+@experimental
 @commands.command("build-image")
 @cli_args.MODEL_URI
 @click.option("--workspace-name", "-w", required=True,

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -253,7 +253,6 @@ def server(backend_store_uri, default_artifact_root, host, port,
         sys.exit(1)
 
 
-cli.add_command(mlflow.data.download)
 cli.add_command(mlflow.pyfunc.cli.commands)
 cli.add_command(mlflow.rfunc.cli.commands)
 cli.add_command(mlflow.sagemaker.cli.commands)

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 import os
 import re
 
-import click
 from six.moves import urllib
 
 from mlflow.utils import process
@@ -76,17 +75,3 @@ def download_uri(uri, output_path):
     else:
         raise DownloadException("`uri` must be a DBFS (%s), S3 (%s), or GCS (%s) URI, got "
                                 "%s" % (DBFS_PREFIX, S3_PREFIX, GS_PREFIX, uri))
-
-
-@click.command("download")
-@click.argument("uri")
-@click.option("--output-path", "-o", metavar="PATH",
-              help="Output path into which to download the artifact.")
-def download(uri, output_path):
-    """
-    Download the artifact at the specified DBFS, S3, or GCS URI into the specified local output
-    path, or the current directory if no output path is specified.
-    """
-    if output_path is None:
-        output_path = os.path.basename(uri)
-    download_uri(uri, output_path)

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -97,12 +97,6 @@ def deploy(app_name, model_uri, execution_role_arn, bucket, image_url, region_na
                             synchronous=(not asynchronous), timeout_seconds=timeout)
 
 
-@commands.command("list-flavors")
-def list_flavors():
-    print("Supported model flavors for SageMaker deployment are: {supported_flavors}".format(
-        supported_flavors=mlflow.sagemaker.SUPPORTED_DEPLOYMENT_FLAVORS))
-
-
 @commands.command("delete")
 @click.option("--app-name", "-a", help="Application name", required=True)
 @click.option("--region-name", "-r", default="us-west-2",

--- a/mlflow/store/cli.py
+++ b/mlflow/store/cli.py
@@ -1,10 +1,14 @@
+from __future__ import print_function
+
 import logging
+import sys
 
 import click
 
+from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.tracking import _get_store
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.store.artifact_repository_registry import get_artifact_repository
+from mlflow.utils.logging_utils import eprint
 from mlflow.utils.proto_json_utils import message_to_json
 
 _logger = logging.getLogger(__name__)
@@ -88,29 +92,31 @@ def _file_infos_to_json(file_infos):
 
 
 @commands.command("download")
-@click.option("--run-id", "-r", required=True,
+@click.option("--run-id", "-r",
               help="Run ID from which to download")
 @click.option("--artifact-path", "-a",
               help="If specified, a path relative to the run's root directory to download")
-def download_artifacts(run_id, artifact_path):
+@click.option("--artifact-uri", "-u",
+              help="URI pointing to the artifact file or artifacts directory.")
+def download_artifacts(run_id, artifact_path, artifact_uri):
     """
     Download an artifact file or directory to a local directory.
     The output is the name of the file or directory on the local disk.
+
+    Either ``--run-id`` or ``--artifact-uri`` must be provided.
     """
+    if run_id is None and artifact_uri is None:
+        eprint("Option 'default-artifact-root' is required, when backend store is not "
+               "local file based.")
+        sys.exit(1)
+
+    if artifact_uri is not None:
+        print(_download_artifact_from_uri(artifact_uri))
+        return
+
     artifact_path = artifact_path if artifact_path is not None else ""
     store = _get_store()
     artifact_uri = store.get_run(run_id).info.artifact_uri
     artifact_repo = get_artifact_repository(artifact_uri)
     artifact_location = artifact_repo.download_artifacts(artifact_path)
     print(artifact_location)
-
-
-@commands.command("download-from-uri")
-@click.option("--artifact-uri", "-a", required=True,
-              help="URI pointing to the artifact file or artifacts directory.")
-def download_artifacts_from_uri(artifact_uri):
-    """
-    Download an artifact file or directory from a given URI to a local directory.
-    The output is the name of the file or directory on the local disk.
-    """
-    print(_download_artifact_from_uri(artifact_uri))

--- a/mlflow/store/cli.py
+++ b/mlflow/store/cli.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import logging
 import sys
 
@@ -8,7 +6,6 @@ import click
 from mlflow.store.artifact_repository_registry import get_artifact_repository
 from mlflow.tracking import _get_store
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils.logging_utils import eprint
 from mlflow.utils.proto_json_utils import message_to_json
 
 _logger = logging.getLogger(__name__)
@@ -95,9 +92,11 @@ def _file_infos_to_json(file_infos):
 @click.option("--run-id", "-r",
               help="Run ID from which to download")
 @click.option("--artifact-path", "-a",
-              help="If specified, a path relative to the run's root directory to download")
+              help="For use with Run ID: if specified, a path relative to the run's root "
+                   "directory to download")
 @click.option("--artifact-uri", "-u",
-              help="URI pointing to the artifact file or artifacts directory.")
+              help="URI pointing to the artifact file or artifacts directory; use as an "
+                   "alternative to specifying --run_id and --artifact-path")
 def download_artifacts(run_id, artifact_path, artifact_uri):
     """
     Download an artifact file or directory to a local directory.
@@ -106,8 +105,7 @@ def download_artifacts(run_id, artifact_path, artifact_uri):
     Either ``--run-id`` or ``--artifact-uri`` must be provided.
     """
     if run_id is None and artifact_uri is None:
-        eprint("Option 'default-artifact-root' is required, when backend store is not "
-               "local file based.")
+        _logger.error("Either ``--run-id`` or ``--artifact-uri`` must be provided.")
         sys.exit(1)
 
     if artifact_uri is not None:

--- a/tests/store/test_cli.py
+++ b/tests/store/test_cli.py
@@ -33,7 +33,7 @@ def test_download_artifacts_from_uri():
             with open(local_path, "w") as f:
                 f.write("test")
             mlflow.log_artifact(local_path, "test")
-    command = ["mlflow", "artifacts", "download-from-uri", "-a"]
+    command = ["mlflow", "artifacts", "download", "-u"]
     # Test with run uri
     run_uri = "runs:/{run_id}/test".format(run_id=run.info.run_id)
     actual_uri = posixpath.join(run.info.artifact_uri, "test")


### PR DESCRIPTION
## What changes are proposed in this pull request?

CLI clean-ups for 1.0:
- conslidate `artifacts download` `artifacts download-from-uri` and `download` into one -- `artifacts download`
- remove `sagemaker list-flavors`
- marked `azureml build-image` as experimental
 
## How is this patch tested?
 
- Existing unit tests
- Check docs for experimental docstring

## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Consolidated CLI commands `artifacts download` `artifacts download-from-uri` and `download` into one -- `artifacts download` and removed the `sagemaker list-flavors` command.
 
### What component(s) does this PR affect?
 
- [x] CLI 
- [x] Artifacts 

### How should the PR be classified in the release notes? Choose one:
 
- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section