### PR TITLE
Fix CLI server and ui commands to work with db driver

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -8,7 +8,6 @@ from functools import wraps
 from flask import Response, request, send_file
 from querystring_parser import parser
 
-from mlflow.store.dbmodels.db_types import DATABASE_ENGINES
 from mlflow.entities import Metric, Param, RunTag, ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.protos import databricks_pb2
@@ -17,7 +16,8 @@ from mlflow.protos.service_pb2 import CreateExperiment, MlflowService, GetExperi
     UpdateRun, LogMetric, LogParam, SetTag, ListExperiments, \
     DeleteExperiment, RestoreExperiment, RestoreRun, DeleteRun, UpdateExperiment, LogBatch
 from mlflow.store.artifact_repository_registry import get_artifact_repository
-from mlflow.tracking.utils import TrackingStoreRegistry
+from mlflow.store.dbmodels.db_types import DATABASE_ENGINES
+from mlflow.tracking.registry import TrackingStoreRegistry
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.search_utils import SearchFilter
 from mlflow.utils.validation import _validate_batch_log_api_req
@@ -48,11 +48,7 @@ def _get_store(backend_store_uri=None, default_artifact_root=None):
     if _store is None:
         store_uri = backend_store_uri or os.environ.get(BACKEND_STORE_URI_ENV_VAR, None)
         artifact_root = default_artifact_root or os.environ.get(ARTIFACT_ROOT_ENV_VAR, None)
-        try:
-            _store = _tracking_store_registry.get_store(store_uri, artifact_root)
-        except MlflowException:
-            raise MlflowException("Unexpected URI type '{}' for backend store. "
-                                  "Expected local file or database type.".format(store_uri))
+        _store = _tracking_store_registry.get_store(store_uri, artifact_root)
     return _store
 
 

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -3,6 +3,7 @@ import warnings
 import entrypoints
 
 from mlflow.exceptions import MlflowException
+from mlflow.tracking import utils
 from mlflow.utils import get_uri_scheme
 
 
@@ -52,7 +53,7 @@ class TrackingStoreRegistry:
         :return: An instance of `mlflow.store.AbstractStore` that fulfills the store URI
                  requirements.
         """
-        store_uri = store_uri if store_uri is not None else get_tracking_uri()
+        store_uri = store_uri if store_uri is not None else utils.get_tracking_uri()
         scheme = store_uri if store_uri == "databricks" else get_uri_scheme(store_uri)
 
         try:
@@ -60,5 +61,5 @@ class TrackingStoreRegistry:
         except KeyError:
             raise MlflowException(
                 "Unexpected URI scheme '{}' for tracking store. "
-                "Valid schemes are: ".format(store_uri, list(self._registry.keys())))
+                "Valid schemes are: {}".format(store_uri, list(self._registry.keys())))
         return store_builder(store_uri=store_uri, artifact_uri=artifact_uri)

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -1,0 +1,64 @@
+import warnings
+
+import entrypoints
+
+from mlflow.exceptions import MlflowException
+from mlflow.utils import get_uri_scheme
+
+
+class TrackingStoreRegistry:
+    """Scheme-based registry for tracking store implementations
+
+    This class allows the registration of a function or class to provide an
+    implementation for a given scheme of `store_uri` through the `register`
+    methods. Implementations declared though the entrypoints
+    `mlflow.tracking_store` group can be automatically registered through the
+    `register_entrypoints` method.
+
+    When instantiating a store through the `get_store` method, the scheme of
+    the store URI provided (or inferred from environment) will be used to
+    select which implementation to instantiate, which will be called with same
+    arguments passed to the `get_store` method.
+    """
+
+    def __init__(self):
+        self._registry = {}
+
+    def register(self, scheme, store_builder):
+        self._registry[scheme] = store_builder
+
+    def register_entrypoints(self):
+        """Register tracking stores provided by other packages"""
+        for entrypoint in entrypoints.get_group_all("mlflow.tracking_store"):
+            try:
+                self.register(entrypoint.name, entrypoint.load())
+            except (AttributeError, ImportError) as exc:
+                warnings.warn(
+                    'Failure attempting to register tracking store for scheme "{}": {}'.format(
+                        entrypoint.name, str(exc)
+                    ),
+                    stacklevel=2
+                )
+
+    def get_store(self, store_uri=None, artifact_uri=None):
+        """Get a store from the registry based on the scheme of store_uri
+
+        :param store_uri: The store URI. If None, it will be inferred from the environment. This URI
+                          is used to select which tracking store implementation to instantiate and
+                          is passed to the constructor of the implementation.
+        :param artifact_uri: Artifact repository URI. Passed through to the tracking store
+                             implementation.
+
+        :return: An instance of `mlflow.store.AbstractStore` that fulfills the store URI
+                 requirements.
+        """
+        store_uri = store_uri if store_uri is not None else get_tracking_uri()
+        scheme = store_uri if store_uri == "databricks" else get_uri_scheme(store_uri)
+
+        try:
+            store_builder = self._registry[scheme]
+        except KeyError:
+            raise MlflowException(
+                "Unexpected URI scheme '{}' for tracking store. "
+                "Valid schemes are: ".format(store_uri, list(self._registry.keys())))
+        return store_builder(store_uri=store_uri, artifact_uri=artifact_uri)

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -3,7 +3,6 @@ import warnings
 import entrypoints
 
 from mlflow.exceptions import MlflowException
-from mlflow.tracking import utils
 from mlflow.utils import get_uri_scheme
 
 
@@ -53,6 +52,7 @@ class TrackingStoreRegistry:
         :return: An instance of `mlflow.store.AbstractStore` that fulfills the store URI
                  requirements.
         """
+        from mlflow.tracking import utils
         store_uri = store_uri if store_uri is not None else utils.get_tracking_uri()
         scheme = store_uri if store_uri == "databricks" else get_uri_scheme(store_uri)
 

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -2,17 +2,15 @@ from __future__ import print_function
 
 import os
 import sys
-import warnings
 
-import entrypoints
 from six.moves import urllib
 
-from mlflow.exceptions import MlflowException
 from mlflow.store import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 from mlflow.store.dbmodels.db_types import DATABASE_ENGINES
 from mlflow.store.file_store import FileStore
 from mlflow.store.rest_store import RestStore
-from mlflow.utils import env, rest_utils, get_uri_scheme
+from mlflow.tracking.registry import TrackingStoreRegistry
+from mlflow.utils import env, rest_utils
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 
@@ -127,67 +125,6 @@ def get_db_profile_from_uri(uri):
 def _get_databricks_rest_store(store_uri, **_):
     profile = get_db_profile_from_uri(store_uri)
     return RestStore(lambda: get_databricks_host_creds(profile))
-
-
-class TrackingStoreRegistry:
-    """Scheme-based registry for tracking store implementations
-
-    This class allows the registration of a function or class to provide an
-    implementation for a given scheme of `store_uri` through the `register`
-    methods. Implementations declared though the entrypoints
-    `mlflow.tracking_store` group can be automatically registered through the
-    `register_entrypoints` method.
-
-    When instantiating a store through the `get_store` method, the scheme of
-    the store URI provided (or inferred from environment) will be used to
-    select which implementation to instantiate, which will be called with same
-    arguments passed to the `get_store` method.
-    """
-
-    def __init__(self):
-        self._registry = {}
-
-    def register(self, scheme, store_builder):
-        self._registry[scheme] = store_builder
-
-    def register_entrypoints(self):
-        """Register tracking stores provided by other packages"""
-        for entrypoint in entrypoints.get_group_all("mlflow.tracking_store"):
-            try:
-                self.register(entrypoint.name, entrypoint.load())
-            except (AttributeError, ImportError) as exc:
-                warnings.warn(
-                    'Failure attempting to register tracking store for scheme "{}": {}'.format(
-                        entrypoint.name, str(exc)
-                    ),
-                    stacklevel=2
-                )
-
-    def get_store(self, store_uri=None, artifact_uri=None):
-        """Get a store from the registry based on the scheme of store_uri
-
-        :param store_uri: The store URI. If None, it will be inferred from the environment. This URI
-                          is used to select which tracking store implementation to instantiate and
-                          is passed to the constructor of the implementation.
-        :param artifact_uri: Artifact repository URI. Passed through to the tracking store
-                             implementation.
-
-        :return: An instance of `mlflow.store.AbstractStore` that fulfills the store URI
-                 requirements.
-        """
-        store_uri = store_uri if store_uri is not None else get_tracking_uri()
-        scheme = store_uri if store_uri == "databricks" else get_uri_scheme(store_uri)
-
-        try:
-            store_builder = self._registry[scheme]
-        except KeyError:
-            raise MlflowException(
-                "Could not find a registered tracking store for: {}. "
-                "Currently registered schemes are: {}".format(
-                    store_uri, list(self._registry.keys())
-                )
-            )
-        return store_builder(store_uri=store_uri, artifact_uri=artifact_uri)
 
 
 _tracking_store_registry = TrackingStoreRegistry()

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -12,7 +12,7 @@ from mlflow.store import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 from mlflow.store.dbmodels.db_types import DATABASE_ENGINES
 from mlflow.store.file_store import FileStore
 from mlflow.store.rest_store import RestStore
-from mlflow.utils import env, rest_utils, file_utils, get_uri_scheme
+from mlflow.utils import env, rest_utils, get_uri_scheme
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 
@@ -90,13 +90,7 @@ def _is_databricks_uri(uri):
 
 
 def _get_file_store(store_uri, **_):
-    return FileStore(file_utils.local_file_uri_to_path(store_uri), store_uri)
-
-
-def _is_database_uri(uri):
-    if urllib.parse.urlparse(uri).scheme not in DATABASE_ENGINES:
-        return False
-    return True
+    return FileStore(store_uri, store_uri)
 
 
 def _get_sqlalchemy_store(store_uri, artifact_uri):

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -8,9 +8,10 @@ from mlflow.store.dbmodels.db_types import DATABASE_ENGINES
 from mlflow.store.file_store import FileStore
 from mlflow.store.rest_store import RestStore
 from mlflow.store.sqlalchemy_store import SqlAlchemyStore
+from mlflow.tracking.registry import TrackingStoreRegistry
 from mlflow.tracking.utils import _get_store, _TRACKING_URI_ENV_VAR, _TRACKING_USERNAME_ENV_VAR, \
     _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, _TRACKING_INSECURE_TLS_ENV_VAR, \
-    get_db_profile_from_uri, TrackingStoreRegistry
+    get_db_profile_from_uri
 
 
 def test_get_store_file_store(tmp_wkdir):
@@ -277,7 +278,7 @@ def test_get_store_for_unregistered_scheme():
     tracking_store = TrackingStoreRegistry()
 
     with pytest.raises(mlflow.exceptions.MlflowException,
-                       match="Could not find a registered tracking store"):
+                       match="Unexpected URI scheme"):
         tracking_store.get_store("unknown-scheme://")
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
#1297 & #1374 added support for using non-default drivers for database URIs, but they do not work with the CLI commands `mlflow server` and `mlflow ui`. Adding support here.
 
## How is this patch tested?

- Added a unit test for verifying that `SQLAlchemyStore` is called with the right arguments for `mlflow server`.
- Manual tests:
  - CLI: start server and view UI
```
mlflow server --backend-store-uri mysql+pymysql://root:password@localhost/mlflow --default-artifact-root /Users/sueann/mlflow-data
```
  - Client: make sure you can create experiments and log metrics.
```
import mlflow
mlflow.set_tracking_uri("mysql+pymysql://root:password@localhost/mlflow")
client = mlflow.tracking.client.MlflowClient()
with mlflow.start_run(experiment_id=0, run_name=("blah")):
    mlflow.log_metric("m_z", 12345)
``` 

## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
CLI commands ``mlflow server`` and ``mlflow ui`` support backend tracking URIs containing non-default database drivers for sqlalchemy.
 
### What component(s) does this PR affect?
 
- [X] CLI 
- [X] Tracking

### How should the PR be classified in the release notes? Choose one:
 
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
