### PR TITLE
Java Client revert searchRuns, create searchRunsV2

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/EmptyPage.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/EmptyPage.java
@@ -1,0 +1,48 @@
+package org.mlflow.tracking;
+
+import java.util.Collections;
+import java.util.Optional;
+
+public class EmptyPage<E> implements Page<E> {
+
+  /**
+   * Creates an empty page
+   */
+  EmptyPage() {}
+
+  /**
+   * @return Zero
+   */
+  public int getPageSize() {
+    return 0;
+  }
+
+  /**
+   * @return False
+   */
+  public boolean hasNextPage() {
+    return false;
+  }
+
+  /**
+   * @return An empty Optional.
+   */
+  public Optional<String> getNextPageToken() {
+    return Optional.empty();
+  }
+
+  /**
+   * @return An {@link org.mlflow.tracking.EmptyPage}
+   */
+  public EmptyPage getNextPage() {
+    return this;
+  }
+
+  /**
+   * @return An empty iterable.
+   */
+  public Iterable getItems() {
+    return Collections.EMPTY_LIST;
+  }
+
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -167,7 +167,7 @@ public class MlflowClient {
    *                    Defaults to ACTIVE_ONLY.
    * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
    *
-   * @return A list of all RunInfos that satisfy search filter.
+   * @return A list of all Runs that satisfy search filter.
    */
   public List<Run> searchRuns(List<String> experimentIds,
                                   String searchFilter,

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -185,7 +185,8 @@ public class MlflowClient {
   public RunsPage searchRuns(List<String> experimentIds,
                                   String searchFilter,
                                   int maxResults) {
-    return searchRuns(experimentIds, searchFilter, ViewType.ACTIVE_ONLY, new ArrayList<>(), maxResults);
+    return searchRuns(experimentIds, searchFilter, ViewType.ACTIVE_ONLY, new ArrayList<>(),
+             maxResults);
   }
 
   /**

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -136,7 +136,8 @@ public class MlflowClient {
    * @return A list of all RunInfos that satisfy search filter.
    */
   public List<RunInfo> searchRuns(List<String> experimentIds, String searchFilter) {
-    return searchRuns(experimentIds, searchFilter, ViewType.ACTIVE_ONLY);
+    return searchRuns(experimentIds, searchFilter, ViewType.ACTIVE_ONLY, 1000).getItems().stream()
+      .map(Run::getInfo).collect(Collectors.toList());
   }
 
   /**
@@ -157,20 +158,8 @@ public class MlflowClient {
   public List<RunInfo> searchRuns(List<String> experimentIds,
                               String searchFilter,
                               ViewType runViewType) {
-    SearchRuns.Builder builder = SearchRuns.newBuilder()
-            .addAllExperimentIds(experimentIds);
-
-    if (searchFilter != null) {
-      builder.setFilter(searchFilter);
-    }
-    if (runViewType != null) {
-      builder.setRunViewType(runViewType);
-    }
-    SearchRuns request = builder.build();
-    String ijson = mapper.toJson(request);
-    String ojson = sendPost("runs/search", ijson);
-    return mapper.toSearchRunsResponse(ojson).getRunsList().stream().map(Run::getInfo)
-            .collect(Collectors.toList());
+    return searchRuns(experimentIds, searchFilter, runViewType, 1000).getItems().stream()
+      .map(Run::getInfo).collect(Collectors.toList());
   }
 
   /**

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -131,6 +131,7 @@ public class MlflowClient {
    * @param searchFilter SQL compatible search query string. Format of this query string is
    *                     similar to that specified on MLflow UI.
    *                     Example : "params.model = 'LogisticRegression' and metrics.acc = 0.9"
+   *                     If null, the result will be equivalent to having an empty search filter.
    *
    * @return A list of all RunInfos that satisfy search filter.
    */
@@ -147,8 +148,9 @@ public class MlflowClient {
    * @param searchFilter SQL compatible search query string. Format of this query string is
    *                     similar to that specified on MLflow UI.
    *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
+   *                     If null, the result will be equivalent to having an empty search filter.
    * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
-   *                    Defaults to ACTIVE_ONLY.
+   *                    If null, only runs with viewtype ACTIVE_ONLY will be searched.
    *
    * @return A list of all RunInfos that satisfy search filter.
    */
@@ -178,9 +180,10 @@ public class MlflowClient {
    * @param searchFilter SQL compatible search query string. Format of this query string is
    *                     similar to that specified on MLflow UI.
    *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
+   *                     If null, the result will be equivalent to having an empty search filter.
    * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
-   *                    Defaults to ACTIVE_ONLY.
-   * @param maxResults Maximum number of runs desired. Defaults to 1000.
+   *                    If null, only runs with viewtype ACTIVE_ONLY will be searched.
+   * @param maxResults Maximum number of runs desired in one page. Defaults to 1000 runs per page.
    *
    * @return A list of all Runs that satisfy search filter.
    */
@@ -199,9 +202,10 @@ public class MlflowClient {
    * @param searchFilter SQL compatible search query string. Format of this query string is
    *                     similar to that specified on MLflow UI.
    *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
+   *                     If null, the result will be equivalent to having an empty search filter.
    * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
-   *                    Defaults to ACTIVE_ONLY.
-   * @param maxResults Maximum number of runs desired. Defaults to 1000.
+   *                    If null, only runs with viewtype ACTIVE_ONLY will be searched.
+   * @param maxResults Maximum number of runs desired in one page. Defaults to 1000 runs per page.
    * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
    *
    * @return A list of all Runs that satisfy search filter.
@@ -221,9 +225,10 @@ public class MlflowClient {
    * @param searchFilter SQL compatible search query string. Format of this query string is
    *                     similar to that specified on MLflow UI.
    *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
+   *                     If null, the result will be equivalent to having an empty search filter.
    * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
-   *                    Defaults to ACTIVE_ONLY.
-   * @param maxResults Maximum number of runs desired. Defaults to 1000.
+   *                    If null, only runs with viewtype ACTIVE_ONLY will be searched.
+   * @param maxResults Maximum number of runs desired in one page. Defaults to 1000 runs per page.
    * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
    * @param pageToken String token specifying the next page of results. It should be obtained from
    *             a call to {@link #searchRuns(List, String)}.

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -304,8 +304,8 @@ public class MlflowClient {
     String ijson = mapper.toJson(request);
     String ojson = sendPost("runs/search", ijson);
     SearchRuns.Response response = mapper.toSearchRunsResponse(ojson);
-    return new RunsPage(response.getRunsList(), response.getNextPageToken(), experimentIds, searchFilter,
-            runViewType, orderBy, maxResults, this);
+    return new RunsPage(response.getRunsList(), response.getNextPageToken(), experimentIds,
+      searchFilter, runViewType, orderBy, maxResults, this);
   }
 
   /** @return  A list of all experiments. */

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -124,8 +124,8 @@ public class MlflowClient {
 
   /**
    * Return RunInfos from provided list of experiments that satisfy the search query.
-   * @deprecated As of 1.1.0 - please use {@link #searchRuns(List, String, int)} or similar
-   *                    that returns a page of Run results.
+   * @deprecated As of 1.1.0 - please use {@link #searchRuns(List, String, ViewType, int)} or
+   *                    similar that returns a page of Run results.
    * 
    * @param experimentIds List of experiment IDs.
    * @param searchFilter SQL compatible search query string. Format of this query string is
@@ -140,8 +140,8 @@ public class MlflowClient {
 
   /**
    * Return RunInfos from provided list of experiments that satisfy the search query.
-   * @deprecated As of 1.1.0 - please use {@link #searchRuns(List, String, int)} or similar
-   *                    that returns a page of Run results.
+   * @deprecated As of 1.1.0 - please use {@link #searchRuns(List, String, ViewType, int)} or 
+   *                    similar that returns a page of Run results.
    *
    * @param experimentIds List of experiment IDs.
    * @param searchFilter SQL compatible search query string. Format of this query string is
@@ -178,66 +178,8 @@ public class MlflowClient {
    * @param searchFilter SQL compatible search query string. Format of this query string is
    *                     similar to that specified on MLflow UI.
    *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
-   * @param maxResults Maximum number of runs desired. Defaults to 1000.
-   *
-   * @return A list of all Runs that satisfy search filter.
-   */
-  public RunsPage searchRuns(List<String> experimentIds,
-                                  String searchFilter,
-                                  int maxResults) {
-    return searchRuns(experimentIds, searchFilter, ViewType.ACTIVE_ONLY, new ArrayList<>(),
-             maxResults);
-  }
-
-  /**
-   * Return runs from provided list of experiments that satisfy the search query.
-   *
-   * @param experimentIds List of experiment IDs.
-   * @param searchFilter SQL compatible search query string. Format of this query string is
-   *                     similar to that specified on MLflow UI.
-   *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
-   * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
-   * @param maxResults Maximum number of runs desired. Defaults to 1000.
-   *
-   * @return A list of all Runs that satisfy search filter.
-   */
-  public RunsPage searchRuns(List<String> experimentIds,
-                                  String searchFilter,
-                                  List<String> orderBy,
-                                  int maxResults) {
-    return searchRuns(experimentIds, searchFilter, ViewType.ACTIVE_ONLY, orderBy, maxResults);
-  }
-
-  /**
-   * Return runs from provided list of experiments that satisfy the search query.
-   *
-   * @param experimentIds List of experiment IDs.
-   * @param searchFilter SQL compatible search query string. Format of this query string is
-   *                     similar to that specified on MLflow UI.
-   *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
    * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
    *                    Defaults to ACTIVE_ONLY.
-   * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
-   *
-   * @return A list of all Runs that satisfy search filter.
-   */
-  public RunsPage searchRuns(List<String> experimentIds,
-                                  String searchFilter,
-                                  ViewType runViewType,
-                                  List<String> orderBy) {
-    return searchRuns(experimentIds, searchFilter, runViewType, orderBy, 1000);
-  }
-
-  /**
-   * Return runs from provided list of experiments that satisfy the search query.
-   *
-   * @param experimentIds List of experiment IDs.
-   * @param searchFilter SQL compatible search query string. Format of this query string is
-   *                     similar to that specified on MLflow UI.
-   *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
-   * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
-   *                    Defaults to ACTIVE_ONLY.
-   * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
    * @param maxResults Maximum number of runs desired. Defaults to 1000.
    *
    * @return A list of all Runs that satisfy search filter.
@@ -245,9 +187,9 @@ public class MlflowClient {
   public RunsPage searchRuns(List<String> experimentIds,
                               String searchFilter,
                               ViewType runViewType,
-                              List<String> orderBy,
                               int maxResults) {
-    return searchRuns(experimentIds,searchFilter, runViewType, orderBy, maxResults,null);
+    return searchRuns(experimentIds, searchFilter, runViewType, maxResults, new ArrayList<>(),
+                      null);
   }
 
   /**
@@ -259,8 +201,30 @@ public class MlflowClient {
    *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
    * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
    *                    Defaults to ACTIVE_ONLY.
-   * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
    * @param maxResults Maximum number of runs desired. Defaults to 1000.
+   * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
+   *
+   * @return A list of all Runs that satisfy search filter.
+   */
+  public RunsPage searchRuns(List<String> experimentIds,
+                              String searchFilter,
+                              ViewType runViewType,
+                              int maxResults,
+                              List<String> orderBy) {
+    return searchRuns(experimentIds, searchFilter, runViewType, maxResults, orderBy, null);
+  }
+
+  /**
+   * Return runs from provided list of experiments that satisfy the search query.
+   *
+   * @param experimentIds List of experiment IDs.
+   * @param searchFilter SQL compatible search query string. Format of this query string is
+   *                     similar to that specified on MLflow UI.
+   *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
+   * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
+   *                    Defaults to ACTIVE_ONLY.
+   * @param maxResults Maximum number of runs desired. Defaults to 1000.
+   * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
    * @param pageToken String token specifying the next page of results. It should be obtained from
    *             a call to {@link #searchRuns(List, String)}.
    *
@@ -269,8 +233,8 @@ public class MlflowClient {
   public RunsPage searchRuns(List<String> experimentIds,
                               String searchFilter,
                               ViewType runViewType,
-                              List<String> orderBy,
                               int maxResults,
+                              List<String> orderBy,
                               String pageToken) {
     SearchRuns.Builder builder = SearchRuns.newBuilder()
             .addAllExperimentIds(experimentIds)
@@ -291,7 +255,7 @@ public class MlflowClient {
     String ojson = sendPost("runs/search", ijson);
     SearchRuns.Response response = mapper.toSearchRunsResponse(ojson);
     return new RunsPage(response.getRunsList(), response.getNextPageToken(), experimentIds,
-      searchFilter, runViewType, orderBy, maxResults, this);
+      searchFilter, runViewType, maxResults, orderBy, this);
   }
 
   /** @return  A list of all experiments. */

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -183,7 +183,7 @@ public class MlflowClient {
    *                     If null, the result will be equivalent to having an empty search filter.
    * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
    *                    If null, only runs with viewtype ACTIVE_ONLY will be searched.
-   * @param maxResults Maximum number of runs desired in one page. Defaults to 1000 runs per page.
+   * @param maxResults Maximum number of runs desired in one page.
    *
    * @return A list of all Runs that satisfy search filter.
    */
@@ -205,7 +205,7 @@ public class MlflowClient {
    *                     If null, the result will be equivalent to having an empty search filter.
    * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
    *                    If null, only runs with viewtype ACTIVE_ONLY will be searched.
-   * @param maxResults Maximum number of runs desired in one page. Defaults to 1000 runs per page.
+   * @param maxResults Maximum number of runs desired in one page.
    * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
    *
    * @return A list of all Runs that satisfy search filter.
@@ -228,7 +228,7 @@ public class MlflowClient {
    *                     If null, the result will be equivalent to having an empty search filter.
    * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
    *                    If null, only runs with viewtype ACTIVE_ONLY will be searched.
-   * @param maxResults Maximum number of runs desired in one page. Defaults to 1000 runs per page.
+   * @param maxResults Maximum number of runs desired in one page.
    * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
    * @param pageToken String token specifying the next page of results. It should be obtained from
    *             a call to {@link #searchRuns(List, String)}.

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -124,7 +124,9 @@ public class MlflowClient {
 
   /**
    * Return RunInfos from provided list of experiments that satisfy the search query.
-   *
+   * @deprecated As of 1.1.0 - please use {@link #searchRuns(List, String, int)} or similar
+   *                    that returns a page of Run results.
+   * 
    * @param experimentIds List of experiment IDs.
    * @param searchFilter SQL compatible search query string. Format of this query string is
    *                     similar to that specified on MLflow UI.
@@ -138,6 +140,8 @@ public class MlflowClient {
 
   /**
    * Return RunInfos from provided list of experiments that satisfy the search query.
+   * @deprecated As of 1.1.0 - please use {@link #searchRuns(List, String, int)} or similar
+   *                    that returns a page of Run results.
    *
    * @param experimentIds List of experiment IDs.
    * @param searchFilter SQL compatible search query string. Format of this query string is
@@ -151,30 +155,8 @@ public class MlflowClient {
   public List<RunInfo> searchRuns(List<String> experimentIds,
                               String searchFilter,
                               ViewType runViewType) {
-    return searchRuns(experimentIds, searchFilter, runViewType, new ArrayList<>());
-  }
-
-
-  /**
-   * Return RunInfos from provided list of experiments that satisfy the search query.
-   *
-   * @param experimentIds List of experiment IDs.
-   * @param searchFilter SQL compatible search query string. Format of this query string is
-   *                     similar to that specified on MLflow UI.
-   *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
-   * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
-   *                    Defaults to ACTIVE_ONLY.
-   * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
-   *
-   * @return A list of all RunInfos that satisfy search filter.
-   */
-  public List<RunInfo> searchRuns(List<String> experimentIds,
-                              String searchFilter,
-                              ViewType runViewType,
-                              List<String> orderBy) {
     SearchRuns.Builder builder = SearchRuns.newBuilder()
-            .addAllExperimentIds(experimentIds)
-            .addAllOrderBy(orderBy);
+            .addAllExperimentIds(experimentIds);
 
     if (searchFilter != null) {
       builder.setFilter(searchFilter);
@@ -195,12 +177,15 @@ public class MlflowClient {
    * @param experimentIds List of experiment IDs.
    * @param searchFilter SQL compatible search query string. Format of this query string is
    *                     similar to that specified on MLflow UI.
-   *                     Example : "params.model = 'LogisticRegression' and metrics.acc = 0.9"
+   *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
+   * @param maxResults Maximum number of runs desired. Defaults to 1000.
    *
    * @return A list of all Runs that satisfy search filter.
    */
-  public RunsPage searchRunsV2(List<String> experimentIds, String searchFilter) {
-    return searchRunsV2(experimentIds, searchFilter, ViewType.ACTIVE_ONLY);
+  public RunsPage searchRuns(List<String> experimentIds,
+                                  String searchFilter,
+                                  int maxResults) {
+    return searchRuns(experimentIds, searchFilter, ViewType.ACTIVE_ONLY, new ArrayList<>(), maxResults);
   }
 
   /**
@@ -210,17 +195,17 @@ public class MlflowClient {
    * @param searchFilter SQL compatible search query string. Format of this query string is
    *                     similar to that specified on MLflow UI.
    *                     Example : "params.model = 'LogisticRegression' and metrics.acc != 0.9"
-   * @param runViewType ViewType for expected runs. One of (ACTIVE_ONLY, DELETED_ONLY, ALL)
-   *                    Defaults to ACTIVE_ONLY.
+   * @param orderBy List of properties to order by. Example: "metrics.acc DESC".
+   * @param maxResults Maximum number of runs desired. Defaults to 1000.
    *
    * @return A list of all Runs that satisfy search filter.
    */
-  public RunsPage searchRunsV2(List<String> experimentIds,
+  public RunsPage searchRuns(List<String> experimentIds,
                                   String searchFilter,
-                                  ViewType runViewType) {
-    return searchRunsV2(experimentIds, searchFilter, runViewType, new ArrayList<>());
+                                  List<String> orderBy,
+                                  int maxResults) {
+    return searchRuns(experimentIds, searchFilter, ViewType.ACTIVE_ONLY, orderBy, maxResults);
   }
-
 
   /**
    * Return runs from provided list of experiments that satisfy the search query.
@@ -235,11 +220,11 @@ public class MlflowClient {
    *
    * @return A list of all Runs that satisfy search filter.
    */
-  public RunsPage searchRunsV2(List<String> experimentIds,
+  public RunsPage searchRuns(List<String> experimentIds,
                                   String searchFilter,
                                   ViewType runViewType,
                                   List<String> orderBy) {
-    return searchRunsV2(experimentIds, searchFilter, runViewType, orderBy, 1000);
+    return searchRuns(experimentIds, searchFilter, runViewType, orderBy, 1000);
   }
 
   /**
@@ -256,12 +241,12 @@ public class MlflowClient {
    *
    * @return A list of all Runs that satisfy search filter.
    */
-  public RunsPage searchRunsV2(List<String> experimentIds,
+  public RunsPage searchRuns(List<String> experimentIds,
                               String searchFilter,
                               ViewType runViewType,
                               List<String> orderBy,
                               int maxResults) {
-    return searchRunsV2(experimentIds,searchFilter, runViewType, orderBy, maxResults,null);
+    return searchRuns(experimentIds,searchFilter, runViewType, orderBy, maxResults,null);
   }
 
   /**
@@ -280,7 +265,7 @@ public class MlflowClient {
    *
    * @return A page of Runs that satisfy the search filter.
    */
-  public RunsPage searchRunsV2(List<String> experimentIds,
+  public RunsPage searchRuns(List<String> experimentIds,
                               String searchFilter,
                               ViewType runViewType,
                               List<String> orderBy,

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
@@ -23,7 +23,7 @@ public interface Page<E> {
 
     /**
      * @return Retrieves the next Page object using the next page token,
-     * or null if there are no more pages.
+     * or returns an empty page if there are no more pages.
      */
     public Page<E> getNextPage();
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
@@ -1,22 +1,22 @@
 package org.mlflow.tracking;
 
-import java.util.List;
+import java.lang.Iterable;
 import java.util.Optional;
 
 interface Page<E> {
 
   /**
-   * @return Returns the number of elements in this page.
+   * @return The number of elements in this page.
    */
   public int getPageSize();
 
   /**
-   * @return Returns true if there are more pages that can be retrieved from the API.
+   * @return True if there are more pages that can be retrieved from the API.
    */
   public boolean hasNextPage();
 
   /**
-   * @return Returns an Optional of the token string to get the next page. 
+   * @return An Optional of the token string to get the next page. 
    * Empty if there is no next page.
    */
   public Optional<String> getNextPageToken();
@@ -28,8 +28,8 @@ interface Page<E> {
   public Page<E> getNextPage();
 
   /**
-   * @return Returns a List of the elements in this Page.
+   * @return A List of the elements in this Page.
    */
-  public List<E> getItems();
+  public Iterable getItems();
 
 }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
@@ -16,12 +16,14 @@ public interface Page<E> {
     public boolean hasNextPage();
 
     /**
-     * @return Returns an Optional of the token string to get the next page. Empty if there is no next page.
+     * @return Returns an Optional of the token string to get the next page. 
+     * Empty if there is no next page.
      */
     public Optional<String> getNextPageToken();
 
     /**
-     * @return Retrieves the next Page object using the next page token, or null if there are no more pages.
+     * @return Retrieves the next Page object using the next page token,
+     * or null if there are no more pages.
      */
     public Page<E> getNextPage();
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
@@ -30,6 +30,6 @@ interface Page<E> {
   /**
    * @return A List of the elements in this Page.
    */
-  public Iterable getItems();
+  public Iterable<E> getItems();
 
 }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
@@ -1,0 +1,33 @@
+package org.mlflow.tracking;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface Page<E> {
+
+    /**
+     * @return Returns the number of elements in this page.
+     */
+    public int getPageSize();
+
+    /**
+     * @return Returns true if there are more pages that can be retrieved from the API.
+     */
+    public boolean hasNextPage();
+
+    /**
+     * @return Returns an Optional of the token string to get the next page. Empty if there is no next page.
+     */
+    public Optional<String> getNextPageToken();
+
+    /**
+     * @return Retrieves the next Page object using the next page token, or null if there are no more pages.
+     */
+    public Page<E> getNextPage();
+
+    /**
+     * @return Returns a List of the elements in this Page.
+     */
+    public List<E> getItems();
+
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
@@ -3,33 +3,33 @@ package org.mlflow.tracking;
 import java.util.List;
 import java.util.Optional;
 
-public interface Page<E> {
+interface Page<E> {
 
-    /**
-     * @return Returns the number of elements in this page.
-     */
-    public int getPageSize();
+  /**
+   * @return Returns the number of elements in this page.
+   */
+  public int getPageSize();
 
-    /**
-     * @return Returns true if there are more pages that can be retrieved from the API.
-     */
-    public boolean hasNextPage();
+  /**
+   * @return Returns true if there are more pages that can be retrieved from the API.
+   */
+  public boolean hasNextPage();
 
-    /**
-     * @return Returns an Optional of the token string to get the next page. 
-     * Empty if there is no next page.
-     */
-    public Optional<String> getNextPageToken();
+  /**
+   * @return Returns an Optional of the token string to get the next page. 
+   * Empty if there is no next page.
+   */
+  public Optional<String> getNextPageToken();
 
-    /**
-     * @return Retrieves the next Page object using the next page token,
-     * or returns an empty page if there are no more pages.
-     */
-    public Page<E> getNextPage();
+  /**
+   * @return Retrieves the next Page object using the next page token,
+   * or returns an empty page if there are no more pages.
+   */
+  public Page<E> getNextPage();
 
-    /**
-     * @return Returns a List of the elements in this Page.
-     */
-    public List<E> getItems();
+  /**
+   * @return Returns a List of the elements in this Page.
+   */
+  public List<E> getItems();
 
 }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
@@ -1,0 +1,78 @@
+package org.mlflow.tracking;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.mlflow.api.proto.Service.*;
+
+public class RunsPage implements Page<Run> {
+
+    private final String token;
+    private final List<Run> runs;
+
+    private final MlflowClient client;
+    private final List<String> experimentIds;
+    private final String searchFilter;
+    private final ViewType runViewType;
+    private final List<String> orderBy;
+    private final int maxResults;
+
+    /**
+     * Creates a fixed size page of Runs.
+     */
+    public RunsPage(List<Run> runs, String token, List<String> experimentIds, String searchFilter,
+                    ViewType runViewType, List<String> orderBy, int maxResults, MlflowClient client) {
+        this.runs = Collections.unmodifiableList(runs);
+        this.token = token;
+        this.experimentIds = experimentIds;
+        this.searchFilter = searchFilter;
+        this.runViewType = runViewType;
+        this.orderBy = orderBy;
+        this.maxResults = maxResults;
+        this.client = client;
+    }
+
+    /**
+     * @return The number of runs in the page.
+     */
+    public int getPageSize() {
+        return this.runs.size();
+    }
+
+    /**
+     * @return True if a token for the next page exists and isn't empty. Otherwise returns false.
+     */
+    public boolean hasNextPage() {
+        return this.token != null && this.token != "";
+    }
+
+    /**
+     * @return An optional with the token for the next page. Empty if the token doesn't exist or is empty.
+     */
+    public Optional<String> getNextPageToken() {
+        if (this.hasNextPage()) {
+            return Optional.of(this.token);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * @return The next page of runs matching the search criteria.
+     */
+    public RunsPage getNextPage() {
+        if (this.hasNextPage()) {
+            return client.searchRunsV2(experimentIds, searchFilter, runViewType, orderBy, maxResults, token);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * @return An iterable over the runs in this page.
+     */
+    public List<Run> getItems() {
+        return runs;
+    }
+
+}

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
@@ -58,7 +58,7 @@ public class RunsPage implements Page<Run> {
     }
 
     /**
-     * @return The next page of runs matching the search criteria.
+     * @return The next page of runs matching the search criteria, or null if there are no more pages.
      */
     public RunsPage getNextPage() {
         if (this.hasNextPage()) {

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
@@ -20,8 +20,14 @@ public class RunsPage implements Page<Run> {
     /**
      * Creates a fixed size page of Runs.
      */
-    public RunsPage(List<Run> runs, String token, List<String> experimentIds, String searchFilter,
-                    ViewType runViewType, List<String> orderBy, int maxResults, MlflowClient client) {
+    public RunsPage(List<Run> runs,
+                    String token,
+                    List<String> experimentIds,
+                    String searchFilter,
+                    ViewType runViewType,
+                    List<String> orderBy,
+                    int maxResults,
+                    MlflowClient client) {
         this.runs = Collections.unmodifiableList(runs);
         this.token = token;
         this.experimentIds = experimentIds;
@@ -47,7 +53,8 @@ public class RunsPage implements Page<Run> {
     }
 
     /**
-     * @return An optional with the token for the next page. Empty if the token doesn't exist or is empty.
+     * @return An optional with the token for the next page. 
+     * Empty if the token doesn't exist or is empty.
      */
     public Optional<String> getNextPageToken() {
         if (this.hasNextPage()) {
@@ -58,11 +65,17 @@ public class RunsPage implements Page<Run> {
     }
 
     /**
-     * @return The next page of runs matching the search criteria, or null if there are no more pages.
+     * @return The next page of runs matching the search criteria,
+     * or null if there are no more pages.
      */
     public RunsPage getNextPage() {
         if (this.hasNextPage()) {
-            return client.searchRunsV2(experimentIds, searchFilter, runViewType, orderBy, maxResults, token);
+            return client.searchRunsV2(experimentIds,
+                                       searchFilter,
+                                       runViewType,
+                                       orderBy,
+                                       maxResults,
+                                       token);
         } else {
             return null;
         }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
@@ -70,7 +70,7 @@ public class RunsPage implements Page<Run> {
      */
     public RunsPage getNextPage() {
         if (this.hasNextPage()) {
-            return client.searchRunsV2(experimentIds,
+            return client.searchRuns(experimentIds,
                                        searchFilter,
                                        runViewType,
                                        orderBy,

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
@@ -8,92 +8,92 @@ import org.mlflow.api.proto.Service.*;
 
 public class RunsPage implements Page<Run> {
 
-    private final String token;
-    private final List<Run> runs;
+  private final String token;
+  private final List<Run> runs;
 
-    private final MlflowClient client;
-    private final List<String> experimentIds;
-    private final String searchFilter;
-    private final ViewType runViewType;
-    private final List<String> orderBy;
-    private final int maxResults;
+  private final MlflowClient client;
+  private final List<String> experimentIds;
+  private final String searchFilter;
+  private final ViewType runViewType;
+  private final List<String> orderBy;
+  private final int maxResults;
 
-    /**
-     * Creates a fixed size page of Runs.
-     */
-    public RunsPage(List<Run> runs,
-                    String token,
-                    List<String> experimentIds,
-                    String searchFilter,
-                    ViewType runViewType,
-                    int maxResults,
-                    List<String> orderBy,
-                    MlflowClient client) {
-        this.runs = Collections.unmodifiableList(runs);
-        this.token = token;
-        this.experimentIds = experimentIds;
-        this.searchFilter = searchFilter;
-        this.runViewType = runViewType;
-        this.orderBy = orderBy;
-        this.maxResults = maxResults;
-        this.client = client;
+  /**
+   * Creates a fixed size page of Runs.
+   */
+  public RunsPage(List<Run> runs,
+                  String token,
+                  List<String> experimentIds,
+                  String searchFilter,
+                  ViewType runViewType,
+                  int maxResults,
+                  List<String> orderBy,
+                  MlflowClient client) {
+    this.runs = Collections.unmodifiableList(runs);
+    this.token = token;
+    this.experimentIds = experimentIds;
+    this.searchFilter = searchFilter;
+    this.runViewType = runViewType;
+    this.orderBy = orderBy;
+    this.maxResults = maxResults;
+    this.client = client;
+  }
+
+  /**
+   * @return The number of runs in the page.
+   */
+  public int getPageSize() {
+    return this.runs.size();
+  }
+
+  /**
+   * @return True if a token for the next page exists and isn't empty. Otherwise returns false.
+   */
+  public boolean hasNextPage() {
+    return this.token != null && this.token != "";
+  }
+
+  /**
+   * @return An optional with the token for the next page. 
+   * Empty if the token doesn't exist or is empty.
+   */
+  public Optional<String> getNextPageToken() {
+    if (this.hasNextPage()) {
+      return Optional.of(this.token);
+    } else {
+      return Optional.empty();
     }
+  }
 
-    /**
-     * @return The number of runs in the page.
-     */
-    public int getPageSize() {
-        return this.runs.size();
+  /**
+   * @return The next page of runs matching the search criteria. 
+   * If there are no more pages, an empty page will be returned with an empty token.
+   */
+  public RunsPage getNextPage() {
+    if (this.hasNextPage()) {
+      return this.client.searchRuns(this.experimentIds,
+                                    this.searchFilter,
+                                    this.runViewType,
+                                    this.maxResults,
+                                    this.orderBy,
+                                    this.token);
+    } else {
+      return new RunsPage(new ArrayList<>(),
+                          "",
+                          this.experimentIds,
+                          this.searchFilter,
+                          this.runViewType,
+                          this.maxResults,
+                          this.orderBy,
+                          this.client);
     }
+  }
 
-    /**
-     * @return True if a token for the next page exists and isn't empty. Otherwise returns false.
-     */
-    public boolean hasNextPage() {
-        return this.token != null && this.token != "";
-    }
-
-    /**
-     * @return An optional with the token for the next page. 
-     * Empty if the token doesn't exist or is empty.
-     */
-    public Optional<String> getNextPageToken() {
-        if (this.hasNextPage()) {
-            return Optional.of(this.token);
-        } else {
-            return Optional.empty();
-        }
-    }
-
-    /**
-     * @return The next page of runs matching the search criteria. 
-     * If there are no more pages, an empty page will be returned with an empty token.
-     */
-    public RunsPage getNextPage() {
-        if (this.hasNextPage()) {
-            return client.searchRuns(experimentIds,
-                                       searchFilter,
-                                       runViewType,
-                                       maxResults,
-                                       orderBy,
-                                       token);
-        } else {
-            return new RunsPage(new ArrayList<>(),
-                                "",
-                                this.experimentIds,
-                                this.searchFilter,
-                                this.runViewType,
-                                this.maxResults,
-                                this.orderBy,
-                                this.client);
-        }
-    }
-
-    /**
-     * @return An iterable over the runs in this page.
-     */
-    public List<Run> getItems() {
-        return runs;
-    }
+  /**
+   * @return An iterable over the runs in this page.
+   */
+  public List<Run> getItems() {
+    return runs;
+  }
 
 }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
@@ -21,7 +21,7 @@ public class RunsPage implements Page<Run> {
   /**
    * Creates a fixed size page of Runs.
    */
-  public RunsPage(List<Run> runs,
+  RunsPage(List<Run> runs,
                   String token,
                   List<String> experimentIds,
                   String searchFilter,
@@ -67,9 +67,9 @@ public class RunsPage implements Page<Run> {
 
   /**
    * @return The next page of runs matching the search criteria. 
-   * If there are no more pages, an empty page will be returned with an empty token.
+   * If there are no more pages, an {@link org.mlflow.tracking.EmptyPage} will be returned.
    */
-  public RunsPage getNextPage() {
+  public Page<Run> getNextPage() {
     if (this.hasNextPage()) {
       return this.client.searchRuns(this.experimentIds,
                                     this.searchFilter,
@@ -78,14 +78,7 @@ public class RunsPage implements Page<Run> {
                                     this.orderBy,
                                     this.token);
     } else {
-      return new RunsPage(new ArrayList<>(),
-                          "",
-                          this.experimentIds,
-                          this.searchFilter,
-                          this.runViewType,
-                          this.maxResults,
-                          this.orderBy,
-                          this.client);
+      return new EmptyPage();
     }
   }
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/RunsPage.java
@@ -2,6 +2,7 @@ package org.mlflow.tracking;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Optional;
 import org.mlflow.api.proto.Service.*;
 
@@ -25,8 +26,8 @@ public class RunsPage implements Page<Run> {
                     List<String> experimentIds,
                     String searchFilter,
                     ViewType runViewType,
-                    List<String> orderBy,
                     int maxResults,
+                    List<String> orderBy,
                     MlflowClient client) {
         this.runs = Collections.unmodifiableList(runs);
         this.token = token;
@@ -65,19 +66,26 @@ public class RunsPage implements Page<Run> {
     }
 
     /**
-     * @return The next page of runs matching the search criteria,
-     * or null if there are no more pages.
+     * @return The next page of runs matching the search criteria. 
+     * If there are no more pages, an empty page will be returned with an empty token.
      */
     public RunsPage getNextPage() {
         if (this.hasNextPage()) {
             return client.searchRuns(experimentIds,
                                        searchFilter,
                                        runViewType,
-                                       orderBy,
                                        maxResults,
+                                       orderBy,
                                        token);
         } else {
-            return null;
+            return new RunsPage(new ArrayList<>(),
+                                "",
+                                this.experimentIds,
+                                this.searchFilter,
+                                this.runViewType,
+                                this.maxResults,
+                                this.orderBy,
+                                this.client);
         }
     }
 

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -255,23 +255,22 @@ public class MlflowClientTest {
 
     // Paged searchRuns
 
-    List<Run> searchRuns = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY,
+    List<Run> searchRuns = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 1000,
             Lists.newArrayList("metrics.accuracy_score")).getItems();
     Assert.assertEquals(searchRuns.get(0).getInfo().getRunUuid(), runId_1);
     Assert.assertEquals(searchRuns.get(1).getInfo().getRunUuid(), runId_2);
 
-    searchRuns = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY,
+    searchRuns = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 1000,
             Lists.newArrayList("params.min_samples_leaf", "metrics.accuracy_score DESC")).getItems();
     Assert.assertEquals(searchRuns.get(1).getInfo().getRunUuid(), runId_1);
     Assert.assertEquals(searchRuns.get(0).getInfo().getRunUuid(), runId_2);
 
-    RunsPage page = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, Lists.newArrayList());
+    RunsPage page = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 1000);
     Assert.assertEquals(page.getPageSize(), 2);
     Assert.assertEquals(page.hasNextPage(), false);
     Assert.assertEquals(page.getNextPageToken(), Optional.empty());
-    Assert.assertNull(page.getNextPage());
 
-    page = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, Lists.newArrayList(), 1);
+    page = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 1);
     Assert.assertEquals(page.getPageSize(), 1);
     Assert.assertEquals(page.hasNextPage(), true);
     Assert.assertNotEquals(page.getNextPageToken(), Optional.empty());
@@ -280,7 +279,10 @@ public class MlflowClientTest {
     Assert.assertEquals(page2.getPageSize(), 1);
     Assert.assertEquals(page2.hasNextPage(), false);
     Assert.assertEquals(page2.getNextPageToken(), Optional.empty());
-    Assert.assertNull(page2.getNextPage());
+    
+    RunsPage page3 = page2.getNextPage();
+    Assert.assertEquals(page3.getPageSize(), 0);
+    Assert.assertEquals(page3.getNextPageToken(), Optional.empty());
   }
 
   @Test

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -255,17 +255,18 @@ public class MlflowClientTest {
 
     // Paged searchRuns
 
-    List<Run> searchRuns = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 1000,
-            Lists.newArrayList("metrics.accuracy_score")).getItems();
+    List<Run> searchRuns = Lists.newArrayList(client.searchRuns(experimentIds, "", 
+            ViewType.ACTIVE_ONLY, 1000, Lists.newArrayList("metrics.accuracy_score")).getItems());
     Assert.assertEquals(searchRuns.get(0).getInfo().getRunUuid(), runId_1);
     Assert.assertEquals(searchRuns.get(1).getInfo().getRunUuid(), runId_2);
 
-    searchRuns = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 1000,
-            Lists.newArrayList("params.min_samples_leaf", "metrics.accuracy_score DESC")).getItems();
+    searchRuns = Lists.newArrayList(client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY,
+            1000, Lists.newArrayList("params.min_samples_leaf", "metrics.accuracy_score DESC"))
+            .getItems());
     Assert.assertEquals(searchRuns.get(1).getInfo().getRunUuid(), runId_1);
     Assert.assertEquals(searchRuns.get(0).getInfo().getRunUuid(), runId_2);
 
-    RunsPage page = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 1000);
+    Page<Run> page = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, 1000);
     Assert.assertEquals(page.getPageSize(), 2);
     Assert.assertEquals(page.hasNextPage(), false);
     Assert.assertEquals(page.getNextPageToken(), Optional.empty());
@@ -275,12 +276,12 @@ public class MlflowClientTest {
     Assert.assertEquals(page.hasNextPage(), true);
     Assert.assertNotEquals(page.getNextPageToken(), Optional.empty());
 
-    RunsPage page2 = page.getNextPage();
+    Page<Run> page2 = page.getNextPage();
     Assert.assertEquals(page2.getPageSize(), 1);
     Assert.assertEquals(page2.hasNextPage(), false);
     Assert.assertEquals(page2.getNextPageToken(), Optional.empty());
     
-    RunsPage page3 = page2.getNextPage();
+    Page<Run> page3 = page2.getNextPage();
     Assert.assertEquals(page3.getPageSize(), 0);
     Assert.assertEquals(page3.getNextPageToken(), Optional.empty());
   }

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -366,6 +366,17 @@ public class MlflowClientTest {
     Assert.assertEquals(page.hasNextPage(), false);
     Assert.assertEquals(page.getNextPageToken(), Optional.empty());
     Assert.assertNull(page.getNextPage());
+
+    page = client.searchRunsV2(experimentIds, "", ViewType.ACTIVE_ONLY, Lists.newArrayList(), 1);
+    Assert.assertEquals(page.getPageSize(), 1);
+    Assert.assertEquals(page.hasNextPage(), true);
+    Assert.assertNotEquals(page.getNextPageToken(), Optional.empty());
+    
+    RunsPage page2 = page.getNextPage();
+    Assert.assertEquals(page2.getPageSize(), 1);
+    Assert.assertEquals(page2.hasNextPage(), false);
+    Assert.assertEquals(page2.getNextPageToken(), Optional.empty());
+    Assert.assertNull(page2.getNextPage());
   }
 
   @Test

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.Optional;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Set;
@@ -254,8 +255,8 @@ public class MlflowClientTest {
 
     searchResult = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY,
       Lists.newArrayList("metrics.accuracy_score"));
-    Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_2);
-    Assert.assertEquals(searchResult.get(1).getRunUuid(), runId_1);
+    Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_1);
+    Assert.assertEquals(searchResult.get(1).getRunUuid(), runId_2);
 
     searchResult = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY,
       Lists.newArrayList("params.min_samples_leaf", "metrics.accuracy_score DESC"));
@@ -360,7 +361,11 @@ public class MlflowClientTest {
     Assert.assertEquals(searchResult.get(0).getInfo().getRunUuid(), runId_2);
 
     // pagination tests
-
+    RunsPage page = client.searchRunsV2(experimentIds, "");
+    Assert.assertEquals(page.getPageSize(), 2);
+    Assert.assertEquals(page.hasNextPage(), false);
+    Assert.assertEquals(page.getNextPageToken(), Optional.empty());
+    Assert.assertNull(page.getNextPage());
   }
 
   @Test

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -253,125 +253,29 @@ public class MlflowClientTest {
     searchResult = client.searchRuns(experimentIds, "tag.test = 'also works'");
     Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_2);
 
-    searchResult = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY,
-      Lists.newArrayList("metrics.accuracy_score"));
-    Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_1);
-    Assert.assertEquals(searchResult.get(1).getRunUuid(), runId_2);
+    // Paged searchRuns
 
-    searchResult = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY,
-      Lists.newArrayList("params.min_samples_leaf", "metrics.accuracy_score DESC"));
-    Assert.assertEquals(searchResult.get(1).getRunUuid(), runId_1);
-    Assert.assertEquals(searchResult.get(0).getRunUuid(), runId_2);
-  }
-
-  @Test
-  public void searchRunsV2() {
-    // Create exp
-    String expName = createExperimentName();
-    String expId = client.createExperiment(expName);
-
-    // Create run
-    String user = System.getenv("USER");
-    long startTime = System.currentTimeMillis();
-    String sourceFile = "MyFile.java";
-
-    RunInfo runCreated_1 = client.createRun(expId);
-    String runId_1 = runCreated_1.getRunUuid();
-    logger.debug("runId=" + runId_1);
-
-    RunInfo runCreated_2 = client.createRun(expId);
-    String runId_2 = runCreated_2.getRunUuid();
-    logger.debug("runId=" + runId_2);
-
-    // Log parameters
-    client.logParam(runId_1, "min_samples_leaf", MIN_SAMPLES_LEAF);
-    client.logParam(runId_2, "min_samples_leaf", MIN_SAMPLES_LEAF);
-
-    client.logParam(runId_1, "max_depth", "5");
-    client.logParam(runId_2, "max_depth", "15");
-
-    // Log metrics
-    client.logMetric(runId_1, "accuracy_score", 0.1);
-    client.logMetric(runId_1, "accuracy_score", 0.4);
-    client.logMetric(runId_2, "accuracy_score", 0.9);
-
-    // Log tag
-    client.setTag(runId_1, "user_email", USER_EMAIL);
-    client.setTag(runId_1, "test", "works");
-    client.setTag(runId_2, "test", "also works");
-
-    List<String> experimentIds = Arrays.asList(expId);
-
-    // metrics based searches
-    List<Run> searchResult = client.searchRunsV2(experimentIds, "metrics.accuracy_score < 0").getItems();
-    Assert.assertEquals(searchResult.size(), 0);
-
-    searchResult = client.searchRunsV2(experimentIds, "metrics.accuracy_score > 0").getItems();
-    Assert.assertEquals(searchResult.size(), 2);
-
-    searchResult = client.searchRunsV2(experimentIds, "metrics.accuracy_score < 0.3").getItems();
-    Assert.assertEquals(searchResult.size(), 0);
-
-    searchResult = client.searchRunsV2(experimentIds, "metrics.accuracy_score < 0.5").getItems();
-    Assert.assertEquals(searchResult.get(0).getInfo().getRunUuid(), runId_1);
-    Assert.assertEquals(searchResult.get(0).getData().getMetricsList().size(), 1);
-    Assert.assertEquals(searchResult.get(0).getData().getParamsList().size(), 2);
-    Assert.assertEquals(searchResult.get(0).getData().getTagsList().size(), 2);
-
-    searchResult = client.searchRunsV2(experimentIds, "metrics.accuracy_score > 0.5").getItems();
-    Assert.assertEquals(searchResult.get(0).getInfo().getRunUuid(), runId_2);
-    Assert.assertEquals(searchResult.get(0).getData().getMetricsList().size(), 1);
-    Assert.assertEquals(searchResult.get(0).getData().getParamsList().size(), 2);
-    Assert.assertEquals(searchResult.get(0).getData().getTagsList().size(), 1);
-
-    // parameter based searches
-    searchResult = client.searchRunsV2(experimentIds,
-            "params.min_samples_leaf = '" + MIN_SAMPLES_LEAF + "'").getItems();
-    Assert.assertEquals(searchResult.size(), 2);
-    searchResult = client.searchRunsV2(experimentIds,
-            "params.min_samples_leaf != '" + MIN_SAMPLES_LEAF + "'").getItems();
-    Assert.assertEquals(searchResult.size(), 0);
-    searchResult = client.searchRunsV2(experimentIds, "params.max_depth = '5'").getItems();
-    Assert.assertEquals(searchResult.get(0).getInfo().getRunUuid(), runId_1);
-
-    searchResult = client.searchRunsV2(experimentIds, "params.max_depth = '15'").getItems();
-    Assert.assertEquals(searchResult.get(0).getInfo().getRunUuid(), runId_2);
-
-    // tag based search
-    searchResult = client.searchRunsV2(experimentIds, "tag.user_email = '" + USER_EMAIL + "'").getItems();
-    Assert.assertEquals(searchResult.get(0).getInfo().getRunUuid(), runId_1);
-
-    searchResult = client.searchRunsV2(experimentIds, "tag.user_email != '" + USER_EMAIL + "'").getItems();
-    Assert.assertEquals(searchResult.size(), 0);
-
-    searchResult = client.searchRunsV2(experimentIds, "tag.test = 'works'").getItems();
-    Assert.assertEquals(searchResult.get(0).getInfo().getRunUuid(), runId_1);
-
-    searchResult = client.searchRunsV2(experimentIds, "tag.test = 'also works'").getItems();
-    Assert.assertEquals(searchResult.get(0).getInfo().getRunUuid(), runId_2);
-
-    searchResult = client.searchRunsV2(experimentIds, "", ViewType.ACTIVE_ONLY,
+    List<Run> searchRuns = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY,
             Lists.newArrayList("metrics.accuracy_score")).getItems();
-    Assert.assertEquals(searchResult.get(0).getInfo().getRunUuid(), runId_1);
-    Assert.assertEquals(searchResult.get(1).getInfo().getRunUuid(), runId_2);
+    Assert.assertEquals(searchRuns.get(0).getInfo().getRunUuid(), runId_1);
+    Assert.assertEquals(searchRuns.get(1).getInfo().getRunUuid(), runId_2);
 
-    searchResult = client.searchRunsV2(experimentIds, "", ViewType.ACTIVE_ONLY,
+    searchRuns = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY,
             Lists.newArrayList("params.min_samples_leaf", "metrics.accuracy_score DESC")).getItems();
-    Assert.assertEquals(searchResult.get(1).getInfo().getRunUuid(), runId_1);
-    Assert.assertEquals(searchResult.get(0).getInfo().getRunUuid(), runId_2);
+    Assert.assertEquals(searchRuns.get(1).getInfo().getRunUuid(), runId_1);
+    Assert.assertEquals(searchRuns.get(0).getInfo().getRunUuid(), runId_2);
 
-    // pagination tests
-    RunsPage page = client.searchRunsV2(experimentIds, "");
+    RunsPage page = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, Lists.newArrayList());
     Assert.assertEquals(page.getPageSize(), 2);
     Assert.assertEquals(page.hasNextPage(), false);
     Assert.assertEquals(page.getNextPageToken(), Optional.empty());
     Assert.assertNull(page.getNextPage());
 
-    page = client.searchRunsV2(experimentIds, "", ViewType.ACTIVE_ONLY, Lists.newArrayList(), 1);
+    page = client.searchRuns(experimentIds, "", ViewType.ACTIVE_ONLY, Lists.newArrayList(), 1);
     Assert.assertEquals(page.getPageSize(), 1);
     Assert.assertEquals(page.hasNextPage(), true);
     Assert.assertNotEquals(page.getNextPageToken(), Optional.empty());
-    
+
     RunsPage page2 = page.getNextPage();
     Assert.assertEquals(page2.getPageSize(), 1);
     Assert.assertEquals(page2.hasNextPage(), false);


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
In this PR, we are unbreaking the `searchRuns` methods in the Java Client that used to return `List<RunInfo>`. They will again return that. Specifically, these methods are:
```
searchRuns(List<String> experimentIds, String searchFilter)
searchRuns(List<String> experimentIds, String searchFilter, Service.ViewType runViewType)
```
The above methods will be marked `Deprecated` as of version `1.1.0`

Additionally, we have overloaded `searchRuns` with differently typed arguments that returns a `RunsPage` that will contain the token and have the ability to get the next page of results if possible. The methods that will return a `RunsPage` will be the following:
```
searchRuns(List<String> experimentIds, String searchFilter, Service.ViewType runViewType, int maxResults)
searchRuns(List<String> experimentIds, String searchFilter, Service.ViewType runViewType, int maxResults, List<String> orderBy)
searchRuns(List<String> experimentIds, String searchFilter, Service.ViewType runViewType, int maxResults, List<String> orderBy, String pageToken)
```

The `RunsPage` class implements the `Page` interface and will have the following methods:
```
List<Service.Run>                               getItems()
RunsPage                                        getNextPage()
Optional<String>                                getNextPageToken()
int                                             getPageSize()
boolean                                         hasNextPage()
```
 
## How is this patch tested?
 
Unit tests
Manual testing by loading JAR in Databricks
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 

`searchRuns` in Java Client now supports pagination of Runs. Please use non-deprecated version of `searchRuns`.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [x] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [x] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
