### PR TITLE
Switch to gunicorn for serving of python models.

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -206,14 +206,9 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
                    "Note that this flag does not impact already-created experiments. "
                    "Default: Within file store, if a file:/ URI is provided. If a sql backend is"
                    " used, then this option is required.")
-@click.option("--host", "-h", metavar="HOST", default="127.0.0.1",
-              help="The network address to listen on (default: 127.0.0.1). "
-                   "Use 0.0.0.0 to bind to all addresses if you want to access the tracking "
-                   "server from other machines.")
-@click.option("--port", "-p", default=5000,
-              help="The port to listen on (default: 5000).")
-@click.option("--workers", "-w", default=4,
-              help="Number of gunicorn worker processes to handle requests (default: 4).")
+@cli_args.HOST
+@cli_args.PORT
+@cli_args.WORKERS
 @click.option("--static-prefix", default=None, callback=_validate_static_prefix,
               help="A prefix which will be prepended to the path of all static paths.")
 @click.option("--gunicorn-opts", default=None,

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -24,17 +24,20 @@ def commands():
 
 @commands.command("serve")
 @cli_args.MODEL_URI
-@click.option("--port", "-p", default=5000, help="Server port. [default: 5000]")
-@click.option("--host", "-h", default="127.0.0.1", help="Server host. [default: 127.0.0.1]")
+@cli_args.PORT
+@cli_args.HOST
+@cli_args.WORKERS
 @cli_args.NO_CONDA
 @cli_args.INSTALL_MLFLOW
-def serve(model_uri, port, host, no_conda=False, install_mlflow=False):
+def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False):
     """
     Serve a model saved with MLflow by launching a webserver on the specified host and port. For
     information about the input data formats accepted by the webserver, see the following
     documentation: https://www.mlflow.org/docs/latest/models.html#model-deployment.
     """
-    return _get_flavor_backend(model_uri, no_conda=no_conda,
+    return _get_flavor_backend(model_uri,
+                               no_conda=no_conda,
+                               workers=workers,
                                install_mlflow=install_mlflow).serve(model_uri=model_uri, port=port,
                                                                     host=host)
 

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -63,7 +63,7 @@ class PyFuncBackend(FlavorBackend):
             # NB: Absolute windows paths do not work with mlflow apis, use file uri to ensure
             # platform compatibility.
             local_uri = path_to_local_file_uri(local_path)
-            command = ("gunicorn --timeout 60  -b {host}:{port} -w {nworkers} "
+            command = ("gunicorn --timeout 60 -b {host}:{port} -w {nworkers} "
                        "mlflow.pyfunc.scoring_server.wsgi:app").format(
                          host=host,
                          port=port,
@@ -76,7 +76,7 @@ class PyFuncBackend(FlavorBackend):
                                              command_env=command_env)
             else:
                 _logger.info("=== Running command '%s'", command)
-                subprocess.Popen(command, env=command_env).wait()
+                subprocess.Popen(command.split(" "), env=command_env).wait()
 
     def can_score_model(self):
         if self._no_conda:

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -19,8 +19,9 @@ class PyFuncBackend(FlavorBackend):
     """
         Flavor backend implementation for the generic python models.
     """
-    def __init__(self, config, no_conda=False, install_mlflow=False, **kwargs):
+    def __init__(self, config, workers=1, no_conda=False, install_mlflow=False, **kwargs):
         super(PyFuncBackend, self).__init__(config=config, **kwargs)
+        self._nworkers = workers
         self._no_conda = no_conda
         self._install_mlflow = install_mlflow
 
@@ -62,22 +63,20 @@ class PyFuncBackend(FlavorBackend):
             # NB: Absolute windows paths do not work with mlflow apis, use file uri to ensure
             # platform compatibility.
             local_uri = path_to_local_file_uri(local_path)
+            command = ("gunicorn --timeout 60  -b {host}:{port} -w {nworkers} "
+                       "mlflow.pyfunc.scoring_server.wsgi:app").format(
+                         host=host,
+                         port=port,
+                         nworkers=self._nworkers)
+            command_env = os.environ.copy()
+            command_env[scoring_server._SERVER_MODEL_PATH] = local_uri
             if not self._no_conda and ENV in self._config:
                 conda_env_path = os.path.join(local_path, self._config[ENV])
-
-                command = ('python -c "from mlflow.pyfunc.scoring_server import _serve; _serve('
-                           'model_uri={model_uri}, '
-                           'port={port}, '
-                           'host={host})"'
-                           ).format(
-                             model_uri=repr(local_uri),
-                             port=repr(port),
-                             host=repr(host))
-
-                return _execute_in_conda_env(conda_env_path, command,
-                                             self._install_mlflow)
+                return _execute_in_conda_env(conda_env_path, command, self._install_mlflow,
+                                             command_env=command_env)
             else:
-                scoring_server._serve(local_uri, port, host)
+                _logger.info("=== Running command '%s'", command)
+                subprocess.Popen(command, env=command_env).wait()
 
     def can_score_model(self):
         if self._no_conda:
@@ -93,7 +92,9 @@ class PyFuncBackend(FlavorBackend):
             return False
 
 
-def _execute_in_conda_env(conda_env_path, command, install_mlflow):
+def _execute_in_conda_env(conda_env_path, command, install_mlflow, command_env=None):
+    if command_env is None:
+        command_env = os.environ
     env_id = os.environ.get("MLFLOW_HOME", VERSION) if install_mlflow else None
     conda_env_name = _get_or_create_conda_env(conda_env_path, env_id=env_id)
     activate_path = _get_conda_bin_executable("activate")
@@ -109,7 +110,7 @@ def _execute_in_conda_env(conda_env_path, command, install_mlflow):
 
     command = " && ".join(activate_conda_env + [command])
     _logger.info("=== Running command '%s'", command)
-    child = subprocess.Popen(["bash", "-c", command], close_fds=True)
+    child = subprocess.Popen(["bash", "-c", command], close_fds=True, env=command_env)
     rc = child.wait()
     if rc != 0:
         raise Exception("Command '{0}' returned non zero return code. Return code = {1}".format(

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -41,6 +41,8 @@ try:
 except ImportError:
     from io import StringIO
 
+_SERVER_MODEL_PATH = "__pyfunc_model_path__"
+
 CONTENT_TYPE_CSV = "text/csv"
 CONTENT_TYPE_JSON = "application/json"
 CONTENT_TYPE_JSON_RECORDS_ORIENTED = "application/json; format=pandas-records"

--- a/mlflow/pyfunc/scoring_server/wsgi.py
+++ b/mlflow/pyfunc/scoring_server/wsgi.py
@@ -1,0 +1,6 @@
+import os
+from mlflow.pyfunc import scoring_server
+from mlflow.pyfunc import load_model
+
+
+app = scoring_server.init(load_model(os.environ[scoring_server._SERVER_MODEL_PATH]))

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -31,3 +31,12 @@ INSTALL_MLFLOW = click.option("--install-mlflow", is_flag=True, default=False,
                                    "mlflow will be installed into the environment after it has been"
                                    " activated. The version of installed mlflow will be the same as"
                                    "the one used to invoke this command.")
+
+HOST = click.option("--host", "-h", metavar="HOST", default="127.0.0.1",
+                    help="The network address to listen on (default: 127.0.0.1). "
+                         "Use 0.0.0.0 to bind to all addresses if you want to access the tracking "
+                         "server from other machines.")
+PORT = click.option("--port", "-p", default=5000,
+                    help="The port to listen on (default: 5000).")
+WORKERS = click.option("--workers", "-w", default=4,
+                       help="Number of gunicorn worker processes to handle requests (default: 4).")

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -120,6 +120,8 @@ def test_model_with_no_deployable_flavors_fails_pollitely():
 
 
 def test_serve_gunicorn_opts(iris_data, sk_model):
+    if sys.platform == "win32":
+        pytest.skip("This test requires gunicorn which is not available on windows.")
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model")
         model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -137,13 +137,6 @@ def test_serve_gunicorn_opts(iris_data, sk_model):
     expected_command_pattern = re.compile((
         "gunicorn.*-w 3.*mlflow.pyfunc.scoring_server.wsgi:app"))
     x = output.getvalue()
-    print()
-    print()
-    print()
-    print(x)
-    print()
-    print()
-    print()
     assert expected_command_pattern.search(x) is not None
 
 

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -1,6 +1,7 @@
 import os
 import pandas as pd
 import pytest
+import re
 import sklearn
 import sklearn.datasets
 import sklearn.neighbors
@@ -14,11 +15,13 @@ except ImportError:
 
 import mlflow
 from mlflow import pyfunc
+from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON_SPLIT_ORIENTED
 import mlflow.sklearn
 from mlflow.utils.file_utils import TempDir, path_to_local_file_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils import PYTHON_VERSION
 from tests.models import test_pyfunc
+from tests.helper_functions import pyfunc_serve_and_score_model
 
 in_travis = 'TRAVIS' in os.environ
 # NB: for now, windows tests on Travis do not have conda available.
@@ -114,6 +117,34 @@ def test_model_with_no_deployable_flavors_fails_pollitely():
         print(stderr)
         assert p.wait() != 0
         assert "No suitable flavor backend was found for the model." in stderr
+
+
+def test_serve_gunicorn_opts(iris_data, sk_model):
+    with mlflow.start_run() as active_run:
+        mlflow.sklearn.log_model(sk_model, "model")
+        model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
+
+    output = StringIO()
+    x, _ = iris_data
+    scoring_response = pyfunc_serve_and_score_model(model_uri, pd.DataFrame(x),
+                                                    content_type=CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+                                                    stdout=output,
+                                                    extra_args=["-w", "3"])
+    actual = pd.read_json(scoring_response.content, orient="records")
+    actual = actual[actual.columns[0]].values
+    expected = sk_model.predict(x)
+    assert all(expected == actual)
+    expected_command_pattern = re.compile((
+        "gunicorn.*-w 3.*mlflow.pyfunc.scoring_server.wsgi:app"))
+    x = output.getvalue()
+    print()
+    print()
+    print()
+    print(x)
+    print()
+    print()
+    print()
+    assert expected_command_pattern.search(x) is not None
 
 
 def test_predict(iris_data, sk_model):


### PR DESCRIPTION
## What changes are proposed in this pull request?
PyFunc serve now uses gunicorn instead of just flask. This makes it more useful out of the box.
 
## How is this patch tested?
Add tests covering the use of new gunicorn arguments added to the cli. Other than that the existing tests should suffice.
 
## Release Notes
The serving of python models now uses gunicorn as its webserver.  The use of gunicorn makes the serving functionality production ready out of the box. 

### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [x] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [x] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
