### PR TITLE
[Easy] Turn args into opts in experiments CLI commands

### DIFF
--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -9,7 +9,7 @@ from mlflow.data import is_uri
 from mlflow.entities import ViewType
 from mlflow.tracking import _get_store
 
-EXPERIMENT_ID = click.argument("experiment_id", type=click.STRING)
+EXPERIMENT_ID = click.option("--experiment-id", "-x", type=click.STRING, required=True)
 
 
 @click.group("experiments")
@@ -22,7 +22,7 @@ def commands():
 
 
 @commands.command()
-@click.argument("experiment_name")
+@click.option("--experiment-name", "-n", type=click.STRING, required=True)
 @click.option("--artifact-location", "-l",
               help="Base location for runs to store artifact results. Artifacts will be stored "
                    "at $artifact_location/$run_id/artifacts. See "
@@ -81,7 +81,7 @@ def restore_experiment(experiment_id):
 
 @commands.command("rename")
 @EXPERIMENT_ID
-@click.argument("new_name")
+@click.option("--new-name", type=click.STRING, required=True)
 def rename_experiment(experiment_id, new_name):
     """
     Renames an active experiment.

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -207,12 +207,15 @@ def test_delete_restore_experiment(mlflow_client):
 
 def test_delete_restore_experiment_cli(mlflow_client, cli_env):
     experiment_name = "DeleteriousCLI"
-    invoke_cli_runner(mlflow.experiments.commands, ['create', experiment_name], env=cli_env)
+    invoke_cli_runner(mlflow.experiments.commands,
+                      ['create', '--experiment-name', experiment_name], env=cli_env)
     experiment_id = mlflow_client.get_experiment_by_name(experiment_name).experiment_id
     assert mlflow_client.get_experiment(experiment_id).lifecycle_stage == 'active'
-    invoke_cli_runner(mlflow.experiments.commands, ['delete', str(experiment_id)], env=cli_env)
+    invoke_cli_runner(mlflow.experiments.commands, ['delete', '-x', str(experiment_id)],
+                      env=cli_env)
     assert mlflow_client.get_experiment(experiment_id).lifecycle_stage == 'deleted'
-    invoke_cli_runner(mlflow.experiments.commands, ['restore', str(experiment_id)], env=cli_env)
+    invoke_cli_runner(mlflow.experiments.commands, ['restore', '-x', str(experiment_id)],
+                      env=cli_env)
     assert mlflow_client.get_experiment(experiment_id).lifecycle_stage == 'active'
 
 
@@ -227,12 +230,14 @@ def test_rename_experiment_cli(mlflow_client, cli_env):
     bad_experiment_name = "CLIBadName"
     good_experiment_name = "CLIGoodName"
 
-    invoke_cli_runner(mlflow.experiments.commands, ['create', bad_experiment_name], env=cli_env)
+    invoke_cli_runner(mlflow.experiments.commands, ['create', '-n', bad_experiment_name],
+                      env=cli_env)
     experiment_id = mlflow_client.get_experiment_by_name(bad_experiment_name).experiment_id
     assert mlflow_client.get_experiment(experiment_id).name == bad_experiment_name
     invoke_cli_runner(
         mlflow.experiments.commands,
-        ['rename', str(experiment_id), good_experiment_name], env=cli_env)
+        ['rename', '--experiment-id', str(experiment_id), '--new-name', good_experiment_name],
+        env=cli_env)
     assert mlflow_client.get_experiment(experiment_id).name == good_experiment_name
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
To be consistent with other CLI commands, made arguments in `experiments` CLI commands options instead.
 
## How is this patch tested?

- Existing unit tests
- Manually tested cli commands
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
In the ``experiments`` CLI commands, arguments are now options.
 
### What component(s) does this PR affect?
 
- [X] CLI 
- [X] Tracking

### How should the PR be classified in the release notes? Choose one:
 
- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
