### PR TITLE
Numpy array conversion in pyfunc scoring server

### DIFF
--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -133,8 +133,8 @@ def parse_split_oriented_json_input_to_numpy(json_input):
         _handle_serving_error(
             error_message=(
                 "Failed to parse input as a Numpy. Ensure that the input is"
-                " a valid JSON-formatted Pandas DataFrame with the records orient"
-                " produced using the `pandas.DataFrame.to_json(..., orient='records')`"
+                " a valid JSON-formatted Pandas DataFrame with the split orient"
+                " produced using the `pandas.DataFrame.to_json(..., orient='split')`"
                 " method."
             ),
             error_code=MALFORMED_REQUEST)

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -48,7 +48,6 @@ CONTENT_TYPE_CSV = "text/csv"
 CONTENT_TYPE_JSON = "application/json"
 CONTENT_TYPE_JSON_RECORDS_ORIENTED = "application/json; format=pandas-records"
 CONTENT_TYPE_JSON_SPLIT_ORIENTED = "application/json; format=pandas-split"
-CONTENT_TYPE_JSON_RECORDS_NUMPY = "application/json-numpy-records"
 CONTENT_TYPE_JSON_SPLIT_NUMPY = "application/json-numpy-split"
 
 CONTENT_TYPES = [
@@ -56,7 +55,6 @@ CONTENT_TYPES = [
     CONTENT_TYPE_JSON,
     CONTENT_TYPE_JSON_RECORDS_ORIENTED,
     CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-    CONTENT_TYPE_JSON_RECORDS_NUMPY,
     CONTENT_TYPE_JSON_SPLIT_NUMPY
 ]
 
@@ -97,29 +95,6 @@ def parse_csv_input(csv_input):
                 "Failed to parse input as a Pandas DataFrame. Ensure that the input is"
                 " a valid CSV-formatted Pandas DataFrame produced using the"
                 " `pandas.DataFrame.to_csv()` method."),
-            error_code=MALFORMED_REQUEST)
-
-
-def parse_records_oriented_json_input_to_numpy(json_input):
-    """
-    :param json_input: A JSON-formatted string representation of a Pandas DataFrame with records
-                       orient, or a stream containing such a string representation.
-    """
-    # pylint: disable=broad-except
-    try:
-        json_input_list = json.loads(json_input, object_pairs_hook=OrderedDict)
-        columns = json_input_list[0].keys()
-        return pd.DataFrame(data=np.array([list(d.values())
-                                           for d in json_input_list]),
-                            columns=columns)
-    except Exception:
-        _handle_serving_error(
-            error_message=(
-                "Failed to parse input as a Numpy. Ensure that the input is"
-                " a valid JSON-formatted Pandas DataFrame with the records orient"
-                " produced using the `pandas.DataFrame.to_json(..., orient='records')`"
-                " method."
-            ),
             error_code=MALFORMED_REQUEST)
 
 
@@ -204,8 +179,6 @@ def init(model):
         elif flask.request.content_type == CONTENT_TYPE_JSON_RECORDS_ORIENTED:
             data = parse_json_input(json_input=flask.request.data.decode('utf-8'),
                                     orient="records")
-        elif flask.request.content_type == CONTENT_TYPE_JSON_RECORDS_NUMPY:
-            data = parse_records_oriented_json_input_to_numpy(flask.request.data.decode('utf-8'))
         elif flask.request.content_type == CONTENT_TYPE_JSON_SPLIT_NUMPY:
             data = parse_split_oriented_json_input_to_numpy(flask.request.data.decode('utf-8'))
         else:

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -108,7 +108,10 @@ def parse_records_oriented_json_input_to_numpy(json_input):
     # pylint: disable=broad-except
     try:
         json_input_list = json.loads(json_input, object_pairs_hook=OrderedDict)
-        return pd.DataFrame(np.array([list(d.values()) for d in json_input_list], dtype=object))
+        columns = json_input_list[0].keys()
+        return pd.DataFrame(data=np.array([list(d.values())
+                                           for d in json_input_list], dtype=object),
+                            columns=columns)
     except Exception:
         _handle_serving_error(
             error_message=(

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -46,8 +46,8 @@ _SERVER_MODEL_PATH = "__pyfunc_model_path__"
 
 CONTENT_TYPE_CSV = "text/csv"
 CONTENT_TYPE_JSON = "application/json"
-CONTENT_TYPE_JSON_RECORDS_ORIENTED = "application/json-pandas-records"
-CONTENT_TYPE_JSON_SPLIT_ORIENTED = "application/json-pandas-split"
+CONTENT_TYPE_JSON_RECORDS_ORIENTED = "application/json; format=pandas-records"
+CONTENT_TYPE_JSON_SPLIT_ORIENTED = "application/json; format=pandas-split"
 CONTENT_TYPE_JSON_RECORDS_NUMPY = "application/json-numpy-records"
 CONTENT_TYPE_JSON_SPLIT_NUMPY = "application/json-numpy-split"
 

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -107,8 +107,9 @@ def parse_records_oriented_json_input_to_numpy(json_input):
     """
     # pylint: disable=broad-except
     try:
+        #return pd.read_json(json_input, orient="records", dtype=False, numpy=True)
         json_input_list = json.loads(json_input, object_pairs_hook=OrderedDict)
-        return np.array([list(d.values()) for d in json_input_list], dtype=object)
+        return pd.DataFrame(np.array([list(d.values()) for d in json_input_list], dtype=object))
     except Exception:
         _handle_serving_error(
             error_message=(
@@ -128,7 +129,9 @@ def parse_split_oriented_json_input_to_numpy(json_input):
     # pylint: disable=broad-except
     try:
         json_input_list = json.loads(json_input, object_pairs_hook=OrderedDict)
-        return np.array(json_input_list['data'], dtype=object)
+        return pd.DataFrame(index=json_input_list['index'],
+                            data=np.array(json_input_list['data'], dtype=object),
+                            columns=json_input_list['columns'])
     except Exception:
         _handle_serving_error(
             error_message=(

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -12,6 +12,7 @@ Defines two endpoints:
 """
 from __future__ import print_function
 
+from collections import OrderedDict
 import flask
 import json
 from json import JSONEncoder
@@ -106,7 +107,7 @@ def parse_records_oriented_json_input_to_numpy(json_input):
     """
     # pylint: disable=broad-except
     try:
-        json_input_list = json.loads(json_input)
+        json_input_list = json.loads(json_input, object_pairs_hook=OrderedDict)
         return np.array([list(d.values()) for d in json_input_list], dtype=object)
     except Exception:
         _handle_serving_error(
@@ -126,7 +127,7 @@ def parse_split_oriented_json_input_to_numpy(json_input):
     """
     # pylint: disable=broad-except
     try:
-        json_input_list = json.loads(json_input)
+        json_input_list = json.loads(json_input, object_pairs_hook=OrderedDict)
         return np.array(json_input_list['data'], dtype=object)
     except Exception:
         _handle_serving_error(
@@ -199,9 +200,9 @@ def init(model):
             data = parse_json_input(json_input=flask.request.data.decode('utf-8'),
                                     orient="records")
         elif flask.request.content_type == CONTENT_TYPE_JSON_RECORDS_NUMPY:
-            data = parse_records_oriented_json_input_to_numpy(flask.request.data)
+            data = parse_records_oriented_json_input_to_numpy(flask.request.data.decode('utf-8'))
         elif flask.request.content_type == CONTENT_TYPE_JSON_SPLIT_NUMPY:
-            data = parse_split_oriented_json_input_to_numpy(flask.request.data)
+            data = parse_split_oriented_json_input_to_numpy(flask.request.data.decode('utf-8'))
         else:
             return flask.Response(
                 response=("This predictor only supports the following content types,"

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -107,8 +107,8 @@ def parse_split_oriented_json_input_to_numpy(json_input):
     try:
         json_input_list = json.loads(json_input, object_pairs_hook=OrderedDict)
         return pd.DataFrame(index=json_input_list['index'],
-                            data=np.array(json_input_list['data']),
-                            columns=json_input_list['columns'])
+                            data=np.array(json_input_list['data'], dtype=object),
+                            columns=json_input_list['columns']).infer_objects()
     except Exception:
         _handle_serving_error(
             error_message=(

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -185,7 +185,7 @@ def init(model):
         """
         Do an inference on a single batch of data. In this sample server,
         we take data as CSV or json, convert it to a Pandas DataFrame or Numpy,
-        generate predictions and convert them back to CSV/json.
+        generate predictions and convert them back to json.
         """
         # Convert from CSV to pandas
         if flask.request.content_type == CONTENT_TYPE_CSV:

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -110,7 +110,7 @@ def parse_records_oriented_json_input_to_numpy(json_input):
         json_input_list = json.loads(json_input, object_pairs_hook=OrderedDict)
         columns = json_input_list[0].keys()
         return pd.DataFrame(data=np.array([list(d.values())
-                                           for d in json_input_list], dtype=object),
+                                           for d in json_input_list]),
                             columns=columns)
     except Exception:
         _handle_serving_error(
@@ -132,7 +132,7 @@ def parse_split_oriented_json_input_to_numpy(json_input):
     try:
         json_input_list = json.loads(json_input, object_pairs_hook=OrderedDict)
         return pd.DataFrame(index=json_input_list['index'],
-                            data=np.array(json_input_list['data'], dtype=object),
+                            data=np.array(json_input_list['data']),
                             columns=json_input_list['columns'])
     except Exception:
         _handle_serving_error(

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -199,9 +199,9 @@ def init(model):
             data = parse_json_input(json_input=flask.request.data.decode('utf-8'),
                                     orient="records")
         elif flask.request.content_type == CONTENT_TYPE_JSON_RECORDS_NUMPY:
-            data = parse_records_oriented_json_input_to_numpy(flask.request.data.decode('utf-8'))
+            data = parse_records_oriented_json_input_to_numpy(flask.request.data)
         elif flask.request.content_type == CONTENT_TYPE_JSON_SPLIT_NUMPY:
-            data = parse_split_oriented_json_input_to_numpy(flask.request.data.decode('utf-8'))
+            data = parse_split_oriented_json_input_to_numpy(flask.request.data)
         else:
             return flask.Response(
                 response=("This predictor only supports the following content types,"

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -107,7 +107,6 @@ def parse_records_oriented_json_input_to_numpy(json_input):
     """
     # pylint: disable=broad-except
     try:
-        #return pd.read_json(json_input, orient="records", dtype=False, numpy=True)
         json_input_list = json.loads(json_input, object_pairs_hook=OrderedDict)
         return pd.DataFrame(np.array([list(d.values()) for d in json_input_list], dtype=object))
     except Exception:

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+import json
 import os
 import random
 import requests
@@ -11,6 +12,7 @@ from subprocess import Popen
 import uuid
 import sys
 
+import numpy as np
 import pandas as pd
 import pytest
 

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-import json
 import os
 import random
 import requests
@@ -12,7 +11,6 @@ from subprocess import Popen
 import uuid
 import sys
 
-import numpy as np
 import pandas as pd
 import pytest
 

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -217,7 +217,7 @@ def test_parse_json_input_split_oriented():
 
 
 @pytest.mark.large
-def test_parse_json_input_records_oriented_to_numpy():
+def test_parse_json_input_records_oriented_to_numpy_array():
     size = 200
     data = {"col_m": [random_int(0, 1000) for _ in range(size)],
             "col_z": [random_str(4) for _ in range(size)],
@@ -231,7 +231,7 @@ def test_parse_json_input_records_oriented_to_numpy():
 
 
 @pytest.mark.large
-def test_parse_json_input_split_oriented_to_numpy():
+def test_parse_json_input_split_oriented_to_numpy_array():
     size = 200
     data = {"col_m": [random_int(0, 1000) for _ in range(size)],
             "col_z": [random_str(4) for _ in range(size)],
@@ -270,7 +270,7 @@ def test_split_oriented_json_to_df():
 
 
 @pytest.mark.large
-def test_records_oriented_json_to_numpy():
+def test_records_oriented_json_to_numpy_array():
     jstr = '[' \
            '{"zip":"95120","cost":10.45,"score":8},' \
            '{"zip":"95128","cost":23.0,"score":0},' \
@@ -284,7 +284,7 @@ def test_records_oriented_json_to_numpy():
 
 
 @pytest.mark.large
-def test_split_oriented_json_to_numpy():
+def test_split_oriented_json_to_numpy_array():
     # test that datatype for "zip" column is not converted to "int64"
     jstr = '{"columns":["zip","cost","count"],"index":[0,1,2],' \
            '"data":[["95120",10.45,-8],["95128",23.0,-1],["95128",12.1,1000]]}'

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -2,7 +2,7 @@ import os
 import json
 import pandas as pd
 import numpy as np
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 
 import pytest
 import sklearn.datasets as datasets
@@ -219,9 +219,9 @@ def test_parse_json_input_split_oriented():
 @pytest.mark.large
 def test_parse_json_input_records_oriented_to_numpy_array():
     size = 200
-    data = {"col_m": [random_int(0, 1000) for _ in range(size)],
-            "col_z": [random_str(4) for _ in range(size)],
-            "col_a": [random_int() for _ in range(size)]}
+    data = OrderedDict([("col_m", [random_int(0, 1000) for _ in range(size)]),
+                        ("col_z", [random_str(4) for _ in range(size)]),
+                        ("col_a", [random_int() for _ in range(size)])])
     p0 = pd.DataFrame.from_dict(data)
     p1 = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])],
                   dtype=object)
@@ -233,9 +233,9 @@ def test_parse_json_input_records_oriented_to_numpy_array():
 @pytest.mark.large
 def test_parse_json_input_split_oriented_to_numpy_array():
     size = 200
-    data = {"col_m": [random_int(0, 1000) for _ in range(size)],
-            "col_z": [random_str(4) for _ in range(size)],
-            "col_a": [random_int() for _ in range(size)]}
+    data = OrderedDict([("col_m", [random_int(0, 1000) for _ in range(size)]),
+                        ("col_z", [random_str(4) for _ in range(size)]),
+                        ("col_a", [random_int() for _ in range(size)])])
     p0 = pd.DataFrame.from_dict(data)
     p1 = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])],
                   dtype=object)

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -154,6 +154,19 @@ def test_scoring_server_successfully_evaluates_correct_dataframes_with_pandas_sp
 
 
 @pytest.mark.large
+def test_scoring_server_successfully_evaluates_correct_numpy(
+        sklearn_model, model_path):
+    mlflow.sklearn.save_model(sk_model=sklearn_model.model, path=model_path)
+
+    pandas_records_content = pd.DataFrame(sklearn_model.inference_data).to_json(orient="records")
+    response_records_content_type = pyfunc_serve_and_score_model(
+            model_uri=os.path.abspath(model_path),
+            data=pandas_records_content,
+            content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_NUMPY)
+    assert response_records_content_type.status_code == 200
+
+
+@pytest.mark.large
 def test_scoring_server_responds_to_invalid_content_type_request_with_unsupported_content_type_code(
         sklearn_model, model_path):
     mlflow.sklearn.save_model(sk_model=sklearn_model.model, path=model_path)
@@ -191,6 +204,18 @@ def test_parse_json_input_split_oriented():
 
 
 @pytest.mark.large
+def test_parse_json_input_records_oriented_to_numpy():
+    size = 200
+    data = {"col_m": [random_int(0, 1000) for _ in range(size)],
+            "col_z": [random_str(4) for _ in range(size)],
+            "col_a": [random_int() for _ in range(size)]}
+    p0 = pd.DataFrame.from_dict(data)
+    p1 = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])])
+    p2 = pyfunc_scoring_server.parse_records_oriented_json_input_to_numpy(p0.to_json(orient="records"))
+    np.testing.assert_array_equal(p1, p2)
+
+
+@pytest.mark.large
 def test_records_oriented_json_to_df():
     # test that datatype for "zip" column is not converted to "int64"
     jstr = '[' \
@@ -213,6 +238,34 @@ def test_split_oriented_json_to_df():
 
     assert set(df.columns) == {'zip', 'cost', 'count'}
     assert set(str(dt) for dt in df.dtypes) == {'object', 'float64', 'int64'}
+
+
+@pytest.mark.large
+def test_records_oriented_json_to_numpy():
+    jstr = '[' \
+           '{"zip":"95120","cost":10.45,"score":8},' \
+           '{"zip":"95128","cost":23.0,"score":0},' \
+           '{"zip":"95128","cost":12.1,"score":10}' \
+           ']'
+    df = pyfunc_scoring_server.parse_records_oriented_json_input_to_numpy(jstr)
+    np.testing.assert_array_equal(np.array([["95120", 10.45, 8],
+                                            ["95128", 23.0, 0],
+                                            ["95128", 12.1, 10]], dtype=[['object, float64, int64'],
+                                                                         ['object, float64, int64'],
+                                                                         ['object, float64, int64']]),
+                                  df)
+
+
+#@pytest.mark.large
+#def test_split_oriented_json_to_numpy():
+    # test that datatype for "zip" column is not converted to "int64"
+#    jstr = '{"columns":["zip","cost","count"],"index":[0,1,2],' \
+#           '"data":[["95120",10.45,-8],["95128",23.0,-1],["95128",12.1,1000]]}'
+#    df = pyfunc_scoring_server.parse_split_oriented_json_input_to_numpy(jstr)
+
+#    for lst in [["95120", 10.45, -8], ["95128", 23.0, -1], ["95128", 12.1, 1000]]:
+#        assert lst in list(df)
+#    assert len(df) == 3
 
 
 def test_get_jsonnable_obj():

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -180,6 +180,19 @@ def test_scoring_server_responds_to_invalid_content_type_request_with_unsupporte
 
 
 @pytest.mark.large
+def test_parse_json_input_records_oriented():
+    size = 20
+    data = {"col_m": [random_int(0, 1000) for _ in range(size)],
+            "col_z": [random_str(4) for _ in range(size)],
+            "col_a": [random_int() for _ in range(size)]}
+    p1 = pd.DataFrame.from_dict(data)
+    p2 = pyfunc_scoring_server.parse_json_input(p1.to_json(orient="records"), orient="records")
+    # "records" orient may shuffle column ordering. Hence comparing each column Series
+    for col in data.keys():
+        assert all(p1[col] == p2[col])
+
+
+@pytest.mark.large
 def test_parse_json_input_split_oriented():
     size = 200
     data = {"col_m": [random_int(0, 1000) for _ in range(size)],

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -197,7 +197,9 @@ def test_parse_json_input_split_oriented_to_numpy_array():
                         ("col_z", [random_str(4) for _ in range(size)]),
                         ("col_a", [random_int() for _ in range(size)])])
     p0 = pd.DataFrame.from_dict(data)
-    np_array = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])], dtype=object)
+    np_array = np.array([[a, b, c] for a, b, c in
+                         zip(data['col_m'], data['col_z'], data['col_a'])],
+                        dtype=object)
     p1 = pd.DataFrame(np_array).infer_objects()
     p2 = pyfunc_scoring_server.parse_split_oriented_json_input_to_numpy(
         p0.to_json(orient="split"))

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -166,7 +166,6 @@ def test_scoring_server_successfully_evaluates_correct_records_to_numpy(
     assert response_records_content_type.status_code == 200
 
 
-
 @pytest.mark.large
 def test_scoring_server_successfully_evaluates_correct_split_to_numpy(
         sklearn_model, model_path):

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -223,8 +223,7 @@ def test_parse_json_input_records_oriented_to_numpy_array():
                         ("col_z", [random_str(4) for _ in range(size)]),
                         ("col_a", [random_int() for _ in range(size)])])
     p0 = pd.DataFrame.from_dict(data)
-    p1 = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])],
-                  )
+    p1 = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])])
     p2 = pyfunc_scoring_server.parse_records_oriented_json_input_to_numpy(
         p0.to_json(orient="records"))
     np.testing.assert_array_equal(p1, p2)
@@ -237,8 +236,7 @@ def test_parse_json_input_split_oriented_to_numpy_array():
                         ("col_z", [random_str(4) for _ in range(size)]),
                         ("col_a", [random_int() for _ in range(size)])])
     p0 = pd.DataFrame.from_dict(data)
-    p1 = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])],
-                  )
+    p1 = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])])
     p2 = pyfunc_scoring_server.parse_split_oriented_json_input_to_numpy(
         p0.to_json(orient="split"))
     np.testing.assert_array_equal(p1, p2)

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -197,7 +197,8 @@ def test_parse_json_input_split_oriented_to_numpy_array():
                         ("col_z", [random_str(4) for _ in range(size)]),
                         ("col_a", [random_int() for _ in range(size)])])
     p0 = pd.DataFrame.from_dict(data)
-    p1 = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])])
+    np_array = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])], dtype=object)
+    p1 = pd.DataFrame(np_array).infer_objects()
     p2 = pyfunc_scoring_server.parse_split_oriented_json_input_to_numpy(
         p0.to_json(orient="split"))
     np.testing.assert_array_equal(p1, p2)
@@ -235,10 +236,8 @@ def test_split_oriented_json_to_numpy_array():
            '"data":[["95120",10.45,-8],["95128",23.0,-1],["95128",12.1,1000]]}'
     df = pyfunc_scoring_server.parse_split_oriented_json_input_to_numpy(jstr)
 
-    np.testing.assert_array_equal(np.array([['95120', 10.45, -8],
-                                            ['95128', 23.0, -1],
-                                            ['95128', 12.1, 1000]]),
-                                  df)
+    assert set(df.columns) == {'zip', 'cost', 'count'}
+    assert set(str(dt) for dt in df.dtypes) == {'object', 'float64', 'int64'}
 
 
 def test_get_jsonnable_obj():

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -226,7 +226,8 @@ def test_parse_json_input_records_oriented_to_numpy():
     p0 = pd.DataFrame.from_dict(data)
     p1 = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])],
                   dtype=object)
-    p2 = pyfunc_scoring_server.parse_records_oriented_json_input_to_numpy(p0.to_json(orient="records"))
+    p2 = pyfunc_scoring_server.parse_records_oriented_json_input_to_numpy(
+        p0.to_json(orient="records"))
     np.testing.assert_array_equal(p1, p2)
 
 
@@ -239,7 +240,8 @@ def test_parse_json_input_split_oriented_to_numpy():
     p0 = pd.DataFrame.from_dict(data)
     p1 = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])],
                   dtype=object)
-    p2 = pyfunc_scoring_server.parse_split_oriented_json_input_to_numpy(p0.to_json(orient="split"))
+    p2 = pyfunc_scoring_server.parse_split_oriented_json_input_to_numpy(
+        p0.to_json(orient="split"))
     np.testing.assert_array_equal(p1, p2)
 
 

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -224,7 +224,7 @@ def test_parse_json_input_records_oriented_to_numpy_array():
                         ("col_a", [random_int() for _ in range(size)])])
     p0 = pd.DataFrame.from_dict(data)
     p1 = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])],
-                  dtype=object)
+                  )
     p2 = pyfunc_scoring_server.parse_records_oriented_json_input_to_numpy(
         p0.to_json(orient="records"))
     np.testing.assert_array_equal(p1, p2)
@@ -238,7 +238,7 @@ def test_parse_json_input_split_oriented_to_numpy_array():
                         ("col_a", [random_int() for _ in range(size)])])
     p0 = pd.DataFrame.from_dict(data)
     p1 = np.array([[a, b, c] for a, b, c in zip(data['col_m'], data['col_z'], data['col_a'])],
-                  dtype=object)
+                  )
     p2 = pyfunc_scoring_server.parse_split_oriented_json_input_to_numpy(
         p0.to_json(orient="split"))
     np.testing.assert_array_equal(p1, p2)
@@ -279,7 +279,7 @@ def test_records_oriented_json_to_numpy_array():
     df = pyfunc_scoring_server.parse_records_oriented_json_input_to_numpy(jstr)
     np.testing.assert_array_equal(np.array([['95120', 10.45, 8],
                                             ['95128', 23.0, 0],
-                                            ['95128', 12.1, 10]], dtype=object),
+                                            ['95128', 12.1, 10]]),
                                   df)
 
 
@@ -292,7 +292,7 @@ def test_split_oriented_json_to_numpy_array():
 
     np.testing.assert_array_equal(np.array([['95120', 10.45, -8],
                                             ['95128', 23.0, -1],
-                                            ['95128', 12.1, 1000]], dtype=object),
+                                            ['95128', 12.1, 1000]]),
                                   df)
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently the REST POST input data is converted to Pandas Dataframe, which takes ~ 5 ms compared with ~ 1 ms on Numpy array conversion. In this PR I added the Numpy conversion from both split oriented JSON data.
  
More details: https://github.com/mlflow/mlflow/issues/1403
 
## How is this patch tested?
 
Unit tests all passed. 

The unit tests on new conversions are added.

The profiler was used locally, and it showed it takes less than 1 ms in Numpy conversion.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Please refer to https://github.com/mlflow/mlflow/issues/1403
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [x] Pyfunc
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
