### PR TITLE
Add migration of sqlalchemy user column to tags

### DIFF
--- a/mlflow/alembic/versions/90e64c465722_migrate_user_column_to_tags.py
+++ b/mlflow/alembic/versions/90e64c465722_migrate_user_column_to_tags.py
@@ -7,8 +7,9 @@ Create Date: 2019-05-29 10:43:52.919427
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy import orm
-from mlflow.store.dbmodels.models import SqlRun, SqlTag
+from sqlalchemy import orm, Column, Integer, String, ForeignKey, PrimaryKeyConstraint
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import relationship, backref
 from mlflow.utils.mlflow_tags import MLFLOW_USER
 
 # revision identifiers, used by Alembic.
@@ -16,6 +17,32 @@ revision = '90e64c465722'
 down_revision = '451aebb31d03'
 branch_labels = None
 depends_on = None
+
+
+Base = declarative_base()
+
+
+class SqlRun(Base):
+    __tablename__ = 'runs'
+    run_uuid = Column(String(32), nullable=False)
+    user_id = Column(String(256), nullable=True, default=None)
+    experiment_id = Column(Integer)
+
+    __table_args__ = (
+        PrimaryKeyConstraint('experiment_id', name='experiment_pk'),
+    )
+
+
+class SqlTag(Base):
+    __tablename__ = 'tags'
+    key = Column(String(250))
+    value = Column(String(250), nullable=True)
+    run_uuid = Column(String(32), ForeignKey('runs.run_uuid'))
+    run = relationship('SqlRun', backref=backref('tags', cascade='all'))
+
+    __table_args__ = (
+        PrimaryKeyConstraint('key', 'run_uuid', name='tag_pk'),
+    )
 
 
 def upgrade():

--- a/mlflow/alembic/versions/90e64c465722_migrate_user_column_to_tags.py
+++ b/mlflow/alembic/versions/90e64c465722_migrate_user_column_to_tags.py
@@ -1,0 +1,41 @@
+"""migrate user column to tags
+
+Revision ID: 90e64c465722
+Revises: 451aebb31d03
+Create Date: 2019-05-29 10:43:52.919427
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy import orm
+from mlflow.store.dbmodels.models import SqlRun, SqlTag
+from mlflow.utils.mlflow_tags import MLFLOW_USER
+
+# revision identifiers, used by Alembic.
+revision = '90e64c465722'
+down_revision = '451aebb31d03'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    bind = op.get_bind()
+    session = orm.Session(bind=bind)
+    runs = session.query(SqlRun).all()
+    for run in runs:
+        if not run.user_id:
+            continue
+
+        tag_exists = False
+        for tag in run.tags:
+            if tag.key == MLFLOW_USER:
+                tag_exists = True
+        if tag_exists:
+            continue
+
+        session.merge(SqlTag(run_uuid=run.run_uuid, key=MLFLOW_USER, value=run.user_id))
+    session.commit()
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Ensures that sqlalchemy databases upgraded from 0.9.0 or 0.9.1 correctly have a `mlflow.user` tag set, since we no longer read from the database column in 1.0.
 
## How is this patch tested?
 
Manually tested migration on database:
- user was correctly moved from column to tags
- existing tags were preserved
- rerunning migration was a no-op (due to alembic's semantics, at least)
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
 
### What component(s) does this PR affect?
 
- [x] Tracking

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
