### PR TITLE
Fix Spark bug loading Spark UDFs on Databricks

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -414,8 +414,10 @@ def spark_udf(spark, model_uri, result_type="double"):
                     "of the following types types: {}".format(str(elem_type), str(supported_types)),
             error_code=INVALID_PARAMETER_VALUE)
 
-    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
-    archive_path = SparkModelCache.add_local_model(spark, local_model_path)
+    with TempDir() as local_tmpdir:
+        local_model_path = _download_artifact_from_uri(
+            artifact_uri=model_uri, output_path=local_tmpdir)
+        archive_path = SparkModelCache.add_local_model(spark, local_model_path)
 
     def predict(*args):
         model = SparkModelCache.get_or_load(archive_path)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -416,7 +416,7 @@ def spark_udf(spark, model_uri, result_type="double"):
 
     with TempDir() as local_tmpdir:
         local_model_path = _download_artifact_from_uri(
-            artifact_uri=model_uri, output_path=local_tmpdir)
+            artifact_uri=model_uri, output_path=local_tmpdir.path())
         archive_path = SparkModelCache.add_local_model(spark, local_model_path)
 
     def predict(*args):

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -72,7 +72,7 @@ class LocalArtifactRepository(ArtifactRepository):
             path = os.path.normpath(path)
         list_dir = os.path.join(self.artifact_dir, path) if path else self.artifact_dir
         if os.path.isdir(list_dir):
-            artifact_files = list_all(list_dir, full_path=True)
+            artifact_files = list_all(list_dir, full_path=True) + [list_dir]
             infos = [get_file_info(f,
                                    relative_path_to_artifact_path(
                                        os.path.relpath(f, self.artifact_dir)))

--- a/mlflow/store/local_artifact_repo.py
+++ b/mlflow/store/local_artifact_repo.py
@@ -72,7 +72,7 @@ class LocalArtifactRepository(ArtifactRepository):
             path = os.path.normpath(path)
         list_dir = os.path.join(self.artifact_dir, path) if path else self.artifact_dir
         if os.path.isdir(list_dir):
-            artifact_files = list_all(list_dir, full_path=True) + [list_dir]
+            artifact_files = list_all(list_dir, full_path=True)
             infos = [get_file_info(f,
                                    relative_path_to_artifact_path(
                                        os.path.relpath(f, self.artifact_dir)))

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -44,7 +44,7 @@ def _get_version_local_git_repo(local_git_repo):
     return repo.git.rev_parse("HEAD")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="module", autouse=True)
 def clean_mlruns_dir():
     yield
     dir_path = os.path.join(TEST_PROJECT_DIR, "mlruns")

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -1,5 +1,6 @@
 import os
 import git
+import shutil
 import tempfile
 import yaml
 
@@ -41,6 +42,14 @@ def _build_uri(base_uri, subdirectory):
 def _get_version_local_git_repo(local_git_repo):
     repo = git.Repo(local_git_repo, search_parent_directories=True)
     return repo.git.rev_parse("HEAD")
+
+
+@pytest.fixture(scope="module")
+def clean_mlruns_dir():
+    yield
+    dir_path = os.path.join(TEST_PROJECT_DIR, "mlruns")
+    if os.path.exists(dir_path):
+        shutil.rmtree(dir_path)
 
 
 @pytest.fixture

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -2,6 +2,7 @@ import json
 import hashlib
 import mock
 import os
+import shutil
 import logging
 
 from click.testing import CliRunner
@@ -24,6 +25,14 @@ def test_run_local_params(tracking_uri_mock):  # pylint: disable=unused-argument
     invoke_cli_runner(cli.run, [TEST_PROJECT_DIR, "-e", "greeter", "-P",
                                 "greeting=hi", "-P", "name=%s" % name,
                                 "-P", "excitement=%s" % excitement_arg])
+
+
+@pytest.fixture(scope="module", autouse=True)
+def clean_mlruns_dir():
+    yield
+    dir_path = os.path.join(TEST_PROJECT_DIR, "mlruns")
+    if os.path.exists(dir_path):
+        shutil.rmtree(dir_path)
 
 
 @pytest.mark.large


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fixes #1657 
 
## How is this patch tested?
 
Existing unit tests & manual testing.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Fixes a bug in MLFlow 1.1.0 where loading MLflow models as Spark UDFs on Databricks would fail with an obscure `ValueError: ZIP does not support timestamps before 1980` error message
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [x] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
