### PR TITLE
Fix broken lint

### DIFF
--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -10,6 +10,7 @@ mock==2.0.0
 onnx==1.4.1; python_version >= "3.0"
 onnxmltools==1.4.0; python_version >= "3.0"
 onnxruntime==0.3.0; python_version >= "3.0"
+mleap==0.8.1
 pandas<=0.23.4
 pyarrow==0.12.1
 pyspark==2.4.0


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Our lint build broke because we removed `mleap` as a dependency of MLflow but didn't add it as a test requirement in `large-requirements.txt`. CI passed at the time because we depend on https://github.com/mlflow/mlflow/blob/master/tests/resources/mlflow-test-plugin/setup.py#L9 as a test dependency, and it in turn installs mlflow from pypi (so we actually have PyPI MLflow as a test dependency, which is an issue we can address separately)
 
## How is this patch tested?
 
Existing tests (lint)
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
