### PR TITLE
Use max precision in toJSON for R model serving

### DIFF
--- a/mlflow/R/mlflow/R/model-serve.R
+++ b/mlflow/R/mlflow/R/model-serve.R
@@ -156,7 +156,8 @@ serve_handlers <- function(host, port) {
           "Content-Type" = paste0(serve_content_type("json"), "; charset=UTF-8")
         ),
         body = charToRaw(enc2utf8(
-          jsonlite::toJSON(list(predictions = results), auto_unbox = TRUE)
+          jsonlite::toJSON(list(predictions = results), auto_unbox = TRUE,
+                           digits = NA)
         ))
       )
     },


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Use maximum precision for serializing predictions from R models to JSON. See also https://github.com/mlflow/mlflow/pull/1191.
 
## How is this patch tested?
 
Existing unit tests.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [x] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
