### PR TITLE
Added fit_generator hooks for autolog

### DIFF
--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -391,6 +391,21 @@ def autolog():
         else:
             kwargs['callbacks'] = [__MLflowKerasCallback()]
         return original(self, *args, **kwargs)
+
+    @gorilla.patch(keras.Model)
+    def fit_generator(self, *args, **kwargs):
+        original = gorilla.get_original_attribute(keras.Model, 'fit_generator')
+        if len(args) >= 5:
+            l = list(args)
+            l[4] += [__MLflowKerasCallback()]
+            args = tuple(l)
+        elif 'callbacks' in kwargs:
+            kwargs['callbacks'] += [__MLflowKerasCallback()]
+        else:
+            kwargs['callbacks'] = [__MLflowKerasCallback()]
+        return original(self, *args, **kwargs)
+
     settings = gorilla.Settings(allow_hit=True, store_hit=True)
     patch = gorilla.Patch(keras.Model, 'fit', fit, settings=settings)
+    patch = gorilla.Patch(keras.Model, 'fit_generator', fit_generator, settings=settings)
     gorilla.apply(patch)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -406,6 +406,5 @@ def autolog():
         return original(self, *args, **kwargs)
 
     settings = gorilla.Settings(allow_hit=True, store_hit=True)
-    patch = gorilla.Patch(keras.Model, 'fit', fit, settings=settings)
-    patch = gorilla.Patch(keras.Model, 'fit_generator', fit_generator, settings=settings)
-    gorilla.apply(patch)
+    gorilla.apply(gorilla.Patch(keras.Model, 'fit', fit, settings=settings))
+    gorilla.apply(gorilla.Patch(keras.Model, 'fit_generator', fit_generator, settings=settings))

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -70,6 +70,7 @@ def test_keras_autolog_logs_expected_data(keras_random_data_run):
 
 
 @pytest.mark.large
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
 def test_keras_autolog_model_can_load_from_artifact(keras_random_data_run, random_train_data):
     artifacts = client.list_artifacts(keras_random_data_run.info.run_id)
     artifacts = map(lambda x: x.path, artifacts)

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -14,8 +14,13 @@ def random_train_data():
     return np.random.random((1000, 32))
 
 
+@pytest.fixture()
+def fit_variant():
+    return "fit"
+
+
 @pytest.fixture
-def keras_random_data_run(random_train_data):
+def keras_random_data_run(random_train_data, fit_variant):
     mlflow.keras.autolog()
 
     def random_one_hot_labels(shape):
@@ -39,12 +44,19 @@ def keras_random_data_run(random_train_data):
                       loss='categorical_crossentropy',
                       metrics=['accuracy'])
 
-        model.fit(data, labels, epochs=10)
+        if fit_variant == 'fit_generator':
+            def generator():
+                while True:
+                    yield data, labels
+            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
+        else:
+            model.fit(data, labels, epochs=10)
 
     return client.get_run(run.info.run_id)
 
 
 @pytest.mark.large
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
 def test_keras_autolog_logs_expected_data(keras_random_data_run):
     data = keras_random_data_run.data
     assert 'acc' in data.metrics


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
When using keras fit_generator instead it fit, the callback hooks are currently not installed. This patch fixes it.
 
## How is this patch tested?
 
Only by running it on my data. I wasn't able to run the test_keras_autolog.py without errors on master with reasonable effort yet.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Keras autolog hooks now work when using model.fit_generator, not just model.fit.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
