### PR TITLE
[Python] Convert log_params and set_tags values into strings

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -217,7 +217,7 @@ def log_params(params):
     :returns: None
     """
     run_id = _get_or_start_run().info.run_id
-    params_arr = [Param(key, value) for key, value in params.items()]
+    params_arr = [Param(key, str(value)) for key, value in params.items()]
     MlflowClient().log_batch(run_id=run_id, metrics=[], params=params_arr, tags=[])
 
 
@@ -229,7 +229,7 @@ def set_tags(tags):
     :returns: None
     """
     run_id = _get_or_start_run().info.run_id
-    tags_arr = [RunTag(key, value) for key, value in tags.items()]
+    tags_arr = [RunTag(key, str(value)) for key, value in tags.items()]
     MlflowClient().log_batch(run_id=run_id, metrics=[], params=[], tags=tags_arr)
 
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -307,7 +307,7 @@ def get_store_mock(tmpdir):
 
 
 def test_set_tags(tracking_uri_mock):
-    exact_expected_tags = {"name_1": "c", "name_2": "b", "nested/nested/name": "5"}
+    exact_expected_tags = {"name_1": "c", "name_2": "b", "nested/nested/name": 5}
     approx_expected_tags = set([MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE])
     with start_run() as active_run:
         run_id = active_run.info.run_id
@@ -319,7 +319,7 @@ def test_set_tags(tracking_uri_mock):
         if tag_key in approx_expected_tags:
             pass
         else:
-            assert exact_expected_tags[tag_key] == tag_val
+            assert str(exact_expected_tags[tag_key]) == tag_val
 
 
 def test_log_metric_validation(tracking_uri_mock):
@@ -344,7 +344,7 @@ def test_log_param(tracking_uri_mock):
 
 
 def test_log_params(tracking_uri_mock):
-    expected_params = {"name_1": "c", "name_2": "b", "nested/nested/name": "5"}
+    expected_params = {"name_1": "c", "name_2": "b", "nested/nested/name": 5}
     with start_run() as active_run:
         run_id = active_run.info.run_id
         mlflow.log_params(expected_params)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds support for `mlflow.log_params({"a": 1})` and equivalent for `set_tags`. This matches support in the fluent API for `log_param`, for example.
 
## How is this patch tested?
 
Unit tests!
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Dictionary values provided to `mlflow.log_params` and `mlflow.set_tags` can now be non-string types (e.g., numbers), and they will be automatically converted to strings.
 
### What component(s) does this PR affect?
 
- [x] Tracking
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
