### PR TITLE
Change default empty tuple arguments to None

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -187,7 +187,7 @@ class MlflowClient(object):
         """
         self.store.delete_tag(run_id, key)
 
-    def log_batch(self, run_id, metrics=(), params=(), tags=()):
+    def log_batch(self, run_id, metrics=None, params=None, tags=None):
         """
         Log multiple metrics, params, and/or tags.
 
@@ -199,6 +199,13 @@ class MlflowClient(object):
         Raises an MlflowException if any errors occur.
         :return: None
         """
+        if metrics is None:
+            metrics = []
+        if params is None:
+            params = []
+        if tags is None:
+            # intentional bug. lets see if tests pass
+            params = []
         if len(metrics) == 0 and len(params) == 0 and len(tags) == 0:
             return
         for metric in metrics:

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -338,7 +338,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             else:
                 self.assertEqual(v, v2)
 
-    def _get_run_configs(self, experiment_id=None, tags=(), start_time=None):
+    def _get_run_configs(self, experiment_id=None, tags=None, start_time=None):
+        if tags is None:
+            tags = []
         return {
             'experiment_id': experiment_id,
             'user_id': 'Anderson',


### PR DESCRIPTION
## What changes are proposed in this pull request?
 As discussed offline, we should have default empty list arguments be equal to None and substitute the empty list in the body of the function. 

https://stackoverflow.com/questions/1132941/least-astonishment-and-the-mutable-default-argument/34172768#34172768

 
## How is this patch tested?
 
(Details)
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
