### PR TITLE
sqlalchemy_store.py: make str format for metrics

### DIFF
--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -408,7 +408,7 @@ class SqlAlchemyStore(AbstractStore):
             self._check_run_is_active(run)
             # ToDo: Consider prior checks for null, type, metric name validations, ... etc.
             self._get_or_create(model=SqlMetric, run_uuid=run_id, key=metric.key,
-                                value=metric.value, timestamp=metric.timestamp, step=metric.step,
+                                value=str(metric.value), timestamp=metric.timestamp, step=str(metric.step),
                                 session=session)
 
     def get_metric_history(self, run_id, metric_key):

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -408,8 +408,8 @@ class SqlAlchemyStore(AbstractStore):
             self._check_run_is_active(run)
             # ToDo: Consider prior checks for null, type, metric name validations, ... etc.
             self._get_or_create(model=SqlMetric, run_uuid=run_id, key=metric.key,
-                                value=str(metric.value), timestamp=metric.timestamp, step=str(metric.step),
-                                session=session)
+                                value=str(metric.value), timestamp=metric.timestamp,
+                                step=str(metric.step), session=session)
 
     def get_metric_history(self, run_id, metric_key):
         with self.ManagedSessionMaker() as session:


### PR DESCRIPTION
I use Google Cloud SQL MySQL database and python 3.7, pymysql==0.9.3. I experienced the following error:
```python
import mlflow
import numpy as np
sql_string = 'mysql+pymysql://<username>:<password>@<ip>:3306/<dbname>'
mlflow.set_tracking_uri(sql_string)

with mlflow.start_run():
    a = np.float64(1.1)
    mlflow.log_metric(key="metrickey", value=a, step=np.float64(3.1))
```
Error Log: MlflowException: 'numpy.float64' object has no attribute 'translate'

Strange that the following works fine:
```python
import mlflow
import numpy as np
sql_string = 'mysql+pymysql://<username>:<password>@<ip>:3306/<dbname>'
mlflow.set_tracking_uri(sql_string)

with mlflow.start_run():
    a = 1.1
    mlflow.log_metric(key="metrickey", value=a, step=3.1)
```

The proposed modification fixes the error and will work in both cases provided.

## What changes are proposed in this pull request?
 
Change format of metrics in sqlalchemy_store.py.
 
## How is this patch tested?
For tests/store/test_sqlalchemy_store.py need password and username and password. Expect that it will be tested automatically after submission.
 
Also the following script did not work before and works after:
```python
import mlflow
import numpy as np
sql_string = 'mysql+pymysql://<username>:<password>@<ip>:3306/<dbname>'
mlflow.set_tracking_uri(sql_string)

with mlflow.start_run():
    a = np.float64(1.1)
    mlflow.log_metric(key="metrickey", value=a, step=np.float64(3.1))
```
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
