### PR TITLE
Re-enable SageMaker tests

### DIFF
--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -156,10 +156,7 @@ def test_model_export(spark_model_iris, model_path, spark_custom_env):
     assert os.path.exists(sparkm.DFS_TMP)
 
 
-# TODO(czumar): Remark this test as "large" instead of "release" after SageMaker docker
-# container build issues have been debugged
-# @pytest.mark.large
-@pytest.mark.release
+@pytest.mark.large
 def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
     sparkm.save_model(spark_model_iris.model, path=model_path,
                       conda_env=spark_custom_env,
@@ -188,7 +185,7 @@ def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
             decimal=4)
 
 
-@pytest.mark.release
+@pytest.mark.large
 def test_sagemaker_docker_model_scoring_with_default_conda_env(spark_model_iris, model_path):
     sparkm.save_model(spark_model_iris.model, path=model_path, conda_env=None)
 

--- a/travis/run-large-python-tests.sh
+++ b/travis/run-large-python-tests.sh
@@ -5,16 +5,8 @@ set -x
 err=0
 trap 'err=1' ERR
 
+mlflow sagemaker build-and-push-container --no-push --mlflow-home .
 
-# TODO(czumar): Re-enable container building and associated SageMaker tests once the container
-# build process is no longer hanging
-# - SAGEMAKER_OUT=$(mktemp)
-# - if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
-#     echo "Sagemaker container build succeeded.";
-#   else
-#     echo "Sagemaker container build failed, output:";
-#     cat $SAGEMAKER_OUT;
-#   fi
 # NB: Also add --ignore'd tests to run-small-python-tests.sh
 pytest tests --large --ignore=tests/h2o --ignore=tests/keras \
   --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn \


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Re-enables SageMaker tests. (Previous, similar PR: https://github.com/mlflow/mlflow/pull/1087/)

The [build](https://travis-ci.org/mlflow/mlflow/jobs/514899656) was failing because "No output has been received in the last 10m0s". Since output was being redirected during image build, the travis build will fail if the image build takes more than 10 minutes, which is likely when building the image from base

This will make build output more verbose.

## How is this patch tested?

`./lint.sh`
`mlflow sagemaker build-and-push-container --no-push --mlflow-home . `
`python -m pytest --verbose tests/spark --large`

21 passed in 477.70 seconds

## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
