### PR TITLE
Fix downloading artifacts from ftp store

### DIFF
--- a/mlflow/store/ftp_artifact_repo.py
+++ b/mlflow/store/ftp_artifact_repo.py
@@ -121,4 +121,4 @@ class FTPArtifactRepository(ArtifactRepository):
             if remote_file_path else self.path
         with self.get_ftp_client() as ftp:
             with open(local_path, 'wb') as f:
-                ftp.retrbinary('RETR ' + remote_full_path, f)
+                ftp.retrbinary('RETR ' + remote_full_path, f.write)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Use the correct callback for downloading artifacts via ftp.
Downloading artifacts from ftp includes visualizing them in the UI.
Before this fix the server would fail with the following error:
```
[2019-06-04 19:57:32,510] ERROR in app: Exception on /get-artifact [GET]                                                                                                                                            
Traceback (most recent call last):                                                                                                                                                                                  
  File "/home/kahlech/.local/lib/python3.6/site-packages/flask/app.py", line 2292, in wsgi_app                                                                                                                      
    response = self.full_dispatch_request()                                                                                                                                                                         
  File "/home/kahlech/.local/lib/python3.6/site-packages/flask/app.py", line 1815, in full_dispatch_request                                                                                                         
    rv = self.handle_user_exception(e)                                                                                                                                                                              
  File "/home/kahlech/.local/lib/python3.6/site-packages/flask/app.py", line 1718, in handle_user_exception                                                                                                         
    reraise(exc_type, exc_value, tb)                                                                                                                                                                                
  File "/home/kahlech/.local/lib/python3.6/site-packages/flask/_compat.py", line 35, in reraise                                                                                                                     
    raise value                                                                                                                                                                                                     
  File "/home/kahlech/.local/lib/python3.6/site-packages/flask/app.py", line 1813, in full_dispatch_request                                                                                                         
    rv = self.dispatch_request()                                                                                                                                                                                    
  File "/home/kahlech/.local/lib/python3.6/site-packages/flask/app.py", line 1799, in dispatch_request                                                                                                              
    return self.view_functions[rule.endpoint](**req.view_args)                                                                                                                                                      
  File "/home/kahlech/packages/mlflow/mlflow/server/__init__.py", line 32, in serve_artifacts                                                                                                                       
    return get_artifact_handler()                                                                                                                                                                                   
  File "/home/kahlech/packages/mlflow/mlflow/server/handlers.py", line 81, in wrapper                                                                                                                               
    return func(*args, **kwargs)                                                                                                                                                                                    
  File "/home/kahlech/packages/mlflow/mlflow/server/handlers.py", line 107, in get_artifact_handler                                                                                                                 
    filename = os.path.abspath(_get_artifact_repo(run).download_artifacts(request_dict['path']))                                                                                                                    
  File "/home/kahlech/packages/mlflow/mlflow/store/artifact_repo.py", line 113, in download_artifacts                                                                                                               
    return download_artifacts_into(artifact_path, dst_path)                                                                                                                                                         
  File "/home/kahlech/packages/mlflow/mlflow/store/artifact_repo.py", line 94, in download_artifacts_into                                                                                                           
    self._download_file(remote_file_path=artifact_path, local_path=local_path)                                                                                                                                      
  File "/home/kahlech/packages/mlflow/mlflow/store/ftp_artifact_repo.py", line 123, in _download_file                                                                                                               
    ftp.retrbinary('RETR ' + remote_full_path, f)                                                                                                                                                                   
  File "/usr/lib/python3.6/ftplib.py", line 447, in retrbinary                                                                                                                                                      
    callback(data)                                                                                                                                                                                                  
TypeError: '_io.BufferedWriter' object is not callable   
```

Actually while were at it the artifact preview in the UI is broken as explained in #1338 So this fix only really makes a difference if the #1338 is fixed as otherwise you are never able to download artifacts via the UI anyway.
 
## How is this patch tested?
I don't think it is possible to mock.
So one would need to start up an actual ftp connection which is probably not an option.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Correctly download artifacts from ftp store (also fixes visualization in UI)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [x] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
