### PR TITLE
Remove reference to run_id in ONNX load_model() docs

### DIFF
--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -186,7 +186,7 @@ def _load_pyfunc(path):
 @experimental
 def load_model(model_uri):
     """
-    Load an ONNX model from a local file (if ``run_id`` is None) or a run.
+    Load an ONNX model from a local file or a run.
 
     :param model_uri: The location, in URI format, of the MLflow model, for example:
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Remove reference to run_id in ONNX `load_model()` docs
 
## How is this patch tested?
 
Manual generation of docs
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [X] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [X] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
