### PR TITLE
add destination path to client artifacts download

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -234,19 +234,24 @@ class MlflowClient(object):
         artifact_repo = get_artifact_repository(artifact_root)
         return artifact_repo.list_artifacts(path)
 
-    def download_artifacts(self, run_id, path):
+    def download_artifacts(self, run_id, path, dst_path=None):
         """
         Download an artifact file or directory from a run to a local directory if applicable,
         and return a local path for it.
 
         :param run_id: The run to download artifacts from.
         :param path: Relative source path to the desired artifact.
+        :param dst_path: Absolute path of the local filesystem destination directory to which to
+                         download the specified artifacts. This directory must already exist.
+                         If unspecified, the artifacts will either be downloaded to a new
+                         uniquely-named directory on the local filesystem or will be returned
+                         directly in the case of the LocalArtifactRepository.
         :return: Local path of desired artifact.
         """
         run = self.get_run(run_id)
         artifact_root = run.info.artifact_uri
         artifact_repo = get_artifact_repository(artifact_root)
-        return artifact_repo.download_artifacts(path)
+        return artifact_repo.download_artifacts(path, dst_path)
 
     def set_terminated(self, run_id, status=None, end_time=None):
         """Set a run's status to terminated.


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fixes #1503 allows to specify destination path when downloading artifacts with mlflow clielnt
 
## How is this patch tested?
 
Tested by hand and also by travis tests specified in contribution guide
 
## Release Notes

 Allows to specify destination path when downloading artifacts with mlflow clielnt

### Is this a user-facing change? 

- [V] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [V] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [V] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
