### PR TITLE
Update search docs to include searching by mlflow tag

### DIFF
--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -52,7 +52,7 @@ Entity Name Contains Special Characters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When a metric, parameter, or tag name contains a special character like hyphen, space, period, and so on,
-enclose the entity name in double quotes. Using backticks also work.
+enclose the entity name in double quotes or backticks.
 
 .. rubric:: Examples
 
@@ -77,7 +77,7 @@ For example:
   metrics."2019-04-02 error rate"
 
 
-Searching by MLflow specific tags
+Searching by MLflow Tags
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 You can also search for the name of an MLflow run and other tags that MLflow tracks internally. To format the search query, you will have to search using the tag ``tag."mlflow.runName"``. Wrapping ```mlflow.runName``` in backticks instead of double quotes also works.
@@ -89,6 +89,10 @@ This functionality will come in a future release.
 .. code-block:: sql
 
   tags."mlflow.runName" = "keras-hyperparam-search"
+
+.. code-block:: sql
+
+  tags.`mlflow.parentRunId` = "f1e4beff214688d45a4b6f0a8dee"
 
 
 Run Attributes

--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -44,7 +44,7 @@ Identifier
 
 Required in the LHS of a search expression. Signifies an entity to compare against. 
 
-An identifier has two parts separated by a period: the type of the entity and the name of the entity. The type of the entity is ``metrics``, ``params``, ``attributes``, or ``tag``. The entity name can contain alphanumeric characters and special characters.
+An identifier has two parts separated by a period: the type of the entity and the name of the entity. The type of the entity is ``metrics``, ``params``, ``attributes``, or ``tags``. The entity name can contain alphanumeric characters and special characters.
 
 This section describes supported entity names and how to specify such names in search expressions.
 
@@ -83,7 +83,7 @@ that have a leading number. If an entity name contains a leading number, enclose
 Run Attributes
 ~~~~~~~~~~~~~~
 
-You can search using two run attributes contained in :py:class:`mlflow.entities.RunInfo`: ``status`` and ``artifact_uri``. Both attributes have string values. Other fields in ``mlflow.entities.RunInfo`` are not currently searchable.
+You can search using two run attributes contained in :py:class:`mlflow.entities.RunInfo`: ``status`` and ``artifact_uri``. Both attributes have string values. Other fields in ``mlflow.entities.RunInfo`` are not searchable.
 
 .. note::
   
@@ -104,9 +104,8 @@ MLflow Tags
 ~~~~~~~~~~~
 
 You can search for MLflow tags by enclosing the tag name in double quotes or backticks. For example, to search for the name of an MLflow run, specify ``tags."mlflow.runName"`` or ``tags.`mlflow.runName```. 
-You can find a list of searchable tags at :ref:`MLflow tags <system_tags>`.
 
-.. note:: MLflow on Databricks does not currently support searching for a user (``tags."mlflow.user"``).
+.. note:: Databricks does not support searching for a user with the tag ``tags."mlflow.user"``.
 
 .. rubric:: Examples
 

--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -18,7 +18,7 @@ The syntax does not support ``OR``. Each expression has three parts: an identifi
 the left-hand side (LHS), a comparator, and constant on the right-hand side (RHS).
 
 Example Expressions
-^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^
 
 - Search for the subset of runs with logged accuracy metric greater than 0.92.
 
@@ -42,14 +42,18 @@ Example Expressions
 Identifier
 ^^^^^^^^^^
 
-Required in the LHS of a search expression. Signifies an entity to compare against. An identifier has two
-parts separated by a period: the type of the entity and the name of the entity. 
-The type of the entity is ``metrics``, ``params``, ``tags``, or ``attributes``. The entity name can
-contain alphanumeric characters and special characters.
-For example: ``metrics.accuracy``.
+Required in the LHS of a search expression. Signifies an entity to compare against. 
 
-Entity Name Contains Special Characters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+An identifier has two parts separated by a period: the type of the entity and the name of the entity. The type of the entity is ``metrics``, ``params``, ``attributes``, or ``tag``. The entity name can contain alphanumeric characters and special characters.
+
+This section describes supported entity names and how to specify such names in search expressions.
+
+.. contents:: In this section:
+  :local:
+  :depth: 1
+
+Entity Names Containing Special Characters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When a metric, parameter, or tag name contains a special character like hyphen, space, period, and so on,
 enclose the entity name in double quotes or backticks.
@@ -62,49 +66,59 @@ enclose the entity name in double quotes or backticks.
 
 .. code-block:: sql
 
-  metrics."error rate"
+  metrics.`error rate`
 
 
-Entity Name Starts with a Number
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Entity Names Starting with a Number
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Unlike SQL syntax for column names, MLflow allows logging metrics, parameters, and tags with names
-that have a leading number. If an entity name contains a leading number, enclose the entity name in double quotes. 
-For example:
+Unlike SQL syntax for column names, MLflow allows logging metrics, parameters, and tags names
+that have a leading number. If an entity name contains a leading number, enclose the entity name in double quotes. For example:
 
 .. code-block:: sql
 
   metrics."2019-04-02 error rate"
 
 
-Searching by MLflow Tags
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You can also search for the name of an MLflow run and other tags that MLflow tracks internally. To format the search query, you will have to search using the tag ``tag."mlflow.runName"``. Wrapping ```mlflow.runName``` in backticks instead of double quotes also works.
-Other searchable MLflow specific tags can be found at :ref:`system_tags`. MLflow inside Dataricks currently does not support searching by User or ``tag."mlflow.user"``.
-This functionality will come in a future release.
-
-.. rubric:: Example
-
-.. code-block:: sql
-
-  tags."mlflow.runName" = "keras-hyperparam-search"
-
-.. code-block:: sql
-
-  tags.`mlflow.parentRunId` = "f1e4beff214688d45a4b6f0a8dee"
-
-
 Run Attributes
 ~~~~~~~~~~~~~~
 
-The search syntax supports searching runs using two attributes: ``status`` and ``artifact_uri``. Both attributes have string values. Other fields in :py:class:`mlflow.entities.RunInfo` are :ref:`system_tags` that are searchable using the UI and the API. The search returns an error if you use other attribute names in the filter string. 
+You can search using two run attributes contained in :py:class:`mlflow.entities.RunInfo`: ``status`` and ``artifact_uri``. Both attributes have string values. 
+
+Other fields in ``mlflow.entities.RunInfo`` are :ref:`MLflow tags <system_tags>` that are searchable as ``tag`` identifiers (see :ref:`mlflow_tags` below); search returns an error if you use these names in the ``attributes`` identifier. 
 
 .. note::
   
   - The experiment ID is implicitly selected by the search API. 
   - A run's ``lifecycle_stage`` attribute is not allowed because it is already encoded as a part of the API's ``run_view_type`` field. To search for runs using ``run_id``, it is more efficient to use ``get_run`` APIs. 
   - The ``start_time`` and ``end_time`` attributes are not supported.
+  
+.. rubric:: Example
+
+.. code-block:: sql
+
+  attributes.artifact_uri
+
+
+.. _mlflow_tags:
+
+MLflow Tags
+~~~~~~~~~~~
+
+You can search for MLflow tags by enclosing the tag name in double quotes or backticks. For example, to search for the name of an MLflow run, specify ``tag."mlflow.runName"`` or ``tag.`mlflow.runName```. 
+
+.. note:: Search on Databricks does not support searching for a user (``tag."mlflow.user"``).
+
+.. rubric:: Examples
+
+.. code-block:: sql
+
+  tag."mlflow.runName"
+
+.. code-block:: sql
+
+  tag.`mlflow.parentRunId`
+
 
 Comparator
 ^^^^^^^^^^
@@ -112,7 +126,7 @@ Comparator
 There are two classes of comparators: numeric and string.
 
 - Numeric comparators (``metrics``): ``=``, ``!=``, ``>``, ``>=``, ``<``, and ``<=``.
-- String comparators (``params``, ``tags``, and ``attributes``): ``=`` and ``!=``.
+- String comparators (``params``, ``tag``, and ``attributes``): ``=`` and ``!=``.
 
 Constant
 ^^^^^^^^

--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -77,6 +77,20 @@ For example:
   metrics."2019-04-02 error rate"
 
 
+Searching by MLflow specific tags
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To search by something like the name of a run, you will have to search using the tag ``tag."mlflow.runName"``.
+Other MLflow specific tags can be found at :ref:`system_tags`. MLflow inside Dataricks currently does not support searching by User or ``tag."mlflow.user"``.
+This functionality will come in a future release.
+
+.. rubric:: Example
+
+.. code-block:: sql
+
+  tags."mlflow.runName" = "keras-hyperparam-search"
+
+
 Run Attributes
 ~~~~~~~~~~~~~~
 

--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -80,8 +80,8 @@ For example:
 Searching by MLflow specific tags
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To search by something like the name of a run, you will have to search using the tag ``tag."mlflow.runName"``. Wrapping ```mlflow.runName``` in backticks instead of double quotes also works.
-Other MLflow specific tags can be found at :ref:`system_tags`. MLflow inside Dataricks currently does not support searching by User or ``tag."mlflow.user"``.
+You can also search for the name of an MLflow run and other tags that MLflow tracks internally. To format the search query, you will have to search using the tag ``tag."mlflow.runName"``. Wrapping ```mlflow.runName``` in backticks instead of double quotes also works.
+Other searchable MLflow specific tags can be found at :ref:`system_tags`. MLflow inside Dataricks currently does not support searching by User or ``tag."mlflow.user"``.
 This functionality will come in a future release.
 
 .. rubric:: Example

--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -83,9 +83,7 @@ that have a leading number. If an entity name contains a leading number, enclose
 Run Attributes
 ~~~~~~~~~~~~~~
 
-You can search using two run attributes contained in :py:class:`mlflow.entities.RunInfo`: ``status`` and ``artifact_uri``. Both attributes have string values. 
-
-Other fields in ``mlflow.entities.RunInfo`` are :ref:`MLflow tags <system_tags>` that are searchable as ``tag`` identifiers (see :ref:`mlflow_tags` below); search returns an error if you use these names in the ``attributes`` identifier. 
+You can search using two run attributes contained in :py:class:`mlflow.entities.RunInfo`: ``status`` and ``artifact_uri``. Both attributes have string values. Other fields in ``mlflow.entities.RunInfo`` are not currently searchable.
 
 .. note::
   
@@ -105,19 +103,20 @@ Other fields in ``mlflow.entities.RunInfo`` are :ref:`MLflow tags <system_tags>`
 MLflow Tags
 ~~~~~~~~~~~
 
-You can search for MLflow tags by enclosing the tag name in double quotes or backticks. For example, to search for the name of an MLflow run, specify ``tag."mlflow.runName"`` or ``tag.`mlflow.runName```. 
+You can search for MLflow tags by enclosing the tag name in double quotes or backticks. For example, to search for the name of an MLflow run, specify ``tags."mlflow.runName"`` or ``tags.`mlflow.runName```. 
+You can find a list of searchable tags at :ref:`MLflow tags <system_tags>`.
 
-.. note:: Search on Databricks does not support searching for a user (``tag."mlflow.user"``).
+.. note:: MLflow on Databricks does not currently support searching for a user (``tags."mlflow.user"``).
 
 .. rubric:: Examples
 
 .. code-block:: sql
 
-  tag."mlflow.runName"
+  tags."mlflow.runName"
 
 .. code-block:: sql
 
-  tag.`mlflow.parentRunId`
+  tags.`mlflow.parentRunId`
 
 
 Comparator
@@ -126,7 +125,7 @@ Comparator
 There are two classes of comparators: numeric and string.
 
 - Numeric comparators (``metrics``): ``=``, ``!=``, ``>``, ``>=``, ``<``, and ``<=``.
-- String comparators (``params``, ``tag``, and ``attributes``): ``=`` and ``!=``.
+- String comparators (``params``, ``tags``, and ``attributes``): ``=`` and ``!=``.
 
 Constant
 ^^^^^^^^

--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -52,7 +52,7 @@ Entity Name Contains Special Characters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When a metric, parameter, or tag name contains a special character like hyphen, space, period, and so on,
-enclose the entity name in double quotes.
+enclose the entity name in double quotes. Using backticks also work.
 
 .. rubric:: Examples
 
@@ -80,7 +80,7 @@ For example:
 Searching by MLflow specific tags
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To search by something like the name of a run, you will have to search using the tag ``tag."mlflow.runName"``.
+To search by something like the name of a run, you will have to search using the tag ``tag."mlflow.runName"``. Wrapping ```mlflow.runName``` in backticks instead of double quotes also works.
 Other MLflow specific tags can be found at :ref:`system_tags`. MLflow inside Dataricks currently does not support searching by User or ``tag."mlflow.user"``.
 This functionality will come in a future release.
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -558,8 +558,8 @@ internal use. The following tags are set automatically by MLflow, when appropria
 +-------------------------------+----------------------------------------------------------------------------------------+
 | ``mlflow.user``               | Identifier of the user who created the run.                                            |
 +-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.source.type``        | Source type (possible values are ``"NOTEBOOK"``, ``"JOB"``, ``"PROJECT"``,             |
-|                               | ``"LOCAL"``, and ``"UNKNOWN"``)                                                        |
+| ``mlflow.source.type``        | Source type. Possible values: ``"NOTEBOOK"``, ``"JOB"``, ``"PROJECT"``,                |
+|                               | ``"LOCAL"``, and ``"UNKNOWN"``                                                         |
 +-------------------------------+----------------------------------------------------------------------------------------+
 | ``mlflow.source.name``        | Source identifier (e.g., GitHub URL, local Python filename, name of notebook)          |
 +-------------------------------+----------------------------------------------------------------------------------------+
@@ -569,7 +569,8 @@ internal use. The following tags are set automatically by MLflow, when appropria
 +-------------------------------+----------------------------------------------------------------------------------------+
 | ``mlflow.source.git.repoURL`` | URL that the executed code was cloned from.                                            |
 +-------------------------------+----------------------------------------------------------------------------------------+
-| ``mlflow.project.env``        | One of "docker" or "conda", indicating the runtime context used by the MLflow project. |
+| ``mlflow.project.env``        | The runtime context used by the MLflow project.                                        |
+|                               | Possible values: ``"docker"`` and ``"conda"``.                                         |
 +-------------------------------+----------------------------------------------------------------------------------------+
 | ``mlflow.project.entryPoint`` | Name of the project entry point associated with the current run, if any.               |
 +-------------------------------+----------------------------------------------------------------------------------------+


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Updating the search documentation to add a note about searching by MLflow tags. Screenshot below:
![Screen Shot 2019-07-17 at 11 19 42 AM](https://user-images.githubusercontent.com/51378244/61400349-ebfebb00-a884-11e9-94de-48b09116e7cf.png)

This was added because users were confused about how to search by `user` and `run name`.
 
## How is this patch tested?

 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [x] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
