### PR TITLE
Reuse ftp client in ftp artifact repo

### DIFF
--- a/tests/store/test_ftp_artifact_repo.py
+++ b/tests/store/test_ftp_artifact_repo.py
@@ -274,22 +274,12 @@ def test_log_artifact_reuse_ftp_client(ftp_mock, tmpdir):
     repo.get_ftp_client.return_value = MagicMock(__enter__=call_mock)
 
     d = tmpdir.mkdir("data")
-    file1 = d.join("test1.txt")
-    file1.write("hello world!")
-    fpath1 = d + '/test1.txt'
-    fpath1 = fpath1.strpath
+    file = d.join("test.txt")
+    file.write("hello world!")
+    fpath = file.strpath
 
-    ftp_mock.cwd = MagicMock(side_effect=[
-        ftplib.error_perm,
-        None,
-        ftplib.error_perm,
-        None,
-        None,
-        None
-    ])
-
-    repo.log_artifact(fpath1)
-    repo.log_artifact(fpath1, "subdir1/subdir2")
-    repo.log_artifact(fpath1, "subdir3")
+    repo.log_artifact(fpath)
+    repo.log_artifact(fpath, "subdir1/subdir2")
+    repo.log_artifact(fpath, "subdir3")
 
     assert repo.get_ftp_client.call_count == 3


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Reuse ftp client in `FTPArtifactRepository` to avoid "Too many connections" error.

Usage of `mlflow.log_artifact` can lead to "Too many connections" error caused by recursion in `_mkdir`. 

```
       with self.get_ftp_client() as ftp:
            try:
                if not self._is_dir(artifact_dir):
                    ftp.mkd(artifact_dir)
            except ftplib.error_perm:
                head, _ = posixpath.split(artifact_dir)
                self._mkdir(head)
                self._mkdir(artifact_dir)
```
 
## How is this patch tested?
 
Add a new test in `tests/store/test_ftp_artifact_repo.py`
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Avoid usage of multiple ftp connections for directory creation.
Can fix issue on "Too many connections" error in FTP Server with a small range of accepted clients. 
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [x] Tracking
- [ ] Projects 
- [x] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
