### PR TITLE
Change serving docs from "mlflow pyfunc serve" to "mlflow models serve"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ MLflow artifacts and then load them again for serving. There is an example train
     Score: 0.666
     Model saved in run <run-id>
 
-    $ mlflow pyfunc serve -r <run-id> -m model
+    $ mlflow models serve --model-uri runs:/<run-id>/model
 
     $ curl -d '{"columns":[0],"index":[0,1],"data":[[1],[-1]]}' -H 'Content-Type: application/json'  localhost:5000/invocations
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -455,7 +455,7 @@ Not all deployment methods are available for all model flavors.
   :local:
   :depth: 1
 
-.. _model_deployment:
+.. _local_model_deployment:
 
 Deploy MLflow models locally
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -644,7 +644,7 @@ MLflow includes the utility function ``build_and_push_container`` to perform thi
 module accept the following data formats as input, depending on the deployment flavor:
 
 * ``python_function``: For this deployment flavor, the endpoint accepts the same formats described
-  in the :ref:`pyfunc deployment documentation <pyfunc_deployment>`.
+  in the :ref:`local model deployment documentation <local_model_deployment>`.
 
 * ``mleap``: For this deployment flavor, the endpoint accepts `only`
   JSON-serialized pandas DataFrames in the ``split`` orientation. For example,

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -643,9 +643,8 @@ MLflow provides a default Docker image definition; however, it is up to you to b
 MLflow includes the utility function ``build_and_push_container`` to perform this step. Once built and uploaded, you can use the MLflow container for all MLflow Models. Model webservers deployed using the :py:mod:`mlflow.sagemaker`
 module accept the following data formats as input, depending on the deployment flavor:
 
-* ``python_function``: For this deployment flavor, the endpoint accepts the same formats
-  as the pyfunc server. These formats are described in the
-  :ref:`pyfunc deployment documentation <pyfunc_deployment>`.
+* ``python_function``: For this deployment flavor, the endpoint accepts the same formats described 
+  in the :ref:`pyfunc deployment documentation <pyfunc_deployment>`.
 
 * ``mleap``: For this deployment flavor, the endpoint accepts `only`
   JSON-serialized pandas DataFrames in the ``split`` orientation. For example,

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -643,7 +643,7 @@ MLflow provides a default Docker image definition; however, it is up to you to b
 MLflow includes the utility function ``build_and_push_container`` to perform this step. Once built and uploaded, you can use the MLflow container for all MLflow Models. Model webservers deployed using the :py:mod:`mlflow.sagemaker`
 module accept the following data formats as input, depending on the deployment flavor:
 
-* ``python_function``: For this deployment flavor, the endpoint accepts the same formats described 
+* ``python_function``: For this deployment flavor, the endpoint accepts the same formats described
   in the :ref:`pyfunc deployment documentation <pyfunc_deployment>`.
 
 * ``mleap``: For this deployment flavor, the endpoint accepts `only`

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -162,18 +162,18 @@ simple REST server for python-based models:
 
 .. code-block:: bash
 
-    mlflow pyfunc serve -r <RUN_ID> -m model
+    mlflow models serve -m runs:/<RUN_ID>/model
 
 .. note::
 
     By default the server runs on port 5000. If that port is already in use, use the `--port` option to
-    specify a different port. For example: ``mlflow pyfunc serve --port 1234 -r <RUN_ID> -m model``
+    specify a different port. For example: ``mlflow models serve -m runs:/<RUN_ID>/model --port 1234``
 
 Once you have started the server, you can pass it some sample data and see the
 predictions.
 
 The following example uses ``curl`` to send a JSON-serialized pandas DataFrame with the ``split``
-orientation to the pyfunc server. For more information about the input data formats accepted by
+orientation to the model server. For more information about the input data formats accepted by
 the pyfunc model server, see the :ref:`MLflow deployment tools documentation <pyfunc_deployment>`.
 
 .. code-block:: bash
@@ -183,16 +183,5 @@ the pyfunc model server, see the :ref:`MLflow deployment tools documentation <py
 which returns::
 
     {"predictions": [1, 0]}
-
-.. note::
-
-    The ``sklearn_logistic_regression/train.py`` script must be run with the same Python version as
-    the version of Python that runs ``mlflow pyfunc serve``. If they are not the same version,
-    the stacktrace below may appear::
-
-        File "/usr/local/lib/python3.6/site-packages/mlflow/sklearn.py", line 54, in _load_model_from_local_file
-        return pickle.load(f)
-        UnicodeDecodeError: 'ascii' codec can't decode byte 0xc6 in position 0: ordinal not in range(128)
-
 
 For more information, see :doc:`models`.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -174,7 +174,7 @@ predictions.
 
 The following example uses ``curl`` to send a JSON-serialized pandas DataFrame with the ``split``
 orientation to the model server. For more information about the input data formats accepted by
-the pyfunc model server, see the :ref:`MLflow deployment tools documentation <pyfunc_deployment>`.
+the pyfunc model server, see the :ref:`MLflow deployment tools documentation <local_model_deployment>`.
 
 .. code-block:: bash
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -298,7 +298,7 @@ in MLflow saved the model as an artifact within the run.
       predictions. The following example uses ``curl`` to send a JSON-serialized pandas DataFrame
       with the ``split`` orientation to the model server. For more information about the input data
       formats accepted by the model server, see the
-      :ref:`MLflow deployment tools documentation <pyfunc_deployment>`.
+      :ref:`MLflow deployment tools documentation <local_model_deployment>`.
 
       .. code-block:: bash
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -285,7 +285,7 @@ in MLflow saved the model as an artifact within the run.
 
       .. code-block:: bash
 
-          mlflow pyfunc serve -m /Users/mlflow/mlflow-prototype/mlruns/0/7c1a0d5c42844dcdb8f5191146925174/artifacts/model -p 1234
+          mlflow models serve -m /Users/mlflow/mlflow-prototype/mlruns/0/7c1a0d5c42844dcdb8f5191146925174/artifacts/model -p 1234
 
       .. note::
 
@@ -296,8 +296,8 @@ in MLflow saved the model as an artifact within the run.
 
       Once you have deployed the server, you can pass it some sample data and see the
       predictions. The following example uses ``curl`` to send a JSON-serialized pandas DataFrame
-      with the ``split`` orientation to the pyfunc server. For more information about the input data
-      formats accepted by the pyfunc model server, see the
+      with the ``split`` orientation to the model server. For more information about the input data
+      formats accepted by the model server, see the
       :ref:`MLflow deployment tools documentation <pyfunc_deployment>`.
 
       .. code-block:: bash

--- a/examples/flower_classifier/README.rst
+++ b/examples/flower_classifier/README.rst
@@ -85,12 +85,12 @@ run_id ``101``.
 
 - To test REST api scoring do the following two steps:
 
-  1. Deploy the model as a local REST endpoint by running mlflow pyfunc serve:
+  1. Deploy the model as a local REST endpoint by running ``mlflow models serve``:
 
   .. code-block:: bash
 
       # deploy the model to local REST api endpoint
-      mlflow pyfunc serve -p 54321 -r 101 -m model
+      mlflow models serve --model-uri runs:/101/model --port 54321
 
 
   2. Apply the model to new data using the provided score_images_rest.py script:


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
The `mlflow pyfunc serve` CLI has been replaced with the more generic `mlflow models serve` CLI. This PR updates MLflow examples and docs to reflect this change.
 
## How is this patch tested?
 
Manual generation of the docs and execution of in-doc examples
 
## Release Notes

Model serving documentation has been updated to reference the `mlflow models serve` CLI, which replaces the `mlflow pyfunc serve` CLI.
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [X] Examples 
- [X] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
