### PR TITLE
Make Page interface public

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/Page.java
@@ -3,7 +3,7 @@ package org.mlflow.tracking;
 import java.lang.Iterable;
 import java.util.Optional;
 
-interface Page<E> {
+public interface Page<E> {
 
   /**
    * @return The number of elements in this page.


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Making the Page interface in the Java client public. This is necessary since `RunsPage`'s `getNextPage()` method returns a `Page` that could be a `RunsPage` or an `EmptyPage`.
## How is this patch tested?

Unit tests
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [x] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
