### PR TITLE
[Easy] Remove mention of --file-store from tracking docs

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -358,11 +358,7 @@ backend as ``./path_to_store`` or ``file:/path_to_store`` and a *database-backed
 `SQLAlchemy database URI <https://docs.sqlalchemy.org/en/latest/core/engines
 .html#database-urls>`_. The database URI typically takes the format ``<dialect>+<driver>://<username>:<password>@<host>:<port>/<database>``.
 MLflow supports the database dialects ``mysql``, ``mssql``, ``sqlite``, and ``postgresql``.
-Drivers are optional. If you do not specify a driver, SQLAlchemy uses a dialect's default driver.
-For backwards compatibility, ``--file-store`` is an alias for ``--backend-store-uri``. 
-For example, ``--backend-store-uri sqlite:///mlflow.db`` would create a local SQLite database.
-
-For backwards compatibility, ``--file-store`` is an alias for ``--backend-store-uri``.
+Drivers are optional. If you do not specify a driver, SQLAlchemy uses a dialect's default driver. For example, ``--backend-store-uri sqlite:///mlflow.db`` would use a local SQLite database.
 
 .. important::
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
`--file-store` option is deprecated for ``mlflow server``. Fixing the docs based on feedback from mlflow slack.
 
## How is this patch tested?
 
Preview doc page
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
### What component(s) does this PR affect?

- [X] Docs
- [X] Tracking

### How should the PR be classified in the release notes? Choose one:
 
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
