### PR TITLE
Fix OSS docs build bug

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -72,7 +72,7 @@ rsthtml:
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 .PHONY: html
-html: javadocs rdocs rsthtml
+html: rdocs rsthtml javadocs
 
 .PHONY: dirhtml
 dirhtml:

--- a/docs/build-javadoc.sh
+++ b/docs/build-javadoc.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Builds the MLflow Javadoc and places it into build/html/java_api/
 
 set -ex


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fixes bug where running `make html` to build the OSS docs would result in the removal of Javadocs by
the R doc build, which deletes the `docs/build` directory ([link](https://github.com/mlflow/mlflow/blob/e81ddbb5f2b35c29e2ba8d3bb1c49c7857398ef4/mlflow/R/mlflow/document.R#L27)) so that Sphinx docs aren't mistakenly included in the R docs. The fix for now is to run the R build first.
 
## How is this patch tested?
 
Manual test
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
