### PR TITLE
Fix the way multiple tags, metrics, etc are displayed in the experiment table

### DIFF
--- a/mlflow/server/js/src/components/CollapsibleTagsCell.js
+++ b/mlflow/server/js/src/components/CollapsibleTagsCell.js
@@ -34,7 +34,14 @@ export class CollapsibleTagsCell extends React.Component {
           const value = entry[1];
           return (
             <div className='tag-cell-item truncate-text single-line' key={tagName}>
-              <span style={styles.tagKey}>{tagName}:</span>{value}
+              { (value === "") ?
+                  <span className='tag-name'>{tagName}</span>
+                :
+                  <span>
+                    <span className='tag-name'>{tagName}:</span>
+                    <span className='metric-param-value'>{value}</span>
+                  </span>
+              }
             </div>
           );
         })}
@@ -49,10 +56,3 @@ export class CollapsibleTagsCell extends React.Component {
     );
   }
 }
-
-const styles = {
-  tagKey: {
-    color: '#888',
-    paddingRight: 10,
-  }
-};

--- a/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
@@ -180,7 +180,9 @@ class ExperimentRunsTableCompactView extends React.Component {
     });
     if (this.shouldShowBaggedColumn(true)) {
       rowContents.push(
-        <div key={"params-container-cell-" + runInfo.run_uuid}>
+        <div key={"params-container-cell-" + runInfo.run_uuid}
+          className="metric-param-container-cell"
+        >
           {paramsCellContents}
         </div>);
     }

--- a/mlflow/server/js/src/components/ExperimentView.css
+++ b/mlflow/server/js/src/components/ExperimentView.css
@@ -194,10 +194,6 @@ span.error-message {
   cursor: pointer;
 }
 
-.ExperimentView .metric-param-name {
-  font-weight: bold;
-}
-
 .ExperimentView .underline-on-hover:hover {
   text-decoration: underline;
 }
@@ -224,16 +220,17 @@ span.error-message {
 
 .ExperimentView .metric-param-container-cell {
   min-width: 280px;
+  padding: 8px;
 }
 
 .ExperimentView .metric-param-cell {
   display: inline-block;
   width: 250px;
-  padding: 4px;
+  padding: 0;
 }
 
-.ExperimentView .metric-param-content {
-  padding-top: 0px;
+.ExperimentView .tag-cell-item {
+  height: 100%;
 }
 
 .ExperimentView-expander:hover {
@@ -263,8 +260,12 @@ span.error-message {
   padding: 8px;
 }
 
-.ExperimentView .ReactVirtualized__Table  .BaggedCell .run-table-container {
-  padding: 4px;
+.ExperimentView .ReactVirtualized__Table  .run-table-container.metric-param-sort-toggle {
+  padding: 0;
+}
+
+.ExperimentView .ReactVirtualized__Table  .run-table-container.metric-param-value {
+  padding: 0;
 }
 
 /**


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
A few fixes to the display of tags, metrics, etc in the experiment table:
- Reduce the spacing between multiple metrics, params, etc (it somehow grew over time due to repeated use of the same CSS class in various places)
- Show tag names in black instead of gray because they are not clickable like the param and metric names right now
- Set the spacing between multiple tags to match the spacing between multiple params, metrics, etc
- Don't show a colon character if a tag has an empty value (this makes it easier to use tags as labels with no value if desired)

Here is how some example data looks before and after this change:

BEFORE:
![Screen Shot 2019-08-15 at 7 20 48 PM](https://user-images.githubusercontent.com/228859/63139185-3497ba00-bf92-11e9-9f38-8f674f87facc.png)

AFTER:
![Screen Shot 2019-08-15 at 7 18 37 PM](https://user-images.githubusercontent.com/228859/63139188-382b4100-bf92-11e9-9f78-d590b4189fe5.png)
 
## How is this patch tested?
 
Manually tested
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Fix several bugs in the display of multiple tags and metrics on the experiment page, such as excessive spacing between them
 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
