### PR TITLE
Include alembic.ini files used for DB migrations in wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def package_files(directory):
 # to include in the wheel, e.g. "../mlflow/server/js/build/index.html"
 js_files = package_files('mlflow/server/js/build')
 sagmaker_server_files = package_files("mlflow/sagemaker/container")
-alembic_files = ["../mlflow/alembic.ini"]
+alembic_files = ["../mlflow/alembic/alembic.ini", "../mlflow/temporary_db_migrations_for_pre_1_users/alembic.ini"]
 
 setup(
     name='mlflow',


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
We added new alembic.ini config files & moved around existing ones in #1292. This PR updates wheel build logic to include the moved .ini files in the wheel - otherwise running `mlflow db upgrade` from a wheel built via `python setup.py bdist_wheel` fails while trying to find the config file:

```
  /tmp mlflow db upgrade sqlite:////tmp/my-db
2019/05/31 12:28:59 INFO mlflow.store.db.utils: Updating database tables at sqlite:////tmp/my-db in preparation for MLflow 1.0 schema migrations
Traceback (most recent call last):
  File "/Users/siddharthmurching/miniconda3/bin/mlflow", line 11, in <module>
    sys.exit(cli())
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/site-packages/mlflow/db.py", line 23, in upgrade
    mlflow.store.db.utils._upgrade_db_initialized_before_mlflow_1(url)
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/site-packages/mlflow/store/db/utils.py", line 90, in _upgrade_db_initialized_before_mlflow_1
    command.upgrade(config, 'heads')
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/site-packages/alembic/command.py", line 276, in upgrade
    script.run_env()
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/site-packages/alembic/script/base.py", line 475, in run_env
    util.load_python_file(self.dir, "env.py")
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/site-packages/alembic/util/pyfiles.py", line 90, in load_python_file
    module = load_module_py(module_id, path)
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/site-packages/alembic/util/compat.py", line 156, in load_module_py
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/site-packages/mlflow/temporary_db_migrations_for_pre_1_users/env.py", line 15, in <module>
    fileConfig(config.config_file_name)
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/logging/config.py", line 71, in fileConfig
    formatters = _create_formatters(cp)
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/logging/config.py", line 104, in _create_formatters
    flist = cp["formatters"]["keys"]
  File "/Users/siddharthmurching/miniconda3/lib/python3.7/configparser.py", line 958, in __getitem__
    raise KeyError(key)
KeyError: 'formatters'
```
 
## How is this patch tested?
 
* Generated a pre-1.0 MLflow tracking DB via `pip install mlflow==0.9.0 && python -c 'import mlflow; mlflow.set_tracking_uri("sqlite:////tmp/my-db"); mlflow.log_param("a","b")'`
* Built wheel via `python setup.py bdist_wheel`
* Installed wheel via `pip install dist/mlflow-1.0.0-py3-none-any.whl`
* Ran `mlflow db upgrade sqlite:////tmp/my-db` against a pre-1.0 MLflow tracking DB
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
