### PR TITLE
Correctly display "permission denied" view in UI

### DIFF
--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -50,7 +50,11 @@ export class ExperimentPage extends Component {
     const orderBy = ExperimentPage.getOrderByExpr(orderByKey, orderByAsc);
     const viewType = lifecycleFilterToRunViewType(lifecycleFilter);
 
-    this.props.getExperimentApi(experimentId, this.getExperimentRequestId);
+    this.props
+      .getExperimentApi(experimentId, this.getExperimentRequestId)
+      .catch((e) => {
+        console.error(e);
+      });
     this.props
       .searchRunsApi([experimentId], searchInput, viewType, orderBy, this.searchRunsRequestId)
       .then(this.updateNextPageToken)
@@ -220,7 +224,7 @@ export class ExperimentPage extends Component {
     }
   }
 
-  renderExperimentView = ({isLoading, shouldRenderError, requests}) => {
+  renderExperimentView = (isLoading, shouldRenderError, requests) => {
     let searchRunsError;
     const getExperimentRequest = Utils.getRequestWithId(
       requests, this.getExperimentRequestId);

--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -231,13 +231,12 @@ export class ExperimentPage extends Component {
             if (shouldRenderError) {
               const searchRunsRequest = Utils.getRequestWithId(
                 requests, this.searchRunsRequestId);
-              if (searchRunsRequest.error) {
-                searchRunsError = searchRunsRequest.error.getMessageField();
-              } else if (getExperimentRequest.error.getErrorCode() ===
-                  ErrorCodes.PERMISSION_DENIED) {
+              if (getExperimentRequest.error.getErrorCode() === ErrorCodes.PERMISSION_DENIED) {
                 return (<PermissionDeniedView
                   errorMessage={getExperimentRequest.error.xhr.responseJSON.message}
                 />);
+              } else if (searchRunsRequest.error) {
+                searchRunsError = searchRunsRequest.error.getMessageField();
               } else {
                 return undefined;
               }

--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -220,48 +220,51 @@ export class ExperimentPage extends Component {
     }
   }
 
+  renderExperimentView = ({isLoading, shouldRenderError, requests}) => {
+    let searchRunsError;
+    const getExperimentRequest = Utils.getRequestWithId(
+      requests, this.getExperimentRequestId);
+
+    if (shouldRenderError) {
+      const searchRunsRequest = Utils.getRequestWithId(
+        requests, this.searchRunsRequestId);
+      if (getExperimentRequest.error.getErrorCode() === ErrorCodes.PERMISSION_DENIED) {
+        return (<PermissionDeniedView
+          errorMessage={getExperimentRequest.error.getMessageField()}
+        />);
+      } else if (searchRunsRequest.error) {
+        searchRunsError = searchRunsRequest.error.getMessageField();
+      } else {
+        return undefined;
+      }
+    }
+    if (!getExperimentRequest || getExperimentRequest.active) {
+      return <Spinner/>;
+    }
+
+    return <ExperimentView
+      paramKeyFilter={new KeyFilter(this.state.persistedState.paramKeyFilterString)}
+      metricKeyFilter={new KeyFilter(this.state.persistedState.metricKeyFilterString)}
+      experimentId={this.props.experimentId}
+      searchRunsRequestId={this.searchRunsRequestId}
+      lifecycleFilter={this.state.lifecycleFilter}
+      onSearch={this.onSearch}
+      searchRunsError={searchRunsError}
+      searchInput={this.state.persistedState.searchInput}
+      isLoading={isLoading && !searchRunsError}
+      orderByKey={this.state.persistedState.orderByKey}
+      orderByAsc={this.state.persistedState.orderByAsc}
+      nextPageToken={this.state.nextPageToken}
+      handleLoadMoreRuns={this.handleLoadMoreRuns}
+      loadingMore={this.state.loadingMore}
+    />;
+  }
+
   render() {
     return (
       <div className="ExperimentPage runs-table-flex-container" style={{height: "100%"}}>
         <RequestStateWrapper shouldOptimisticallyRender requestIds={this.getRequestIds()}>
-          {(isLoading, shouldRenderError, requests) => {
-            let searchRunsError;
-            const getExperimentRequest = Utils.getRequestWithId(
-              requests, this.getExperimentRequestId);
-            if (shouldRenderError) {
-              const searchRunsRequest = Utils.getRequestWithId(
-                requests, this.searchRunsRequestId);
-              if (getExperimentRequest.error.getErrorCode() === ErrorCodes.PERMISSION_DENIED) {
-                return (<PermissionDeniedView
-                  errorMessage={getExperimentRequest.error.xhr.responseJSON.message}
-                />);
-              } else if (searchRunsRequest.error) {
-                searchRunsError = searchRunsRequest.error.getMessageField();
-              } else {
-                return undefined;
-              }
-            }
-            if (!getExperimentRequest || getExperimentRequest.active) {
-              return <Spinner/>;
-            }
-
-            return <ExperimentView
-              paramKeyFilter={new KeyFilter(this.state.persistedState.paramKeyFilterString)}
-              metricKeyFilter={new KeyFilter(this.state.persistedState.metricKeyFilterString)}
-              experimentId={this.props.experimentId}
-              searchRunsRequestId={this.searchRunsRequestId}
-              lifecycleFilter={this.state.lifecycleFilter}
-              onSearch={this.onSearch}
-              searchRunsError={searchRunsError}
-              searchInput={this.state.persistedState.searchInput}
-              isLoading={isLoading && !searchRunsError}
-              orderByKey={this.state.persistedState.orderByKey}
-              orderByAsc={this.state.persistedState.orderByAsc}
-              nextPageToken={this.state.nextPageToken}
-              handleLoadMoreRuns={this.handleLoadMoreRuns}
-              loadingMore={this.state.loadingMore}
-            />;
-          }}
+          {this.renderExperimentView}
         </RequestStateWrapper>
       </div>
     );

--- a/mlflow/server/js/src/components/ExperimentPage.test.js
+++ b/mlflow/server/js/src/components/ExperimentPage.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import qs from 'qs';
 import { shallow } from 'enzyme';
+import ErrorCodes from '../sdk/ErrorCodes';
 import { ExperimentPage } from './ExperimentPage';
 import { ViewType } from '../sdk/MlflowEnums';
 
@@ -105,6 +106,17 @@ test('Loading state with all URL params', () => {
   expect(state.persistedState.searchInput).toEqual("c");
   expect(state.persistedState.orderByKey).toEqual("d");
   expect(state.persistedState.orderByAsc).toEqual(false);
+});
+
+test('should render permission denied view when getExperiment yields permission error', () => {
+  getExperimentApi = jest.fn(() => Promise.resolve({
+    error_code: ErrorCodes.PERMISSION_DENIED,
+    message: "User 'corey.zumar@databricks.com' does not have permission to 'View' experiment with id 772"
+  }));
+  const wrapper = getExperimentPageMock();
+  const instance = wrapper.instance();
+  const rendered = instance.render();
+  console.log(rendered.props.children[0]);
 });
 
 test('should update next page token initially', () => {

--- a/mlflow/server/js/src/components/ExperimentPage.test.js
+++ b/mlflow/server/js/src/components/ExperimentPage.test.js
@@ -2,7 +2,9 @@ import React from 'react';
 import qs from 'qs';
 import { shallow } from 'enzyme';
 import ErrorCodes from '../sdk/ErrorCodes';
+import { ErrorWrapper } from '../Actions';
 import { ExperimentPage } from './ExperimentPage';
+import PermissionDeniedView from "./PermissionDeniedView";
 import { ViewType } from '../sdk/MlflowEnums';
 
 
@@ -109,14 +111,28 @@ test('Loading state with all URL params', () => {
 });
 
 test('should render permission denied view when getExperiment yields permission error', () => {
-  getExperimentApi = jest.fn(() => Promise.resolve({
-    error_code: ErrorCodes.PERMISSION_DENIED,
-    message: "User 'corey.zumar@databricks.com' does not have permission to 'View' experiment with id 772"
-  }));
   const wrapper = getExperimentPageMock();
   const instance = wrapper.instance();
-  const rendered = instance.render();
-  console.log(rendered.props.children[0]);
+  const searchRunsErrorRequest = {
+    id: instance.searchRunsRequestId,
+    active: false,
+    error: new ErrorWrapper({
+      responseText: `{"error_code": "${ErrorCodes.PERMISSION_DENIED}"}`
+    })
+  };
+  const getExperimentErrorRequest = {
+    id: instance.getExperimentRequestId,
+    active: false,
+    error: new ErrorWrapper({
+      responseText: `{"error_code": "${ErrorCodes.PERMISSION_DENIED}", "message": "Access denied"}`,
+    })
+  };
+  const experimentView = shallow(instance.renderExperimentView({
+    isLoading: false,
+    shouldRenderError: true,
+    requests: [searchRunsErrorRequest, getExperimentErrorRequest]
+  }));
+  expect(experimentView.instance()).toBeInstanceOf(PermissionDeniedView);
 });
 
 test('should update next page token initially', () => {

--- a/mlflow/server/js/src/components/ExperimentPage.test.js
+++ b/mlflow/server/js/src/components/ExperimentPage.test.js
@@ -111,23 +111,22 @@ test('Loading state with all URL params', () => {
 });
 
 test('should render permission denied view when getExperiment yields permission error', () => {
-  const wrapper = getExperimentPageMock();
-  const instance = wrapper.instance();
+  const experimentPageInstance = getExperimentPageMock().instance();
   const searchRunsErrorRequest = {
-    id: instance.searchRunsRequestId,
+    id: experimentPageInstance.searchRunsRequestId,
     active: false,
     error: new ErrorWrapper({
       responseText: `{"error_code": "${ErrorCodes.PERMISSION_DENIED}"}`
     })
   };
   const getExperimentErrorRequest = {
-    id: instance.getExperimentRequestId,
+    id: experimentPageInstance.getExperimentRequestId,
     active: false,
     error: new ErrorWrapper({
       responseText: `{"error_code": "${ErrorCodes.PERMISSION_DENIED}", "message": "Access denied"}`,
     })
   };
-  const experimentView = shallow(instance.renderExperimentView({
+  const experimentView = shallow(experimentPageInstance.renderExperimentView({
     isLoading: false,
     shouldRenderError: true,
     requests: [searchRunsErrorRequest, getExperimentErrorRequest]

--- a/mlflow/server/js/src/components/ExperimentPage.test.js
+++ b/mlflow/server/js/src/components/ExperimentPage.test.js
@@ -126,11 +126,11 @@ test('should render permission denied view when getExperiment yields permission 
     active: false,
     error: responseErrorWrapper,
   };
-  const experimentViewInstance = shallow(experimentPageInstance.renderExperimentView({
-    isLoading: false,
-    shouldRenderError: true,
-    requests: [searchRunsErrorRequest, getExperimentErrorRequest],
-  })).instance();
+  const experimentViewInstance = shallow(experimentPageInstance.renderExperimentView(
+    false,
+    true,
+    [searchRunsErrorRequest, getExperimentErrorRequest],
+  )).instance();
   expect(experimentViewInstance).toBeInstanceOf(PermissionDeniedView);
   expect(experimentViewInstance.props.errorMessage).toEqual(errorMessage);
 });

--- a/mlflow/server/js/src/components/ExperimentPage.test.js
+++ b/mlflow/server/js/src/components/ExperimentPage.test.js
@@ -112,26 +112,27 @@ test('Loading state with all URL params', () => {
 
 test('should render permission denied view when getExperiment yields permission error', () => {
   const experimentPageInstance = getExperimentPageMock().instance();
+  const errorMessage = "Access Denied";
+  const responseErrorWrapper = new ErrorWrapper({
+    responseText: `{"error_code": "${ErrorCodes.PERMISSION_DENIED}", "message": "${errorMessage}"}`
+  });
   const searchRunsErrorRequest = {
     id: experimentPageInstance.searchRunsRequestId,
     active: false,
-    error: new ErrorWrapper({
-      responseText: `{"error_code": "${ErrorCodes.PERMISSION_DENIED}"}`
-    })
+    error: responseErrorWrapper,
   };
   const getExperimentErrorRequest = {
     id: experimentPageInstance.getExperimentRequestId,
     active: false,
-    error: new ErrorWrapper({
-      responseText: `{"error_code": "${ErrorCodes.PERMISSION_DENIED}", "message": "Access denied"}`,
-    })
+    error: responseErrorWrapper,
   };
-  const experimentView = shallow(experimentPageInstance.renderExperimentView({
+  const experimentViewInstance = shallow(experimentPageInstance.renderExperimentView({
     isLoading: false,
     shouldRenderError: true,
-    requests: [searchRunsErrorRequest, getExperimentErrorRequest]
-  }));
-  expect(experimentView.instance()).toBeInstanceOf(PermissionDeniedView);
+    requests: [searchRunsErrorRequest, getExperimentErrorRequest],
+  })).instance();
+  expect(experimentViewInstance).toBeInstanceOf(PermissionDeniedView);
+  expect(experimentViewInstance.props.errorMessage).toEqual(errorMessage);
 });
 
 test('should update next page token initially', () => {


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
When loading the page for a particular experiment, the UI issues a `searchRuns` request and a `getExperiment` request. Currently, error handling logic for the `searchRuns` API response prevents the page from checking for the `PERMISSION_DENIED` error code; as a result, users do not see the Permission Denied page when attempting to access experiments without adequate permissions.

This PR adjusts the error handling logic to fix this issue and includes a test to prevent reoccurrence.
 
## How is this patch tested?
 
UI unit tests
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

This is a user-facing change, but it is unlikely to impact most users. We should classify this as a small UI fix.

### What component(s) does this PR affect?
 
- [X] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
