### PR TITLE
log_batch should not require every param to be set

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -187,17 +187,20 @@ class MlflowClient(object):
         """
         self.store.delete_tag(run_id, key)
 
-    def log_batch(self, run_id, metrics, params, tags):
+    def log_batch(self, run_id, metrics=(), params=(), tags=()):
         """
         Log multiple metrics, params, and/or tags.
 
-        :param metrics: List of Metric(key, value, timestamp) instances.
-        :param params: List of Param(key, value) instances.
-        :param tags: List of RunTag(key, value) instances.
+        :param run_id: String ID of the run
+        :param metrics: If provided, List of Metric(key, value, timestamp) instances.
+        :param params: If provided, List of Param(key, value) instances.
+        :param tags: If provided, List of RunTag(key, value) instances.
 
         Raises an MlflowException if any errors occur.
-        :returns: None
+        :return: None
         """
+        if len(metrics) == 0 and len(params) == 0 and len(tags) == 0:
+            return
         for metric in metrics:
             _validate_metric(metric.key, metric.value, metric.timestamp, metric.step)
         for param in params:

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -224,6 +224,16 @@ def test_log_batch(tracking_uri_mock, tmpdir):
             assert exact_expected_tags[tag_key] == tag_value
     # Validate params
     assert finished_run.data.params == expected_params
+    # test that log_batch works with fewer params
+    new_tags = {"1": "2", "3": "4", "5": "6"}
+    tags = [RunTag(key=key, value=value) for key, value in new_tags.items()]
+    client.log_batch(run_id=run_id, tags=tags)
+    finished_run_2 = client.get_run(run_id)
+    # Validate tags (for automatically-set tags)
+    assert len(finished_run_2.data.tags) == len(finished_run.data.tags) + 3
+    for tag_key, tag_value in finished_run_2.data.tags.items():
+        if tag_key in new_tags:
+            assert new_tags[tag_key] == tag_value
 
 
 def test_log_metric(tracking_uri_mock):


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Add all the params as optional in the Python client. The R and Java clients use the REST API, which does not seem to require the parameters to be there (per this description: https://www.mlflow.org/docs/latest/rest-api.html#log-batch). Also, fixed up some of the Python docs.
 
## How is this patch tested?
 
Added to the existing log_batch test and it seems to work.
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [x] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
