### PR TITLE
Exclude map files from Python distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ def package_files(directory):
     paths = []
     for (path, _, filenames) in os.walk(directory):
         for filename in filenames:
-            paths.append(os.path.join('..', path, filename))
+            # Don't include CSS and JS map files in distributions.
+            # These files are quite large and don't provide much value to endusers.
+            if not filename.endswith('.map'):
+                paths.append(os.path.join('..', path, filename))
     return paths
 
 


### PR DESCRIPTION
Fixes #1386

## What changes are proposed in this pull request?
 
No longer ship the JS and CSS map files in Python wheels. By removing them, the frontend stacktraces can no longer resolve to readable lines but this shrinks the size of the wheel from 13M to 3.9M and also the on-disk size from 52M to 11M.
 
## How is this patch tested?
 
Removed the files and the UI was still working as expected.
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
