### PR TITLE
Validate MLproject contents

### DIFF
--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -17,10 +17,10 @@ DEFAULT_CONDA_FILE_NAME = "conda.yaml"
 
 
 def load_project(directory):
-
     mlproject_path = os.path.join(directory, MLPROJECT_FILE_NAME)
     if os.path.exists(mlproject_path):
-        yaml_obj = yaml.safe_load(open(mlproject_path))
+        with open(mlproject_path) as mlproject_file:
+            yaml_obj = yaml.safe_load(mlproject_file.read())
     else:
         yaml_obj = {}
 
@@ -30,7 +30,6 @@ def load_project(directory):
     conda_path = yaml_obj.get("conda_env")
     docker_env = yaml_obj.get("docker_env")
     entry_points = {}
-
     for name, entry_point_yaml in yaml_obj.get("entry_points", {}).items():
         parameters = entry_point_yaml.get("parameters", {})
         command = entry_point_yaml.get("command")

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -8,7 +8,7 @@ from six.moves import shlex_quote
 
 from mlflow import data
 from mlflow.exceptions import ExecutionException
-from mlflow.projects.utils import validate_project_yaml
+from mlflow.projects.utils import validate_conda_env_path, validate_project_yaml
 from mlflow.utils.file_utils import get_local_path_or_none
 
 
@@ -38,9 +38,7 @@ def load_project(directory):
 
     if conda_path:
         conda_env_path = os.path.join(directory, conda_path)
-        if not os.path.exists(conda_env_path):
-            raise ExecutionException("Project specified conda environment file %s, but no such "
-                                     "file was found." % conda_env_path)
+        validate_conda_env_path(conda_env_path)
         return Project(conda_env_path=conda_env_path, entry_points=entry_points,
                        docker_env=docker_env, name=project_name,)
 

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -8,6 +8,7 @@ from six.moves import shlex_quote
 
 from mlflow import data
 from mlflow.exceptions import ExecutionException
+from mlflow.projects.utils import validate_project_yaml
 from mlflow.utils.file_utils import get_local_path_or_none
 
 
@@ -17,10 +18,10 @@ DEFAULT_CONDA_FILE_NAME = "conda.yaml"
 
 def load_project(directory):
     mlproject_path = os.path.join(directory, MLPROJECT_FILE_NAME)
-    # TODO: Validate structure of YAML loaded from the file
     if os.path.exists(mlproject_path):
         with open(mlproject_path) as mlproject_file:
             yaml_obj = yaml.safe_load(mlproject_file.read())
+        validate_project_yaml(yaml_obj)
     else:
         yaml_obj = {}
     project_name = yaml_obj.get("name")

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -17,28 +17,25 @@ DEFAULT_CONDA_FILE_NAME = "conda.yaml"
 
 
 def load_project(directory):
+
     mlproject_path = os.path.join(directory, MLPROJECT_FILE_NAME)
     if os.path.exists(mlproject_path):
-        with open(mlproject_path) as mlproject_file:
-            yaml_obj = yaml.safe_load(mlproject_file.read())
-        validate_project_yaml(yaml_obj)
+        yaml_obj = yaml.safe_load(open(mlproject_path))
     else:
         yaml_obj = {}
+
+    validate_project_yaml(yaml_obj)
+
     project_name = yaml_obj.get("name")
-    if not project_name:
-        project_name = None
     conda_path = yaml_obj.get("conda_env")
     docker_env = yaml_obj.get("docker_env")
-    if docker_env and not docker_env.get("image"):
-        raise ExecutionException("Docker environment specified but no image "
-                                 "attribute found.")
-    if conda_path and docker_env:
-        raise ExecutionException("Project cannot contain both a docker and conda environment.")
     entry_points = {}
+
     for name, entry_point_yaml in yaml_obj.get("entry_points", {}).items():
         parameters = entry_point_yaml.get("parameters", {})
         command = entry_point_yaml.get("command")
         entry_points[name] = EntryPoint(name, parameters, command)
+
     if conda_path:
         conda_env_path = os.path.join(directory, conda_path)
         if not os.path.exists(conda_env_path):
@@ -46,10 +43,12 @@ def load_project(directory):
                                      "file was found." % conda_env_path)
         return Project(conda_env_path=conda_env_path, entry_points=entry_points,
                        docker_env=docker_env, name=project_name,)
+
     default_conda_path = os.path.join(directory, DEFAULT_CONDA_FILE_NAME)
     if os.path.exists(default_conda_path):
         return Project(conda_env_path=default_conda_path, entry_points=entry_points,
                        docker_env=docker_env, name=project_name)
+
     return Project(conda_env_path=None, entry_points=entry_points,
                    docker_env=docker_env, name=project_name)
 

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -8,6 +8,7 @@ _logger = logging.getLogger(__name__)
 
 MLPROJECT_PARAMETER_TYPES = ('string', 'float', 'path', 'uri')
 BAD_MLPROJECT_MESSAGE = "Invalid MLproject file: {}"
+MLPROJECT_MESSAGE = "MLproject file: %s"
 
 
 def validate_conda_env_path(path):
@@ -47,11 +48,11 @@ def validate_project_yaml(project_yaml):
 
 def _validate_entries_are_allowed(yaml_level, present_entries, allowed_entries):
     """helper to validate that entry keys are in an allowable set"""
-    for k in present_entries:
-        if k not in allowed_entries:
-            message = "{} entry {} not one of allowed entries {{{}}}"\
-                .format(yaml_level, k, ', '.join(allowed_entries))
-            raise ExecutionException(BAD_MLPROJECT_MESSAGE.format(message))
+    unparsed_entries = set(present_entries) - set(allowed_entries)
+    if unparsed_entries:
+        message = "{} entries {{{}}} will not be parsed by MLflow projects"\
+            .format(yaml_level, ', '.join(sorted(unparsed_entries)))
+        _logger.info(MLPROJECT_MESSAGE, message)
 
 
 def _validate_entry_point_yaml(entry_point_name, entry_point_yaml):

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -1,6 +1,10 @@
 import os
+import logging
 
 from mlflow.exceptions import ExecutionException
+
+_logger = logging.getLogger(__name__)
+
 
 MLPROJECT_PARAMETER_TYPES = ('string', 'float', 'path', 'uri')
 BAD_MLPROJECT_MESSAGE = "Invalid MLproject file: {}"
@@ -74,9 +78,10 @@ def _validate_entry_point_parameter_yaml(entry_point_name, parameter_name, param
     def check_parameter_type(attempted_type):
         if attempted_type not in MLPROJECT_PARAMETER_TYPES:
             unsupported_parameter_type_message = (
-                "unsupported type for parameter {} in entry point {} will be converted to string"
+                "unsupported type for parameter {} in entry point {}, "
+                "parameter value will be converted to string"
             ).format(parameter_name, entry_point_name)
-            print(unsupported_parameter_type_message)
+            _logger.warning(unsupported_parameter_type_message)
 
     # interpret the entry as a type if it's a single string
     if isinstance(parameter_yaml, str):
@@ -103,8 +108,8 @@ def _validate_docker_env_yaml(docker_env_yaml):
 
     if not isinstance(docker_env_yaml, dict) or not isinstance(docker_env_yaml.get('image'), str):
         bad_docker_entry_message = (
-            "docker_env must have an 'image' entry representing a Docker image "
-            "that is accessible on the system executing the project"
+            "docker_env must be a YAML object with a string 'image' entry representing "
+            "a Docker image that is accessible on the system executing the project"
         )
         raise ExecutionException(BAD_MLPROJECT_MESSAGE.format(bad_docker_entry_message))
 

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -107,7 +107,7 @@ def _validate_conda_env_yaml(conda_env_yaml):
     if not isinstance(conda_env_yaml, str):
         bad_conda_env_message = (
             "conda_env should be a string representing the relative path to a "
-            "Conda environment YAML file in the MLflow project’s directory"
+            "Conda environment YAML file in the MLflow project's directory"
         )
         raise ExecutionException(BAD_MLPROJECT_MESSAGE.format(bad_conda_env_message))
 

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -1,0 +1,117 @@
+from mlflow.exceptions import ExecutionException
+
+MLPROJECT_PARAMETER_TYPES = ('string', 'float', 'path', 'uri')
+BAD_MLPROJECT_MESSAGE = "Invalid MLproject file: %s"
+
+
+def validate_project_yaml(project_yaml):
+    """validate the yaml in an MLproject file"""
+    project_allowed_entries = ('name', 'conda_env', 'docker_env', 'entry_points')
+
+    project_entries = project_yaml.keys()
+
+    # make sure there are no extraneous entries
+    _validate_entries_are_allowed('project-level', project_entries, project_allowed_entries)
+
+    if 'name' in project_entries:
+        _validate_name_yaml(project_yaml.get('name'))
+
+    if 'docker_env' in project_entries:
+        _validate_docker_env_yaml(project_yaml.get('docker_env'))
+        # disallow conda and docker envs together in the same MLproject file
+        if 'conda_env' in project_entries:
+            multi_env_message = "cannot specify conda_env and docker_env in the same project"
+            raise ExecutionException(BAD_MLPROJECT_MESSAGE.format(multi_env_message))
+
+    if 'conda_env' in project_entries:
+        _validate_conda_env_yaml(project_yaml.get('conda_env'))
+
+    if 'entry_points' in project_entries:
+        for name, entry_point in project_yaml.get('entry_points').items():
+            _validate_entry_point_yaml(name, entry_point)
+
+
+def _validate_entries_are_allowed(yaml_level, present_entries, allowed_entries):
+    """helper to validate that entry keys are in an allowable set"""
+    for k in present_entries:
+        if k not in allowed_entries:
+            message = "{} item {} not one of allowed keys {}"\
+                .format(yaml_level, k, ', '.join(allowed_entries))
+            raise ExecutionException(BAD_MLPROJECT_MESSAGE.format(message))
+
+
+def _validate_entry_point_yaml(entry_point_name, entry_point_yaml):
+    """helper to validate entry point yaml"""
+    entry_point_allowed_entries = ('parameters', 'command')
+
+    entry_point_entries = entry_point_yaml.keys()
+    _validate_entries_are_allowed('entry point', entry_point_entries, entry_point_allowed_entries)
+
+    if 'command' not in entry_point_entries:
+        no_command_message = "entry point {} has no corresponding command".format(entry_point_name)
+        raise ExecutionException(BAD_MLPROJECT_MESSAGE.format(no_command_message))
+
+    if 'parameters' in entry_point_entries:
+        for parameter_name, parameter_yaml in entry_point_yaml.get('parameters').items():
+            _validate_entry_point_parameter_yaml(entry_point_name, parameter_name, parameter_yaml)
+
+
+def _validate_entry_point_parameter_yaml(entry_point_name, parameter_name, parameter_yaml):
+    """helper to validate parameter yaml within an entry point"""
+    parameter_allowed_entries = ('type', 'default')
+
+    # define this here so we can provide a more informative error message
+    def check_parameter_type(attempted_type):
+        if attempted_type not in MLPROJECT_PARAMETER_TYPES:
+            unsupported_parameter_type_message = (
+                "unsupported type for parameter {} in entry point {} will be converted to string"
+            ).format(parameter_name, entry_point_name)
+            print(unsupported_parameter_type_message)
+
+    # interpret the entry as a type if it's a single string
+    if isinstance(parameter_yaml, str):
+        check_parameter_type(parameter_yaml)
+        return
+
+    # otherwise expect sub-entries, at least for 'type', potentially also for 'default'
+    parameter_entries = parameter_yaml.keys()
+    _validate_entries_are_allowed('parameter', parameter_entries, parameter_allowed_entries)
+
+    if 'type' not in parameter_entries:
+        missing_parameter_type_message = "parameter {} in entry point {} must specify a type" \
+            .format(parameter_name, entry_point_name)
+        raise ExecutionException(BAD_MLPROJECT_MESSAGE.format(missing_parameter_type_message))
+
+    # TODO: validate 'default' parameter value somehow
+    if 'default' in parameter_entries:
+        pass
+
+    check_parameter_type(parameter_yaml.get('type'))
+
+
+def _validate_docker_env_yaml(docker_env_yaml):
+    docker_env_entries = docker_env_yaml.keys()
+    _validate_entries_are_allowed('docker env', docker_env_entries, ('image',))
+
+    # TODO: make this condition more specific
+    if not isinstance(docker_env_yaml.get('image'), str):
+        missing_image_entry_message = (
+            "docker_env must have an 'image' entry representing a Docker image "
+            "that is accessible on the system executing the project"
+        )
+        raise ExecutionException(BAD_MLPROJECT_MESSAGE.format(missing_image_entry_message))
+
+
+def _validate_conda_env_yaml(conda_env_yaml):
+    # TODO: make this condition more specific
+    if not isinstance(conda_env_yaml, str):
+        bad_conda_env_message = (
+            "conda_env should be a string representing the relative path to a "
+            "Conda environment YAML file in the MLflow project’s directory"
+        )
+        raise ExecutionException(BAD_MLPROJECT_MESSAGE.format(bad_conda_env_message))
+
+
+def _validate_name_yaml(name_yaml):
+    if not isinstance(name_yaml, str):
+        raise ExecutionException(BAD_MLPROJECT_MESSAGE.format("name must be a single string"))

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -3,7 +3,7 @@ import os
 from mlflow.exceptions import ExecutionException
 
 MLPROJECT_PARAMETER_TYPES = ('string', 'float', 'path', 'uri')
-BAD_MLPROJECT_MESSAGE = "Invalid MLproject file: %s"
+BAD_MLPROJECT_MESSAGE = "Invalid MLproject file: {}"
 
 
 def validate_conda_env_path(path):
@@ -70,7 +70,7 @@ def _validate_entry_point_parameter_yaml(entry_point_name, parameter_name, param
     """helper to validate parameter yaml within an entry point"""
     parameter_allowed_entries = ('type', 'default')
 
-    # define this here so we can provide a more informative error message
+    # define this here so we can provide a more informative message
     def check_parameter_type(attempted_type):
         if attempted_type not in MLPROJECT_PARAMETER_TYPES:
             unsupported_parameter_type_message = (

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -100,16 +100,16 @@ def _validate_entry_point_parameter_yaml(entry_point_name, parameter_name, param
 
 
 def _validate_docker_env_yaml(docker_env_yaml):
-    docker_env_entries = docker_env_yaml.keys()
-    _validate_entries_are_allowed('docker env', docker_env_entries, ('image',))
 
-    # TODO: make this condition more specific
-    if not isinstance(docker_env_yaml.get('image'), str):
-        missing_image_entry_message = (
+    if not isinstance(docker_env_yaml, dict) or not isinstance(docker_env_yaml.get('image'), str):
+        bad_docker_entry_message = (
             "docker_env must have an 'image' entry representing a Docker image "
             "that is accessible on the system executing the project"
         )
-        raise ExecutionException(BAD_MLPROJECT_MESSAGE.format(missing_image_entry_message))
+        raise ExecutionException(BAD_MLPROJECT_MESSAGE.format(bad_docker_entry_message))
+
+    docker_env_entries = docker_env_yaml.keys()
+    _validate_entries_are_allowed('docker env', docker_env_entries, ('image',))
 
 
 def _validate_conda_env_yaml(conda_env_yaml):

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -45,7 +45,7 @@ def _validate_entries_are_allowed(yaml_level, present_entries, allowed_entries):
     """helper to validate that entry keys are in an allowable set"""
     for k in present_entries:
         if k not in allowed_entries:
-            message = "{} item {} not one of allowed keys {}"\
+            message = "{} entry {} not one of allowed entries {{{}}}"\
                 .format(yaml_level, k, ', '.join(allowed_entries))
             raise ExecutionException(BAD_MLPROJECT_MESSAGE.format(message))
 

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -1,7 +1,17 @@
+import os
+
 from mlflow.exceptions import ExecutionException
 
 MLPROJECT_PARAMETER_TYPES = ('string', 'float', 'path', 'uri')
 BAD_MLPROJECT_MESSAGE = "Invalid MLproject file: %s"
+
+
+def validate_conda_env_path(path):
+    if not os.path.exists(path):
+        bad_conda_path_message = "conda environment file {} not found".format(path)
+        raise ExecutionException(
+            BAD_MLPROJECT_MESSAGE.format(bad_conda_path_message)
+        )
 
 
 def validate_project_yaml(project_yaml):

--- a/tests/projects/test_project_spec.py
+++ b/tests/projects/test_project_spec.py
@@ -146,7 +146,7 @@ bad_ml_project_file_test_cases = (
     ),
     # docker env has only a string image entry
     (
-        "must have an 'image' entry",
+        "must be a YAML object with a string 'image' entry",
         (
             """
             docker_env: blah

--- a/tests/projects/test_project_spec.py
+++ b/tests/projects/test_project_spec.py
@@ -85,41 +85,6 @@ def test_validate_conda_env_path():
 
 
 bad_ml_project_file_test_cases = (
-    # bad sub-entries at various points
-    (
-        "not one of allowed entries",
-        (
-            """
-            name: test
-            blah: blah
-            """,
-            """
-            docker_env:
-              image: some-image
-              some_entry: shrug
-            """,
-            """
-            entry_points:
-              ep:
-                parameters:
-                  p:
-                    type: test
-                    blah: test
-                command: pass
-            """,
-            """
-            entry_points:
-              ep:
-                command: pass
-                blah: blah
-            """,
-            """
-            docker_env:
-              image: hi
-              blah: blah
-            """
-        )
-    ),
     # conda and docker in the same project
     (
         "conda_env and docker_env in the same project",

--- a/tests/projects/test_project_spec.py
+++ b/tests/projects/test_project_spec.py
@@ -76,22 +76,109 @@ def test_load_docker_project(tmpdir):
     assert project.docker_env.get("image") == "some-image"
 
 
-@pytest.mark.parametrize("invalid_project_contents, expected_error_msg", [
-    (textwrap.dedent("""
-    docker_env:
-        image: some-image
-    conda_env: some-file.yaml
-    """), "Invalid MLproject file:"),
-    (textwrap.dedent("""
-    docker_env:
-        not-image-attribute: blah
-    """), "Invalid MLproject file:"),
-    (textwrap.dedent("""
-    docker_env: blah
-    """), "Invalid MLproject file:"),
+bad_ml_project_file_test_cases = (
+    # bad sub-entries at various points
+    (
+        "not one of allowed entries",
+        (
+            """
+            name: test
+            blah: blah
+            """,
+            """
+            docker_env:
+              image: some-image
+              some_entry: shrug
+            """,
+            """
+            entry_points:
+              ep:
+                parameters:
+                  p:
+                    type: test
+                    blah: test
+                command: pass
+            """,
+            """
+            entry_points:
+              ep:
+                command: pass
+                blah: blah
+            """,
+            """
+            docker_env:
+              image: hi
+              blah: blah
+            """
+        )
+    ),
+    # conda and docker in the same project
+    (
+        "conda_env and docker_env in the same project",
+        (
+            """
+            docker_env:
+              image: some-image
+            conda_env: some-file.yaml
+            """,
+        )
+    ),
+    # entry point parameter with entries must list type
+    (
+        "parameter p in entry point ep must specify a type",
+        (
+            """
+            entry_points:
+              ep:
+                parameters:
+                  p: {default: 1}
+                command: pass
+            """,
+        )
+    ),
+    # docker env has only a string image entry
+    (
+        "must have an 'image' entry",
+        (
+            """
+            docker_env: blah
+            """,
+            """
+            docker_env:
+              not-image-attribute: blah
+            """
+        )
+    ),
+    # conda is a path
+    (
+        "conda_env should be a string representing the relative path",
+        (
+            """
+            conda_env:
+              some_item: blah
+            """,
+        )
+    ),
+    # name is simple string
+    (
+        "name must be a single string",
+        (
+            """
+            name:
+              some_item: blah
+            """,
+        )
+    )
+)
+
+
+@pytest.mark.parametrize("invalid_project_content_strings, expected_error_msg", [
+    ((textwrap.dedent(p) for p in bad_ml_projects), error_fragment)
+    for error_fragment, bad_ml_projects in bad_ml_project_file_test_cases
 ])
-def test_load_invalid_project(tmpdir, invalid_project_contents, expected_error_msg):
-    tmpdir.join("MLproject").write(invalid_project_contents)
-    with pytest.raises(ExecutionException) as e:
-        _project_spec.load_project(tmpdir.strpath)
-    assert expected_error_msg in str(e.value)
+def test_load_invalid_project(tmpdir, invalid_project_content_strings, expected_error_msg):
+    for content in invalid_project_content_strings:
+        tmpdir.join("MLproject").write(content)
+        with pytest.raises(ExecutionException) as e:
+            _project_spec.load_project(tmpdir.strpath)
+        assert expected_error_msg in str(e.value)

--- a/tests/projects/test_project_spec.py
+++ b/tests/projects/test_project_spec.py
@@ -41,7 +41,6 @@ def test_project_get_unspecified_entry_point():
 
 @pytest.mark.parametrize("mlproject, conda_env_path, conda_env_contents", [
     (None, None, ""),
-    ("key: value", "conda.yaml", "hi"),
     ("conda_env: some-env.yaml", "some-env.yaml", "hi")
 ])
 def test_load_project(tmpdir, mlproject, conda_env_path, conda_env_contents):
@@ -82,11 +81,11 @@ def test_load_docker_project(tmpdir):
     docker_env:
         image: some-image
     conda_env: some-file.yaml
-    """), "cannot contain both a docker and conda env"),
+    """), "Invalid MLproject file:"),
     (textwrap.dedent("""
     docker_env:
         not-image-attribute: blah
-    """), "no image attribute found"),
+    """), "Invalid MLproject file:"),
 ])
 def test_load_invalid_project(tmpdir, invalid_project_contents, expected_error_msg):
     tmpdir.join("MLproject").write(invalid_project_contents)

--- a/tests/projects/test_project_spec.py
+++ b/tests/projects/test_project_spec.py
@@ -86,6 +86,9 @@ def test_load_docker_project(tmpdir):
     docker_env:
         not-image-attribute: blah
     """), "Invalid MLproject file:"),
+    (textwrap.dedent("""
+    docker_env: blah
+    """), "Invalid MLproject file:"),
 ])
 def test_load_invalid_project(tmpdir, invalid_project_contents, expected_error_msg):
     tmpdir.join("MLproject").write(invalid_project_contents)

--- a/tests/projects/test_project_spec.py
+++ b/tests/projects/test_project_spec.py
@@ -76,6 +76,14 @@ def test_load_docker_project(tmpdir):
     assert project.docker_env.get("image") == "some-image"
 
 
+def test_validate_conda_env_path(tmpdir):
+    nonexistent_file = 'nonexistent_conda_path.yaml'
+    with pytest.raises(ExecutionException) as e:
+        _project_spec.validate_conda_env_path(nonexistent_file)
+    expected_error_msg = "conda environment file {} not found".format(nonexistent_file)
+    assert expected_error_msg in str(e)
+
+
 bad_ml_project_file_test_cases = (
     # bad sub-entries at various points
     (

--- a/tests/projects/test_project_spec.py
+++ b/tests/projects/test_project_spec.py
@@ -76,7 +76,7 @@ def test_load_docker_project(tmpdir):
     assert project.docker_env.get("image") == "some-image"
 
 
-def test_validate_conda_env_path(tmpdir):
+def test_validate_conda_env_path():
     nonexistent_file = 'nonexistent_conda_path.yaml'
     with pytest.raises(ExecutionException) as e:
         _project_spec.validate_conda_env_path(nonexistent_file)


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Validate MLproject files against MLflow project specs. 

- separate validation code from the business process of parsing an MLproject file
- remove redundant validation code
- improve clarity of MLproject file-related error messages
- add tests for the validation process

MLproject files are currently validated piecemeal at various points in the parsing process. They put out inconsistent error messages, which often make it hard to understand that the underlying issue is with the MLproject file structure.

This change improves the clarity of these MLproject error messages by pointing to specific elements that are incorrect (e.g. `parameter XXX in entry point YYY must specify a type`, or `entry point YYY has no command`), and by prefixing all errors with `Invalid MLproject file:` to make it clear the error comes from the configuration itself.

A full list of validation items is below.

## Validation Items

- project-level:
  - entries limited to 'name', 'docker_env', 'conda_env', and 'entry_points'
  - 'docker_env' and 'conda_env' not allowed in the same file
- entry points:
  - each entry point's sub-entries are limited to 'command' and 'parameters' and require a 'command' sub-entry
- parameters:
  - require 'type', which can be a standalone string or a 'type' sub-entry
  - print a message that the parameter will be converted to a string if not one of 'string', 'float', 'path', 'uri'
- docker_env:
  - require the string 'image' sub-entry
  - check the image value is a string
- conda_env
  - check the value is a string if present
  - check the path exists
- name
  - check the value is a string if present

### Out of scope

- with the exception of conda_env (validated in its own function), does not validate whether any files or paths exist *where* the MLproject says they should
- does not validate string items (`command: abe&%^` passes) beyond confirming they're strings
- does not check that parameter defaults fit their assigned type

## How is this patch tested?
 
Restructured and extended MLproject validation unit tests. Wrote test cases for each of the validation items covered.
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
  
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [x] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
