### PR TITLE
Pass Configuration to Tracking Store

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -10,7 +10,6 @@ from click import UsageError
 
 import mlflow.azureml.cli
 import mlflow.projects as projects
-import mlflow.data
 import mlflow.experiments
 import mlflow.models.cli
 
@@ -237,8 +236,11 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
               help="Additional command line options forwarded to gunicorn processes.")
 @click.option("--waitress-opts", default=None,
               help="Additional command line options for waitress-serve.")
+@click.option("--store-opts", default=None,
+              help="Additional options for the tracking store.")
 def server(backend_store_uri, default_artifact_root, host, port,
-           workers, static_prefix, gunicorn_opts, waitress_opts):
+           workers, static_prefix, gunicorn_opts, waitress_opts,
+           store_opts):
     """
     Run the MLflow tracking server.
 
@@ -262,7 +264,7 @@ def server(backend_store_uri, default_artifact_root, host, port,
             sys.exit(1)
 
     try:
-        _get_store(backend_store_uri, default_artifact_root)
+        _get_store(backend_store_uri, default_artifact_root, store_opts)
     except Exception as e:  # pylint: disable=broad-except
         _logger.error("Error initializing backend store")
         _logger.exception(e)
@@ -270,7 +272,7 @@ def server(backend_store_uri, default_artifact_root, host, port,
 
     try:
         _run_server(backend_store_uri, default_artifact_root, host, port,
-                    static_prefix, workers, gunicorn_opts, waitress_opts)
+                    static_prefix, workers, gunicorn_opts, waitress_opts, store_opts)
     except ShellCommandException:
         eprint("Running the mlflow server failed. Please see the logs above for details.")
         sys.exit(1)

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -12,6 +12,7 @@ from mlflow.utils.process import exec_cmd
 # the cli and the forked gunicorn processes.
 BACKEND_STORE_URI_ENV_VAR = "_MLFLOW_SERVER_FILE_STORE"
 ARTIFACT_ROOT_ENV_VAR = "_MLFLOW_SERVER_ARTIFACT_ROOT"
+STORE_OPTIONS_ENV_VAR = "_MLFLOW_STORE_OPTIONS"
 
 REL_STATIC_DIR = "js/build"
 
@@ -60,7 +61,7 @@ def _build_gunicorn_command(gunicorn_opts, host, port, workers):
 
 
 def _run_server(file_store_path, default_artifact_root, host, port, static_prefix=None,
-                workers=None, gunicorn_opts=None, waitress_opts=None):
+                workers=None, gunicorn_opts=None, waitress_opts=None, store_opts=None):
     """
     Run the MLflow server, wrapping it in gunicorn or waitress on windows
     :param static_prefix: If set, the index.html asset will be served from the path static_prefix.
@@ -74,6 +75,8 @@ def _run_server(file_store_path, default_artifact_root, host, port, static_prefi
         env_map[ARTIFACT_ROOT_ENV_VAR] = default_artifact_root
     if static_prefix:
         env_map[STATIC_PREFIX_ENV_VAR] = static_prefix
+    if store_opts:
+        env_map[STORE_OPTIONS_ENV_VAR] = store_opts
 
     # TODO: eventually may want waitress on non-win32
     if sys.platform == 'win32':

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -55,7 +55,7 @@ class SqlAlchemyStore(AbstractStore):
     ARTIFACTS_FOLDER_NAME = "artifacts"
     DEFAULT_EXPERIMENT_ID = "0"
 
-    def __init__(self, db_uri, default_artifact_root):
+    def __init__(self, db_uri, default_artifact_root, options=None):
         """
         Create a database backed store.
 
@@ -66,12 +66,14 @@ class SqlAlchemyStore(AbstractStore):
                        ``mssql``, ``sqlite``, and ``postgresql``.
         :param default_artifact_root: Path/URI to location suitable for large data (such as a blob
                                       store object, DBFS path, or shared NFS file system).
+        :param options: A dictionary of arguments and their values passed to
+                        SQLAlchemy's ``create_engine`` function.
         """
         super(SqlAlchemyStore, self).__init__()
         self.db_uri = db_uri
         self.db_type = extract_db_type_from_uri(db_uri)
         self.artifact_root_uri = default_artifact_root
-        self.engine = sqlalchemy.create_engine(db_uri)
+        self.engine = sqlalchemy.create_engine(db_uri, **options or {})
         insp = sqlalchemy.inspect(self.engine)
         # On a completely fresh MLflow installation against an empty database (verify database
         # emptiness by checking that 'experiments' etc aren't in the list of table names), run all

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -40,7 +40,7 @@ class TrackingStoreRegistry:
                     stacklevel=2
                 )
 
-    def get_store(self, store_uri=None, artifact_uri=None):
+    def get_store(self, store_uri=None, artifact_uri=None, options=None):
         """Get a store from the registry based on the scheme of store_uri
 
         :param store_uri: The store URI. If None, it will be inferred from the environment. This URI
@@ -48,6 +48,8 @@ class TrackingStoreRegistry:
                           is passed to the constructor of the implementation.
         :param artifact_uri: Artifact repository URI. Passed through to the tracking store
                              implementation.
+        :param options: A dictionary of arguments and their values passed as configuration
+                        to the tracking store implementation.
 
         :return: An instance of `mlflow.store.AbstractStore` that fulfills the store URI
                  requirements.
@@ -62,4 +64,4 @@ class TrackingStoreRegistry:
             raise MlflowException(
                 "Unexpected URI scheme '{}' for tracking store. "
                 "Valid schemes are: {}".format(store_uri, list(self._registry.keys())))
-        return store_builder(store_uri=store_uri, artifact_uri=artifact_uri)
+        return store_builder(store_uri=store_uri, artifact_uri=artifact_uri, options=options)

--- a/mlflow/tracking/utils.py
+++ b/mlflow/tracking/utils.py
@@ -91,11 +91,11 @@ def _get_file_store(store_uri, **_):
     return FileStore(store_uri, store_uri)
 
 
-def _get_sqlalchemy_store(store_uri, artifact_uri):
+def _get_sqlalchemy_store(store_uri, artifact_uri, options=None):
     from mlflow.store.sqlalchemy_store import SqlAlchemyStore
     if artifact_uri is None:
         artifact_uri = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
-    return SqlAlchemyStore(store_uri, artifact_uri)
+    return SqlAlchemyStore(store_uri, artifact_uri, options)
 
 
 def _get_rest_store(store_uri, **_):
@@ -141,8 +141,8 @@ for scheme in DATABASE_ENGINES:
 _tracking_store_registry.register_entrypoints()
 
 
-def _get_store(store_uri=None, artifact_uri=None):
-    return _tracking_store_registry.get_store(store_uri, artifact_uri)
+def _get_store(store_uri=None, artifact_uri=None, options=None):
+    return _tracking_store_registry.get_store(store_uri, artifact_uri, options)
 
 
 # TODO(sueann): move to a projects utils module

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/__init__.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/__init__.py
@@ -8,7 +8,7 @@ from mlflow.tracking.context.abstract_context import RunContextProvider
 class PluginFileStore(FileStore):
     """FileStore provided through entrypoints system"""
 
-    def __init__(self, store_uri=None, artifact_uri=None):
+    def __init__(self, store_uri=None, artifact_uri=None, **_):
         path = urllib.parse.urlparse(store_uri).path if store_uri else None
         self.is_plugin = True
         super(PluginFileStore, self).__init__(path, artifact_uri)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,7 +49,21 @@ def test_tracking_uri_validation_sql_driver_uris(command):
         CliRunner().invoke(command,
                            ["--backend-store-uri", "mysql+pymysql://user:pwd@host:5432/mydb",
                             "--default-artifact-root", "./mlruns"])
-        sql_store.assert_called_once_with("mysql+pymysql://user:pwd@host:5432/mydb", "./mlruns")
+        sql_store.assert_called_once_with("mysql+pymysql://user:pwd@host:5432/mydb", "./mlruns", {})
+        run_server_mock.assert_called()
+
+
+def test_server_store_options():
+    handlers._store = None
+    with mock.patch("mlflow.cli._run_server") as run_server_mock,\
+            mock.patch("mlflow.store.sqlalchemy_store.SqlAlchemyStore") as sql_store:
+        CliRunner().invoke(server,
+                           ["--backend-store-uri", "mysql+pymysql://user:pwd@host:5432/mydb",
+                            "--default-artifact-root", "./mlruns",
+                            "--store-opts", "pool_pre_ping=True"])
+        sql_store.assert_called_once_with("mysql+pymysql://user:pwd@host:5432/mydb",
+                                          "./mlruns",
+                                          {"pool_pre_ping": True})
         run_server_mock.assert_called()
 
 

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -231,7 +231,7 @@ def test_plugin_registration():
     tracking_store.register(test_scheme, mock_plugin)
     assert test_scheme in tracking_store._registry
     assert tracking_store.get_store(test_uri) == mock_plugin.return_value
-    mock_plugin.assert_called_once_with(store_uri=test_uri, artifact_uri=None)
+    mock_plugin.assert_called_once_with(store_uri=test_uri, artifact_uri=None, options=None)
 
 
 def test_plugin_registration_via_entrypoints():
@@ -248,7 +248,8 @@ def test_plugin_registration_via_entrypoints():
 
     assert tracking_store.get_store("mock-scheme://") == mock_plugin_function.return_value
 
-    mock_plugin_function.assert_called_once_with(store_uri="mock-scheme://", artifact_uri=None)
+    mock_plugin_function.assert_called_once_with(store_uri="mock-scheme://", artifact_uri=None,
+                                                 options=None)
     mock_get_group_all.assert_called_once_with("mlflow.tracking_store")
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
We allow store options to be passed via CLI when starting a MLFlow tracking server.
 
## How is this patch tested?
 
We added a unit test. We also passed arguments to SQLAlchemy via `--store-opts` and the server was created successfully. We started a server with SQLAlchemy parameters that do not exists and a corresponding error was issued.
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [X] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
