### PR TITLE
MLflow docs tutorial: add instruction about installing scikit-learn

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -28,6 +28,7 @@ To run this tutorial, you'll need to:
     .. container:: python
 
        - Install MLflow (via ``pip install mlflow``)
+       - Install scikit-learn (via ``pip install scikit-learn``)
        - Install `conda <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_
        - Clone (download) the MLflow repository via ``git clone https://github.com/mlflow/mlflow``
        - ``cd`` into the ``examples`` directory within your clone of MLflow - we'll use this working

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -27,8 +27,13 @@ To run this tutorial, you'll need to:
 
     .. container:: python
 
-       - Install MLflow (via ``pip install mlflow``)
-       - Install scikit-learn (via ``pip install scikit-learn``)
+       - Install MLflow and scikit-learn. There are two options for installing these dependencies:
+
+           1. Install MLflow with extra dependencies, including scikit-learn
+              (via ``pip install mlflow[extras]``)
+           2. Install MLflow (via ``pip install mlflow``) and install scikit-learn separately
+              (via ``pip install sckit-learn``)
+
        - Install `conda <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_
        - Clone (download) the MLflow repository via ``git clone https://github.com/mlflow/mlflow``
        - ``cd`` into the ``examples`` directory within your clone of MLflow - we'll use this working


### PR DESCRIPTION
## What changes are proposed in this pull request?

In MLflow 1.0, we are removing `scikit-learn` from the minimal set of dependencies required by MLflow. This PR updates the [MLflow docs tutorial](https://mlflow.org/docs/latest/tutorial.html) to include instructions for downloading scikit-learn.
 
## How is this patch tested?
 
Manual testing of the tutorial
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
- [X] Yes, but this is a minor docs change and should not have a dedicated release note.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [X] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
