### PR TITLE
Make @deprecate log a warning

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -33,6 +33,7 @@ from mlflow.version import VERSION as __version__
 import warnings
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")  # noqa: E402
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E402
+warnings.filterwarnings("module", category=DeprecationWarning)
 
 # pylint: disable=wrong-import-position
 import mlflow.projects as projects  # noqa

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -24,9 +24,9 @@ implement mutual exclusion manually.
 
 For a lower level API, see the :py:mod:`mlflow.tracking` module.
 """
-import mlflow.tracking.fluent
 from mlflow.version import VERSION as __version__
 from mlflow.utils.logging_utils import _configure_mlflow_loggers
+import mlflow.tracking.fluent
 
 # Filter annoying Cython warnings that serve no good purpose, and so before
 # importing other modules.

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -34,7 +34,7 @@ import mlflow.tracking.fluent
 import warnings
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")  # noqa: E402
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E402
-# log a deprecated warning only one per module
+# log a deprecated warning only once per function per module
 warnings.filterwarnings("module", category=DeprecationWarning)
 
 # pylint: disable=wrong-import-position

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -24,8 +24,9 @@ implement mutual exclusion manually.
 
 For a lower level API, see the :py:mod:`mlflow.tracking` module.
 """
-
+import mlflow.tracking.fluent
 from mlflow.version import VERSION as __version__
+from mlflow.utils.logging_utils import _configure_mlflow_loggers
 
 # Filter annoying Cython warnings that serve no good purpose, and so before
 # importing other modules.
@@ -38,8 +39,7 @@ warnings.filterwarnings("module", category=DeprecationWarning)
 # pylint: disable=wrong-import-position
 import mlflow.projects as projects  # noqa
 import mlflow.tracking as tracking  # noqa
-import mlflow.tracking.fluent
-from mlflow.utils.logging_utils import _configure_mlflow_loggers
+
 
 _configure_mlflow_loggers(root_module_name=__name__)
 

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -34,12 +34,12 @@ import mlflow.tracking.fluent
 import warnings
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")  # noqa: E402
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E402
+# log a deprecated warning only one per module
 warnings.filterwarnings("module", category=DeprecationWarning)
 
 # pylint: disable=wrong-import-position
 import mlflow.projects as projects  # noqa
 import mlflow.tracking as tracking  # noqa
-
 
 _configure_mlflow_loggers(root_module_name=__name__)
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -281,7 +281,7 @@ def load_model(model_uri, suppress_warnings=False):
     return load_pyfunc(model_uri, suppress_warnings)
 
 
-@deprecated("pyfunc.load_model", 1.0)
+@deprecated("mlflow.pyfunc.load_model", 1.0)
 def load_pyfunc(model_uri, suppress_warnings=False):
     """
     Load a model stored in Python function format.

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -29,7 +29,7 @@ def deprecated(alternative=None, since=None):
         if alternative is not None and alternative.strip():
             notice += " Use ``%s`` instead." % alternative
         func.__doc__ = notice + "\n" + func.__doc__
-        warnings.warn(notice)
+        warnings.warn(notice, stacklevel=2)
         return func
     return deprecated_func
 

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -22,17 +22,19 @@ def deprecated(alternative=None, since=None):
     :param func: A function to mark
     :returns Decorated function.
     """
+
     def deprecated_decorator(func):
+        @wraps(func)
         def deprecated_func(*args, **kwargs):
             since_str = " since %s" % since if since else ""
-            notice = ".. Warning:: Deprecated%s: This method will be removed in " % since_str + \
+            notice = ".. Warning::" + func.__name__ + " is deprecated%s: This method will be removed in " % since_str + \
                      "a near future release."
             if alternative is not None and alternative.strip():
                 notice += " Use ``%s`` instead." % alternative
             if func.__doc__ is not None:
                 func.__doc__ = notice + "\n" + func.__doc__
-            warnings.warn(notice, DeprecationWarning, stacklevel=2)
-            warnings.simplefilter('default', DeprecationWarning)
+            warnings.warn(notice, category=DeprecationWarning, stacklevel=2)
+
             return func(*args, **kwargs)
         return deprecated_func
     return deprecated_decorator

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -24,20 +24,26 @@ def deprecated(alternative=None, since=None):
     """
 
     def deprecated_decorator(func):
+        since_str = " since %s" % since if since else ""
+        notice = (
+            ".. Warning:: {function_name} is deprecated{since_string}. This method will be"
+            " removed in a near future release".format(
+                function_name=func.__name__,
+                since_string=since_str)
+        )
+        if alternative is not None and alternative.strip():
+            notice += " Use ``%s`` instead." % alternative
+
         @wraps(func)
         def deprecated_func(*args, **kwargs):
-            since_str = " since %s" % since if since else ""
-            notice = ".. Warning::" + \
-                     func.__name__ + " is deprecated%s: This method will be removed in "\
-                     % since_str + "a near future release."
-            if alternative is not None and alternative.strip():
-                notice += " Use ``%s`` instead." % alternative
-            if func.__doc__ is not None:
-                func.__doc__ = notice + "\n" + func.__doc__
             warnings.warn(notice, category=DeprecationWarning, stacklevel=2)
-
             return func(*args, **kwargs)
+
+        if func.__doc__ is not None:
+            deprecated_func.__doc__ = notice + "\n" + func.__doc__
+
         return deprecated_func
+
     return deprecated_decorator
 
 

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -26,7 +26,7 @@ def deprecated(alternative=None, since=None):
     def deprecated_decorator(func):
         since_str = " since %s" % since if since else ""
         notice = (
-            ".. Warning:: {function_name} is deprecated{since_string}. This method will be"
+            ".. Warning:: ``{function_name}`` is deprecated{since_string}. This method will be"
             " removed in a near future release".format(
                 function_name='.'.join([func.__module__, func.__name__]),
                 since_string=since_str)

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -28,7 +28,7 @@ def deprecated(alternative=None, since=None):
         notice = (
             ".. Warning:: {function_name} is deprecated{since_string}. This method will be"
             " removed in a near future release".format(
-                function_name=func.__name__,
+                function_name='.'.join([func.__module__, func.__name__]),
                 since_string=since_str)
         )
         if alternative is not None and alternative.strip():

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -22,16 +22,20 @@ def deprecated(alternative=None, since=None):
     :param func: A function to mark
     :returns Decorated function.
     """
-    def deprecated_func(func):
-        since_str = " since %s" % since if since else ""
-        notice = ".. Warning:: Deprecated%s: This method will be removed in " % since_str + \
-                 "a near future release."
-        if alternative is not None and alternative.strip():
-            notice += " Use ``%s`` instead." % alternative
-        func.__doc__ = notice + "\n" + func.__doc__
-        warnings.warn(notice, stacklevel=2)
-        return func
-    return deprecated_func
+    def deprecated_decorator(func):
+        def deprecated_func(*args, **kwargs):
+            since_str = " since %s" % since if since else ""
+            notice = ".. Warning:: Deprecated%s: This method will be removed in " % since_str + \
+                     "a near future release."
+            if alternative is not None and alternative.strip():
+                notice += " Use ``%s`` instead." % alternative
+            if func.__doc__ is not None:
+                func.__doc__ = notice + "\n" + func.__doc__
+            warnings.warn(notice, DeprecationWarning, stacklevel=2)
+            warnings.simplefilter('default', DeprecationWarning)
+            return func(*args, **kwargs)
+        return deprecated_func
+    return deprecated_decorator
 
 
 def keyword_only(func):

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -27,8 +27,9 @@ def deprecated(alternative=None, since=None):
         @wraps(func)
         def deprecated_func(*args, **kwargs):
             since_str = " since %s" % since if since else ""
-            notice = ".. Warning::" + func.__name__ + " is deprecated%s: This method will be removed in " % since_str + \
-                     "a near future release."
+            notice = ".. Warning::" + \
+                     func.__name__ + " is deprecated%s: This method will be removed in "\
+                     % since_str + "a near future release."
             if alternative is not None and alternative.strip():
                 notice += " Use ``%s`` instead." % alternative
             if func.__doc__ is not None:

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -1,3 +1,4 @@
+import warnings
 from functools import wraps
 
 
@@ -28,6 +29,7 @@ def deprecated(alternative=None, since=None):
         if alternative is not None and alternative.strip():
             notice += " Use ``%s`` instead." % alternative
         func.__doc__ = notice + "\n" + func.__doc__
+        warnings.warn(notice)
         return func
     return deprecated_func
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
MLflow's deprecate decorator appends a warning to the `.__doc__` property of the function in question. This PR makes the deprecation more explicit to the user by logging a warning at the stack level of the function being deprecated.
 
## How is this patch tested?
 
(Details)
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
