### PR TITLE
Make sql alchemy's log_metric work with NaNs and infs.

### DIFF
--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -17,7 +17,7 @@ mlflow_log_metric <- function(key, value, timestamp = NULL, step = NULL, run_id 
                               client = NULL) {
   c(client, run_id) %<-% resolve_client_and_run_id(client, run_id)
   key <- cast_string(key)
-  value <- cast_scalar_double(value, allow_na=TRUE)
+  value <- cast_scalar_double(value, allow_na = TRUE)
   timestamp <- cast_nullable_scalar_double(timestamp)
   timestamp <- round(timestamp %||% current_time())
   step <- round(cast_nullable_scalar_double(step) %||% 0)

--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -17,7 +17,7 @@ mlflow_log_metric <- function(key, value, timestamp = NULL, step = NULL, run_id 
                               client = NULL) {
   c(client, run_id) %<-% resolve_client_and_run_id(client, run_id)
   key <- cast_string(key)
-  value <- cast_scalar_double(value)
+  value <- cast_scalar_double(value, allow_na=TRUE)
   timestamp <- cast_nullable_scalar_double(timestamp)
   timestamp <- round(timestamp %||% current_time())
   step <- round(cast_nullable_scalar_double(step) %||% 0)

--- a/mlflow/R/mlflow/R/tracking-utils.R
+++ b/mlflow/R/mlflow/R/tracking-utils.R
@@ -164,6 +164,7 @@ parse_run_data <- function(d) {
     purrr::map(unlist) %>%
     purrr::map_at("timestamp", milliseconds_to_date) %>%
     purrr::map_at("step", as.double) %>%
+    purrr::map_at("value", as.double) %>%
     tibble::as_tibble() %>%
     list()
 }

--- a/mlflow/R/mlflow/R/tracking-utils.R
+++ b/mlflow/R/mlflow/R/tracking-utils.R
@@ -133,7 +133,7 @@ resolve_client_and_run_id <- function(client, run_id) {
 parse_run <- function(r) {
   info <- parse_run_info(r$info)
 
-  info$metrics <- parse_run_data(r$data$metrics)
+  info$metrics <- parse_metric_data(r$data$metrics)
   info$params <- parse_run_data(r$data$params)
   info$tags <- parse_run_data(r$data$tags)
 
@@ -157,7 +157,7 @@ parse_run_info <- function(r) {
     tibble::as_tibble()
 }
 
-parse_run_data <- function(d) {
+parse_metric_data <- function(d) {
   if (is.null(d)) return(NA)
   d %>%
     purrr::transpose() %>%
@@ -165,6 +165,15 @@ parse_run_data <- function(d) {
     purrr::map_at("timestamp", milliseconds_to_date) %>%
     purrr::map_at("step", as.double) %>%
     purrr::map_at("value", as.double) %>%
+    tibble::as_tibble() %>%
+    list()
+}
+
+parse_run_data <- function(d) {
+  if (is.null(d)) return(NA)
+  d %>%
+    purrr::transpose() %>%
+    purrr::map(unlist) %>%
     tibble::as_tibble() %>%
     list()
 }

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -72,7 +72,7 @@ test_that("logging functionality", {
   expect_true(is.nan(nanValue))
   posInfValue <- metrics$value[metrics$key == "inf"]
   expect_true(posInfValue >= 1.7976931348623157e308)
-  negInfValue <- metrics$$value[metrics$key == "-inf"]
+  negInfValue <- metrics$value[metrics$key == "-inf"]
   expect_true(posInfValue <= -1.7976931348623157e308)
   run_id <- run$run_uuid
   tags <- run$tags[[1]]

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -67,13 +67,13 @@ test_that("logging functionality", {
   mlflow_log_param("param_key", "param_value")
 
   run <- mlflow_get_run()
-  metrics = run$metrics[[1]]
-  nanValue <- metrics$value[metrics$key == "nan"]
-  expect_true(is.nan(nanValue))
-  posInfValue <- metrics$value[metrics$key == "inf"]
-  expect_true(posInfValue >= 1.7976931348623157e308)
-  negInfValue <- metrics$value[metrics$key == "-inf"]
-  expect_true(posInfValue <= -1.7976931348623157e308)
+  metrics <- run$metrics[[1]]
+  nan_value <- metrics$value[metrics$key == "nan"]
+  expect_true(is.nan(nan_value))
+  pos_inf_value <- metrics$value[metrics$key == "inf"]
+  expect_true(pos_inf_value >= 1.7976931348623157e308)
+  neg_inf_value <- metrics$value[metrics$key == "-inf"]
+  expect_true(neg_inf_value <= -1.7976931348623157e308)
   run_id <- run$run_uuid
   tags <- run$tags[[1]]
   expect_identical("tag_value", tags$value[tags$key == "tag_key"])

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -59,11 +59,21 @@ test_that("logging functionality", {
 
   mlflow_log_metric("mse", 24)
   mlflow_log_metric("mse", 25)
+  mlflow_log_metric("nan", NaN)
+  mlflow_log_metric("inf", Inf)
+  mlflow_log_metric("-inf", -Inf)
 
   mlflow_set_tag("tag_key", "tag_value")
   mlflow_log_param("param_key", "param_value")
 
   run <- mlflow_get_run()
+  metrics = run$metrics[[1]]
+  nanValue <- metrics$value[metrics$key == "nan"]
+  expect_true(is.nan(nanValue))
+  posInfValue <- metrics$value[metrics$$key == "inf"]
+  expect_true(posInfValue >= 1.7976931348623157e308)
+  negInfValue <- metrics$$value[metrics$$key == "-inf"]
+  expect_true(posInfValue <= -1.7976931348623157e308)
   run_id <- run$run_uuid
   tags <- run$tags[[1]]
   expect_identical("tag_value", tags$value[tags$key == "tag_key"])

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -70,9 +70,9 @@ test_that("logging functionality", {
   metrics = run$metrics[[1]]
   nanValue <- metrics$value[metrics$key == "nan"]
   expect_true(is.nan(nanValue))
-  posInfValue <- metrics$value[metrics$$key == "inf"]
+  posInfValue <- metrics$value[metrics$key == "inf"]
   expect_true(posInfValue >= 1.7976931348623157e308)
-  negInfValue <- metrics$$value[metrics$$key == "-inf"]
+  negInfValue <- metrics$$value[metrics$key == "-inf"]
   expect_true(posInfValue <= -1.7976931348623157e308)
   run_id <- run$run_uuid
   tags <- run$tags[[1]]

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -303,7 +303,7 @@ public class MlflowClientTest {
     assertParam(params, "max_depth", MAX_DEPTH);
 
     List<Metric> metrics = run.getData().getMetricsList();
-    Assert.assertEquals(metrics.size(), 4);
+    Assert.assertEquals(metrics.size(), 7);
     assertMetric(metrics, "accuracy_score", ACCURACY_SCORE);
     assertMetric(metrics, "zero_one_loss", ZERO_ONE_LOSS);
     assertMetric(metrics, "multi_log_default_step_ts", -1.0);

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -143,9 +143,9 @@ public class MlflowClientTest {
     client.logMetric(runId, "multi_log_specified_step_ts", 4.0, 2999, 4);
 
     // Log NaNs and Infs
-    client.logMetric(runId, "nan_metric", Double.NaN);
-    client.logMetric(runId, "pos_inf", Double.POSITIVE_INFINITY);
-    client.logMetric(runId, "neg_inf", Double.NEGATIVE_INFINITY);
+    client.logMetric(runId, "nan_metric", java.lang.Double.NaN);
+    client.logMetric(runId, "pos_inf", java.lang.Double.POSITIVE_INFINITY);
+    client.logMetric(runId, "neg_inf", java.lang.Double.NEGATIVE_INFINITY);
 
     // Log tag
     client.setTag(runId, "user_email", USER_EMAIL);
@@ -308,7 +308,7 @@ public class MlflowClientTest {
     assertMetric(metrics, "zero_one_loss", ZERO_ONE_LOSS);
     assertMetric(metrics, "multi_log_default_step_ts", -1.0);
     assertMetric(metrics, "multi_log_specified_step_ts", -3.0);
-    assertMetric(metrics, "nan_metric", Double.NaN)
+    assertMetric(metrics, "nan_metric", Double.NaN);
     assert(metrics.get(0).getTimestamp() > 0) : metrics.get(0).getTimestamp();
 
     List<Metric> multiDefaultMetricHistory = client.getMetricHistory(

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -309,6 +309,8 @@ public class MlflowClientTest {
     assertMetric(metrics, "multi_log_default_step_ts", -1.0);
     assertMetric(metrics, "multi_log_specified_step_ts", -3.0);
     assertMetric(metrics, "nan_metric", Double.NaN);
+    assertMetric(metrics, ""pos_inf"", Double.MAX_VALUE);
+    assertMetric(metrics, "neg_inf", -Double.MAX_VALUE);
     assert(metrics.get(0).getTimestamp() > 0) : metrics.get(0).getTimestamp();
 
     List<Metric> multiDefaultMetricHistory = client.getMetricHistory(

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -142,6 +142,11 @@ public class MlflowClientTest {
     client.logMetric(runId, "multi_log_specified_step_ts", -3.0, 3000, 4);
     client.logMetric(runId, "multi_log_specified_step_ts", 4.0, 2999, 4);
 
+    // Log NaNs and Infs
+    client.logMetric(runId, "nan_metric", Double.NaN);
+    client.logMetric(runId, "pos_inf", Double.POSITIVE_INFINITY);
+    client.logMetric(runId, "neg_inf", Double.NEGATIVE_INFINITY);
+
     // Log tag
     client.setTag(runId, "user_email", USER_EMAIL);
 
@@ -303,6 +308,7 @@ public class MlflowClientTest {
     assertMetric(metrics, "zero_one_loss", ZERO_ONE_LOSS);
     assertMetric(metrics, "multi_log_default_step_ts", -1.0);
     assertMetric(metrics, "multi_log_specified_step_ts", -3.0);
+    assertMetric(metrics, "nan_metric", Double.NaN)
     assert(metrics.get(0).getTimestamp() > 0) : metrics.get(0).getTimestamp();
 
     List<Metric> multiDefaultMetricHistory = client.getMetricHistory(

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -309,8 +309,8 @@ public class MlflowClientTest {
     assertMetric(metrics, "multi_log_default_step_ts", -1.0);
     assertMetric(metrics, "multi_log_specified_step_ts", -3.0);
     assertMetric(metrics, "nan_metric", Double.NaN);
-    assertMetric(metrics, "pos_inf", Double.MAX_VALUE);
-    assertMetric(metrics, "neg_inf", -Double.MAX_VALUE);
+    assertMetric(metrics, "pos_inf", Double.POSITIVE_INFINITY);
+    assertMetric(metrics, "neg_inf", Double.NEGATIVE_INFINITY);
     assert(metrics.get(0).getTimestamp() > 0) : metrics.get(0).getTimestamp();
 
     List<Metric> multiDefaultMetricHistory = client.getMetricHistory(

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -309,7 +309,7 @@ public class MlflowClientTest {
     assertMetric(metrics, "multi_log_default_step_ts", -1.0);
     assertMetric(metrics, "multi_log_specified_step_ts", -3.0);
     assertMetric(metrics, "nan_metric", Double.NaN);
-    assertMetric(metrics, ""pos_inf"", Double.MAX_VALUE);
+    assertMetric(metrics, "pos_inf", Double.MAX_VALUE);
     assertMetric(metrics, "neg_inf", -Double.MAX_VALUE);
     assert(metrics.get(0).getTimestamp() > 0) : metrics.get(0).getTimestamp();
 

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
@@ -25,7 +25,11 @@ public class TestUtils {
   }
 
   public static void assertMetric(List<Metric> metrics, String key, double value) {
-    Assert.assertTrue(metrics.stream().filter(e -> e.getKey().equals(key) && equals(e.getValue(), value)).findFirst().isPresent());
+    if (Double.isNaN(value)) {
+      Assert.assertTrue(metrics.stream().filter(e -> e.getKey().equals(key) && Double.isNaN(e.getValue())).findFirst().isPresent());
+    } else {
+      Assert.assertTrue(metrics.stream().filter(e -> e.getKey().equals(key) && equals(e.getValue(), value)).findFirst().isPresent());
+    }
   }
 
   public static void assertMetric(List<Metric> metrics, String key, double value, long timestamp, long step) {

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/TestUtils.java
@@ -25,8 +25,13 @@ public class TestUtils {
   }
 
   public static void assertMetric(List<Metric> metrics, String key, double value) {
+
     if (Double.isNaN(value)) {
       Assert.assertTrue(metrics.stream().filter(e -> e.getKey().equals(key) && Double.isNaN(e.getValue())).findFirst().isPresent());
+    } else if(Double.isInfinite(value) && value > 0) {
+      Assert.assertTrue(metrics.stream().filter(e -> e.getKey().equals(key) && e.getValue() >= Double.MAX_VALUE).findFirst().isPresent());
+    } else if(Double.isInfinite(value) && value < 0) {
+      Assert.assertTrue(metrics.stream().filter(e -> e.getKey().equals(key) && e.getValue() <= -Double.MAX_VALUE).findFirst().isPresent());
     } else {
       Assert.assertTrue(metrics.stream().filter(e -> e.getKey().equals(key) && equals(e.getValue(), value)).findFirst().isPresent());
     }

--- a/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
+++ b/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
@@ -18,13 +18,6 @@ depends_on = None
 
 def upgrade():
     op.add_column('metrics', sa.Column('is_nan', sa.Boolean(), nullable=False, server_default='0'))
-    # bind = op.get_bind()
-    # session = orm.Session(bind=bind)
-    # metrics = session.query(SqlMetric).all()
-    # for metric in metrics:
-    #     metric.is_nan = False
-    #     session.merge(metric)
-    # session.commit()
     with op.batch_alter_table("metrics") as batch_op:
         batch_op.drop_constraint(constraint_name='metric_pk', type_="primary")
         batch_op.create_primary_key(

--- a/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
+++ b/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
@@ -17,7 +17,8 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table("metrics") as batch_op:
-        batch_op.add_column(sa.Column('is_nan', sa.Boolean(), nullable=False, server_default='0'))
+        batch_op.add_column(sa.Column('is_nan', sa.Boolean(create_constraint=False), nullable=False,
+                                      server_default='0'))
         batch_op.drop_constraint(constraint_name='metric_pk', type_="primary")
         batch_op.create_primary_key(
             constraint_name='metric_pk',

--- a/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
+++ b/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
@@ -18,13 +18,6 @@ depends_on = None
 
 def upgrade():
     op.add_column('metrics', sa.Column('is_nan', sa.Boolean(), nullable=True, server_default="0"))
-    # with op.batch_alter_table("metrics") as batch_op:
-    #     batch_op.drop_constraint(constraint_name='metric_pk', type_="primary")
-    #     batch_op.alter_column(column_name="value",
-    #                           nullable=True)
-    #     batch_op.create_unique_constraint(
-    #         constraint_name='metric_uniq',
-    #         columns=['key', 'timestamp', 'step', 'run_uuid', 'value'])
 
 
 def downgrade():

--- a/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
+++ b/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
@@ -7,7 +7,7 @@ Create Date: 2019-07-10 22:40:18.787993
 """
 from alembic import op
 import sqlalchemy as sa
-
+from sqlalchemy import orm, Column, Integer, String, ForeignKey, PrimaryKeyConstraint
 
 # revision identifiers, used by Alembic.
 revision = '181f10493468'
@@ -17,7 +17,19 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('metrics', sa.Column('is_nan', sa.Boolean(), nullable=True, server_default="0"))
+    op.add_column('metrics', sa.Column('is_nan', sa.Boolean(), nullable=False, server_default='0'))
+    # bind = op.get_bind()
+    # session = orm.Session(bind=bind)
+    # metrics = session.query(SqlMetric).all()
+    # for metric in metrics:
+    #     metric.is_nan = False
+    #     session.merge(metric)
+    # session.commit()
+    with op.batch_alter_table("metrics") as batch_op:
+        batch_op.drop_constraint(constraint_name='metric_pk', type_="primary")
+        batch_op.create_primary_key(
+            constraint_name='metric_pk',
+            columns=['key', 'timestamp', 'step', 'run_uuid', 'value', 'is_nan'])
 
 
 def downgrade():

--- a/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
+++ b/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
@@ -1,0 +1,31 @@
+"""allow nulls for metric values
+
+Revision ID: 181f10493468
+Revises: 90e64c465722
+Create Date: 2019-07-10 22:40:18.787993
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '181f10493468'
+down_revision = '90e64c465722'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('metrics', sa.Column('is_nan', sa.Boolean(), nullable=True, server_default="0"))
+    # with op.batch_alter_table("metrics") as batch_op:
+    #     batch_op.drop_constraint(constraint_name='metric_pk', type_="primary")
+    #     batch_op.alter_column(column_name="value",
+    #                           nullable=True)
+    #     batch_op.create_unique_constraint(
+    #         constraint_name='metric_uniq',
+    #         columns=['key', 'timestamp', 'step', 'run_uuid', 'value'])
+
+
+def downgrade():
+    pass

--- a/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
+++ b/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
@@ -16,8 +16,8 @@ depends_on = None
 
 
 def upgrade():
-    op.add_column('metrics', sa.Column('is_nan', sa.Boolean(), nullable=False, server_default='0'))
     with op.batch_alter_table("metrics") as batch_op:
+        batch_op.add_column(sa.Column('is_nan', sa.Boolean(), nullable=False, server_default='0'))
         batch_op.drop_constraint(constraint_name='metric_pk', type_="primary")
         batch_op.create_primary_key(
             constraint_name='metric_pk',

--- a/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
+++ b/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
@@ -7,7 +7,6 @@ Create Date: 2019-07-10 22:40:18.787993
 """
 from alembic import op
 import sqlalchemy as sa
-from sqlalchemy import orm, Column, Integer, String, ForeignKey, PrimaryKeyConstraint
 
 # revision identifiers, used by Alembic.
 revision = '181f10493468'

--- a/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
+++ b/mlflow/store/db_migrations/versions/181f10493468_allow_nulls_for_metric_values.py
@@ -17,6 +17,7 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table("metrics") as batch_op:
+        batch_op.alter_column("value", type_=sa.types.Float(precision=53), nullable=False)
         batch_op.add_column(sa.Column('is_nan', sa.Boolean(create_constraint=False), nullable=False,
                                       server_default='0'))
         batch_op.drop_constraint(constraint_name='metric_pk', type_="primary")

--- a/mlflow/store/db_migrations/versions/451aebb31d03_add_metric_step.py
+++ b/mlflow/store/db_migrations/versions/451aebb31d03_add_metric_step.py
@@ -22,6 +22,7 @@ def upgrade():
     # databases (see more info at https://alembic.sqlalchemy.org/en/latest/
     # batch.html#running-batch-migrations-for-sqlite-and-other-databases)
     with op.batch_alter_table("metrics") as batch_op:
+        batch_op.alter_column("value", type_=sa.types.Float(precision=64))
         batch_op.drop_constraint(constraint_name='metric_pk', type_="primary")
         batch_op.create_primary_key(
             constraint_name='metric_pk',

--- a/mlflow/store/db_migrations/versions/451aebb31d03_add_metric_step.py
+++ b/mlflow/store/db_migrations/versions/451aebb31d03_add_metric_step.py
@@ -22,7 +22,6 @@ def upgrade():
     # databases (see more info at https://alembic.sqlalchemy.org/en/latest/
     # batch.html#running-batch-migrations-for-sqlite-and-other-databases)
     with op.batch_alter_table("metrics") as batch_op:
-        batch_op.alter_column("value", type_=sa.types.Float(precision=64))
         batch_op.drop_constraint(constraint_name='metric_pk', type_="primary")
         batch_op.create_primary_key(
             constraint_name='metric_pk',

--- a/mlflow/store/dbmodels/models.py
+++ b/mlflow/store/dbmodels/models.py
@@ -2,7 +2,7 @@ import time
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy import (
     Column, String, Float, ForeignKey, Integer, CheckConstraint,
-    BigInteger, PrimaryKeyConstraint, UniqueConstraint, Boolean)
+    BigInteger, PrimaryKeyConstraint, Boolean)
 from sqlalchemy.ext.declarative import declarative_base
 from mlflow.entities import (
     Experiment, RunTag, Metric, Param, RunData, RunInfo,
@@ -235,7 +235,7 @@ class SqlMetric(Base):
     """
     Metric key: `String` (limit 250 characters). Part of *Primary Key* for ``metrics`` table.
     """
-    value = Column(Float, nullable=True)
+    value = Column(Float, nullable=False)
     """
     Metric value: `Float`. Defined as *Non-null* in schema.
     """
@@ -277,9 +277,6 @@ class SqlMetric(Base):
         """
         return Metric(
             key=self.key,
-            # NB: NaNs are encoded as NULL in the DB, we need to translate them back.
-            #  +/- Inf is translated to max / min float value but we can not distinguish them from
-            # the actual values so we do not turn them back to Infs.
             value=self.value if not self.is_nan else float("nan"),
             timestamp=self.timestamp,
             step=self.step)

--- a/mlflow/store/dbmodels/models.py
+++ b/mlflow/store/dbmodels/models.py
@@ -1,7 +1,8 @@
 import time
 from sqlalchemy.orm import relationship, backref
+import sqlalchemy as sa
 from sqlalchemy import (
-    Column, String, Float, ForeignKey, Integer, CheckConstraint,
+    Column, String, ForeignKey, Integer, CheckConstraint,
     BigInteger, PrimaryKeyConstraint, Boolean)
 from sqlalchemy.ext.declarative import declarative_base
 from mlflow.entities import (
@@ -235,7 +236,7 @@ class SqlMetric(Base):
     """
     Metric key: `String` (limit 250 characters). Part of *Primary Key* for ``metrics`` table.
     """
-    value = Column(Float, nullable=False)
+    value = Column(sa.types.Float(precision=64), nullable=False)
     """
     Metric value: `Float`. Defined as *Non-null* in schema.
     """

--- a/mlflow/store/dbmodels/models.py
+++ b/mlflow/store/dbmodels/models.py
@@ -236,7 +236,7 @@ class SqlMetric(Base):
     """
     Metric key: `String` (limit 250 characters). Part of *Primary Key* for ``metrics`` table.
     """
-    value = Column(sa.types.Float(precision=64), nullable=False)
+    value = Column(sa.types.Float(precision=53), nullable=False)
     """
     Metric value: `Float`. Defined as *Non-null* in schema.
     """

--- a/mlflow/store/dbmodels/models.py
+++ b/mlflow/store/dbmodels/models.py
@@ -248,7 +248,7 @@ class SqlMetric(Base):
     """
     Step recorded for this metric entry: `BigInteger`.
     """
-    is_nan = Column(Boolean, nullable=True, default=False)
+    is_nan = Column(Boolean, nullable=False, default=False)
     """
     True if the value is in fact NaN.
     """
@@ -263,7 +263,8 @@ class SqlMetric(Base):
     """
 
     __table_args__ = (
-        PrimaryKeyConstraint('key', 'timestamp', 'step', 'run_uuid', 'value', name='metric_pk'),
+        PrimaryKeyConstraint('key', 'timestamp', 'step', 'run_uuid', 'value', "is_nan",
+                             name='metric_pk'),
     )
 
     def __repr__(self):

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -409,7 +409,7 @@ class SqlAlchemyStore(AbstractStore):
         if is_nan:
             value = 0
         elif not math.isfinite(metric.value):
-            #  NB: Sql can not represent Infs = > We replace +/- Inf with max/min 64B float value
+            #  NB: Sql can not represent Infs = > We replace +/- Inf with max/min 64b float value
             value = 1.7976931348623157e308 if metric.value > 0 else -1.7976931348623157e308
         else:
             value = metric.value

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -408,7 +408,7 @@ class SqlAlchemyStore(AbstractStore):
         is_nan = math.isnan(metric.value)
         if is_nan:
             value = 0
-        elif not math.isfinite(metric.value):
+        elif math.isinf(metric.value):
             #  NB: Sql can not represent Infs = > We replace +/- Inf with max/min 64b float value
             value = 1.7976931348623157e308 if metric.value > 0 else -1.7976931348623157e308
         else:

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from contextlib import contextmanager
 
+import math
 import posixpath
 from alembic.script import ScriptDirectory
 import sqlalchemy
@@ -404,13 +405,21 @@ class SqlAlchemyStore(AbstractStore):
 
     def log_metric(self, run_id, metric):
         _validate_metric(metric.key, metric.value, metric.timestamp, metric.step)
+        is_nan = math.isnan(metric.value)
+        if is_nan:
+            value = 0
+        elif not math.isfinite(metric.value):
+            #  NB: Sql can not represent Infs = > We replace +/- Inf with max/min 64B float value
+            value = 1.7976931348623157e308 if metric.value > 0 else -1.7976931348623157e308
+        else:
+            value = metric.value
         with self.ManagedSessionMaker() as session:
             run = self._get_run(run_uuid=run_id, session=session)
             self._check_run_is_active(run)
             # ToDo: Consider prior checks for null, type, metric name validations, ... etc.
             self._get_or_create(model=SqlMetric, run_uuid=run_id, key=metric.key,
-                                value=metric.value, timestamp=metric.timestamp, step=metric.step,
-                                session=session)
+                                value=value, timestamp=metric.timestamp, step=metric.step,
+                                session=session, is_nan=is_nan)
 
     def get_metric_history(self, run_id, metric_key):
         with self.ManagedSessionMaker() as session:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -156,12 +156,12 @@ class MlflowClient(object):
         """
         Log a metric against the run ID.
 
-        :param run_id: The run id to which the metric should be logged to.
+        :param run_id: The run id to which the metric should be logged.
         :param key: Metric name.
         :param value: Metric value (float). Note that some special values such
-        as +/- Infinity may be replaced by other values depending on the store. For example, sql
-        based store may replace +/- Inf with max / min float values.
-        :param timestamp: Time when this metric was calculated. Defaults to current system time.
+        as +/- Infinity may be replaced by other values depending on the store. For example, the
+        SQLAlchemy store replaces +/- Inf with max / min float values.
+        :param timestamp: Time when this metric was calculated. Defaults to the current system time.
         :param step: Training step (iteration) at which was the metric calculated. Defaults to 0.
         """
         timestamp = timestamp if timestamp is not None else int(time.time())

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -154,8 +154,15 @@ class MlflowClient(object):
 
     def log_metric(self, run_id, key, value, timestamp=None, step=None):
         """
-        Log a metric against the run ID. The timestamp defaults to the current timestamp.
-        The step defaults to 0.
+        Log a metric against the run ID.
+
+        :param run_id: The run id to which the metric should be logged to.
+        :param key: Metric name.
+        :param value: Metric value (float). Note that some special values such
+        as +/- Infinity may be replaced by other values depending on the store. For example, sql
+        based store may replace +/- Inf with max / min float values.
+        :param timestamp: Time when this metric was calculated. Defaults to current system time.
+        :param step: Training step (iteration) at which was the metric calculated. Defaults to 0.
         """
         timestamp = timestamp if timestamp is not None else int(time.time())
         step = step if step is not None else 0

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -192,7 +192,9 @@ def log_metric(key, value, step=None):
     Log a metric under the current run, creating a run if necessary.
 
     :param key: Metric name (string).
-    :param value: Metric value (float).
+    :param value: Metric value (float). Note that some special values such as +/- Infinity may be
+                  replaced by other values depending on the store. For example, sql based store may
+                  replace +/- Inf with max / min float values.
     :param step: Metric step (int). Defaults to zero if unspecified.
     """
     run_id = _get_or_start_run().info.run_id
@@ -202,7 +204,9 @@ def log_metric(key, value, step=None):
 def log_metrics(metrics, step=None):
     """
     Log multiple metrics for the current run, starting a run if no runs are active.
-    :param metrics: Dictionary of metric_name: String -> value: Float
+    :param metrics: Dictionary of metric_name: String -> value: Float. Note that some special values
+                    such as +/- Infinity may be replaced by other values depending on the store.
+                    For example, sql based store may replace +/- Inf with max / min float values.
     :param step: A single integer step at which to log the specified
                  Metrics. If unspecified, each metric is logged at step zero.
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -193,8 +193,8 @@ def log_metric(key, value, step=None):
 
     :param key: Metric name (string).
     :param value: Metric value (float). Note that some special values such as +/- Infinity may be
-                  replaced by other values depending on the store. For example, sql based store may
-                  replace +/- Inf with max / min float values.
+                  replaced by other values depending on the store. For example, sFor example, the
+                  SQLAlchemy store replaces +/- Inf with max / min float values.
     :param step: Metric step (int). Defaults to zero if unspecified.
     """
     run_id = _get_or_start_run().info.run_id

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -10,6 +10,7 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
 import math
 
+
 class SearchUtils(object):
     VALID_METRIC_COMPARATORS = set(['>', '>=', '!=', '=', '<', '<='])
     VALID_PARAM_COMPARATORS = set(['!=', '='])
@@ -259,6 +260,7 @@ class SearchUtils(object):
 
         def run_matches(run):
             return all([cls._does_run_match_clause(run, s) for s in parsed])
+
         return [run for run in runs if run_matches(run)]
 
     @classmethod

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -306,7 +306,7 @@ class SearchUtils(object):
                                   error_code=INVALID_PARAMETER_VALUE)
 
         # Return a key such that None values are always at the end.
-        is_null_or_nan = sort_value is None or math.isnan(sort_value)
+        is_null_or_nan = sort_value is None or isinstance(sort_value, float) and math.isnan(sort_value)
         if ascending:
             return (is_null_or_nan, sort_value)
         return (not is_null_or_nan, sort_value)

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -306,7 +306,8 @@ class SearchUtils(object):
                                   error_code=INVALID_PARAMETER_VALUE)
 
         # Return a key such that None values are always at the end.
-        is_null_or_nan = sort_value is None or isinstance(sort_value, float) and math.isnan(sort_value)
+        is_null_or_nan = sort_value is None or (isinstance(sort_value, float)
+                                                and math.isnan(sort_value))
         if ascending:
             return (is_null_or_nan, sort_value)
         return (not is_null_or_nan, sort_value)

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -8,6 +8,7 @@ from mlflow.entities import RunInfo
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
+import math
 
 class SearchUtils(object):
     VALID_METRIC_COMPARATORS = set(['>', '>=', '!=', '=', '<', '<='])
@@ -303,9 +304,10 @@ class SearchUtils(object):
                                   error_code=INVALID_PARAMETER_VALUE)
 
         # Return a key such that None values are always at the end.
+        is_null_or_nan = sort_value is None or math.isnan(sort_value)
         if ascending:
-            return (sort_value is None, sort_value)
-        return (sort_value is not None, sort_value)
+            return (is_null_or_nan, sort_value)
+        return (not is_null_or_nan, sort_value)
 
     @classmethod
     def sort(cls, runs, order_by_list):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -5,8 +5,6 @@ import numbers
 import posixpath
 import re
 
-import numpy as np
-
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.dbmodels.db_types import DATABASE_ENGINES

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -62,8 +62,7 @@ def _validate_metric(key, value, timestamp, step):
     it isn't.
     """
     _validate_metric_name(key)
-    if not isinstance(value, numbers.Number) or value > np.finfo(np.float64).max \
-            or value < np.finfo(np.float64).min:
+    if not isinstance(value, numbers.Number):
         raise MlflowException(
             "Got invalid value %s for metric '%s' (timestamp=%s). Please specify value as a valid "
             "double (64-bit floating point)" % (value, key, timestamp),

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -13,7 +13,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_DOCKER_IMAGE_NAM
     MLFLOW_DOCKER_IMAGE_ID
 
 from tests.projects.utils import TEST_DOCKER_PROJECT_DIR
-from tests.projects.utils import build_docker_example_base_image
+from tests.projects.utils import docker_example_base_image
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 from mlflow.projects import _project_spec
 
@@ -26,8 +26,8 @@ def _build_uri(base_uri, subdirectory):
 
 @pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
 def test_docker_project_execution(
-        use_start_run, tmpdir, tracking_uri_mock):  # pylint: disable=unused-argument
-    build_docker_example_base_image()
+        use_start_run,
+        tmpdir, tracking_uri_mock, docker_example_base_image):  # pylint: disable=unused-argument
     expected_params = {"use_start_run": use_start_run}
     submitted_run = mlflow.projects.run(
         TEST_DOCKER_PROJECT_DIR, experiment_id=file_store.FileStore.DEFAULT_EXPERIMENT_ID,
@@ -64,8 +64,7 @@ def test_docker_project_execution(
 @mock.patch('databricks_cli.configure.provider.ProfileConfigProvider')
 def test_docker_project_tracking_uri_propagation(
         ProfileConfigProvider, tmpdir, tracking_uri,
-        expected_command_segment):  # pylint: disable=unused-argument
-    build_docker_example_base_image()
+        expected_command_segment, docker_example_base_image):  # pylint: disable=unused-argument
     mock_provider = mock.MagicMock()
     mock_provider.get_config.return_value = \
         DatabricksConfig("host", "user", "pass", None, insecure=True)
@@ -85,9 +84,9 @@ def test_docker_project_tracking_uri_propagation(
         mlflow.set_tracking_uri(old_uri)
 
 
-def test_docker_uri_mode_validation(tracking_uri_mock):  # pylint: disable=unused-argument
+def test_docker_uri_mode_validation(
+        tracking_uri_mock, docker_example_base_image):  # pylint: disable=unused-argument
     with pytest.raises(ExecutionException):
-        build_docker_example_base_image()
         mlflow.projects.run(TEST_DOCKER_PROJECT_DIR, backend="databricks")
 
 

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -13,7 +13,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_DOCKER_IMAGE_NAM
     MLFLOW_DOCKER_IMAGE_ID
 
 from tests.projects.utils import TEST_DOCKER_PROJECT_DIR
-from tests.projects.utils import docker_example_base_image
+from tests.projects.utils import docker_example_base_image  # pylint: disable=unused-import
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 from mlflow.projects import _project_spec
 

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -3,9 +3,12 @@ import os
 import docker
 from docker.errors import BuildError, APIError
 
+
 import pytest
 
 import mlflow
+from mlflow.utils.file_utils import TempDir, _copy_project
+
 from mlflow.entities import RunStatus
 from mlflow.projects import _project_spec
 from mlflow.utils.file_utils import path_to_local_sqlite_uri
@@ -38,18 +41,34 @@ def assert_dirs_equal(expected, actual):
 
 
 def build_docker_example_base_image():
-    print(os.path.join(TEST_DOCKER_PROJECT_DIR, 'Dockerfile'))
-    client = docker.from_env()
-    try:
-        client.images.build(tag='mlflow-docker-example', forcerm=True,
-                            dockerfile='Dockerfile', path=TEST_DOCKER_PROJECT_DIR)
-    except BuildError as build_error:
-        for chunk in build_error.build_log:
-            print(chunk)
-        raise build_error
-    except APIError as api_error:
-        print(api_error.explanation)
-        raise api_error
+    mlflow_home = os.environ.get("MLFLOW_HOME", None)
+    if not mlflow_home:
+        raise Exception("MLFLOW_HOME environment variable is not set. Please set the variable to "
+                        "point to your mlflow dev root.")
+    with TempDir() as tmp:
+        cwd = tmp.path()
+        mlflow_dir = _copy_project(
+            src_path=mlflow_home, dst_path=cwd)
+        import shutil
+        shutil.copy(os.path.join(TEST_DOCKER_PROJECT_DIR, "Dockerfile"), tmp.path("Dockerfile"))
+        with open(tmp.path("Dockerfile"), "a") as f:
+            f.write(("COPY {mlflow_dir} /opt/mlflow\n"
+                     "RUN pip install -U -e /opt/mlflow\n").format(
+                mlflow_dir=mlflow_dir))
+            with open(os.path.join(TEST_DOCKER_PROJECT_DIR, 'Dockerfile'), "r") as example_docker:
+                f.writelines(example_docker.read())
+
+        client = docker.from_env()
+        try:
+            client.images.build(tag='mlflow-docker-example', forcerm=True,
+                                dockerfile='Dockerfile', path=cwd)
+        except BuildError as build_error:
+            for chunk in build_error.build_log:
+                print(chunk)
+            raise build_error
+        except APIError as api_error:
+            print(api_error.explanation)
+            raise api_error
 
 
 @pytest.fixture()

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -40,7 +40,8 @@ def assert_dirs_equal(expected, actual):
     assert len(dir_comparison.funny_files) == 0
 
 
-def build_docker_example_base_image():
+@pytest.fixture(scope="session")
+def docker_example_base_image():
     mlflow_home = os.environ.get("MLFLOW_HOME", None)
     if not mlflow_home:
         raise Exception("MLFLOW_HOME environment variable is not set. Please set the variable to "
@@ -55,12 +56,10 @@ def build_docker_example_base_image():
             f.write(("COPY {mlflow_dir} /opt/mlflow\n"
                      "RUN pip install -U -e /opt/mlflow\n").format(
                 mlflow_dir=mlflow_dir))
-            with open(os.path.join(TEST_DOCKER_PROJECT_DIR, 'Dockerfile'), "r") as example_docker:
-                f.writelines(example_docker.read())
 
         client = docker.from_env()
         try:
-            client.images.build(tag='mlflow-docker-example', forcerm=True,
+            client.images.build(tag='mlflow-docker-example', forcerm=True, nocache=True,
                                 dockerfile='Dockerfile', path=cwd)
         except BuildError as build_error:
             for chunk in build_error.build_log:

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -43,8 +43,9 @@ CREATE TABLE metrics (
 	value FLOAT NOT NULL, 
 	timestamp BIGINT NOT NULL, 
 	run_uuid VARCHAR(32) NOT NULL, 
-	step BIGINT DEFAULT '0' NOT NULL, 
-	CONSTRAINT metric_pk PRIMARY KEY (key, value, timestamp, run_uuid, step), 
+	step BIGINT DEFAULT '0' NOT NULL,
+	is_nan BOOLEAN DEFAULT '0' NOT NULL,
+	CONSTRAINT metric_pk PRIMARY KEY (key, value, timestamp, run_uuid, step, is_nan),
 	FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
 )
 

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -15,7 +15,7 @@ import uuid
 
 import mlflow.db
 from mlflow.entities import ViewType, RunTag, SourceType, RunStatus, Experiment, Metric, Param
-from mlflow.protos.databricks_pb2 import ErrorCode, RESOURCE_DOES_NOT_EXIST,\
+from mlflow.protos.databricks_pb2 import ErrorCode, RESOURCE_DOES_NOT_EXIST, \
     INVALID_PARAMETER_VALUE, INTERNAL_ERROR
 from mlflow.store import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.db.utils import _get_schema_version
@@ -26,7 +26,6 @@ from mlflow.store.sqlalchemy_store import SqlAlchemyStore
 from mlflow.utils import extract_db_type_from_uri
 from tests.resources.db.initial_models import Base as InitialBase
 from tests.integration.utils import invoke_cli_runner
-
 
 DB_URI = 'sqlite:///'
 ARTIFACT_URI = 'artifact_folder'
@@ -428,7 +427,6 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.log_metric(run.info.run_id, pos_inf_metric)
         self.store.log_metric(run.info.run_id, neg_inf_metric)
 
-
         run = self.store.get_run(run.info.run_id)
         self.assertTrue(tkey in run.data.metrics and run.data.metrics[tkey] == tval)
 
@@ -442,7 +440,6 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             self.assertTrue(math.isnan(run.data.metrics["NaN"]))
             self.assertTrue(run.data.metrics["PosInf"] > 1e308)
             self.assertTrue(run.data.metrics["NegInf"] < -1e308)
-
 
     def test_log_metric_allows_multiple_values_at_same_ts_and_run_data_uses_max_ts_value(self):
         run = self._run_factory()
@@ -980,9 +977,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # reverse the ordering, since we created in increasing order of start_time
         runs.reverse()
 
-        assert(runs[:1000] == self._search(exp))
+        assert (runs[:1000] == self._search(exp))
         for n in [0, 1, 2, 4, 8, 10, 20, 50, 100, 500, 1000, 1200, 2000]:
-            assert(runs[:min(1200, n)] == self._search(exp, max_results=n))
+            assert (runs[:min(1200, n)] == self._search(exp, max_results=n))
 
         with self.assertRaises(MlflowException) as e:
             self._search(exp, max_results=int(1e10))
@@ -995,7 +992,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         runs = sorted([self._run_factory(self._get_run_configs(exp, start_time=10)).info.run_id
                        for r in range(10)])
         for n in [0, 1, 2, 4, 8, 10, 20]:
-            assert(runs[:min(10, n)] == self._search(exp, max_results=n))
+            assert (runs[:min(10, n)] == self._search(exp, max_results=n))
 
     def test_search_runs_pagination(self):
         exp = self._experiment_factory('test_search_runs_pagination')
@@ -1089,9 +1086,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         def _raise_exception_fn(*args, **kwargs):  # pylint: disable=unused-argument
             raise Exception("Some internal error")
+
         with mock.patch("mlflow.store.sqlalchemy_store.SqlAlchemyStore.log_metric") as metric_mock,\
                 mock.patch(
-                    "mlflow.store.sqlalchemy_store.SqlAlchemyStore.log_param") as param_mock,\
+                    "mlflow.store.sqlalchemy_store.SqlAlchemyStore.log_param") as param_mock, \
                 mock.patch("mlflow.store.sqlalchemy_store.SqlAlchemyStore.set_tag") as tags_mock:
             metric_mock.side_effect = _raise_exception_fn
             param_mock.side_effect = _raise_exception_fn
@@ -1174,6 +1172,7 @@ class TestSqlAlchemyStoreSqliteMigratedDB(TestSqlAlchemyStoreSqlite):
     then migrates their DB. TODO: update this test in MLflow 1.1 to use InitialBase from
     mlflow.store.db.initial_models.
     """
+
     def setUp(self):
         fd, self.temp_dbfile = tempfile.mkstemp()
         os.close(fd)
@@ -1225,5 +1224,5 @@ class TestSqlAlchemyStoreMysqlDb(TestSqlAlchemyStoreSqlite):
         run = self._run_factory()
         for i in range(100):
             self.store.log_metric(run.info.run_id, entities.Metric("key", i, i * 2, i * 3))
-            self.store.log_param(run.info.run_id, entities.Param("pkey-%s" % i,  "pval-%s" % i))
-            self.store.set_tag(run.info.run_id, entities.RunTag("tkey-%s" % i,  "tval-%s" % i))
+            self.store.log_param(run.info.run_id, entities.Param("pkey-%s" % i, "pval-%s" % i))
+            self.store.set_tag(run.info.run_id, entities.RunTag("tkey-%s" % i, "tval-%s" % i))

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -435,8 +435,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # MLflow RunData contains only the last reported values for metrics.
         with self.store.ManagedSessionMaker() as session:
             sql_run_metrics = self.store._get_run(session, run.info.run_id).metrics
-            self.assertEqual(4, len(sql_run_metrics))
-            self.assertEqual(3, len(run.data.metrics))
+            self.assertEqual(5, len(sql_run_metrics))
+            self.assertEqual(4, len(run.data.metrics))
             self.assertTrue(math.isnan(run.data.metrics["NaN"]))
             self.assertTrue(run.data.metrics["PosInf"] > 1e308)
             self.assertTrue(run.data.metrics["NegInf"] < -1e308)

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -438,8 +438,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             self.assertEqual(5, len(sql_run_metrics))
             self.assertEqual(4, len(run.data.metrics))
             self.assertTrue(math.isnan(run.data.metrics["NaN"]))
-            self.assertTrue(run.data.metrics["PosInf"] > 1e308)
-            self.assertTrue(run.data.metrics["NegInf"] < -1e308)
+            self.assertTrue(run.data.metrics["PosInf"] == 1.7976931348623157e308)
+            self.assertTrue(run.data.metrics["NegInf"] == -1.7976931348623157e308)
 
     def test_log_metric_allows_multiple_values_at_same_ts_and_run_data_uses_max_ts_value(self):
         run = self._run_factory()

--- a/tests/store/test_sqlalchemy_store_schema.py
+++ b/tests/store/test_sqlalchemy_store_schema.py
@@ -34,8 +34,8 @@ def _assert_schema_files_equal(generated_schema_file, expected_schema_file):
     # so sort the lines within the statements before comparing them.
     for generated_schema_table, expected_schema_table \
             in zip(generated_schema_table_chunks, expected_schema_table_chunks):
-        generated_lines = sorted(generated_schema_table.split("\n"))
-        expected_lines = sorted(expected_schema_table.split("\n"))
+        generated_lines = [x.strip() for x in sorted(generated_schema_table.split("\n"))]
+        expected_lines = [x.strip() for x in sorted(expected_schema_table.split("\n"))]
         assert generated_lines == expected_lines,\
             "Generated schema did not match expected schema. Generated schema had table " \
             "definition:\n{generated_table}\nExpected schema had table definition:" \

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -288,11 +288,18 @@ def test_log_metrics_params_tags(mlflow_client, backend_store_uri):
     created_run = mlflow_client.create_run(experiment_id)
     run_id = created_run.info.run_id
     mlflow_client.log_metric(run_id, key='metric', value=123.456, timestamp=789, step=2)
+    mlflow_client.log_metric(run_id, key='nan_metric', value=float("nan"))
+    mlflow_client.log_metric(run_id, key='inf_metric', value=float("inf"))
+    mlflow_client.log_metric(run_id, key='-inf_metric', value=-float("inf"))
     mlflow_client.log_metric(run_id, key='stepless-metric', value=987.654, timestamp=321)
     mlflow_client.log_param(run_id, 'param', 'value')
     mlflow_client.set_tag(run_id, 'taggity', 'do-dah')
     run = mlflow_client.get_run(run_id)
     assert run.data.metrics.get('metric') == 123.456
+    import math
+    assert math.isnan(run.data.metrics.get('nan_metric'))
+    assert run.data.metrics.get('inf_metric') >= 1.7976931348623157e308
+    assert run.data.metrics.get('-inf_metric') <= -1.7976931348623157e308
     assert run.data.metrics.get('stepless-metric') == 987.654
     assert run.data.params.get('param') == 'value'
     assert run.data.tags.get('taggity') == 'do-dah'

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -286,6 +286,28 @@ def test_correct_sorting(order_bys, matching_runs):
     assert sorted_run_indices == matching_runs
 
 
+def test_order_by_metric_with_nans_and_infs():
+    metric_vals_str = ["nan", "inf", "-inf", "-1000", "0", "1000"]
+    runs = [
+        Run(run_info=RunInfo(run_id=x, run_uuid=x, experiment_id=0, user_id="user",
+                             status=RunStatus.to_string(RunStatus.FINISHED),
+                             start_time=0, end_time=1, lifecycle_stage=LifecycleStage.ACTIVE),
+            run_data=RunData(
+                metrics=[Metric("x", float(x), 1, 0)])
+            ) for x in metric_vals_str
+    ]
+    sorted_runs_asc = [
+        x.info.run_id for x in SearchUtils.sort(runs, ["metrics.x asc"])
+    ]
+    sorted_runs_desc = [
+        x.info.run_id for x in SearchUtils.sort(runs, ["metrics.x desc"])
+    ]
+    # asc
+    assert ["-inf", "-1000", "0", "1000", "inf", "nan"] == sorted_runs_asc
+    # desc
+    assert ["inf", "1000", "0", "-1000", "-inf", "nan"] == sorted_runs_desc
+
+
 @pytest.mark.parametrize("order_by, error_message", [
     ("m.acc", "Invalid entity type"),
     ("acc", "Invalid identifier"),


### PR DESCRIPTION
## What changes are proposed in this pull request?
Update SQL alchemy store to handle NaN and +/- Inf values. 
NaNs and Infs are not handled by sql databases so this required some minor changes:

1. NaNs:
Added a is_nan not-nullable column which was added to the primary key. NaNs are stored as (0, True), all other values are stored as (value, False)

2. Infs
Rather than storing information about inf in a separate column, replace the Infs with max / min float value. This is not ideal, but it saves db complexity and infs are expected to be an exception rather than commonly used value in mlflow.

 
## How is this patch tested?
**Unit tests:**
1. Sql alchemy test verifying we can store and read back NaN and +/-Inf values. 
2. Sql alchemy test verifying order by works as expected.

**Manual:**
1. I have verified db migration as well as creation of db from scratch work as expected for MySQL and SQLite.
2. UI: I have tested this with ui. The behavior is not optimal with NaNs and Infs but it does not break in major way. The observed behavior is that both NaNs and Infs do not show in the plot and break any plot lines. However, the regular numbers show as expected (points need to be turned on if a value is surrounded by nans/infs). 


 
## Release Notes
Enable users of sql alchemy store to log NaNs and Infs as metric values without throwing an exception.
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
