### PR TITLE
Allow tags to be set to empty strings in the UI, and hide tags list by default

### DIFF
--- a/mlflow/server/js/src/components/EditableTagsTableView.js
+++ b/mlflow/server/js/src/components/EditableTagsTableView.js
@@ -104,7 +104,7 @@ export class EditableTagsTableView extends React.Component {
             </Form.Item>
             <Form.Item>
               {getFieldDecorator('value', {
-                rules: [{ required: true, message: 'Value is required.'}]
+                rules: []
               })(
                 <Input placeholder='Value' style={styles.addTagForm.valueInput}/>
               )}

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -59,7 +59,7 @@ class RunView extends Component {
     showParameters: true,
     showMetrics: true,
     showArtifacts: true,
-    showTags: true,
+    showTags: false,
     showRunRenameModal: false,
   };
 

--- a/mlflow/server/js/src/components/tables/EditableFormTable.js
+++ b/mlflow/server/js/src/components/tables/EditableFormTable.js
@@ -37,12 +37,7 @@ class EditableCell extends React.Component {
             {editing ? (
               <Form.Item style={{ margin: 0 }}>
                 {getFieldDecorator(dataIndex, {
-                  rules: [
-                    {
-                      required: true,
-                      message: `${title} is required.`,
-                    },
-                  ],
+                  rules: [],
                   initialValue: record[dataIndex],
                 })(<Input onKeyDown={this.handleKeyPress} />)}
               </Form.Item>

--- a/mlflow/server/js/src/components/tables/EditableFormTable.js
+++ b/mlflow/server/js/src/components/tables/EditableFormTable.js
@@ -29,7 +29,7 @@ class EditableCell extends React.Component {
   };
 
   render() {
-    const { editing, dataIndex, title, record, children } = this.props;
+    const { editing, dataIndex, record, children } = this.props;
     return (
       <EditableContext.Consumer>
         {({ getFieldDecorator }) => (


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
We actually allow tags to have empty strings as their value, so don't prevent that (it can be useful if you just want to use a tag as a label, for instance). Also, because we expect a lot of automatically-set tags to exist in the future, this PR makes the tag list hidden by default.
 
## How is this patch tested?
 
Tested manually.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Allow users to set tags to an empty string through the UI.
 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes