### PR TITLE
Fix experiment id resolution in projects

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -59,7 +59,7 @@ def _resolve_experiment_id(experiment_name=None, experiment_id=None):
 
     Verifies either one or other is specified - cannot be both selected.
 
-    If `experiment_name` is provided and does not exist, an experiment
+    If ``experiment_name`` is provided and does not exist, an experiment
     of that name is created and its id is returned.
 
     :param experiment_name: Name of experiment under which to launch the run.

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -59,7 +59,7 @@ def _resolve_experiment_id(experiment_name=None, experiment_id=None):
 
     Verifies either one or other is specified - cannot be both selected.
 
-    If experiment_name is provided and does not exist, an experiment
+    If `experiment_name` is provided and does not exist, an experiment
     of that name is created and its id is returned.
 
     :param experiment_name: Name of experiment under which to launch the run.

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -59,6 +59,9 @@ def _resolve_experiment_id(experiment_name=None, experiment_id=None):
 
     Verifies either one or other is specified - cannot be both selected.
 
+    If experiment_name is provided and does not exist, an experiment
+    of that name is created and its id is returned.
+
     :param experiment_name: Name of experiment under which to launch the run.
     :param experiment_id: ID of experiment under which to launch the run.
     :return: int
@@ -70,9 +73,13 @@ def _resolve_experiment_id(experiment_name=None, experiment_id=None):
     exp_id = experiment_id
     if experiment_name:
         client = tracking.MlflowClient()
-        exp_id = client.get_experiment_by_name(experiment_name).experiment_id
-    exp_id = exp_id or _get_experiment_id()
-    return exp_id
+        exp = client.get_experiment_by_name(experiment_name)
+        if exp:
+            return exp.experiment_id
+        else:
+            print("INFO: '{}' does not exist. Creating a new experiment".format(experiment_name))
+            return client.create_experiment(experiment_name)
+    return exp_id or _get_experiment_id()
 
 
 def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -64,14 +64,14 @@ def _resolve_experiment_id(experiment_name=None, experiment_id=None):
 
     :param experiment_name: Name of experiment under which to launch the run.
     :param experiment_id: ID of experiment under which to launch the run.
-    :return: int
+    :return: str
     """
 
     if experiment_name and experiment_id:
         raise MlflowException("Specify only one of 'experiment_name' or 'experiment_id'.")
 
     if experiment_id:
-        return experiment_id
+        return str(experiment_id)
 
     if experiment_name:
         client = tracking.MlflowClient()

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -70,7 +70,9 @@ def _resolve_experiment_id(experiment_name=None, experiment_id=None):
     if experiment_name and experiment_id:
         raise MlflowException("Specify only one of 'experiment_name' or 'experiment_id'.")
 
-    exp_id = experiment_id
+    if experiment_id:
+        return experiment_id
+
     if experiment_name:
         client = tracking.MlflowClient()
         exp = client.get_experiment_by_name(experiment_name)
@@ -79,7 +81,8 @@ def _resolve_experiment_id(experiment_name=None, experiment_id=None):
         else:
             print("INFO: '{}' does not exist. Creating a new experiment".format(experiment_name))
             return client.create_experiment(experiment_name)
-    return exp_id or _get_experiment_id()
+
+    return _get_experiment_id()
 
 
 def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -12,7 +12,7 @@ import pytest
 import mlflow
 
 from mlflow.entities import RunStatus, ViewType, Experiment, SourceType
-from mlflow.exceptions import ExecutionException, MlflowException
+from mlflow.exceptions import ExecutionException
 from mlflow.store.file_store import FileStore
 from mlflow.utils import env
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_USER, MLFLOW_SOURCE_NAME, \
@@ -241,27 +241,6 @@ def test_run_local_git_repo(patch_user,  # pylint: disable=unused-argument
         assert tags[MLFLOW_GIT_REPO_URL] == local_git_repo_uri
         assert tags[LEGACY_MLFLOW_GIT_BRANCH_NAME] == "master"
         assert tags[LEGACY_MLFLOW_GIT_REPO_URL] == local_git_repo_uri
-
-
-@pytest.mark.parametrize("experiment_id,experiment_name,expected",
-                         [("1", None, "1"), (None, 'name', "33")])
-def test_resolve_experiment_id(experiment_id, experiment_name, expected):
-    with mock.patch('mlflow.tracking.MlflowClient.get_experiment_by_name') \
-            as get_experiment_by_name_mock:
-        get_experiment_by_name_mock.return_value = Experiment(experiment_id="33", name='Name',
-                                                              artifact_location=None,
-                                                              lifecycle_stage=None)
-
-        exp_id = mlflow.projects._resolve_experiment_id(experiment_name=experiment_name,
-                                                        experiment_id=experiment_id)
-        assert exp_id == expected
-
-
-def test_resolve_experiment_id_should_not_allow_both_name_and_id_in_use():
-    with pytest.raises(MlflowException,
-                       match="Specify only one of 'experiment_name' or 'experiment_id'."):
-        _ = mlflow.projects._resolve_experiment_id(experiment_name='experiment_named',
-                                                   experiment_id="44")
 
 
 def test_invalid_version_local_git_repo(local_git_repo_uri,

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -11,7 +11,7 @@ import pytest
 
 import mlflow
 
-from mlflow.entities import RunStatus, ViewType, Experiment, SourceType
+from mlflow.entities import RunStatus, ViewType, SourceType
 from mlflow.exceptions import ExecutionException
 from mlflow.store.file_store import FileStore
 from mlflow.utils import env

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -126,4 +126,3 @@ def test_resolve_experiment_id_should_not_allow_both_name_and_id_in_use():
     with pytest.raises(MlflowException,
                        match="Specify only one of 'experiment_name' or 'experiment_id'."):
         _resolve_experiment_id(experiment_name='experiment_named', experiment_id="44")
-

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -102,5 +102,3 @@ def test_run_databricks_cluster_spec(tmpdir):
                       json.dumps(cluster_spec) + "JUNK", "-e", "greeter", "-P", "name=hi"],
             env={'MLFLOW_TRACKING_URI': 'databricks://profile'})
         assert res.exit_code != 0
-
-

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -13,6 +13,7 @@ from mlflow.utils import process
 from tests.integration.utils import invoke_cli_runner
 from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_URI, \
     TEST_NO_SPEC_PROJECT_DIR
+from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 _logger = logging.getLogger(__name__)
 

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -9,13 +9,10 @@ from click.testing import CliRunner
 import pytest
 
 from mlflow import cli
-from mlflow.exceptions import MlflowException
 from mlflow.utils import process
-from mlflow.projects import _resolve_experiment_id
 from tests.integration.utils import invoke_cli_runner
 from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_URI, \
     TEST_NO_SPEC_PROJECT_DIR
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 _logger = logging.getLogger(__name__)
 
@@ -107,22 +104,3 @@ def test_run_databricks_cluster_spec(tmpdir):
         assert res.exit_code != 0
 
 
-@pytest.mark.parametrize('experiment_name,experiment_id,expected', [
-    ('Default', None, '0'),
-    ('add an experiment', None, '1'),
-    (None, 2, '2'),
-    (None, '2', '2'),
-    (None, None, '0')
-])
-def test_resolve_experiment_id(experiment_name,
-                               experiment_id,
-                               expected,
-                               tracking_uri_mock):  # pylint: disable=unused-argument
-    assert expected == _resolve_experiment_id(experiment_name=experiment_name,
-                                              experiment_id=experiment_id)
-
-
-def test_resolve_experiment_id_should_not_allow_both_name_and_id_in_use():
-    with pytest.raises(MlflowException,
-                       match="Specify only one of 'experiment_name' or 'experiment_id'."):
-        _resolve_experiment_id(experiment_name='experiment_named', experiment_id="44")

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -9,7 +9,9 @@ from click.testing import CliRunner
 import pytest
 
 from mlflow import cli
+from mlflow.exceptions import MlflowException
 from mlflow.utils import process
+from mlflow.projects import _resolve_experiment_id
 from tests.integration.utils import invoke_cli_runner
 from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_URI, \
     TEST_NO_SPEC_PROJECT_DIR
@@ -103,3 +105,25 @@ def test_run_databricks_cluster_spec(tmpdir):
                       json.dumps(cluster_spec) + "JUNK", "-e", "greeter", "-P", "name=hi"],
             env={'MLFLOW_TRACKING_URI': 'databricks://profile'})
         assert res.exit_code != 0
+
+
+@pytest.mark.parametrize('experiment_name,experiment_id,expected', [
+    ('Default', None, '0'),
+    ('add an experiment', None, '1'),
+    (None, 2, '2'),
+    (None, '2', '2'),
+    (None, None, '0')
+])
+def test_resolve_experiment_id(experiment_name,
+                               experiment_id,
+                               expected,
+                               tracking_uri_mock):  # pylint: disable=unused-argument
+    assert expected == _resolve_experiment_id(experiment_name=experiment_name,
+                                              experiment_id=experiment_id)
+
+
+def test_resolve_experiment_id_should_not_allow_both_name_and_id_in_use():
+    with pytest.raises(MlflowException,
+                       match="Specify only one of 'experiment_name' or 'experiment_id'."):
+        _resolve_experiment_id(experiment_name='experiment_named', experiment_id="44")
+


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Addresses #1353. 

- Fixes bug where we try to access `experiment.experiment_id` before knowing `experiment` exists
- We now create an experiment if the given experiment name is not found, which is the behavior in other parts of MLflow (see tracking.fluent.set_experiment)
 
## How is this patch tested?
 
Simplified and extended unit tests for `_resolve_experiment_id`.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Passing `--experiment-name` to a project run will create the experiment if it doesn't exist, matching the behavior in the fluent api.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [x] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [x] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
