### PR TITLE
Added Splice Machine Support for MLFlow as a Tracking Backend

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -386,13 +386,13 @@ In project folder you need to create a ``backend_config.json`` with the followin
 {
   "kube-context": "docker-for-desktop",
   
-  "image-uri": "username/mlflow-kubernetes-example",
+  "repository-uri": "username/mlflow-kubernetes-example",
 
   "kube-job-template-path": "kubernetes_job_template.yaml"
 }
 
-The ``kube-context`` attribute is the kubernetes context where mlflow will run the Job. ``image-uri`` points to the 
-registry/repository/image where the image will be pushed so kubernetes can download it and run. Remeber that mlflow 
+The ``kube-context`` attribute is the kubernetes context where mlflow will run the Job. ``repository-uri`` points to the
+repository where the image will be pushed so kubernetes can download it and run. Remember that mlflow
 expects that login credentials are already stored for both kubernetes context and docker repository to push images.
 
 The ``kube-job-template-path`` points to a yaml file with the kubernetes Job/Batch specification to run the traning on 

--- a/examples/docker/kubernetes_config.json
+++ b/examples/docker/kubernetes_config.json
@@ -1,5 +1,5 @@
 {
     "kube-context": "docker-for-desktop",
     "kube-job-template-path": "examples/docker/kubernetes_job_template.yaml",
-    "image-uri": "username/mlflow-kubernetes-example"
+    "repository-uri": "username/mlflow-kubernetes-example"
 }

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -5,8 +5,20 @@ import logging
 from alembic.migration import MigrationContext  # pylint: disable=import-error
 import sqlalchemy
 
-
 _logger = logging.getLogger(__name__)
+
+
+def _get_splicemachine_impl():
+    """
+    Return an Alembic Impl so
+    Splice Machine migrations work
+    """
+    from alembic.ddl import impl
+    return type('SpliceMachineImpl', (impl.DefaultImpl, object),
+                {'__dialect__': 'splicemachinesa', 'transactional_ddl': False})
+
+
+SpliceMachineImpl = _get_splicemachine_impl()
 
 
 def _get_package_dir():
@@ -29,7 +41,7 @@ def _get_alembic_config(db_url, alembic_dir=None):
     names.
     """
     from alembic.config import Config
-    final_alembic_dir = os.path.join(_get_package_dir(), 'store', 'db_migrations')\
+    final_alembic_dir = os.path.join(_get_package_dir(), 'store', 'db_migrations') \
         if alembic_dir is None else alembic_dir
     config = Config(os.path.join(final_alembic_dir, 'alembic.ini'))
     config.set_main_option('script_location', final_alembic_dir)

--- a/mlflow/store/db_migrations/env.py
+++ b/mlflow/store/db_migrations/env.py
@@ -3,8 +3,9 @@ from logging.config import fileConfig
 
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
-
 from alembic import context
+
+from mlflow.store.db.utils import SpliceMachineImpl
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/mlflow/store/dbmodels/db_types.py
+++ b/mlflow/store/dbmodels/db_types.py
@@ -6,10 +6,12 @@ POSTGRES = 'postgresql'
 MYSQL = 'mysql'
 SQLITE = 'sqlite'
 MSSQL = 'mssql'
+SPLICE = 'splicemachinesa'
 
 DATABASE_ENGINES = [
     POSTGRES,
     MYSQL,
     SQLITE,
-    MSSQL
+    MSSQL,
+    SPLICE
 ]

--- a/mlflow/temporary_db_migrations_for_pre_1_users/env.py
+++ b/mlflow/temporary_db_migrations_for_pre_1_users/env.py
@@ -6,6 +6,8 @@ from sqlalchemy import pool
 
 from alembic import context
 
+from mlflow.store.db.utils import SpliceMachineImpl
+
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -187,17 +187,20 @@ class MlflowClient(object):
         """
         self.store.delete_tag(run_id, key)
 
-    def log_batch(self, run_id, metrics, params, tags):
+    def log_batch(self, run_id, metrics=(), params=(), tags=()):
         """
         Log multiple metrics, params, and/or tags.
 
-        :param metrics: List of Metric(key, value, timestamp) instances.
-        :param params: List of Param(key, value) instances.
-        :param tags: List of RunTag(key, value) instances.
+        :param run_id: String ID of the run
+        :param metrics: If provided, List of Metric(key, value, timestamp) instances.
+        :param params: If provided, List of Param(key, value) instances.
+        :param tags: If provided, List of RunTag(key, value) instances.
 
         Raises an MlflowException if any errors occur.
-        :returns: None
+        :return: None
         """
+        if len(metrics) == 0 and len(params) == 0 and len(tags) == 0:
+            return
         for metric in metrics:
             _validate_metric(metric.key, metric.value, metric.timestamp, metric.step)
         for param in params:

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -14,7 +14,7 @@ MLFLOW_GIT_BRANCH = "mlflow.source.git.branch"
 MLFLOW_GIT_REPO_URL = "mlflow.source.git.repoURL"
 MLFLOW_PROJECT_ENV = "mlflow.project.env"
 MLFLOW_PROJECT_ENTRY_POINT = "mlflow.project.entryPoint"
-MLFLOW_DOCKER_IMAGE_NAME = "mlflow.docker.image.name"
+MLFLOW_DOCKER_IMAGE_URI = "mlflow.docker.image.uri"
 MLFLOW_DOCKER_IMAGE_ID = "mlflow.docker.image.id"
 
 MLFLOW_DATABRICKS_NOTEBOOK_ID = "mlflow.databricks.notebookID"

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -7,9 +7,9 @@ from databricks_cli.configure.provider import DatabricksConfig
 
 import mlflow
 from mlflow.entities import ViewType
-from mlflow.projects import ExecutionException, _get_docker_tag_name
+from mlflow.projects import ExecutionException, _get_docker_image_uri
 from mlflow.store import file_store
-from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_DOCKER_IMAGE_NAME, \
+from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_DOCKER_IMAGE_URI, \
     MLFLOW_DOCKER_IMAGE_ID
 
 from tests.projects.utils import TEST_DOCKER_PROJECT_DIR
@@ -46,7 +46,7 @@ def test_docker_project_execution(
     assert run.data.metrics == {"some_key": 3}
     exact_expected_tags = {MLFLOW_PROJECT_ENV: "docker"}
     approx_expected_tags = {
-        MLFLOW_DOCKER_IMAGE_NAME: "docker-example",
+        MLFLOW_DOCKER_IMAGE_URI: "docker-example",
         MLFLOW_DOCKER_IMAGE_ID: "sha256:",
     }
     run_tags = run.data.tags
@@ -92,18 +92,18 @@ def test_docker_uri_mode_validation(tracking_uri_mock):  # pylint: disable=unuse
 
 
 @mock.patch('mlflow.projects._get_git_commit')
-def test_docker_tag_name_with_git(get_git_commit_mock):
+def test_docker_image_uri_with_git(get_git_commit_mock):
     get_git_commit_mock.return_value = '1234567890'
-    tag_name = _get_docker_tag_name("my_project", "my_workdir")
-    assert tag_name == "my_project:1234567"
+    image_uri = _get_docker_image_uri("my_project", "my_workdir")
+    assert image_uri == "my_project:1234567"
     get_git_commit_mock.assert_called_with('my_workdir')
 
 
 @mock.patch('mlflow.projects._get_git_commit')
-def test_docker_tag_name_no_git(get_git_commit_mock):
+def test_docker_image_uri_no_git(get_git_commit_mock):
     get_git_commit_mock.return_value = None
-    tag_name = _get_docker_tag_name("my_project", "my_workdir")
-    assert tag_name == "my_project"
+    image_uri = _get_docker_image_uri("my_project", "my_workdir")
+    assert image_uri == "my_project"
     get_git_commit_mock.assert_called_with('my_workdir')
 
 

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -371,7 +371,7 @@ def test_parse_kubernetes_config():
     kubernetes_config = {
         "kube-context": "docker-for-desktop",
         "kube-job-template-path": os.path.join(work_dir, "kubernetes_job_template.yaml"),
-        "image-uri": "dockerhub_account/mlflow-kubernetes-example"
+        "repository-uri": "dockerhub_account/mlflow-kubernetes-example"
     }
     yaml_obj = None
     with open(kubernetes_config["kube-job-template-path"], 'r') as job_template:
@@ -379,13 +379,13 @@ def test_parse_kubernetes_config():
     kube_config = mlflow.projects._parse_kubernetes_config(kubernetes_config)
     assert kube_config["kube-context"] == kubernetes_config["kube-context"]
     assert kube_config["kube-job-template-path"] == kubernetes_config["kube-job-template-path"]
-    assert kube_config["image-uri"] == kubernetes_config["image-uri"]
+    assert kube_config["repository-uri"] == kubernetes_config["repository-uri"]
     assert kube_config["kube-job-template"] == yaml_obj
 
 
 def test_parse_kubernetes_config_without_context():
     kubernetes_config = {
-        "image-uri": "dockerhub_account/mlflow-kubernetes-example",
+        "repository-uri": "dockerhub_account/mlflow-kubernetes-example",
         "kube-job-template-path": "kubernetes_job_template.yaml"
     }
     with pytest.raises(ExecutionException):
@@ -404,7 +404,7 @@ def test_parse_kubernetes_config_without_image_uri():
 def test_parse_kubernetes_config_invalid_template_job_file():
     kubernetes_config = {
         "kube-context": "docker-for-desktop",
-        "image-uri": "username/mlflow-kubernetes-example",
+        "repository-uri": "username/mlflow-kubernetes-example",
         "kube-job-template-path": "file_not_found.yaml"
     }
     with pytest.raises(ExecutionException):

--- a/tests/resources/example_docker_project/kubernetes_config.json
+++ b/tests/resources/example_docker_project/kubernetes_config.json
@@ -1,5 +1,5 @@
 {
     "kube-context": "docker-for-desktop",
     "kube-job-template-path": "examples/docker/kubernetes_job_template.yaml",
-    "image-uri": "username/mlflow-kubernetes-example"
+    "repository-uri": "username/mlflow-kubernetes-example"
 }

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -41,7 +41,8 @@ class TestParseDbUri(unittest.TestCase):
                            'pypostgresql', 'pygresql', 'zxjdbc'),
             'mysql': ('mysqldb', 'pymysql', 'mysqlconnector', 'cymysql',
                       'oursql', 'mysqldb', 'gaerdbms', 'pyodbc', 'zxjdbc'),
-            'mssql': ('pyodbc', 'mxodbc', 'pymssql', 'zxjdbc', 'adodbapi')
+            'mssql': ('pyodbc', 'mxodbc', 'pymssql', 'zxjdbc', 'adodbapi'),
+            'splicemachinesa': ('pyodbc',)
         }
         for target_db_type, drivers in target_db_type_uris.items():
             # try the driver-less version, which will revert SQLAlchemy to the default driver

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -224,6 +224,16 @@ def test_log_batch(tracking_uri_mock, tmpdir):
             assert exact_expected_tags[tag_key] == tag_value
     # Validate params
     assert finished_run.data.params == expected_params
+    # test that log_batch works with fewer params
+    new_tags = {"1": "2", "3": "4", "5": "6"}
+    tags = [RunTag(key=key, value=value) for key, value in new_tags.items()]
+    client.log_batch(run_id=run_id, tags=tags)
+    finished_run_2 = client.get_run(run_id)
+    # Validate tags (for automatically-set tags)
+    assert len(finished_run_2.data.tags) == len(finished_run.data.tags) + 3
+    for tag_key, tag_value in finished_run_2.data.tags.items():
+        if tag_key in new_tags:
+            assert new_tags[tag_key] == tag_value
 
 
 def test_log_metric(tracking_uri_mock):

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -195,6 +195,7 @@ def test_standard_store_registry_with_mocked_entrypoint():
             'mysql',
             'sqlite',
             'mssql',
+            'splicemachinesa',
             'databricks',
             'mock-scheme'
         }


### PR DESCRIPTION
At Splice Machine, we have been using MLFlow extensively (from its very start) as a core component of our MLManager platform. We have contributed support for Splice Machine as a tracking backend for users who would like to use it.

P.S -- sorry for the multiple pull requests... my git was acting up! 

## What changes are proposed in this pull request?

Code:
1. Added Splice Machine Dialect (`splicemachinesa` - https://github.com/splicemachine/splice_sqlachemy) to list of supported dialects (in `mlflow/store/dbmodels/db_types.py`). Our SQLAlchemy driver can be installed via `pip install git+https://github.com/splicemachine/splice_sqlalchemy`

2. Since Alembic on Splice Machine doesn't work out of the box, we added a simple `SpliceMachineImpl` type (in `mlflow/store/db/utils.py`) that uses the underlying `splicemachinesa` dialect to handle Alembic migrations (doesn't interfere with migrations for any other dialect, even if `splicemachinesa` is not installed). This class has to be in the global variable scope everywhere alembic is run-- alembic searches the global scope for these `Impl` subclasses to provide migration support for non-default databases.

3. Added String conversion to posix path in `mlflow/store/sqlalchemy_store.py` because it was not being quoted in Python2.7 (in default experiment creation)-- it is a unicode string in Python 2 and the decorator function only checks if it is of type string before quoting it

## How is this patch tested?

Test:
1. Added Splice Machine dialect to the TestParseDbUri test case (in `mlflow/tests/store/test_sqlalchemy_store.py`)

2. Added Splice Machine dialect to `test_standard_store_registry_with_mocked_entrypoint` test in `mlflow/tests/tracking/test_utils.py `

3. Splice Machine dialect has been extensively tested via its own test cases

(By the way, we have tested Splice Machine SQLAlchemy pretty heavily via MLFlow,
but to test it on your own, we can provide you a cloud cluster (just ask!) or you
can run standalone edition of Splice Machine: <a href="https://github.com/splicemachine/spliceegine">Repository</a> )

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

MLFlow now supports Splice Machine as a supported tracking store. When starting an MLFlow Tracking Server,
the `--backend-store-uri` option can be equal to a URL of the form `splicemachinesa://[user]:[password]@[host]:[port]/[database]`

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [X] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

Thanks so much for building such an awesome platform-- we would love to be a part of its development going forward :)
