### PR TITLE
[Docs] Remove vestigial refernces to "mlflow sklearn"

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -56,7 +56,7 @@ And its ``MLmodel`` file describes two flavors:
         loader_module: mlflow.sklearn
 
 This model can then be used with any tool that supports *either* the ``sklearn`` or
-``python_function`` model flavor. For example, the ``mlflow sklearn`` command can serve a
+``python_function`` model flavor. For example, the ``mlflow models serve`` command can serve a
 model with the ``sklearn`` flavor:
 
 .. code-block:: bash

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -295,7 +295,7 @@ in MLflow saved the model as an artifact within the run.
 
       .. note::
 
-          The version of Python used to create the model must be the same as the one running ``mlflow sklearn``.
+          The version of Python used to create the model must be the same as the one running ``mlflow models serve``.
           If this is not the case, you may see the error
           ``UnicodeDecodeError: 'ascii' codec can't decode byte 0x9f in position 1: ordinal not in range(128)``
           or ``raise ValueError, "unsupported pickle protocol: %d"``.


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
The actual code blocks were right, just not the description!
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
 
### What component(s) does this PR affect?
 
- [x] Docs

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
