### PR TITLE
Change Param to cast input key and value to str

### DIFF
--- a/mlflow/entities/param.py
+++ b/mlflow/entities/param.py
@@ -14,12 +14,12 @@ class Param(_MLflowObject):
     @property
     def key(self):
         """String key corresponding to the parameter name."""
-        return self._key
+        return str(self._key)
 
     @property
     def value(self):
         """String value of the parameter."""
-        return self._value
+        return str(self._value)
 
     def to_proto(self):
         param = ProtoParam()


### PR DESCRIPTION
Cast inputs to Param to `str` type as indicated by doc strings.

## What changes are proposed in this pull request?
 
Changes mlflow.entities.param.Param to automatically cast input key and val to str as was indicated in the Param  `@property` doc strings

```
    @property
    def key(self):
        """String key corresponding to the parameter name."""
        return self._key

    @property
    def value(self):
        """String value of the parameter."""
        return self._value
```
becomes
```
    @property
    def key(self):
        """String key corresponding to the parameter name."""
        return str(self._key)

    @property
    def value(self):
        """String value of the parameter."""
        return str(self._value)
```
## How is this patch tested?
 
I wrote a small test:
```
   import mlflow
   from mlflow.utils.validation import _validate_param


   def test_mlflow_takes_int_as_valid_input():
       try:
           param = mlflow.entities.Param("hi", 4)
           _validate_param(param.key, param.value)
           assert True
       except TypeError:
           assert False
       except Exception as e:
           raise(e)
 ```
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
