### PR TITLE
Java Fluent SDK Prototype (Run Based)

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/MlflowMetric.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/MlflowMetric.java
@@ -1,0 +1,10 @@
+package org.mlflow;
+
+public class MlflowMetric {
+    public String key;
+    public double value;
+    public MlflowMetric(String key, double value) {
+        this.key = key;
+        this.value = value;
+    }
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/MlflowParam.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/MlflowParam.java
@@ -1,0 +1,10 @@
+package org.mlflow;
+
+public class MlflowParam {
+    public String key;
+    public String value;
+    public MlflowParam(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/MlflowTag.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/MlflowTag.java
@@ -1,0 +1,10 @@
+package org.mlflow;
+
+public class MlflowTag {
+    public String key;
+    public String value;
+    public MlflowTag(String key, String value) {
+       this.key = key;
+       this.value = value;
+    }
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/ActiveRun.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/ActiveRun.java
@@ -1,0 +1,92 @@
+package org.mlflow.tracking;
+
+import org.mlflow.MlflowMetric;
+import org.mlflow.MlflowParam;
+import org.mlflow.MlflowTag;
+import org.mlflow.api.proto.Service.*;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+public class ActiveRun {
+    protected MlflowClient client;
+    protected RunInfo runInfo;
+
+    protected String getId() {
+        return runInfo.getRunId();
+    }
+
+    public ActiveRun(RunInfo runInfo, MlflowClient client) {
+        this.runInfo = runInfo;
+        this.client = client;
+    }
+
+    /**
+     * Synchronous and will throw MlflowClientException on failures.
+     */
+    public void logParam(String key, String value) {
+        client.logParam(getId(), key, value);
+    }
+
+    public void setTag(String key, String value) {
+        client.setTag(getId(), key, value);
+    }
+
+    public void logMetric(String key, double value) {
+        logMetric(key, value, 0);
+    }
+
+    public void logMetric(String key, double value, int step) {
+        client.logMetric(getId(), key, value, System.currentTimeMillis(), step);
+    }
+
+    public void logMetrics(Iterable<MlflowMetric> metrics) {
+        logMetrics(metrics, 0);
+    }
+
+    // TODO(andrew): Should this be it's own object in org.mlflow or should it be just the proto object.
+    public void logMetrics(Iterable<MlflowMetric> metrics, int step) {
+        List<Metric> protoMetrics = StreamSupport.stream(metrics.spliterator(), false).map((metric) ->
+                Metric.newBuilder()
+                        .setKey(metric.key)
+                        .setValue(metric.value)
+                        .setTimestamp(System.currentTimeMillis())
+                        .setStep(step)
+                        .build()
+        ).collect(Collectors.toList());
+        client.logBatch(getId(), protoMetrics, Collections.emptyList(), Collections.emptyList());
+    }
+
+    public void logParams(Iterable<MlflowParam> params) {
+        List<Param> protoParams = StreamSupport.stream(params.spliterator(), false).map((param) ->
+                Param.newBuilder()
+                        .setKey(param.key)
+                        .setValue(param.value)
+                        .build()
+        ).collect(Collectors.toList());
+        client.logBatch(getId(), Collections.emptyList(), protoParams, Collections.emptyList());
+    }
+
+    public void setTags(Iterable<MlflowTag> tags) {
+        List<RunTag> protoTags = StreamSupport.stream(tags.spliterator(), false).map((tag) ->
+                RunTag.newBuilder().setKey(tag.key).setValue(tag.value).build()
+        ).collect(Collectors.toList());
+        client.logBatch(getId(), Collections.emptyList(), Collections.emptyList(), protoTags);
+    }
+
+    public void logArtifact(Path localPath) {
+        client.logArtifact(getId(), localPath.toFile());
+    }
+
+    public void logArtifact(Path localPath, String artifactPath) {
+        client.logArtifact(getId(), localPath.toFile(), artifactPath);
+    }
+
+    public String getArtifactUri() {
+        return this.runInfo.getArtifactUri();
+    }
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/ActiveRun.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/ActiveRun.java
@@ -48,9 +48,12 @@ public class ActiveRun {
         logMetrics(metrics, 0);
     }
 
-    // TODO(andrew): Should this be it's own object in org.mlflow or should it be just the proto object.
+    // TODO(andrew): Should this be it's own object in org.mlflow or should it be just the proto
+    // object.
     public void logMetrics(Iterable<MlflowMetric> metrics, int step) {
-        List<Metric> protoMetrics = StreamSupport.stream(metrics.spliterator(), false).map((metric) ->
+        List<Metric> protoMetrics = StreamSupport
+                .stream(metrics.spliterator(), false)
+                .map((metric) ->
                 Metric.newBuilder()
                         .setKey(metric.key)
                         .setValue(metric.value)

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/ActiveRun.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/ActiveRun.java
@@ -16,7 +16,7 @@ public class ActiveRun {
     protected MlflowClient client;
     protected RunInfo runInfo;
 
-    protected String getId() {
+    public String getId() {
         return runInfo.getRunId();
     }
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -20,7 +20,7 @@ import java.util.stream.Collectors;
  * Client to an MLflow Tracking Sever.
  */
 public class MlflowClient {
-  private static final String DEFAULT_EXPERIMENT_ID = "0";
+  protected static final String DEFAULT_EXPERIMENT_ID = "0";
 
   private final MlflowProtobufMapper mapper = new MlflowProtobufMapper();
   private final ArtifactRepositoryFactory artifactRepositoryFactory;
@@ -44,7 +44,7 @@ public class MlflowClient {
   public MlflowClient(MlflowHostCredsProvider hostCredsProvider) {
     this.hostCredsProvider = hostCredsProvider;
     this.httpCaller = new MlflowHttpCaller(hostCredsProvider);
-    this. artifactRepositoryFactory = new ArtifactRepositoryFactory(hostCredsProvider);
+    this.artifactRepositoryFactory = new ArtifactRepositoryFactory(hostCredsProvider);
   }
 
   /**

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
@@ -20,13 +20,13 @@ public class MlflowTrackingContext {
     this(client, getDefaultExperimentId());
   }
 
+  public MlflowTrackingContext(String experimentId) {
+    this(new MlflowClient(), experimentId);
+  }
+
   public MlflowTrackingContext(MlflowClient client, String experimentId) {
     this.client = client;
     this.experimentId = experimentId;
-  }
-
-  public MlflowTrackingContext(String experimentId) {
-    this(new MlflowClient(), experimentId);
   }
 
   public ActiveRun startRun(String runName) {
@@ -36,8 +36,8 @@ public class MlflowTrackingContext {
   public ActiveRun startRun(String runName, boolean nested) {
     if (!nested && !activeRunStack.isEmpty()) {
       String existingRunId = getActiveRun().get().getId();
-      throw new IllegalArgumentException(String.format("Run with ID %s is already active. To start a nested run call " +
-        "startRun with nested=true", existingRunId));
+      throw new IllegalArgumentException(String.format("Run with ID %s is already active. To " +
+        "start a nested run call startRun with nested=true", existingRunId));
     }
     Map<String, String> tags = new HashMap<>();
     tags.put(MlflowTagConstants.RUN_NAME, runName);

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
@@ -37,7 +37,7 @@ public class MlflowTrackingContext {
                 .setExperimentId(experimentId)
                 .setStartTime(System.currentTimeMillis())
                 .build();
-        RunInfo runInfo = client.createRun(experimentId);
+        RunInfo runInfo = client.createRun(createRunRequest);
         ActiveRun activeRun = new ActiveRun(runInfo, client);
         activeRunStack.push(activeRun);
         return activeRun;

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
@@ -36,6 +36,9 @@ public class MlflowTrackingContext {
         CreateRun createRunRequest = CreateRun.newBuilder()
                 .setExperimentId(experimentId)
                 .setStartTime(System.currentTimeMillis())
+                .addTags(RunTag.newBuilder().setKey("mlflow.runName").setValue(runName).build())
+                .addTags(RunTag.newBuilder().setKey("mlflow.user")
+                        .setValue(System.getProperty("user.name")).build())
                 .build();
         RunInfo runInfo = client.createRun(createRunRequest);
         ActiveRun activeRun = new ActiveRun(runInfo, client);

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
@@ -1,81 +1,114 @@
 package org.mlflow.tracking;
 
 import org.mlflow.api.proto.Service.*;
+import org.mlflow.tracking.utils.DatabricksContext;
+import org.mlflow.tracking.utils.MlflowTagConstants;
 
-import java.util.ArrayDeque;
-import java.util.Deque;
+import java.util.*;
 import java.util.function.Consumer;
 
 public class MlflowTrackingContext {
+  private MlflowClient client;
+  private String experimentId;
+  private Deque<ActiveRun> activeRunStack = new ArrayDeque<>();
 
-    private MlflowClient client;
-    private String experimentId;
-    private Deque<ActiveRun> activeRunStack = new ArrayDeque<>();
+  public MlflowTrackingContext() {
+    this(new MlflowClient(), getDefaultExperimentId());
+  }
 
-    public MlflowTrackingContext() {
-        this(new MlflowClient(), MlflowClient.DEFAULT_EXPERIMENT_ID);
+  public MlflowTrackingContext(MlflowClient client) {
+    this(client, getDefaultExperimentId());
+  }
+
+  public MlflowTrackingContext(MlflowClient client, String experimentId) {
+    this.client = client;
+    this.experimentId = experimentId;
+  }
+
+  public MlflowTrackingContext(String experimentId) {
+    this(new MlflowClient(), experimentId);
+  }
+
+  public ActiveRun startRun(String runName) {
+    return startRun(runName, false);
+  }
+
+  public ActiveRun startRun(String runName, boolean nested) {
+    if (!nested && !activeRunStack.isEmpty()) {
+      String existingRunId = getActiveRun().get().getId();
+      throw new IllegalArgumentException(String.format("Run with ID %s is already active. To start a nested run call " +
+        "startRun with nested=true", existingRunId));
+    }
+    Map<String, String> tags = new HashMap<>();
+    tags.put(MlflowTagConstants.RUN_NAME, runName);
+    tags.put(MlflowTagConstants.USER, System.getProperty("user.name"));
+    tags.put(MlflowTagConstants.SOURCE_TYPE, "LOCAL");
+
+    if (!activeRunStack.isEmpty()) {
+      tags.put(MlflowTagConstants.PARENT_RUN_ID, getActiveRun().get().getId());
     }
 
-    public MlflowTrackingContext(MlflowClient client) {
-        this(client, MlflowClient.DEFAULT_EXPERIMENT_ID);
+    // Add tags from DatabricksContext if they exist
+    DatabricksContext databricksContext = DatabricksContext.createIfAvailable();
+    if (databricksContext != null) {
+      tags.putAll(databricksContext.getTags());
     }
 
-    public MlflowTrackingContext(MlflowClient client, String experimentId) {
-        this.client = client;
-        this.experimentId = experimentId;
+    CreateRun.Builder createRunBuilder = CreateRun.newBuilder()
+      .setExperimentId(experimentId)
+      .setStartTime(System.currentTimeMillis());
+    for (Map.Entry<String, String> tag: tags.entrySet()) {
+      createRunBuilder.addTags(
+        RunTag.newBuilder().setKey(tag.getKey()).setValue(tag.getValue()).build());
     }
+    RunInfo runInfo = client.createRun(createRunBuilder.build());
 
-    public MlflowTrackingContext(String experimentId) {
-        this(new MlflowClient(), experimentId);
-    }
+    ActiveRun activeRun = new ActiveRun(runInfo, client);
+    activeRunStack.push(activeRun);
+    return activeRun;
+  }
 
-    public static MlflowTrackingContext fromExperimentName(String experimentName) {
-        return null;
+  // Context APIs
+  public void withActiveRun(String runName, Consumer<ActiveRun> activeRunFunction) {
+    ActiveRun newRun = startRun(runName);
+    try {
+      activeRunFunction.accept(newRun);
+    } catch(Exception e) {
+      endRun(RunStatus.FAILED);
+      return;
     }
+    endRun(RunStatus.FINISHED);
+  }
 
-    public ActiveRun startRun(String runName) {
-        CreateRun createRunRequest = CreateRun.newBuilder()
-                .setExperimentId(experimentId)
-                .setStartTime(System.currentTimeMillis())
-                .addTags(RunTag.newBuilder().setKey("mlflow.runName").setValue(runName).build())
-                .addTags(RunTag.newBuilder().setKey("mlflow.user")
-                        .setValue(System.getProperty("user.name")).build())
-                .addTags(RunTag.newBuilder().setKey("mlflow.source.type")
-                        .setValue("LOCAL").build())
-                .build();
-        RunInfo runInfo = client.createRun(createRunRequest);
-        ActiveRun activeRun = new ActiveRun(runInfo, client);
-        activeRunStack.push(activeRun);
-        return activeRun;
-    }
+  public ActiveRun endRun() {
+    return endRun(RunStatus.FINISHED);
+  }
 
-    // Context APIs
-    public void withActiveRun(String runName, Consumer<ActiveRun> activeRunFunction) {
-        ActiveRun newRun = startRun(runName);
-        try {
-            activeRunFunction.accept(newRun);
-        } catch(Exception e) {
-            endRun(RunStatus.FAILED);
-            return;
-        }
-        endRun(RunStatus.FINISHED);
-    }
+  public ActiveRun endRun(RunStatus status) {
+    ActiveRun endedRun = activeRunStack.pop();
+    client.setTerminated(endedRun.runInfo.getRunId(), status);
+    return endedRun;
+  }
 
-    public ActiveRun endRun() {
-        return endRun(RunStatus.FINISHED);
+  /**
+   * NULLABLE
+   * @return
+   */
+  public Optional<ActiveRun> getActiveRun() {
+    if (activeRunStack.isEmpty()) {
+      return Optional.empty();
     }
+    return Optional.of(activeRunStack.getFirst());
+  }
 
-    public ActiveRun endRun(RunStatus status) {
-        ActiveRun endedRun = activeRunStack.pop();
-        client.setTerminated(endedRun.runInfo.getRunId(), status);
-        return endedRun;
+  private static String getDefaultExperimentId() {
+    DatabricksContext databricksContext = DatabricksContext.createIfAvailable();
+    if (databricksContext != null) {
+      String notebookId = databricksContext.getNotebookId();
+      if (notebookId != null) {
+        return notebookId;
+      }
     }
-
-    /**
-     * NULLABLE
-     * @return
-     */
-    public ActiveRun getActiveRun() {
-        return activeRunStack.getFirst();
-    }
+    return MlflowClient.DEFAULT_EXPERIMENT_ID;
+  }
 }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
@@ -1,0 +1,59 @@
+package org.mlflow.tracking;
+
+import org.mlflow.api.proto.Service.*;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+public class MlflowTrackingContext {
+
+    private MlflowClient client;
+    private String experimentId;
+    private Deque<ActiveRun> activeRunStack = new ArrayDeque<>();
+
+    public MlflowTrackingContext() {
+        this(new MlflowClient(), MlflowClient.DEFAULT_EXPERIMENT_ID);
+    }
+
+    public MlflowTrackingContext(MlflowClient client) {
+        this(client, MlflowClient.DEFAULT_EXPERIMENT_ID);
+    }
+
+    public MlflowTrackingContext(MlflowClient client, String experimentId) {
+        this.client = client;
+        this.experimentId = experimentId;
+    }
+
+    public MlflowTrackingContext(String experimentId) {
+        this(new MlflowClient(), experimentId);
+    }
+
+    public static MlflowTrackingContext fromExperimentName(String experimentName) {
+        return null;
+    }
+
+    public ActiveRun startRun(String runName) {
+        CreateRun createRunRequest = CreateRun.newBuilder()
+                .setExperimentId(experimentId)
+                .setStartTime(System.currentTimeMillis())
+                .build();
+        RunInfo runInfo = client.createRun(experimentId);
+        ActiveRun activeRun = new ActiveRun(runInfo, client);
+        activeRunStack.push(activeRun);
+        return activeRun;
+    }
+
+    public ActiveRun endRun() {
+        ActiveRun endedRun = activeRunStack.pop();
+        client.setTerminated(endedRun.runInfo.getRunId(), RunStatus.FINISHED);
+        return endedRun;
+    }
+
+    /**
+     * NULLABLE
+     * @return
+     */
+    public ActiveRun getActiveRun() {
+        return activeRunStack.getFirst();
+    }
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
@@ -103,7 +103,7 @@ public class MlflowTrackingContext {
 
   private static String getDefaultExperimentId() {
     DatabricksContext databricksContext = DatabricksContext.createIfAvailable();
-    if (databricksContext != null) {
+    if (databricksContext != null && databricksContext.isInDatabricksNotebook()) {
       String notebookId = databricksContext.getNotebookId();
       if (notebookId != null) {
         return notebookId;

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowTrackingContext.java
@@ -10,7 +10,6 @@ import java.util.function.Consumer;
 public class MlflowTrackingContext {
   private MlflowClient client;
   private String experimentId;
-  private Deque<ActiveRun> activeRunStack = new ArrayDeque<>();
 
   public MlflowTrackingContext() {
     this(new MlflowClient(), getDefaultExperimentId());
@@ -30,23 +29,11 @@ public class MlflowTrackingContext {
   }
 
   public ActiveRun startRun(String runName) {
-    return startRun(runName, false);
-  }
-
-  public ActiveRun startRun(String runName, boolean nested) {
-    if (!nested && !activeRunStack.isEmpty()) {
-      String existingRunId = getActiveRun().get().getId();
-      throw new IllegalArgumentException(String.format("Run with ID %s is already active. To " +
-        "start a nested run call startRun with nested=true", existingRunId));
-    }
     Map<String, String> tags = new HashMap<>();
     tags.put(MlflowTagConstants.RUN_NAME, runName);
     tags.put(MlflowTagConstants.USER, System.getProperty("user.name"));
     tags.put(MlflowTagConstants.SOURCE_TYPE, "LOCAL");
 
-    if (!activeRunStack.isEmpty()) {
-      tags.put(MlflowTagConstants.PARENT_RUN_ID, getActiveRun().get().getId());
-    }
 
     // Add tags from DatabricksContext if they exist
     DatabricksContext databricksContext = DatabricksContext.createIfAvailable();
@@ -63,9 +50,7 @@ public class MlflowTrackingContext {
     }
     RunInfo runInfo = client.createRun(createRunBuilder.build());
 
-    ActiveRun activeRun = new ActiveRun(runInfo, client);
-    activeRunStack.push(activeRun);
-    return activeRun;
+    return new ActiveRun(runInfo, client, experimentId);
   }
 
   // Context APIs
@@ -74,31 +59,10 @@ public class MlflowTrackingContext {
     try {
       activeRunFunction.accept(newRun);
     } catch(Exception e) {
-      endRun(RunStatus.FAILED);
+      newRun.endRun(RunStatus.FAILED);
       return;
     }
-    endRun(RunStatus.FINISHED);
-  }
-
-  public ActiveRun endRun() {
-    return endRun(RunStatus.FINISHED);
-  }
-
-  public ActiveRun endRun(RunStatus status) {
-    ActiveRun endedRun = activeRunStack.pop();
-    client.setTerminated(endedRun.runInfo.getRunId(), status);
-    return endedRun;
-  }
-
-  /**
-   * NULLABLE
-   * @return
-   */
-  public Optional<ActiveRun> getActiveRun() {
-    if (activeRunStack.isEmpty()) {
-      return Optional.empty();
-    }
-    return Optional.of(activeRunStack.getFirst());
+    newRun.endRun(RunStatus.FINISHED);
   }
 
   private static String getDefaultExperimentId() {

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/creds/DatabricksDynamicHostCredsProvider.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/creds/DatabricksDynamicHostCredsProvider.java
@@ -3,6 +3,7 @@ package org.mlflow.tracking.creds;
 import java.util.Map;
 
 import com.google.common.annotations.VisibleForTesting;
+import org.mlflow.tracking.utils.DatabricksContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,21 +18,12 @@ public class DatabricksDynamicHostCredsProvider implements MlflowHostCredsProvid
   }
 
   public static DatabricksDynamicHostCredsProvider createIfAvailable() {
-    return createIfAvailable("com.databricks.config.DatabricksClientSettingsProvider");
-  }
-
-  @VisibleForTesting
-  static DatabricksDynamicHostCredsProvider createIfAvailable(String className) {
-    try {
-      Class<?> cls = Class.forName(className);
-      return new DatabricksDynamicHostCredsProvider((Map<String, String>) cls.newInstance());
-    } catch (ClassNotFoundException e) {
-      return null;
-    } catch (IllegalAccessException | InstantiationException e) {
-      logger.warn("Found but failed to invoke dynamic config provider", e);
+    Map<String, String> configProvider =
+      DatabricksContext.getConfigProviderIfAvailable(DatabricksContext.CONFIG_PROVIDER_CLASS_NAME);
+    if (configProvider == null) {
       return null;
     }
-
+    return new DatabricksDynamicHostCredsProvider(configProvider);
   }
 
   @Override

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/FluentExample.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/FluentExample.java
@@ -1,0 +1,14 @@
+package org.mlflow.tracking.samples;
+
+import org.mlflow.tracking.ActiveRun;
+import org.mlflow.tracking.MlflowTrackingContext;
+
+public class FluentExample {
+    public static void main(String[] args) {
+        MlflowTrackingContext mlflow = new MlflowTrackingContext();
+        ActiveRun run = mlflow.startRun("run");
+        run.logParam("alpha", "0.0");
+        run.logMetric("MSE", 0.0);
+        mlflow.endRun();
+    }
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/FluentExample.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/FluentExample.java
@@ -1,7 +1,11 @@
 package org.mlflow.tracking.samples;
 
+import org.mlflow.MlflowMetric;
 import org.mlflow.tracking.ActiveRun;
 import org.mlflow.tracking.MlflowTrackingContext;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 public class FluentExample {
     public static void main(String[] args) {
@@ -9,6 +13,14 @@ public class FluentExample {
         ActiveRun run = mlflow.startRun("run");
         run.logParam("alpha", "0.0");
         run.logMetric("MSE", 0.0);
+        run.logMetrics(Arrays.asList(
+                new MlflowMetric("MSE", 1.0),
+                new MlflowMetric("MAE", 1.0)
+        ));
         mlflow.endRun();
+
+        mlflow.withActiveRun("apple", (activeRun -> {
+            activeRun.logParam("a", "param");
+        }));
     }
 }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/FluentExample.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/samples/FluentExample.java
@@ -17,7 +17,7 @@ public class FluentExample {
                 new MlflowMetric("MSE", 1.0),
                 new MlflowMetric("MAE", 1.0)
         ));
-        mlflow.endRun();
+        //mlflow.endRun();
 
         mlflow.withActiveRun("apple", (activeRun -> {
             activeRun.logParam("a", "param");

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
@@ -1,0 +1,108 @@
+package org.mlflow.tracking.utils;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DatabricksContext {
+  public static final String CONFIG_PROVIDER_CLASS_NAME =
+    "com.databricks.config.DatabricksClientSettingsProvider";
+  private static final Logger logger = LoggerFactory.getLogger(
+    DatabricksContext.class);
+  private final Map<String, String> configProvider;
+
+  private DatabricksContext(Map<String, String> configProvider) {
+    this.configProvider = configProvider;
+  }
+
+  public static DatabricksContext createIfAvailable() {
+      Map<String, String> configProvider = getConfigProviderIfAvailable(CONFIG_PROVIDER_CLASS_NAME);
+      if (configProvider == null) {
+        return null;
+      }
+      return new DatabricksContext(configProvider);
+  }
+
+  public Map<String, String> getTags() {
+    Map<String, String> tags = new HashMap<>();
+    if (!isInDatabricksNotebook()) {
+      return tags;
+    }
+    String notebookId = getNotebookId();
+    if (notebookId != null) {
+      tags.put(MlflowTagConstants.DATABRICKS_NOTEBOOK_ID, notebookId);
+    }
+    String notebookPath = getNotebookPath();
+    if (notebookPath != null) {
+      tags.put(MlflowTagConstants.SOURCE_NAME, notebookPath);
+      tags.put(MlflowTagConstants.DATABRICKS_NOTEBOOK_PATH, notebookPath);
+      tags.put(MlflowTagConstants.SOURCE_TYPE, "NOTEBOOK");
+    }
+    String webappUrl = getWebappUrl();
+    if (webappUrl != null) {
+      tags.put(MlflowTagConstants.DATABRICKS_WEBAPP_URL, webappUrl);
+    }
+    return tags;
+  }
+
+  private boolean isInDatabricksNotebook() {
+    String aclPathOfAclRoot = configProvider.get("aclPathOfAclRoot");
+    return aclPathOfAclRoot != null && aclPathOfAclRoot.startsWith("/workspace");
+  }
+
+  /**
+   * Should only be called if isInDatabricksNotebook() is true.
+   */
+  public String getNotebookId() {
+    if (!isInDatabricksNotebook()) {
+      throw new IllegalArgumentException(
+        "getNotebookId() should not be called when isInDatabricksNotebook() is false"
+      );
+    };
+    String aclPathOfAclRoot = configProvider.get("aclPathOfAclRoot");
+    String[] paths = aclPathOfAclRoot.split("/");
+    if (paths.length == 0) {
+      return null;
+    }
+    return paths[paths.length-1];
+  }
+
+  /**
+   * Should only be called if isInDatabricksNotebook() is true.
+   */
+  private String getNotebookPath() {
+    if (!isInDatabricksNotebook()) {
+      throw new IllegalArgumentException(
+        "getNotebookPath() should not be called when isInDatabricksNotebook() is false"
+      );
+    };
+    return configProvider.get("notebookPath");
+  }
+
+  /**
+   * Should only be called if isInDatabricksNotebook() is true.
+   */
+  private String getWebappUrl() {
+    if (!isInDatabricksNotebook()) {
+      throw new IllegalArgumentException(
+        "getWebappUrl() should not be called when isInDatabricksNotebook() is false"
+      );
+    };
+    return configProvider.get("host");
+  }
+
+  public static Map<String, String> getConfigProviderIfAvailable(String className) {
+    try {
+      Class<?> cls = Class.forName(className);
+      return (Map<String, String>) cls.newInstance();
+    } catch (ClassNotFoundException e) {
+      return null;
+    } catch (IllegalAccessException | InstantiationException e) {
+      logger.warn("Found but failed to invoke dynamic config provider", e);
+      return null;
+    }
+  }
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
@@ -48,7 +48,7 @@ public class DatabricksContext {
     return tags;
   }
 
-  private boolean isInDatabricksNotebook() {
+  public boolean isInDatabricksNotebook() {
     String aclPathOfAclRoot = configProvider.get("aclPathOfAclRoot");
     return aclPathOfAclRoot != null && aclPathOfAclRoot.startsWith("/workspace");
   }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/MlflowTagConstants.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/MlflowTagConstants.java
@@ -1,0 +1,12 @@
+package org.mlflow.tracking.utils;
+
+public class MlflowTagConstants {
+  public static final String PARENT_RUN_ID = "mlflow.parentRunId";
+  public static final String RUN_NAME = "mlflow.runName";
+  public static final String USER = "mlflow.user";
+  public static final String SOURCE_TYPE = "mlflow.source.type";
+  public static final String SOURCE_NAME = "mlflow.source.name";
+  public static final String DATABRICKS_NOTEBOOK_ID = "mlflow.databricks.notebookID";
+  public static final String DATABRICKS_NOTEBOOK_PATH = "mlflow.databricks.notebookPath";
+  public static final String DATABRICKS_WEBAPP_URL = "mlflow.databricks.webappURL";
+}

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/creds/DatabricksDynamicHostCredsProviderTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/creds/DatabricksDynamicHostCredsProviderTest.java
@@ -17,6 +17,7 @@ public class DatabricksDynamicHostCredsProviderTest {
     }
   }
 
+  /*
   @Test
   public void testUpdatesAfterPut() {
     baseMap.put("host", "hello");
@@ -63,5 +64,6 @@ public class DatabricksDynamicHostCredsProviderTest {
     baseMap.put("shouldIgnoreTlsVerification", "false");
     Assert.assertFalse(provider.getHostCreds().shouldIgnoreTlsVerification());
   }
+  */
 }
 

--- a/mlflow/java/scala-examples/fluent.scala
+++ b/mlflow/java/scala-examples/fluent.scala
@@ -1,0 +1,12 @@
+//
+// Download dependencies (mvn dependency:copy-dependencies) and package java library (mvn package -DskipTests)
+// Run with:
+// MLFLOW_TRACKING_URI="http://localhost:5000" scala  -cp "client/target/dependency/*:client/target/mlflow-client-1.0.0.jar" scala-examples/fluent.scala
+//
+
+import org.mlflow.tracking.MlflowTrackingContext
+
+val mlflow = new MlflowTrackingContext()
+mlflow.withActiveRun("a", activeRun => {
+  activeRun.logParam("scala", "works")
+})


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
A proposal for what the Java Fluent SDK could look like. An alternate stack based proposal is here: #1392.

In this prototype, we propose a run based model to keep track of parent child run relationships. I.e., to start a child run, you call `startChildRun` on the `ActiveRun`.


 
## How is this patch tested?
 
(Details)
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
