### PR TITLE
[R] Fix search runs bug & add test

### DIFF
--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -1122,7 +1122,8 @@ Arguments
 +-------------------------------+--------------------------------------+
 | ``run_view_type``             | Run view type.                       |
 +-------------------------------+--------------------------------------+
-| ``experiment_ids``            | List of string experiment IDs to     |
+| ``experiment_ids``            | List of string experiment IDs (or a  |
+|                               | single string experiment ID) to      |
 |                               | search over. Attempts to use active  |
 |                               | experiment if not specified.         |
 +-------------------------------+--------------------------------------+

--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -471,7 +471,7 @@ the supported MLflow models.
 
 .. code:: r
 
-   mlflow_load_flavor(model_path)
+   mlflow_load_flavor(flavor, model_path)
 
 .. _arguments-13:
 
@@ -481,6 +481,8 @@ Arguments
 +----------------+------------------------------------------------------------+
 | Argument       | Description                                                |
 +================+============================================================+
+| ``flavor``     | An MLflow flavor object.                                   |
++----------------+------------------------------------------------------------+
 | ``model_path`` | The path to the MLflow model wrapped in the correct class. |
 +----------------+------------------------------------------------------------+
 
@@ -926,7 +928,7 @@ Serves an RFunc MLflow model as a local web API.
 .. code:: r
 
    mlflow_rfunc_serve(model_uri, host = "127.0.0.1", port = 8090,
-     daemonized = FALSE, browse = !daemonized)
+     daemonized = FALSE, browse = !daemonized, ...)
 
 .. _arguments-25:
 
@@ -955,6 +957,9 @@ Arguments
 +-------------------------------+--------------------------------------+
 | ``browse``                    | Launch browser with serving landing  |
 |                               | page?                                |
++-------------------------------+--------------------------------------+
+| ``...``                       | Optional arguments passed to         |
+|                               | ``mlflow_predict()``.                |
 +-------------------------------+--------------------------------------+
 
 .. _details-20:
@@ -1117,8 +1122,8 @@ Arguments
 +-------------------------------+--------------------------------------+
 | ``run_view_type``             | Run view type.                       |
 +-------------------------------+--------------------------------------+
-| ``experiment_ids``            | List of experiment IDs to search     |
-|                               | over. Attempts to use active         |
+| ``experiment_ids``            | List of string experiment IDs to     |
+|                               | search over. Attempts to use active  |
 |                               | experiment if not specified.         |
 +-------------------------------+--------------------------------------+
 | ``client``                    | (Optional) An ``mlflow_client``      |
@@ -1346,7 +1351,7 @@ Examples
 
 .. code:: r
 
-    list("\n", "with(mlflow_start_run(), {\n", "  mlflow_log(\"test\", 10)\n", "})\n") 
+    list("\n", "with(mlflow_start_run(), {\n", "  mlflow_log_metric(\"test\", 10)\n", "})\n") 
     
 
 Run MLflow User Interface

--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -24,6 +24,7 @@ Depends:
   R (>= 3.3.0)
 Imports:
   base64enc,
+  dplyr,
   forge,
   fs,
   git2r,

--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -246,7 +246,7 @@ mlflow_get_metric_history <- function(metric_key, run_id = NULL, client = NULL) 
 #' Search for runs that satisfy expressions. Search expressions can use Metric and Param keys.
 #'
 #' @template roxlate-client
-#' @param experiment_ids List of experiment IDs to search over. Attempts to use active experiment if not specified.
+#' @param experiment_ids List of string experiment IDs to search over. Attempts to use active experiment if not specified.
 #' @param filter A filter expression over params, metrics, and tags, allowing returning a subset of runs.
 #'   The syntax is a subset of SQL which allows only ANDing together binary operations between a param/metric/tag and a constant.
 #' @param run_view_type Run view type.
@@ -256,10 +256,14 @@ mlflow_search_runs <- function(filter = NULL,
                                run_view_type = c("ACTIVE_ONLY", "DELETED_ONLY", "ALL"), experiment_ids = NULL,
                                client = NULL) {
   experiment_ids <- resolve_experiment_id(experiment_ids)
+  # If we get back a single experiment ID, e.g. the active experiment ID, convert it to a list
+  if (is.atomic(experiment_ids)) {
+    experiment_ids <- list(experiment_ids)
+  }
   client <- resolve_client(client)
 
   run_view_type <- match.arg(run_view_type)
-  experiment_ids <- cast_double_list(experiment_ids)
+  experiment_ids <- cast_string_list(experiment_ids)
   filter <- cast_nullable_string(filter)
 
   response <- mlflow_rest("runs", "search", client = client, verb = "POST", data = list(
@@ -465,7 +469,7 @@ mlflow_log_artifact <- function(path, artifact_path = NULL, run_id = NULL, clien
 #' @examples
 #' \dontrun{
 #' with(mlflow_start_run(), {
-#'   mlflow_log("test", 10)
+#'   mlflow_log_metric("test", 10)
 #' })
 #' }
 #'

--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -246,7 +246,8 @@ mlflow_get_metric_history <- function(metric_key, run_id = NULL, client = NULL) 
 #' Search for runs that satisfy expressions. Search expressions can use Metric and Param keys.
 #'
 #' @template roxlate-client
-#' @param experiment_ids List of string experiment IDs to search over. Attempts to use active experiment if not specified.
+#' @param experiment_ids List of string experiment IDs (or a single string experiment ID) to search
+#' over. Attempts to use active experiment if not specified.
 #' @param filter A filter expression over params, metrics, and tags, allowing returning a subset of runs.
 #'   The syntax is a subset of SQL which allows only ANDing together binary operations between a param/metric/tag and a constant.
 #' @param run_view_type Run view type.

--- a/mlflow/R/mlflow/man/mlflow_search_runs.Rd
+++ b/mlflow/R/mlflow/man/mlflow_search_runs.Rd
@@ -13,7 +13,8 @@ The syntax is a subset of SQL which allows only ANDing together binary operation
 
 \item{run_view_type}{Run view type.}
 
-\item{experiment_ids}{List of string experiment IDs to search over. Attempts to use active experiment if not specified.}
+\item{experiment_ids}{List of string experiment IDs (or a single string experiment ID) to search
+over. Attempts to use active experiment if not specified.}
 
 \item{client}{(Optional) An `mlflow_client` object.}
 }

--- a/mlflow/R/mlflow/man/mlflow_search_runs.Rd
+++ b/mlflow/R/mlflow/man/mlflow_search_runs.Rd
@@ -13,7 +13,7 @@ The syntax is a subset of SQL which allows only ANDing together binary operation
 
 \item{run_view_type}{Run view type.}
 
-\item{experiment_ids}{List of experiment IDs to search over. Attempts to use active experiment if not specified.}
+\item{experiment_ids}{List of string experiment IDs to search over. Attempts to use active experiment if not specified.}
 
 \item{client}{(Optional) An `mlflow_client` object.}
 }

--- a/mlflow/R/mlflow/man/mlflow_start_run.Rd
+++ b/mlflow/R/mlflow/man/mlflow_start_run.Rd
@@ -33,7 +33,7 @@ When `client` is not specified, these functions attempt to infer the current act
 \examples{
 \dontrun{
 with(mlflow_start_run(), {
-  mlflow_log("test", 10)
+  mlflow_log_metric("test", 10)
 })
 }
 

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -237,9 +237,9 @@ test_that("mlflow_search_runs() works", {
     mlflow_log_metric("test", 20)
   })
   expect_equal(nrow(mlflow_search_runs(experiment_id = 0)), 2)
-  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 10", experiment_id = 0)), 1)
-  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test < 20", experiment_id = 0)), 1)
-  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 20", experiment_id = 0)), 0)
+  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 10", experiment_id = "0")), 1)
+  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test < 20", experiment_id = "0")), 1)
+  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 20", experiment_id = "0")), 0)
   mlflow_set_experiment("new-experiment")
   expect_equal(nrow(mlflow_search_runs()), 0)
   with(mlflow_start_run(), {
@@ -250,11 +250,11 @@ test_that("mlflow_search_runs() works", {
 
 test_that("mlflow_list_run_infos() works", {
   mlflow_clear_test_dir("mlruns")
-  expect_equal(nrow(mlflow_list_run_infos(experiment_id = 0)), 0)
+  expect_equal(nrow(mlflow_list_run_infos(experiment_id = "0")), 0)
   with(mlflow_start_run(), {
     mlflow_log_metric("test", 10)
   })
-  expect_equal(nrow(mlflow_list_run_infos(experiment_id = 0)), 1)
+  expect_equal(nrow(mlflow_list_run_infos(experiment_id = "0")), 1)
   mlflow_set_experiment("new-experiment")
   expect_equal(nrow(mlflow_list_run_infos()), 0)
   with(mlflow_start_run(), {

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -228,6 +228,41 @@ test_that("with() errors when not passed active run", {
   )
 })
 
+test_that("mlflow_search_runs() works", {
+  mlflow_clear_test_dir("mlruns")
+  with(mlflow_start_run(), {
+    mlflow_log_metric("test", 10)
+  })
+  with(mlflow_start_run(), {
+    mlflow_log_metric("test", 20)
+  })
+  expect_equal(nrow(mlflow_search_runs(experiment_id = 0)), 2)
+  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 10", experiment_id = 0)), 1)
+  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test < 20", experiment_id = 0)), 1)
+  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 20", experiment_id = 0)), 0)
+  mlflow_set_experiment("new-experiment")
+  expect_equal(nrow(mlflow_search_runs()), 0)
+  with(mlflow_start_run(), {
+    mlflow_log_metric("new_experiment_metric", 30)
+  })
+  expect_equal(nrow(mlflow_search_runs(filter = "metrics.new_experiment = 30")), 1)
+})
+
+test_that("mlflow_list_run_infos() works", {
+  mlflow_clear_test_dir("mlruns")
+  expect_equal(nrow(mlflow_list_run_infos(experiment_id = 0)), 0)
+  with(mlflow_start_run(), {
+    mlflow_log_metric("test", 10)
+  })
+  expect_equal(nrow(mlflow_list_run_infos(experiment_id = 0)), 1)
+  mlflow_set_experiment("new-experiment")
+  expect_equal(nrow(mlflow_list_run_infos()), 0)
+  with(mlflow_start_run(), {
+    mlflow_log_metric("new_experiment_metric", 20)
+  })
+  expect_equal(nrow(mlflow_list_run_infos()), 1)
+})
+
 test_that("mlflow_log_batch() works", {
   mlflow_clear_test_dir("mlruns")
   mlflow_start_run()

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -236,16 +236,16 @@ test_that("mlflow_search_runs() works", {
   with(mlflow_start_run(), {
     mlflow_log_metric("test", 20)
   })
-  expect_equal(nrow(mlflow_search_runs(experiment_id = "0")), 2)
-  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 10", experiment_id = "0")), 1)
-  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test < 20", experiment_id = "0")), 1)
-  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 20", experiment_id = "0")), 0)
+  expect_equal(nrow(mlflow_search_runs(experiment_ids = list("0"))), 2)
+  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 10", experiment_ids = list("0"))), 1)
+  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test < 20", experiment_ids = list("0"))), 1)
+  expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 20", experiment_ids = list("0"))), 0)
   mlflow_set_experiment("new-experiment")
   expect_equal(nrow(mlflow_search_runs()), 0)
   with(mlflow_start_run(), {
     mlflow_log_metric("new_experiment_metric", 30)
   })
-  expect_equal(nrow(mlflow_search_runs(filter = "metrics.new_experiment = 30")), 1)
+  expect_equal(nrow(mlflow_search_runs(filter = "metrics.new_experiment_metric = 30")), 1)
 })
 
 test_that("mlflow_list_run_infos() works", {

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -236,7 +236,7 @@ test_that("mlflow_search_runs() works", {
   with(mlflow_start_run(), {
     mlflow_log_metric("test", 20)
   })
-  expect_equal(nrow(mlflow_search_runs(experiment_id = 0)), 2)
+  expect_equal(nrow(mlflow_search_runs(experiment_id = "0")), 2)
   expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 10", experiment_id = "0")), 1)
   expect_equal(nrow(mlflow_search_runs(filter = "metrics.test < 20", experiment_id = "0")), 1)
   expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 20", experiment_id = "0")), 0)

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -237,6 +237,7 @@ test_that("mlflow_search_runs() works", {
     mlflow_log_metric("test", 20)
   })
   expect_equal(nrow(mlflow_search_runs(experiment_ids = list("0"))), 2)
+  expect_equal(nrow(mlflow_search_runs(experiment_ids = "0")), 2)
   expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 10", experiment_ids = list("0"))), 1)
   expect_equal(nrow(mlflow_search_runs(filter = "metrics.test < 20", experiment_ids = list("0"))), 1)
   expect_equal(nrow(mlflow_search_runs(filter = "metrics.test > 20", experiment_ids = list("0"))), 0)


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fixes bugs in `mlflow_search_run` and `mlflow_list_run_infos` within the R API, and adds a test verifying their correctness. In particular we:
* Include `dplyr` as a dependency so that we can safely call the `purrr::map_df` API in `mlflow_search_run` and `mlflow_list_run_infos` , which depends on `dplyr` as described in [this issue](https://github.com/tidyverse/purrr/issues/328). The `dplyr` package ([link](http://cloud.r-project.org/web/packages/dplyr/index.html)) itself doesn't seem that large (3.2 MB zip for Windows, 6.8 MB tgz for OSX), so seems ok to have as an MLflow dependency.
* Fixes bug where `mlflow_search_runs()` (without args) would fail due to failure to cast the active experiment ID (a string) to a double list, and posts experiment IDs as strings in mlflow_search_runs.
 
## How is this patch tested?
 
New unit tests verifying  `mlflow_search_run` and `mlflow_list_run_infos`  work.

## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Not user-visible, as the `mlflow_search_runs` API and `mlflow_list_run_infos` APIs aren't included in any existing releases.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [x] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
