### PR TITLE
Fix `mlflow runs list` CLI command

### DIFF
--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -26,7 +26,7 @@ def commands():
 
 @commands.command("list")
 @click.option("--experiment-id", envvar=mlflow.tracking._EXPERIMENT_ID_ENV_VAR, type=click.STRING,
-              help="Specify the experiment ID for list of runs.")
+              help="Specify the experiment ID for list of runs.", required=True)
 @click.option("--view", "-v", default="active_only",
               help="Select view type for list experiments. Valid view types are "
                    "'active_only' (default), 'deleted_only', and 'all'.")
@@ -39,7 +39,7 @@ def list_run(experiment_id, view):
     runs = store.search_runs([experiment_id], None, view_type)
     table = []
     for run in runs:
-        tags = {t.key: t.value for t in run.data.tags}
+        tags = {k: v for k, v in run.data.tags.items()}
         run_name = tags.get(MLFLOW_RUN_NAME, "")
         table.append([conv_longdate_to_str(run.info.start_time), run_name, run.info.run_id])
     print(tabulate(sorted(table, reverse=True), headers=["Date", "Name", "ID"]))

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1,0 +1,14 @@
+from click.testing import CliRunner
+from mlflow.runs import list_run
+import mlflow
+
+def test_list_run():
+    with mlflow.start_run(run_name='apple'):
+        pass
+    result = CliRunner().invoke(list_run, ["--experiment-id", "0"])
+    assert 'apple' in result.output
+
+def test_list_run_experiment_id_required():
+    result = CliRunner().invoke(list_run, [])
+    assert 'Missing option "--experiment-id"' in result.output
+

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -2,13 +2,14 @@ from click.testing import CliRunner
 from mlflow.runs import list_run
 import mlflow
 
+
 def test_list_run():
     with mlflow.start_run(run_name='apple'):
         pass
     result = CliRunner().invoke(list_run, ["--experiment-id", "0"])
     assert 'apple' in result.output
 
+
 def test_list_run_experiment_id_required():
     result = CliRunner().invoke(list_run, [])
     assert 'Missing option "--experiment-id"' in result.output
-


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
`mlflow runs list` is broken in master since it doesn't understand that `run.data.tags` no longer have key and value fields.

Also a small fix so that `--experiment-id` is a required option for list_runs.
## How is this patch tested?
 
Unit tests and manual tests.
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [x] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
