### PR TITLE
Kubernetes projects: Change image-uri attribute to repository-uri

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -391,8 +391,8 @@ In project folder you need to create a ``backend_config.json`` with the followin
   "kube-job-template-path": "kubernetes_job_template.yaml"
 }
 
-The ``kube-context`` attribute is the kubernetes context where mlflow will run the Job. ``repository-uri`` points to the 
-repository where the image will be pushed so kubernetes can download it and run. Remeber that mlflow 
+The ``kube-context`` attribute is the kubernetes context where mlflow will run the Job. ``repository-uri`` points to the
+repository where the image will be pushed so kubernetes can download it and run. Remember that mlflow
 expects that login credentials are already stored for both kubernetes context and docker repository to push images.
 
 The ``kube-job-template-path`` points to a yaml file with the kubernetes Job/Batch specification to run the traning on 

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -386,13 +386,13 @@ In project folder you need to create a ``backend_config.json`` with the followin
 {
   "kube-context": "docker-for-desktop",
   
-  "image-uri": "username/mlflow-kubernetes-example",
+  "repository-uri": "username/mlflow-kubernetes-example",
 
   "kube-job-template-path": "kubernetes_job_template.yaml"
 }
 
-The ``kube-context`` attribute is the kubernetes context where mlflow will run the Job. ``image-uri`` points to the 
-registry/repository/image where the image will be pushed so kubernetes can download it and run. Remeber that mlflow 
+The ``kube-context`` attribute is the kubernetes context where mlflow will run the Job. ``repository-uri`` points to the 
+repository where the image will be pushed so kubernetes can download it and run. Remeber that mlflow 
 expects that login credentials are already stored for both kubernetes context and docker repository to push images.
 
 The ``kube-job-template-path`` points to a yaml file with the kubernetes Job/Batch specification to run the traning on 

--- a/examples/docker/kubernetes_config.json
+++ b/examples/docker/kubernetes_config.json
@@ -1,5 +1,5 @@
 {
     "kube-context": "docker-for-desktop",
     "kube-job-template-path": "examples/docker/kubernetes_job_template.yaml",
-    "image-uri": "username/mlflow-kubernetes-example"
+    "repository-uri": "username/mlflow-kubernetes-example"
 }

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -14,7 +14,7 @@ MLFLOW_GIT_BRANCH = "mlflow.source.git.branch"
 MLFLOW_GIT_REPO_URL = "mlflow.source.git.repoURL"
 MLFLOW_PROJECT_ENV = "mlflow.project.env"
 MLFLOW_PROJECT_ENTRY_POINT = "mlflow.project.entryPoint"
-MLFLOW_DOCKER_IMAGE_NAME = "mlflow.docker.image.name"
+MLFLOW_DOCKER_IMAGE_URI = "mlflow.docker.image.uri"
 MLFLOW_DOCKER_IMAGE_ID = "mlflow.docker.image.id"
 
 MLFLOW_DATABRICKS_NOTEBOOK_ID = "mlflow.databricks.notebookID"

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -9,7 +9,7 @@ import mlflow
 from mlflow.entities import ViewType
 from mlflow.projects import ExecutionException, _get_docker_image_uri
 from mlflow.store import file_store
-from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_DOCKER_IMAGE_NAME, \
+from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_DOCKER_IMAGE_URI, \
     MLFLOW_DOCKER_IMAGE_ID
 
 from tests.projects.utils import TEST_DOCKER_PROJECT_DIR
@@ -46,7 +46,7 @@ def test_docker_project_execution(
     assert run.data.metrics == {"some_key": 3}
     exact_expected_tags = {MLFLOW_PROJECT_ENV: "docker"}
     approx_expected_tags = {
-        MLFLOW_DOCKER_IMAGE_NAME: "docker-example",
+        MLFLOW_DOCKER_IMAGE_URI: "docker-example",
         MLFLOW_DOCKER_IMAGE_ID: "sha256:",
     }
     run_tags = run.data.tags

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -7,7 +7,7 @@ from databricks_cli.configure.provider import DatabricksConfig
 
 import mlflow
 from mlflow.entities import ViewType
-from mlflow.projects import ExecutionException, _get_docker_tag_name
+from mlflow.projects import ExecutionException, _get_docker_image_uri
 from mlflow.store import file_store
 from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_DOCKER_IMAGE_NAME, \
     MLFLOW_DOCKER_IMAGE_ID
@@ -92,18 +92,18 @@ def test_docker_uri_mode_validation(tracking_uri_mock):  # pylint: disable=unuse
 
 
 @mock.patch('mlflow.projects._get_git_commit')
-def test_docker_tag_name_with_git(get_git_commit_mock):
+def test_docker_image_uri_with_git(get_git_commit_mock):
     get_git_commit_mock.return_value = '1234567890'
-    tag_name = _get_docker_tag_name("my_project", "my_workdir")
-    assert tag_name == "my_project:1234567"
+    image_uri = _get_docker_image_uri("my_project", "my_workdir")
+    assert image_uri == "my_project:1234567"
     get_git_commit_mock.assert_called_with('my_workdir')
 
 
 @mock.patch('mlflow.projects._get_git_commit')
-def test_docker_tag_name_no_git(get_git_commit_mock):
+def test_docker_image_uri_no_git(get_git_commit_mock):
     get_git_commit_mock.return_value = None
-    tag_name = _get_docker_tag_name("my_project", "my_workdir")
-    assert tag_name == "my_project"
+    image_uri = _get_docker_image_uri("my_project", "my_workdir")
+    assert image_uri == "my_project"
     get_git_commit_mock.assert_called_with('my_workdir')
 
 

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -371,7 +371,7 @@ def test_parse_kubernetes_config():
     kubernetes_config = {
         "kube-context": "docker-for-desktop",
         "kube-job-template-path": os.path.join(work_dir, "kubernetes_job_template.yaml"),
-        "image-uri": "dockerhub_account/mlflow-kubernetes-example"
+        "repository-uri": "dockerhub_account/mlflow-kubernetes-example"
     }
     yaml_obj = None
     with open(kubernetes_config["kube-job-template-path"], 'r') as job_template:
@@ -379,13 +379,13 @@ def test_parse_kubernetes_config():
     kube_config = mlflow.projects._parse_kubernetes_config(kubernetes_config)
     assert kube_config["kube-context"] == kubernetes_config["kube-context"]
     assert kube_config["kube-job-template-path"] == kubernetes_config["kube-job-template-path"]
-    assert kube_config["image-uri"] == kubernetes_config["image-uri"]
+    assert kube_config["repository-uri"] == kubernetes_config["repository-uri"]
     assert kube_config["kube-job-template"] == yaml_obj
 
 
 def test_parse_kubernetes_config_without_context():
     kubernetes_config = {
-        "image-uri": "dockerhub_account/mlflow-kubernetes-example",
+        "repository-uri": "dockerhub_account/mlflow-kubernetes-example",
         "kube-job-template-path": "kubernetes_job_template.yaml"
     }
     with pytest.raises(ExecutionException):
@@ -404,7 +404,7 @@ def test_parse_kubernetes_config_without_image_uri():
 def test_parse_kubernetes_config_invalid_template_job_file():
     kubernetes_config = {
         "kube-context": "docker-for-desktop",
-        "image-uri": "username/mlflow-kubernetes-example",
+        "repository-uri": "username/mlflow-kubernetes-example",
         "kube-job-template-path": "file_not_found.yaml"
     }
     with pytest.raises(ExecutionException):

--- a/tests/resources/example_docker_project/kubernetes_config.json
+++ b/tests/resources/example_docker_project/kubernetes_config.json
@@ -1,5 +1,5 @@
 {
     "kube-context": "docker-for-desktop",
     "kube-job-template-path": "examples/docker/kubernetes_job_template.yaml",
-    "image-uri": "username/mlflow-kubernetes-example"
+    "repository-uri": "username/mlflow-kubernetes-example"
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
The current Kubernetes project execution API refers to repository URIs as image URIs. There is a subtle but important distinction between these URIs (e.g., it's important that the user specifies a URI that does *not* contain a tag because the project execution API appends its own tag to the specified URI in order to obtain an image URI. However, image URIs may contain tags, leading to a confusing UX).
 
## How is this patch tested?
 
Manual execution of Kubernetes project APIs and existing unit tests.
 
## Release Notes

This is part of the Kubernetes projects feature and should be included under the same release notes item!
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [X] Examples 
- [X] Docs
- [ ] Tracking
- [X] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
