### PR TITLE
Fixing incorrect docs about log_artifacts

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -338,7 +338,7 @@ For example:
 
 .. code-block:: py
 
-  mlflow.tracking.log_artifacts("<mlflow_run_id>", "/path/to/artifact")
+  mlflow.log_artifacts("<mlflow_run_id>", "/path/to/artifact")
   
 .. rubric:: Models API
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
tracking.rst has an example of `mlflow.tracking.log_artifacts` instead of `mlflow.log_artifacts`.
 
## How is this patch tested?
 

 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [X] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
