### PR TITLE
Get run last metrics optimization

### DIFF
--- a/mlflow/store/dbmodels/models.py
+++ b/mlflow/store/dbmodels/models.py
@@ -217,7 +217,8 @@ class SqlRun(Base):
                        SqlMetric.run_uuid == metrics_with_max_timestamp.c.run_uuid,
                        SqlMetric.key == metrics_with_max_timestamp.c.key,
                        SqlMetric.step == metrics_with_max_timestamp.c.step)) \
-            .group_by(SqlMetric.run_uuid, SqlMetric.key, SqlMetric.step, SqlMetric.timestamp, SqlMetric.is_nan) \
+            .group_by(SqlMetric.run_uuid, SqlMetric.key,
+                      SqlMetric.step, SqlMetric.timestamp, SqlMetric.is_nan) \
             .all()
         return metrics_with_max_value
 

--- a/mlflow/store/dbmodels/models.py
+++ b/mlflow/store/dbmodels/models.py
@@ -206,7 +206,7 @@ class SqlRun(Base):
                   and_(SqlMetric.step == metrics_with_max_step.c.step,
                        SqlMetric.run_uuid == metrics_with_max_step.c.run_uuid,
                        SqlMetric.key == metrics_with_max_step.c.key)) \
-            .group_by(SqlMetric.key, SqlMetric.run_uuid) \
+            .group_by(SqlMetric.key, SqlMetric.run_uuid, SqlMetric.step) \
             .subquery('metrics_with_max_timestamp')
         metrics_with_max_value = session \
             .query(SqlMetric.run_uuid, SqlMetric.key, SqlMetric.step, SqlMetric.timestamp,
@@ -217,7 +217,7 @@ class SqlRun(Base):
                        SqlMetric.run_uuid == metrics_with_max_timestamp.c.run_uuid,
                        SqlMetric.key == metrics_with_max_timestamp.c.key,
                        SqlMetric.step == metrics_with_max_timestamp.c.step)) \
-            .group_by(SqlMetric.key, SqlMetric.run_uuid, SqlMetric.is_nan) \
+            .group_by(SqlMetric.run_uuid, SqlMetric.key, SqlMetric.step, SqlMetric.timestamp, SqlMetric.is_nan) \
             .all()
         return metrics_with_max_value
 

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -345,7 +345,7 @@ class SqlAlchemyStore(AbstractStore):
             run.tags = [SqlTag(key=key, value=value) for key, value in tags_dict.items()]
             self._save_to_db(objs=run, session=session)
 
-            return run.to_mlflow_entity()
+            return run.to_mlflow_entity(session)
 
     def _get_run(self, session, run_uuid):
         runs = session.query(SqlRun).filter(SqlRun.run_uuid == run_uuid).all()
@@ -380,14 +380,14 @@ class SqlAlchemyStore(AbstractStore):
             run.end_time = end_time
 
             self._save_to_db(objs=run, session=session)
-            run = run.to_mlflow_entity()
+            run = run.to_mlflow_entity(session)
 
             return run.info
 
     def get_run(self, run_id):
         with self.ManagedSessionMaker() as session:
             run = self._get_run(run_uuid=run_id, session=session)
-            return run.to_mlflow_entity()
+            return run.to_mlflow_entity(session)
 
     def restore_run(self, run_id):
         with self.ManagedSessionMaker() as session:
@@ -503,7 +503,7 @@ class SqlAlchemyStore(AbstractStore):
                                                                      max_results),
                                   INVALID_PARAMETER_VALUE)
         with self.ManagedSessionMaker() as session:
-            runs = [run.to_mlflow_entity()
+            runs = [run.to_mlflow_entity(session)
                     for exp in experiment_ids
                     for run in self._list_runs(session, exp, run_view_type)]
             filtered = SearchUtils.filter(runs, filter_string)

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -325,7 +325,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             'lifecycle_stage': entities.LifecycleStage.ACTIVE,
             'artifact_uri': '//'
         }
-        run = models.SqlRun(**config).to_mlflow_entity()
+        with self.store.ManagedSessionMaker() as session:
+            run = models.SqlRun(**config).to_mlflow_entity(session)
 
         for k, v in config.items():
             # These keys were removed from RunInfo.

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -77,11 +77,12 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         return SqlAlchemyStore(db_uri, ARTIFACT_URI)
 
     def setUp(self):
-        self.maxDiff = None  # print all differences on assert failures
-        fd, self.temp_dbfile = tempfile.mkstemp()
-        # Close handle immediately so that we can remove the file later on in Windows
-        os.close(fd)
-        self.db_url = "%s%s" % (DB_URI, self.temp_dbfile)
+        # self.maxDiff = None  # print all differences on assert failures
+        # fd, self.temp_dbfile = tempfile.mkstemp()
+        # # Close handle immediately so that we can remove the file later on in Windows
+        # os.close(fd)
+        # self.db_url = "%s%s" % (DB_URI, self.temp_dbfile)
+        self.db_url = "mysql://root:password@localhost:33060"
         self.store = self._get_store(self.db_url)
 
     def tearDown(self):

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -77,12 +77,11 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         return SqlAlchemyStore(db_uri, ARTIFACT_URI)
 
     def setUp(self):
-        # self.maxDiff = None  # print all differences on assert failures
-        # fd, self.temp_dbfile = tempfile.mkstemp()
-        # # Close handle immediately so that we can remove the file later on in Windows
-        # os.close(fd)
-        # self.db_url = "%s%s" % (DB_URI, self.temp_dbfile)
-        self.db_url = "mysql://root:password@localhost:33060"
+        self.maxDiff = None  # print all differences on assert failures
+        fd, self.temp_dbfile = tempfile.mkstemp()
+        # Close handle immediately so that we can remove the file later on in Windows
+        os.close(fd)
+        self.db_url = "%s%s" % (DB_URI, self.temp_dbfile)
         self.store = self._get_store(self.db_url)
 
     def tearDown(self):
@@ -326,8 +325,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             'lifecycle_stage': entities.LifecycleStage.ACTIVE,
             'artifact_uri': '//'
         }
-        with self.store.ManagedSessionMaker() as session:
-            run = models.SqlRun(**config).to_mlflow_entity(session)
+        run = models.SqlRun(**config).to_mlflow_entity()
 
         for k, v in config.items():
             # These keys were removed from RunInfo.


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
To improve the speed of the UI when it has to load a lot of runs with lots of time series metrics, we changed the way we get the last recorded metric for each run. We removed the python loop that loops over all metrics by a SQL query that directly gets the last recorded metrics.
Following this issue: https://github.com/mlflow/mlflow/issues/1571

I compared the execution time before and after this change by directly calling the search_runs method of SqlAlchemyStore and timing it with %%prun in a jupyter notebook.
In our case, it went from 11.3 seconds to 3.7 seconds.
We have 617 runs with 202967 metrics in total.
 
## How is this patch tested?
 
Using the tests already present in the repository (we have not changed the current functionalities)
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [X] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
