### PR TITLE
Pass mlflow.keras.load_model extra arguments to keras.models.load_model

### DIFF
--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -153,7 +153,7 @@ def _load_model(model_file, *args, **kwargs):
 
     from distutils.version import StrictVersion
 
-    if StrictVersion(keras.__version__) >= StrictVersion("2.2.3"):
+    if StrictVersion(keras.__version__.split('-')[0]) >= StrictVersion("2.2.3"):
         # NOTE: Keras 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.
         with h5py.File(os.path.abspath(model_file), "r") as model_file:

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -146,7 +146,7 @@ def log_model(keras_model, artifact_path, conda_env=None, **kwargs):
               keras_model=keras_model, conda_env=conda_env, **kwargs)
 
 
-def _load_model(model_file, *args, **kwargs):
+def _load_model(model_file, **kwargs):
     import keras
     import keras.models
     import h5py
@@ -157,10 +157,10 @@ def _load_model(model_file, *args, **kwargs):
         # NOTE: Keras 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.
         with h5py.File(os.path.abspath(model_file), "r") as model_file:
-            return keras.models.load_model(model_file, *args, **kwargs)
+            return keras.models.load_model(model_file, **kwargs)
     else:
         # NOTE: Older versions of Keras only handle filepath.
-        return keras.models.load_model(model_file, *args, **kwargs)
+        return keras.models.load_model(model_file, **kwargs)
 
 
 class _KerasModelWrapper:
@@ -177,7 +177,7 @@ class _KerasModelWrapper:
         return predicted
 
 
-def _load_pyfunc(path, *args, **kwargs):
+def _load_pyfunc(path, **kwargs):
     """
     Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
 
@@ -195,13 +195,13 @@ def _load_pyfunc(path, *args, **kwargs):
         with graph.as_default():
             with sess.as_default():  # pylint:disable=not-context-manager
                 K.set_learning_phase(0)
-                m = _load_model(path, *args, **kwargs)
+                m = _load_model(path, **kwargs)
         return _KerasModelWrapper(m, graph, sess)
     else:
         raise Exception("Unsupported backend '%s'" % K._BACKEND)
 
 
-def load_model(model_uri, *args, **kwargs):
+def load_model(model_uri, **kwargs):
     """
     Load a Keras model from a local file (if ``run_id`` is None) or a run.
     Extra arguments are passed through to keras.load_model.
@@ -228,4 +228,4 @@ def load_model(model_uri, *args, **kwargs):
     # Flavor configurations for models saved in MLflow version <= 0.8.0 may not contain a
     # `data` key; in this case, we assume the model artifact path to be `model.h5`
     keras_model_artifacts_path = os.path.join(local_model_path, flavor_conf.get("data", "model.h5"))
-    return _load_model(model_file=keras_model_artifacts_path, *args, **kwargs)
+    return _load_model(model_file=keras_model_artifacts_path, **kwargs)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -203,7 +203,8 @@ def _load_pyfunc(path, *args, **kwargs):
 
 def load_model(model_uri, *args, **kwargs):
     """
-    Load a Keras model from a local file (if ``run_id`` is None) or a run. Extra arguments are passed through to keras.load_model.
+    Load a Keras model from a local file (if ``run_id`` is None) or a run.
+    Extra arguments are passed through to keras.load_model.
 
     :param model_uri: The location, in URI format, of the MLflow model, for example:
 

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -177,7 +177,7 @@ class _KerasModelWrapper:
         return predicted
 
 
-def _load_pyfunc(path, **kwargs):
+def _load_pyfunc(path):
     """
     Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
 
@@ -195,7 +195,7 @@ def _load_pyfunc(path, **kwargs):
         with graph.as_default():
             with sess.as_default():  # pylint:disable=not-context-manager
                 K.set_learning_phase(0)
-                m = _load_model(path, **kwargs)
+                m = _load_model(path, compile=False)
         return _KerasModelWrapper(m, graph, sess)
     else:
         raise Exception("Unsupported backend '%s'" % K._BACKEND)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -146,7 +146,7 @@ def log_model(keras_model, artifact_path, conda_env=None, **kwargs):
               keras_model=keras_model, conda_env=conda_env, **kwargs)
 
 
-def _load_model(model_file):
+def _load_model(model_file, *args, **kwargs):
     import keras
     import keras.models
     import h5py
@@ -157,10 +157,10 @@ def _load_model(model_file):
         # NOTE: Keras 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.
         with h5py.File(os.path.abspath(model_file), "r") as model_file:
-            return keras.models.load_model(model_file)
+            return keras.models.load_model(model_file, *args, **kwargs)
     else:
         # NOTE: Older versions of Keras only handle filepath.
-        return keras.models.load_model(model_file)
+        return keras.models.load_model(model_file, *args, **kwargs)
 
 
 class _KerasModelWrapper:
@@ -177,7 +177,7 @@ class _KerasModelWrapper:
         return predicted
 
 
-def _load_pyfunc(path):
+def _load_pyfunc(path, *args, **kwargs):
     """
     Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
 
@@ -195,15 +195,15 @@ def _load_pyfunc(path):
         with graph.as_default():
             with sess.as_default():  # pylint:disable=not-context-manager
                 K.set_learning_phase(0)
-                m = _load_model(path)
+                m = _load_model(path, *args, **kwargs)
         return _KerasModelWrapper(m, graph, sess)
     else:
         raise Exception("Unsupported backend '%s'" % K._BACKEND)
 
 
-def load_model(model_uri):
+def load_model(model_uri, *args, **kwargs):
     """
-    Load a Keras model from a local file (if ``run_id`` is None) or a run.
+    Load a Keras model from a local file (if ``run_id`` is None) or a run. Extra arguments are passed through to keras.load_model.
 
     :param model_uri: The location, in URI format, of the MLflow model, for example:
 
@@ -227,4 +227,4 @@ def load_model(model_uri):
     # Flavor configurations for models saved in MLflow version <= 0.8.0 may not contain a
     # `data` key; in this case, we assume the model artifact path to be `model.h5`
     keras_model_artifacts_path = os.path.join(local_model_path, flavor_conf.get("data", "model.h5"))
-    return _load_model(model_file=keras_model_artifacts_path)
+    return _load_model(model_file=keras_model_artifacts_path, *args, **kwargs)


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Pass load_model arguments to keras to allow compile=False and custom_objects to be specified. Without this, it's impossible to load models with custom metrics. This fixes #1201.

Additionally, this adds a .split to the keras version check so it will work with "2.2.4-tf".
 
## How is this patch tested?
 
Running it in production.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
It is now possible to pass extra arguments to mlflow.keras.load_model, that will be passed through to keras.load_model.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [x] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
