### PR TITLE
add jsonnet as a valid text file format

### DIFF
--- a/mlflow/server/js/src/utils/FileUtils.js
+++ b/mlflow/server/js/src/utils/FileUtils.js
@@ -11,4 +11,4 @@ export const getExtension = (path) => {
 export const IMAGE_EXTENSIONS = new Set(['jpg', 'bmp', 'jpeg', 'png', 'gif', 'svg']);
 export const TEXT_EXTENSIONS = new Set(
   ['txt', 'log', 'py', 'js', 'yaml', 'yml', 'json', 'csv', 'tsv',
-    'md', 'rst', 'MLmodel', 'MLproject']);
+    'md', 'rst', 'MLmodel', 'MLproject', 'jsonnet']);


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fixes #921 
Displays JSONNet files as text.

## How is this patch tested?
 
![Screen Shot 2019-07-30 at 3 24 38 PM](https://user-images.githubusercontent.com/52183359/62169828-4d3f7900-b2de-11e9-83a6-cad19458c958.png)

 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
JSONNet files are now displayed as text files in artifact preview.
 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
