### PR TITLE
Add Environment Variable for S3 Upload File ExtraArgs as per issue #1298

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -542,6 +542,15 @@ the environment variables ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY`` de
 these are available. For more information on how to set credentials, see
 `Set up AWS Credentials and Region for Development <https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/setup-credentials.html>`_.
 
+To add S3 file upload extra arguments, set ``MLFLOW_S3_UPLOAD_EXTRA_ARGS`` to a JSON object of key/value pairs.
+For example, if you want to upload to a KMS Encrypted bucket using the KMS Key 1234:
+
+.. code-block:: bash
+
+  export MLFLOW_S3_UPLOAD_EXTRA_ARGS="{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"1234\"}"
+
+For a list of available extra args see `Boto3 ExtraArgs Documentation <https://github.com/boto/boto3/blob/develop/docs/source/guide/s3-uploading-files.rst#the-extraargs-parameter>`_.
+
 To store artifacts in a custom endpoint, set the ``MLFLOW_S3_ENDPOINT_URL`` to your endpoint's URL.
 For example, if you have a MinIO server at 1.2.3.4 on port 9000:
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -547,7 +547,7 @@ For example, if you want to upload to a KMS Encrypted bucket using the KMS Key 1
 
 .. code-block:: bash
 
-  export MLFLOW_S3_UPLOAD_EXTRA_ARGS="{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"1234\"}"
+  export MLFLOW_S3_UPLOAD_EXTRA_ARGS='{"ServerSideEncryption": "aws:kms", "SSEKMSKeyId": "1234"}'
 
 For a list of available extra args see `Boto3 ExtraArgs Documentation <https://github.com/boto/boto3/blob/develop/docs/source/guide/s3-uploading-files.rst#the-extraargs-parameter>`_.
 

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -23,6 +23,15 @@ class S3ArtifactRepository(ArtifactRepository):
             path = path[1:]
         return parsed.netloc, path
 
+    @staticmethod
+    def get_s3_file_upload_extra_args():
+        import json
+        s3_file_upload_extra_args = os.environ.get('MLFLOW_S3_UPLOAD_EXTRA_ARGS')
+        if s3_file_upload_extra_args:
+            return json.loads(s3_file_upload_extra_args)
+        else:
+            return None
+
     def _get_s3_client(self):
         import boto3
         s3_endpoint_url = os.environ.get('MLFLOW_S3_ENDPOINT_URL')
@@ -35,7 +44,7 @@ class S3ArtifactRepository(ArtifactRepository):
         dest_path = posixpath.join(
             dest_path, os.path.basename(local_file))
         s3_client = self._get_s3_client()
-        s3_client.upload_file(local_file, bucket, dest_path)
+        s3_client.upload_file(local_file, bucket, dest_path, self.get_s3_file_upload_extra_args())
 
     def log_artifacts(self, local_dir, artifact_path=None):
         (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)
@@ -53,7 +62,8 @@ class S3ArtifactRepository(ArtifactRepository):
                 s3_client.upload_file(
                         os.path.join(root, f),
                         bucket,
-                        posixpath.join(upload_path, f))
+                        posixpath.join(upload_path, f),
+                        self.get_s3_file_upload_extra_args())
 
     def list_artifacts(self, path=None):
         (bucket, artifact_path) = data.parse_s3_uri(self.artifact_uri)

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -48,7 +48,7 @@ class S3ArtifactRepository(ArtifactRepository):
             Filename=local_file,
             Bucket=bucket,
             Key=dest_path,
-            ExtraArgs=self.get_s3_file_upload_extra_args)
+            ExtraArgs=self.get_s3_file_upload_extra_args())
 
     def log_artifacts(self, local_dir, artifact_path=None):
         (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -34,8 +34,11 @@ class S3ArtifactRepository(ArtifactRepository):
 
     def _get_s3_client(self):
         import boto3
+        from botocore.client import Config
         s3_endpoint_url = os.environ.get('MLFLOW_S3_ENDPOINT_URL')
-        return boto3.client('s3', endpoint_url=s3_endpoint_url)
+        return boto3.client('s3',
+                            config=Config(signature_version='s3v4'),
+                            endpoint_url=s3_endpoint_url)
 
     def log_artifact(self, local_file, artifact_path=None):
         (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -44,7 +44,11 @@ class S3ArtifactRepository(ArtifactRepository):
         dest_path = posixpath.join(
             dest_path, os.path.basename(local_file))
         s3_client = self._get_s3_client()
-        s3_client.upload_file(local_file, bucket, dest_path, self.get_s3_file_upload_extra_args())
+        s3_client.upload_file(
+            Filename=local_file,
+            Bucket=bucket,
+            Key=dest_path,
+            ExtraArgs=self.get_s3_file_upload_extra_args)
 
     def log_artifacts(self, local_dir, artifact_path=None):
         (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)
@@ -60,10 +64,10 @@ class S3ArtifactRepository(ArtifactRepository):
                 upload_path = posixpath.join(dest_path, rel_path)
             for f in filenames:
                 s3_client.upload_file(
-                        os.path.join(root, f),
-                        bucket,
-                        posixpath.join(upload_path, f),
-                        self.get_s3_file_upload_extra_args())
+                        Filename=os.path.join(root, f),
+                        Bucket=bucket,
+                        Key=posixpath.join(upload_path, f),
+                        ExtraArgs=self.get_s3_file_upload_extra_args())
 
     def list_artifacts(self, path=None):
         (bucket, artifact_path) = data.parse_s3_uri(self.artifact_uri)

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -36,8 +36,11 @@ class S3ArtifactRepository(ArtifactRepository):
         import boto3
         from botocore.client import Config
         s3_endpoint_url = os.environ.get('MLFLOW_S3_ENDPOINT_URL')
+        # NOTE: If you need to specify this env variable, please file an issue at
+        # https://github.com/mlflow/mlflow/issues so we know your use-case!
+        signature_version = os.environ.get('MLFLOW_EXPERIMENTAL_S3_SIGNATURE_VERSION', 's3v4')
         return boto3.client('s3',
-                            config=Config(signature_version='s3v4'),
+                            config=Config(signature_version=signature_version),
                             endpoint_url=s3_endpoint_url)
 
     def log_artifact(self, local_file, artifact_path=None):

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -4,6 +4,7 @@ import posixpath
 import pytest
 
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
+from mlflow.store.s3_artifact_repo import S3ArtifactRepository
 
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
@@ -12,6 +13,11 @@ from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-impo
 @pytest.fixture
 def s3_artifact_root(mock_s3_bucket):
     return "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
+
+
+def teardown_function():
+    if 'MLFLOW_S3_UPLOAD_EXTRA_ARGS' in os.environ:
+        del os.environ['MLFLOW_S3_UPLOAD_EXTRA_ARGS']
 
 
 def test_file_artifact_is_logged_and_downloaded_successfully(s3_artifact_root, tmpdir):
@@ -127,3 +133,26 @@ def test_download_file_artifact_succeeds_when_artifact_root_is_s3_bucket_root(
     downloaded_file_path = repo.download_artifacts(file_a_name)
     with open(downloaded_file_path, "r") as f:
         assert f.read() == file_a_text
+
+
+def test_get_s3_file_upload_extra_args():
+    os.environ.setdefault('MLFLOW_S3_UPLOAD_EXTRA_ARGS',
+                          '{"ServerSideEncryption": "aws:kms", "SSEKMSKeyId": "123456"}')
+
+    parsed_args = S3ArtifactRepository.get_s3_file_upload_extra_args()
+
+    assert parsed_args == {'ServerSideEncryption': 'aws:kms', 'SSEKMSKeyId': '123456'}
+
+
+def test_get_s3_file_upload_extra_args_env_var_not_present():
+    parsed_args = S3ArtifactRepository.get_s3_file_upload_extra_args()
+
+    assert parsed_args is None
+
+
+def test_get_s3_file_upload_extra_args_invalid_json():
+    os.environ.setdefault('MLFLOW_S3_UPLOAD_EXTRA_ARGS',
+                          '"ServerSideEncryption": "aws:kms", "SSEKMSKeyId": "123456"}')
+
+    with pytest.raises(ValueError):
+        S3ArtifactRepository.get_s3_file_upload_extra_args()

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -4,7 +4,7 @@ import posixpath
 import pytest
 
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
-from mlflow.store.s3_artifact_repo import S3ArtifactRepository
+from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import


### PR DESCRIPTION
Co-authored-by: Keith Hall <keith@flyingkitesconsulting.com>
Co-authored-by: Austin Poulton <austin.poulton@gmail.com>

## What changes are proposed in this pull request?
 
Add Environment Variable for S3 Upload File ExtraArgs as per issue #1298

## How is this patch tested?
 
Unit tests in `test_s3_artifact_repo.py`
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Optional `MLFLOW_S3_UPLOAD_EXTRA_ARGS` environment variable added to enable setting of Boto3 S3 File Upload ExtraArgs on logging of Artefacts.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [X] Docs
- [X] Tracking
- [ ] Projects 
- [X] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
