### PR TITLE
[UI] Round 2: Preferentially read user from tag over attribute

### DIFF
--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -244,7 +244,7 @@ class RunView extends Component {
           }
           <div className="run-info">
             <span className="metadata-header">User: </span>
-            <span className="metadata-info">{run.getUserId()}</span>
+            <span className="metadata-info">{Utils.getUser(run, tags)}</span>
           </div>
           {duration !== null ?
             <div className="run-info">

--- a/mlflow/server/js/src/sdk/MlflowMessages.js
+++ b/mlflow/server/js/src/sdk/MlflowMessages.js
@@ -157,9 +157,6 @@ const extended_RunInfo = ModelBuilder.extend(RunInfo, {
   getExperimentId() {
     return this.experiment_id !== undefined ? this.experiment_id : 0;
   },
-  getUserId() {
-    return this.user_id !== undefined ? this.user_id : '';
-  },
   getStatus() {
     return this.status !== undefined ? this.status : 'RUNNING';
   },


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Pulled the trigger too fast on #1275 (looked only for references to user_id, not UserId). This allows the tag to be used as the canonical source for the RunView page.
 