### PR TITLE
[Java] Add order_by support to Java tracking client

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -151,7 +151,30 @@ public class MlflowClient {
   public List<RunInfo> searchRuns(List<String> experimentIds,
                                   String searchFilter,
                                   ViewType runViewType) {
-    SearchRuns.Builder builder = SearchRuns.newBuilder().addAllExperimentIds(experimentIds);
+    return searchRuns(experimentIds, searchFilter, runViewType, new ArrayList<>());
+  }
+
+
+  /**
+   * Return runs from provided list of experiments that satisfy the search query.
+   *
+   * @param experimentIds List of experiment IDs.
+   * @param searchFilter SQL compatible search query string. Format of this query string is
+   *                     similar to that specified on MLflow UI.
+   *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
+   * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
+   *                    Defaults to ACTIVE_ONLY.
+   * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
+   *
+   * @return A list of all RunInfos that satisfy search filter.
+   */
+  public List<RunInfo> searchRuns(List<String> experimentIds,
+                                  String searchFilter,
+                                  ViewType runViewType,
+                                  List<String> orderBy) {
+    SearchRuns.Builder builder = SearchRuns.newBuilder()
+      .addAllExperimentIds(experimentIds)
+      .addAllOrderBy(orderBy);
 
     if (searchFilter != null) {
       builder.setFilter(searchFilter);

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -13,6 +13,7 @@ import java.util.Stack;
 import java.util.Vector;
 import java.util.LinkedList;
 
+import com.google.common.collect.Lists;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -249,6 +250,16 @@ public class MlflowClientTest {
     Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_1);
 
     searchResult = client.searchRuns(experimentIds, "tag.test = 'also works'");
+    Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_2);
+
+    searchResult = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY,
+      Lists.newArrayList("metrics.accuracy_score"));
+    Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_1);
+    Assert.assertEquals(searchResult.get(1).getRunUuid(), runId_2);
+
+    searchResult = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY,
+      Lists.newArrayList("params.min_samples_leaf", "metrics.accuracy_score DESC"));
+    Assert.assertEquals(searchResult.get(1).getRunUuid(), runId_1);
     Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_2);
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Adds a new parameter to searchRuns in the Java tracking server.
 
## How is this patch tested?
 
Unit tests
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.

Part of new order_by support in general.
 
### What component(s) does this PR affect?
 
- [x] Tracking
- [x] Java

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
