### PR TITLE
Make requests to ajax-api in JavaScript relative

### DIFF
--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -18,15 +18,16 @@ REL_STATIC_DIR = "js/build"
 app = Flask(__name__, static_folder=REL_STATIC_DIR)
 STATIC_DIR = os.path.join(app.root_path, REL_STATIC_DIR)
 
-for http_path, handler, methods in handlers.get_endpoints():
-    app.add_url_rule(http_path, handler.__name__, handler, methods=methods)
-
 
 def _add_static_prefix(route):
     prefix = os.environ.get(STATIC_PREFIX_ENV_VAR)
     if prefix:
         return prefix + route
     return route
+
+
+for http_path, handler, methods in handlers.get_endpoints():
+    app.add_url_rule(_add_static_prefix(http_path), handler.__name__, handler, methods=methods)
 
 
 # Serve the "get-artifact" route.

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -4,14 +4,13 @@ import shlex
 from flask import Flask, send_from_directory
 
 from mlflow.server import handlers
-from mlflow.server.handlers import get_artifact_handler
+from mlflow.server.handlers import get_artifact_handler, STATIC_PREFIX_ENV_VAR, _add_static_prefix
 from mlflow.utils.process import exec_cmd
 
 # NB: These are intenrnal environment variables used for communication between
 # the cli and the forked gunicorn processes.
 BACKEND_STORE_URI_ENV_VAR = "_MLFLOW_SERVER_FILE_STORE"
 ARTIFACT_ROOT_ENV_VAR = "_MLFLOW_SERVER_ARTIFACT_ROOT"
-STATIC_PREFIX_ENV_VAR = "_MLFLOW_STATIC_PREFIX"
 
 REL_STATIC_DIR = "js/build"
 
@@ -19,15 +18,8 @@ app = Flask(__name__, static_folder=REL_STATIC_DIR)
 STATIC_DIR = os.path.join(app.root_path, REL_STATIC_DIR)
 
 
-def _add_static_prefix(route):
-    prefix = os.environ.get(STATIC_PREFIX_ENV_VAR)
-    if prefix:
-        return prefix + route
-    return route
-
-
 for http_path, handler, methods in handlers.get_endpoints():
-    app.add_url_rule(_add_static_prefix(http_path), handler.__name__, handler, methods=methods)
+    app.add_url_rule(http_path, handler.__name__, handler, methods=methods)
 
 
 # Serve the "get-artifact" route.

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -22,6 +22,14 @@ from mlflow.utils.search_utils import SearchFilter
 from mlflow.utils.validation import _validate_batch_log_api_req
 
 _store = None
+STATIC_PREFIX_ENV_VAR = "_MLFLOW_STATIC_PREFIX"
+
+
+def _add_static_prefix(route):
+    prefix = os.environ.get(STATIC_PREFIX_ENV_VAR)
+    if prefix:
+        return prefix + route
+    return route
 
 
 def _get_store(backend_store_uri=None, default_artifact_root=None):
@@ -360,7 +368,7 @@ def _get_paths(base_path):
     We should register paths like /api/2.0/preview/mlflow/experiment and
     /ajax-api/2.0/preview/mlflow/experiment in the Flask router.
     """
-    return ['/api/2.0{}'.format(base_path), '/ajax-api/2.0{}'.format(base_path)]
+    return ['/api/2.0{}'.format(base_path), _add_static_prefix('/ajax-api/2.0{}'.format(base_path))]
 
 
 def get_endpoints():

--- a/mlflow/server/js/src/sdk/MlflowService.js
+++ b/mlflow/server/js/src/sdk/MlflowService.js
@@ -21,7 +21,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static createExperiment({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/experiments/create', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/experiments/create', {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -38,7 +38,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static listExperiments({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/experiments/list', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/experiments/list', {
       type: 'GET',
       dataType: 'json',
       converters: {
@@ -58,7 +58,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static getExperiment({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/experiments/get', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/experiments/get', {
       type: 'GET',
       dataType: 'json',
       converters: {
@@ -78,7 +78,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static createRun({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/runs/create', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/runs/create', {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -95,7 +95,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static deleteRun({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/runs/delete', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/runs/delete', {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -112,7 +112,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static restoreRun({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/runs/restore', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/runs/restore', {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -129,7 +129,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static updateRun({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/runs/update', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/runs/update', {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -146,7 +146,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static logMetric({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/runs/log-metric', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/runs/log-metric', {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -163,7 +163,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static logParam({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/runs/log-parameter', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/runs/log-parameter', {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -180,7 +180,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static getRun({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/runs/get', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/runs/get', {
       type: 'GET',
       dataType: 'json',
       converters: {
@@ -200,7 +200,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static searchRuns({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/runs/search', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/runs/search', {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -217,7 +217,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static listArtifacts({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/artifacts/list', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/artifacts/list', {
       type: 'GET',
       dataType: 'json',
       converters: {
@@ -237,7 +237,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static getMetricHistory({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/metrics/get-history', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/metrics/get-history', {
       type: 'GET',
       dataType: 'json',
       converters: {
@@ -257,7 +257,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static setTag({ data, success, error }) {
-    return $.ajax('/ajax-api/2.0/preview/mlflow/runs/set-tag', {
+    return $.ajax('ajax-api/2.0/preview/mlflow/runs/set-tag', {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),


### PR DESCRIPTION
## What changes are proposed in this pull request?

When running the mlflow UI behind a proxy, it may no longer be served directly
 on `/` but in a subpath. As it is a single page web-app, the JavaScript code will
always be executed in the same path and thus we don't need any absolute references.

Fixes #1120

## How is this patch tested?
 
Started `mlflow ui` and accessed the UI through `jupyter-server-proxy` which serves it behind `/proxy/5000/`. Previously this would break as `ajax-api` was served via `/proxy/5000/ajax-api` but the JavaScript code requested the API at `/ajax-api`. Now the UI works as it would be sitting directly on `/`.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
`mlflow` can now be served from a (non-root) path behind a proxy.
 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
