### PR TITLE
Pyfunc API docs: Clarify distinction between save_model and log_model

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -464,7 +464,8 @@ def save_model(path, loader_module=None, data_path=None, code_path=None, conda_e
     save_model(path, loader_module=None, data_path=None, code_path=None, conda_env=None,\
                mlflow_model=Model(), python_model=None, artifacts=None)
 
-    Create a custom Pyfunc model, incorporating custom inference logic and data dependencies.
+    Save a Pyfunc model with custom inference logic and optional data dependencies to a path on the
+    local filesystem.
 
     For information about the workflows that this method supports, please see :ref:`"workflows for
     creating custom pyfunc models" <pyfunc-create-custom-workflows>` and
@@ -579,7 +580,8 @@ def save_model(path, loader_module=None, data_path=None, code_path=None, conda_e
 def log_model(artifact_path, loader_module=None, data_path=None, code_path=None, conda_env=None,
               python_model=None, artifacts=None):
     """
-    Create a custom Pyfunc model, incorporating custom inference logic and data dependencies.
+    Log a Pyfunc model with custom inference logic and optional data dependencies as an MLflow
+    artifact for the current run.
 
     For information about the workflows that this method supports, see :ref:`Workflows for
     creating custom pyfunc models <pyfunc-create-custom-workflows>` and


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
This PR clarifies that `mlflow.pyfunc.save_model` writes a custom pyfunc model to the local filesystem, while `mlflow.pyfunc.log_model` logs a custom pyfunc model as an MLflow artifact.
 
## How is this patch tested?
 
Manual generation of Sphinx API docs.
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section. <<< Not significant enough to warrant a release note.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [X] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
