### PR TITLE
Fix failing log_artifact due to existing directory on FTP server

### DIFF
--- a/mlflow/store/ftp_artifact_repo.py
+++ b/mlflow/store/ftp_artifact_repo.py
@@ -50,8 +50,7 @@ class FTPArtifactRepository(ArtifactRepository):
     def _mkdir(self, artifact_dir):
         with self.get_ftp_client() as ftp:
             try:
-                head, _ = posixpath.split(artifact_dir)
-                if artifact_dir not in ftp.nlst(head):
+                if not self._is_dir(artifact_dir):
                     ftp.mkd(artifact_dir)
             except ftplib.error_perm:
                 head, _ = posixpath.split(artifact_dir)

--- a/mlflow/store/ftp_artifact_repo.py
+++ b/mlflow/store/ftp_artifact_repo.py
@@ -50,7 +50,9 @@ class FTPArtifactRepository(ArtifactRepository):
     def _mkdir(self, artifact_dir):
         with self.get_ftp_client() as ftp:
             try:
-                ftp.mkd(artifact_dir)
+                head, _ = posixpath.split(artifact_dir)
+                if artifact_dir not in ftp.nlst(head):
+                    ftp.mkd(artifact_dir)
             except ftplib.error_perm:
                 head, _ = posixpath.split(artifact_dir)
                 self._mkdir(head)

--- a/tests/store/test_ftp_artifact_repo.py
+++ b/tests/store/test_ftp_artifact_repo.py
@@ -118,10 +118,12 @@ def test_log_artifact(ftp_mock, tmpdir):
     fpath = d + '/test.txt'
     fpath = fpath.strpath
 
+    ftp_mock.cwd = MagicMock(side_effect=[ftplib.error_perm, None])
+
     repo.log_artifact(fpath)
 
     ftp_mock.mkd.assert_called_once_with('/some/path')
-    ftp_mock.cwd.assert_called_once_with('/some/path')
+    ftp_mock.cwd.assert_called_with('/some/path')
     ftp_mock.storbinary.assert_called_once()
     assert ftp_mock.storbinary.call_args_list[0][0][0] == 'STOR test.txt'
 
@@ -137,6 +139,8 @@ def test_log_artifacts(ftp_mock, tmpdir):
     subd.join("a.txt").write("A")
     subd.join("b.txt").write("B")
     subd.join("c.txt").write("C")
+
+    ftp_mock.cwd = MagicMock(side_effect=[ftplib.error_perm, None, None, None, None, None])
 
     repo.log_artifacts(subd.strpath)
 

--- a/tests/store/test_ftp_artifact_repo.py
+++ b/tests/store/test_ftp_artifact_repo.py
@@ -128,6 +128,54 @@ def test_log_artifact(ftp_mock, tmpdir):
     assert ftp_mock.storbinary.call_args_list[0][0][0] == 'STOR test.txt'
 
 
+def test_log_artifact_multiple_calls(ftp_mock, tmpdir):
+    repo = FTPArtifactRepository("ftp://test_ftp/some/path")
+
+    repo.get_ftp_client = MagicMock()
+    call_mock = MagicMock(return_value=ftp_mock)
+    repo.get_ftp_client.return_value = MagicMock(__enter__=call_mock)
+
+    d = tmpdir.mkdir("data")
+    file1 = d.join("test1.txt")
+    file1.write("hello world!")
+    fpath1 = d + '/test1.txt'
+    fpath1 = fpath1.strpath
+
+    file2 = d.join("test2.txt")
+    file2.write("hello world!")
+    fpath2 = d + '/test2.txt'
+    fpath2 = fpath2.strpath
+
+    ftp_mock.cwd = MagicMock(side_effect=[
+        ftplib.error_perm,
+        None,
+        ftplib.error_perm,
+        None,
+        None,
+        None
+    ])
+
+    repo.log_artifact(fpath1)
+    ftp_mock.mkd.assert_called_once_with('/some/path')
+    ftp_mock.cwd.assert_called_with('/some/path')
+    ftp_mock.storbinary.assert_called()
+    assert ftp_mock.storbinary.call_args_list[0][0][0] == 'STOR test1.txt'
+    ftp_mock.reset_mock()
+
+    repo.log_artifact(fpath1, "subdir")
+    ftp_mock.mkd.assert_called_once_with('/some/path/subdir')
+    ftp_mock.cwd.assert_called_with('/some/path/subdir')
+    ftp_mock.storbinary.assert_called()
+    assert ftp_mock.storbinary.call_args_list[0][0][0] == 'STOR test1.txt'
+    ftp_mock.reset_mock()
+
+    repo.log_artifact(fpath2)
+    ftp_mock.mkd.assert_not_called()
+    ftp_mock.cwd.assert_called_with('/some/path')
+    ftp_mock.storbinary.assert_called()
+    assert ftp_mock.storbinary.call_args_list[0][0][0] == 'STOR test2.txt'
+
+
 def test_log_artifacts(ftp_mock, tmpdir):
     repo = FTPArtifactRepository("ftp://test_ftp/some/path")
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
When running log_artifact() twice without adding
an artifact_path the upload fails due to ftp.mkd(artifact_dir)
failing. ftp.mkd(artifact_dir) fails because artifact_dir already exists on
the server after the first call. This is now avoided by first checking whether the directory
already exists on the server before trying to create it.
 
## How is this patch tested?

Tested manually with a vsftpd ftp, I think the existing unittests should suffice.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Fixes bug which caused ftp artifact upload to fail on subsequent calls to log_artifact due to already existing directory.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [x] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
