### PR TITLE
R docs: update run selection description in mlflow_get_run

### DIFF
--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -92,7 +92,7 @@ mlflow_restore_run <- function(run_id, client = NULL) {
 #' Get Run
 #'
 #' Gets metadata, params, tags, and metrics for a run. Returns a single value for each metric
-#" key: the most recently logged metric value at the largest step.
+#' key: the most recently logged metric value at the largest step.
 #'
 #' @template roxlate-run-id
 #' @template roxlate-client

--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -91,9 +91,8 @@ mlflow_restore_run <- function(run_id, client = NULL) {
 
 #' Get Run
 #'
-#' Gets metadata, params, tags, and metrics for a run. In the case where multiple metrics with the
-#' same key are logged for the run, returns only the value with the latest timestamp. If there are
-#' multiple values with the latest timestamp, returns the maximum of these values.
+#' Gets metadata, params, tags, and metrics for a run. Returns a single value for each metric
+#" key: the most recently logged metric value at the largest step.
 #'
 #' @template roxlate-run-id
 #' @template roxlate-client


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Update docs for `mlflow_get_run()` in R to reflect updated metric summary selection behavior
 
## How is this patch tested?
 
Manual generation of docs
 
## Release Notes

Update docs for `mlflow_get_run()` in R to reflect updated metric summary selection behavior based on the new x-coordinates (metric step) feature.
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [X] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [X] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
