### PR TITLE
Refactor rest store and rest utils to support custom verification/processing of the response

### DIFF
--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -39,7 +39,7 @@ class RestException(MlflowException):
     def __init__(self, json):
         error_code = json.get('error_code', INTERNAL_ERROR)
         message = "%s: %s" % (error_code, json['message']) if 'message' in json else \
-                  "%s: Response: %s" % (error_code, json)
+                  "%s: %s" % (error_code, json)
 
         super(RestException, self).__init__(message, error_code=error_code)
         self.json = json

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -38,8 +38,7 @@ class RestException(MlflowException):
     """Exception thrown on non 200-level responses from the REST API"""
     def __init__(self, json):
         error_code = json.get('error_code', INTERNAL_ERROR)
-        message = "%s: %s" % (error_code, json['message']) if 'message' in json else \
-                  "%s: %s" % (error_code, json)
+        message = json['message'] if 'message' in json else "Response: " + str(json)
 
         super(RestException, self).__init__(message, error_code=error_code)
         self.json = json

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -38,7 +38,8 @@ class RestException(MlflowException):
     """Exception thrown on non 200-level responses from the REST API"""
     def __init__(self, json):
         error_code = json.get('error_code', INTERNAL_ERROR)
-        message = json['message'] if 'message' in json else "Response: %s" % (json)
+        message = "%s: %s" % (error_code, json['message']) if 'message' in json else \
+                  "%s: Response: %s" % (error_code, json)
 
         super(RestException, self).__init__(message, error_code=error_code)
         self.json = json

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -38,9 +38,8 @@ class RestException(MlflowException):
     """Exception thrown on non 200-level responses from the REST API"""
     def __init__(self, json):
         error_code = json.get('error_code', INTERNAL_ERROR)
-        message = error_code
-        if 'message' in json:
-            message = "%s: %s" % (error_code, json['message'])
+        message = json['message'] if 'message' in json else "Response: %s" % (json)
+
         super(RestException, self).__init__(message, error_code=error_code)
         self.json = json
 

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -38,7 +38,8 @@ class RestException(MlflowException):
     """Exception thrown on non 200-level responses from the REST API"""
     def __init__(self, json):
         error_code = json.get('error_code', INTERNAL_ERROR)
-        message = json['message'] if 'message' in json else "Response: " + str(json)
+        message = "%s: %s" % (error_code,
+                              json['message'] if 'message' in json else "Response: " + str(json))
 
         super(RestException, self).__init__(message, error_code=error_code)
         self.json = json

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -65,7 +65,7 @@ class RestStore(AbstractStore):
         else:
             response = http_request(
                 host_creds=host_creds, endpoint=endpoint, method=method, json=json_body)
-        
+
         response = self._validate_response(response, endpoint)
 
         js_dict = json.loads(response.text)

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -6,7 +6,7 @@ from mlflow.store.abstract_store import AbstractStore
 from mlflow.entities import Experiment, Run, RunInfo, Metric, ViewType
 
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
-from mlflow.utils.rest_utils import http_request_safe
+from mlflow.utils.rest_utils import http_request, http_response_handler
 
 from mlflow.protos.service_pb2 import CreateExperiment, MlflowService, GetExperiment, \
     GetRun, SearchRuns, ListExperiments, GetMetricHistory, LogMetric, LogParam, SetTag, \
@@ -48,6 +48,9 @@ class RestStore(AbstractStore):
         super(RestStore, self).__init__()
         self.get_host_creds = get_host_creds
 
+    def _validate_response(self, response, endpoint):
+        return http_response_handler(response, endpoint)
+
     def _call_endpoint(self, api, json_body):
         endpoint, method = _METHOD_TO_INFO[api]
         response_proto = api.Response()
@@ -57,11 +60,13 @@ class RestStore(AbstractStore):
         host_creds = self.get_host_creds()
 
         if method == 'GET':
-            response = http_request_safe(
+            response = http_request(
                 host_creds=host_creds, endpoint=endpoint, method=method, params=json_body)
         else:
-            response = http_request_safe(
+            response = http_request(
                 host_creds=host_creds, endpoint=endpoint, method=method, json=json_body)
+        
+        response = self._validate_response(response, endpoint)
 
         js_dict = json.loads(response.text)
         parse_dict(js_dict=js_dict, message=response_proto)

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -6,7 +6,7 @@ from mlflow.store.abstract_store import AbstractStore
 from mlflow.entities import Experiment, Run, RunInfo, Metric, ViewType
 
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
-from mlflow.utils.rest_utils import http_request, http_response_handler
+from mlflow.utils.rest_utils import http_request, verify_rest_response
 
 from mlflow.protos.service_pb2 import CreateExperiment, MlflowService, GetExperiment, \
     GetRun, SearchRuns, ListExperiments, GetMetricHistory, LogMetric, LogParam, SetTag, \
@@ -48,8 +48,8 @@ class RestStore(AbstractStore):
         super(RestStore, self).__init__()
         self.get_host_creds = get_host_creds
 
-    def _validate_response(self, response, endpoint):
-        return http_response_handler(response, endpoint)
+    def _verify_rest_response(self, response, endpoint):
+        return verify_rest_response(response, endpoint)
 
     def _call_endpoint(self, api, json_body):
         endpoint, method = _METHOD_TO_INFO[api]
@@ -66,7 +66,7 @@ class RestStore(AbstractStore):
             response = http_request(
                 host_creds=host_creds, endpoint=endpoint, method=method, json=json_body)
 
-        response = self._validate_response(response, endpoint)
+        response = self._verify_rest_response(response, endpoint)
 
         js_dict = json.loads(response.text)
         parse_dict(js_dict=js_dict, message=response_proto)

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -77,13 +77,11 @@ def http_request_safe(host_creds, endpoint, **kwargs):
     Wrapper around ``http_request`` that also verifies that the request succeeds with code 200.
     """
     response = http_request(host_creds=host_creds, endpoint=endpoint, **kwargs)
-    return http_response_handler(response, endpoint)
+    return verify_rest_response(response, endpoint)
 
 
-def http_response_handler(response, endpoint):
-    """
-    Handler for ``http_request`` returned response verifies the request succeeds with code 200.
-    """
+def verify_rest_response(response, endpoint):
+    """Verify the return code and raise exception if the request was not successful."""
     if response.status_code != 200:
         base_msg = "API request to endpoint %s failed with error code " \
                    "%s != 200" % (endpoint, response.status_code)

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -77,6 +77,13 @@ def http_request_safe(host_creds, endpoint, **kwargs):
     Wrapper around ``http_request`` that also verifies that the request succeeds with code 200.
     """
     response = http_request(host_creds=host_creds, endpoint=endpoint, **kwargs)
+    return http_response_handler(response, endpoint)
+
+
+def http_response_handler(response, endpoint):
+    """
+    Handler for ``http_request`` returned response verifies the request succeeds with code 200.
+    """
     if response.status_code != 200:
         base_msg = "API request to endpoint %s failed with error code " \
                    "%s != 200" % (endpoint, response.status_code)

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -20,7 +20,7 @@ class MyCoolException(Exception):
 
 
 class CustomErrorHandlingRestStore(RestStore):
-    def _validate_response(self, response, endpoint):
+    def _verify_rest_response(self, response, endpoint):
         if response.status_code != 200:
             raise MyCoolException()
 

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -15,6 +15,16 @@ from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import MlflowHostCreds, _DEFAULT_HEADERS
 
 
+class MyCoolException(Exception):
+    pass
+
+
+class CustomErrorHandlingRestStore(RestStore):
+    def _validate_response(self, response, endpoint):
+        if response.status_code != 200:
+            raise MyCoolException()
+
+
 class TestRestStore(unittest.TestCase):
     @mock.patch('requests.request')
     def test_successful_http_request(self, request):
@@ -50,6 +60,17 @@ class TestRestStore(unittest.TestCase):
         with self.assertRaises(MlflowException) as cm:
             store.list_experiments()
         self.assertIn("RESOURCE_DOES_NOT_EXIST: No experiment", str(cm.exception))
+
+    @mock.patch('requests.request')
+    def test_failed_http_request_custom_handler(self, request):
+        response = mock.MagicMock
+        response.status_code = 404
+        response.text = '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "No experiment"}'
+        request.return_value = response
+
+        store = CustomErrorHandlingRestStore(lambda: MlflowHostCreds('https://hello'))
+        with self.assertRaises(MyCoolException):
+            store.list_experiments()
 
     @mock.patch('requests.request')
     def test_response_with_unknown_fields(self, request):
@@ -106,7 +127,7 @@ class TestRestStore(unittest.TestCase):
         source_type_patch = mock.patch(
             "mlflow.tracking.context._get_source_type", return_value=SourceType.LOCAL
         )
-        with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http, \
+        with mock.patch('mlflow.store.rest_store.http_request') as mock_http, \
                 mock.patch('mlflow.tracking.utils._get_store', return_value=store), \
                 mock.patch('mlflow.tracking.client._get_user_id', return_value=user_name), \
                 mock.patch('time.time', return_value=13579), \
@@ -122,28 +143,28 @@ class TestRestStore(unittest.TestCase):
                 exp_calls = [("runs/create", "POST", cr_body)]
                 self._verify_request_has_calls(mock_http, creds, exp_calls)
 
-        with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
+        with mock.patch('mlflow.store.rest_store.http_request') as mock_http:
             store.log_param("some_uuid", Param("k1", "v1"))
             body = message_to_json(LogParam(
                 run_uuid="some_uuid", run_id="some_uuid", key="k1", value="v1"))
             self._verify_requests(mock_http, creds,
                                   "runs/log-parameter", "POST", body)
 
-        with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
+        with mock.patch('mlflow.store.rest_store.http_request') as mock_http:
             store.set_tag("some_uuid", RunTag("t1", "abcd"*1000))
             body = message_to_json(SetTag(
                 run_uuid="some_uuid", run_id="some_uuid", key="t1", value="abcd"*1000))
             self._verify_requests(mock_http, creds,
                                   "runs/set-tag", "POST", body)
 
-        with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
+        with mock.patch('mlflow.store.rest_store.http_request') as mock_http:
             store.log_metric("u2", Metric("m1", 0.87, 12345, 3))
             body = message_to_json(LogMetric(
                 run_uuid="u2", run_id="u2", key="m1", value=0.87, timestamp=12345, step=3))
             self._verify_requests(mock_http, creds,
                                   "runs/log-metric", "POST", body)
 
-        with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
+        with mock.patch('mlflow.store.rest_store.http_request') as mock_http:
             metrics = [Metric("m1", 0.87, 12345, 0), Metric("m2", 0.49, 12345, -1),
                        Metric("m3", 0.58, 12345, 2)]
             params = [Param("p1", "p1val"), Param("p2", "p2val")]
@@ -157,25 +178,25 @@ class TestRestStore(unittest.TestCase):
             self._verify_requests(mock_http, creds,
                                   "runs/log-batch", "POST", body)
 
-        with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
+        with mock.patch('mlflow.store.rest_store.http_request') as mock_http:
             store.delete_run("u25")
             self._verify_requests(mock_http, creds,
                                   "runs/delete", "POST",
                                   message_to_json(DeleteRun(run_id="u25")))
 
-        with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
+        with mock.patch('mlflow.store.rest_store.http_request') as mock_http:
             store.restore_run("u76")
             self._verify_requests(mock_http, creds,
                                   "runs/restore", "POST",
                                   message_to_json(RestoreRun(run_id="u76")))
 
-        with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
+        with mock.patch('mlflow.store.rest_store.http_request') as mock_http:
             store.delete_experiment("0")
             self._verify_requests(mock_http, creds,
                                   "experiments/delete", "POST",
                                   message_to_json(DeleteExperiment(experiment_id="0")))
 
-        with mock.patch('mlflow.store.rest_store.http_request_safe') as mock_http:
+        with mock.patch('mlflow.store.rest_store.http_request') as mock_http:
             store.restore_experiment("0")
             self._verify_requests(mock_http, creds,
                                   "experiments/restore", "POST",

--- a/tests/utils/test_exception.py
+++ b/tests/utils/test_exception.py
@@ -1,9 +1,11 @@
+import json
 from mlflow.exceptions import ExecutionException, RestException
 
 
 def test_execution_exception_string_repr():
     exc = ExecutionException("Uh oh")
     assert str(exc) == "Uh oh"
+    json.loads(exc.serialize_as_json())
 
 
 def test_rest_exception_default_error_code():
@@ -16,14 +18,17 @@ def test_rest_exception_error_code_is_not_none():
     exc = RestException({"message": error_string})
     assert "None" not in error_string
     assert "None" not in str(exc)
+    json.loads(exc.serialize_as_json())
 
 
 def test_rest_exception_without_message():
     exc = RestException({"my_property": "something important."})
     assert "something important." in str(exc)
+    json.loads(exc.serialize_as_json())
 
 
 def test_rest_exception_error_code_and_no_message():
     exc = RestException({"error_code": 2, "messages": "something important."})
     assert "something important." in str(exc)
     assert "2" in str(exc)
+    json.loads(exc.serialize_as_json())

--- a/tests/utils/test_exception.py
+++ b/tests/utils/test_exception.py
@@ -16,3 +16,14 @@ def test_rest_exception_error_code_is_not_none():
     exc = RestException({"message": error_string})
     assert "None" not in error_string
     assert "None" not in str(exc)
+
+
+def test_rest_exception_without_message():
+    exc = RestException({"my_property": "something important."})
+    assert "something important." in str(exc)
+
+
+def test_rest_exception_error_code_and_no_message():
+    exc = RestException({"error_code": 2, "messages": "something important."})
+    assert "something important." in str(exc)
+    assert "2" in str(exc)


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Refactor rest_utils to separate http_request_safe into two components. Allow RestStore to override the default deserialization of the response from http_request.

 
## How is this patch tested?
An override test was added. Verification of the internal error strings not being dropped is added. Original http_request_safe continued to run as before.
 
(Details)
 
## Release Notes
 
### Is this a user-facing change? 

- [ X ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ X ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ X ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
