### PR TITLE
Add Content-Type header to Java tracking client.

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
@@ -73,6 +73,7 @@ class MlflowHttpCaller {
     HttpPost request = new HttpPost();
     fillRequestSettings(request, path);
     request.setEntity(new StringEntity(json, StandardCharsets.UTF_8));
+    request.setHeader("Content-Type", "application/json");
     try {
       HttpResponse response = httpClient.execute(request);
       checkError(response);


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Setting the Content-Type header on java client post to application/json
 
## How is this patch tested?
 
The updated Java client was used to make a CreateExperiment http post request to the AzureML tracking service which requires the Content-Type header to be set.
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [x] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
