### PR TITLE
Stop truncating user email addresses in the ExperimentView UI

### DIFF
--- a/mlflow/server/js/src/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/components/ExperimentViewUtil.js
@@ -44,7 +44,7 @@ export default class ExperimentViewUtil {
    */
   static getRunInfoCellsForRow(runInfo, tags, isParent, cellType, handleCellToggle) {
     const CellComponent = `${cellType}`;
-    const user = Utils.formatUser(Utils.getUser(runInfo, tags));
+    const user = Utils.getUser(runInfo, tags);
     const queryParams = window.location && window.location.search ? window.location.search : "";
     const sourceType = Utils.renderSource(tags, queryParams);
     const startTime = runInfo.start_time;
@@ -291,7 +291,7 @@ export default class ExperimentViewUtil {
       const sortValue = (sortState.isMetric ? metricsMap : paramsMap)[sortState.key];
       return (sortValue === undefined ? undefined : sortValue.value);
     } else if (sortState.key === 'user_id') {
-      return Utils.formatUser(Utils.getUser(runInfo, tags));
+      return Utils.getUser(runInfo, tags);
     } else if (sortState.key === 'source') {
       return Utils.formatSource(runInfo, tags);
     } else if (sortState.key === 'run_name') {

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -105,10 +105,6 @@ class Utils {
     }
   }
 
-  static formatUser(userId) {
-    return userId.replace(/@.*/, "");
-  }
-
   static baseName(path) {
     const pieces = path.split("/");
     return pieces[pieces.length - 1];

--- a/mlflow/server/js/src/utils/Utils.test.js
+++ b/mlflow/server/js/src/utils/Utils.test.js
@@ -59,12 +59,6 @@ test("formatDuration", () => {
   expect(Utils.formatDuration(480 * 60 * 60 * 1000)).toEqual("20.0d");
 });
 
-test("formatUser", () => {
-  expect(Utils.formatUser("bob")).toEqual("bob");
-  expect(Utils.formatUser("bob.mcbob")).toEqual("bob.mcbob");
-  expect(Utils.formatUser("bob@example.com")).toEqual("bob");
-});
-
 test("baseName", () => {
   expect(Utils.baseName("foo")).toEqual("foo");
   expect(Utils.baseName("foo/bar/baz")).toEqual("baz");


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Stop truncating user email addresses in the ExperimentView UI
 
## How is this patch tested?
 
Manual testing, ensure unit tests still pass
 
## Release Notes

The ExperimentView UI now displays the email domain associated with the `mlflow.user` tag, if it is present.
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
### What component(s) does this PR affect?
 
- [X] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
