### PR TITLE
Python auto-pagination: allow token to be None

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -400,7 +400,7 @@ def _get_paginated_runs(experiment_ids, filter_string, run_view_type, max_result
             runs = MlflowClient().search_runs(experiment_ids, filter_string, run_view_type,
                                               NUM_RUNS_PER_PAGE_PANDAS, order_by, next_page_token)
         all_runs.extend(runs)
-        if hasattr(runs, 'token') and runs.token != '':
+        if hasattr(runs, 'token') and runs.token != '' and runs.token != None:
             next_page_token = runs.token
         else:
             break

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -400,7 +400,7 @@ def _get_paginated_runs(experiment_ids, filter_string, run_view_type, max_result
             runs = MlflowClient().search_runs(experiment_ids, filter_string, run_view_type,
                                               NUM_RUNS_PER_PAGE_PANDAS, order_by, next_page_token)
         all_runs.extend(runs)
-        if hasattr(runs, 'token') and runs.token != '' and runs.token != None:
+        if hasattr(runs, 'token') and runs.token != '' and runs.token is not None:
             next_page_token = runs.token
         else:
             break

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -399,7 +399,7 @@ def test_search_runs_data():
 
 
 def test_search_runs_no_arguments():
-    """"
+    """
     When no experiment ID is specified, it should try to get the implicit one or
     create a new experiment
     """
@@ -416,7 +416,7 @@ def test_search_runs_no_arguments():
 
 
 def test_get_paginated_runs_lt_maxresults_onepage():
-    """"
+    """
     Number of runs is less than max_results and fits on one page,
     so we only need to fetch one page.
     """
@@ -431,7 +431,7 @@ def test_get_paginated_runs_lt_maxresults_onepage():
 
 
 def test_get_paginated_runs_lt_maxresults_multipage():
-    """"
+    """
     Number of runs is less than max_results, but multiple pages are necessary to get all runs
     """
     tokenized_runs = PagedList([create_run() for i in range(10)], "token")
@@ -445,6 +445,20 @@ def test_get_paginated_runs_lt_maxresults_multipage():
             paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None)
             assert len(paginated_runs) == TOTAL_RUNS
 
+
+def test_get_paginated_runs_lt_maxresults_onepage_nonetoken():
+    """
+    Number of runs is less than max_results and fits on one page.
+    The token passed back on the last page is None, not the emptystring
+    """
+    runs = [create_run() for i in range(5)]
+    tokenized_runs = PagedList(runs, None)
+    max_results = 50
+    with mock.patch("mlflow.tracking.fluent.NUM_RUNS_PER_PAGE_PANDAS", 10):
+        with mock.patch.object(MlflowClient, "search_runs", return_value=tokenized_runs):
+            paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None)
+            MlflowClient.search_runs.assert_called_once()
+            assert len(paginated_runs) == 5
 
 def test_get_paginated_runs_eq_maxresults_blanktoken():
     """

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -460,6 +460,7 @@ def test_get_paginated_runs_lt_maxresults_onepage_nonetoken():
             MlflowClient.search_runs.assert_called_once()
             assert len(paginated_runs) == 5
 
+
 def test_get_paginated_runs_eq_maxresults_blanktoken():
     """
     Runs returned are equal to max_results which are equal to a full number of pages.


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
This patch allows the `token` attribute of the list returned from Python tracking module's `search_runs()` method to be `None`. The behavior in this case as it related to auto-pagination is that this should be treated as the last page of runs available, and no more pages should be requested. 
 
## How is this patch tested?
 
Unit tests
Tested by building a wheel and trying on Databricks
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
