### PR TITLE
Change mentions of MLProject -> MLproject

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -59,7 +59,7 @@ By default, any Git repository or local directory can be treated as an MLflow pr
 invoke any bash or Python script contained in the directory as a project entry point. The 
 :ref:`project-directories` section describes how MLflow interprets directories as projects.
 
-To provide additional control over a project's attributes, you can also include an :ref:`MLProject
+To provide additional control over a project's attributes, you can also include an :ref:`MLproject
 file <mlproject-file>` in your project's repository or directory.
 
 Finally, MLflow projects allow you to specify the software :ref:`environment <project-environments>`
@@ -84,7 +84,7 @@ Conda environment
 
   You can specify a Conda environment for your MLflow project by including a ``conda.yaml``
   file in the root of the project directory or by including a ``conda_env`` entry in your
-  ``MLProject`` file. For details, see the :ref:`project-directories` and :ref:`mlproject-specify-environment` sections.
+  ``MLproject`` file. For details, see the :ref:`project-directories` and :ref:`mlproject-specify-environment` sections.
 
 .. _project-docker-container-environments:
 
@@ -110,15 +110,15 @@ Docker container environment
   project with a Docker environment.
 
   To specify a Docker container environment, you *must* add an 
-  :ref:`MLProject file <mlproject-file>` to your project. For information about specifying
-  a Docker container environment in an ``MLProject`` file, see
+  :ref:`MLproject file <mlproject-file>` to your project. For information about specifying
+  a Docker container environment in an ``MLproject`` file, see
   :ref:`mlproject-specify-environment`.
     
 System environment
   You can also run MLflow Projects directly in your current system environment. All of the 
   project's dependencies must be installed on your system prior to project execution. The system 
   environment is supplied at runtime. It is not part of the MLflow Project's directory contents 
-  or ``MLProject`` file. For information about using the system environment when running 
+  or ``MLproject`` file. For information about using the system environment when running 
   a project, see the ``Environment`` parameter description in the :ref:`running-projects` section. 
 
 .. _project-directories:
@@ -126,7 +126,7 @@ System environment
 Project Directories
 ^^^^^^^^^^^^^^^^^^^
 
-When running an MLflow Project directory or repository that does *not* contain an ``MLProject`` 
+When running an MLflow Project directory or repository that does *not* contain an ``MLproject`` 
 file, MLflow uses the following conventions to determine the project's attributes:
 
 * The project's name is the name of the directory.
@@ -141,7 +141,7 @@ file, MLflow uses the following conventions to determine the project's attribute
   the ``.sh`` extension. For more information about specifying project entrypoints at runtime,
   see :ref:`running-projects`.
 
-* By default, entry points do not have any parameters when an ``MLProject`` file is not included.
+* By default, entry points do not have any parameters when an ``MLproject`` file is not included.
   Parameters can be supplied at runtime via the ``mlflow run`` CLI or the 
   :py:func:`mlflow.projects.run` Python API. Runtime parameters are passed to the entry point on the 
   command line using ``--key value`` syntax. For more information about running projects and
@@ -149,12 +149,12 @@ file, MLflow uses the following conventions to determine the project's attribute
 
 .. _mlproject-file: 
 
-MLProject File
+MLproject File
 ^^^^^^^^^^^^^^
 
 You can get more control over an MLflow Project by adding an ``MLproject`` file, which is a text
 file in YAML syntax, to the project's root directory. The following is an example of an 
-``MLProject`` file: 
+``MLproject`` file: 
 
 .. code-block:: yaml
 
@@ -186,11 +186,11 @@ Specifically, each entry point defines a :ref:`command to run <mlproject-command
 Specifying an Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This section describes how to specify Conda and Docker container environments in an ``MLProject`` file.
-``MLProject`` files cannot specify *both* a Conda environment and a Docker environment.
+This section describes how to specify Conda and Docker container environments in an ``MLproject`` file.
+``MLproject`` files cannot specify *both* a Conda environment and a Docker environment.
 
 Conda environment
-  Include a top-level ``conda_env`` entry in the ``MLProject`` file.
+  Include a top-level ``conda_env`` entry in the ``MLproject`` file.
   The value of this entry must be a *relative* path to a `Conda environment YAML file 
   <https://conda.io/docs/user-guide/tasks/manage-environments.html#create-env-file-manually>`_
   within the MLflow project's directory. In the following example: 
@@ -204,7 +204,7 @@ Conda environment
   ``<MLFLOW_PROJECT_DIRECTORY>`` is the path to the MLflow project's root directory.
 
 Docker container environment
-  Include a top-level ``docker_env`` entry in the ``MLProject`` file. The value of this entry must be the name
+  Include a top-level ``docker_env`` entry in the ``MLproject`` file. The value of this entry must be the name
   of a Docker image that is accessible on the system executing the project; this image name
   may include a registry path and tags. Here are a couple of examples.
 
@@ -327,7 +327,7 @@ Deployment Mode
 
 Environment
     By default, MLflow Projects are run in the environment specified by the project directory
-    or the ``MLProject`` file (see :ref:`Specifying Project Environments <project-environments>`).
+    or the ``MLproject`` file (see :ref:`Specifying Project Environments <project-environments>`).
     You can ignore a project's specified environment and run the project in the current
     system environment by supplying the ``--no-conda`` flag.
 

--- a/examples/docker/README.rst
+++ b/examples/docker/README.rst
@@ -14,7 +14,7 @@ MLflow Tracking APIs to log the model and its metadata (e.g., hyperparameters an
 for later use and reference. ``train.py`` operates on the Wine Quality Dataset, which is included
 in ``wine-quality.csv``.
 
-Most importantly, the project also includes an ``MLProject`` file, which specifies the Docker 
+Most importantly, the project also includes an ``MLproject`` file, which specifies the Docker 
 container environment in which to run the project using the ``docker_env`` field:
 
 .. code-block:: yaml

--- a/examples/docker/README.rst
+++ b/examples/docker/README.rst
@@ -27,7 +27,7 @@ image (see `Docker docs <https://docs.docker.com/engine/reference/run/#general-f
 example references a locally-stored image (``mlflow-docker-example``) by tag.
 
 Finally, the project includes a ``Dockerfile`` that is used to build the image referenced by the
-``MLProject`` file. The ``Dockerfile`` specifies library dependencies required by the project, such 
+``MLproject`` file. The ``Dockerfile`` specifies library dependencies required by the project, such 
 as ``mlflow`` and ``scikit-learn``.
 
 Running this Example
@@ -46,7 +46,7 @@ name:
   docker build -t mlflow-docker-example -f Dockerfile .
 
 Note that the name if the image used in the ``docker build`` command, ``mlflow-docker-example``, 
-matches the name of the image referenced in the ``MLProject`` file.
+matches the name of the image referenced in the ``MLproject`` file.
 
 Finally, run the example project using ``mlflow run examples/docker -P alpha=0.5``.
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -115,7 +115,7 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
     elif backend == "local" or backend is None:
         command = []
         command_separator = " "
-        # If a docker_env attribute is defined in MLProject then it takes precedence over conda yaml
+        # If a docker_env attribute is defined in MLproject then it takes precedence over conda yaml
         # environments, so the project will be executed inside a docker container.
         if project.docker_env:
             tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_ENV, "docker")
@@ -694,7 +694,7 @@ def _build_docker_image(work_dir, project, active_run):
     built image with the project name specified by `project`.
     """
     if not project.name:
-        raise ExecutionException("Project name in MLProject must be specified when using docker "
+        raise ExecutionException("Project name in MLproject must be specified when using docker "
                                  "for image tagging.")
     tag_name = "mlflow-{name}-{version}".format(
         name=(project.name if project.name else "docker-project"),

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -21,7 +21,7 @@ RUN_ID = click.option("--run-id", "-r", default=None, required=False, metavar="I
                       help="ID of the MLflow run that generated the referenced content.")
 
 NO_CONDA = click.option("--no-conda", is_flag=True,
-                        help="If specified, will assume that MLModel/MLProject is running within "
+                        help="If specified, will assume that MLModel/MLproject is running within "
                              "a Conda environmen with the necessary dependencies for "
                              "the current project instead of attempting to create a new "
                              "conda environment.")


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Our MLflow projects only work if the file is called `MLproject`. In our docs, we sometimes confusingly call it `MLProject` which can cause hard to diagnose errors.

In the future, we can also consider being flexible in accepting both `MLproject` and `MLProject`.

 
## How is this patch tested?
 
`git grep MLProject` 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
