### PR TITLE
Add feature flag for enabling use of absolute Ajax URLs in the MLflow UI

### DIFF
--- a/mlflow/server/js/config-overrides.js
+++ b/mlflow/server/js/config-overrides.js
@@ -44,7 +44,9 @@ module.exports = {
         'HIDE_EXPERIMENT_LIST':
           process.env.HIDE_EXPERIMENT_LIST ? JSON.stringify('true') : JSON.stringify('false'),
         'SHOW_GDPR_PURGING_MESSAGES':
-          process.env.SHOW_GDPR_PURGING_MESSAGES ? JSON.stringify('true') : JSON.stringify('false')
+          process.env.SHOW_GDPR_PURGING_MESSAGES ? JSON.stringify('true') : JSON.stringify('false'),
+        'USE_ABSOLUTE_AJAX_URLS':
+            process.env.USE_ABSOLUTE_AJAX_URLS ? JSON.stringify('true') : JSON.stringify('false'),
       }
     });
     return config;

--- a/mlflow/server/js/package-lock.json
+++ b/mlflow/server/js/package-lock.json
@@ -5782,7 +5782,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6197,7 +6198,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -6253,6 +6255,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6296,12 +6299,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
-          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k="
+          "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
+          "optional": true
         }
       }
     },

--- a/mlflow/server/js/src/sdk/MlflowService.js
+++ b/mlflow/server/js/src/sdk/MlflowService.js
@@ -9,6 +9,7 @@
 
 import $ from 'jquery';
 import JsonBigInt from 'json-bigint';
+import Utils from "../utils/Utils";
 
 const StrictJsonBigInt = JsonBigInt({ strict: true, storeAsString: true });
 
@@ -21,7 +22,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static createExperiment({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/experiments/create', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/experiments/create'), {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -38,7 +39,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static listExperiments({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/experiments/list', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/experiments/list'), {
       type: 'GET',
       dataType: 'json',
       converters: {
@@ -58,7 +59,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static getExperiment({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/experiments/get', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/experiments/get'), {
       type: 'GET',
       dataType: 'json',
       converters: {
@@ -78,7 +79,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static createRun({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/runs/create', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/create'), {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -95,7 +96,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static deleteRun({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/runs/delete', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/delete'), {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -112,7 +113,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static restoreRun({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/runs/restore', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/restore'), {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -129,7 +130,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static updateRun({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/runs/update', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/update'), {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -146,7 +147,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static logMetric({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/runs/log-metric', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/log-metric'), {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -163,7 +164,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static logParam({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/runs/log-parameter', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/log-parameter'), {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -180,7 +181,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static getRun({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/runs/get', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/get'), {
       type: 'GET',
       dataType: 'json',
       converters: {
@@ -200,7 +201,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static searchRuns({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/runs/search', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/search'), {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),
@@ -217,7 +218,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static listArtifacts({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/artifacts/list', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/artifacts/list'), {
       type: 'GET',
       dataType: 'json',
       converters: {
@@ -237,7 +238,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static getMetricHistory({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/metrics/get-history', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/metrics/get-history'), {
       type: 'GET',
       dataType: 'json',
       converters: {
@@ -257,7 +258,7 @@ export class MlflowService {
    * @return {Promise}
    */
   static setTag({ data, success, error }) {
-    return $.ajax('ajax-api/2.0/preview/mlflow/runs/set-tag', {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/set-tag'), {
       type: 'POST',
       dataType: 'json',
       data: JSON.stringify(data),

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -388,6 +388,13 @@ class Utils {
       !t[0].startsWith(MLFLOW_INTERNAL_PREFIX)
     );
   }
+
+  static getAjaxUrl(relativeUrl) {
+    if (process.env.USE_ABSOLUTE_AJAX_URLS && process.env.USE_ABSOLUTE_AJAX_URLS === "true") {
+      return '/' + relativeUrl;
+    }
+    return relativeUrl;
+  }
 }
 
 export default Utils;

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -390,7 +390,7 @@ class Utils {
   }
 
   static getAjaxUrl(relativeUrl) {
-    if (process.env.USE_ABSOLUTE_AJAX_URLS && process.env.USE_ABSOLUTE_AJAX_URLS === "true") {
+    if (process.env.USE_ABSOLUTE_AJAX_URLS === "true") {
       return '/' + relativeUrl;
     }
     return relativeUrl;


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Follow-up to #1413, which changes the behavior of the MLflow UI Javascript to use relative AJAX URLs when making API requests, to simplify hosting the OSS server behind an nginx proxy (e.g. you can host the UI at `http://my-proxy/mlflow-ui`, and AJAX requests will be made to `http://my-proxy/mlflow-ui/ajax-api/...` instead of `http://my-proxy/ajax-api/...`). 

This PR adds a feature flag (setting the `USE_ABSOLUTE_AJAX_URLS` environment variable to `true`, off by default) to enable the old behavior of using absolute Ajax URLs when serving the MLflow UI
 
## How is this patch tested?
 
Tested manually - in particular:
* Ran `npm run build` from the mlflow/server/js directory
* Ran the server via `mlflow server --static-prefix /mlflow-server`, verified the UI could be loaded at http://localhost:5000/mlflow-server (& that AJAX API requests were made to `http://localhost:5000/mlflow-server/ajax-api/...`)
![image](https://user-images.githubusercontent.com/2358483/60453733-ca47d780-9be6-11e9-8207-6c18f520b584.png)

* Rebuilt OSS JS with the feature flag flipped, e.g. `USE_ABSOLUTE_AJAX_URLS=true npm run build`, and relaunched the server via `mlflow server --static-prefix /mlflow-server`
* Verified that AJAX API requests were made to `http://localhost:5000/ajax-api/...` (resulting in a broken UI)
 
![image](https://user-images.githubusercontent.com/2358483/60453989-86090700-9be7-11e9-8269-6de5229be055.png)

## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
