### PR TITLE
[Easy] Do not show database URI in the error message for migration

### DIFF
--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -147,10 +147,10 @@ class SqlAlchemyStore(AbstractStore):
         if current_rev != head_revision:
             raise MlflowException(
                 "Detected out-of-date database schema (found version %s, but expected %s). "
-                "Take a backup of your database, then run 'mlflow db upgrade %s' to migrate "
-                "your database to the latest schema. NOTE: schema migration may result in "
-                "database downtime - please consult your database's documentation for more "
-                "detail." % (current_rev, head_revision, str(engine.url)))
+                "Take a backup of your database, then run 'mlflow db upgrade <database_uri>' "
+                "to migrate your database to the latest schema. NOTE: schema migration may "
+                "result in database downtime - please consult your database's documentation for "
+                "more detail." % (current_rev, head_revision))
 
     @staticmethod
     def _get_managed_session_maker(SessionMaker):


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Currently the error message in sqlchemy upon detecting a need for migration shows the database URI, which may contains auth information, and it is sent as part of the response to REST API requests on error. Removing the 

## How is this patch tested?

Manual testing - run server in 1.0 after creating a (postgres) database in 0.9.0. Send a REST API request to it to log metric, see that the error message no longer contains the URI.
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
### How should the PR be classified in the release notes? Choose one:
 
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
