### PR TITLE
Add ONNX docs to Python API section

### DIFF
--- a/docs/source/python_api/mlflow.onnx.rst
+++ b/docs/source/python_api/mlflow.onnx.rst
@@ -1,0 +1,7 @@
+mlflow.onnx
+==================
+
+.. automodule:: mlflow.onnx
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -1,6 +1,6 @@
 """
 The ``mlflow.onnx`` module provides APIs for logging and loading ONNX models in the MLflow Model
-format. This module exports MLflow models with the following flavors:
+format. This module exports MLflow Models with the following flavors:
 
 ONNX (native) format
     This is the main flavor that can be loaded back as an ONNX model object.

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -23,7 +23,7 @@ FLAVOR_NAME = "onnx"
 def get_default_conda_env():
     """
     :return: The default Conda environment for MLflow Models produced by calls to
-    :func:`save_model()` and :func:`log_model()`.
+             :func:`save_model()` and :func:`log_model()`.
     """
     import onnx
     import onnxruntime

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -1,3 +1,13 @@
+"""
+The ``mlflow.onnx`` module provides APIs for logging and loading ONNX models in the MLflow Model
+format. This module exports MLflow models with the following flavors:
+
+ONNX (native) format
+    This is the main flavor that can be loaded back as an ONNX model object.
+:py:mod:`mlflow.pyfunc`
+    Produced for use by generic pyfunc-based deployment tools and batch inference.
+"""
+
 from __future__ import absolute_import
 
 import os


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Add ONNX docs to Python API section
 
## How is this patch tested?
 
Manual generation of docs and verification that content looks as expected.
 
## Release Notes

ONNX support via a new ``onnx`` flavor in MLflow Models, including docs
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [X] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [X] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
