### PR TITLE
Update DbfsArtifactRepository logic that checks whether DBFS FUSE is available to not write to stdout

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -52,10 +52,12 @@ def is_in_databricks_notebook():
 
 
 def is_dbfs_fuse_available():
-    try:
-        return subprocess.call(["mountpoint", "/dbfs"]) == 0
-    except Exception:  # pylint: disable=broad-except
-        return False
+    with open(os.devnull, 'w') as devnull_stderr, open(os.devnull, 'w') as devnull_stdout:
+        try:
+            return subprocess.call(
+                ["mountpoint", "/dbfs"], stderr=devnull_stderr, stdout=devnull_stdout) == 0
+        except Exception:  # pylint: disable=broad-except
+            return False
 
 
 def get_notebook_id():

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import subprocess
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Logic invoked by the DbfsArtifactRepository used to check whether DBFS FUSE is available currently writes some output to stdout, which breaks parsing logic in the Java & R artifact repository implementations. This PR redirects output to `/dev/null` as a fix.
 
## How is this patch tested?
Manual testing.
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
