### PR TITLE
[Python] Make search_runs filter optional and accept single experiment id

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -271,14 +271,14 @@ class MlflowClient(object):
         """
         self.store.restore_run(run_id)
 
-    def search_runs(self, experiment_ids, filter_string,
+    def search_runs(self, experiment_ids, filter_string="",
                     run_view_type=ViewType.ACTIVE_ONLY,
                     max_results=SEARCH_MAX_RESULTS_DEFAULT):
         """
         Search experiments that fit the search criteria.
 
-        :param experiment_ids: List of experiment IDs
-        :param filter_string: Filter query string.
+        :param experiment_ids: List of experiment IDs, or a single int or string id.
+        :param filter_string: Filter query string, defaults to searching all runs.
         :param run_view_type: one of enum values ACTIVE_ONLY, DELETED_ONLY, or ALL runs
                               defined in :py:class:`mlflow.entities.ViewType`.
         :param max_results: Maximum number of runs desired.
@@ -286,6 +286,8 @@ class MlflowClient(object):
         :return: A list of :py:class:`mlflow.entities.Run` objects that satisfy the search
             expressions
         """
+        if isinstance(experiment_ids, int) or isinstance(experiment_ids, str):
+            experiment_ids = [experiment_ids]
         return self.store.search_runs(experiment_ids=experiment_ids,
                                       search_filter=SearchFilter(filter_string=filter_string),
                                       run_view_type=run_view_type,

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -6,6 +6,7 @@ from mlflow.store import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.tracking import MlflowClient
 from mlflow.utils.mlflow_tags import MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, \
     MLFLOW_PARENT_RUN_ID, MLFLOW_GIT_COMMIT, MLFLOW_PROJECT_ENTRY_POINT
+from mlflow.utils.search_utils import SearchFilter
 
 
 @pytest.fixture
@@ -19,12 +20,6 @@ def mock_time():
     time = 1552319350.244724
     with mock.patch("time.time", return_value=time):
         yield time
-
-
-@pytest.fixture
-def mock_search_filter():
-    with mock.patch("mlflow.tracking.client.SearchFilter") as mock_search_filter:
-        yield mock_search_filter.return_value
 
 
 def test_client_create_run(mock_store, mock_time):
@@ -75,28 +70,59 @@ def test_client_create_run_overrides(mock_store):
     )
 
 
-def test_client_search_runs(mock_store, mock_search_filter):
-    experiment_ids = [mock.Mock() for _ in range(5)]
+class SearchFilterMatcher:
+    """Matches a SearchFilter object by comparing it to the given filter string."""
+    def __init__(self, filter):
+        self.filter = filter
 
-    # Test defaults for view type and max results
-    MlflowClient().search_runs(experiment_ids, "metrics.acc > 0.93")
-    mock_store.search_runs.assert_called_once_with(experiment_ids=experiment_ids,
-                                                   search_filter=mock_search_filter,
+    def __eq__(self, other):
+        assert(isinstance(other, SearchFilter))
+        return self.filter == other.filter_string
+
+
+def test_client_search_runs_defaults(mock_store):
+    MlflowClient().search_runs([1, 2, 3])
+    mock_store.search_runs.assert_called_once_with(experiment_ids=[1, 2, 3],
+                                                   search_filter=SearchFilterMatcher(""),
                                                    run_view_type=ViewType.ACTIVE_ONLY,
                                                    max_results=SEARCH_MAX_RESULTS_DEFAULT)
 
-    # Test alternate view type
-    mock_store.reset_mock()
-    MlflowClient().search_runs(experiment_ids, "dummy filter", ViewType.DELETED_ONLY)
-    mock_store.search_runs.assert_called_once_with(experiment_ids=experiment_ids,
-                                                   search_filter=mock_search_filter,
+
+def test_client_search_runs_filter(mock_store):
+    MlflowClient().search_runs(["a", "b", "c"], "my filter")
+    mock_store.search_runs.assert_called_once_with(experiment_ids=["a", "b", "c"],
+                                                   search_filter=SearchFilterMatcher("my filter"),
+                                                   run_view_type=ViewType.ACTIVE_ONLY,
+                                                   max_results=SEARCH_MAX_RESULTS_DEFAULT)
+
+
+def test_client_search_runs_view_type(mock_store):
+    MlflowClient().search_runs(["a", "b", "c"], "my filter", ViewType.DELETED_ONLY)
+    mock_store.search_runs.assert_called_once_with(experiment_ids=["a", "b", "c"],
+                                                   search_filter=SearchFilterMatcher("my filter"),
                                                    run_view_type=ViewType.DELETED_ONLY,
                                                    max_results=SEARCH_MAX_RESULTS_DEFAULT)
 
-    # Test with non-default max_results value
-    mock_store.reset_mock()
-    MlflowClient().search_runs(experiment_ids, "dummy filter", ViewType.ALL, 2876)
-    mock_store.search_runs.assert_called_once_with(experiment_ids=experiment_ids,
-                                                   search_filter=mock_search_filter,
+
+def test_client_search_runs_max_results(mock_store):
+    MlflowClient().search_runs([5], "my filter", ViewType.ALL, 2876)
+    mock_store.search_runs.assert_called_once_with(experiment_ids=[5],
+                                                   search_filter=SearchFilterMatcher("my filter"),
                                                    run_view_type=ViewType.ALL,
                                                    max_results=2876)
+
+
+def test_client_search_runs_int_experiment_id(mock_store):
+    MlflowClient().search_runs(123)
+    mock_store.search_runs.assert_called_once_with(experiment_ids=[123],
+                                                   search_filter=SearchFilterMatcher(""),
+                                                   run_view_type=ViewType.ACTIVE_ONLY,
+                                                   max_results=SEARCH_MAX_RESULTS_DEFAULT)
+
+
+def test_client_search_runs_string_experiment_id(mock_store):
+    MlflowClient().search_runs("abc")
+    mock_store.search_runs.assert_called_once_with(experiment_ids=["abc"],
+                                                   search_filter=SearchFilterMatcher(""),
+                                                   run_view_type=ViewType.ACTIVE_ONLY,
+                                                   max_results=SEARCH_MAX_RESULTS_DEFAULT)


### PR DESCRIPTION
## What changes are proposed in this pull request?

`search_runs` is a good alternative to `list_run_infos` because it returns the data as well. However, it does not align with this API right now for two reasons:

- `search_runs` requires a filter string, even if you want all runs.
- `search_runs` requires a list argument of experiment ids, even if you typically only want to search one. The error message for this case isn't great, something like "int object isn't iterable".

This PR proposes making filter optional (default to empty string) and to allow passing a single int or string experiment id, which is converted to a list under the hood.
 
## How is this patch tested?
 
Unit tests!
 
## Release Notes
 
### Is this a user-facing change? 

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
MlflowClient.search_runs has a default value for filter_string of "" (returning all runs). Additionally, clients can pass a single experiment_id int or string value instead of a list of experiment_ids.
 
### What component(s) does this PR affect?
 
- [x] Tracking
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
