### PR TITLE
Check conda version to activate conda env

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -666,7 +666,7 @@ def _get_conda_command(conda_env_name):
 
     # in case os name is not 'nt', we are not running on windows. It introduces
     # bash command otherwise.
-    if os.name != "nt" and (conda_env_version_major == 4 and conda_env_version_minor < 7):
+    if os.name != "nt" and (conda_env_version_major == 4 and conda_env_version_minor < 6):
         return ["source %s %s" % (activate_path, conda_env_name)]
     else:
         return ["conda %s %s" % (activate_path, conda_env_name)]


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Check conda version to either use `conda activate` or `source activate`

From : https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html 

> conda activate and conda deactivate only work on conda 4.6 and later versions.

Also, fix issue : https://github.com/mlflow/mlflow/issues/1543
 
## How is this patch tested?
 
Manual test

```
conda create -n mlflow
conda activate mlflow
conda info # Check conda version
pip install mlflow 
mlflow run git@github.com:mlflow/mlflow-example.git -P alpha=0.5
```
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [x] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
