### PR TITLE
Fix Java & R travis build failures

### DIFF
--- a/mlflow/R/mlflow/R/install.R
+++ b/mlflow/R/mlflow/R/install.R
@@ -10,11 +10,10 @@ mlflow_conda_env_name <- function() {
 
 # Create conda env used by MLflow if it doesn't already exist
 #' @importFrom reticulate conda_install conda_create conda_list
+#' @param python_version Python version to use within conda environment created for
+#' installing the MLflow CLI.
 mlflow_maybe_create_conda_env <- function(python_version) {
-  packages <- c()
-  if (is.null(python_version)) {
-    packages <- c(paste("python", python_version, sep = "="))
-  }
+  packages <- c(paste("python", python_version, sep = "="))
   conda <- mlflow_conda_bin()
   conda_env_name <- mlflow_conda_env_name()
   if (!conda_env_name %in% conda_list(conda = conda)$name) {

--- a/mlflow/R/mlflow/R/install.R
+++ b/mlflow/R/mlflow/R/install.R
@@ -10,11 +10,15 @@ mlflow_conda_env_name <- function() {
 
 # Create conda env used by MLflow if it doesn't already exist
 #' @importFrom reticulate conda_install conda_create conda_list
-mlflow_maybe_create_conda_env <- function() {
+mlflow_maybe_create_conda_env <- function(python_version) {
+  packages <- c()
+  if (is.null(python_version)) {
+    packages <- c(paste("python", python_version, sep = "="))
+  }
   conda <- mlflow_conda_bin()
   conda_env_name <- mlflow_conda_env_name()
   if (!conda_env_name %in% conda_list(conda = conda)$name) {
-    conda_create(conda_env_name, conda = conda)
+    conda_create(conda_env_name, conda = conda, packages = packages)
   }
 }
 
@@ -33,9 +37,11 @@ mlflow_maybe_create_conda_env <- function() {
 #' }
 #'
 #' @importFrom reticulate conda_install conda_create conda_list
+#' @param python_version Optional Python version to use within conda environment created for
+#' installing the MLflow CLI. If unspecified, defaults to using Python 3.6
 #' @export
-install_mlflow <- function() {
-  mlflow_maybe_create_conda_env()
+install_mlflow <- function(python_version = "3.6") {
+  mlflow_maybe_create_conda_env(python_version)
   # Install the Python MLflow package with version == the current R package version
   packages <- c(paste("mlflow", "==", mlflow_version(), sep = ""))
   conda <- mlflow_conda_bin()

--- a/mlflow/R/mlflow/man/install_mlflow.Rd
+++ b/mlflow/R/mlflow/man/install_mlflow.Rd
@@ -4,7 +4,11 @@
 \alias{install_mlflow}
 \title{Install MLflow}
 \usage{
-install_mlflow()
+install_mlflow(python_version = "3.6")
+}
+\arguments{
+\item{python_version}{Optional Python version to use within conda environment created for
+installing the MLflow CLI. If unspecified, defaults to using Python 3.6}
 }
 \description{
 Installs auxiliary dependencies of MLflow (e.g. the MLflow CLI). As a one-time setup step, you

--- a/mlflow/R/mlflow/tests/testthat.R
+++ b/mlflow/R/mlflow/tests/testthat.R
@@ -3,7 +3,7 @@ library(mlflow)
 library(reticulate)
 
 if (identical(Sys.getenv("NOT_CRAN"), "true")) {
-  mlflow:::mlflow_maybe_create_conda_env()
+  mlflow:::mlflow_maybe_create_conda_env(python_version = "3.6")
   message("Current working directory: ", getwd())
   mlflow_home <- Sys.getenv("MLFLOW_HOME", "../../../../.")
   conda_install(c(mlflow_home), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -18,7 +18,11 @@ hash -r
 conda config --set always_yes yes --set changeps1 no
 # Useful for debugging any issues with conda
 conda info -a
-conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+if [[ -n "$TRAVIS_PYTHON_VERSION" ]]; then
+  conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
+else
+  conda create -q -n test-environment python=3.6
+fi
 source activate test-environment
 python --version
 pip install --upgrade pip

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -7,9 +7,9 @@ sudo chown travis /travis-install
 # We do this conditionally because it saves us some downloading if the
 # version is the same.
 if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-  wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O /travis-install/miniconda.sh;
+  wget https://repo.continuum.io/miniconda/Miniconda2-4.7.10-Linux-x86_64.sh -O /travis-install/miniconda.sh;
 else
-  wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /travis-install/miniconda.sh;
+  wget https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh -O /travis-install/miniconda.sh;
 fi
 
 bash /travis-install/miniconda.sh -b -p $HOME/miniconda
@@ -29,7 +29,6 @@ fi
 if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   pip install -r ./travis/large-requirements.txt
 fi
-pip install "pandas<0.25.0"
 pip install .
 export MLFLOW_HOME=$(pwd)
 # Remove boto config present in Travis VMs (https://github.com/travis-ci/travis-ci/issues/7940)

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -29,6 +29,7 @@ fi
 if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   pip install -r ./travis/large-requirements.txt
 fi
+pip install "pandas<0.25.0"
 pip install .
 export MLFLOW_HOME=$(pwd)
 # Remove boto config present in Travis VMs (https://github.com/travis-ci/travis-ci/issues/7940)

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -7,9 +7,9 @@ sudo chown travis /travis-install
 # We do this conditionally because it saves us some downloading if the
 # version is the same.
 if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
-  wget https://repo.continuum.io/miniconda/Miniconda2-4.7.10-Linux-x86_64.sh -O /travis-install/miniconda.sh;
+  wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O /travis-install/miniconda.sh;
 else
-  wget https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh -O /travis-install/miniconda.sh;
+  wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /travis-install/miniconda.sh;
 fi
 
 bash /travis-install/miniconda.sh -b -p $HOME/miniconda


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Installing MLflow from pip within a Python 3.7.4 conda environment fails with compilation errors during installation of `pandas` (a dependency of MLflow). This PR:
* Updates Travis logic to use a Python 3.6 conda environment for R & Java tests (the same as with Python)
* Updates the R `mlflow_install` API to install the MLflow CLI into a Python 3.6 environment by default, so that the R API depends on an MLflow CLI installation that uses a tested Python version. Also provides users with an optional argument to override the Python version of the installation as an escape hatch if they wish.

Note that `pip` is unable to successfully install `pandas`, `conda install pandas` does work within the Python 3.7.4 environment (so an issue filed upstream against conda or pandas, while still potentially helpful, seems unlikely to get much attention). Longer term, we should consider relying on the conda installation of MLflow from the R package (i.e. install the MLflow CLI via `conda install mlflow`), and/or testing the Python package against Python 3.7 & removing the Python 3.6 restriction from the R package.
 
## How is this patch tested?
 
Existing tests
 
## Release Notes
 
### Is this a user-facing change? 
Adds an optional `python_version` argument to the R `mlflow_install` API for specifying the  Python version (e.g. "3.5") to use within the conda environment created for installing the MLflow CLI. If `python_version` is unspecified, `mlflow_install` defaults to using Python 3.6.

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [x] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
