### PR TITLE
Simplify "mlflow ui" command and clarify relationship to "mlflow server"

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -153,17 +153,12 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, b
               help="Path to local directory to store artifacts, for new experiments. "
                    "Note that this flag does not impact already-created experiments. "
                    "Default: " + DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
-@click.option("--host", "-h", metavar="HOST", default="127.0.0.1",
-              help="The network address to listen on (default: 127.0.0.1). "
-                   "Use 0.0.0.0 to bind to all addresses if you want to access the UI from "
-                   "other machines.")
 @click.option("--port", "-p", default=5000,
               help="The port to listen on (default: 5000).")
-@click.option("--gunicorn-opts", default=None,
-              help="Additional command line options forwarded to gunicorn processes.")
-def ui(backend_store_uri, default_artifact_root, host, port, gunicorn_opts):
+def ui(backend_store_uri, default_artifact_root, host, port):
     """
-    Launch the MLflow tracking UI.
+    Launch the MLflow tracking UI for local viewing of run results. To launch a production
+    server, use the "mlflow server" command instead.
 
     The UI will be visible at http://localhost:5000 by default.
     """
@@ -179,7 +174,7 @@ def ui(backend_store_uri, default_artifact_root, host, port, gunicorn_opts):
 
     # TODO: We eventually want to disable the write path in this version of the server.
     try:
-        _run_server(backend_store_uri, default_artifact_root, host, port, 1, None, gunicorn_opts)
+        _run_server(backend_store_uri, default_artifact_root, "127.0.0.1", port, 1, None, [])
     except ShellCommandException:
         eprint("Running the mlflow server failed. Please see the logs above for details.")
         sys.exit(1)
@@ -210,7 +205,8 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 @click.option("--default-artifact-root", metavar="URI", default=None,
               help="Local or S3 URI to store artifacts, for new experiments. "
                    "Note that this flag does not impact already-created experiments. "
-                   "Default: Within file store")
+                   "Default: Within file store, if a file:/ URI is provided. If a sql backend is"
+                   " used, then this option is required.")
 @click.option("--host", "-h", metavar="HOST", default="127.0.0.1",
               help="The network address to listen on (default: 127.0.0.1). "
                    "Use 0.0.0.0 to bind to all addresses if you want to access the tracking "

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -155,7 +155,7 @@ def run(uri, entry_point, version, param_list, experiment_name, experiment_id, b
                    "Default: " + DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
 @click.option("--port", "-p", default=5000,
               help="The port to listen on (default: 5000).")
-def ui(backend_store_uri, default_artifact_root, host, port):
+def ui(backend_store_uri, default_artifact_root, port):
     """
     Launch the MLflow tracking UI for local viewing of run results. To launch a production
     server, use the "mlflow server" command instead.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, both "mlflow ui" and "mlflow server" take similar arguments and do similar things. "mlflow ui" is intended for very simple local use-cases, though, while "mlflow server" is intended for hosting servers. Here we disallow setting the "--host" and "--gunicorn-opts" options on "mlflow ui" and refer users to "mlflow server" instead.
