### PR TITLE
Fixes infinite loop when downloading from s3

### DIFF
--- a/mlflow/store/s3_artifact_repo.py
+++ b/mlflow/store/s3_artifact_repo.py
@@ -79,6 +79,8 @@ class S3ArtifactRepository(ArtifactRepository):
             # Objects listed directly will be files
             for obj in result.get('Contents', []):
                 file_path = obj.get("Key")
+                if file_path.endswith('/'):
+                    continue
                 self._verify_listed_object_contains_artifact_path_prefix(
                     listed_object_path=file_path, artifact_path=artifact_path)
                 file_rel_path = posixpath.relpath(path=file_path, start=artifact_path)


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fixes issue #1458
Folders uploaded to s3 using a databricks fuse mount enter an infinite in the s3 artifact repository

This quick hack checks to see if the current key ends with '/' and exits the loop early
 
## How is this patch tested?
 
See steps to replicate in #1458 
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [x] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
