### PR TITLE
Calling mlflow.pyfunc.log_model() does not create a run if one does not exist

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -199,7 +199,7 @@ from copy import deepcopy
 import mlflow
 import mlflow.pyfunc.model
 import mlflow.pyfunc.utils
-from mlflow.tracking.fluent import active_run, log_artifacts
+from mlflow.tracking.fluent import _get_or_start_run, log_artifacts
 from mlflow.models import Model
 from mlflow.pyfunc.model import PythonModel, PythonModelContext, get_default_conda_env
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -646,7 +646,7 @@ def log_model(artifact_path, loader_module=None, data_path=None, code_path=None,
     """
     with TempDir() as tmp:
         local_path = tmp.path(artifact_path)
-        run_id = active_run().info.run_id
+        run_id = _get_or_start_run().info.run_id
         save_model(path=local_path, model=Model(artifact_path=artifact_path, run_id=run_id),
                    loader_module=loader_module, data_path=data_path, code_path=code_path,
                    conda_env=conda_env, python_model=python_model, artifacts=artifacts)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -461,7 +461,7 @@ def spark_udf(spark, model_uri, result_type="double"):
 def save_model(path, loader_module=None, data_path=None, code_path=None, conda_env=None,
                mlflow_model=Model(), python_model=None, artifacts=None, **kwargs):
     """
-    save_model(path, loader_module=None, data_path=None, code_path=None, conda_env=None,
+    save_model(path, loader_module=None, data_path=None, code_path=None, conda_env=None,\
                mlflow_model=Model(), python_model=None, artifacts=None)
 
     Create a custom Pyfunc model, incorporating custom inference logic and data dependencies.
@@ -505,7 +505,8 @@ def save_model(path, loader_module=None, data_path=None, code_path=None, conda_e
                                 'cloudpickle==0.5.8'
                             ]
                         }
-    :param mlflow_model: :py:mod:`mlflow.models.Model` configuration to which to add the pyfunc flavor
+    :param mlflow_model: :py:mod:`mlflow.models.Model` configuration to which to add the
+                         **python_function** flavor.
     :param python_model: An instance of a subclass of :class:`~PythonModel`. This class is
                          serialized using the CloudPickle library. Any dependencies of the class
                          should be included in one of the following locations:

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -199,7 +199,7 @@ from copy import deepcopy
 import mlflow
 import mlflow.pyfunc.model
 import mlflow.pyfunc.utils
-from mlflow.tracking.fluent import _get_or_start_run, log_artifacts
+from mlflow.tracking.fluent import log_artifacts
 from mlflow.models import Model
 from mlflow.pyfunc.model import PythonModel, PythonModelContext, get_default_conda_env
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -460,7 +460,7 @@ def spark_udf(spark, model_uri, result_type="double"):
 
 
 def save_model(path, loader_module=None, data_path=None, code_path=None, conda_env=None,
-               mlflow_model=Model(), python_model=None, artifacts=None):
+               model=Model(), python_model=None, artifacts=None, **kwargs):
     """
     Create a custom Pyfunc model, incorporating custom inference logic and data dependencies.
 
@@ -534,6 +534,8 @@ def save_model(path, loader_module=None, data_path=None, code_path=None, conda_e
 
                       If ``None``, no artifacts are added to the model.
     """
+    if 'mlflow_model' in kwargs:
+        model = kwargs['mlflow_model']
     first_argument_set = {
         "loader_module": loader_module,
         "data_path": data_path,
@@ -563,11 +565,11 @@ def save_model(path, loader_module=None, data_path=None, code_path=None, conda_e
     if first_argument_set_specified:
         return _save_model_with_loader_module_and_data_path(
                 path=path, loader_module=loader_module, data_path=data_path,
-                code_paths=code_path, conda_env=conda_env, mlflow_model=mlflow_model)
+                code_paths=code_path, conda_env=conda_env, mlflow_model=model)
     elif second_argument_set_specified:
         return mlflow.pyfunc.model._save_model_with_class_artifacts_params(
             path=path, python_model=python_model, artifacts=artifacts, conda_env=conda_env,
-            code_paths=code_path, mlflow_model=mlflow_model)
+            code_paths=code_path, mlflow_model=model)
 
 
 def log_model(artifact_path, loader_module=None, data_path=None, code_path=None, conda_env=None,

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -146,9 +146,35 @@ def test_model_save_load(sklearn_knn_model, main_scoped_model_class, iris_data, 
         loaded_pyfunc_model.predict(model_input=iris_data[0]),
         test_predict(sk_model=sklearn_knn_model, model_input=iris_data[0]))
 
+@pytest.mark.large
+def test_pyfunc_model_log_load_no_run(sklearn_knn_model, main_scoped_model_class, iris_data):
+    sklearn_artifact_path = "sk_model_no_run"
+    with mlflow.start_run():
+        mlflow.sklearn.log_model(sk_model=sklearn_knn_model, artifact_path=sklearn_artifact_path)
+        sklearn_model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id,
+            artifact_path=sklearn_artifact_path)
+
+    def test_predict(sk_model, model_input):
+        return sk_model.predict(model_input) * 2
+
+    pyfunc_artifact_path = "pyfunc_model"
+    mlflow.pyfunc.log_model(artifact_path=pyfunc_artifact_path,
+                            artifacts={"sk_model": sklearn_model_uri},
+                            python_model=main_scoped_model_class(test_predict))
+    pyfunc_model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id,
+            artifact_path=pyfunc_artifact_path)
+    loaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(model_uri=pyfunc_model_uri)
+    np.testing.assert_array_equal(
+            loaded_pyfunc_model.predict(model_input=iris_data[0]),
+            test_predict(sk_model=sklearn_knn_model, model_input=iris_data[0]))
+    mlflow.end_run()
+
 
 @pytest.mark.large
 def test_model_log_load(sklearn_knn_model, main_scoped_model_class, iris_data):
+    print("ACTIVE RUN:", mlflow.active_run())
     sklearn_artifact_path = "sk_model"
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=sklearn_knn_model, artifact_path=sklearn_artifact_path)

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -146,6 +146,7 @@ def test_model_save_load(sklearn_knn_model, main_scoped_model_class, iris_data, 
         loaded_pyfunc_model.predict(model_input=iris_data[0]),
         test_predict(sk_model=sklearn_knn_model, model_input=iris_data[0]))
 
+
 @pytest.mark.large
 def test_pyfunc_model_log_load_no_run(sklearn_knn_model, main_scoped_model_class, iris_data):
     sklearn_artifact_path = "sk_model_no_run"
@@ -174,7 +175,6 @@ def test_pyfunc_model_log_load_no_run(sklearn_knn_model, main_scoped_model_class
 
 @pytest.mark.large
 def test_model_log_load(sklearn_knn_model, main_scoped_model_class, iris_data):
-    print("ACTIVE RUN:", mlflow.active_run())
     sklearn_artifact_path = "sk_model"
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=sklearn_knn_model, artifact_path=sklearn_artifact_path)

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -148,7 +148,7 @@ def test_model_save_load(sklearn_knn_model, main_scoped_model_class, iris_data, 
 
 
 @pytest.mark.large
-def test_pyfunc_model_log_load_no_run(sklearn_knn_model, main_scoped_model_class, iris_data):
+def test_pyfunc_model_log_load_no_active_run(sklearn_knn_model, main_scoped_model_class, iris_data):
     sklearn_artifact_path = "sk_model_no_run"
     with mlflow.start_run():
         mlflow.sklearn.log_model(sk_model=sklearn_knn_model, artifact_path=sklearn_artifact_path)
@@ -160,6 +160,7 @@ def test_pyfunc_model_log_load_no_run(sklearn_knn_model, main_scoped_model_class
         return sk_model.predict(model_input) * 2
 
     pyfunc_artifact_path = "pyfunc_model"
+    assert mlflow.active_run() is None
     mlflow.pyfunc.log_model(artifact_path=pyfunc_artifact_path,
                             artifacts={"sk_model": sklearn_model_uri},
                             python_model=main_scoped_model_class(test_predict))

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -94,6 +94,29 @@ def test_model_log_load(sklearn_knn_model, iris_data, tmpdir):
 
 
 @pytest.mark.large
+def test_model_log_load_no_run(sklearn_knn_model, iris_data, tmpdir):
+    sk_model_path = os.path.join(str(tmpdir), "knn.pkl")
+    with open(sk_model_path, "wb") as f:
+        pickle.dump(sklearn_knn_model, f)
+
+    pyfunc_artifact_path = "pyfunc_model"
+    mlflow.pyfunc.log_model(artifact_path=pyfunc_artifact_path,
+                            data_path=sk_model_path,
+                            loader_module=os.path.basename(__file__)[:-3],
+                            code_path=[__file__])
+    pyfunc_model_path = _download_artifact_from_uri("runs:/{run_id}/{artifact_path}".format(
+        run_id=mlflow.active_run().info.run_id, artifact_path=pyfunc_artifact_path))
+
+    model_config = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
+    assert mlflow.pyfunc.FLAVOR_NAME in model_config.flavors
+    assert mlflow.pyfunc.PY_VERSION in model_config.flavors[mlflow.pyfunc.FLAVOR_NAME]
+    reloaded_model = mlflow.pyfunc.load_pyfunc(pyfunc_model_path)
+    np.testing.assert_array_equal(
+        sklearn_knn_model.predict(iris_data[0]), reloaded_model.predict(iris_data[0]))
+    mlflow.end_run()
+
+
+@pytest.mark.large
 def test_save_model_with_unsupported_argument_combinations_throws_exception(model_path):
     with pytest.raises(MlflowException) as exc_info:
         mlflow.pyfunc.save_model(path=model_path,

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -94,12 +94,13 @@ def test_model_log_load(sklearn_knn_model, iris_data, tmpdir):
 
 
 @pytest.mark.large
-def test_model_log_load_no_run(sklearn_knn_model, iris_data, tmpdir):
+def test_model_log_load_no_active_run(sklearn_knn_model, iris_data, tmpdir):
     sk_model_path = os.path.join(str(tmpdir), "knn.pkl")
     with open(sk_model_path, "wb") as f:
         pickle.dump(sklearn_knn_model, f)
 
     pyfunc_artifact_path = "pyfunc_model"
+    assert mlflow.active_run() is None
     mlflow.pyfunc.log_model(artifact_path=pyfunc_artifact_path,
                             data_path=sk_model_path,
                             loader_module=os.path.basename(__file__)[:-3],

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -59,7 +59,7 @@ def test_model_save_load(sklearn_knn_model, iris_data, tmpdir, model_path):
                              data_path=sk_model_path,
                              loader_module=os.path.basename(__file__)[:-3],
                              code_path=[__file__],
-                             model=model_config)
+                             mlflow_model=model_config)
 
     reloaded_model_config = Model.load(os.path.join(model_path, "MLmodel"))
     assert model_config.__dict__ == reloaded_model_config.__dict__


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
When logging a pyfunc model with MLflow via the mlflow.pyfunc.log_model() API, MLflow should either log the model in the currently active run or create a new run if an active run does not exist.

Currently, if an active run does not exist, mlflow.pyfunc.log_model() does not create a run. As a result, the logging call fails. This is documented in the corresponding open source (OSS) GitHub issue located here: https://github.com/mlflow/mlflow/issues/1209.

This commit fixes that issue and adds tests to test for it.
 
## How is this patch tested?
 
Add a test that tries to log a model without calling mlflow.start_run()
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
mlflow.pyfunc.log_model now works without explicitly specifying `with mlflow.start_run():`.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
