### PR TITLE
[UI] Avoid calling list-experiments when sidebar disabled

### DIFF
--- a/mlflow/server/js/src/components/HomePage.js
+++ b/mlflow/server/js/src/components/HomePage.js
@@ -17,13 +17,16 @@ class HomePage extends Component {
   };
 
   componentWillMount() {
-    this.props.dispatchListExperimentsApi(this.state.listExperimentsRequestId);
+    if (process.env.HIDE_EXPERIMENT_LIST !== 'true') {
+      this.props.dispatchListExperimentsApi(this.state.listExperimentsRequestId);
+    }
   }
 
   render() {
-    return (
+    const homeView = <HomeView experimentId={this.props.experimentId}/>;
+    return process.env.HIDE_EXPERIMENT_LIST === 'true' ? homeView : (
       <RequestStateWrapper requestIds={[this.state.listExperimentsRequestId]}>
-        <HomeView experimentId={this.props.experimentId}/>
+        {homeView}
       </RequestStateWrapper>
     );
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
When the sidebar is disabled, there is no reason to list all experiments, this is just extra latency. We already get the experiment that is selected.
