### PR TITLE
Show run search filters in URL

### DIFF
--- a/mlflow/server/js/src/Routes.js
+++ b/mlflow/server/js/src/Routes.js
@@ -25,6 +25,12 @@ class Routes {
   }
 
   static compareRunPageRoute = "/compare-runs"
+
+  static getRunSearchPageRoute(paramKeyFilterInput, metricKeyFilterInput, searchInput, lifecycleFilterInput) {
+    return `/s?params=${paramKeyFilterInput}&metrics=${metricKeyFilterInput}`
+            +`&searchInput=${searchInput}&lifecycle=${lifecycleFilterInput}`
+  }
+
 }
 
 export default Routes;

--- a/mlflow/server/js/src/Routes.js
+++ b/mlflow/server/js/src/Routes.js
@@ -7,6 +7,8 @@ class Routes {
 
   static experimentPageRoute = "/experiments/:experimentId";
 
+  static experimentPageSearchRoute = "/experiments/:experimentId/:searchString";
+
   static getRunPageRoute(experimentId, runUuid) {
     return `/experiments/${experimentId}/runs/${runUuid}`;
   }
@@ -25,11 +27,6 @@ class Routes {
   }
 
   static compareRunPageRoute = "/compare-runs"
-
-  static getRunSearchPageRoute(paramKeyFilterInput, metricKeyFilterInput, searchInput, lifecycleFilterInput) {
-    return `/s?params=${paramKeyFilterInput}&metrics=${metricKeyFilterInput}`
-            +`&searchInput=${searchInput}&lifecycle=${lifecycleFilterInput}`
-  }
 
 }
 

--- a/mlflow/server/js/src/Routes.js
+++ b/mlflow/server/js/src/Routes.js
@@ -27,7 +27,6 @@ class Routes {
   }
 
   static compareRunPageRoute = "/compare-runs"
-
 }
 
 export default Routes;

--- a/mlflow/server/js/src/components/App.js
+++ b/mlflow/server/js/src/components/App.js
@@ -13,6 +13,7 @@ import CompareRunPage from './CompareRunPage';
 import AppErrorBoundary from './error-boundaries/AppErrorBoundary';
 import { connect } from 'react-redux';
 import HomePage from './HomePage';
+import ExperimentPage from './ExperimentPage'
 import ErrorModal from './modals/ErrorModal';
 import PageNotFoundView from './PageNotFoundView';
 import { Switch } from 'react-router';
@@ -52,6 +53,7 @@ class App extends Component {
               <Route exact path={Routes.runPageRoute} component={RunPage}/>
               <Route exact path={Routes.metricPageRoute} component={MetricPage}/>
               <Route exact path={Routes.compareRunPageRoute} component={CompareRunPage}/>
+              <Route path={Routes.experimentPageSearchRoute} component={HomePage}/>
               <Route component={PageNotFoundView}/>
             </Switch>
           </AppErrorBoundary>

--- a/mlflow/server/js/src/components/App.js
+++ b/mlflow/server/js/src/components/App.js
@@ -13,7 +13,6 @@ import CompareRunPage from './CompareRunPage';
 import AppErrorBoundary from './error-boundaries/AppErrorBoundary';
 import { connect } from 'react-redux';
 import HomePage from './HomePage';
-import ExperimentPage from './ExperimentPage'
 import ErrorModal from './modals/ErrorModal';
 import PageNotFoundView from './PageNotFoundView';
 import { Switch } from 'react-router';

--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -7,14 +7,12 @@ import ExperimentView from './ExperimentView';
 import RequestStateWrapper from './RequestStateWrapper';
 import KeyFilter from '../utils/KeyFilter';
 import { ViewType } from '../sdk/MlflowEnums';
-import LocalStorageUtils from "../utils/LocalStorageUtils";
 import { ExperimentPagePersistedState } from "../sdk/MlflowLocalStorageMessages";
 import Utils from "../utils/Utils";
 import ErrorCodes from "../sdk/ErrorCodes";
 import PermissionDeniedView from "./PermissionDeniedView";
 import {Spinner} from "./Spinner";
 import { withRouter } from 'react-router-dom';
-import Routes from '../Routes';
 
 export const LIFECYCLE_FILTER = { ACTIVE: 'Active', DELETED: 'Deleted' };
 
@@ -35,6 +33,7 @@ class ExperimentPage extends Component {
     dispatchSearchRuns: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
     searchString: PropTypes.string.isRequired,
+    location: PropTypes.object,
   };
 
   /** Returns default values for state attributes that aren't persisted in the URL. */
@@ -69,7 +68,7 @@ class ExperimentPage extends Component {
     if (props.experimentId !== state.lastExperimentId) {
       const newState = {
         ...ExperimentPage.getDefaultUnpersistedState(),
-        persistedState: state.lastExperimentId == undefined ?
+        persistedState: state.lastExperimentId === undefined ?
             state.persistedState : (new ExperimentPagePersistedState()).toJSON(),
         lastExperimentId: props.experimentId,
         lifecycleFilter: LIFECYCLE_FILTER.ACTIVE,
@@ -98,14 +97,13 @@ class ExperimentPage extends Component {
       this.props.experimentId, searchInput, lifecycleFilterInput);
     this.setState({ searchRunsRequestId });
     this.updateUrlWithSearchFilter({
-        paramKeyFilterString,
-        metricKeyFilterString,
-        searchInput,
-      });
+      paramKeyFilterString,
+      metricKeyFilterString,
+      searchInput,
+    });
   }
 
   updateUrlWithSearchFilter(state) {
-    var stateObj = {};
     this.props.history
         .push(`/experiments/${this.props.experimentId}/s?${Utils.getSearchUrlFromState(state)}`);
   }

--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -21,11 +21,9 @@ export const LIFECYCLE_FILTER = { ACTIVE: 'Active', DELETED: 'Deleted' };
 class ExperimentPage extends Component {
   constructor(props) {
     super(props);
-    debugger;
     this.onSearch = this.onSearch.bind(this);
     this.getRequestIds = this.getRequestIds.bind(this);
     const urlState = Utils.getSearchParamsFromUrl(props.location.search);
-
     this.state = {
       ...ExperimentPage.getDefaultUnpersistedState(),
       persistedState: urlState,
@@ -36,7 +34,7 @@ class ExperimentPage extends Component {
     experimentId: PropTypes.number.isRequired,
     dispatchSearchRuns: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
-    searchString: PropTypes.string.isRequired
+    searchString: PropTypes.string.isRequired,
   };
 
   /** Returns default values for state attributes that aren't persisted in the URL. */
@@ -96,8 +94,8 @@ class ExperimentPage extends Component {
       }).toJSON(),
       lifecycleFilter: lifecycleFilterInput,
     });
-    const searchRunsRequestId = this.props.dispatchSearchRuns(this.props.experimentId,
-        searchInput, lifecycleFilterInput);
+    const searchRunsRequestId = this.props.dispatchSearchRuns(
+      this.props.experimentId, searchInput, lifecycleFilterInput);
     this.setState({ searchRunsRequestId });
     this.updateUrlWithSearchFilter({
         paramKeyFilterString,
@@ -145,7 +143,7 @@ class ExperimentPage extends Component {
               lifecycleFilter={this.state.lifecycleFilter}
               onSearch={this.onSearch}
               searchRunsError={searchRunsError}
-              searchInput={this.state.persistedState.searchInput==undefined?'':this.state.persistedState.searchInput}
+              searchInput={this.state.persistedState.searchInput}
               isLoading={isLoading && !searchRunsError}
             />;
           }}

--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -24,7 +24,11 @@ class ExperimentPage extends Component {
     const urlState = Utils.getSearchParamsFromUrl(props.location.search);
     this.state = {
       ...ExperimentPage.getDefaultUnpersistedState(),
-      persistedState: urlState,
+      persistedState: {
+        paramKeyFilterString: urlState['params'],
+        metricKeyFilterString: urlState['metrics'],
+        searchInput: urlState['search'],
+      },
     };
   }
 
@@ -97,9 +101,9 @@ class ExperimentPage extends Component {
       this.props.experimentId, searchInput, lifecycleFilterInput);
     this.setState({ searchRunsRequestId });
     this.updateUrlWithSearchFilter({
-      paramKeyFilterString,
-      metricKeyFilterString,
-      searchInput,
+      params: paramKeyFilterString,
+      metrics: metricKeyFilterString,
+      search: searchInput,
     });
   }
 

--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -25,9 +25,9 @@ class ExperimentPage extends Component {
     this.state = {
       ...ExperimentPage.getDefaultUnpersistedState(),
       persistedState: {
-        paramKeyFilterString: urlState['params'],
-        metricKeyFilterString: urlState['metrics'],
-        searchInput: urlState['search'],
+        paramKeyFilterString: urlState.params,
+        metricKeyFilterString: urlState.metrics,
+        searchInput: urlState.search,
       },
     };
   }

--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -14,6 +14,8 @@ import ErrorCodes from "../sdk/ErrorCodes";
 import PermissionDeniedView from "./PermissionDeniedView";
 import {Spinner} from "./Spinner";
 
+import Routes from '../Routes';
+
 export const LIFECYCLE_FILTER = { ACTIVE: 'Active', DELETED: 'Deleted' };
 
 class ExperimentPage extends Component {
@@ -108,6 +110,13 @@ class ExperimentPage extends Component {
     const searchRunsRequestId = this.props.dispatchSearchRuns(
       this.props.experimentId, searchInput, lifecycleFilterInput);
     this.setState({ searchRunsRequestId });
+    this.updateUrlWithSearchFilter(paramKeyFilterString, metricKeyFilterString, searchInput, lifecycleFilterInput);
+  }
+
+  updateUrlWithSearchFilter(paramKeyFilterInput, metricKeyFilterInput, searchInput, lifecycleFilterInput) {
+    var stateObj = {};
+    window.history.replaceState(stateObj, "search page",
+        Routes.getRunSearchPageRoute(paramKeyFilterInput, metricKeyFilterInput, searchInput, lifecycleFilterInput));
   }
 
   render() {

--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -23,14 +23,14 @@ class ExperimentPage extends Component {
     super(props);
     this.onSearch = this.onSearch.bind(this);
     this.getRequestIds = this.getRequestIds.bind(this);
-    const store = ExperimentPage.getLocalStore(this.props.experimentId);
+    const urlState = Utils.getSearchParamsFromUrl(window.location.search);
+
     // Load state data persisted in localStorage. If data isn't present in localStorage (e.g. the
     // first time we construct this component in a browser), the default values in
     // ExperimentPagePersistedState will take precedence.
-    const persistedState = new ExperimentPagePersistedState(store.loadComponentState());
     this.state = {
       ...ExperimentPage.getDefaultUnpersistedState(),
-      persistedState: persistedState.toJSON(),
+      persistedState: urlState,
     };
   }
 
@@ -53,18 +53,9 @@ class ExperimentPage extends Component {
     };
   }
 
-  /**
-   * Returns a LocalStorageStore instance that can be used to persist data associated with the
-   * ExperimentPage component (e.g. component state like metric/param filter info), for the
-   * specified experiment.
-   */
-  static getLocalStore(experimentId) {
-    return LocalStorageUtils.getStoreForComponent("ExperimentPage", experimentId);
-  }
-
   snapshotComponentState() {
-    const store = ExperimentPage.getLocalStore(this.props.experimentId);
-    store.saveComponentState(new ExperimentPagePersistedState(this.state.persistedState));
+    debugger;
+    this.updateUrlWithSearchFilter();
   }
 
   componentDidUpdate() {
@@ -79,11 +70,10 @@ class ExperimentPage extends Component {
 
   static getDerivedStateFromProps(props, state) {
     if (props.experimentId !== state.lastExperimentId) {
-      const store = ExperimentPage.getLocalStore(props.experimentId);
-      const loadedState = new ExperimentPagePersistedState(store.loadComponentState()).toJSON();
       const newState = {
         ...ExperimentPage.getDefaultUnpersistedState(),
-        persistedState: loadedState,
+        persistedState: state.lastExperimentId == undefined ?
+            state.persistedState : (new ExperimentPagePersistedState()).toJSON(),
         lastExperimentId: props.experimentId,
         lifecycleFilter: LIFECYCLE_FILTER.ACTIVE,
       };
@@ -99,6 +89,7 @@ class ExperimentPage extends Component {
   }
 
   onSearch(paramKeyFilterString, metricKeyFilterString, searchInput, lifecycleFilterInput) {
+
     this.setState({
       persistedState: new ExperimentPagePersistedState({
         paramKeyFilterString,
@@ -110,13 +101,13 @@ class ExperimentPage extends Component {
     const searchRunsRequestId = this.props.dispatchSearchRuns(
       this.props.experimentId, searchInput, lifecycleFilterInput);
     this.setState({ searchRunsRequestId });
-    this.updateUrlWithSearchFilter(paramKeyFilterString, metricKeyFilterString, searchInput, lifecycleFilterInput);
+    //this.updateUrlWithSearchFilter();
   }
 
-  updateUrlWithSearchFilter(paramKeyFilterInput, metricKeyFilterInput, searchInput, lifecycleFilterInput) {
+  updateUrlWithSearchFilter() {
     var stateObj = {};
     window.history.replaceState(stateObj, "search page",
-        Routes.getRunSearchPageRoute(paramKeyFilterInput, metricKeyFilterInput, searchInput, lifecycleFilterInput));
+        `s?${Utils.getSearchUrlFromState(this.state.persistedState)}`);
   }
 
   render() {

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -91,7 +91,7 @@ export class ExperimentView extends Component {
     // The initial searchInput
     searchInput: PropTypes.string.isRequired,
     searchRunsError: PropTypes.string,
-    isLoading: PropTypes.bool.isRequired
+    isLoading: PropTypes.bool.isRequired,
   };
 
   /** Returns default values for state attributes that aren't persisted in local storage. */

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -91,11 +91,7 @@ export class ExperimentView extends Component {
     // The initial searchInput
     searchInput: PropTypes.string.isRequired,
     searchRunsError: PropTypes.string,
-    isLoading: PropTypes.bool.isRequired,
-
-    //history object for pushing entry
-    history: PropTypes.object.isRequired
-
+    isLoading: PropTypes.bool.isRequired
   };
 
   /** Returns default values for state attributes that aren't persisted in local storage. */
@@ -609,17 +605,13 @@ export class ExperimentView extends Component {
     try {
       this.props.onSearch(paramKeyFilterInput, metricKeyFilterInput, searchInput,
         lifecycleFilterInput);
-      this.updateUrlWithSearchFilter(paramKeyFilterInput, metricKeyFilterInput, searchInput, lifecycleFilterInput);
+
     } catch (ex) {
       this.setState({ searchErrorMessage: ex.errorMessage });
     }
   }
 
-  updateUrlWithSearchFilter(paramKeyFilterInput, metricKeyFilterInput, searchInput, lifecycleFilterInput) {
-    var stateObj = {};
-    window.history.replaceState(stateObj, "search page",
-        Routes.getRunSearchPageRoute(paramKeyFilterInput, metricKeyFilterInput, searchInput, lifecycleFilterInput));
-  }
+
 
   onClear() {
     // When user clicks "Clear", preserve multicolumn toggle state but reset other persisted state

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -92,6 +92,10 @@ export class ExperimentView extends Component {
     searchInput: PropTypes.string.isRequired,
     searchRunsError: PropTypes.string,
     isLoading: PropTypes.bool.isRequired,
+
+    //history object for pushing entry
+    history: PropTypes.object.isRequired
+
   };
 
   /** Returns default values for state attributes that aren't persisted in local storage. */
@@ -162,6 +166,8 @@ export class ExperimentView extends Component {
     // componentDidUpdate doesn't fire.
     this.snapshotComponentState();
   }
+
+
 
   static getDerivedStateFromProps(nextProps, prevState) {
     // Compute the actual runs selected. (A run cannot be selected if it is not passed in as a
@@ -603,9 +609,15 @@ export class ExperimentView extends Component {
     try {
       this.props.onSearch(paramKeyFilterInput, metricKeyFilterInput, searchInput,
         lifecycleFilterInput);
+      this.updateUrlWithSearchFilter(searchInput);
     } catch (ex) {
       this.setState({ searchErrorMessage: ex.errorMessage });
     }
+  }
+
+  updateUrlWithSearchFilter(searchInput) {
+    var stateObj = { foo: "bar" };
+    window.history.replaceState(stateObj, "search page", `/s/${searchInput}`);
   }
 
   onClear() {

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -609,15 +609,16 @@ export class ExperimentView extends Component {
     try {
       this.props.onSearch(paramKeyFilterInput, metricKeyFilterInput, searchInput,
         lifecycleFilterInput);
-      this.updateUrlWithSearchFilter(searchInput);
+      this.updateUrlWithSearchFilter(paramKeyFilterInput, metricKeyFilterInput, searchInput, lifecycleFilterInput);
     } catch (ex) {
       this.setState({ searchErrorMessage: ex.errorMessage });
     }
   }
 
-  updateUrlWithSearchFilter(searchInput) {
-    var stateObj = { foo: "bar" };
-    window.history.replaceState(stateObj, "search page", `/s/${searchInput}`);
+  updateUrlWithSearchFilter(paramKeyFilterInput, metricKeyFilterInput, searchInput, lifecycleFilterInput) {
+    var stateObj = {};
+    window.history.replaceState(stateObj, "search page",
+        Routes.getRunSearchPageRoute(paramKeyFilterInput, metricKeyFilterInput, searchInput, lifecycleFilterInput));
   }
 
   onClear() {

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -163,8 +163,6 @@ export class ExperimentView extends Component {
     this.snapshotComponentState();
   }
 
-
-
   static getDerivedStateFromProps(nextProps, prevState) {
     // Compute the actual runs selected. (A run cannot be selected if it is not passed in as a
     // prop)
@@ -605,13 +603,10 @@ export class ExperimentView extends Component {
     try {
       this.props.onSearch(paramKeyFilterInput, metricKeyFilterInput, searchInput,
         lifecycleFilterInput);
-
     } catch (ex) {
       this.setState({ searchErrorMessage: ex.errorMessage });
     }
   }
-
-
 
   onClear() {
     // When user clicks "Clear", preserve multicolumn toggle state but reset other persisted state

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -350,12 +350,14 @@ class Utils {
 
   static getSearchParamsFromUrl(search) {
     const params = qs.parse(search, {ignoreQueryPrefix: true});
+    debugger;
     var str =  JSON.stringify(params, function (key, value) {return (value === undefined) ? "" : value});
 
     return params ? JSON.parse(str) : [];
   }
 
   static getSearchUrlFromState(state) {
+  debugger;
     for (var key in state) {
       if (state[key] === undefined) {
         state[key] = '';

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -367,7 +367,7 @@ class Utils {
         replaced[key] = state[key];
       }
     }
-    return qs.stringify(state);
+    return qs.stringify(replaced);
   }
 
   static compareByTimestamp(history1, history2) {

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -350,6 +350,7 @@ class Utils {
 
   static getSearchParamsFromUrl(search) {
     const params = qs.parse(search, {ignoreQueryPrefix: true});
+
     const str = JSON.stringify(params,
       function replaceUndefined(key, value) {
         return (value === undefined) ? "" : value;

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -350,15 +350,21 @@ class Utils {
 
   static getSearchParamsFromUrl(search) {
     const params = qs.parse(search, {ignoreQueryPrefix: true});
-    var str =  JSON.stringify(params, function (key, value) {return (value === undefined) ? "" : value});
+    const str = JSON.stringify(params,
+      function replaceUndefined(key, value) {
+        return (value === undefined) ? "" : value;
+      });
 
     return params ? JSON.parse(str) : [];
   }
 
   static getSearchUrlFromState(state) {
-    for (var key in state) {
+    const replaced = {};
+    for (const key in state) {
       if (state[key] === undefined) {
-        state[key] = '';
+        replaced[key] = '';
+      } else {
+        replaced[key] = state[key];
       }
     }
     return qs.stringify(state);

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -350,14 +350,12 @@ class Utils {
 
   static getSearchParamsFromUrl(search) {
     const params = qs.parse(search, {ignoreQueryPrefix: true});
-    debugger;
     var str =  JSON.stringify(params, function (key, value) {return (value === undefined) ? "" : value});
 
     return params ? JSON.parse(str) : [];
   }
 
   static getSearchUrlFromState(state) {
-  debugger;
     for (var key in state) {
       if (state[key] === undefined) {
         state[key] = '';

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -349,8 +349,19 @@ class Utils {
   }
 
   static getSearchParamsFromUrl(search) {
-    const params = qs.parse(search);
-    return params ? JSON.parse(params) : [];
+    const params = qs.parse(search, {ignoreQueryPrefix: true});
+    var str =  JSON.stringify(params, function (key, value) {return (value === undefined) ? "" : value});
+
+    return params ? JSON.parse(str) : [];
+  }
+
+  static getSearchUrlFromState(state) {
+    for (var key in state) {
+      if (state[key] === undefined) {
+        state[key] = '';
+      }
+    }
+    return qs.stringify(state);
   }
 
   static compareByTimestamp(history1, history2) {

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -348,6 +348,11 @@ class Utils {
     return plotMetricKeysStr ? JSON.parse(plotMetricKeysStr) : [];
   }
 
+  static getSearchParamsFromUrl(search) {
+    const params = qs.parse(search);
+    return params ? JSON.parse(params) : [];
+  }
+
   static compareByTimestamp(history1, history2) {
     return history1.timestamp - history2.timestamp;
   }

--- a/mlflow/server/js/src/utils/Utils.test.js
+++ b/mlflow/server/js/src/utils/Utils.test.js
@@ -211,3 +211,29 @@ test('getPlotMetricKeysFromUrl', () => {
   expect(Utils.getPlotMetricKeysFromUrl(url1)).toEqual(['metric_1']);
   expect(Utils.getPlotMetricKeysFromUrl(url2)).toEqual(['metric_1', 'metric_2']);
 });
+
+test('getSearchParamsFromUrl', () => {
+  const url0 = '?paramKeyFilterString=filt&metricKeyFilterString=metrics&searchInput=';
+  const url1 = '?p=&q=&r=';
+  const url2 = '?';
+  const url3 = '?paramKeyFilterString=some=param&metricKeyFilterString=somemetric&searchInput=some-Input';
+  expect(Utils.getSearchParamsFromUrl(url0)).toEqual({paramKeyFilterString: "filt",
+    metricKeyFilterString: "metrics",
+    searchInput: ""});
+  expect(Utils.getSearchParamsFromUrl(url1)).toEqual({p: "", q: "", r: ""});
+  expect(Utils.getSearchParamsFromUrl(url2)).toEqual({});
+  expect(Utils.getSearchParamsFromUrl(url3)).toEqual({paramKeyFilterString: "some=param",
+    metricKeyFilterString: "somemetric",
+    searchInput: "some-Input"});
+});
+
+test('getSearchUrlFromState', () => {
+  const st0 = {};
+  const st1 = {a: "example"};
+  const st2 = {b: "bbbbbb"};
+  const st3 = {param: "params", metrics: undefined, searchInput: "someExpression"};
+  expect(Utils.getSearchUrlFromState(st0)).toEqual("");
+  expect(Utils.getSearchUrlFromState(st1)).toEqual("a=example");
+  expect(Utils.getSearchUrlFromState(st2)).toEqual("b=bbbbbb");
+  expect(Utils.getSearchUrlFromState(st3)).toEqual("param=params&metrics=&searchInput=someExpression");
+});


### PR DESCRIPTION
## What changes are proposed in this pull request?
When users search for runs using filters in the MLFlow UI, these filters are saved in local storage for restoration upon future page loads. This PR moves filter persistence from local storage to a query string in the URL, to enable link sharing of search results.
 
## How is this patch tested?
 Manual tests of the query string encoding/decoding logic.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Search filters are now reproduced in the URL, allowing link-sharing of results.
 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
