### PR TITLE
Fix handling of file uri parameters in projects

### DIFF
--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -6,6 +6,7 @@ import re
 from six.moves import urllib
 
 from mlflow.utils import process
+from mlflow.utils.file_utils import local_file_uri_to_path
 
 DBFS_PREFIX = "dbfs:/"
 S3_PREFIX = "s3://"
@@ -75,3 +76,14 @@ def download_uri(uri, output_path):
     else:
         raise DownloadException("`uri` must be a DBFS (%s), S3 (%s), or GCS (%s) URI, got "
                                 "%s" % (DBFS_PREFIX, S3_PREFIX, GS_PREFIX, uri))
+
+
+def get_local_path(path_or_uri):
+    """Check if the argument is a local path (no scheme or file:///) and return local path if true,
+    None otherwise.
+    """
+    parsed_uri = urllib.parse.urlparse(path_or_uri)
+    if len(parsed_uri.scheme) == 0 or parsed_uri.scheme == "file" and len(parsed_uri.netloc) == 0:
+        return local_file_uri_to_path(path_or_uri)
+    else:
+        return None

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -6,7 +6,6 @@ import re
 from six.moves import urllib
 
 from mlflow.utils import process
-from mlflow.utils.file_utils import local_file_uri_to_path
 
 DBFS_PREFIX = "dbfs:/"
 S3_PREFIX = "s3://"
@@ -76,14 +75,3 @@ def download_uri(uri, output_path):
     else:
         raise DownloadException("`uri` must be a DBFS (%s), S3 (%s), or GCS (%s) URI, got "
                                 "%s" % (DBFS_PREFIX, S3_PREFIX, GS_PREFIX, uri))
-
-
-def get_local_path(path_or_uri):
-    """Check if the argument is a local path (no scheme or file:///) and return local path if true,
-    None otherwise.
-    """
-    parsed_uri = urllib.parse.urlparse(path_or_uri)
-    if len(parsed_uri.scheme) == 0 or parsed_uri.scheme == "file" and len(parsed_uri.netloc) == 0:
-        return local_file_uri_to_path(path_or_uri)
-    else:
-        return None

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -158,11 +158,12 @@ class Parameter(object):
         return user_param_value
 
     def _compute_path_value(self, user_param_value, storage_dir):
-        if not data.is_uri(user_param_value):
-            if not os.path.exists(user_param_value):
+        local_path = data.get_local_path(user_param_value)
+        if local_path:
+            if not os.path.exists(local_path):
                 raise ExecutionException("Got value %s for parameter %s, but no such file or "
                                          "directory was found." % (user_param_value, self.name))
-            return os.path.abspath(user_param_value)
+            return os.path.abspath(local_path)
         basename = os.path.basename(user_param_value)
         dest_path = os.path.join(storage_dir, basename)
         if dest_path != user_param_value:

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -8,6 +8,7 @@ from six.moves import shlex_quote
 
 from mlflow import data
 from mlflow.exceptions import ExecutionException
+from mlflow.utils.file_utils import get_local_path_or_none
 
 
 MLPROJECT_FILE_NAME = "MLproject"
@@ -158,7 +159,7 @@ class Parameter(object):
         return user_param_value
 
     def _compute_path_value(self, user_param_value, storage_dir):
-        local_path = data.get_local_path(user_param_value)
+        local_path = get_local_path_or_none(user_param_value)
         if local_path:
             if not os.path.exists(local_path):
                 raise ExecutionException("Got value %s for parameter %s, but no such file or "

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -367,3 +367,14 @@ def local_file_uri_to_path(uri):
     """
     path = urllib.parse.urlparse(uri).path if uri.startswith("file:") else uri
     return urllib.request.url2pathname(path)
+
+
+def get_local_path_or_none(path_or_uri):
+    """Check if the argument is a local path (no scheme or file:///) and return local path if true,
+    None otherwise.
+    """
+    parsed_uri = urllib.parse.urlparse(path_or_uri)
+    if len(parsed_uri.scheme) == 0 or parsed_uri.scheme == "file" and len(parsed_uri.netloc) == 0:
+        return local_file_uri_to_path(path_or_uri)
+    else:
+        return None

--- a/tests/projects/test_entry_point.py
+++ b/tests/projects/test_entry_point.py
@@ -6,7 +6,7 @@ from six.moves import shlex_quote
 
 from mlflow.exceptions import ExecutionException
 from mlflow.projects._project_spec import EntryPoint
-from mlflow.utils.file_utils import TempDir
+from mlflow.utils.file_utils import TempDir, path_to_local_file_uri
 from tests.projects.utils import load_project, TEST_PROJECT_DIR
 
 
@@ -68,6 +68,13 @@ def test_path_parameter():
                 storage_dir=dst_dir)
             assert params["path"] == os.path.abspath(local_path)
             assert download_uri_mock.call_count == 0
+
+            params, _ = entry_point.compute_parameters(
+                user_parameters={"path": path_to_local_file_uri(local_path)},
+                storage_dir=dst_dir)
+            assert params["path"] == os.path.abspath(local_path)
+            assert download_uri_mock.call_count == 0
+
         # Verify that we raise an exception when passing a non-existent local file to a
         # parameter of type "path"
         with TempDir() as tmp, pytest.raises(ExecutionException):


### PR DESCRIPTION
## What changes are proposed in this pull request?
Recognize file:///path, file:/path and file:path uris as local files when evaluating project parameters. 
## How is this patch tested?
Updated existing test. 
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [x] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
