### PR TITLE
Strip out SQLAlchemy driver before checking registered tracking store

### DIFF
--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -4,11 +4,39 @@ import numpy as np
 import pandas as pd
 from six.moves import urllib
 
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+
+from mlflow.store.dbmodels.db_types import DATABASE_ENGINES
 from mlflow.utils.annotations import deprecated, experimental, keyword_only
+from mlflow.utils.validation import _validate_db_type_string
 
 PYTHON_VERSION = "{major}.{minor}.{micro}".format(major=version_info.major,
                                                   minor=version_info.minor,
                                                   micro=version_info.micro)
+_INVALID_DB_URI_MSG = "Please refer to https://mlflow.org/docs/latest/tracking.html#storage for " \
+                      "format specifications."
+
+
+def extract_db_type_from_uri(db_uri):
+    """
+    Parse the specified DB URI to extract the database type. Confirm the database type is
+    supported. If a driver is specified, confirm it passes a plausible regex.
+    """
+    scheme = urllib.parse.urlparse(db_uri).scheme
+    scheme_plus_count = scheme.count('+')
+
+    if scheme_plus_count == 0:
+        db_type = scheme
+    elif scheme_plus_count == 1:
+        db_type, _ = scheme.split('+')
+    else:
+        error_msg = "Invalid database URI: '%s'. %s" % (db_uri, _INVALID_DB_URI_MSG)
+        raise MlflowException(error_msg, INVALID_PARAMETER_VALUE)
+
+    _validate_db_type_string(db_type)
+
+    return db_type
 
 
 def get_major_minor_py_version(py_version):
@@ -46,4 +74,8 @@ def get_unique_resource_id(max_length=None):
 
 
 def get_uri_scheme(uri_or_path):
-    return urllib.parse.urlparse(uri_or_path).scheme
+    scheme = urllib.parse.urlparse(uri_or_path).scheme
+    if any([scheme.lower().startswith(db) for db in DATABASE_ENGINES]):
+        return extract_db_type_from_uri(uri_or_path)
+    else:
+        return scheme

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -21,7 +21,8 @@ from mlflow.store.db.utils import _get_schema_version
 from mlflow.store.dbmodels import models
 from mlflow import entities
 from mlflow.exceptions import MlflowException
-from mlflow.store.sqlalchemy_store import SqlAlchemyStore, _parse_db_uri_extract_db_type
+from mlflow.store.sqlalchemy_store import SqlAlchemyStore
+from mlflow.utils import extract_db_type_from_uri
 from mlflow.utils.search_utils import SearchFilter
 from tests.resources.db.initial_models import Base as InitialBase
 from tests.integration.utils import invoke_cli_runner
@@ -46,18 +47,18 @@ class TestParseDbUri(unittest.TestCase):
         for target_db_type, drivers in target_db_type_uris.items():
             # try the driver-less version, which will revert SQLAlchemy to the default driver
             uri = "%s://..." % target_db_type
-            parsed_db_type = _parse_db_uri_extract_db_type(uri)
+            parsed_db_type = extract_db_type_from_uri(uri)
             self.assertEqual(target_db_type, parsed_db_type)
             # try each of the popular drivers (per SQLAlchemy's dialect pages)
             for driver in drivers:
                 uri = "%s+%s://..." % (target_db_type, driver)
-                parsed_db_type = _parse_db_uri_extract_db_type(uri)
+                parsed_db_type = extract_db_type_from_uri(uri)
                 self.assertEqual(target_db_type, parsed_db_type)
 
     def _db_uri_error(self, db_uris, expected_message_part):
         for db_uri in db_uris:
             with self.assertRaises(MlflowException) as e:
-                _parse_db_uri_extract_db_type(db_uri)
+                extract_db_type_from_uri(db_uri)
             self.assertIn(expected_message_part, e.exception.message)
 
     def test_fail_on_unsupported_db_type(self):

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -31,5 +31,5 @@ def test_extract_db_type_from_uri():
 
 
 for unsupported_db in ["a", "aa", "sql"]:
-        with pytest.raises(MlflowException):
-            extract_db_type_from_uri(unsupported_db)
+    with pytest.raises(MlflowException):
+        extract_db_type_from_uri(unsupported_db)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,6 +1,8 @@
 import pytest
 
-from mlflow.utils import get_unique_resource_id
+from mlflow.exceptions import MlflowException
+from mlflow.store.dbmodels.db_types import DATABASE_ENGINES
+from mlflow.utils import get_unique_resource_id, extract_db_type_from_uri, get_uri_scheme
 
 
 def test_get_unique_resource_id_respects_max_length():
@@ -15,3 +17,19 @@ def test_get_unique_resource_id_with_invalid_max_length_throws_exception():
 
     with pytest.raises(ValueError):
         get_unique_resource_id(max_length=0)
+
+
+def test_extract_db_type_from_uri():
+    uri = "{}://username:password@host:port/database"
+    for legit_db in DATABASE_ENGINES:
+        assert legit_db == extract_db_type_from_uri(uri.format(legit_db))
+        assert legit_db == get_uri_scheme(uri.format(legit_db))
+
+        with_driver = legit_db + "+driver-string"
+        assert legit_db == extract_db_type_from_uri(uri.format(with_driver))
+        assert legit_db == get_uri_scheme(uri.format(with_driver))
+
+
+for unsupported_db in ["a", "aa", "sql"]:
+        with pytest.raises(MlflowException):
+            extract_db_type_from_uri(unsupported_db)

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -29,7 +29,6 @@ def test_extract_db_type_from_uri():
         assert legit_db == extract_db_type_from_uri(uri.format(with_driver))
         assert legit_db == get_uri_scheme(uri.format(with_driver))
 
-
-for unsupported_db in ["a", "aa", "sql"]:
-    with pytest.raises(MlflowException):
-        extract_db_type_from_uri(unsupported_db)
+    for unsupported_db in ["a", "aa", "sql"]:
+        with pytest.raises(MlflowException):
+            extract_db_type_from_uri(unsupported_db)


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Tracking store registry expects a string match for registered `scheme` types. When URI of SQL type is used to create `SqlAlchemyStore` strips out driver type. Using the same code to extract db schema type before checking registry.
 
## How is this patch tested?
 
- [x] Unit tests
- [x] Manual tests 

## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
