### PR TITLE
Remove beta warnings from MLflow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,6 @@ currently run ML code (e.g. in notebooks, standalone applications or the cloud).
   you easily deploy the same model (from any ML library) to batch and real-time scoring on platforms such as
   Docker, Apache Spark, Azure ML and AWS SageMaker.
 
-**Note:** The current version of MLflow is a beta. This means that APIs and data formats
-are subject to change! However, the next release, MLflow 1.0, will stabilize these.
-The current release also does not support Windows, although 1.0 will.
-
 |docs| |travis| |pypi| |conda-forge|
 
 .. |docs| image:: https://img.shields.io/badge/docs-latest-success.svg

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -32,8 +32,3 @@ Get started using the :ref:`quickstart` or by reading about the :ref:`key concep
     R-api
     java_api/index
     rest-api
-
-.. warning::
-
-    The current version of MLflow is a beta release. This means that APIs and storage formats
-    are subject to breaking change.


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
With MLflow 1.0, we no longer have to warn users that we're beta!