### PR TITLE
Fixes to parallel coordinates plot

### DIFF
--- a/mlflow/server/js/src/components/ParallelCoordinatesPlotPanel.js
+++ b/mlflow/server/js/src/components/ParallelCoordinatesPlotPanel.js
@@ -3,7 +3,8 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import ParallelCoordinatesPlotView from './ParallelCoordinatesPlotView';
 import { ParallelCoordinatesPlotControls } from './ParallelCoordinatesPlotControls';
-import { getSharedMetricKeysByRunUuids, getSharedParamKeysByRunUuids } from '../reducers/Reducers';
+import { getAllParamKeysByRunUuids, getAllMetricKeysByRunUuids, getSharedMetricKeysByRunUuids,
+         getSharedParamKeysByRunUuids } from '../reducers/Reducers';
 import _ from 'lodash';
 import { Empty } from 'antd';
 
@@ -12,6 +13,10 @@ import './ParallelCoordinatesPlotPanel.css';
 export class ParallelCoordinatesPlotPanel extends React.Component {
   static propTypes = {
     runUuids: PropTypes.arrayOf(String).isRequired,
+    // An array of all parameter keys across runs
+    allParamKeys: PropTypes.arrayOf(String).isRequired,
+    // An array of all metric keys across runs
+    allMetricKeys: PropTypes.arrayOf(String).isRequired,
     // An array of parameter keys shared by all runs
     sharedParamKeys: PropTypes.arrayOf(String).isRequired,
     // An array of metric keys shared by all runs
@@ -35,13 +40,13 @@ export class ParallelCoordinatesPlotPanel extends React.Component {
   };
 
   render() {
-    const { runUuids, sharedParamKeys, sharedMetricKeys } = this.props;
+    const { runUuids, allParamKeys, allMetricKeys } = this.props;
     const { selectedParamKeys, selectedMetricKeys } = this.state;
     return (
       <div className='parallel-coorinates-plot-panel'>
         <ParallelCoordinatesPlotControls
-          paramKeys={sharedParamKeys}
-          metricKeys={sharedMetricKeys}
+          paramKeys={allParamKeys}
+          metricKeys={allMetricKeys}
           selectedParamKeys={selectedParamKeys}
           selectedMetricKeys={selectedMetricKeys}
           handleMetricsSelectChange={this.handleMetricsSelectChange}
@@ -61,9 +66,11 @@ export class ParallelCoordinatesPlotPanel extends React.Component {
 
 const mapStateToProps = (state, ownProps) => {
   const { runUuids } = ownProps;
+  const allParamKeys = getAllParamKeysByRunUuids(runUuids, state);
+  const allMetricKeys = getAllMetricKeysByRunUuids(runUuids, state);
   const sharedParamKeys = getSharedParamKeysByRunUuids(runUuids, state);
   const sharedMetricKeys = getSharedMetricKeysByRunUuids(runUuids, state);
-  return { sharedParamKeys, sharedMetricKeys };
+  return { allParamKeys, allMetricKeys, sharedParamKeys, sharedMetricKeys };
 };
 
 export default connect(mapStateToProps)(ParallelCoordinatesPlotPanel);

--- a/mlflow/server/js/src/components/ParallelCoordinatesPlotView.test.js
+++ b/mlflow/server/js/src/components/ParallelCoordinatesPlotView.test.js
@@ -21,20 +21,24 @@ describe('unit tests', () => {
         {
           label: 'param_0',
           values: [1, 2],
+          tickformat: 'f',
         },
         {
           label: 'param_1',
           values: [2, 3],
+          tickformat: 'f',
         },
       ],
       metricDimensions: [
         {
           label: 'metric_0',
           values: [1, 2],
+          tickformat: 'f',
         },
         {
           label: 'metric_1',
           values: [2, 3],
+          tickformat: 'f',
         },
       ],
     };
@@ -124,6 +128,48 @@ describe('unit tests', () => {
     expect(inferType(key, runUuids, entryByRunUuid)).toBe('string');
   });
 
+  test('inferType works with numeric dimension that includes NaNs', () => {
+    const key = 'metric_0';
+    const runUuids = ['runUuid_0', 'runUuid_1'];
+    const entryByRunUuid = {
+      runUuid_0: {
+        metric_0: { value: NaN },
+      },
+      runUuid_1: {
+        metric_0: { value: NaN },
+      },
+    };
+    expect(inferType(key, runUuids, entryByRunUuid)).toBe('number');
+  });
+
+  test('inferType works with numeric dimension specified as strings', () => {
+    const key = 'metric_0';
+    const runUuids = ['runUuid_0', 'runUuid_1'];
+    const entryByRunUuid = {
+      runUuid_0: {
+        metric_0: { value: '1.0' },
+      },
+      runUuid_1: {
+        metric_0: { value: 'NaN' },
+      },
+    };
+    expect(inferType(key, runUuids, entryByRunUuid)).toBe('number');
+  });
+
+  test('inferType works with mixed string and number dimension', () => {
+    const key = 'metric_0';
+    const runUuids = ['runUuid_0', 'runUuid_1'];
+    const entryByRunUuid = {
+      runUuid_0: {
+        metric_0: { value: '1.0' },
+      },
+      runUuid_1: {
+        metric_0: { value: 'this thing is a string' },
+      },
+    };
+    expect(inferType(key, runUuids, entryByRunUuid)).toBe('string');
+  });
+
   test('createDimension should work with numeric dimension', () => {
     const key = 'metric_0';
     const runUuids = ['runUuid_0', 'runUuid_1'];
@@ -138,6 +184,7 @@ describe('unit tests', () => {
     expect(createDimension(key, runUuids, entryByRunUuid)).toEqual({
       label: 'metric_0',
       values: [1, 2],
+      tickformat: 'f',
     });
   });
 

--- a/mlflow/server/js/src/reducers/Reducers.js
+++ b/mlflow/server/js/src/reducers/Reducers.js
@@ -329,6 +329,16 @@ export const getSharedMetricKeysByRunUuids = (runUuids, state) =>
         ...runUuids.map((runUuid) => Object.keys(state.entities.latestMetricsByRunUuid[runUuid])),
     );
 
+export const getAllParamKeysByRunUuids = (runUuids, state) =>
+    _.union(
+        ...runUuids.map((runUuid) => Object.keys(state.entities.paramsByRunUuid[runUuid])),
+    );
+
+export const getAllMetricKeysByRunUuids = (runUuids, state) =>
+    _.union(
+        ...runUuids.map((runUuid) => Object.keys(state.entities.latestMetricsByRunUuid[runUuid])),
+    );
+
 export const getApis = (requestIds, state) => {
   return requestIds.map((id) => state.apis[id] || {});
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
- The parallel coordinates plot used to only let you compare fields that are present in all the selected runs, which might be no fields if you selected runs with very different parameters and metrics. This follows the behavior of the scatter plot, to only plot the points that have your selected fields, but let you use any of the available fields.
- Plotly formatted numbers on the axes with the D3 "s" number format (SI unit prefixes) by default, which is weird for ML metrics. For example, values like 0.1, 0.2, 0.3, etc would show up as "100m", "200m", "300m", etc (m being the SI prefix for "milli"). This uses the float format for these numbers.
- Improved the type inference logic to support number columns that contain NaNs (before, we thought these were strings).
 
## How is this patch tested?
 
Manual testing plus new unit tests.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Bug fixes in the parallel coordinates plot (show all available fields for comparison and format numerical axes better).
 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
