### PR TITLE
Fix for URL search parameters errors/warnings

### DIFF
--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -107,7 +107,6 @@ class ExperimentPage extends Component {
   }
 
   updateUrlWithSearchFilter(state) {
-    console.log(this.props.history);
     const newUrl = `/experiments/${this.props.experimentId}` +
       `/s?${Utils.getSearchUrlFromState(state)}`;
     if (newUrl !== (this.props.history.location.pathname

--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -36,7 +36,6 @@ class ExperimentPage extends Component {
     experimentId: PropTypes.number.isRequired,
     dispatchSearchRuns: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
-    //searchString: PropTypes.string.isRequired,
     location: PropTypes.object,
   };
 
@@ -109,9 +108,11 @@ class ExperimentPage extends Component {
 
   updateUrlWithSearchFilter(state) {
     console.log(this.props.history);
-    const newUrl = `/experiments/${this.props.experimentId}/s?${Utils.getSearchUrlFromState(state)}`;
-    if (newUrl !== (this.props.history.location.pathname + this.props.history.location.search)) {
-      this.props.history.push(`/experiments/${this.props.experimentId}/s?${Utils.getSearchUrlFromState(state)}`);
+    const newUrl = `/experiments/${this.props.experimentId}` +
+      `/s?${Utils.getSearchUrlFromState(state)}`;
+    if (newUrl !== (this.props.history.location.pathname
+      + this.props.history.location.search)) {
+      this.props.history.push(newUrl);
     }
   }
 

--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -25,9 +25,9 @@ class ExperimentPage extends Component {
     this.state = {
       ...ExperimentPage.getDefaultUnpersistedState(),
       persistedState: {
-        paramKeyFilterString: urlState.params,
-        metricKeyFilterString: urlState.metrics,
-        searchInput: urlState.search,
+        paramKeyFilterString: urlState.params === undefined ? "" : urlState.params,
+        metricKeyFilterString: urlState.metrics === undefined ? "" : urlState.metrics,
+        searchInput: urlState.search === undefined ? "" : urlState.search,
       },
     };
   }
@@ -36,7 +36,7 @@ class ExperimentPage extends Component {
     experimentId: PropTypes.number.isRequired,
     dispatchSearchRuns: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,
-    searchString: PropTypes.string.isRequired,
+    //searchString: PropTypes.string.isRequired,
     location: PropTypes.object,
   };
 
@@ -108,8 +108,11 @@ class ExperimentPage extends Component {
   }
 
   updateUrlWithSearchFilter(state) {
-    this.props.history
-        .push(`/experiments/${this.props.experimentId}/s?${Utils.getSearchUrlFromState(state)}`);
+    console.log(this.props.history);
+    const newUrl = `/experiments/${this.props.experimentId}/s?${Utils.getSearchUrlFromState(state)}`;
+    if (newUrl !== (this.props.history.location.pathname + this.props.history.location.search)) {
+      this.props.history.push(`/experiments/${this.props.experimentId}/s?${Utils.getSearchUrlFromState(state)}`);
+    }
   }
 
   render() {

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -32,6 +32,7 @@ export const DEFAULT_EXPANDED_VALUE = false;
 
 export class ExperimentView extends Component {
   constructor(props) {
+    debugger;
     super(props);
     this.onCheckbox = this.onCheckbox.bind(this);
     this.onCompare = this.onCompare.bind(this);

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -32,7 +32,6 @@ export const DEFAULT_EXPANDED_VALUE = false;
 
 export class ExperimentView extends Component {
   constructor(props) {
-    debugger;
     super(props);
     this.onCheckbox = this.onCheckbox.bind(this);
     this.onCompare = this.onCompare.bind(this);

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -351,7 +351,7 @@ class Utils {
 
   static getSearchParamsFromUrl(search) {
     const params = qs.parse(search, {ignoreQueryPrefix: true});
-
+    debugger;
     const str = JSON.stringify(params,
       function replaceUndefined(key, value) {
         return (value === undefined) ? "" : value;

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -351,7 +351,6 @@ class Utils {
 
   static getSearchParamsFromUrl(search) {
     const params = qs.parse(search, {ignoreQueryPrefix: true});
-    debugger;
     const str = JSON.stringify(params,
       function replaceUndefined(key, value) {
         return (value === undefined) ? "" : value;


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fixes various errors/warnings being logged to console:

- `Warning: Failed prop type: The prop searchString is marked as required in ExperimentPage, but its value is undefined.`
- `Warning: Failed prop type: The prop searchInput is marked as required in ExperimentPage, but its value is undefined.`
- `Warning: Hash history cannot PUSH the same path; a new entry will not be added to the history stack.`
 
## How is this patch tested?
 
N/A
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
