### PR TITLE
Added Splice Machine support to MLFlow as a Tracking Backend

### DIFF
--- a/mlflow/alembic/env.py
+++ b/mlflow/alembic/env.py
@@ -3,8 +3,9 @@ from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
-
 from alembic import context
+
+from mlflow.store.db.utils import SpliceMachineImpl
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -3,11 +3,22 @@ import os
 import logging
 
 from alembic.migration import MigrationContext  # pylint: disable=import-error
+
 import sqlalchemy
 
 
 _logger = logging.getLogger(__name__)
 
+def _get_splicemachine_impl():
+    """
+    Return an Alembic Impl so
+    Splice Machine migrations work
+    """
+    from alembic.ddl import impl
+    return type('SpliceMachineImpl',(impl.DefaultImpl, object), 
+                {'__dialect__':'splicemachinesa','transactional_ddl':False}) 
+
+SpliceMachineImpl = _get_splicemachine_impl()
 
 def _get_package_dir():
     """Returns directory containing MLflow python package."""

--- a/mlflow/store/dbmodels/db_types.py
+++ b/mlflow/store/dbmodels/db_types.py
@@ -6,10 +6,12 @@ POSTGRES = 'postgresql'
 MYSQL = 'mysql'
 SQLITE = 'sqlite'
 MSSQL = 'mssql'
+SPLICE = 'splicemachinesa'
 
 DATABASE_ENGINES = [
     POSTGRES,
     MYSQL,
     SQLITE,
-    MSSQL
+    MSSQL,
+    SPLICE
 ]

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -32,7 +32,7 @@ _logger = logging.getLogger(__name__)
 class SqlAlchemyStore(AbstractStore):
     """
     SQLAlchemy compliant backend store for tracking meta data for MLflow entities. MLflow
-    supports the database dialects ``mysql``, ``mssql``, ``sqlite``, and ``postgresql``.
+    supports the database dialects ``mysql``, ``mssql``, ``sqlite``, ``splicemachinesa`` and ``postgresql``.
     As specified in the
     `SQLAlchemy docs <https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls>`_ ,
     the database URI is expected in the format
@@ -62,7 +62,7 @@ class SqlAlchemyStore(AbstractStore):
                        the `SQLAlchemy docs
                        <https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls>`_
                        for format specifications. Mlflow supports the dialects ``mysql``,
-                       ``mssql``, ``sqlite``, and ``postgresql``.
+                       ``mssql``, ``sqlite``, ``splicemachinesa`` and ``postgresql``.
         :param default_artifact_root: Path/URI to location suitable for large data (such as a blob
                                       store object, DBFS path, or shared NFS file system).
         """
@@ -223,7 +223,8 @@ class SqlAlchemyStore(AbstractStore):
         return instance, created
 
     def _get_artifact_location(self, experiment_id):
-        return posixpath.join(self.artifact_root_uri, str(experiment_id))
+        # python2.7 unicode strings are not decorated properly in SQL
+        return str(posixpath.join(self.artifact_root_uri, str(experiment_id)))
 
     def create_experiment(self, name, artifact_location=None):
         if name is None or name == '':

--- a/mlflow/temporary_db_migrations_for_pre_1_users/env.py
+++ b/mlflow/temporary_db_migrations_for_pre_1_users/env.py
@@ -6,6 +6,8 @@ from sqlalchemy import pool
 
 from alembic import context
 
+from mlflow.store.db.utils import SpliceMachineImpl
+
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -41,7 +41,8 @@ class TestParseDbUri(unittest.TestCase):
                            'pypostgresql', 'pygresql', 'zxjdbc'),
             'mysql': ('mysqldb', 'pymysql', 'mysqlconnector', 'cymysql',
                       'oursql', 'mysqldb', 'gaerdbms', 'pyodbc', 'zxjdbc'),
-            'mssql': ('pyodbc', 'mxodbc', 'pymssql', 'zxjdbc', 'adodbapi')
+            'mssql': ('pyodbc', 'mxodbc', 'pymssql', 'zxjdbc', 'adodbapi'),
+            'splicemachinesa': ('pyodbc')
         }
         for target_db_type, drivers in target_db_type_uris.items():
             # try the driver-less version, which will revert SQLAlchemy to the default driver

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -195,6 +195,7 @@ def test_standard_store_registry_with_mocked_entrypoint():
             'mysql',
             'sqlite',
             'mssql',
+            'splicemachinesa',
             'databricks',
             'mock-scheme'
         }


### PR DESCRIPTION
At Splice Machine, we have been using MLFlow extensively as a core component of our MLManager platform-- we would like to contribute support for Splice Machine as a tracking backend for users who would like to use it.

## What changes are proposed in this pull request?

Code:
1. Added Splice Machine Dialect (`splicemachinesa` - https://github.com/splicemachine/splice_sqlachemy) to list of supported dialects (in `mlflow/store/dbmodels/db_types.py`). Our SQLAlchemy driver can be installed via `pip install git+https://github.com/splicemachine/splice_sqlalchemy`

2. Since Alembic on Splice Machine doesn't work out of the box, we added a simple `SpliceMachineImpl` type (in `mlflow/store/db/utils.py`) that uses the underlying `splicemachinesa` dialect to handle Alembic migrations (doesn't interfere with migrations for any other dialect, even if `splicemachinesa` is not installed). This class has to be in the global variable scope everywhere alembic is run-- alembic searches the global scope for these `Impl` subclasses to provide migration support for non-default databases.

3. Added String conversion to posix path in `mlflow/store/sqlalchemy_store.py` because it was not being quoted in Python2.7 (in default experiment creation)-- it is a unicode string in Python 2 and the decorator function only checks if it is of type string before quoting it

## How is this patch tested?

Test:
1. Added Splice Machine dialect to the TestParseDbUri test case (in `mlflow/tests/store/test_sqlalchemy_store.py`)

2. Added Splice Machine dialect to `test_standard_store_registry_with_mocked_entrypoint` test in `mlflow/tests/tracking/test_utils.py `

3. Splice Machine dialect has been extensively tested via its own test cases

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

MLFlow now supports Splice Machine as a supported tracking store. When starting an MLFlow Tracking Server,
the `--backend-store-uri` option can be equal to a URL of the form `splicemachinesa:///?DRIVER=/path/to/odbc/driver&URL=<X>&PORT=<X>&UID=<X>&PWD=<X>`
For example, one might use `mlflow server --backed-store-uri 'splicemachinesa:///?DRIVER=libsplice_odbc.so&URL=127.0.0.1&PORT=1527&UID=splice&PWD=admin' --default-artifact-store '/tmp'`
### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [X] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
