### PR TITLE
Return appropriate HTTP status codes for MLflowException

### DIFF
--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -1,6 +1,8 @@
 import json
 
-from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, ErrorCode
+from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, TEMPORARILY_UNAVAILABLE, \
+    ENDPOINT_NOT_FOUND, PERMISSION_DENIED, REQUEST_LIMIT_EXCEEDED, BAD_REQUEST, \
+    INVALID_PARAMETER_VALUE, ErrorCode
 
 
 class MlflowException(Exception):
@@ -32,6 +34,19 @@ class MlflowException(Exception):
         exception_dict = {'error_code': self.error_code, 'message': self.message}
         exception_dict.update(self.json_kwargs)
         return json.dumps(exception_dict)
+
+    def get_http_status_code(self):
+        http_error_map = {
+            ErrorCode.Name(INTERNAL_ERROR): 500,
+            ErrorCode.Name(TEMPORARILY_UNAVAILABLE): 503,
+            ErrorCode.Name(ENDPOINT_NOT_FOUND): 404,
+            ErrorCode.Name(PERMISSION_DENIED): 403,
+            ErrorCode.Name(REQUEST_LIMIT_EXCEEDED): 429,
+            ErrorCode.Name(BAD_REQUEST): 400,
+            ErrorCode.Name(INVALID_PARAMETER_VALUE): 400
+        }
+        default_error_code = 500
+        return http_error_map.get(self.error_code, default_error_code)
 
 
 class RestException(MlflowException):

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -2,7 +2,8 @@ import json
 
 from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, TEMPORARILY_UNAVAILABLE, \
     ENDPOINT_NOT_FOUND, PERMISSION_DENIED, REQUEST_LIMIT_EXCEEDED, BAD_REQUEST, \
-    INVALID_PARAMETER_VALUE, ErrorCode
+    INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST, INVALID_STATE, RESOURCE_ALREADY_EXISTS, \
+    ErrorCode
 
 
 class MlflowException(Exception):
@@ -38,11 +39,14 @@ class MlflowException(Exception):
     def get_http_status_code(self):
         http_error_map = {
             ErrorCode.Name(INTERNAL_ERROR): 500,
+            ErrorCode.Name(INVALID_STATE): 500,
             ErrorCode.Name(TEMPORARILY_UNAVAILABLE): 503,
-            ErrorCode.Name(ENDPOINT_NOT_FOUND): 404,
-            ErrorCode.Name(PERMISSION_DENIED): 403,
             ErrorCode.Name(REQUEST_LIMIT_EXCEEDED): 429,
+            ErrorCode.Name(ENDPOINT_NOT_FOUND): 404,
+            ErrorCode.Name(RESOURCE_DOES_NOT_EXIST): 404,
+            ErrorCode.Name(PERMISSION_DENIED): 403,
             ErrorCode.Name(BAD_REQUEST): 400,
+            ErrorCode.Name(RESOURCE_ALREADY_EXISTS): 400,
             ErrorCode.Name(INVALID_PARAMETER_VALUE): 400
         }
         default_error_code = 500

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -5,6 +5,19 @@ from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, TEMPORARILY_UNAVAILABLE
     INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST, INVALID_STATE, RESOURCE_ALREADY_EXISTS, \
     ErrorCode
 
+ERROR_CODE_TO_HTTP_STATUS = {
+    ErrorCode.Name(INTERNAL_ERROR): 500,
+    ErrorCode.Name(INVALID_STATE): 500,
+    ErrorCode.Name(TEMPORARILY_UNAVAILABLE): 503,
+    ErrorCode.Name(REQUEST_LIMIT_EXCEEDED): 429,
+    ErrorCode.Name(ENDPOINT_NOT_FOUND): 404,
+    ErrorCode.Name(RESOURCE_DOES_NOT_EXIST): 404,
+    ErrorCode.Name(PERMISSION_DENIED): 403,
+    ErrorCode.Name(BAD_REQUEST): 400,
+    ErrorCode.Name(RESOURCE_ALREADY_EXISTS): 400,
+    ErrorCode.Name(INVALID_PARAMETER_VALUE): 400
+}
+
 
 class MlflowException(Exception):
     """
@@ -37,20 +50,8 @@ class MlflowException(Exception):
         return json.dumps(exception_dict)
 
     def get_http_status_code(self):
-        http_error_map = {
-            ErrorCode.Name(INTERNAL_ERROR): 500,
-            ErrorCode.Name(INVALID_STATE): 500,
-            ErrorCode.Name(TEMPORARILY_UNAVAILABLE): 503,
-            ErrorCode.Name(REQUEST_LIMIT_EXCEEDED): 429,
-            ErrorCode.Name(ENDPOINT_NOT_FOUND): 404,
-            ErrorCode.Name(RESOURCE_DOES_NOT_EXIST): 404,
-            ErrorCode.Name(PERMISSION_DENIED): 403,
-            ErrorCode.Name(BAD_REQUEST): 400,
-            ErrorCode.Name(RESOURCE_ALREADY_EXISTS): 400,
-            ErrorCode.Name(INVALID_PARAMETER_VALUE): 400
-        }
         default_error_code = 500
-        return http_error_map.get(self.error_code, default_error_code)
+        return ERROR_CODE_TO_HTTP_STATUS.get(self.error_code, default_error_code)
 
 
 class RestException(MlflowException):

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -50,8 +50,7 @@ class MlflowException(Exception):
         return json.dumps(exception_dict)
 
     def get_http_status_code(self):
-        default_error_code = 500
-        return ERROR_CODE_TO_HTTP_STATUS.get(self.error_code, default_error_code)
+        return ERROR_CODE_TO_HTTP_STATUS.get(self.error_code, 500)
 
 
 class RestException(MlflowException):

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -92,7 +92,7 @@ def catch_mlflow_exception(func):
         except MlflowException as e:
             response = Response(mimetype='application/json')
             response.set_data(e.serialize_as_json())
-            response.status_code = 500
+            response.status_code = e.get_http_status_code()
             return response
     return wrapper
 

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -88,7 +88,7 @@ def test_search_runs_default_view_type(mock_get_request_message, mock_store):
 def test_log_batch_api_req(mock_get_request_json):
     mock_get_request_json.return_value = "a" * (MAX_BATCH_LOG_REQUEST_SIZE + 1)
     response = _log_batch()
-    assert response.status_code == 500
+    assert response.status_code == 400
     json_response = json.loads(response.get_data())
     assert json_response["error_code"] == ErrorCode.Name(INVALID_PARAMETER_VALUE)
     assert ("Batched logging API requests must be at most %s bytes" % MAX_BATCH_LOG_REQUEST_SIZE

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,7 +1,8 @@
 import json
 
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, TEMPORARILY_UNAVAILABLE, \
+    ENDPOINT_NOT_FOUND, INTERNAL_ERROR
 
 
 class TestMlflowException(object):
@@ -17,3 +18,13 @@ class TestMlflowException(object):
         deserialized = json.loads(mlflow_exception.serialize_as_json())
         assert deserialized['message'] == 'test'
         assert deserialized['error_code'] == 'INTERNAL_ERROR'
+
+    def test_get_http_status_code(self):
+        assert MlflowException('text', error_code=TEMPORARILY_UNAVAILABLE).get_http_status_code() \
+             == 503
+        assert MlflowException('text', error_code=ENDPOINT_NOT_FOUND).get_http_status_code() \
+            == 404
+        assert MlflowException('test', error_code=INVALID_PARAMETER_VALUE).get_http_status_code() \
+            == 400
+        assert MlflowException('test', error_code=INTERNAL_ERROR).get_http_status_code() \
+            == 500

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -20,8 +20,9 @@ class TestMlflowException(object):
         assert deserialized['error_code'] == 'INTERNAL_ERROR'
 
     def test_get_http_status_code(self):
+        assert MlflowException('test default').get_http_status_code() == 500
         assert MlflowException('test', error_code=INVALID_STATE).get_http_status_code() \
-             == 500
+            == 500
         assert MlflowException('test', error_code=ENDPOINT_NOT_FOUND).get_http_status_code() \
             == 404
         assert MlflowException('test', error_code=INVALID_PARAMETER_VALUE).get_http_status_code() \

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -2,7 +2,7 @@ import json
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, INVALID_STATE, \
-    ENDPOINT_NOT_FOUND, INTERNAL_ERROR, RESOURCE_ALREADY_EXISTS
+    ENDPOINT_NOT_FOUND, INTERNAL_ERROR, RESOURCE_ALREADY_EXISTS, IO_ERROR
 
 
 class TestMlflowException(object):
@@ -21,6 +21,8 @@ class TestMlflowException(object):
 
     def test_get_http_status_code(self):
         assert MlflowException('test default').get_http_status_code() == 500
+        assert MlflowException('code not in map', error_code=IO_ERROR).get_http_status_code() \
+            == 500
         assert MlflowException('test', error_code=INVALID_STATE).get_http_status_code() \
             == 500
         assert MlflowException('test', error_code=ENDPOINT_NOT_FOUND).get_http_status_code() \

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,8 +1,8 @@
 import json
 
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, TEMPORARILY_UNAVAILABLE, \
-    ENDPOINT_NOT_FOUND, INTERNAL_ERROR
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, INVALID_STATE, \
+    ENDPOINT_NOT_FOUND, INTERNAL_ERROR, RESOURCE_ALREADY_EXISTS
 
 
 class TestMlflowException(object):
@@ -20,11 +20,13 @@ class TestMlflowException(object):
         assert deserialized['error_code'] == 'INTERNAL_ERROR'
 
     def test_get_http_status_code(self):
-        assert MlflowException('text', error_code=TEMPORARILY_UNAVAILABLE).get_http_status_code() \
-             == 503
-        assert MlflowException('text', error_code=ENDPOINT_NOT_FOUND).get_http_status_code() \
+        assert MlflowException('test', error_code=INVALID_STATE).get_http_status_code() \
+             == 500
+        assert MlflowException('test', error_code=ENDPOINT_NOT_FOUND).get_http_status_code() \
             == 404
         assert MlflowException('test', error_code=INVALID_PARAMETER_VALUE).get_http_status_code() \
             == 400
         assert MlflowException('test', error_code=INTERNAL_ERROR).get_http_status_code() \
             == 500
+        assert MlflowException('test', error_code=RESOURCE_ALREADY_EXISTS).get_http_status_code() \
+            == 400


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
This changes the HTTP status code returned when MLflowExceptions are thrown on the tracking server. All exceptions used to result in a `500 Internal Server Error` response, but the tracking server now supports the following status codes:
- 500 (Internal Error)
- 503 (Temporarily Unavailable)
- 404 (Not Found)
- 403 (Permission Denied)
- 429 (Request limit exceeded)
- 400 (Invalid request)
 
## How is this patch tested?
 
Tested with pytest and by inspecting mlflow UI to view invalid request headers.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Send back appropriate status code in the HTTP response when exceptions are thrown on the tracking server.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [x] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
