### PR TITLE
Bug fix: update batch metric logging to use millisecond timestamps

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -194,7 +194,7 @@ def log_metrics(metrics, step=None):
     :returns: None
     """
     run_id = _get_or_start_run().info.run_id
-    timestamp = int(time.time())
+    timestamp = int(time.time() * 1000)
     metrics_arr = [Metric(key, value, timestamp, step or 0) for key, value in metrics.items()]
     MlflowClient().log_batch(run_id=run_id, metrics=metrics_arr, params=[], tags=[])
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Currently, calls to the `mlflow.log_metrics()` fluent API use a timestamp having *second* resolution, instead of *millisecond* resolution. This PR updates to *millisecond* resolution for consistency with `mlflow.log_metric()`
 
## How is this patch tested?
 
Augmentation of existing unit tests introduced by #1177.
 
## Release Notes

The `mlflow.log_metrics()` API now uses a default timestamp with *millisecond* resolution.
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [X] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
