### PR TITLE
Prevent an infinite loop in download_artifacts

### DIFF
--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -74,7 +74,7 @@ class ArtifactRepository:
         """
 
         # TODO: Probably need to add a more efficient method to stream just a single artifact
-        # without downloading it, or to get a pre-signed URL for cloud storage.
+        #       without downloading it, or to get a pre-signed URL for cloud storage.
 
         def download_artifacts_into(artifact_path, dest_dir):
             basename = posixpath.basename(artifact_path)

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -85,6 +85,9 @@ class ArtifactRepository:
                 if not os.path.exists(local_path):
                     os.mkdir(local_path)
                 for file_info in listing:
+                    # prevent an infinite loop (sometimes the current path is listed e.g. as “.”)
+                    if file_info.path == "." or file_info.path == artifact_path:
+                        continue
                     download_artifacts_into(artifact_path=file_info.path, dest_dir=local_path)
             else:
                 self._download_file(remote_file_path=artifact_path, local_path=local_path)

--- a/mlflow/store/artifact_repo.py
+++ b/mlflow/store/artifact_repo.py
@@ -85,7 +85,7 @@ class ArtifactRepository:
                 if not os.path.exists(local_path):
                     os.mkdir(local_path)
                 for file_info in listing:
-                    # prevent an infinite loop (sometimes the current path is listed e.g. as “.”)
+                    # prevent an infinite loop (sometimes the current path is listed e.g. as ".")
                     if file_info.path == "." or file_info.path == artifact_path:
                         continue
                     download_artifacts_into(artifact_path=file_info.path, dest_dir=local_path)

--- a/tests/store/test_artifact_repo.py
+++ b/tests/store/test_artifact_repo.py
@@ -1,0 +1,41 @@
+import mock
+import pytest
+
+from mlflow.entities import FileInfo
+from mlflow.store.artifact_repo import ArtifactRepository
+
+
+class ArtifactRepositoryImpl(ArtifactRepository):
+
+    def log_artifact(self, local_file, artifact_path=None):
+        raise NotImplementedError()
+
+    def log_artifacts(self, local_dir, artifact_path=None):
+        raise NotImplementedError()
+
+    def list_artifacts(self, path):
+        raise NotImplementedError()
+
+    def _download_file(self, remote_file_path, local_path):
+        print("download_file called with ", remote_file_path)
+
+
+@pytest.mark.parametrize("base_uri, download_arg, list_return_val, expected_args", [
+    ('12345/model', '', ['modelfile'], ['modelfile']),
+    ('12345/model', '', ['.', 'modelfile'], ['modelfile']),
+    ('12345', 'model', ['model/modelfile'], ['model/modelfile']),
+    ('12345', 'model', ['model', 'model/modelfile'], ['model/modelfile']),
+    ('', '12345/model', ['12345/model/modelfile'], ['12345/model/modelfile']),
+    ('', '12345/model', ['12345/model', '12345/model/modelfile'], ['12345/model/modelfile']),
+])
+def test_download_artifacts_does_not_infinitely_loop(base_uri, download_arg, list_return_val, expected_args):
+
+    def list_artifacts_mock(self, path):
+        if path.endswith("model"):
+            return [FileInfo(item, False, 123) for item in list_return_val]
+        else:
+            return []
+
+    with mock.patch.object(ArtifactRepositoryImpl, "list_artifacts", new_callable=lambda: list_artifacts_mock):
+        repo = ArtifactRepositoryImpl(base_uri)
+        repo.download_artifacts(download_arg)

--- a/tests/store/test_artifact_repo.py
+++ b/tests/store/test_artifact_repo.py
@@ -28,7 +28,8 @@ class ArtifactRepositoryImpl(ArtifactRepository):
     ('', '12345/model', ['12345/model/modelfile'], ['12345/model/modelfile']),
     ('', '12345/model', ['12345/model', '12345/model/modelfile'], ['12345/model/modelfile']),
 ])
-def test_download_artifacts_does_not_infinitely_loop(base_uri, download_arg, list_return_val, expected_args):
+def test_download_artifacts_does_not_infinitely_loop(base_uri, download_arg, list_return_val,
+                                                     expected_args):
 
     def list_artifacts_mock(self, path):
         if path.endswith("model"):
@@ -36,6 +37,7 @@ def test_download_artifacts_does_not_infinitely_loop(base_uri, download_arg, lis
         else:
             return []
 
-    with mock.patch.object(ArtifactRepositoryImpl, "list_artifacts", new_callable=lambda: list_artifacts_mock):
+    with mock.patch.object(ArtifactRepositoryImpl, "list_artifacts",
+                           new_callable=lambda: list_artifacts_mock):
         repo = ArtifactRepositoryImpl(base_uri)
         repo.download_artifacts(download_arg)


### PR DESCRIPTION
## What changes are proposed in this pull request?

With some data stores, `ArtifactRepository.list_artifacts` returns the current path in addition to its children. This was reported in https://github.com/mlflow/mlflow/issues/1458 and https://github.com/mlflow/mlflow/pull/1524 proposes to fix it for S3. This is an alternative solution that will hopefully prevent problems with any other artifact stores. 
 
## How is this patch tested?

- [X] Unit tests

Added unit tests though it only tests the cases we know about so far. Ultimately we should have integration tests for all stores.
 
- [X] Manual Testing

1. log keras model to S3 via dbfs (in Databricks) as described in https://github.com/mlflow/mlflow/issues/1458
2. load the model via `S3ArtifactRepository` by 
```
>>> import mlflow
>>> mlflow.keras.load_model("s3://<bucket-name>/path/to/model")
```
3. also tried loading directly using artifact repository:
```
>>> from mlflow.store.artifact_repository_registry import get_artifact_repository
>>> repo = get_artifact_repository("s3://<bucket-name>/path/to/model")
>>> repo.download_artifacts("")      # then check the contents
'/var/folders/_j/d0nth8_1305g9p0zbbnjj_mw0000gp/T/tmp__vercnt/'
>>> 
>>> repo2 = get_artifact_repository("s3://<bucket-name>/path/to")
>>> repo2.download_artifacts("model")      # then check the contents
'/var/folders/_j/d0nth8_1305g9p0zbbnjj_mw0000gp/T/tmpkcs_tapk/model'
>>> 
>>> repo3 = get_artifact_repository("s3://<bucket-name>/")
>>> repo3.download_artifacts("path/to/model")      # then check the contents
'/var/folders/_j/d0nth8_1305g9p0zbbnjj_mw0000gp/T/tmp4ooxruai/20190716T231126'
```
 
## Release Notes
 
### Is this a user-facing change? 

- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Fixes an infinite loop in downloading artifacts logged via dbfs and retrieved via S3.
 
### What component(s) does this PR affect?
 
- [X] API 
- [X] Artifacts 
- [X] Models 

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
