### PR TITLE
Fix bug: change run_id to run_uuid in example/rest_api

### DIFF
--- a/examples/rest_api/mlflow_tracking_rest_api.py
+++ b/examples/rest_api/mlflow_tracking_rest_api.py
@@ -31,7 +31,7 @@ class MLFlowTrackingRestApi:
 		r = requests.post(url, json=payload)
 		run_id = None
 		if r.status_code == 200:
-			run_id = r.json()['run']['info']['run_id']
+			run_id = r.json()['run']['info']['run_uuid']
 		else:
 			print("Creating run failed!")
 		return run_id
@@ -48,14 +48,14 @@ class MLFlowTrackingRestApi:
 	def log_param(self, param):
 		"""Log a parameter dict for the given run."""
 		url = self.base_url + '/runs/log-parameter'
-		payload = {'run_id': self.run_id, 'key': param['key'], 'value': param['value']}
+		payload = {'run_uuid': self.run_id, 'key': param['key'], 'value': param['value']}
 		r = requests.post(url, json=payload)
 		return r.status_code
 
 	def log_metric(self, metric):
 		"""Log a metric dict for the given run."""
 		url = self.base_url + '/runs/log-metric'
-		payload = {'run_id': self.run_id, 'key': metric['key'], 'value': metric['value']}
+		payload = {'run_uuid': self.run_id, 'key': metric['key'], 'value': metric['value']}
 		r = requests.post(url, json=payload)
 		return r.status_code
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
(Please fill in changes proposed in this fix)
change run_id to run_uuid because run_id does not exist in the json payload.
 
## How is this patch tested?
 
(Details)
Since examples/rest_api is not in the main mlflow source code, no need to run python test.
 
## Release Notes
 
### Is this a user-facing change? 

- [ v] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [v ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [v ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
