### PR TITLE
Fix MLFlow Server MIME-Types in the Frontend

### DIFF
--- a/mlflow/server/js/src/sdk/MlflowService.js
+++ b/mlflow/server/js/src/sdk/MlflowService.js
@@ -203,6 +203,7 @@ export class MlflowService {
   static searchRuns({ data, success, error }) {
     return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/search'), {
       type: 'POST',
+      contentType: "application/json; charset=utf-8",
       dataType: 'json',
       data: JSON.stringify(data),
       jsonp: false,

--- a/mlflow/server/js/src/sdk/MlflowService.js
+++ b/mlflow/server/js/src/sdk/MlflowService.js
@@ -24,6 +24,7 @@ export class MlflowService {
   static createExperiment({ data, success, error }) {
     return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/experiments/create'), {
       type: 'POST',
+      contentType: 'application/json; charset=utf-8',
       dataType: 'json',
       data: JSON.stringify(data),
       jsonp: false,
@@ -81,6 +82,7 @@ export class MlflowService {
   static createRun({ data, success, error }) {
     return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/create'), {
       type: 'POST',
+      contentType: 'application/json; charset=utf-8',
       dataType: 'json',
       data: JSON.stringify(data),
       jsonp: false,
@@ -98,6 +100,7 @@ export class MlflowService {
   static deleteRun({ data, success, error }) {
     return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/delete'), {
       type: 'POST',
+      contentType: 'application/json; charset=utf-8',
       dataType: 'json',
       data: JSON.stringify(data),
       jsonp: false,
@@ -115,6 +118,7 @@ export class MlflowService {
   static restoreRun({ data, success, error }) {
     return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/restore'), {
       type: 'POST',
+      contentType: 'application/json; charset=utf-8',
       dataType: 'json',
       data: JSON.stringify(data),
       jsonp: false,
@@ -132,6 +136,7 @@ export class MlflowService {
   static updateRun({ data, success, error }) {
     return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/update'), {
       type: 'POST',
+      contentType: 'application/json; charset=utf-8',
       dataType: 'json',
       data: JSON.stringify(data),
       jsonp: false,
@@ -149,6 +154,7 @@ export class MlflowService {
   static logMetric({ data, success, error }) {
     return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/log-metric'), {
       type: 'POST',
+      contentType: 'application/json; charset=utf-8',
       dataType: 'json',
       data: JSON.stringify(data),
       jsonp: false,
@@ -166,6 +172,7 @@ export class MlflowService {
   static logParam({ data, success, error }) {
     return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/log-parameter'), {
       type: 'POST',
+      contentType: 'application/json; charset=utf-8',
       dataType: 'json',
       data: JSON.stringify(data),
       jsonp: false,
@@ -203,7 +210,7 @@ export class MlflowService {
   static searchRuns({ data, success, error }) {
     return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/search'), {
       type: 'POST',
-      contentType: "application/json; charset=utf-8",
+      contentType: 'application/json; charset=utf-8',
       dataType: 'json',
       data: JSON.stringify(data),
       jsonp: false,
@@ -261,6 +268,7 @@ export class MlflowService {
   static setTag({ data, success, error }) {
     return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/set-tag'), {
       type: 'POST',
+      contentType: 'application/json; charset=utf-8',
       dataType: 'json',
       data: JSON.stringify(data),
       jsonp: false,


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
The MLFlow Server Frontend uses JQuery AJAX Requests without specifying the contentType as application/json. Without doing so the contentType is set by default to x-www-form-urlencoded and some corporate proxies block POST requests, where the body is not of the type that is specified in contentType.
 
## How is this patch tested?
 
The patch was tested locally, as well as with a corporate proxy that blocks any requests with a mismatch between contentType and the data type of the body.
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
