### PR TITLE
Added the possibility of serving a model through a gunicorn socket

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,34 @@
 ## What changes are proposed in this pull request?
  
-(Please fill in changes proposed in this fix)
+The possibility of binding gunicorn to a socket instead of a TCP host:port tuple
+while serving a model. This allows to serve a model through HTTPS with Nginx 
  
 ## How is this patch tested?
  
-(Details)
- 
+A new cli option is added to mlflow models serve to server the model through a gunicorn socket:
+```bash
+mlflow models serve -m path_to_model -s socket_name.sock
+```
+
+This is thought to be used with Nginx and HTTPS protocol, but it can be easily
+tested with the following command (for the Tutorial example):
+```bash
+curl -X POST -H "Content-Type:application/json; format=pandas-split" --data '{"coluhlorides", "citric acid", "density", "fixed acidity", "free sulfur dioxide", "pH", "residual sugar", "sulphates", "total sulfur dioxide", "volatile acidity"],"data":[[12.8, 0.029, 0.48, 0.98, 6.2, 29, 3.33, 1.2, 0.39, 75, 0.66]]}' --unix-socket /path_to_your_socket/socket_name.sock http://localhost/invocations
+```
+
 ## Release Notes
  
 ### Is this a user-facing change? 
 
 - [ ] No. You can skip the rest of this section.
-- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
+- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
  
-(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
+Explanation in the previous description.
  
 ### What component(s) does this PR affect?
  
 - [ ] UI
-- [ ] CLI 
+- [X] CLI 
 - [ ] API 
 - [ ] REST-API 
 - [ ] Examples 
@@ -26,7 +36,7 @@
 - [ ] Tracking
 - [ ] Projects 
 - [ ] Artifacts 
-- [ ] Models 
+- [X] Models 
 - [ ] Scoring 
 - [ ] Serving
 - [ ] R
@@ -37,6 +47,6 @@
  
 - [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
 - [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
-- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
+- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
 - [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
 - [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -39,9 +39,10 @@ def serve(model_uri, port, host, socket, workers, no_conda=False, install_mlflow
     """
     return _get_flavor_backend(model_uri,
                                no_conda=no_conda,
+                               socket=socket,
                                workers=workers,
                                install_mlflow=install_mlflow).serve(model_uri=model_uri, port=port,
-                                                                    host=host, socket=socket)
+                                                                    host=host)
 
 
 @commands.command("predict")

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -27,10 +27,11 @@ def commands():
 @cli_args.MODEL_URI
 @cli_args.PORT
 @cli_args.HOST
+@cli_args.SOCKET
 @cli_args.WORKERS
 @cli_args.NO_CONDA
 @cli_args.INSTALL_MLFLOW
-def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False):
+def serve(model_uri, port, host, socket, workers, no_conda=False, install_mlflow=False):
     """
     Serve a model saved with MLflow by launching a webserver on the specified host and port. For
     information about the input data formats accepted by the webserver, see the following
@@ -40,7 +41,7 @@ def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False):
                                no_conda=no_conda,
                                workers=workers,
                                install_mlflow=install_mlflow).serve(model_uri=model_uri, port=port,
-                                                                    host=host)
+                                                                    host=host, socket=socket)
 
 
 @commands.command("predict")

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -40,3 +40,5 @@ PORT = click.option("--port", "-p", default=5000,
                     help="The port to listen on (default: 5000).")
 WORKERS = click.option("--workers", "-w", default=4,
                        help="Number of gunicorn worker processes to handle requests (default: 4).")
+SOCKET = click.option("--socket", "-s", default=None,
+                    help="If a unix socket is prefered instead of a TCP host:port tuple")

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -41,4 +41,4 @@ PORT = click.option("--port", "-p", default=5000,
 WORKERS = click.option("--workers", "-w", default=4,
                        help="Number of gunicorn worker processes to handle requests (default: 4).")
 SOCKET = click.option("--socket", "-s", default=None,
-                    help="If a unix socket is prefered instead of a TCP host:port tuple")
+                      help="If a unix socket is prefered instead of a TCP host:port tuple")


### PR DESCRIPTION
Added the possibility of serving a model through a gunicorn socket as a cli parameter in mlflow models serve command

## What changes are proposed in this pull request?
 
The possibility of binding gunicorn to a socket instead of a TCP host:port tuple
while serving a model. This allows to serve a model through HTTPS with Nginx 
 
## How is this patch tested?
 
A new cli option is added to mlflow models serve to server the model through a gunicorn socket:
```bash
mlflow models serve -m path_to_model -s socket_name.sock
```

This is thought to be used with Nginx and HTTPS protocol, but it can be easily
tested with the following command (for the Tutorial example):
```bash
curl -X POST -H "Content-Type:application/json; format=pandas-split" --data '{"coluhlorides", "citric acid", "density", "fixed acidity", "free sulfur dioxide", "pH", "residual sugar", "sulphates", "total sulfur dioxide", "volatile acidity"],"data":[[12.8, 0.029, 0.48, 0.98, 6.2, 29, 3.33, 1.2, 0.39, 75, 0.66]]}' --unix-socket /path_to_your_socket/socket_name.sock http://localhost/invocations
```

## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Explanation in the previous description.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [X] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [X] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
