### PR TITLE
Fix GCS Artifact Logging of Subdirectories

### DIFF
--- a/mlflow/store/gcs_artifact_repo.py
+++ b/mlflow/store/gcs_artifact_repo.py
@@ -56,7 +56,7 @@ class GCSArtifactRepository(ArtifactRepository):
         for (root, _, filenames) in os.walk(local_dir):
             upload_path = dest_path
             if root != local_dir:
-                rel_path = os.path.relpath(local_dir, root)
+                rel_path = os.path.relpath(root, local_dir)
                 rel_path = relative_path_to_artifact_path(rel_path)
                 upload_path = posixpath.join(dest_path, rel_path)
             for f in filenames:


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Correcting the use of `os.path.relpath` when preparing to upload artifacts from the staged/temp directory to GCS. This will resolve the following bug: https://github.com/mlflow/mlflow/issues/1281
 
## How is this patch tested?

Log a model with artifacts locally, then use `get_artifact_repository` with a GCS bucket to get the `GCSArtifactRepository` and call `log_artifacts` passing the path of the local run and artifacts.
```
from mlflow.store.artifact_repository_registry import get_artifact_repository

artifact_repo = get_artifact_repository('gs://<bucket>/test')
artifact_repo.log_artifacts('<existing-local-run>/artifacts')
```
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [x] Artifacts 
- [x] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes