### PR TITLE
Fix formatting bugs in contributor guide

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -155,6 +155,7 @@ run tests annotated with @pytest.mark.large. For example, to run all pyfunc test
 (including large tests), you can run:
 
 .. code-block:: bash
+
     pytest tests/pyfunc --large
 
 Note: Certain model tests are not well-isolated (can result in OOMs when run in the same Python
@@ -185,19 +186,19 @@ MLflow's Tracking component supports storing experiment and run data in a SQL ba
 make changes to the tracking database schema, run the following from your
 checkout of MLflow:
 
-```
-# starting at the root of the project
-$ pwd
-~/mlflow
-$ cd mlflow
-# MLflow relies on Alembic (https://alembic.sqlalchemy.org) for schema migrations.
-$ alembic revision -m "add new field to db"
-  Generating ~/mlflow/mlflow/alembic/versions/12341123_add_new_field_to_db.py
+.. code-block:: bash
 
-```
+    # starting at the root of the project
+    $ pwd
+    ~/mlflow
+    $ cd mlflow
+    # MLflow relies on Alembic (https://alembic.sqlalchemy.org) for schema migrations.
+    $ alembic revision -m "add new field to db"
+      Generating ~/mlflow/mlflow/alembic/versions/12341123_add_new_field_to_db.py
+
 
 These commands generate a new migration script (e.g. at
-~/mlflow/mlflow/alembic/versions/12341123_add_new_field_to_db.py) that you should then edit to add
+``~/mlflow/mlflow/alembic/versions/12341123_add_new_field_to_db.py``) that you should then edit to add
 migration logic.
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fix small formatting bugs in the MLflow contributor guide that result in some sections not showing up or appearing malformed in https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst
 
## How is this patch tested?
Manually viewing the updated .rst files 
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
