### PR TITLE
[Easy] doc fix for project cli option name change

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -371,7 +371,7 @@ for your run. Then, run your project using the command
 
 .. code-block:: bash
 
-  mlflow run <project_uri> -m databricks --cluster-spec <json-cluster-spec>
+  mlflow run <project_uri> -b databricks --backend-config <json-cluster-spec>
 
 where ``<project_uri>`` is a Git repository URI or a folder.
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Just a small fix in the docs since `--mode` was renamed to `--backend`, etc.
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
