### PR TITLE
Run docker projects tests against Python 3 container

### DIFF
--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -1,3 +1,3 @@
-FROM continuumio/miniconda:4.5.4
+FROM continuumio/miniconda3:4.6.14
 
 RUN pip install mlflow==0.8.1


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fixes test failures due to the Scikit-learn library dependency of MLflow removing support for Python 2 (while simultaneously failing to restrict the available package versions accessible via `pip2`).
 
## How is this patch tested?
 
- [X] Unit tests
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
