### PR TITLE
Include start_time, end_time into mlflow.search_runs result

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -334,7 +334,8 @@ def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.AC
     runs = _get_paginated_runs(experiment_ids, filter_string, run_view_type, max_results,
                                order_by)
     info = {'run_id': [], 'experiment_id': [],
-            'status': [], 'artifact_uri': [], }
+            'status': [], 'artifact_uri': [],
+            'start_time': [], 'end_time': []}
     params, metrics, tags = ({}, {}, {})
     PARAM_NULL, METRIC_NULL, TAG_NULL = (None, np.nan, None)
     for i, run in enumerate(runs):
@@ -342,6 +343,8 @@ def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.AC
         info['experiment_id'].append(run.info.experiment_id)
         info['status'].append(run.info.status)
         info['artifact_uri'].append(run.info.artifact_uri)
+        info['start_time'].append(run.info.start_time)
+        info['end_time'].append(run.info.end_time)
 
         # Params
         param_keys = set(params.keys())
@@ -387,7 +390,12 @@ def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.AC
         data['params.' + key] = params[key]
     for key in tags:
         data['tags.' + key] = tags[key]
-    return pd.DataFrame(data)
+
+    df = pd.DataFrame(data)
+    df['start_time'] = pd.to_datetime(df['start_time'], unit="ms", utc=True)
+    df['end_time'] = pd.to_datetime(df['end_time'], unit="ms", utc=True)
+
+    return df
 
 
 def _get_paginated_runs(experiment_ids, filter_string, run_view_type, max_results,

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -343,8 +343,8 @@ def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.AC
         info['experiment_id'].append(run.info.experiment_id)
         info['status'].append(run.info.status)
         info['artifact_uri'].append(run.info.artifact_uri)
-        info['start_time'].append(run.info.start_time)
-        info['end_time'].append(run.info.end_time)
+        info['start_time'].append(pd.to_datetime(run.info.start_time, unit="ms", utc=True))
+        info['end_time'].append(pd.to_datetime(run.info.end_time, unit="ms", utc=True))
 
         # Params
         param_keys = set(params.keys())
@@ -390,12 +390,7 @@ def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.AC
         data['params.' + key] = params[key]
     for key in tags:
         data['tags.' + key] = tags[key]
-
-    df = pd.DataFrame(data)
-    df['start_time'] = pd.to_datetime(df['start_time'], unit="ms", utc=True)
-    df['end_time'] = pd.to_datetime(df['end_time'], unit="ms", utc=True)
-
-    return df
+    return pd.DataFrame(data)
 
 
 def _get_paginated_runs(experiment_ids, filter_string, run_view_type, max_results,


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Include start_time, end_time to the pandas Dataframe that is returned by mlflow.search_runs
 
## How is this patch tested?
 
Locally with and without the changes with our ml flow server
 
## Release Notes
 
### Is this a user-facing change? 

- [x ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users. 

### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [x ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
