### PR TITLE
Added Splice Machine Tracking Backend Support

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -5,8 +5,8 @@ import logging
 from alembic.migration import MigrationContext  # pylint: disable=import-error
 import sqlalchemy
 
-
 _logger = logging.getLogger(__name__)
+
 
 def _get_splicemachine_impl():
     """
@@ -19,6 +19,7 @@ def _get_splicemachine_impl():
 
 
 SpliceMachineImpl = _get_splicemachine_impl()
+
 
 def _get_package_dir():
     """Returns directory containing MLflow python package."""
@@ -40,7 +41,7 @@ def _get_alembic_config(db_url, alembic_dir=None):
     names.
     """
     from alembic.config import Config
-    final_alembic_dir = os.path.join(_get_package_dir(), 'store', 'db_migrations')\
+    final_alembic_dir = os.path.join(_get_package_dir(), 'store', 'db_migrations') \
         if alembic_dir is None else alembic_dir
     config = Config(os.path.join(final_alembic_dir, 'alembic.ini'))
     config.set_main_option('script_location', final_alembic_dir)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -8,6 +8,17 @@ import sqlalchemy
 
 _logger = logging.getLogger(__name__)
 
+def _get_splicemachine_impl():
+    """
+    Return an Alembic Impl so
+    Splice Machine migrations work
+    """
+    from alembic.ddl import impl
+    return type('SpliceMachineImpl', (impl.DefaultImpl, object),
+                {'__dialect__': 'splicemachinesa', 'transactional_ddl': False})
+
+
+SpliceMachineImpl = _get_splicemachine_impl()
 
 def _get_package_dir():
     """Returns directory containing MLflow python package."""

--- a/mlflow/store/db_migrations/env.py
+++ b/mlflow/store/db_migrations/env.py
@@ -6,6 +6,8 @@ from sqlalchemy import pool
 
 from alembic import context
 
+from mlflow.store.db.utils import SpliceMachineImpl
+
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config

--- a/mlflow/store/dbmodels/db_types.py
+++ b/mlflow/store/dbmodels/db_types.py
@@ -6,10 +6,12 @@ POSTGRES = 'postgresql'
 MYSQL = 'mysql'
 SQLITE = 'sqlite'
 MSSQL = 'mssql'
+SPLICE = 'splicemachinesa'
 
 DATABASE_ENGINES = [
     POSTGRES,
     MYSQL,
     SQLITE,
-    MSSQL
+    MSSQL,
+    SPLICE
 ]

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -32,9 +32,12 @@ _logger = logging.getLogger(__name__)
 class SqlAlchemyStore(AbstractStore):
     """
     SQLAlchemy compliant backend store for tracking meta data for MLflow entities. MLflow
-    supports the database dialects ``mysql``, ``mssql``, ``sqlite``, and ``postgresql``.
+    supports the database dialects ``mysql``, ``mssql``, ``sqlite``, ``splicemachinesa`` and
+    ``postgresql``.
+    The Splice Machine dialect can be installed from PyPi: ``pip install splicemachinesa``
+
     As specified in the
-    `SQLAlchemy docs <https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls>`_ ,
+    `SQLAlchemy docs <https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls>`,
     the database URI is expected in the format
     ``<dialect>+<driver>://<username>:<password>@<host>:<port>/<database>``. If you do not
     specify a driver, SQLAlchemy uses a dialect's default driver.
@@ -222,11 +225,10 @@ class SqlAlchemyStore(AbstractStore):
 
         return instance, created
 
-
     def _get_artifact_location(self, experiment_id):
         # python2.7 unicode strings are not decorated properly in SQL
         return str(posixpath.join(self.artifact_root_uri, str(experiment_id)))
-    
+
     def create_experiment(self, name, artifact_location=None):
         if name is None or name == '':
             raise MlflowException('Invalid experiment name', INVALID_PARAMETER_VALUE)

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -222,9 +222,11 @@ class SqlAlchemyStore(AbstractStore):
 
         return instance, created
 
-    def _get_artifact_location(self, experiment_id):
-        return posixpath.join(self.artifact_root_uri, str(experiment_id))
 
+    def _get_artifact_location(self, experiment_id):
+        # python2.7 unicode strings are not decorated properly in SQL
+        return str(posixpath.join(self.artifact_root_uri, str(experiment_id)))
+    
     def create_experiment(self, name, artifact_location=None):
         if name is None or name == '':
             raise MlflowException('Invalid experiment name', INVALID_PARAMETER_VALUE)

--- a/mlflow/temporary_db_migrations_for_pre_1_users/env.py
+++ b/mlflow/temporary_db_migrations_for_pre_1_users/env.py
@@ -6,6 +6,8 @@ from sqlalchemy import pool
 
 from alembic import context
 
+from mlflow.store.db.utils import SpliceMachineImpl
+
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 config = context.config

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -41,7 +41,8 @@ class TestParseDbUri(unittest.TestCase):
                            'pypostgresql', 'pygresql', 'zxjdbc'),
             'mysql': ('mysqldb', 'pymysql', 'mysqlconnector', 'cymysql',
                       'oursql', 'mysqldb', 'gaerdbms', 'pyodbc', 'zxjdbc'),
-            'mssql': ('pyodbc', 'mxodbc', 'pymssql', 'zxjdbc', 'adodbapi')
+            'mssql': ('pyodbc', 'mxodbc', 'pymssql', 'zxjdbc', 'adodbapi'),
+	    'splicemachinesa': ('pyodbc')
         }
         for target_db_type, drivers in target_db_type_uris.items():
             # try the driver-less version, which will revert SQLAlchemy to the default driver

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -42,7 +42,7 @@ class TestParseDbUri(unittest.TestCase):
             'mysql': ('mysqldb', 'pymysql', 'mysqlconnector', 'cymysql',
                       'oursql', 'mysqldb', 'gaerdbms', 'pyodbc', 'zxjdbc'),
             'mssql': ('pyodbc', 'mxodbc', 'pymssql', 'zxjdbc', 'adodbapi'),
-	    'splicemachinesa': ('pyodbc')
+            'splicemachinesa': ('pyodbc',)
         }
         for target_db_type, drivers in target_db_type_uris.items():
             # try the driver-less version, which will revert SQLAlchemy to the default driver

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -195,7 +195,7 @@ def test_standard_store_registry_with_mocked_entrypoint():
             'mysql',
             'sqlite',
             'mssql',
-	    'splicemachinesa',
+            'splicemachinesa',
             'databricks',
             'mock-scheme'
         }

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -195,6 +195,7 @@ def test_standard_store_registry_with_mocked_entrypoint():
             'mysql',
             'sqlite',
             'mssql',
+	    'splicemachinesa',
             'databricks',
             'mock-scheme'
         }


### PR DESCRIPTION
At Splice Machine, we have been using MLFlow extensively (from its very start) as a core component of our MLManager platform. We have contributed support for Splice Machine as a tracking backend for users who would like to use it.

*Again, SO SORRY for so many PRs for the same thing-- `git` is not functioning properly on my computer. Have fixed the issue now.*

## What changes are proposed in this pull request?

Code:
1. Added Splice Machine Dialect (`splicemachinesa` - https://github.com/splicemachine/splice_sqlachemy) to list of supported dialects (in `mlflow/store/dbmodels/db_types.py`). Our SQLAlchemy driver can be installed via `pip install git+https://github.com/splicemachine/splice_sqlalchemy`

2. Since Alembic on Splice Machine doesn't work out of the box, we added a simple `SpliceMachineImpl` type (in `mlflow/store/db/utils.py`) that uses the underlying `splicemachinesa` dialect to handle Alembic migrations (doesn't interfere with migrations for any other dialect, even if `splicemachinesa` is not installed). This class has to be in the global variable scope everywhere alembic is run-- alembic searches the global scope for these `Impl` subclasses to provide migration support for non-default databases.

3. Added String conversion to posix path in `mlflow/store/sqlalchemy_store.py` because it was not being quoted in Python2.7 (in default experiment creation)-- it is a unicode string in Python 2 and the decorator function only checks if it is of type string before quoting it

## How is this patch tested?

Test:
1. Added Splice Machine dialect to the TestParseDbUri test case (in `mlflow/tests/store/test_sqlalchemy_store.py`)

2. Added Splice Machine dialect to `test_standard_store_registry_with_mocked_entrypoint` test in `mlflow/tests/tracking/test_utils.py `

3. Splice Machine dialect has been extensively tested via its own test cases

(By the way, we have tested Splice Machine SQLAlchemy pretty heavily via MLFlow,
but to test it on your own, we can provide you a cloud cluster (just ask!) or you
can run standalone edition of Splice Machine: <a href="https://github.com/splicemachine/spliceegine">Repository</a> )

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

MLFlow now supports Splice Machine as a supported tracking store. When starting an MLFlow Tracking Server,
the `--backend-store-uri` option can be equal to a URL of the form `splicemachinesa://[user]:[password]@[host]:[port]/[database]`

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [X] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

Thanks so much for building such an awesome platform-- we would love to be a part of its development going forward :)