### PR TITLE
Pin travis env to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+dist: trusty
+
 services:
   - docker
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Travis autoupgraded our build environment from trusty to xenial ([link](https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment)), which resulted in a JDK upgrade that breaks Spark tests in our master build (see [this build](https://travis-ci.org/mlflow/mlflow/builds/535420049) for example). This PR pins the environment to trusty (as it was before) as described [here](https://docs.travis-ci.com/user/reference/trusty/#using-trusty). Long term we should get tests to pass against xenial.
 
## How is this patch tested?
 
Is own test.

## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
