### PR TITLE
Python fluent API search_runs auto-pagination

### DIFF
--- a/mlflow/store/__init__.py
+++ b/mlflow/store/__init__.py
@@ -12,4 +12,3 @@ Several constants are used by multiple backend store implementations.
 DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH = "./mlruns"
 SEARCH_MAX_RESULTS_DEFAULT = 1000
 SEARCH_MAX_RESULTS_THRESHOLD = 50000
-SEARCH_MAX_RESULTS_PANDAS = 50000

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -314,7 +314,7 @@ def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.AC
     if not experiment_ids:
         experiment_ids = _get_experiment_id()
     runs = _get_paginated_runs(experiment_ids, filter_string, run_view_type, max_results,
-                                      order_by)
+                               order_by)
     info = {'run_id': [], 'experiment_id': [],
             'status': [], 'artifact_uri': [], }
     params, metrics, tags = ({}, {}, {})
@@ -380,13 +380,12 @@ def _get_paginated_runs(experiment_ids, filter_string, run_view_type, max_result
         runs_to_get = max_results-len(all_runs)
         if runs_to_get < NUM_RUNS_PER_PAGE_PANDAS:
             runs = MlflowClient().search_runs(experiment_ids, filter_string, run_view_type,
-                                              runs_to_get, order_by, page_token=next_page_token)
+                                              runs_to_get, order_by, next_page_token)
         else:
             runs = MlflowClient().search_runs(experiment_ids, filter_string, run_view_type,
-                                              NUM_RUNS_PER_PAGE_PANDAS, order_by,
-                                              page_token=next_page_token)
+                                              NUM_RUNS_PER_PAGE_PANDAS, order_by, next_page_token)
         all_runs.extend(runs)
-        if runs.token and runs.token != '':
+        if hasattr(runs, 'token') and runs.token != '':
             next_page_token = runs.token
         else:
             break

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -295,7 +295,7 @@ def get_artifact_uri(artifact_path=None):
 def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.ACTIVE_ONLY,
                 max_results=SEARCH_MAX_RESULTS_PANDAS, order_by=None):
     """
-    Search experiments that fit the search criteria.
+    Get a pandas DataFrame of runs that fit the search criteria.
 
     :param experiment_ids: List of experiment IDs. None will default to the active experiment.
     :param filter_string: Filter query string, defaults to searching all runs.
@@ -306,10 +306,10 @@ def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.AC
     :param order_by: List of columns to order by (e.g., "metrics.rmse"). The default
                         ordering is to sort by start_time DESC, then run_id.
 
-    :return: A pandas.DataFrame object of runs, where each metric, parameter, and tag
+    :return: A pandas.DataFrame of runs, where each metric, parameter, and tag
         are expanded into their own columns named metrics.*, params.*, and tags.*
         respectively. For runs that don't have a particular metric, parameter, or tag, their
-        value will be np.nan, None, or None respectively
+        value will be (Numpy) Nan, None, or None respectively
     """
     if not experiment_ids:
         experiment_ids = _get_experiment_id()

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -12,12 +12,13 @@ import mlflow
 from mlflow.entities import LifecycleStage, SourceType, Run, RunInfo, RunData, RunStatus, Metric, \
     Param, RunTag, ViewType
 from mlflow.exceptions import MlflowException
-from mlflow.store import SEARCH_MAX_RESULTS_PANDAS
+from mlflow.store.abstract_store import PagedList
 from mlflow.tracking.client import MlflowClient
 import mlflow.tracking.fluent
 import mlflow.tracking.context
 from mlflow.tracking.fluent import start_run, _get_experiment_id, _get_experiment_id_from_env, \
-    search_runs, _EXPERIMENT_NAME_ENV_VAR, _EXPERIMENT_ID_ENV_VAR, _RUN_ID_ENV_VAR
+    search_runs, _EXPERIMENT_NAME_ENV_VAR, _EXPERIMENT_ID_ENV_VAR, _RUN_ID_ENV_VAR, \
+    _get_paginated_runs, NUM_RUNS_PER_PAGE_PANDAS
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils import mlflow_tags
 
@@ -359,7 +360,7 @@ def test_start_run_existing_run_deleted(empty_active_run_stack):
 def test_search_runs_attributes():
     runs = [create_run(status=RunStatus.FINISHED, a_uri="dbfs:/test", run_id='abc', exp_id="123"),
             create_run(status=RunStatus.SCHEDULED, a_uri="dbfs:/test2", run_id='def', exp_id="321")]
-    with mock.patch.object(MlflowClient, "search_runs", return_value=runs):
+    with mock.patch('mlflow.tracking.fluent._get_paginated_runs', return_value=runs):
         pdf = search_runs()
         data = {'status': [RunStatus.FINISHED, RunStatus.SCHEDULED],
                 'artifact_uri': ["dbfs:/test", "dbfs:/test2"],
@@ -379,7 +380,7 @@ def test_search_runs_data():
             metrics=[Metric("mse", 0.6, 0, 0), Metric("loss", 1.2, 0, 5)],
             params=[Param("param2", "val"), Param("k", "v")],
             tags=[RunTag("tag2", "v2")])]
-    with mock.patch.object(MlflowClient, "search_runs", return_value=runs):
+    with mock.patch('mlflow.tracking.fluent._get_paginated_runs', return_value=runs):
         pdf = search_runs()
         data = {
             'status': [RunStatus.FINISHED]*2,
@@ -397,33 +398,86 @@ def test_search_runs_data():
         pd.testing.assert_frame_equal(pdf, expected_df, check_like=True, check_frame_type=False)
 
 
-def test_search_runs_no_arguments():
-    # When no experiment ID is specified,
-    # it should try to get the implicit one or create a new experiment
-    mock_experiment_id = mock.Mock()
-    experiment_id_patch = mock.patch(
-        "mlflow.tracking.fluent._get_experiment_id", return_value=mock_experiment_id
-    )
-    with experiment_id_patch, mock.patch.object(MlflowClient, "search_runs", return_value=[]):
-        pdf = search_runs()
-        MlflowClient.search_runs.assert_called_once_with(
-            mock_experiment_id, '', ViewType.ACTIVE_ONLY, SEARCH_MAX_RESULTS_PANDAS, None
-        )
+# def test_search_runs_no_arguments():
+#     # When no experiment ID is specified,
+#     # it should try to get the implicit one or create a new experiment
+#     mock_experiment_id = mock.Mock()
+#     experiment_id_patch = mock.patch(
+#         "mlflow.tracking.fluent._get_experiment_id", return_value=mock_experiment_id
+#     )
+#     with experiment_id_patch, mock.patch.object(MlflowClient, 'search_runs', return_value=[]):
+#         pdf = search_runs()
+#         MlflowClient.search_runs.assert_called_once_with(
+#             mock_experiment_id, '', ViewType.ACTIVE_ONLY, NUM_RUNS_PER_PAGE_PANDAS, None
+#         )
 
 
-def test_search_runs_with_arguments():
-    mock_experiment_ids = mock.Mock()
-    mock_filter_string = mock.Mock()
-    mock_view_type = mock.Mock()
-    mock_max_results = mock.Mock()
-    mock_order_by = mock.Mock()
-    with mock.patch.object(MlflowClient, "search_runs", return_value=[]):
-        pdf = search_runs(mock_experiment_ids, mock_filter_string, mock_view_type,
-                          mock_max_results, mock_order_by)
-        MlflowClient.search_runs.assert_called_once_with(
-            mock_experiment_ids,
-            mock_filter_string,
-            mock_view_type,
-            mock_max_results,
-            mock_order_by
-        )
+# def test_search_runs_with_arguments():
+#     mock_experiment_ids = mock.Mock()
+#     mock_filter_string = mock.Mock()
+#     mock_view_type = mock.Mock(return_value=NUM_RUNS_PER_PAGE_PANDAS-1)
+#     mock_max_results = mock.Mock()
+#     mock_order_by = mock.Mock()
+#     with mock.patch.object(MlflowClient, 'search_runs', return_value=[]):
+#         pdf = search_runs(mock_experiment_ids, mock_filter_string, mock_view_type,
+#                           mock_max_results, mock_order_by)
+#         MlflowClient.search_runs.assert_called_once_with(
+#             mock_experiment_ids,
+#             mock_filter_string,
+#             mock_view_type,
+#             mock_max_results,
+#             mock_order_by
+#         )
+
+ORIGINAL_RUNS_PER_PAGE_PANDAS = mlflow.tracking.fluent.NUM_RUNS_PER_PAGE_PANDAS
+def set_runs_per_page_pandas(num):
+    ORIGINAL_RUNS_PER_PAGE_PANDAS = mlflow.tracking.fluent.NUM_RUNS_PER_PAGE_PANDAS
+    mlflow.tracking.fluent.NUM_RUNS_PER_PAGE_PANDAS = num
+
+def reset_runs_per_page_pandas():
+    mlflow.tracking.fluent.NUM_RUNS_PER_PAGE_PANDAS = ORIGINAL_RUNS_PER_PAGE_PANDAS
+
+def test_get_paginated_runs_lt_maxresults():
+    runs = [create_run() for i in range(5)]
+    tokenized_runs = PagedList(runs, "") # No token passed back
+    max_results = 50
+    set_runs_per_page_pandas(10)
+    with mock.patch.object(MlflowClient, "search_runs", return_value=tokenized_runs):
+        paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None)
+        MlflowClient.search_runs.assert_called_once()
+        assert len(paginated_runs) == 5
+    reset_runs_per_page_pandas()
+        
+
+def test_get_paginated_runs_eq_maxresults():
+    # Currently we can't test runs = maxresults for runs > NUM_RUNS_PER_PAGE_PANDAS
+    # because the return value to search_runs would have to change dynamically to 
+    # include / exclude token
+    runs = [create_run() for i in range(10)]
+    tokenized_runs = PagedList(runs, "")
+    max_results = 10
+    set_runs_per_page_pandas(10)
+    with mock.patch.object(MlflowClient, "search_runs", return_value=tokenized_runs):
+        paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None)
+        MlflowClient.search_runs.assert_called_once()
+        assert len(paginated_runs) == 10
+
+
+def test_get_paginated_runs_gt_maxresults():
+    runs = [create_run() for i in range(10)]
+    tokenized_runs = PagedList(runs, "abc")
+    max_results = 20
+    set_runs_per_page_pandas(10)
+    with mock.patch.object(MlflowClient, "search_runs", return_value=tokenized_runs):
+        paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None)
+        assert len(paginated_runs) == 20
+
+
+def test_get_paginated_maxresults_lt_runs_per_page():
+    runs = [create_run() for i in range(10)]
+    tokenized_runs = PagedList(runs, "")
+    max_results = 10
+    set_runs_per_page_pandas(20)
+    with mock.patch.object(MlflowClient, "search_runs", return_value=tokenized_runs):
+        paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None)
+        assert len(paginated_runs) == 10


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
The `mlflow.search_runs()` API in the Python fluent client returns a pandas Dataframe with the active experiment's runs in it. Currently, it will return up to 50,000 runs by default and won't return more since current database implementations won't return more than 50,000 runs back in one request.

This PR changes this behavior to return up to 100,000 runs by default, with the option to get more by passing in a larger value for `max_results`. The changes in this PR automatically break up the requests to the database into pages of 10,000 runs, and will concatenate them together before returning the DataFrame.

## How is this patch tested?
 
Unit Tests in `test_fluent.py`
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Related to #1483. Allows users to get all their experiment data in a pandas dataframe format, with filterstring, order by, and max results supported.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [x] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
