### PR TITLE
Adding support for both preview and non-preview APIs

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
@@ -3398,7 +3398,7 @@ public final class Service {
   }
   /**
    * <pre>
-   * Run data (metrics, params, etc).
+   * Run data (metrics, params, and tags).
    * </pre>
    *
    * Protobuf type {@code mlflow.RunData}
@@ -3861,7 +3861,7 @@ public final class Service {
     }
     /**
      * <pre>
-     * Run data (metrics, params, etc).
+     * Run data (metrics, params, and tags).
      * </pre>
      *
      * Protobuf type {@code mlflow.RunData}
@@ -11226,7 +11226,7 @@ public final class Service {
 
       /**
        * <pre>
-       * All experiments
+       * All experiments.
        * </pre>
        *
        * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11235,7 +11235,7 @@ public final class Service {
           getExperimentsList();
       /**
        * <pre>
-       * All experiments
+       * All experiments.
        * </pre>
        *
        * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11243,7 +11243,7 @@ public final class Service {
       org.mlflow.api.proto.Service.Experiment getExperiments(int index);
       /**
        * <pre>
-       * All experiments
+       * All experiments.
        * </pre>
        *
        * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11251,7 +11251,7 @@ public final class Service {
       int getExperimentsCount();
       /**
        * <pre>
-       * All experiments
+       * All experiments.
        * </pre>
        *
        * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11260,7 +11260,7 @@ public final class Service {
           getExperimentsOrBuilderList();
       /**
        * <pre>
-       * All experiments
+       * All experiments.
        * </pre>
        *
        * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11356,7 +11356,7 @@ public final class Service {
       private java.util.List<org.mlflow.api.proto.Service.Experiment> experiments_;
       /**
        * <pre>
-       * All experiments
+       * All experiments.
        * </pre>
        *
        * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11366,7 +11366,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * All experiments
+       * All experiments.
        * </pre>
        *
        * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11377,7 +11377,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * All experiments
+       * All experiments.
        * </pre>
        *
        * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11387,7 +11387,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * All experiments
+       * All experiments.
        * </pre>
        *
        * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11397,7 +11397,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * All experiments
+       * All experiments.
        * </pre>
        *
        * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11764,7 +11764,7 @@ public final class Service {
 
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11778,7 +11778,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11792,7 +11792,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11806,7 +11806,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11827,7 +11827,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11845,7 +11845,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11865,7 +11865,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11886,7 +11886,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11904,7 +11904,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11922,7 +11922,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11941,7 +11941,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11958,7 +11958,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11975,7 +11975,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -11986,7 +11986,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -12000,7 +12000,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -12015,7 +12015,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -12026,7 +12026,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -12038,7 +12038,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * All experiments
+         * All experiments.
          * </pre>
          *
          * <code>repeated .mlflow.Experiment experiments = 1;</code>
@@ -12679,7 +12679,7 @@ public final class Service {
 
       /**
        * <pre>
-       * Returns experiment details.
+       * Experiment details.
        * </pre>
        *
        * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -12687,7 +12687,7 @@ public final class Service {
       boolean hasExperiment();
       /**
        * <pre>
-       * Returns experiment details.
+       * Experiment details.
        * </pre>
        *
        * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -12695,7 +12695,7 @@ public final class Service {
       org.mlflow.api.proto.Service.Experiment getExperiment();
       /**
        * <pre>
-       * Returns experiment details.
+       * Experiment details.
        * </pre>
        *
        * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -12848,7 +12848,7 @@ public final class Service {
       private org.mlflow.api.proto.Service.Experiment experiment_;
       /**
        * <pre>
-       * Returns experiment details.
+       * Experiment details.
        * </pre>
        *
        * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -12858,7 +12858,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Returns experiment details.
+       * Experiment details.
        * </pre>
        *
        * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -12868,7 +12868,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Returns experiment details.
+       * Experiment details.
        * </pre>
        *
        * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -13316,7 +13316,7 @@ public final class Service {
             org.mlflow.api.proto.Service.Experiment, org.mlflow.api.proto.Service.Experiment.Builder, org.mlflow.api.proto.Service.ExperimentOrBuilder> experimentBuilder_;
         /**
          * <pre>
-         * Returns experiment details.
+         * Experiment details.
          * </pre>
          *
          * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -13326,7 +13326,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Returns experiment details.
+         * Experiment details.
          * </pre>
          *
          * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -13340,7 +13340,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Returns experiment details.
+         * Experiment details.
          * </pre>
          *
          * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -13360,7 +13360,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Returns experiment details.
+         * Experiment details.
          * </pre>
          *
          * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -13378,7 +13378,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Returns experiment details.
+         * Experiment details.
          * </pre>
          *
          * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -13402,7 +13402,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Returns experiment details.
+         * Experiment details.
          * </pre>
          *
          * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -13419,7 +13419,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Returns experiment details.
+         * Experiment details.
          * </pre>
          *
          * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -13431,7 +13431,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Returns experiment details.
+         * Experiment details.
          * </pre>
          *
          * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -13446,7 +13446,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Returns experiment details.
+         * Experiment details.
          * </pre>
          *
          * <code>optional .mlflow.Experiment experiment = 1;</code>
@@ -15401,7 +15401,7 @@ public final class Service {
 
     /**
      * <pre>
-     * Identifier to get an experiment
+     * ID of the associated experiment.
      * </pre>
      *
      * <code>optional string experiment_id = 1 [(.mlflow.validate_required) = true];</code>
@@ -15409,7 +15409,7 @@ public final class Service {
     boolean hasExperimentId();
     /**
      * <pre>
-     * Identifier to get an experiment
+     * ID of the associated experiment.
      * </pre>
      *
      * <code>optional string experiment_id = 1 [(.mlflow.validate_required) = true];</code>
@@ -15417,7 +15417,7 @@ public final class Service {
     java.lang.String getExperimentId();
     /**
      * <pre>
-     * Identifier to get an experiment
+     * ID of the associated experiment.
      * </pre>
      *
      * <code>optional string experiment_id = 1 [(.mlflow.validate_required) = true];</code>
@@ -15920,7 +15920,7 @@ public final class Service {
     private volatile java.lang.Object experimentId_;
     /**
      * <pre>
-     * Identifier to get an experiment
+     * ID of the associated experiment.
      * </pre>
      *
      * <code>optional string experiment_id = 1 [(.mlflow.validate_required) = true];</code>
@@ -15930,7 +15930,7 @@ public final class Service {
     }
     /**
      * <pre>
-     * Identifier to get an experiment
+     * ID of the associated experiment.
      * </pre>
      *
      * <code>optional string experiment_id = 1 [(.mlflow.validate_required) = true];</code>
@@ -15951,7 +15951,7 @@ public final class Service {
     }
     /**
      * <pre>
-     * Identifier to get an experiment
+     * ID of the associated experiment.
      * </pre>
      *
      * <code>optional string experiment_id = 1 [(.mlflow.validate_required) = true];</code>
@@ -16289,7 +16289,7 @@ public final class Service {
       private java.lang.Object experimentId_ = "";
       /**
        * <pre>
-       * Identifier to get an experiment
+       * ID of the associated experiment.
        * </pre>
        *
        * <code>optional string experiment_id = 1 [(.mlflow.validate_required) = true];</code>
@@ -16299,7 +16299,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Identifier to get an experiment
+       * ID of the associated experiment.
        * </pre>
        *
        * <code>optional string experiment_id = 1 [(.mlflow.validate_required) = true];</code>
@@ -16320,7 +16320,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Identifier to get an experiment
+       * ID of the associated experiment.
        * </pre>
        *
        * <code>optional string experiment_id = 1 [(.mlflow.validate_required) = true];</code>
@@ -16340,7 +16340,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Identifier to get an experiment
+       * ID of the associated experiment.
        * </pre>
        *
        * <code>optional string experiment_id = 1 [(.mlflow.validate_required) = true];</code>
@@ -16357,7 +16357,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Identifier to get an experiment
+       * ID of the associated experiment.
        * </pre>
        *
        * <code>optional string experiment_id = 1 [(.mlflow.validate_required) = true];</code>
@@ -16370,7 +16370,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Identifier to get an experiment
+       * ID of the associated experiment.
        * </pre>
        *
        * <code>optional string experiment_id = 1 [(.mlflow.validate_required) = true];</code>
@@ -16470,7 +16470,7 @@ public final class Service {
 
     /**
      * <pre>
-     * If provided, the experiment's name will be changed to this. The new name must be unique.
+     * If provided, the experiment's name is changed to the new name. The new name must be unique.
      * </pre>
      *
      * <code>optional string new_name = 2;</code>
@@ -16478,7 +16478,7 @@ public final class Service {
     boolean hasNewName();
     /**
      * <pre>
-     * If provided, the experiment's name will be changed to this. The new name must be unique.
+     * If provided, the experiment's name is changed to the new name. The new name must be unique.
      * </pre>
      *
      * <code>optional string new_name = 2;</code>
@@ -16486,7 +16486,7 @@ public final class Service {
     java.lang.String getNewName();
     /**
      * <pre>
-     * If provided, the experiment's name will be changed to this. The new name must be unique.
+     * If provided, the experiment's name is changed to the new name. The new name must be unique.
      * </pre>
      *
      * <code>optional string new_name = 2;</code>
@@ -17050,7 +17050,7 @@ public final class Service {
     private volatile java.lang.Object newName_;
     /**
      * <pre>
-     * If provided, the experiment's name will be changed to this. The new name must be unique.
+     * If provided, the experiment's name is changed to the new name. The new name must be unique.
      * </pre>
      *
      * <code>optional string new_name = 2;</code>
@@ -17060,7 +17060,7 @@ public final class Service {
     }
     /**
      * <pre>
-     * If provided, the experiment's name will be changed to this. The new name must be unique.
+     * If provided, the experiment's name is changed to the new name. The new name must be unique.
      * </pre>
      *
      * <code>optional string new_name = 2;</code>
@@ -17081,7 +17081,7 @@ public final class Service {
     }
     /**
      * <pre>
-     * If provided, the experiment's name will be changed to this. The new name must be unique.
+     * If provided, the experiment's name is changed to the new name. The new name must be unique.
      * </pre>
      *
      * <code>optional string new_name = 2;</code>
@@ -17545,7 +17545,7 @@ public final class Service {
       private java.lang.Object newName_ = "";
       /**
        * <pre>
-       * If provided, the experiment's name will be changed to this. The new name must be unique.
+       * If provided, the experiment's name is changed to the new name. The new name must be unique.
        * </pre>
        *
        * <code>optional string new_name = 2;</code>
@@ -17555,7 +17555,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * If provided, the experiment's name will be changed to this. The new name must be unique.
+       * If provided, the experiment's name is changed to the new name. The new name must be unique.
        * </pre>
        *
        * <code>optional string new_name = 2;</code>
@@ -17576,7 +17576,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * If provided, the experiment's name will be changed to this. The new name must be unique.
+       * If provided, the experiment's name is changed to the new name. The new name must be unique.
        * </pre>
        *
        * <code>optional string new_name = 2;</code>
@@ -17596,7 +17596,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * If provided, the experiment's name will be changed to this. The new name must be unique.
+       * If provided, the experiment's name is changed to the new name. The new name must be unique.
        * </pre>
        *
        * <code>optional string new_name = 2;</code>
@@ -17613,7 +17613,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * If provided, the experiment's name will be changed to this. The new name must be unique.
+       * If provided, the experiment's name is changed to the new name. The new name must be unique.
        * </pre>
        *
        * <code>optional string new_name = 2;</code>
@@ -17626,7 +17626,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * If provided, the experiment's name will be changed to this. The new name must be unique.
+       * If provided, the experiment's name is changed to the new name. The new name must be unique.
        * </pre>
        *
        * <code>optional string new_name = 2;</code>
@@ -17752,7 +17752,7 @@ public final class Service {
 
     /**
      * <pre>
-     * Unix timestamp of when the run started in milliseconds.
+     * Unix timestamp in milliseconds of when the run started.
      * </pre>
      *
      * <code>optional int64 start_time = 7;</code>
@@ -17760,7 +17760,7 @@ public final class Service {
     boolean hasStartTime();
     /**
      * <pre>
-     * Unix timestamp of when the run started in milliseconds.
+     * Unix timestamp in milliseconds of when the run started.
      * </pre>
      *
      * <code>optional int64 start_time = 7;</code>
@@ -18705,7 +18705,7 @@ public final class Service {
     private long startTime_;
     /**
      * <pre>
-     * Unix timestamp of when the run started in milliseconds.
+     * Unix timestamp in milliseconds of when the run started.
      * </pre>
      *
      * <code>optional int64 start_time = 7;</code>
@@ -18715,7 +18715,7 @@ public final class Service {
     }
     /**
      * <pre>
-     * Unix timestamp of when the run started in milliseconds.
+     * Unix timestamp in milliseconds of when the run started.
      * </pre>
      *
      * <code>optional int64 start_time = 7;</code>
@@ -19405,7 +19405,7 @@ public final class Service {
       private long startTime_ ;
       /**
        * <pre>
-       * Unix timestamp of when the run started in milliseconds.
+       * Unix timestamp in milliseconds of when the run started.
        * </pre>
        *
        * <code>optional int64 start_time = 7;</code>
@@ -19415,7 +19415,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Unix timestamp of when the run started in milliseconds.
+       * Unix timestamp in milliseconds of when the run started.
        * </pre>
        *
        * <code>optional int64 start_time = 7;</code>
@@ -19425,7 +19425,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Unix timestamp of when the run started in milliseconds.
+       * Unix timestamp in milliseconds of when the run started.
        * </pre>
        *
        * <code>optional int64 start_time = 7;</code>
@@ -19438,7 +19438,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Unix timestamp of when the run started in milliseconds.
+       * Unix timestamp in milliseconds of when the run started.
        * </pre>
        *
        * <code>optional int64 start_time = 7;</code>
@@ -19892,7 +19892,7 @@ public final class Service {
 
     /**
      * <pre>
-     *Unix timestamp of when the run ended in milliseconds.
+     *Unix timestamp in milliseconds of when the run ended.
      * </pre>
      *
      * <code>optional int64 end_time = 3;</code>
@@ -19900,7 +19900,7 @@ public final class Service {
     boolean hasEndTime();
     /**
      * <pre>
-     *Unix timestamp of when the run ended in milliseconds.
+     *Unix timestamp in milliseconds of when the run ended.
      * </pre>
      *
      * <code>optional int64 end_time = 3;</code>
@@ -20829,7 +20829,7 @@ public final class Service {
     private long endTime_;
     /**
      * <pre>
-     *Unix timestamp of when the run ended in milliseconds.
+     *Unix timestamp in milliseconds of when the run ended.
      * </pre>
      *
      * <code>optional int64 end_time = 3;</code>
@@ -20839,7 +20839,7 @@ public final class Service {
     }
     /**
      * <pre>
-     *Unix timestamp of when the run ended in milliseconds.
+     *Unix timestamp in milliseconds of when the run ended.
      * </pre>
      *
      * <code>optional int64 end_time = 3;</code>
@@ -21502,7 +21502,7 @@ public final class Service {
       private long endTime_ ;
       /**
        * <pre>
-       *Unix timestamp of when the run ended in milliseconds.
+       *Unix timestamp in milliseconds of when the run ended.
        * </pre>
        *
        * <code>optional int64 end_time = 3;</code>
@@ -21512,7 +21512,7 @@ public final class Service {
       }
       /**
        * <pre>
-       *Unix timestamp of when the run ended in milliseconds.
+       *Unix timestamp in milliseconds of when the run ended.
        * </pre>
        *
        * <code>optional int64 end_time = 3;</code>
@@ -21522,7 +21522,7 @@ public final class Service {
       }
       /**
        * <pre>
-       *Unix timestamp of when the run ended in milliseconds.
+       *Unix timestamp in milliseconds of when the run ended.
        * </pre>
        *
        * <code>optional int64 end_time = 3;</code>
@@ -21535,7 +21535,7 @@ public final class Service {
       }
       /**
        * <pre>
-       *Unix timestamp of when the run ended in milliseconds.
+       *Unix timestamp in milliseconds of when the run ended.
        * </pre>
        *
        * <code>optional int64 end_time = 3;</code>
@@ -21604,14 +21604,26 @@ public final class Service {
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     * <pre>
+     * ID of the run to delete.
+     * </pre>
+     *
      * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
      */
     boolean hasRunId();
     /**
+     * <pre>
+     * ID of the run to delete.
+     * </pre>
+     *
      * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
      */
     java.lang.String getRunId();
     /**
+     * <pre>
+     * ID of the run to delete.
+     * </pre>
+     *
      * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
      */
     com.google.protobuf.ByteString
@@ -22111,12 +22123,20 @@ public final class Service {
     public static final int RUN_ID_FIELD_NUMBER = 1;
     private volatile java.lang.Object runId_;
     /**
+     * <pre>
+     * ID of the run to delete.
+     * </pre>
+     *
      * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
      */
     public boolean hasRunId() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
+     * <pre>
+     * ID of the run to delete.
+     * </pre>
+     *
      * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
      */
     public java.lang.String getRunId() {
@@ -22134,6 +22154,10 @@ public final class Service {
       }
     }
     /**
+     * <pre>
+     * ID of the run to delete.
+     * </pre>
+     *
      * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
      */
     public com.google.protobuf.ByteString
@@ -22468,12 +22492,20 @@ public final class Service {
 
       private java.lang.Object runId_ = "";
       /**
+       * <pre>
+       * ID of the run to delete.
+       * </pre>
+       *
        * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
        */
       public boolean hasRunId() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
+       * <pre>
+       * ID of the run to delete.
+       * </pre>
+       *
        * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
        */
       public java.lang.String getRunId() {
@@ -22491,6 +22523,10 @@ public final class Service {
         }
       }
       /**
+       * <pre>
+       * ID of the run to delete.
+       * </pre>
+       *
        * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
        */
       public com.google.protobuf.ByteString
@@ -22507,6 +22543,10 @@ public final class Service {
         }
       }
       /**
+       * <pre>
+       * ID of the run to delete.
+       * </pre>
+       *
        * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
        */
       public Builder setRunId(
@@ -22520,6 +22560,10 @@ public final class Service {
         return this;
       }
       /**
+       * <pre>
+       * ID of the run to delete.
+       * </pre>
+       *
        * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
        */
       public Builder clearRunId() {
@@ -22529,6 +22573,10 @@ public final class Service {
         return this;
       }
       /**
+       * <pre>
+       * ID of the run to delete.
+       * </pre>
+       *
        * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
        */
       public Builder setRunIdBytes(
@@ -22599,14 +22647,26 @@ public final class Service {
       com.google.protobuf.MessageOrBuilder {
 
     /**
+     * <pre>
+     * ID of the run to restore.
+     * </pre>
+     *
      * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
      */
     boolean hasRunId();
     /**
+     * <pre>
+     * ID of the run to restore.
+     * </pre>
+     *
      * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
      */
     java.lang.String getRunId();
     /**
+     * <pre>
+     * ID of the run to restore.
+     * </pre>
+     *
      * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
      */
     com.google.protobuf.ByteString
@@ -23106,12 +23166,20 @@ public final class Service {
     public static final int RUN_ID_FIELD_NUMBER = 1;
     private volatile java.lang.Object runId_;
     /**
+     * <pre>
+     * ID of the run to restore.
+     * </pre>
+     *
      * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
      */
     public boolean hasRunId() {
       return ((bitField0_ & 0x00000001) == 0x00000001);
     }
     /**
+     * <pre>
+     * ID of the run to restore.
+     * </pre>
+     *
      * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
      */
     public java.lang.String getRunId() {
@@ -23129,6 +23197,10 @@ public final class Service {
       }
     }
     /**
+     * <pre>
+     * ID of the run to restore.
+     * </pre>
+     *
      * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
      */
     public com.google.protobuf.ByteString
@@ -23463,12 +23535,20 @@ public final class Service {
 
       private java.lang.Object runId_ = "";
       /**
+       * <pre>
+       * ID of the run to restore.
+       * </pre>
+       *
        * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
        */
       public boolean hasRunId() {
         return ((bitField0_ & 0x00000001) == 0x00000001);
       }
       /**
+       * <pre>
+       * ID of the run to restore.
+       * </pre>
+       *
        * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
        */
       public java.lang.String getRunId() {
@@ -23486,6 +23566,10 @@ public final class Service {
         }
       }
       /**
+       * <pre>
+       * ID of the run to restore.
+       * </pre>
+       *
        * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
        */
       public com.google.protobuf.ByteString
@@ -23502,6 +23586,10 @@ public final class Service {
         }
       }
       /**
+       * <pre>
+       * ID of the run to restore.
+       * </pre>
+       *
        * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
        */
       public Builder setRunId(
@@ -23515,6 +23603,10 @@ public final class Service {
         return this;
       }
       /**
+       * <pre>
+       * ID of the run to restore.
+       * </pre>
+       *
        * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
        */
       public Builder clearRunId() {
@@ -23524,6 +23616,10 @@ public final class Service {
         return this;
       }
       /**
+       * <pre>
+       * ID of the run to restore.
+       * </pre>
+       *
        * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
        */
       public Builder setRunIdBytes(
@@ -28970,7 +29066,7 @@ public final class Service {
 
       /**
        * <pre>
-       * Run metadata (name, start time, etc) and data (metrics, params, etc).
+       * Run metadata (name, start time, etc) and data (metrics, params, and tags).
        * </pre>
        *
        * <code>optional .mlflow.Run run = 1;</code>
@@ -28978,7 +29074,7 @@ public final class Service {
       boolean hasRun();
       /**
        * <pre>
-       * Run metadata (name, start time, etc) and data (metrics, params, etc).
+       * Run metadata (name, start time, etc) and data (metrics, params, and tags).
        * </pre>
        *
        * <code>optional .mlflow.Run run = 1;</code>
@@ -28986,7 +29082,7 @@ public final class Service {
       org.mlflow.api.proto.Service.Run getRun();
       /**
        * <pre>
-       * Run metadata (name, start time, etc) and data (metrics, params, etc).
+       * Run metadata (name, start time, etc) and data (metrics, params, and tags).
        * </pre>
        *
        * <code>optional .mlflow.Run run = 1;</code>
@@ -29082,7 +29178,7 @@ public final class Service {
       private org.mlflow.api.proto.Service.Run run_;
       /**
        * <pre>
-       * Run metadata (name, start time, etc) and data (metrics, params, etc).
+       * Run metadata (name, start time, etc) and data (metrics, params, and tags).
        * </pre>
        *
        * <code>optional .mlflow.Run run = 1;</code>
@@ -29092,7 +29188,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Run metadata (name, start time, etc) and data (metrics, params, etc).
+       * Run metadata (name, start time, etc) and data (metrics, params, and tags).
        * </pre>
        *
        * <code>optional .mlflow.Run run = 1;</code>
@@ -29102,7 +29198,7 @@ public final class Service {
       }
       /**
        * <pre>
-       * Run metadata (name, start time, etc) and data (metrics, params, etc).
+       * Run metadata (name, start time, etc) and data (metrics, params, and tags).
        * </pre>
        *
        * <code>optional .mlflow.Run run = 1;</code>
@@ -29440,7 +29536,7 @@ public final class Service {
             org.mlflow.api.proto.Service.Run, org.mlflow.api.proto.Service.Run.Builder, org.mlflow.api.proto.Service.RunOrBuilder> runBuilder_;
         /**
          * <pre>
-         * Run metadata (name, start time, etc) and data (metrics, params, etc).
+         * Run metadata (name, start time, etc) and data (metrics, params, and tags).
          * </pre>
          *
          * <code>optional .mlflow.Run run = 1;</code>
@@ -29450,7 +29546,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Run metadata (name, start time, etc) and data (metrics, params, etc).
+         * Run metadata (name, start time, etc) and data (metrics, params, and tags).
          * </pre>
          *
          * <code>optional .mlflow.Run run = 1;</code>
@@ -29464,7 +29560,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Run metadata (name, start time, etc) and data (metrics, params, etc).
+         * Run metadata (name, start time, etc) and data (metrics, params, and tags).
          * </pre>
          *
          * <code>optional .mlflow.Run run = 1;</code>
@@ -29484,7 +29580,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Run metadata (name, start time, etc) and data (metrics, params, etc).
+         * Run metadata (name, start time, etc) and data (metrics, params, and tags).
          * </pre>
          *
          * <code>optional .mlflow.Run run = 1;</code>
@@ -29502,7 +29598,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Run metadata (name, start time, etc) and data (metrics, params, etc).
+         * Run metadata (name, start time, etc) and data (metrics, params, and tags).
          * </pre>
          *
          * <code>optional .mlflow.Run run = 1;</code>
@@ -29526,7 +29622,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Run metadata (name, start time, etc) and data (metrics, params, etc).
+         * Run metadata (name, start time, etc) and data (metrics, params, and tags).
          * </pre>
          *
          * <code>optional .mlflow.Run run = 1;</code>
@@ -29543,7 +29639,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Run metadata (name, start time, etc) and data (metrics, params, etc).
+         * Run metadata (name, start time, etc) and data (metrics, params, and tags).
          * </pre>
          *
          * <code>optional .mlflow.Run run = 1;</code>
@@ -29555,7 +29651,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Run metadata (name, start time, etc) and data (metrics, params, etc).
+         * Run metadata (name, start time, etc) and data (metrics, params, and tags).
          * </pre>
          *
          * <code>optional .mlflow.Run run = 1;</code>
@@ -29570,7 +29666,7 @@ public final class Service {
         }
         /**
          * <pre>
-         * Run metadata (name, start time, etc) and data (metrics, params, etc).
+         * Run metadata (name, start time, etc) and data (metrics, params, and tags).
          * </pre>
          *
          * <code>optional .mlflow.Run run = 1;</code>
@@ -30394,18 +30490,17 @@ public final class Service {
 
     /**
      * <pre>
-     * A filter expression over params, metrics, and tags, allowing returning a subset of
-     * runs. The syntax is a subset of SQL which allows only ANDing together binary operations
-     * between a param/metric/tag and a constant.
+     * A filter expression over params, metrics, and tags, that allows returning a subset of
+     * runs. The syntax is a subset of SQL that supports ANDing together binary operations
+     * between a param, metric, or tag and a constant.
      * Example: ``metrics.rmse &lt; 1 and params.model_class = 'LogisticRegression'``
-     * You can also select columns with spaces by using backticks or double quotes:
-     * ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``
-     * Supported operators are =, !=, &gt;, &gt;=, &lt;, &lt;=, and LIKE.
-     * LIKE syntax: ``params.model_class LIKE 'Linear%'``
-     * 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE
+     * You can select columns with special characters (hyphen, space, period, etc.) by using double quotes:
+     * ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``
+     * Supported operators are ``=``, ``!=``, ``&gt;``, ``&gt;=``, ``&lt;``, and ``&lt;=``.
+     * You cannot provide ``filter`` when ``anded_expressions`` is present; an ``INVALID_PARAMETER_VALUE``
      * error will be returned if both are specified.
-     * If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments
-     * will be returned.
+     * If both ``filter`` and ``anded_expressions`` are absent, all runs part of the given experiments
+     * 
      * </pre>
      *
      * <code>optional string filter = 4;</code>
@@ -30413,18 +30508,17 @@ public final class Service {
     boolean hasFilter();
     /**
      * <pre>
-     * A filter expression over params, metrics, and tags, allowing returning a subset of
-     * runs. The syntax is a subset of SQL which allows only ANDing together binary operations
-     * between a param/metric/tag and a constant.
+     * A filter expression over params, metrics, and tags, that allows returning a subset of
+     * runs. The syntax is a subset of SQL that supports ANDing together binary operations
+     * between a param, metric, or tag and a constant.
      * Example: ``metrics.rmse &lt; 1 and params.model_class = 'LogisticRegression'``
-     * You can also select columns with spaces by using backticks or double quotes:
-     * ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``
-     * Supported operators are =, !=, &gt;, &gt;=, &lt;, &lt;=, and LIKE.
-     * LIKE syntax: ``params.model_class LIKE 'Linear%'``
-     * 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE
+     * You can select columns with special characters (hyphen, space, period, etc.) by using double quotes:
+     * ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``
+     * Supported operators are ``=``, ``!=``, ``&gt;``, ``&gt;=``, ``&lt;``, and ``&lt;=``.
+     * You cannot provide ``filter`` when ``anded_expressions`` is present; an ``INVALID_PARAMETER_VALUE``
      * error will be returned if both are specified.
-     * If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments
-     * will be returned.
+     * If both ``filter`` and ``anded_expressions`` are absent, all runs part of the given experiments
+     * 
      * </pre>
      *
      * <code>optional string filter = 4;</code>
@@ -30432,18 +30526,17 @@ public final class Service {
     java.lang.String getFilter();
     /**
      * <pre>
-     * A filter expression over params, metrics, and tags, allowing returning a subset of
-     * runs. The syntax is a subset of SQL which allows only ANDing together binary operations
-     * between a param/metric/tag and a constant.
+     * A filter expression over params, metrics, and tags, that allows returning a subset of
+     * runs. The syntax is a subset of SQL that supports ANDing together binary operations
+     * between a param, metric, or tag and a constant.
      * Example: ``metrics.rmse &lt; 1 and params.model_class = 'LogisticRegression'``
-     * You can also select columns with spaces by using backticks or double quotes:
-     * ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``
-     * Supported operators are =, !=, &gt;, &gt;=, &lt;, &lt;=, and LIKE.
-     * LIKE syntax: ``params.model_class LIKE 'Linear%'``
-     * 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE
+     * You can select columns with special characters (hyphen, space, period, etc.) by using double quotes:
+     * ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``
+     * Supported operators are ``=``, ``!=``, ``&gt;``, ``&gt;=``, ``&lt;``, and ``&lt;=``.
+     * You cannot provide ``filter`` when ``anded_expressions`` is present; an ``INVALID_PARAMETER_VALUE``
      * error will be returned if both are specified.
-     * If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments
-     * will be returned.
+     * If both ``filter`` and ``anded_expressions`` are absent, all runs part of the given experiments
+     * 
      * </pre>
      *
      * <code>optional string filter = 4;</code>
@@ -31541,18 +31634,17 @@ public final class Service {
     private volatile java.lang.Object filter_;
     /**
      * <pre>
-     * A filter expression over params, metrics, and tags, allowing returning a subset of
-     * runs. The syntax is a subset of SQL which allows only ANDing together binary operations
-     * between a param/metric/tag and a constant.
+     * A filter expression over params, metrics, and tags, that allows returning a subset of
+     * runs. The syntax is a subset of SQL that supports ANDing together binary operations
+     * between a param, metric, or tag and a constant.
      * Example: ``metrics.rmse &lt; 1 and params.model_class = 'LogisticRegression'``
-     * You can also select columns with spaces by using backticks or double quotes:
-     * ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``
-     * Supported operators are =, !=, &gt;, &gt;=, &lt;, &lt;=, and LIKE.
-     * LIKE syntax: ``params.model_class LIKE 'Linear%'``
-     * 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE
+     * You can select columns with special characters (hyphen, space, period, etc.) by using double quotes:
+     * ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``
+     * Supported operators are ``=``, ``!=``, ``&gt;``, ``&gt;=``, ``&lt;``, and ``&lt;=``.
+     * You cannot provide ``filter`` when ``anded_expressions`` is present; an ``INVALID_PARAMETER_VALUE``
      * error will be returned if both are specified.
-     * If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments
-     * will be returned.
+     * If both ``filter`` and ``anded_expressions`` are absent, all runs part of the given experiments
+     * 
      * </pre>
      *
      * <code>optional string filter = 4;</code>
@@ -31562,18 +31654,17 @@ public final class Service {
     }
     /**
      * <pre>
-     * A filter expression over params, metrics, and tags, allowing returning a subset of
-     * runs. The syntax is a subset of SQL which allows only ANDing together binary operations
-     * between a param/metric/tag and a constant.
+     * A filter expression over params, metrics, and tags, that allows returning a subset of
+     * runs. The syntax is a subset of SQL that supports ANDing together binary operations
+     * between a param, metric, or tag and a constant.
      * Example: ``metrics.rmse &lt; 1 and params.model_class = 'LogisticRegression'``
-     * You can also select columns with spaces by using backticks or double quotes:
-     * ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``
-     * Supported operators are =, !=, &gt;, &gt;=, &lt;, &lt;=, and LIKE.
-     * LIKE syntax: ``params.model_class LIKE 'Linear%'``
-     * 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE
+     * You can select columns with special characters (hyphen, space, period, etc.) by using double quotes:
+     * ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``
+     * Supported operators are ``=``, ``!=``, ``&gt;``, ``&gt;=``, ``&lt;``, and ``&lt;=``.
+     * You cannot provide ``filter`` when ``anded_expressions`` is present; an ``INVALID_PARAMETER_VALUE``
      * error will be returned if both are specified.
-     * If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments
-     * will be returned.
+     * If both ``filter`` and ``anded_expressions`` are absent, all runs part of the given experiments
+     * 
      * </pre>
      *
      * <code>optional string filter = 4;</code>
@@ -31594,18 +31685,17 @@ public final class Service {
     }
     /**
      * <pre>
-     * A filter expression over params, metrics, and tags, allowing returning a subset of
-     * runs. The syntax is a subset of SQL which allows only ANDing together binary operations
-     * between a param/metric/tag and a constant.
+     * A filter expression over params, metrics, and tags, that allows returning a subset of
+     * runs. The syntax is a subset of SQL that supports ANDing together binary operations
+     * between a param, metric, or tag and a constant.
      * Example: ``metrics.rmse &lt; 1 and params.model_class = 'LogisticRegression'``
-     * You can also select columns with spaces by using backticks or double quotes:
-     * ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``
-     * Supported operators are =, !=, &gt;, &gt;=, &lt;, &lt;=, and LIKE.
-     * LIKE syntax: ``params.model_class LIKE 'Linear%'``
-     * 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE
+     * You can select columns with special characters (hyphen, space, period, etc.) by using double quotes:
+     * ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``
+     * Supported operators are ``=``, ``!=``, ``&gt;``, ``&gt;=``, ``&lt;``, and ``&lt;=``.
+     * You cannot provide ``filter`` when ``anded_expressions`` is present; an ``INVALID_PARAMETER_VALUE``
      * error will be returned if both are specified.
-     * If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments
-     * will be returned.
+     * If both ``filter`` and ``anded_expressions`` are absent, all runs part of the given experiments
+     * 
      * </pre>
      *
      * <code>optional string filter = 4;</code>
@@ -32205,18 +32295,17 @@ public final class Service {
       private java.lang.Object filter_ = "";
       /**
        * <pre>
-       * A filter expression over params, metrics, and tags, allowing returning a subset of
-       * runs. The syntax is a subset of SQL which allows only ANDing together binary operations
-       * between a param/metric/tag and a constant.
+       * A filter expression over params, metrics, and tags, that allows returning a subset of
+       * runs. The syntax is a subset of SQL that supports ANDing together binary operations
+       * between a param, metric, or tag and a constant.
        * Example: ``metrics.rmse &lt; 1 and params.model_class = 'LogisticRegression'``
-       * You can also select columns with spaces by using backticks or double quotes:
-       * ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``
-       * Supported operators are =, !=, &gt;, &gt;=, &lt;, &lt;=, and LIKE.
-       * LIKE syntax: ``params.model_class LIKE 'Linear%'``
-       * 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE
+       * You can select columns with special characters (hyphen, space, period, etc.) by using double quotes:
+       * ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``
+       * Supported operators are ``=``, ``!=``, ``&gt;``, ``&gt;=``, ``&lt;``, and ``&lt;=``.
+       * You cannot provide ``filter`` when ``anded_expressions`` is present; an ``INVALID_PARAMETER_VALUE``
        * error will be returned if both are specified.
-       * If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments
-       * will be returned.
+       * If both ``filter`` and ``anded_expressions`` are absent, all runs part of the given experiments
+       * 
        * </pre>
        *
        * <code>optional string filter = 4;</code>
@@ -32226,18 +32315,17 @@ public final class Service {
       }
       /**
        * <pre>
-       * A filter expression over params, metrics, and tags, allowing returning a subset of
-       * runs. The syntax is a subset of SQL which allows only ANDing together binary operations
-       * between a param/metric/tag and a constant.
+       * A filter expression over params, metrics, and tags, that allows returning a subset of
+       * runs. The syntax is a subset of SQL that supports ANDing together binary operations
+       * between a param, metric, or tag and a constant.
        * Example: ``metrics.rmse &lt; 1 and params.model_class = 'LogisticRegression'``
-       * You can also select columns with spaces by using backticks or double quotes:
-       * ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``
-       * Supported operators are =, !=, &gt;, &gt;=, &lt;, &lt;=, and LIKE.
-       * LIKE syntax: ``params.model_class LIKE 'Linear%'``
-       * 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE
+       * You can select columns with special characters (hyphen, space, period, etc.) by using double quotes:
+       * ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``
+       * Supported operators are ``=``, ``!=``, ``&gt;``, ``&gt;=``, ``&lt;``, and ``&lt;=``.
+       * You cannot provide ``filter`` when ``anded_expressions`` is present; an ``INVALID_PARAMETER_VALUE``
        * error will be returned if both are specified.
-       * If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments
-       * will be returned.
+       * If both ``filter`` and ``anded_expressions`` are absent, all runs part of the given experiments
+       * 
        * </pre>
        *
        * <code>optional string filter = 4;</code>
@@ -32258,18 +32346,17 @@ public final class Service {
       }
       /**
        * <pre>
-       * A filter expression over params, metrics, and tags, allowing returning a subset of
-       * runs. The syntax is a subset of SQL which allows only ANDing together binary operations
-       * between a param/metric/tag and a constant.
+       * A filter expression over params, metrics, and tags, that allows returning a subset of
+       * runs. The syntax is a subset of SQL that supports ANDing together binary operations
+       * between a param, metric, or tag and a constant.
        * Example: ``metrics.rmse &lt; 1 and params.model_class = 'LogisticRegression'``
-       * You can also select columns with spaces by using backticks or double quotes:
-       * ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``
-       * Supported operators are =, !=, &gt;, &gt;=, &lt;, &lt;=, and LIKE.
-       * LIKE syntax: ``params.model_class LIKE 'Linear%'``
-       * 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE
+       * You can select columns with special characters (hyphen, space, period, etc.) by using double quotes:
+       * ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``
+       * Supported operators are ``=``, ``!=``, ``&gt;``, ``&gt;=``, ``&lt;``, and ``&lt;=``.
+       * You cannot provide ``filter`` when ``anded_expressions`` is present; an ``INVALID_PARAMETER_VALUE``
        * error will be returned if both are specified.
-       * If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments
-       * will be returned.
+       * If both ``filter`` and ``anded_expressions`` are absent, all runs part of the given experiments
+       * 
        * </pre>
        *
        * <code>optional string filter = 4;</code>
@@ -32289,18 +32376,17 @@ public final class Service {
       }
       /**
        * <pre>
-       * A filter expression over params, metrics, and tags, allowing returning a subset of
-       * runs. The syntax is a subset of SQL which allows only ANDing together binary operations
-       * between a param/metric/tag and a constant.
+       * A filter expression over params, metrics, and tags, that allows returning a subset of
+       * runs. The syntax is a subset of SQL that supports ANDing together binary operations
+       * between a param, metric, or tag and a constant.
        * Example: ``metrics.rmse &lt; 1 and params.model_class = 'LogisticRegression'``
-       * You can also select columns with spaces by using backticks or double quotes:
-       * ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``
-       * Supported operators are =, !=, &gt;, &gt;=, &lt;, &lt;=, and LIKE.
-       * LIKE syntax: ``params.model_class LIKE 'Linear%'``
-       * 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE
+       * You can select columns with special characters (hyphen, space, period, etc.) by using double quotes:
+       * ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``
+       * Supported operators are ``=``, ``!=``, ``&gt;``, ``&gt;=``, ``&lt;``, and ``&lt;=``.
+       * You cannot provide ``filter`` when ``anded_expressions`` is present; an ``INVALID_PARAMETER_VALUE``
        * error will be returned if both are specified.
-       * If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments
-       * will be returned.
+       * If both ``filter`` and ``anded_expressions`` are absent, all runs part of the given experiments
+       * 
        * </pre>
        *
        * <code>optional string filter = 4;</code>
@@ -32317,18 +32403,17 @@ public final class Service {
       }
       /**
        * <pre>
-       * A filter expression over params, metrics, and tags, allowing returning a subset of
-       * runs. The syntax is a subset of SQL which allows only ANDing together binary operations
-       * between a param/metric/tag and a constant.
+       * A filter expression over params, metrics, and tags, that allows returning a subset of
+       * runs. The syntax is a subset of SQL that supports ANDing together binary operations
+       * between a param, metric, or tag and a constant.
        * Example: ``metrics.rmse &lt; 1 and params.model_class = 'LogisticRegression'``
-       * You can also select columns with spaces by using backticks or double quotes:
-       * ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``
-       * Supported operators are =, !=, &gt;, &gt;=, &lt;, &lt;=, and LIKE.
-       * LIKE syntax: ``params.model_class LIKE 'Linear%'``
-       * 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE
+       * You can select columns with special characters (hyphen, space, period, etc.) by using double quotes:
+       * ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``
+       * Supported operators are ``=``, ``!=``, ``&gt;``, ``&gt;=``, ``&lt;``, and ``&lt;=``.
+       * You cannot provide ``filter`` when ``anded_expressions`` is present; an ``INVALID_PARAMETER_VALUE``
        * error will be returned if both are specified.
-       * If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments
-       * will be returned.
+       * If both ``filter`` and ``anded_expressions`` are absent, all runs part of the given experiments
+       * 
        * </pre>
        *
        * <code>optional string filter = 4;</code>
@@ -32341,18 +32426,17 @@ public final class Service {
       }
       /**
        * <pre>
-       * A filter expression over params, metrics, and tags, allowing returning a subset of
-       * runs. The syntax is a subset of SQL which allows only ANDing together binary operations
-       * between a param/metric/tag and a constant.
+       * A filter expression over params, metrics, and tags, that allows returning a subset of
+       * runs. The syntax is a subset of SQL that supports ANDing together binary operations
+       * between a param, metric, or tag and a constant.
        * Example: ``metrics.rmse &lt; 1 and params.model_class = 'LogisticRegression'``
-       * You can also select columns with spaces by using backticks or double quotes:
-       * ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``
-       * Supported operators are =, !=, &gt;, &gt;=, &lt;, &lt;=, and LIKE.
-       * LIKE syntax: ``params.model_class LIKE 'Linear%'``
-       * 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE
+       * You can select columns with special characters (hyphen, space, period, etc.) by using double quotes:
+       * ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``
+       * Supported operators are ``=``, ``!=``, ``&gt;``, ``&gt;=``, ``&lt;``, and ``&lt;=``.
+       * You cannot provide ``filter`` when ``anded_expressions`` is present; an ``INVALID_PARAMETER_VALUE``
        * error will be returned if both are specified.
-       * If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments
-       * will be returned.
+       * If both ``filter`` and ``anded_expressions`` are absent, all runs part of the given experiments
+       * 
        * </pre>
        *
        * <code>optional string filter = 4;</code>
@@ -40432,70 +40516,88 @@ public final class Service {
       "pe\022\014\n\010NOTEBOOK\020\001\022\007\n\003JOB\020\002\022\013\n\007PROJECT\020\003\022\t" +
       "\n\005LOCAL\020\004\022\014\n\007UNKNOWN\020\350\007*M\n\tRunStatus\022\013\n\007" +
       "RUNNING\020\001\022\r\n\tSCHEDULED\020\002\022\014\n\010FINISHED\020\003\022\n" +
-      "\n\006FAILED\020\004\022\n\n\006KILLED\020\0052\271\023\n\rMlflowService" +
-      "\022\234\001\n\020createExperiment\022\030.mlflow.CreateExp" +
+      "\n\006FAILED\020\004\022\n\n\006KILLED\020\0052\214\031\n\rMlflowService" +
+      "\022\306\001\n\020createExperiment\022\030.mlflow.CreateExp" +
       "eriment\032!.mlflow.CreateExperiment.Respon" +
-      "se\"K\362\206\031G\n0\n\004POST\022\"/preview/mlflow/experi" +
-      "ments/create\032\004\010\002\020\000\020\001*\021Create Experiment\022" +
-      "\225\001\n\017listExperiments\022\027.mlflow.ListExperim" +
-      "ents\032 .mlflow.ListExperiments.Response\"G" +
-      "\362\206\031C\n-\n\003GET\022 /preview/mlflow/experiments" +
-      "/list\032\004\010\002\020\000\020\001*\020List Experiments\022\214\001\n\rgetE" +
-      "xperiment\022\025.mlflow.GetExperiment\032\036.mlflo" +
-      "w.GetExperiment.Response\"D\362\206\031@\n,\n\003GET\022\037/" +
-      "preview/mlflow/experiments/get\032\004\010\002\020\000\020\001*\016" +
-      "Get Experiment\022\234\001\n\020deleteExperiment\022\030.ml" +
-      "flow.DeleteExperiment\032!.mlflow.DeleteExp" +
-      "eriment.Response\"K\362\206\031G\n0\n\004POST\022\"/preview" +
-      "/mlflow/experiments/delete\032\004\010\002\020\000\020\001*\021Dele" +
-      "te Experiment\022\241\001\n\021restoreExperiment\022\031.ml" +
-      "flow.RestoreExperiment\032\".mlflow.RestoreE" +
-      "xperiment.Response\"M\362\206\031I\n1\n\004POST\022#/previ" +
-      "ew/mlflow/experiments/restore\032\004\010\002\020\000\020\001*\022R" +
-      "estore Experiment\022\234\001\n\020updateExperiment\022\030" +
-      ".mlflow.UpdateExperiment\032!.mlflow.Update" +
-      "Experiment.Response\"K\362\206\031G\n0\n\004POST\022\"/prev" +
-      "iew/mlflow/experiments/update\032\004\010\002\020\000\020\001*\021U" +
-      "pdate Experiment\022y\n\tcreateRun\022\021.mlflow.C" +
-      "reateRun\032\032.mlflow.CreateRun.Response\"=\362\206" +
-      "\0319\n)\n\004POST\022\033/preview/mlflow/runs/create\032" +
-      "\004\010\002\020\000\020\001*\nCreate Run\022y\n\tupdateRun\022\021.mlflo" +
-      "w.UpdateRun\032\032.mlflow.UpdateRun.Response\"" +
-      "=\362\206\0319\n)\n\004POST\022\033/preview/mlflow/runs/upda" +
-      "te\032\004\010\002\020\000\020\001*\nUpdate Run\022m\n\tdeleteRun\022\021.ml" +
-      "flow.DeleteRun\032\032.mlflow.DeleteRun.Respon" +
-      "se\"1\362\206\031-\n)\n\004POST\022\033/preview/mlflow/runs/d" +
-      "elete\032\004\010\002\020\000\020\001\022q\n\nrestoreRun\022\022.mlflow.Res" +
-      "toreRun\032\033.mlflow.RestoreRun.Response\"2\362\206" +
-      "\031.\n*\n\004POST\022\034/preview/mlflow/runs/restore" +
-      "\032\004\010\002\020\000\020\001\022}\n\tlogMetric\022\021.mlflow.LogMetric" +
-      "\032\032.mlflow.LogMetric.Response\"A\362\206\031=\n-\n\004PO" +
-      "ST\022\037/preview/mlflow/runs/log-metric\032\004\010\002\020" +
-      "\000\020\001*\nLog Metric\022|\n\010logParam\022\020.mlflow.Log" +
-      "Param\032\031.mlflow.LogParam.Response\"C\362\206\031?\n0" +
-      "\n\004POST\022\"/preview/mlflow/runs/log-paramet" +
-      "er\032\004\010\002\020\000\020\001*\tLog Param\022n\n\006setTag\022\016.mlflow" +
-      ".SetTag\032\027.mlflow.SetTag.Response\";\362\206\0317\n*" +
-      "\n\004POST\022\034/preview/mlflow/runs/set-tag\032\004\010\002" +
-      "\020\000\020\001*\007Set Tag\022i\n\006getRun\022\016.mlflow.GetRun\032" +
-      "\027.mlflow.GetRun.Response\"6\362\206\0312\n%\n\003GET\022\030/" +
-      "preview/mlflow/runs/get\032\004\010\002\020\000\020\001*\007Get Run" +
-      "\022\247\001\n\nsearchRuns\022\022.mlflow.SearchRuns\032\033.ml" +
-      "flow.SearchRuns.Response\"h\362\206\031d\n)\n\004POST\022\033" +
-      "/preview/mlflow/runs/search\032\004\010\002\020\000\n(\n\003GET" +
-      "\022\033/preview/mlflow/runs/search\032\004\010\002\020\000\020\001*\013S" +
-      "earch Runs\022\213\001\n\rlistArtifacts\022\025.mlflow.Li" +
-      "stArtifacts\032\036.mlflow.ListArtifacts.Respo" +
-      "nse\"C\362\206\031?\n+\n\003GET\022\036/preview/mlflow/artifa" +
-      "cts/list\032\004\010\002\020\000\020\001*\016List Artifacts\022\235\001\n\020get" +
-      "MetricHistory\022\030.mlflow.GetMetricHistory\032" +
-      "!.mlflow.GetMetricHistory.Response\"L\362\206\031H" +
-      "\n0\n\003GET\022#/preview/mlflow/metrics/get-his" +
-      "tory\032\004\010\002\020\000\020\001*\022Get Metric History\022x\n\010logB" +
-      "atch\022\020.mlflow.LogBatch\032\031.mlflow.LogBatch" +
-      ".Response\"?\362\206\031;\n,\n\004POST\022\036/preview/mlflow" +
-      "/runs/log-batch\032\004\010\002\020\000\020\001*\tLog BatchB\036\n\024or" +
-      "g.mlflow.api.proto\220\001\001\342?\002\020\001"
+      "se\"u\362\206\031q\n(\n\004POST\022\032/mlflow/experiments/cr" +
+      "eate\032\004\010\002\020\000\n0\n\004POST\022\"/preview/mlflow/expe" +
+      "riments/create\032\004\010\002\020\000\020\001*\021Create Experimen" +
+      "t\022\274\001\n\017listExperiments\022\027.mlflow.ListExper" +
+      "iments\032 .mlflow.ListExperiments.Response" +
+      "\"n\362\206\031j\n%\n\003GET\022\030/mlflow/experiments/list\032" +
+      "\004\010\002\020\000\n-\n\003GET\022 /preview/mlflow/experiment" +
+      "s/list\032\004\010\002\020\000\020\001*\020List Experiments\022\262\001\n\rget" +
+      "Experiment\022\025.mlflow.GetExperiment\032\036.mlfl" +
+      "ow.GetExperiment.Response\"j\362\206\031f\n$\n\003GET\022\027" +
+      "/mlflow/experiments/get\032\004\010\002\020\000\n,\n\003GET\022\037/p" +
+      "review/mlflow/experiments/get\032\004\010\002\020\000\020\001*\016G" +
+      "et Experiment\022\306\001\n\020deleteExperiment\022\030.mlf" +
+      "low.DeleteExperiment\032!.mlflow.DeleteExpe" +
+      "riment.Response\"u\362\206\031q\n(\n\004POST\022\032/mlflow/e" +
+      "xperiments/delete\032\004\010\002\020\000\n0\n\004POST\022\"/previe" +
+      "w/mlflow/experiments/delete\032\004\010\002\020\000\020\001*\021Del" +
+      "ete Experiment\022\314\001\n\021restoreExperiment\022\031.m" +
+      "lflow.RestoreExperiment\032\".mlflow.Restore" +
+      "Experiment.Response\"x\362\206\031t\n)\n\004POST\022\033/mlfl" +
+      "ow/experiments/restore\032\004\010\002\020\000\n1\n\004POST\022#/p" +
+      "review/mlflow/experiments/restore\032\004\010\002\020\000\020" +
+      "\001*\022Restore Experiment\022\306\001\n\020updateExperime" +
+      "nt\022\030.mlflow.UpdateExperiment\032!.mlflow.Up" +
+      "dateExperiment.Response\"u\362\206\031q\n(\n\004POST\022\032/" +
+      "mlflow/experiments/update\032\004\010\002\020\000\n0\n\004POST\022" +
+      "\"/preview/mlflow/experiments/update\032\004\010\002\020" +
+      "\000\020\001*\021Update Experiment\022\234\001\n\tcreateRun\022\021.m" +
+      "lflow.CreateRun\032\032.mlflow.CreateRun.Respo" +
+      "nse\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/create\032\004" +
+      "\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/runs/creat" +
+      "e\032\004\010\002\020\000\020\001*\nCreate Run\022\234\001\n\tupdateRun\022\021.ml" +
+      "flow.UpdateRun\032\032.mlflow.UpdateRun.Respon" +
+      "se\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/update\032\004\010" +
+      "\002\020\000\n)\n\004POST\022\033/preview/mlflow/runs/update" +
+      "\032\004\010\002\020\000\020\001*\nUpdate Run\022\234\001\n\tdeleteRun\022\021.mlf" +
+      "low.DeleteRun\032\032.mlflow.DeleteRun.Respons" +
+      "e\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/delete\032\004\010\002" +
+      "\020\000\n)\n\004POST\022\033/preview/mlflow/runs/delete\032" +
+      "\004\010\002\020\000\020\001*\nDelete Run\022\242\001\n\nrestoreRun\022\022.mlf" +
+      "low.RestoreRun\032\033.mlflow.RestoreRun.Respo" +
+      "nse\"c\362\206\031_\n\"\n\004POST\022\024/mlflow/runs/restore\032" +
+      "\004\010\002\020\000\n*\n\004POST\022\034/preview/mlflow/runs/rest" +
+      "ore\032\004\010\002\020\000\020\001*\013Restore Run\022\244\001\n\tlogMetric\022\021" +
+      ".mlflow.LogMetric\032\032.mlflow.LogMetric.Res" +
+      "ponse\"h\362\206\031d\n%\n\004POST\022\027/mlflow/runs/log-me" +
+      "tric\032\004\010\002\020\000\n-\n\004POST\022\037/preview/mlflow/runs" +
+      "/log-metric\032\004\010\002\020\000\020\001*\nLog Metric\022\246\001\n\010logP" +
+      "aram\022\020.mlflow.LogParam\032\031.mlflow.LogParam" +
+      ".Response\"m\362\206\031i\n(\n\004POST\022\032/mlflow/runs/lo" +
+      "g-parameter\032\004\010\002\020\000\n0\n\004POST\022\"/preview/mlfl" +
+      "ow/runs/log-parameter\032\004\010\002\020\000\020\001*\tLog Param" +
+      "\022\222\001\n\006setTag\022\016.mlflow.SetTag\032\027.mlflow.Set" +
+      "Tag.Response\"_\362\206\031[\n\"\n\004POST\022\024/mlflow/runs" +
+      "/set-tag\032\004\010\002\020\000\n*\n\004POST\022\034/preview/mlflow/" +
+      "runs/set-tag\032\004\010\002\020\000\020\001*\007Set Tag\022\210\001\n\006getRun" +
+      "\022\016.mlflow.GetRun\032\027.mlflow.GetRun.Respons" +
+      "e\"U\362\206\031Q\n\035\n\003GET\022\020/mlflow/runs/get\032\004\010\002\020\000\n%" +
+      "\n\003GET\022\030/preview/mlflow/runs/get\032\004\010\002\020\000\020\001*" +
+      "\007Get Run\022\314\001\n\nsearchRuns\022\022.mlflow.SearchR" +
+      "uns\032\033.mlflow.SearchRuns.Response\"\214\001\362\206\031\207\001" +
+      "\n!\n\004POST\022\023/mlflow/runs/search\032\004\010\002\020\000\n)\n\004P" +
+      "OST\022\033/preview/mlflow/runs/search\032\004\010\002\020\000\n(" +
+      "\n\003GET\022\033/preview/mlflow/runs/search\032\004\010\002\020\000" +
+      "\020\001*\013Search Runs\022\260\001\n\rlistArtifacts\022\025.mlfl" +
+      "ow.ListArtifacts\032\036.mlflow.ListArtifacts." +
+      "Response\"h\362\206\031d\n#\n\003GET\022\026/mlflow/artifacts" +
+      "/list\032\004\010\002\020\000\n+\n\003GET\022\036/preview/mlflow/arti" +
+      "facts/list\032\004\010\002\020\000\020\001*\016List Artifacts\022\307\001\n\020g" +
+      "etMetricHistory\022\030.mlflow.GetMetricHistor" +
+      "y\032!.mlflow.GetMetricHistory.Response\"v\362\206" +
+      "\031r\n(\n\003GET\022\033/mlflow/metrics/get-history\032\004" +
+      "\010\002\020\000\n0\n\003GET\022#/preview/mlflow/metrics/get" +
+      "-history\032\004\010\002\020\000\020\001*\022Get Metric History\022\236\001\n" +
+      "\010logBatch\022\020.mlflow.LogBatch\032\031.mlflow.Log" +
+      "Batch.Response\"e\362\206\031a\n$\n\004POST\022\026/mlflow/ru" +
+      "ns/log-batch\032\004\010\002\020\000\n,\n\004POST\022\036/preview/mlf" +
+      "low/runs/log-batch\032\004\010\002\020\000\020\001*\tLog BatchB\036\n" +
+      "\024org.mlflow.api.proto\220\001\001\342?\002\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -23,6 +23,10 @@ service MlflowService {
     option (rpc) = {
       endpoints: [{
         method: "POST",
+        path: "/mlflow/experiments/create"
+        since { major: 2, minor: 0 },
+      }, {
+        method: "POST",
         path: "/preview/mlflow/experiments/create"
         since { major: 2, minor: 0 },
       }],
@@ -37,6 +41,10 @@ service MlflowService {
     option (rpc) = {
       endpoints: [{
         method: "GET",
+        path: "/mlflow/experiments/list"
+        since { major: 2, minor: 0 },
+      }, {
+        method: "GET",
         path: "/preview/mlflow/experiments/list"
         since { major: 2, minor: 0 },
       }],
@@ -46,10 +54,14 @@ service MlflowService {
   }
 
   // Get metadata for an experiment and a list of runs for the experiment.
-  // This RPC will work on deleted experiments.
+  // This method works on deleted experiments.
   rpc getExperiment (GetExperiment) returns (GetExperiment.Response) {
     option (rpc) = {
       endpoints: [{
+        method: "GET",
+        path: "/mlflow/experiments/get"
+        since { major: 2, minor: 0 },
+      }, {
         method: "GET",
         path: "/preview/mlflow/experiments/get"
         since { major: 2, minor: 0 },
@@ -59,12 +71,16 @@ service MlflowService {
     };
   }
 
-  // Mark an experiment and associated runs, params, metrics, ... etc for deletion.
+  // Mark an experiment and associated metadata, runs, metrics, params, and tags for deletion.
   // If the experiment uses FileStore, artifacts associated with experiment are also deleted.
   //
   rpc deleteExperiment (DeleteExperiment) returns (DeleteExperiment.Response) {
     option (rpc) = {
       endpoints: [{
+        method: "POST",
+        path: "/mlflow/experiments/delete"
+        since { major: 2, minor: 0 },
+      }, {
         method: "POST",
         path: "/preview/mlflow/experiments/delete"
         since { major: 2, minor: 0 },
@@ -75,7 +91,7 @@ service MlflowService {
   }
 
   // Restore an experiment marked for deletion. This also restores
-  // associated metadata, runs, metrics, and params. If experiment uses FileStore, underlying
+  // associated metadata, runs, metrics, params, and tags. If experiment uses FileStore, underlying
   // artifacts associated with experiment are also restored.
   //
   // Throws ``RESOURCE_DOES_NOT_EXIST`` if experiment was never created or was permanently deleted.
@@ -83,6 +99,10 @@ service MlflowService {
   rpc restoreExperiment (RestoreExperiment) returns (RestoreExperiment.Response) {
     option (rpc) = {
       endpoints: [{
+        method: "POST",
+        path: "/mlflow/experiments/restore"
+        since { major: 2, minor: 0 },
+      }, {
         method: "POST",
         path: "/preview/mlflow/experiments/restore"
         since { major: 2, minor: 0 },
@@ -92,11 +112,15 @@ service MlflowService {
     };
   }
 
-  // Updates an experiment metadata.
+  // Update experiment metadata.
   //
   rpc updateExperiment (UpdateExperiment) returns (UpdateExperiment.Response) {
     option (rpc) = {
       endpoints: [{
+        method: "POST",
+        path: "/mlflow/experiments/update"
+        since { major: 2, minor: 0 },
+      }, {
         method: "POST",
         path: "/preview/mlflow/experiments/update"
         since { major: 2, minor: 0 },
@@ -114,6 +138,10 @@ service MlflowService {
     option (rpc) = {
       endpoints: [{
         method: "POST",
+        path: "/mlflow/runs/create"
+        since { major: 2, minor: 0 },
+      }, {
+        method: "POST",
         path: "/preview/mlflow/runs/create"
         since { major: 2, minor: 0 },
       }],
@@ -129,6 +157,10 @@ service MlflowService {
     option (rpc) = {
       endpoints: [{
         method: "POST",
+        path: "/mlflow/runs/update"
+        since { major: 2, minor: 0 },
+      }, {
+        method: "POST",
         path: "/preview/mlflow/runs/update"
         since { major: 2, minor: 0 },
       }],
@@ -138,15 +170,20 @@ service MlflowService {
     };
   }
 
-  // This operation will mark the run for deletion.
+  // Mark a run for deletion.
   rpc deleteRun(DeleteRun) returns (DeleteRun.Response) {
     option (rpc) = {
       endpoints: [{
+        method: "POST",
+        path: "/mlflow/runs/delete"
+        since { major: 2, minor: 0 },
+      }, {
         method: "POST",
         path: "/preview/mlflow/runs/delete"
         since { major: 2, minor: 0 },
       }],
       visibility: PUBLIC,
+      rpc_doc_title: "Delete Run",
     };
   }
 
@@ -155,10 +192,15 @@ service MlflowService {
     option (rpc) = {
       endpoints: [{
         method: "POST",
+        path: "/mlflow/runs/restore"
+        since { major: 2, minor: 0 },
+      }, {
+        method: "POST",
         path: "/preview/mlflow/runs/restore"
         since { major: 2, minor: 0 },
       }],
       visibility: PUBLIC,
+      rpc_doc_title: "Restore Run",
     };
   }
 
@@ -169,6 +211,10 @@ service MlflowService {
   rpc logMetric(LogMetric) returns (LogMetric.Response) {
     option (rpc) = {
       endpoints: [{
+        method: "POST",
+        path: "/mlflow/runs/log-metric"
+        since { major: 2, minor: 0 },
+      }, {
         method: "POST",
         path: "/preview/mlflow/runs/log-metric"
         since { major: 2, minor: 0 },
@@ -187,6 +233,10 @@ service MlflowService {
     option (rpc) = {
       endpoints: [{
         method: "POST",
+        path: "/mlflow/runs/log-parameter"
+        since { major: 2, minor: 0 },
+      }, {
+        method: "POST",
         path: "/preview/mlflow/runs/log-parameter"
         since { major: 2, minor: 0 },
       }],
@@ -203,6 +253,10 @@ service MlflowService {
     option (rpc) = {
       endpoints: [{
         method: "POST",
+        path: "/mlflow/runs/set-tag"
+        since { major: 2, minor: 0 },
+      }, {
+        method: "POST",
         path: "/preview/mlflow/runs/set-tag"
         since { major: 2, minor: 0 },
       }],
@@ -212,12 +266,16 @@ service MlflowService {
     };
   }
 
-  // Get metadata, params, tags, and metrics for a run. In the case where multiple metrics
+  // Get metadata, metrics, params, and tags for a run. In the case where multiple metrics
   // with the same key are logged for a run, return only the value with the latest timestamp.
   // If there are multiple values with the latest timestamp, return the maximum of these values.
   rpc getRun (GetRun) returns (GetRun.Response) {
     option (rpc) = {
       endpoints: [{
+        method: "GET",
+        path: "/mlflow/runs/get"
+        since { major: 2, minor: 0 },
+      }, {
         method: "GET",
         path: "/preview/mlflow/runs/get"
         since { major: 2, minor: 0 },
@@ -234,6 +292,10 @@ service MlflowService {
   rpc searchRuns (SearchRuns) returns (SearchRuns.Response) {
     option (rpc) = {
       endpoints: [{
+        method: "POST",
+        path: "/mlflow/runs/search"
+        since { major: 2, minor: 0 },
+      }, {
         method: "POST",
         path: "/preview/mlflow/runs/search"
         since { major: 2, minor: 0 },
@@ -254,6 +316,10 @@ service MlflowService {
     option (rpc) = {
       endpoints: [{
         method: "GET",
+        path: "/mlflow/artifacts/list"
+        since { major: 2, minor: 0 },
+      }, {
+        method: "GET",
         path: "/preview/mlflow/artifacts/list"
         since { major: 2, minor: 0 },
       }],
@@ -268,6 +334,10 @@ service MlflowService {
     option (rpc) = {
       endpoints: [{
         method: "GET",
+        path: "/mlflow/metrics/get-history"
+        since { major: 2, minor: 0 },
+      }, {
+        method: "GET",
         path: "/preview/mlflow/metrics/get-history"
         since { major: 2, minor: 0 },
       }],
@@ -276,42 +346,38 @@ service MlflowService {
     };
   }
 
-  // Log a batch of metrics, params, and/or tags for a run.
-  // The server will respond with an error (non-200 status code) if any data failed to be persisted.
+  // Log a batch of metrics, params, and tags for a run.
+  // If any data failed to be persisted, the server will respond with an error (non-200 status code).
   // In case of error (due to internal server error or an invalid request), partial data may
   // be written.
   //
-  // Metrics, params, and tags may be written in interleaving fashion, but within a given entity
-  // type, are guaranteed to follow the order specified in the request body. That is, for an API
-  // request like:
+  // You can write metrics, params, and tags in interleaving fashion, but within a given entity
+  // type are guaranteed to follow the order specified in the request body. That is, for an API
+  // request like
   //
-  // {
-  //  "run_id": "2a14ed5c6a87499199e0106c3501eab8",
-  //  "metrics": [
-  //    {"key": "mae", "value": 2.5, "timestamp": 1552550804},
-  //    {"key": "rmse", "value": 2.7, "timestamp": 1552550804},
-  //  ],
-  //  "params": [
-  //    {"key": "model_class", "value": "LogisticRegression"},
-  //  ]
-  // }
+  // .. code-block:: json
   //
-  // The server is guaranteed to write metric "rmse" after "mae", though it may write param
+  //   {
+  //      "run_id": "2a14ed5c6a87499199e0106c3501eab8",
+  //      "metrics": [
+  //        {"key": "mae", "value": 2.5, "timestamp": 1552550804},
+  //        {"key": "rmse", "value": 2.7, "timestamp": 1552550804},
+  //      ],
+  //      "params": [
+  //        {"key": "model_class", "value": "LogisticRegression"},
+  //      ]
+  //   }
+  //
+  // the server is guaranteed to write metric "rmse" after "mae", though it may write param
   // "model_class" before both metrics, after "mae", or after both metrics.
   //
   // The overwrite behavior for metrics, params, and tags is as follows:
   //
-  // Metrics: metric values are never overwritten. Logging a metric (key, value, timestamp)
-  // appends to the set of values for the metric with the provided key.
+  // - Metrics: metric values are never overwritten. Logging a metric (key, value, timestamp) appends to the set of values for the metric with the provided key.
   //
-  // Tags: tag values may be overwritten by successive writes to the same tag key. That is, if
-  // multiple tag values with the same key are provided in the same API request, the last-provided
-  // tag value is written. Logging the same tag (key, value) is permitted - that is, logging a tag
-  // is idempotent.
+  // - Tags: tag values can be overwritten by successive writes to the same tag key. That is, if multiple tag values with the same key are provided in the same API request, the last-provided tag value is written. Logging the same tag (key, value) is permitted - that is, logging a tag is idempotent.
   //
-  // Params: once written, param values may not be changed (attempting to overwrite a param value
-  // will result in an error). However, logging the same param (key, value) is permitted - that is,
-  // logging a param is idempotent.
+  // - Params: once written, param values cannot be changed (attempting to overwrite a param value will result in an error). However, logging the same param (key, value) is permitted - that is, logging a param is idempotent.
   //
   // Request Limits
   // --------------
@@ -323,15 +389,19 @@ service MlflowService {
   // - Up to 100 tags
   //
   // For example, a valid request might contain 900 metrics, 50 params, and 50 tags, but logging
-  // 900 metrics, 50 params, and 51 tags would be invalid. The following limits also apply
-  // to metric, param, and tag keys & values:
+  // 900 metrics, 50 params, and 51 tags is invalid. The following limits also apply
+  // to metric, param, and tag keys and values:
   //
-  // - Metric, param, and tag keys may be up to 250 characters in length
-  // - Param and tag values may be up to 250 characters in length
+  // - Metric, param, and tag keys can be up to 250 characters in length
+  // - Param and tag values can be up to 250 characters in length
   //
   rpc logBatch (LogBatch) returns (LogBatch.Response) {
     option (rpc) = {
       endpoints: [{
+        method: "POST",
+        path: "/mlflow/runs/log-batch"
+        since { major: 2, minor: 0 },
+      }, {
         method: "POST",
         path: "/preview/mlflow/runs/log-batch"
         since { major: 2, minor: 0 },
@@ -422,7 +492,7 @@ message Run {
   optional RunData data = 2;
 }
 
-// Run data (metrics, params, etc).
+// Run data (metrics, params, and tags).
 message RunData {
   // Run metrics.
   repeated Metric metrics = 1;
@@ -521,7 +591,7 @@ message ListExperiments {
   optional ViewType view_type = 1;
 
   message Response {
-    // All experiments
+    // All experiments.
     repeated Experiment experiments = 1;
   }
 }
@@ -533,7 +603,7 @@ message GetExperiment {
   optional string experiment_id = 1 [(validate_required) = true];
 
   message Response {
-    // Returns experiment details.
+    // Experiment details.
     optional Experiment experiment = 1;
 
     // All (max limit to be imposed) active runs associated with this experiment.
@@ -554,7 +624,7 @@ message DeleteExperiment {
 message RestoreExperiment {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
-  // Identifier to get an experiment
+  // ID of the associated experiment.
   optional string experiment_id = 1 [(validate_required) = true];
 
   message Response {
@@ -567,7 +637,7 @@ message UpdateExperiment {
   // ID of the associated experiment.
   optional string experiment_id = 1 [(validate_required) = true];
 
-  // If provided, the experiment's name will be changed to this. The new name must be unique.
+  // If provided, the experiment's name is changed to the new name. The new name must be unique.
   optional string new_name = 2;
 
   message Response {
@@ -583,7 +653,7 @@ message CreateRun {
   // ID of the user executing the run.
   optional string user_id = 2;
 
-  // Unix timestamp of when the run started in milliseconds.
+  // Unix timestamp in milliseconds of when the run started.
   optional int64 start_time = 7;
 
   // Additional metadata for run.
@@ -608,7 +678,7 @@ message UpdateRun {
   // Updated status of the run.
   optional RunStatus status = 2;
 
-  //Unix timestamp of when the run ended in milliseconds.
+  //Unix timestamp in milliseconds of when the run ended.
   optional int64 end_time = 3;
 
   message Response {
@@ -620,6 +690,7 @@ message UpdateRun {
 message DeleteRun {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
+  // ID of the run to delete.
   optional string run_id = 1 [(validate_required) = true];
 
   message Response {}
@@ -628,6 +699,7 @@ message DeleteRun {
 message RestoreRun {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
+  // ID of the run to restore.
   optional string run_id = 1 [(validate_required) = true];
 
   message Response {}
@@ -711,7 +783,7 @@ message GetRun {
   optional string run_id = 2;
 
   message Response {
-    // Run metadata (name, start time, etc) and data (metrics, params, etc).
+    // Run metadata (name, start time, etc) and data (metrics, params, and tags).
     optional Run run = 1;
   }
 }
@@ -722,22 +794,22 @@ message SearchRuns {
   // List of experiment IDs to search over.
   repeated string experiment_ids = 1;
 
-  // A filter expression over params, metrics, and tags, allowing returning a subset of
-  // runs. The syntax is a subset of SQL which allows only ANDing together binary operations
-  // between a param/metric/tag and a constant.
+  // A filter expression over params, metrics, and tags, that allows returning a subset of
+  // runs. The syntax is a subset of SQL that supports ANDing together binary operations
+  // between a param, metric, or tag and a constant.
   //
   // Example: ``metrics.rmse < 1 and params.model_class = 'LogisticRegression'``
   //
-  // You can also select columns with spaces by using backticks or double quotes:
-  // ``metrics.`model class` = 'LinearRegression' and tags."user name" = 'Tomas'``
   //
-  // Supported operators are =, !=, >, >=, <, <=, and LIKE.
-  // LIKE syntax: ``params.model_class LIKE 'Linear%'``
+  // You can select columns with special characters (hyphen, space, period, etc.) by using double quotes:
+  // ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``
   //
-  // 'filter' may not be provided when anded_expressions is present; an INVALID_PARAMETER_VALUE
+  // Supported operators are ``=``, ``!=``, ``>``, ``>=``, ``<``, and ``<=``.
+  //
+  // You cannot provide ``filter`` when ``anded_expressions`` is present; an ``INVALID_PARAMETER_VALUE``
   // error will be returned if both are specified.
-  // If both 'filter' and 'anded_expressions' are absent, all runs part of the given experiments
-  // will be returned.
+  // If both ``filter`` and ``anded_expressions`` are absent, all runs part of the given experiments
+  // 
   optional string filter = 4;
 
   // Whether to display only active, only deleted, or all runs.

--- a/mlflow/protos/service_pb2.py
+++ b/mlflow/protos/service_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\024org.mlflow.api.proto\220\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"H\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x04step\x18\x04 \x01(\x03:\x01\x30\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xcb\x01\n\x07RunInfo\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x0f \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\x96\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x01\n\x0fListExperiments\x12#\n\tview_type\x18\x01 \x01(\x0e\x32\x10.mlflow.ViewType\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1aQ\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12\x1d\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x10UpdateExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xbe\x01\n\tUpdateRun\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tLogMetric\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\xf8\x86\x19\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\xf8\x86\x19\x01\x12\x0f\n\x04step\x18\x05 \x01(\x03:\x01\x30\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8d\x01\n\x08LogParam\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8b\x01\n\x06SetTag\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"}\n\x06GetRun\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xd9\x01\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\t\x12\x0e\n\x06\x66ilter\x18\x04 \x01(\t\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x12\x19\n\x0bmax_results\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x1a%\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xab\x01\n\rListArtifacts\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"\xa8\x01\n\x10GetMetricHistory\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb1\x01\n\x08LogBatch\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x1f\n\x07metrics\x18\x02 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x03 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x04 \x03(\x0b\x32\x0e.mlflow.RunTag\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\xb9\x13\n\rMlflowService\x12\x9c\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"K\xf2\x86\x19G\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\x95\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"G\xf2\x86\x19\x43\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\x8c\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"D\xf2\x86\x19@\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\x9c\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"K\xf2\x86\x19G\n0\n\x04POST\x12\"/preview/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\xa1\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"M\xf2\x86\x19I\n1\n\x04POST\x12#/preview/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12\x9c\x01\n\x10updateExperiment\x12\x18.mlflow.UpdateExperiment\x1a!.mlflow.UpdateExperiment.Response\"K\xf2\x86\x19G\n0\n\x04POST\x12\"/preview/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x11Update Experiment\x12y\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"=\xf2\x86\x19\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12y\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"=\xf2\x86\x19\x39\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12m\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"1\xf2\x86\x19-\n)\n\x04POST\x12\x1b/preview/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01\x12q\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"2\xf2\x86\x19.\n*\n\x04POST\x12\x1c/preview/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01\x12}\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"A\xf2\x86\x19=\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12|\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"C\xf2\x86\x19?\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12n\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\";\xf2\x86\x19\x37\n*\n\x04POST\x12\x1c/preview/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12i\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"6\xf2\x86\x19\x32\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12\xa7\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"h\xf2\x86\x19\x64\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\x8b\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"C\xf2\x86\x19?\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\x9d\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"L\xf2\x86\x19H\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric History\x12x\n\x08logBatch\x12\x10.mlflow.LogBatch\x1a\x19.mlflow.LogBatch.Response\"?\xf2\x86\x19;\n,\n\x04POST\x12\x1e/preview/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog BatchB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"H\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x04step\x18\x04 \x01(\x03:\x01\x30\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xcb\x01\n\x07RunInfo\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x0f \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\x96\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x01\n\x0fListExperiments\x12#\n\tview_type\x18\x01 \x01(\x0e\x32\x10.mlflow.ViewType\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1aQ\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12\x1d\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x10UpdateExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xbe\x01\n\tUpdateRun\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tLogMetric\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\xf8\x86\x19\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\xf8\x86\x19\x01\x12\x0f\n\x04step\x18\x05 \x01(\x03:\x01\x30\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8d\x01\n\x08LogParam\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8b\x01\n\x06SetTag\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"}\n\x06GetRun\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xd9\x01\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\t\x12\x0e\n\x06\x66ilter\x18\x04 \x01(\t\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x12\x19\n\x0bmax_results\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x1a%\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xab\x01\n\rListArtifacts\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"\xa8\x01\n\x10GetMetricHistory\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb1\x01\n\x08LogBatch\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x1f\n\x07metrics\x18\x02 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x03 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x04 \x03(\x0b\x32\x0e.mlflow.RunTag\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\x8c\x19\n\rMlflowService\x12\xc6\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\xbc\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"n\xf2\x86\x19j\n%\n\x03GET\x12\x18/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\xb2\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"j\xf2\x86\x19\x66\n$\n\x03GET\x12\x17/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\xc6\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\xcc\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"x\xf2\x86\x19t\n)\n\x04POST\x12\x1b/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\n1\n\x04POST\x12#/preview/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12\xc6\x01\n\x10updateExperiment\x12\x18.mlflow.UpdateExperiment\x1a!.mlflow.UpdateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x11Update Experiment\x12\x9c\x01\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12\x9c\x01\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12\x9c\x01\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Run\x12\xa2\x01\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"c\xf2\x86\x19_\n\"\n\x04POST\x12\x14/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bRestore Run\x12\xa4\x01\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"h\xf2\x86\x19\x64\n%\n\x04POST\x12\x17/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12\xa6\x01\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"m\xf2\x86\x19i\n(\n\x04POST\x12\x1a/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12\x92\x01\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\"_\xf2\x86\x19[\n\"\n\x04POST\x12\x14/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12\x88\x01\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"U\xf2\x86\x19Q\n\x1d\n\x03GET\x12\x10/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12\xcc\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"\x8c\x01\xf2\x86\x19\x87\x01\n!\n\x04POST\x12\x13/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\xb0\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"h\xf2\x86\x19\x64\n#\n\x03GET\x12\x16/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\xc7\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"v\xf2\x86\x19r\n(\n\x03GET\x12\x1b/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric History\x12\x9e\x01\n\x08logBatch\x12\x10.mlflow.LogBatch\x1a\x19.mlflow.LogBatch.Response\"e\xf2\x86\x19\x61\n$\n\x04POST\x12\x16/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\n,\n\x04POST\x12\x1e/preview/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog BatchB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -2248,7 +2248,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   index=0,
   serialized_options=None,
   serialized_start=3745,
-  serialized_end=6234,
+  serialized_end=6957,
   methods=[
   _descriptor.MethodDescriptor(
     name='createExperiment',
@@ -2257,7 +2257,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_CREATEEXPERIMENT,
     output_type=_CREATEEXPERIMENT_RESPONSE,
-    serialized_options=_b('\362\206\031G\n0\n\004POST\022\"/preview/mlflow/experiments/create\032\004\010\002\020\000\020\001*\021Create Experiment'),
+    serialized_options=_b('\362\206\031q\n(\n\004POST\022\032/mlflow/experiments/create\032\004\010\002\020\000\n0\n\004POST\022\"/preview/mlflow/experiments/create\032\004\010\002\020\000\020\001*\021Create Experiment'),
   ),
   _descriptor.MethodDescriptor(
     name='listExperiments',
@@ -2266,7 +2266,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_LISTEXPERIMENTS,
     output_type=_LISTEXPERIMENTS_RESPONSE,
-    serialized_options=_b('\362\206\031C\n-\n\003GET\022 /preview/mlflow/experiments/list\032\004\010\002\020\000\020\001*\020List Experiments'),
+    serialized_options=_b('\362\206\031j\n%\n\003GET\022\030/mlflow/experiments/list\032\004\010\002\020\000\n-\n\003GET\022 /preview/mlflow/experiments/list\032\004\010\002\020\000\020\001*\020List Experiments'),
   ),
   _descriptor.MethodDescriptor(
     name='getExperiment',
@@ -2275,7 +2275,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_GETEXPERIMENT,
     output_type=_GETEXPERIMENT_RESPONSE,
-    serialized_options=_b('\362\206\031@\n,\n\003GET\022\037/preview/mlflow/experiments/get\032\004\010\002\020\000\020\001*\016Get Experiment'),
+    serialized_options=_b('\362\206\031f\n$\n\003GET\022\027/mlflow/experiments/get\032\004\010\002\020\000\n,\n\003GET\022\037/preview/mlflow/experiments/get\032\004\010\002\020\000\020\001*\016Get Experiment'),
   ),
   _descriptor.MethodDescriptor(
     name='deleteExperiment',
@@ -2284,7 +2284,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_DELETEEXPERIMENT,
     output_type=_DELETEEXPERIMENT_RESPONSE,
-    serialized_options=_b('\362\206\031G\n0\n\004POST\022\"/preview/mlflow/experiments/delete\032\004\010\002\020\000\020\001*\021Delete Experiment'),
+    serialized_options=_b('\362\206\031q\n(\n\004POST\022\032/mlflow/experiments/delete\032\004\010\002\020\000\n0\n\004POST\022\"/preview/mlflow/experiments/delete\032\004\010\002\020\000\020\001*\021Delete Experiment'),
   ),
   _descriptor.MethodDescriptor(
     name='restoreExperiment',
@@ -2293,7 +2293,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_RESTOREEXPERIMENT,
     output_type=_RESTOREEXPERIMENT_RESPONSE,
-    serialized_options=_b('\362\206\031I\n1\n\004POST\022#/preview/mlflow/experiments/restore\032\004\010\002\020\000\020\001*\022Restore Experiment'),
+    serialized_options=_b('\362\206\031t\n)\n\004POST\022\033/mlflow/experiments/restore\032\004\010\002\020\000\n1\n\004POST\022#/preview/mlflow/experiments/restore\032\004\010\002\020\000\020\001*\022Restore Experiment'),
   ),
   _descriptor.MethodDescriptor(
     name='updateExperiment',
@@ -2302,7 +2302,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_UPDATEEXPERIMENT,
     output_type=_UPDATEEXPERIMENT_RESPONSE,
-    serialized_options=_b('\362\206\031G\n0\n\004POST\022\"/preview/mlflow/experiments/update\032\004\010\002\020\000\020\001*\021Update Experiment'),
+    serialized_options=_b('\362\206\031q\n(\n\004POST\022\032/mlflow/experiments/update\032\004\010\002\020\000\n0\n\004POST\022\"/preview/mlflow/experiments/update\032\004\010\002\020\000\020\001*\021Update Experiment'),
   ),
   _descriptor.MethodDescriptor(
     name='createRun',
@@ -2311,7 +2311,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_CREATERUN,
     output_type=_CREATERUN_RESPONSE,
-    serialized_options=_b('\362\206\0319\n)\n\004POST\022\033/preview/mlflow/runs/create\032\004\010\002\020\000\020\001*\nCreate Run'),
+    serialized_options=_b('\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/create\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/runs/create\032\004\010\002\020\000\020\001*\nCreate Run'),
   ),
   _descriptor.MethodDescriptor(
     name='updateRun',
@@ -2320,7 +2320,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_UPDATERUN,
     output_type=_UPDATERUN_RESPONSE,
-    serialized_options=_b('\362\206\0319\n)\n\004POST\022\033/preview/mlflow/runs/update\032\004\010\002\020\000\020\001*\nUpdate Run'),
+    serialized_options=_b('\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/update\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/runs/update\032\004\010\002\020\000\020\001*\nUpdate Run'),
   ),
   _descriptor.MethodDescriptor(
     name='deleteRun',
@@ -2329,7 +2329,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_DELETERUN,
     output_type=_DELETERUN_RESPONSE,
-    serialized_options=_b('\362\206\031-\n)\n\004POST\022\033/preview/mlflow/runs/delete\032\004\010\002\020\000\020\001'),
+    serialized_options=_b('\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/delete\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/runs/delete\032\004\010\002\020\000\020\001*\nDelete Run'),
   ),
   _descriptor.MethodDescriptor(
     name='restoreRun',
@@ -2338,7 +2338,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_RESTORERUN,
     output_type=_RESTORERUN_RESPONSE,
-    serialized_options=_b('\362\206\031.\n*\n\004POST\022\034/preview/mlflow/runs/restore\032\004\010\002\020\000\020\001'),
+    serialized_options=_b('\362\206\031_\n\"\n\004POST\022\024/mlflow/runs/restore\032\004\010\002\020\000\n*\n\004POST\022\034/preview/mlflow/runs/restore\032\004\010\002\020\000\020\001*\013Restore Run'),
   ),
   _descriptor.MethodDescriptor(
     name='logMetric',
@@ -2347,7 +2347,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_LOGMETRIC,
     output_type=_LOGMETRIC_RESPONSE,
-    serialized_options=_b('\362\206\031=\n-\n\004POST\022\037/preview/mlflow/runs/log-metric\032\004\010\002\020\000\020\001*\nLog Metric'),
+    serialized_options=_b('\362\206\031d\n%\n\004POST\022\027/mlflow/runs/log-metric\032\004\010\002\020\000\n-\n\004POST\022\037/preview/mlflow/runs/log-metric\032\004\010\002\020\000\020\001*\nLog Metric'),
   ),
   _descriptor.MethodDescriptor(
     name='logParam',
@@ -2356,7 +2356,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_LOGPARAM,
     output_type=_LOGPARAM_RESPONSE,
-    serialized_options=_b('\362\206\031?\n0\n\004POST\022\"/preview/mlflow/runs/log-parameter\032\004\010\002\020\000\020\001*\tLog Param'),
+    serialized_options=_b('\362\206\031i\n(\n\004POST\022\032/mlflow/runs/log-parameter\032\004\010\002\020\000\n0\n\004POST\022\"/preview/mlflow/runs/log-parameter\032\004\010\002\020\000\020\001*\tLog Param'),
   ),
   _descriptor.MethodDescriptor(
     name='setTag',
@@ -2365,7 +2365,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_SETTAG,
     output_type=_SETTAG_RESPONSE,
-    serialized_options=_b('\362\206\0317\n*\n\004POST\022\034/preview/mlflow/runs/set-tag\032\004\010\002\020\000\020\001*\007Set Tag'),
+    serialized_options=_b('\362\206\031[\n\"\n\004POST\022\024/mlflow/runs/set-tag\032\004\010\002\020\000\n*\n\004POST\022\034/preview/mlflow/runs/set-tag\032\004\010\002\020\000\020\001*\007Set Tag'),
   ),
   _descriptor.MethodDescriptor(
     name='getRun',
@@ -2374,7 +2374,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_GETRUN,
     output_type=_GETRUN_RESPONSE,
-    serialized_options=_b('\362\206\0312\n%\n\003GET\022\030/preview/mlflow/runs/get\032\004\010\002\020\000\020\001*\007Get Run'),
+    serialized_options=_b('\362\206\031Q\n\035\n\003GET\022\020/mlflow/runs/get\032\004\010\002\020\000\n%\n\003GET\022\030/preview/mlflow/runs/get\032\004\010\002\020\000\020\001*\007Get Run'),
   ),
   _descriptor.MethodDescriptor(
     name='searchRuns',
@@ -2383,7 +2383,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_SEARCHRUNS,
     output_type=_SEARCHRUNS_RESPONSE,
-    serialized_options=_b('\362\206\031d\n)\n\004POST\022\033/preview/mlflow/runs/search\032\004\010\002\020\000\n(\n\003GET\022\033/preview/mlflow/runs/search\032\004\010\002\020\000\020\001*\013Search Runs'),
+    serialized_options=_b('\362\206\031\207\001\n!\n\004POST\022\023/mlflow/runs/search\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/runs/search\032\004\010\002\020\000\n(\n\003GET\022\033/preview/mlflow/runs/search\032\004\010\002\020\000\020\001*\013Search Runs'),
   ),
   _descriptor.MethodDescriptor(
     name='listArtifacts',
@@ -2392,7 +2392,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_LISTARTIFACTS,
     output_type=_LISTARTIFACTS_RESPONSE,
-    serialized_options=_b('\362\206\031?\n+\n\003GET\022\036/preview/mlflow/artifacts/list\032\004\010\002\020\000\020\001*\016List Artifacts'),
+    serialized_options=_b('\362\206\031d\n#\n\003GET\022\026/mlflow/artifacts/list\032\004\010\002\020\000\n+\n\003GET\022\036/preview/mlflow/artifacts/list\032\004\010\002\020\000\020\001*\016List Artifacts'),
   ),
   _descriptor.MethodDescriptor(
     name='getMetricHistory',
@@ -2401,7 +2401,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_GETMETRICHISTORY,
     output_type=_GETMETRICHISTORY_RESPONSE,
-    serialized_options=_b('\362\206\031H\n0\n\003GET\022#/preview/mlflow/metrics/get-history\032\004\010\002\020\000\020\001*\022Get Metric History'),
+    serialized_options=_b('\362\206\031r\n(\n\003GET\022\033/mlflow/metrics/get-history\032\004\010\002\020\000\n0\n\003GET\022#/preview/mlflow/metrics/get-history\032\004\010\002\020\000\020\001*\022Get Metric History'),
   ),
   _descriptor.MethodDescriptor(
     name='logBatch',
@@ -2410,7 +2410,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     containing_service=None,
     input_type=_LOGBATCH,
     output_type=_LOGBATCH_RESPONSE,
-    serialized_options=_b('\362\206\031;\n,\n\004POST\022\036/preview/mlflow/runs/log-batch\032\004\010\002\020\000\020\001*\tLog Batch'),
+    serialized_options=_b('\362\206\031a\n$\n\004POST\022\026/mlflow/runs/log-batch\032\004\010\002\020\000\n,\n\004POST\022\036/preview/mlflow/runs/log-batch\032\004\010\002\020\000\020\001*\tLog Batch'),
   ),
 ])
 _sym_db.RegisterServiceDescriptor(_MLFLOWSERVICE)

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -35,7 +35,7 @@ def mock_store():
 def test_get_endpoints():
     endpoints = get_endpoints()
     create_experiment_endpoint = [e for e in endpoints if e[1] == _create_experiment]
-    assert len(create_experiment_endpoint) == 2
+    assert len(create_experiment_endpoint) == 4
 
 
 def test_can_parse_json():

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -24,7 +24,7 @@ class TestRestStore(unittest.TestCase):
             assert kwargs == {
                 'method': 'GET',
                 'params': {'view_type': 'ACTIVE_ONLY'},
-                'url': 'https://hello/api/2.0/preview/mlflow/experiments/list',
+                'url': 'https://hello/api/2.0/mlflow/experiments/list',
                 'headers': _DEFAULT_HEADERS,
                 'verify': True,
             }
@@ -74,7 +74,7 @@ class TestRestStore(unittest.TestCase):
 
     def _args(self, host_creds, endpoint, method, json_body):
         return {'host_creds': host_creds,
-                'endpoint': "/api/2.0/preview/mlflow/%s" % endpoint,
+                'endpoint': "/api/2.0/mlflow/%s" % endpoint,
                 'method': method,
                 'json': json.loads(json_body)}
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
- Adding non-`preview` versions of MLflow APIs.
- Continue to support `preview` APIs (these will be deprecated/removed in future) 
- Including documentation fixes made by @stbof 
 
## How is this patch tested?
- [x] Fixed unit tests
- [x] Manual testing  
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [x] API 
- [x] REST-API 
- [ ] Examples 
- [ ] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
