### PR TITLE
Fix db migration: remove drop check constraint

### DIFF
--- a/mlflow/temporary_db_migrations_for_pre_1_users/versions/ff01da956556_ensure_unique_constraint_names.py
+++ b/mlflow/temporary_db_migrations_for_pre_1_users/versions/ff01da956556_ensure_unique_constraint_names.py
@@ -164,13 +164,11 @@ def upgrade():
     # in Alembic's ability to reflect CHECK constraints, as described in
     # https://alembic.sqlalchemy.org/en/latest/batch.html#working-in-offline-mode
     with op.batch_alter_table("experiments", copy_from=SqlExperiment.__table__) as batch_op:
-        batch_op.drop_constraint(constraint_name='lifecycle_stage', type_="check")
         batch_op.create_check_constraint(
             constraint_name="experiments_lifecycle_stage",
             condition=column('lifecycle_stage').in_(["active", "deleted"])
         )
     with op.batch_alter_table("runs", copy_from=SqlRun.__table__) as batch_op:
-        batch_op.drop_constraint(constraint_name='lifecycle_stage', type_="check")
         batch_op.create_check_constraint(
             constraint_name="runs_lifecycle_stage",
             condition=column('lifecycle_stage').in_(["active", "deleted"])

--- a/mlflow/temporary_db_migrations_for_pre_1_users/versions/ff01da956556_ensure_unique_constraint_names.py
+++ b/mlflow/temporary_db_migrations_for_pre_1_users/versions/ff01da956556_ensure_unique_constraint_names.py
@@ -163,12 +163,21 @@ def upgrade():
     # Also, we directly pass the schema of the table we're modifying to circumvent shortcomings
     # in Alembic's ability to reflect CHECK constraints, as described in
     # https://alembic.sqlalchemy.org/en/latest/batch.html#working-in-offline-mode
+    bind = op.get_bind()
     with op.batch_alter_table("experiments", copy_from=SqlExperiment.__table__) as batch_op:
+        # We skip running drop_constraint for mysql, because it creates an invalid statement
+        # in alembic<=1.0.10
+        if bind.engine.name != 'mysql':
+            batch_op.drop_constraint(constraint_name='lifecycle_stage', type_="check")
         batch_op.create_check_constraint(
             constraint_name="experiments_lifecycle_stage",
             condition=column('lifecycle_stage').in_(["active", "deleted"])
         )
     with op.batch_alter_table("runs", copy_from=SqlRun.__table__) as batch_op:
+        # We skip running drop_constraint for mysql, because it creates an invalid statement
+        # in alembic<=1.0.10
+        if bind.engine.name != 'mysql':
+            batch_op.drop_constraint(constraint_name='lifecycle_stage', type_="check")
         batch_op.create_check_constraint(
             constraint_name="runs_lifecycle_stage",
             condition=column('lifecycle_stage').in_(["active", "deleted"])


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove the `drop_constraint` calls to `alembic`  since it generates invalid `DROP CONSTRAINT` statements for mysql. Solves #1397.

More detail:

The migration script introduced in #1292 drops some `CHECK` constraints. To drop a check constraint in MySQL,
- in versions 8.0.16+, you can use DROP CHECK
- in previous versions, dropping checks is not supported

However, `alembic` creates a `DROP CONSTRAINT` statement in its `drop_constraint` method, so the migration script here fails.

It is safe to remove the “DROP CONSTRAINT” portion of the migration since:
- DBs that require the constraint names to be unique (e.g. mysql 8.0.16+) could not have been created pre-1.0, so they do not need to be migrated.
- DBs that do not require the constraint names to be unique (e.g. mysql 8.0.15-, postgres) do not need the “DROP CONSTRAINT” portion of the migration.
 
## How is this patch tested?
 
Unit test - tests migration for sqlite

Manual QA: run migration with the new code
- from mlflow 0.9.1: there is an experiment_id type error when logging metrics, so you can't meaningfully use the DBs. however, migrating a basic db with just the default experiment works for:
  - [x] mysql 5.7
  - [x] postgres
  - [x] sqlite
- from mlflow 0.9.0:
  - [x] mysql 5.7
  - [x] postgres
  - [x] sqlite

Manual test steps:
- create a db in mlflow 0.9.0, run server
- create some experiments & log runs with tags (e.g. `run_name`, `source_name`), check UI
- run server in mlflow 1.0, see error telling you to migrate the db
- run `mlflow db upgrade <db_uri>` with the new code here
- run server in mlflow 1.0, see that the UI displays the runs & experiments created in 0.9.0
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Fix the database migration script.
 
### What component(s) does this PR affect?
 
- [X] Tracking

### How should the PR be classified in the release notes? Choose one:
 
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
