### PR TITLE
[mlflow/R] Avoid insecure warnings when accessing artifacts in Databricks.

### DIFF
--- a/mlflow/R/mlflow/R/databricks-utils.R
+++ b/mlflow/R/mlflow/R/databricks-utils.R
@@ -28,6 +28,9 @@ databricks_config_as_env <- function(config) {
   if (config$config_source != "cfgfile") { # pass the auth info via environment vars
     res <- config[!is.na(config)]
     res$config_source <- NULL
+    if (!as.logical(res$insecure)) {
+      res$insecure <- NULL
+    }
     names(res) <- lapply(names(res), function (x) config_variable_map[[x]])
     res
   } else if (!is.na(Sys.getenv(DATABRICKS_CONFIG_FILE, NA))) {

--- a/mlflow/R/mlflow/R/tracking-rest.R
+++ b/mlflow/R/mlflow/R/tracking-rest.R
@@ -33,10 +33,8 @@ get_rest_config <- function(host_creds) {
   if (!is.na(auth_header)) {
     headers$Authorization <- auth_header
   }
-
   headers$`User-Agent` <- paste("mlflow-r-client", utils::packageVersion("mlflow"), sep = "/")
-
-  is_insecure <- list(true = TRUE, false = FALSE)[[tolower(host_creds$insecure)]]
+  is_insecure <- as.logical(host_creds$insecure)
   list(
     headers = headers,
     config = if (is_insecure) {

--- a/mlflow/R/mlflow/tests/testthat/test-databricks-utils.R
+++ b/mlflow/R/mlflow/tests/testthat/test-databricks-utils.R
@@ -154,8 +154,7 @@ test_that("mlflow can read databricks env congfig", {
   )
   env <- list(DATABRICKS_HOST = "envhost",
               DATABRICKS_USERNAME = "envusername",
-              DATABRICKS_TOKEN = "envtoken",
-              DATABRICKS_INSECURE = "False")
+              DATABRICKS_TOKEN = "envtoken")
 
   with_envvar(env, {
     envprofile <- mlflow:::get_databricks_config_from_env()


### PR DESCRIPTION
## What changes are proposed in this pull request?
Leave DATABRICKS_INSECURE env var unset unless insecure=True.
Databricks cli treats any non null value as True.
 

## How is this patch tested?
Existing tests updated to expect var not set instead of being "false" 

## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [x] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
