### PR TITLE
Add pagination support to sqlalchemy and file stores

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -308,6 +308,8 @@ def _search_runs():
     run_entities = _get_store().search_runs(experiment_ids, filter_string, run_view_type,
                                             max_results, order_by, page_token)
     response_message.runs.extend([r.to_proto() for r in run_entities])
+    if run_entities.token:
+        response_message.next_page_token = run_entities.token
     response = Response(mimetype='application/json')
     response.set_data(message_to_json(response_message))
     return response

--- a/mlflow/store/rest_store.py
+++ b/mlflow/store/rest_store.py
@@ -215,7 +215,11 @@ class RestStore(AbstractStore):
         req_body = message_to_json(sr)
         response_proto = self._call_endpoint(SearchRuns, req_body)
         runs = [Run.from_proto(proto_run) for proto_run in response_proto.runs]
-        return runs, response_proto.next_page_token
+        # If next_page_token is not set, we will see it as "". We need to convert this to None.
+        next_page_token = None
+        if response_proto.next_page_token:
+            next_page_token = response_proto.next_page_token
+        return runs, next_page_token
 
     def delete_run(self, run_id):
         req_body = message_to_json(DeleteRun(run_id=run_id))

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -465,9 +465,6 @@ class SqlAlchemyStore(AbstractStore):
 
     def _search_runs(self, experiment_ids, filter_string, run_view_type, max_results, order_by,
                      page_token):
-        if page_token:
-            raise MlflowException("SQLAlchemy-backed tracking stores do not yet support pagination"
-                                  "tokens.")
         # TODO: push search query into backend database layer
         if max_results > SEARCH_MAX_RESULTS_THRESHOLD:
             raise MlflowException("Invalid value for request parameter max_results. It must be at "
@@ -479,8 +476,9 @@ class SqlAlchemyStore(AbstractStore):
                     for exp in experiment_ids
                     for run in self._list_runs(session, exp, run_view_type)]
             filtered = SearchUtils.filter(runs, filter_string)
-            runs = SearchUtils.sort(filtered, order_by)[:max_results]
-            return runs, None
+            sorted_runs = SearchUtils.sort(filtered, order_by)
+            runs, next_page_token = SearchUtils.paginate(sorted_runs, page_token, max_results)
+            return runs, next_page_token
 
     def _list_runs(self, session, experiment_id, run_view_type):
         exp = self._list_experiments(

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -358,6 +358,10 @@ class SearchUtils(object):
 
     @classmethod
     def paginate(cls, runs, page_token, max_results):
+        """Paginates a set of runs based on an offset encoded into the page_token and a max
+        results limit. Returns a pair containing the set of paginated runs, followed by
+        an optional next_page_token if there are further results that need to be returned.
+        """
         initial_offset = cls._parse_offset_from_page_token(page_token)
         final_offset = initial_offset + max_results
 

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -356,7 +356,13 @@ class SearchUtils(object):
             raise MlflowException("Invalid page token, parsed value=%s" % parsed_token,
                                   error_code=INVALID_PARAMETER_VALUE)
 
-        return int(offset_str)
+        try:
+            offset = int(offset_str)
+        except ValueError:
+            raise MlflowException("Invalid page token, not stringable %s" % offset_str,
+                                  error_code=INVALID_PARAMETER_VALUE)
+
+        return offset
 
     @classmethod
     def _create_page_token(cls, offset):

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -347,9 +347,6 @@ class SearchUtils(object):
         except ValueError:
             raise MlflowException("Invalid page token, decoded value=%s" % decoded_token,
                                   error_code=INVALID_PARAMETER_VALUE)
-        # except json.decoder.JSONDecodeError:
-        #     raise MlflowException("Invalid page token, decoded value=%s" % decoded_token,
-        #                           error_code=INVALID_PARAMETER_VALUE)
 
         offset_str = parsed_token.get("offset")
         if not offset_str:

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -327,6 +327,9 @@ class SearchUtils(object):
 
     @classmethod
     def _parse_offset_from_page_token(cls, page_token):
+        # Note: the page_token is expected to be a base64-encoded JSON that looks like
+        # { "offset": xxx }. However, this format is not stable, so it should not be
+        # relied upon outside of this method.
         if not page_token:
             return 0
 
@@ -350,6 +353,10 @@ class SearchUtils(object):
         return int(offset_str)
 
     @classmethod
+    def _create_page_token(cls, offset):
+        return base64.b64encode(json.dumps({"offset": offset}).encode("utf-8"))
+
+    @classmethod
     def paginate(cls, runs, page_token, max_results):
         initial_offset = cls._parse_offset_from_page_token(page_token)
         final_offset = initial_offset + max_results
@@ -357,5 +364,5 @@ class SearchUtils(object):
         paginated_runs = runs[initial_offset:final_offset]
         next_page_token = None
         if final_offset < len(runs):
-            next_page_token = base64.b64encode(json.dumps({"offset": final_offset}).encode("utf-8"))
+            next_page_token = cls._create_page_token(final_offset)
         return (paginated_runs, next_page_token)

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -338,12 +338,18 @@ class SearchUtils(object):
         except TypeError:
             raise MlflowException("Invalid page token, could not base64-decode",
                                   error_code=INVALID_PARAMETER_VALUE)
+        except base64.binascii.Error:
+            raise MlflowException("Invalid page token, could not base64-decode",
+                                  error_code=INVALID_PARAMETER_VALUE)
 
         try:
             parsed_token = json.loads(decoded_token)
-        except TypeError:
+        except ValueError:
             raise MlflowException("Invalid page token, decoded value=%s" % decoded_token,
                                   error_code=INVALID_PARAMETER_VALUE)
+        # except json.decoder.JSONDecodeError:
+        #     raise MlflowException("Invalid page token, decoded value=%s" % decoded_token,
+        #                           error_code=INVALID_PARAMETER_VALUE)
 
         offset_str = parsed_token.get("offset")
         if not offset_str:

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -326,7 +326,7 @@ class SearchUtils(object):
         return runs
 
     @classmethod
-    def _parse_offset_from_page_token(cls, page_token):
+    def _parse_start_offset_from_page_token(cls, page_token):
         # Note: the page_token is expected to be a base64-encoded JSON that looks like
         # { "offset": xxx }. However, this format is not stable, so it should not be
         # relied upon outside of this method.
@@ -368,10 +368,10 @@ class SearchUtils(object):
         results limit. Returns a pair containing the set of paginated runs, followed by
         an optional next_page_token if there are further results that need to be returned.
         """
-        initial_offset = cls._parse_offset_from_page_token(page_token)
-        final_offset = initial_offset + max_results
+        start_offset = cls._parse_start_offset_from_page_token(page_token)
+        final_offset = start_offset + max_results
 
-        paginated_runs = runs[initial_offset:final_offset]
+        paginated_runs = runs[start_offset:final_offset]
         next_page_token = None
         if final_offset < len(runs):
             next_page_token = cls._create_page_token(final_offset)

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -8,6 +8,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, INVALID_PARAMETER_VALUE, ErrorCode
 from mlflow.server.handlers import get_endpoints, _create_experiment, _get_request_message, \
     _search_runs, _log_batch, catch_mlflow_exception
+from mlflow.store.abstract_store import PagedList
 from mlflow.protos.service_pb2 import CreateExperiment, SearchRuns
 from mlflow.utils.validation import MAX_BATCH_LOG_REQUEST_SIZE
 
@@ -80,6 +81,7 @@ def test_search_runs_default_view_type(mock_get_request_message, mock_store):
     Search Runs default view type is filled in as ViewType.ACTIVE_ONLY
     """
     mock_get_request_message.return_value = SearchRuns(experiment_ids=["0"])
+    mock_store.search_runs.return_value = PagedList([], None)
     _search_runs()
     args, _ = mock_store.search_runs.call_args
     assert args[2] == ViewType.ACTIVE_ONLY

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -392,8 +392,6 @@ def test_search_pagination(mlflow_client, backend_store_uri):
     runs = [mlflow_client.create_run(experiment_id, start_time=1).info.run_id for _ in range(0, 10)]
     runs = sorted(runs)
     result = mlflow_client.search_runs([experiment_id], max_results=4, page_token=None)
-    print("Runs1: %s" % [r.info.run_id for r in result])
-    print("Runs2: %s" % runs[0:4])
     assert [r.info.run_id for r in result] == runs[0:4]
     assert result.token is not None
     result = mlflow_client.search_runs([experiment_id], max_results=4, page_token=result.token)

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -385,3 +385,20 @@ def test_artifacts(mlflow_client):
 
     dir_artifacts = mlflow_client.download_artifacts(run_id, 'dir')
     assert open('%s/my.file' % dir_artifacts, 'r').read() == 'Hello, World!'
+
+
+def test_search_pagination(mlflow_client, backend_store_uri):
+    experiment_id = mlflow_client.create_experiment('search_pagination')
+    runs = [mlflow_client.create_run(experiment_id, start_time=1).info.run_id for _ in range(0, 10)]
+    runs = sorted(runs)
+    result = mlflow_client.search_runs([experiment_id], max_results=4, page_token=None)
+    print("Runs1: %s" % [r.info.run_id for r in result])
+    print("Runs2: %s" % runs[0:4])
+    assert [r.info.run_id for r in result] == runs[0:4]
+    assert result.token is not None
+    result = mlflow_client.search_runs([experiment_id], max_results=4, page_token=result.token)
+    assert [r.info.run_id for r in result] == runs[4:8]
+    assert result.token is not None
+    result = mlflow_client.search_runs([experiment_id], max_results=4, page_token=result.token)
+    assert [r.info.run_id for r in result] == runs[8:]
+    assert result.token is None

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -352,3 +352,15 @@ def test_pagination(page_token, max_results, matching_runs, expected_next_page_t
     if next_page_token:
         decoded_next_page_token = json.loads(base64.b64decode(next_page_token))
     assert decoded_next_page_token == expected_next_page_token
+
+
+@pytest.mark.parametrize("page_token, error_message", [
+    (base64.b64encode(json.dumps({}).encode("utf-8")), "Invalid page token"),
+    (base64.b64encode(json.dumps({"offsoot": 7}).encode("utf-8")), "Invalid page token"),
+    (base64.b64encode("not json".encode("utf-8")), "Invalid page token"),
+    ("not base64", "Invalid page token"),
+])
+def test_invalid_page_tokens(page_token, error_message):
+    with pytest.raises(MlflowException) as e:
+        SearchUtils.paginate([], page_token, 1)
+    assert error_message in e.value.message

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -356,6 +356,7 @@ def test_pagination(page_token, max_results, matching_runs, expected_next_page_t
 
 @pytest.mark.parametrize("page_token, error_message", [
     (base64.b64encode(json.dumps({}).encode("utf-8")), "Invalid page token"),
+    (base64.b64encode(json.dumps({"offset": "a"}).encode("utf-8")), "Invalid page token"),
     (base64.b64encode(json.dumps({"offsoot": 7}).encode("utf-8")), "Invalid page token"),
     (base64.b64encode("not json".encode("utf-8")), "Invalid page token"),
     ("not base64", "Invalid page token"),

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -1,3 +1,5 @@
+import base64
+import json
 import pytest
 
 from mlflow.entities import RunInfo, RunData, Run, LifecycleStage, RunStatus, Metric, Param, RunTag
@@ -300,3 +302,53 @@ def test_invalid_order_by(order_by, error_message):
     with pytest.raises(MlflowException) as e:
         SearchUtils._parse_order_by(order_by)
     assert error_message in e.value.message
+
+
+@pytest.mark.parametrize("page_token, max_results, matching_runs, expected_next_page_token", [
+    (None, 1, [0], {"offset": 1}),
+    (None, 2, [0, 1], {"offset": 2}),
+    (None, 3, [0, 1, 2], None),
+    (None, 5, [0, 1, 2], None),
+    ({"offset": 1}, 1, [1], {"offset": 2}),
+    ({"offset": 1}, 2, [1, 2], None),
+    ({"offset": 1}, 3, [1, 2], None),
+    ({"offset": 2}, 1, [2], None),
+    ({"offset": 2}, 2, [2], None),
+    ({"offset": 2}, 0, [], {"offset": 2}),
+    ({"offset": 3}, 1, [], None),
+])
+def test_pagination(page_token, max_results, matching_runs, expected_next_page_token):
+    runs = [
+        Run(run_info=RunInfo(
+            run_uuid="0", run_id="0", experiment_id=0,
+            user_id="user-id", status=RunStatus.to_string(RunStatus.FAILED),
+            start_time=0, end_time=1, lifecycle_stage=LifecycleStage.ACTIVE),
+            run_data=RunData([], [], [])),
+        Run(run_info=RunInfo(
+            run_uuid="1", run_id="1", experiment_id=0,
+            user_id="user-id", status=RunStatus.to_string(RunStatus.FAILED),
+            start_time=0, end_time=1, lifecycle_stage=LifecycleStage.ACTIVE),
+            run_data=RunData([], [], [])),
+        Run(run_info=RunInfo(
+            run_uuid="2", run_id="2", experiment_id=0,
+            user_id="user-id", status=RunStatus.to_string(RunStatus.FAILED),
+            start_time=0, end_time=1, lifecycle_stage=LifecycleStage.ACTIVE),
+            run_data=RunData([], [], []))
+    ]
+    encoded_page_token = None
+    if page_token:
+        encoded_page_token = base64.b64encode(json.dumps(page_token).encode("utf-8"))
+    paginated_runs, next_page_token = SearchUtils.paginate(runs, encoded_page_token, max_results)
+
+    paginated_run_indices = []
+    for run in paginated_runs:
+        for i, r in enumerate(runs):
+            if r == run:
+                paginated_run_indices.append(i)
+                break
+    assert paginated_run_indices == matching_runs
+
+    decoded_next_page_token = None
+    if next_page_token:
+        decoded_next_page_token = json.loads(base64.b64decode(next_page_token))
+    assert decoded_next_page_token == expected_next_page_token


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
The server will now return a `page_token` if the results require pagination (i.e., exceed `max_results`). The page token is entirely internal to the implementation of the store; it is not an API that clients are expected to construct directly, and so the format is not stable.

The current implementation is minimal: we do not implement extra validation that the page token is associated with the same search as before, because our implementation does not benefit from this check.
 
## How is this patch tested?
 
Unit tests

## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow API now has full support for pagination -- Python's `MlflowClient.search_runs` will return a list that contains a `token` parameter which can be provided to `search_runs` to receive the next page of results, with analogous support in the REST API.
 
### What component(s) does this PR affect?
 
- [x] Tracking
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
