### PR TITLE
source activate updated to conda activate while model serving

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -656,6 +656,7 @@ def _get_conda_command(conda_env_name):
         activate_conda_env = ['source ' + os.path.dirname(conda_path) +
                               '/../etc/profile.d/conda.sh']
     activate_conda_env += ["conda activate {0}".format(conda_env_name)]
+    return activate_conda_env
 
 
 def _validate_execution_environment(project, backend):

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -661,9 +661,9 @@ def _get_conda_command(conda_env_name):
         # in case os name is not 'nt', we are not running on windows. It introduces
         # bash command otherwise.
         if os.name != "nt":
-            return ["source %s %s" % (activate_path, conda_env_name)]
+            return ["source %s %s 1>&2" % (activate_path, conda_env_name)]
         else:
-            return ["conda %s %s" % (activate_path, conda_env_name)]
+            return ["conda %s %s 1>&2" % (activate_path, conda_env_name)]
     return activate_conda_env
 
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -652,7 +652,10 @@ def _invoke_mlflow_run_subprocess(
 def _get_conda_command(conda_env_name):
     conda_path = _get_conda_bin_executable("conda")
     activate_conda_env = []
-    activate_conda_env += ["{0} activate {1}".format(conda_path, conda_env_name)]
+    if conda_path != 'conda':
+        activate_conda_env = ['source ' + os.path.dirname(conda_path) +
+                              '/../etc/profile.d/conda.sh']
+    activate_conda_env += ["conda activate {0}".format(conda_env_name)]
     return activate_conda_env
 
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -460,6 +460,10 @@ def _get_conda_bin_executable(executable_name):
     conda_home = os.environ.get(MLFLOW_CONDA_HOME)
     if conda_home:
         return os.path.join(conda_home, "bin/%s" % executable_name)
+    # Use CONDA_EXE as per https://github.com/conda/conda/issues/7126
+    if "CONDA_EXE" in os.environ:
+        conda_bin_dir = os.path.dirname(os.environ["CONDA_EXE"])
+        return os.path.join(conda_bin_dir, executable_name)
     return executable_name
 
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -650,12 +650,20 @@ def _invoke_mlflow_run_subprocess(
 
 
 def _get_conda_command(conda_env_name):
-    conda_path = _get_conda_bin_executable("conda")
-    activate_conda_env = []
-    if conda_path != 'conda':
+    #  Checking for newer conda versions
+    if 'CONDA_EXE' in os.environ or 'MLFLOW_CONDA_HOME' in os.environ:
+        conda_path = _get_conda_bin_executable("conda")
         activate_conda_env = ['source ' + os.path.dirname(conda_path) +
                               '/../etc/profile.d/conda.sh']
-    activate_conda_env += ["conda activate {0}".format(conda_env_name)]
+        activate_conda_env += ["conda activate {0} 1>&2".format(conda_env_name)]
+    else:
+        activate_path = _get_conda_bin_executable("activate")
+        # in case os name is not 'nt', we are not running on windows. It introduces
+        # bash command otherwise.
+        if os.name != "nt":
+            return ["source %s %s" % (activate_path, conda_env_name)]
+        else:
+            return ["conda %s %s" % (activate_path, conda_env_name)]
     return activate_conda_env
 
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -652,10 +652,7 @@ def _invoke_mlflow_run_subprocess(
 def _get_conda_command(conda_env_name):
     conda_path = _get_conda_bin_executable("conda")
     activate_conda_env = []
-    if conda_path != 'conda':
-        activate_conda_env = ['source ' + os.path.dirname(conda_path) +
-                              '/../etc/profile.d/conda.sh']
-    activate_conda_env += ["conda activate {0}".format(conda_env_name)]
+    activate_conda_env += ["{0} activate {1}".format(conda_path, conda_env_name)]
     return activate_conda_env
 
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -650,13 +650,12 @@ def _invoke_mlflow_run_subprocess(
 
 
 def _get_conda_command(conda_env_name):
-    activate_path = _get_conda_bin_executable("activate")
-    # in case os name is not 'nt', we are not running on windows. It introduces
-    # bash command otherwise.
-    if os.name != "nt":
-        return ["source %s %s" % (activate_path, conda_env_name)]
-    else:
-        return ["conda %s %s" % (activate_path, conda_env_name)]
+    conda_path = _get_conda_bin_executable("conda")
+    activate_conda_env = []
+    if conda_path != 'conda':
+        activate_conda_env = ['source ' + os.path.dirname(conda_path) +
+                              '/../etc/profile.d/conda.sh']
+    activate_conda_env += ["conda activate {0}".format(conda_env_name)]
 
 
 def _validate_execution_environment(project, backend):

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -127,9 +127,12 @@ def _execute_in_conda_env(conda_env_path, command, install_mlflow, command_env=N
         command_env = os.environ
     env_id = os.environ.get("MLFLOW_HOME", VERSION) if install_mlflow else None
     conda_env_name = _get_or_create_conda_env(conda_env_path, env_id=env_id)
-    activate_path = _get_conda_bin_executable("activate")
-    activate_conda_env = ["source {0} {1} 1>&2".format(activate_path, conda_env_name)]
-
+    conda_path = _get_conda_bin_executable("conda")
+    activate_conda_env = []
+    if conda_path != 'conda':
+        activate_conda_env = ['source ' + os.path.dirname(conda_path) +
+                              '/../etc/profile.d/conda.sh']
+    activate_conda_env += ["conda activate {0} 1>&2".format(conda_env_name)]
     if install_mlflow:
         if "MLFLOW_HOME" in os.environ:  # dev version
             install_mlflow = "pip install -e {} 1>&2".format(os.environ["MLFLOW_HOME"])

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -129,7 +129,10 @@ def _execute_in_conda_env(conda_env_path, command, install_mlflow, command_env=N
     conda_env_name = _get_or_create_conda_env(conda_env_path, env_id=env_id)
     conda_path = _get_conda_bin_executable("conda")
     activate_conda_env = []
-    activate_conda_env += ["{0} activate {1} 1>&2".format(conda_path, conda_env_name)]
+    if conda_path != 'conda':
+        activate_conda_env = ['source ' + os.path.dirname(conda_path) +
+                              '/../etc/profile.d/conda.sh']
+    activate_conda_env += ["conda activate {0} 1>&2".format(conda_env_name)]
     if install_mlflow:
         if "MLFLOW_HOME" in os.environ:  # dev version
             install_mlflow = "pip install -e {} 1>&2".format(os.environ["MLFLOW_HOME"])

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -127,12 +127,15 @@ def _execute_in_conda_env(conda_env_path, command, install_mlflow, command_env=N
         command_env = os.environ
     env_id = os.environ.get("MLFLOW_HOME", VERSION) if install_mlflow else None
     conda_env_name = _get_or_create_conda_env(conda_env_path, env_id=env_id)
-    conda_path = _get_conda_bin_executable("conda")
-    activate_conda_env = []
-    if conda_path != 'conda':
+    #  Checking for newer conda versions
+    if 'CONDA_EXE' in os.environ or 'MLFLOW_CONDA_HOME' in os.environ:
+        conda_path = _get_conda_bin_executable("conda")
         activate_conda_env = ['source ' + os.path.dirname(conda_path) +
                               '/../etc/profile.d/conda.sh']
-    activate_conda_env += ["conda activate {0} 1>&2".format(conda_env_name)]
+        activate_conda_env += ["conda activate {0} 1>&2".format(conda_env_name)]
+    else:
+        activate_path = _get_conda_bin_executable("activate")
+        activate_conda_env = ["source {0} {1} 1>&2".format(activate_path, conda_env_name)]
     if install_mlflow:
         if "MLFLOW_HOME" in os.environ:  # dev version
             install_mlflow = "pip install -e {} 1>&2".format(os.environ["MLFLOW_HOME"])

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -8,7 +8,8 @@ from mlflow.models.docker_utils import _build_image, DISABLE_ENV_CREATION
 from mlflow.pyfunc import ENV
 from mlflow.pyfunc import scoring_server
 
-from mlflow.projects import _get_or_create_conda_env, _get_conda_bin_executable
+from mlflow.projects import _get_or_create_conda_env, _get_conda_bin_executable, \
+                            _get_conda_command
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.version import VERSION
@@ -127,15 +128,7 @@ def _execute_in_conda_env(conda_env_path, command, install_mlflow, command_env=N
         command_env = os.environ
     env_id = os.environ.get("MLFLOW_HOME", VERSION) if install_mlflow else None
     conda_env_name = _get_or_create_conda_env(conda_env_path, env_id=env_id)
-    #  Checking for newer conda versions
-    if 'CONDA_EXE' in os.environ or 'MLFLOW_CONDA_HOME' in os.environ:
-        conda_path = _get_conda_bin_executable("conda")
-        activate_conda_env = ['source ' + os.path.dirname(conda_path) +
-                              '/../etc/profile.d/conda.sh']
-        activate_conda_env += ["conda activate {0} 1>&2".format(conda_env_name)]
-    else:
-        activate_path = _get_conda_bin_executable("activate")
-        activate_conda_env = ["source {0} {1} 1>&2".format(activate_path, conda_env_name)]
+    activate_conda_env = _get_conda_command(conda_env_name)
     if install_mlflow:
         if "MLFLOW_HOME" in os.environ:  # dev version
             install_mlflow = "pip install -e {} 1>&2".format(os.environ["MLFLOW_HOME"])

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -129,10 +129,7 @@ def _execute_in_conda_env(conda_env_path, command, install_mlflow, command_env=N
     conda_env_name = _get_or_create_conda_env(conda_env_path, env_id=env_id)
     conda_path = _get_conda_bin_executable("conda")
     activate_conda_env = []
-    if conda_path != 'conda':
-        activate_conda_env = ['source ' + os.path.dirname(conda_path) +
-                              '/../etc/profile.d/conda.sh']
-    activate_conda_env += ["conda activate {0} 1>&2".format(conda_env_name)]
+    activate_conda_env += ["{0} activate {1} 1>&2".format(conda_path, conda_env_name)]
     if install_mlflow:
         if "MLFLOW_HOME" in os.environ:  # dev version
             install_mlflow = "pip install -e {} 1>&2".format(os.environ["MLFLOW_HOME"])

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -338,8 +338,13 @@ def test_run_async(tracking_uri_mock):  # pylint: disable=unused-argument
 def test_conda_path(mock_env, expected_conda, expected_activate):
     """Verify that we correctly determine the path to conda executables"""
     with mock.patch.dict("os.environ", mock_env):
-        assert mlflow.projects._get_conda_bin_executable("conda") == expected_conda
-        assert mlflow.projects._get_conda_bin_executable("activate") == expected_activate
+        obtained_conda = mlflow.projects._get_conda_bin_executable("conda")
+        obtained_activate = mlflow.projects._get_conda_bin_executable("activate")
+        if not mock_env:
+            obtained_conda = obtained_conda.split('/')[-1]
+            obtained_activate = obtained_activate.split('/')[-1]
+        assert obtained_conda == expected_conda
+        assert obtained_activate == expected_activate
 
 
 def test_cancel_run(tracking_uri_mock):  # pylint: disable=unused-argument

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -336,7 +336,7 @@ def test_run_async(tracking_uri_mock):  # pylint: disable=unused-argument
 @pytest.mark.parametrize(
     "mock_env,expected_conda,expected_activate",
     [
-        ({"CONDA_EXE": ""}, "conda", "activate"),
+        ({"CONDA_EXE": "/abc/conda"}, "/abc/conda", "/abc/activate"),
         ({mlflow.projects.MLFLOW_CONDA_HOME: "/some/dir/"}, "/some/dir/bin/conda",
          "/some/dir/bin/activate")
     ]

--- a/tests/store/test_rest_store.py
+++ b/tests/store/test_rest_store.py
@@ -232,5 +232,6 @@ class TestRestStore(unittest.TestCase):
                                   message_to_json(expected_message))
             assert result.token == "67890fghij"
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -13,7 +13,7 @@ else
 fi
 
 bash /travis-install/miniconda.sh -b -p $HOME/miniconda
-source ~/.bashrc
+source ~/.bash_profile
 hash -r
 conda config --set always_yes yes --set changeps1 no
 # Useful for debugging any issues with conda

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -13,7 +13,7 @@ else
 fi
 
 bash /travis-install/miniconda.sh -b -p $HOME/miniconda
-export PATH="$HOME/miniconda/bin:$PATH"
+source ~/.bashrc
 hash -r
 conda config --set always_yes yes --set changeps1 no
 # Useful for debugging any issues with conda

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -13,7 +13,7 @@ else
 fi
 
 bash /travis-install/miniconda.sh -b -p $HOME/miniconda
-source ~/.bash_profile
+export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 conda config --set always_yes yes --set changeps1 no
 # Useful for debugging any issues with conda

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -13,7 +13,7 @@ else
 fi
 
 bash /travis-install/miniconda.sh -b -p $HOME/miniconda
-source ~/.bash_profile
+source ~/.bashrc
 hash -r
 conda config --set always_yes yes --set changeps1 no
 # Useful for debugging any issues with conda

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -13,7 +13,7 @@ else
 fi
 
 bash /travis-install/miniconda.sh -b -p $HOME/miniconda
-source ~/.bashrc
+export PATH="$HOME/miniconda/bin:$PATH"
 hash -r
 conda config --set always_yes yes --set changeps1 no
 # Useful for debugging any issues with conda

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -13,7 +13,7 @@ else
 fi
 
 bash /travis-install/miniconda.sh -b -p $HOME/miniconda
-export PATH="$HOME/miniconda/bin:$PATH"
+source ~/.bash_profile
 hash -r
 conda config --set always_yes yes --set changeps1 no
 # Useful for debugging any issues with conda


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Source activate updated to conda activate while model serving
 
## How is this patch tested?
 Deployed the mlflow/examples/sklearn_logistic_regression model and tried serving the model.
Ran ./lint.sh
 
## Release Notes
 Newer conda versions has been handled while model serving
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [x] Scoring 
- [x] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
