### PR TITLE
Update mlflow.spark.log_model() to accept descendants of pyspark.Model

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -255,7 +255,8 @@ def _save_model_metadata(dst_dir, spark_model, mlflow_model, sample_input, conda
 
 def _validate_model(spark_model):
     from pyspark.ml.util import MLReadable, MLWritable
-    if not isinstance(spark_model, Model) \
+    from pyspark.ml import Model as PySparkModel
+    if not isinstance(spark_model, PySparkModel) \
             or not isinstance(spark_model, MLReadable) \
             or not isinstance(spark_model, MLWritable):
         raise MlflowException(

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -65,7 +65,7 @@ def log_model(spark_model, artifact_path, conda_env=None, dfs_tmpdir=None,
     Log a Spark MLlib model as an MLflow artifact for the current run. This uses the
     MLlib persistence format and produces an MLflow Model with the Spark flavor.
 
-    :param spark_model: Spark model to be saved - MLFlow can only save descendants of 
+    :param spark_model: Spark model to be saved - MLFlow can only save descendants of
                         pyspark.ml.Model which implement MLReadable and MLWritable.
     :param artifact_path: Run relative artifact path.
     :param conda_env: Either a dictionary representation of a Conda environment or the path to a
@@ -273,7 +273,7 @@ def save_model(spark_model, path, mlflow_model=Model(), conda_env=None,
     Additionally, if a sample input is specified using the ``sample_input`` parameter, the model
     is also serialized in MLeap format and the MLeap flavor is added.
 
-    :param spark_model: Spark model to be saved - MLFlow can only save descendants of 
+    :param spark_model: Spark model to be saved - MLFlow can only save descendants of
                         pyspark.ml.Model which implement MLReadable and MLWritable.
     :param path: Local path where the model is to be saved.
     :param mlflow_model: MLflow model config this flavor is being added to.

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -259,7 +259,8 @@ def _validate_model(spark_model):
             or not isinstance(spark_model, MLReadable) \
             or not isinstance(spark_model, MLWritable):
         raise MlflowException(
-                "Not a descendant of pyspark.Model. SparkML can only save descendants of pyspark.Model that implement MLWritable and MLReadable.", 
+                "Cannot serialize this model. MLFlow can only save descendants of pyspark.Model"
+                "that implement MLWritable and MLReadable.",
                 INVALID_PARAMETER_VALUE)
 
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -65,7 +65,8 @@ def log_model(spark_model, artifact_path, conda_env=None, dfs_tmpdir=None,
     Log a Spark MLlib model as an MLflow artifact for the current run. This uses the
     MLlib persistence format and produces an MLflow Model with the Spark flavor.
 
-    :param spark_model: PipelineModel to be saved.
+    :param spark_model: Spark model to be saved - MLFlow can only save descendants of 
+                        pyspark.ml.Model which implement MLReadable and MLWritable.
     :param artifact_path: Run relative artifact path.
     :param conda_env: Either a dictionary representation of a Conda environment or the path to a
                       Conda environment yaml file. If provided, this decribes the environment
@@ -253,7 +254,6 @@ def _save_model_metadata(dst_dir, spark_model, mlflow_model, sample_input, conda
 
 
 def _validate_model(spark_model):
-    from pyspark.ml import Model
     from pyspark.ml.util import MLReadable, MLWritable
     if not isinstance(spark_model, Model) \
             or not isinstance(spark_model, MLReadable) \
@@ -267,13 +267,14 @@ def _validate_model(spark_model):
 def save_model(spark_model, path, mlflow_model=Model(), conda_env=None,
                dfs_tmpdir=None, sample_input=None):
     """
-    Save a Spark MLlib PipelineModel to a local path.
+    Save a Spark MLlib Model to a local path.
 
     By default, this function saves models using the Spark MLlib persistence mechanism.
     Additionally, if a sample input is specified using the ``sample_input`` parameter, the model
     is also serialized in MLeap format and the MLeap flavor is added.
 
-    :param spark_model: Spark PipelineModel to be saved. Can save only PipelineModels.
+    :param spark_model: Spark model to be saved - MLFlow can only save descendants of 
+                        pyspark.ml.Model which implement MLReadable and MLWritable.
     :param path: Local path where the model is to be saved.
     :param mlflow_model: MLflow model config this flavor is being added to.
     :param conda_env: Either a dictionary representation of a Conda environment or the path to a

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -111,6 +111,8 @@ def log_model(spark_model, artifact_path, conda_env=None, dfs_tmpdir=None,
     from py4j.protocol import Py4JJavaError
 
     _validate_model(spark_model)
+    if isinstance(spark_model, Estimator) or isinstance(spark_model, Transformer):
+        spark_model = PipelineModel([spark_model])
     run_id = mlflow.tracking.fluent._get_or_start_run().info.run_id
     run_root_artifact_uri = mlflow.get_artifact_uri()
     # If the artifact URI is a local filesystem path, defer to Model.log() to persist the model,
@@ -251,8 +253,11 @@ def _save_model_metadata(dst_dir, spark_model, mlflow_model, sample_input, conda
 
 def _validate_model(spark_model):
     from pyspark.ml.pipeline import PipelineModel
-
-    if not isinstance(spark_model, PipelineModel):
+    from pyspark.ml import Estimator
+    from pyspark.ml import Transformer
+    if not isinstance(spark_model, PipelineModel)
+       and not isinstance(spark_model, Estimator)
+       and not isinstance(spark_model, Transformer):
         raise MlflowException("Not a PipelineModel. SparkML can only save PipelineModels.",
                               INVALID_PARAMETER_VALUE)
 
@@ -303,6 +308,8 @@ def save_model(spark_model, path, mlflow_model=Model(), conda_env=None,
     >>> mlflow.spark.save_model(model, "spark-model")
     """
     _validate_model(spark_model)
+    if isinstance(spark_model, Estimator) or isinstance(spark_model, Transformer):
+        spark_model = PipelineModel([spark_model])
     # Spark ML stores the model on DFS if running on a cluster
     # Save it to a DFS temp dir first and copy it to local path
     if dfs_tmpdir is None:

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -155,6 +155,9 @@ def test_model_export(spark_model_iris, model_path, spark_custom_env):
     assert spark_model_iris.predictions == preds3
     assert os.path.exists(sparkm.DFS_TMP)
 
+@pytest.mark.large
+def test_estimator_model_export(spark_model_iris, model_path, spark_custom_env)
+
 
 # TODO(czumar): Remark this test as "large" instead of "release" after SageMaker docker
 # container build issues have been debugged

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -92,6 +92,49 @@ def spark_model_iris(spark_context):
                               predictions=preds)
 
 
+@pytest.fixture(scope="session")
+def spark_model_transformer(spark_context):
+    iris = datasets.load_iris()
+    X = iris.data  # we only take the first two features.
+    y = iris.target
+    feature_names = ["0", "1", "2", "3"]
+    pandas_df = pd.DataFrame(X, columns=feature_names)  # to make spark_udf work
+    pandas_df['label'] = pd.Series(y)
+    spark_session = pyspark.sql.SparkSession(spark_context)
+    spark_df = spark_session.createDataFrame(pandas_df)
+    assembler = VectorAssembler(inputCols=feature_names, outputCol="features")
+    # Fit the model
+    preds_df = assembler.transform(spark_df)
+    preds = [x.features for x in preds_df.select("features").collect()]
+    return SparkModelWithData(model=assembler,
+                              spark_df=spark_df,
+                              pandas_df=pandas_df,
+                              predictions=preds)
+
+
+@pytest.fixture(scope="session")
+def spark_model_estimator(spark_context):
+    iris = datasets.load_iris()
+    X = iris.data  # we only take the first two features.
+    y = iris.target
+    feature_names = ["0", "1", "2", "3"]
+    pandas_df = pd.DataFrame(X, columns=feature_names)  # to make spark_udf work
+    pandas_df['label'] = pd.Series(y)
+    spark_session = pyspark.sql.SparkSession(spark_context)
+    spark_df = spark_session.createDataFrame(pandas_df)
+    assembler = VectorAssembler(inputCols=feature_names, outputCol="features")
+    features_df = assembler.transform(spark_df)
+    lr = LogisticRegression(maxIter=50, regParam=0.1, elasticNetParam=0.8)
+    # Fit the model
+    model = lr.fit(features_df)
+    preds_df = model.transform(features_df)
+    preds = [x.prediction for x in preds_df.select("prediction").collect()]
+    return SparkModelWithData(model=model,
+                              spark_df=features_df,
+                              pandas_df=pandas_df,
+                              predictions=preds)
+
+
 @pytest.fixture
 def model_path(tmpdir):
     return str(tmpdir.mkdir("model"))
@@ -156,7 +199,19 @@ def test_model_export(spark_model_iris, model_path, spark_custom_env):
     assert os.path.exists(sparkm.DFS_TMP)
 
 @pytest.mark.large
-def test_estimator_model_export(spark_model_iris, model_path, spark_custom_env)
+def test_estimator_model_export(spark_model_estimator, model_path, spark_custom_env):
+    sparkm.save_model(spark_model_estimator.model, path=model_path, conda_env=spark_custom_env)
+    # score and compare the reloaded sparkml model
+    reloaded_model = sparkm.load_model(model_uri=model_path)
+    preds_df = reloaded_model.transform(spark_model_estimator.spark_df)
+    preds = [x.prediction for x in preds_df.select("prediction").collect()]
+    assert spark_model_estimator.predictions == preds
+
+
+@pytest.mark.large
+def test_transformer_model_export(spark_model_transformer, model_path, spark_custom_env):
+    with pytest.raises(MlflowException):
+        sparkm.save_model(spark_model_transformer.model, path=model_path, conda_env=spark_custom_env)
 
 
 # TODO(czumar): Remark this test as "large" instead of "release" after SageMaker docker
@@ -244,6 +299,50 @@ def test_sparkml_model_log(tmpdir, spark_model_iris):
 
 
 @pytest.mark.large
+def test_sparkml_estimator_model_log(tmpdir, spark_model_estimator):
+    # Print the coefficients and intercept for multinomial logistic regression
+    old_tracking_uri = mlflow.get_tracking_uri()
+    cnt = 0
+    # should_start_run tests whether or not calling log_model() automatically starts a run.
+    for should_start_run in [False, True]:
+        for dfs_tmp_dir in [None, os.path.join(str(tmpdir), "test")]:
+            print("should_start_run =", should_start_run, "dfs_tmp_dir =", dfs_tmp_dir)
+            try:
+                tracking_dir = os.path.abspath(str(tmpdir.join("mlruns")))
+                mlflow.set_tracking_uri("file://%s" % tracking_dir)
+                if should_start_run:
+                    mlflow.start_run()
+                artifact_path = "model%d" % cnt
+                cnt += 1
+                sparkm.log_model(artifact_path=artifact_path, spark_model=spark_model_estimator.model,
+                                 dfs_tmpdir=dfs_tmp_dir)
+                model_uri = "runs:/{run_id}/{artifact_path}".format(
+                    run_id=mlflow.active_run().info.run_id,
+                    artifact_path=artifact_path)
+
+                # test reloaded model
+                reloaded_model = sparkm.load_model(model_uri=model_uri, dfs_tmpdir=dfs_tmp_dir)
+                preds_df = reloaded_model.transform(spark_model_estimator.spark_df)
+                preds = [x.prediction for x in preds_df.select("prediction").collect()]
+                assert spark_model_estimator.predictions == preds
+            finally:
+                mlflow.end_run()
+                mlflow.set_tracking_uri(old_tracking_uri)
+                x = dfs_tmp_dir or sparkm.DFS_TMP
+                shutil.rmtree(x)
+                shutil.rmtree(tracking_dir)
+
+
+@pytest.mark.large
+def test_sparkml_model_log_invalid_args(spark_model_transformer, model_path):
+    with pytest.raises(MlflowException) as e:
+        sparkm.log_model(
+            spark_model=spark_model_transformer.model,
+            artifact_path="model0")
+    assert "Not a descendant of pyspark.Model" in e.value.message
+
+
+@pytest.mark.large
 def test_sparkml_model_load_from_remote_uri_succeeds(spark_model_iris, model_path, mock_s3_bucket):
     sparkm.save_model(spark_model=spark_model_iris.model, path=model_path)
 
@@ -276,15 +375,6 @@ def test_sparkml_model_save_persists_specified_conda_env_in_mlflow_model_directo
     with open(saved_conda_env_path, "r") as f:
         saved_conda_env_parsed = yaml.safe_load(f)
     assert saved_conda_env_parsed == spark_custom_env_parsed
-
-
-@pytest.mark.large
-def test_sparkml_model_log_invalid_args(spark_model_iris, model_path):
-    with pytest.raises(MlflowException) as e:
-        sparkm.log_model(
-            spark_model=spark_model_iris.model.stages[0],
-            artifact_path="model0")
-        assert e.message.contains("SparkML can only save PipelineModels")
 
 
 @pytest.mark.large

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -203,12 +203,6 @@ def test_estimator_model_export(spark_model_estimator, model_path, spark_custom_
     m = pyfunc.load_pyfunc(model_path)
     preds2 = m.predict(spark_model_estimator.spark_df.toPandas())
     assert spark_model_estimator.predictions == preds2
-    # 3. score and compare reloaded pyfunc Spark udf
-    my_pandas_df = spark_model_estimator.pandas_df
-    print(spark_model_estimator.spark_df.toPandas())
-    preds3 = score_model_as_udf(model_uri=model_path, pandas_df=spark_model_estimator.spark_df.toPandas())
-    assert spark_model_estimator.predictions == preds3
-    assert os.path.exists(sparkm.DFS_TMP)
 
 
 @pytest.mark.large


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
The mlflow.spark.log_model() method defines a spark_model parameter. This parameter corresponds to the PySpark Pipeline that the caller is persisting in MLflow format. Currently, the spark_model parameter must be of type pyspark.ml.PipelineModel; the mlflow.spark._validate_model() method throws an exception if spark_model is not of type PipelineModel.

However, a PipelineModel is just a collection of PySpark stages, and each stage is a descendant of pyspark.ml.Transformer. We should be able to handle any descendant of pyspark.ml.Model (a descendant of Transformer) because those generate predictions, and we can wrap these under the hood in a PipelineModel that we then save. We cannot support arbitrary Transformers because many of them generate "features" and not predictions which breaks some other assumptions in mlflow.spark

This commit extends the set of supported types for the spark_model parameter of mlflow.spark.log_model() to include any descendant of pyspark.ml.Model. We convert it to a PipelineModel to use a consistent save/load implementation before serializing
 
## How is this patch tested?
 
Added new tests for different types of pyspark models for `log_model` and `save_model`
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
mlflow.spark.log_model and mlflow.spark.save_model can now serialize any descendant of pyspark.ml.Model which implements MLReadable and MLWritable.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [x] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
