### PR TITLE
[DBUtils] Look for notebook id and path in TaskContext when in SparkExecutor.

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -37,7 +37,7 @@ def _get_property_from_spark_context_or_none(property):
         task_context = TaskContext.get()
         if task_context:
             return task_context.getLocalProperty(property)
-    except ImportError:
+    except Exception:  # pylint: disable=broad-except
         return None
 
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -31,12 +31,12 @@ def _get_extra_context(context_key):
     return java_dbutils.notebook().getContext().extraContext().get(context_key).get()
 
 
-def _get_property_from_spark_context(property):
+def _get_property_from_spark_context(key):
     try:
         from pyspark import TaskContext  # pylint: disable=import-error
         task_context = TaskContext.get()
         if task_context:
-            return task_context.getLocalProperty(property)
+            return task_context.getLocalProperty(key)
     except Exception:  # pylint: disable=broad-except
         return None
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -42,7 +42,7 @@ def _get_property_from_spark_context(property):
 
 
 def is_in_databricks_notebook():
-    if _get_property_from_spark_context_or_none("spark.databricks.notebook.id") is not None:
+    if _get_property_from_spark_context("spark.databricks.notebook.id") is not None:
         return True
     try:
         return _get_extra_context("aclPathOfAclRoot").startswith('/workspace')
@@ -52,7 +52,7 @@ def is_in_databricks_notebook():
 
 def get_notebook_id():
     """Should only be called if is_in_databricks_notebook is true"""
-    id = _get_property_from_spark_context_or_none("spark.databricks.notebook.id")
+    id = _get_property_from_spark_context("spark.databricks.notebook.id")
     if id is not None:
         return id
     acl_path = _get_extra_context("aclPathOfAclRoot")
@@ -63,7 +63,7 @@ def get_notebook_id():
 
 def get_notebook_path():
     """Should only be called if is_in_databricks_notebook is true"""
-    path = _get_property_from_spark_context_or_none("spark.databricks.notebook.path")
+    path = _get_property_from_spark_context("spark.databricks.notebook.path")
     if path is not None:
         return path
     return _get_extra_context("notebook_path")
@@ -71,7 +71,7 @@ def get_notebook_path():
 
 def get_webapp_url():
     """Should only be called if is_in_databricks_notebook is true"""
-    url = _get_property_from_spark_context_or_none("spark.databricks.api.url")
+    url = _get_property_from_spark_context("spark.databricks.api.url")
     if url is not None:
         return url
     return _get_extra_context("api_url")

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -52,9 +52,9 @@ def is_in_databricks_notebook():
 
 def get_notebook_id():
     """Should only be called if is_in_databricks_notebook is true"""
-    id = _get_property_from_spark_context("spark.databricks.notebook.id")
-    if id is not None:
-        return id
+    notebook_id = _get_property_from_spark_context("spark.databricks.notebook.id")
+    if notebook_id is not None:
+        return notebook_id
     acl_path = _get_extra_context("aclPathOfAclRoot")
     if acl_path.startswith('/workspace'):
         return acl_path.split('/')[-1]

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -31,7 +31,7 @@ def _get_extra_context(context_key):
     return java_dbutils.notebook().getContext().extraContext().get(context_key).get()
 
 
-def _get_property_from_spark_context_or_none(property):
+def _get_property_from_spark_context(property):
     try:
         from pyspark import TaskContext  # pylint: disable=import-error
         task_context = TaskContext.get()


### PR DESCRIPTION
## What changes are proposed in this pull request?
When running in Spark Executor, some of the context info is in TaskContext. 

## How is this patch tested?
Not tested.
 
## Release Notes
Makes default experiment id work on Spark Executors on Databricks in Python.
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 


(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
