### PR TITLE
[SFTPArtifactRepository] reading port and user configuration from ~/.ssh/config

### DIFF
--- a/mlflow/store/sftp_artifact_repo.py
+++ b/mlflow/store/sftp_artifact_repo.py
@@ -15,7 +15,7 @@ class SFTPArtifactRepository(ArtifactRepository):
         parsed = urllib.parse.urlparse(artifact_uri)
         self.config = {
             'host': parsed.hostname,
-            'port': 22 if parsed.port is None else parsed.port,
+            'port': parsed.port,
             'username': parsed.username,
             'password': parsed.password
         }
@@ -41,8 +41,14 @@ class SFTPArtifactRepository(ArtifactRepository):
             if 'hostname' in user_config:
                 self.config['host'] = user_config['hostname']
 
-            if self.config.get('username', None) is None and 'username' in user_config:
-                self.config['username'] = user_config['username']
+            if self.config.get('username', None) is None and 'user' in user_config:
+                self.config['username'] = user_config['user']
+
+            if self.config.get('port', None) is None:
+                if 'port' in user_config:
+                    self.config['port'] = int(user_config['port'])
+                else:
+                    self.config['port'] = 22
 
             if 'identityfile' in user_config:
                 self.config['private_key'] = user_config['identityfile'][0]


### PR DESCRIPTION
## What changes are proposed in this pull request?
1. reading port from the ssh config file instead of the default value when people not set port value in the `MLFLOW_TRACKING_URI`.
 2. fix username read bug. username in `user_config` with configuration key  `user` not `username`.

## How is this patch tested?
 
I tested it manually.
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
