### PR TITLE
Added support for third-party plugins for MLFlow server

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -49,6 +49,7 @@ _tracking_store_registry.register('file', _get_file_store)
 for scheme in DATABASE_ENGINES:
     _tracking_store_registry.register(scheme, _get_sqlalchemy_store)
 
+_tracking_store_registry.register_entrypoints()
 
 def _get_store(backend_store_uri=None, default_artifact_root=None):
     from mlflow.server import BACKEND_STORE_URI_ENV_VAR, ARTIFACT_ROOT_ENV_VAR

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -51,6 +51,7 @@ for scheme in DATABASE_ENGINES:
 
 _tracking_store_registry.register_entrypoints()
 
+
 def _get_store(backend_store_uri=None, default_artifact_root=None):
     from mlflow.server import BACKEND_STORE_URI_ENV_VAR, ARTIFACT_ROOT_ENV_VAR
     global _store

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -122,6 +122,10 @@ def test_mlflow_server_with_installed_plugin(tmpdir):
         BACKEND_STORE_URI_ENV_VAR: "file-plugin:%s" % tmpdir.strpath,
     }
     with mock.patch.dict(os.environ, env):
-        plugin_file_store = mlflow.server.handlers._get_store()
+        mlflow.server.handlers._store = None
+        try:
+            plugin_file_store = mlflow.server.handlers._get_store()
+        finally:
+            mlflow.server.handlers._store = None
         assert isinstance(plugin_file_store, PluginFileStore)
         assert plugin_file_store.is_plugin

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -3,11 +3,14 @@ import json
 import mock
 import pytest
 
+import os
+import mlflow
 from mlflow.entities import ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, INVALID_PARAMETER_VALUE, ErrorCode
 from mlflow.server.handlers import get_endpoints, _create_experiment, _get_request_message, \
     _search_runs, _log_batch, catch_mlflow_exception
+from mlflow.server import BACKEND_STORE_URI_ENV_VAR
 from mlflow.store.abstract_store import PagedList
 from mlflow.protos.service_pb2 import CreateExperiment, SearchRuns
 from mlflow.utils.validation import MAX_BATCH_LOG_REQUEST_SIZE
@@ -108,3 +111,17 @@ def test_catch_mlflow_exception():
     assert response.status_code == 500
     assert json_response['error_code'] == ErrorCode.Name(INTERNAL_ERROR)
     assert json_response['message'] == 'test error'
+
+
+@pytest.mark.large
+def test_mlflow_server_with_installed_plugin(tmpdir):
+    """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
+    from mlflow_test_plugin import PluginFileStore
+
+    env = {
+        BACKEND_STORE_URI_ENV_VAR: "file-plugin:%s" % tmpdir.strpath,
+    }
+    with mock.patch.dict(os.environ, env):
+        plugin_file_store = mlflow.server.handlers._get_store()
+        assert isinstance(plugin_file_store, PluginFileStore)
+        assert plugin_file_store.is_plugin


### PR DESCRIPTION
## What changes are proposed in this pull request?
- Register third party endpoints in mlflow/server/handlers.py

(Please fill in changes proposed in this fix)

## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Third party Plugins can now be used in the `mlflow server` command

### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [X] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
