### PR TITLE
[WIP]Add support for run artifacts uri with nested artifact path

### DIFF
--- a/tests/tracking/test_artifact_utils.py
+++ b/tests/tracking/test_artifact_utils.py
@@ -1,7 +1,8 @@
 import os
+import pytest
 
 import mlflow
-from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri, _parse_artifact_uri
 
 
 def test_artifact_can_be_downloaded_from_absolute_uri_successfully(tmpdir):
@@ -45,3 +46,14 @@ def test_download_artifact_from_absolute_uri_persists_data_to_specified_output_d
     with open(os.path.join(
             artifact_output_path, logged_artifact_subdir, artifact_file_name), "r") as f:
         assert f.read() == artifact_text
+
+
+@pytest.mark.parametrize("uri,expected_root_uri,expected_artifact_path", [
+    ('runs:/my_id/file.txt', 'runs:/my_id', 'file.txt'),
+    ('runs:/my_id/nested_dir/file.txt', 'runs:/my_id/nested_dir', 'nested_dir/file.txt'),
+    ('runs:/my_id/more/nested/dir/my_file.txt', 'runs:/my_id/more/nested/dir', 'more/nested/dir/my_file.txt')
+])
+def test_artifact_path_is_correct_for_runs_artifacts_uri(uri, expected_root_uri, expected_artifact_path):
+    outs = _parse_artifact_uri(uri)
+    assert outs[0] == expected_root_uri
+    assert outs[1] == expected_artifact_path


### PR DESCRIPTION


## What changes are proposed in this pull request?
 Extract the artifact_path from the artifact_uri when _download_artifact_from_uri receives a RunsArtifactRepo uri: 
 runs:/run_id/nested/file.txt 
(Please fill in changes proposed in this fix)
 
## How is this patch tested?
Original test are run. Tests for correct parsing of the artifact_uri for a nested and non nested runs uris were added.
 
(Details)
 
## Release Notes
Patch internal download util that limited certain code paths from supporting nested artifact paths.
 
### Is this a user-facing change? 
Internal but affects behavior seen by users.

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [X ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
