### PR TITLE
Revert behavior change of _is_local_uri

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -40,7 +40,8 @@ def before_run_validations(tracking_uri, backend_config):
     if backend_config is None:
         raise ExecutionException("Backend spec must be provided when launching MLflow project "
                                  "runs on Databricks.")
-    if tracking.utils._is_databricks_uri(tracking_uri) or tracking.utils._is_http_uri(tracking_uri):
+    if not tracking.utils._is_databricks_uri(tracking_uri) and \
+            not tracking.utils._is_http_uri(tracking_uri):
         raise ExecutionException(
             "When running on Databricks, the MLflow tracking URI must be of the form "
             "'databricks' or 'databricks://profile', or a remote HTTP URI accessible to both the "

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -40,7 +40,7 @@ def before_run_validations(tracking_uri, backend_config):
     if backend_config is None:
         raise ExecutionException("Backend spec must be provided when launching MLflow project "
                                  "runs on Databricks.")
-    if tracking.utils._is_local_uri(tracking_uri):
+    if tracking.utils._is_databricks_uri(tracking_uri) or tracking.utils._is_http_uri(tracking_uri):
         raise ExecutionException(
             "When running on Databricks, the MLflow tracking URI must be of the form "
             "'databricks' or 'databricks://profile', or a remote HTTP URI accessible to both the "

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -73,8 +73,9 @@ def get_tracking_uri():
 
 
 def _is_local_uri(uri):
+    """Returns true if this is a local file path (/foo or file:/foo)."""
     scheme = urllib.parse.urlparse(uri).scheme
-    return uri != 'databricks' and (scheme == '' or scheme == 'file' or scheme == "sqlite")
+    return uri != 'databricks' and (scheme == '' or scheme == 'file')
 
 
 def _is_http_uri(uri):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,7 +25,7 @@ def test_server_static_prefix_validation():
 
 def test_server_default_artifact_root_validation():
     with mock.patch("mlflow.cli._run_server") as run_server_mock:
-        result = CliRunner().invoke(server, ["--backend-store-uri", "postgresql://"])
+        result = CliRunner().invoke(server, ["--backend-store-uri", "sqlite:///my.db"])
         assert result.output.startswith("Option 'default-artifact-root' is required")
         run_server_mock.assert_not_called()
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
From #1347, this allows the newly-added code in `mlflow server` and `mlflow ui` CLI commands to correctly validate server params when given a `sqlite` backend uri.
 
## How is this patch tested?
 
Unit tests
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.

 
### What component(s) does this PR affect?
 
- [x] CLI 
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
