### PR TITLE
Updated environment variables used in R client.

### DIFF
--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -100,7 +100,7 @@ get_env_var <- function(x) {
     old_name <- paste("MLFLOW_", x, sep="")
     res <- Sys.getenv(old_name, NA)
     if (!is.na(res)) {
-      warning(paste("'", old_name, "' is deprectaed. Please use '", new_name, "' instead."), sep="")
+      warning(paste("'", old_name, "' is deprecated. Please use '", new_name, "' instead."), sep="")
     }
   }
   res

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -101,7 +101,7 @@ get_env_var <- function(x) {
     res <- Sys.getenv(old_name, NA)
     if (!is.na(res)) {
       warning(paste("'", old_name, "' is deprecated. Please use '", new_name, "' instead."),
-                    sep= "" )
+                    sepc = "" )
     }
   }
   res

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -94,13 +94,14 @@ new_mlflow_client.default <- function(tracking_uri) {
 }
 
 get_env_var <- function(x) {
-  new_name <- paste("MLFLOW_TRACKING_", x, sep="")
+  new_name <- paste("MLFLOW_TRACKING_", x, sep = "")
   res <- Sys.getenv(new_name, NA)
   if (is.na(res)) {
-    old_name <- paste("MLFLOW_", x, sep="")
+    old_name <- paste("MLFLOW_", x, sep = "")
     res <- Sys.getenv(old_name, NA)
     if (!is.na(res)) {
-      warning(paste("'", old_name, "' is deprecated. Please use '", new_name, "' instead."), sep="")
+      warning(paste("'", old_name, "' is deprecated. Please use '", new_name, "' instead."),
+                    sep= "" )
     }
   }
   res

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -93,23 +93,37 @@ new_mlflow_client.default <- function(tracking_uri) {
   stop(paste("Unsupported scheme: '", tracking_uri$scheme, "'", sep = ""))
 }
 
+get_env_var <- function(x) {
+  new_name <- paste("MLFLOW_TRACKING_", x, sep="")
+  res <- Sys.getenv(new_name, NA)
+  if (is.na(res)) {
+    old_name <- paste("MLFLOW_", x, sep="")
+    res <- Sys.getenv(old_name, NA)
+    if (!is.na(res)) {
+      warning(paste("'", old_name, "' is deprectaed. Please use '", new_name, "' instead."), sep="")
+    }
+  }
+  res
+}
+
 basic_http_client <- function(tracking_uri) {
   host <- paste(tracking_uri$scheme, tracking_uri$path, sep = "://")
   get_host_creds <- function () {
     new_mlflow_host_creds(
       host = host,
-      username = Sys.getenv("MLFLOW_USERNAME", NA),
-      password = Sys.getenv("MLFLOW_PASSWORD", NA),
-      token = Sys.getenv("MLFLOW_TOKEN", NA),
-      insecure = Sys.getenv("MLFLOW_INSECURE", NA)
+      username = get_env_var("USERNAME"),
+      password = get_env_var("PASSWORD"),
+      token = get_env_var("TOKEN"),
+      insecure = get_env_var("INSECURE")
     )
   }
   cli_env <- function() {
+    creds <- get_host_creds()
     res <- list(
-      MLFLOW_USERNAME = Sys.getenv("MLFLOW_USERNAME", NA),
-      MLFLOW_PASSWORD = Sys.getenv("MLFLOW_PASSWORD", NA),
-      MLFLOW_TOKEN = Sys.getenv("MLFLOW_TOKEN", NA),
-      MLFLOW_INSECURE = Sys.getenv("MLFLOW_INSECURE", NA)
+      MLFLOW_TRACKING_USERNAME = creds$username,
+      MLFLOW_TRACKING_PASSWORD = creds$password,
+      MLFLOW_TRACKING_TOKEN = creds$token,
+      MLFLOW_TRACKING_INSECURE = creds$insecure
     )
     res[!is.na(res)]
   }

--- a/mlflow/R/mlflow/tests/testthat/test-client.R
+++ b/mlflow/R/mlflow/tests/testthat/test-client.R
@@ -9,10 +9,10 @@ test_that("http(s) clients work as expected", {
   }, {
     with_mock(.env = "mlflow", mlflow_register_local_server = function(...) NA, {
       env <- list(
-        MLFLOW_USERNAME = "DonaldDuck",
-        MLFLOW_PASSWORD = "Quack",
-        MLFLOW_TOKEN = "$$$",
-        MLFLOW_INSECURE = "True"
+        MLFLOW_TRACKING_USERNAME = "DonaldDuck",
+        MLFLOW_TRACKING_PASSWORD = "Quack",
+        MLFLOW_TRACKING_TOKEN = "$$$",
+        MLFLOW_TRACKING_INSECURE = "True"
       )
       with_envvar(env, {
         http_host <- "http://remote"
@@ -32,6 +32,54 @@ test_that("http(s) clients work as expected", {
         env_str_2 <- paste(client2$get_cli_env(), collapse = "|")
         expect_true(env_str == env_str_2)
       })
+      with_mock(.env = "mlflow", mlflow_server = function(...) list(server_url = "local_server"), {
+        client3 <- mlflow:::mlflow_client()
+        config <- client3$get_host_creds()
+        expect_true(config$host == "local_server")
+      })
+    })
+  })
+})
+
+
+test_that("http(s) clients works with deprecated env vars", {
+  mlflow_clear_test_dir("mlruns")
+  with_mock(.env = "mlflow", mlflow_rest = function(..., client) {
+    args <- list(...)
+    expect_true(paste(args, collapse = "/") == "experiments/list")
+    list(experiments = c(1, 2, 3))
+  }, {
+    with_mock(.env = "mlflow", mlflow_register_local_server = function(...) NA, {
+      env <- list(
+        MLFLOW_USERNAME = "DonaldDuck",
+        MLFLOW_PASSWORD = "Quack",
+        MLFLOW_TOKEN = "$$$",
+        MLFLOW_INSECURE = "True"
+      )
+      with_envvar(env, {
+        http_host <- "http://remote"
+        client1 <- mlflow:::mlflow_client(http_host)
+        config <- client1$get_host_creds()
+        print(config)
+        expect_true(config$host == http_host)
+        expect_true(config$username == "DonaldDuck")
+        expect_true(config$password == "Quack")
+        expect_true(config$token == "$$$")
+        expect_true(config$insecure == "True")
+        https_host <- "https://remote"
+        client2 <- mlflow:::mlflow_client("https://remote")
+        config <- client2$get_host_creds()
+        expect_true(config$host == https_host)
+        env_str <- paste(list(
+          MLFLOW_TRACKING_USERNAME = "DonaldDuck",
+          MLFLOW_TRACKING_PASSWORD = "Quack",
+          MLFLOW_TRACKING_TOKEN = "$$$",
+          MLFLOW_TRACKING_INSECURE = "True"
+        ), collapse = "|")
+        env_str_2 <- paste(client2$get_cli_env(), collapse = "|")
+        expect_true(env_str == env_str_2)
+      })
+
       with_mock(.env = "mlflow", mlflow_server = function(...) list(server_url = "local_server"), {
         client3 <- mlflow:::mlflow_client()
         config <- client3$get_host_creds()


### PR DESCRIPTION
## What changes are proposed in this pull request?
This fixes #1593. 
Update environment variables used in R http client to match those in python. 
The old variables still work but are now deprecated (Mlflow will print warning).
 
## How is this patch tested?
Updated existing unit tests to check that both new and old (deprecated) variables work.
 
## Release Notes
 The environment variables used in R client to read tracking server credentials have been updated to match the variables used in python. For example, MLFLOW_USERNAME is now MLFLOW_TRACKING_USERNAME. The old variables still work but are now deprecated. 

### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [x] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
