### PR TITLE
Fix [SETUP-BUG] #1748

### DIFF
--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -159,14 +159,16 @@ class SqlAlchemyStore(AbstractStore):
 
         return make_managed_session
 
-    def _set_no_auto_for_zero_values(self, session):
+    def _set_zero_value_insertion_for_autoincrement_column(self, session):
         if self.db_type == MYSQL:
+            #config letting MySQL override default to allow 0 value for experiment ID (auto increment column)
             session.execute("SET @@SESSION.sql_mode='NO_AUTO_VALUE_ON_ZERO';")
         if self.db_type == MSSQL:
+            #config letting MSSQL override default to allow any manual value inserted into IDENTITY column
             session.execute("SET IDENTITY_INSERT experiments ON;")
 
     # DB helper methods to allow zero values for columns with auto increments
-    def _unset_no_auto_for_zero_values(self, session):
+    def _unset_zero_value_insertion_for_autoincrement_column(self, session):
         if self.db_type == MYSQL:
             session.execute("SET @@SESSION.sql_mode='';")
         if self.db_type == MSSQL:

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -9,7 +9,7 @@ import sqlalchemy
 
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.store import SEARCH_MAX_RESULTS_THRESHOLD
-from mlflow.store.dbmodels.db_types import MYSQL
+from mlflow.store.dbmodels.db_types import MYSQL, MSSQL
 from mlflow.store.dbmodels.models import Base, SqlExperiment, SqlRun, SqlMetric, SqlParam, SqlTag, \
     SqlExperimentTag
 from mlflow.entities import RunStatus, SourceType, Experiment
@@ -162,11 +162,15 @@ class SqlAlchemyStore(AbstractStore):
     def _set_no_auto_for_zero_values(self, session):
         if self.db_type == MYSQL:
             session.execute("SET @@SESSION.sql_mode='NO_AUTO_VALUE_ON_ZERO';")
+        if self.db_type == MSSQL:
+            session.execute("SET IDENTITY_INSERT experiments ON;")
 
     # DB helper methods to allow zero values for columns with auto increments
     def _unset_no_auto_for_zero_values(self, session):
         if self.db_type == MYSQL:
             session.execute("SET @@SESSION.sql_mode='';")
+        if self.db_type == MSSQL:
+            session.execute("SET IDENTITY_INSERT experiments OFF;")
 
     def _create_default_experiment(self, session):
         """

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -161,10 +161,12 @@ class SqlAlchemyStore(AbstractStore):
 
     def _set_zero_value_insertion_for_autoincrement_column(self, session):
         if self.db_type == MYSQL:
-            #config letting MySQL override default to allow 0 value for experiment ID (auto increment column)
+            # config letting MySQL override default
+            # to allow 0 value for experiment ID (auto increment column)
             session.execute("SET @@SESSION.sql_mode='NO_AUTO_VALUE_ON_ZERO';")
         if self.db_type == MSSQL:
-            #config letting MSSQL override default to allow any manual value inserted into IDENTITY column
+            # config letting MSSQL override default
+            # to allow any manual value inserted into IDENTITY column
             session.execute("SET IDENTITY_INSERT experiments ON;")
 
     # DB helper methods to allow zero values for columns with auto increments

--- a/mlflow/store/sqlalchemy_store.py
+++ b/mlflow/store/sqlalchemy_store.py
@@ -202,11 +202,11 @@ class SqlAlchemyStore(AbstractStore):
         values = ", ".join([decorate(default_experiment.get(c)) for c in columns])
 
         try:
-            self._set_no_auto_for_zero_values(session)
+            self._set_zero_value_insertion_for_autoincrement_column(session)
             session.execute("INSERT INTO {} ({}) VALUES ({});".format(
                 table, ", ".join(columns), values))
         finally:
-            self._unset_no_auto_for_zero_values(session)
+            self._unset_zero_value_insertion_for_autoincrement_column(session)
 
     def _save_to_db(self, session, objs):
         """

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -20,6 +20,7 @@ from mlflow.protos.databricks_pb2 import ErrorCode, RESOURCE_DOES_NOT_EXIST, \
 from mlflow.store import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.db.utils import _get_schema_version
 from mlflow.store.dbmodels import models
+from mlflow.store.dbmodels.db_types import MYSQL, MSSQL
 from mlflow import entities
 from mlflow.exceptions import MlflowException
 from mlflow.store.sqlalchemy_store import SqlAlchemyStore
@@ -1338,29 +1339,31 @@ class TestSqlAlchemyStoreMysqlDb(TestSqlAlchemyStoreSqlite):
             self.store.log_param(run.info.run_id, entities.Param("pkey-%s" % i, "pval-%s" % i))
             self.store.set_tag(run.info.run_id, entities.RunTag("tkey-%s" % i, "tval-%s" % i))
 
-from mlflow.store.dbmodels.db_types import MYSQL, MSSQL
-@mock.patch('sqlalchemy.orm.session.Session',spec=True)
+
+@mock.patch('sqlalchemy.orm.session.Session', spec=True)
 class TestZeroValueInsertion(unittest.TestCase):
     def test_set_zero_value_insertion_for_autoincrement_column_MYSQL(self, mock_session):
         mock_store = mock.Mock(SqlAlchemyStore)
         mock_store.db_type = MYSQL
-        SqlAlchemyStore._set_zero_value_insertion_for_autoincrement_column(mock_store,mock_session)
+        SqlAlchemyStore._set_zero_value_insertion_for_autoincrement_column(mock_store, mock_session)
         mock_session.execute.assert_called_with("SET @@SESSION.sql_mode='NO_AUTO_VALUE_ON_ZERO';")
 
     def test_set_zero_value_insertion_for_autoincrement_column_MSSQL(self, mock_session):
         mock_store = mock.Mock(SqlAlchemyStore)
         mock_store.db_type = MSSQL
-        SqlAlchemyStore._set_zero_value_insertion_for_autoincrement_column(mock_store,mock_session)
+        SqlAlchemyStore._set_zero_value_insertion_for_autoincrement_column(mock_store, mock_session)
         mock_session.execute.assert_called_with("SET IDENTITY_INSERT experiments ON;")
 
-    def test_unset_zero_value_insertion_for_autoincrement_column_MYSQL(self,mock_session):
+    def test_unset_zero_value_insertion_for_autoincrement_column_MYSQL(self, mock_session):
         mock_store = mock.Mock(SqlAlchemyStore)
         mock_store.db_type = MYSQL
-        SqlAlchemyStore._unset_zero_value_insertion_for_autoincrement_column(mock_store,mock_session)
+        SqlAlchemyStore._unset_zero_value_insertion_for_autoincrement_column(mock_store,
+                                                                             mock_session)
         mock_session.execute.assert_called_with("SET @@SESSION.sql_mode='';")
 
-    def test_unset_zero_value_insertion_for_autoincrement_column_MSSQL(self,mock_session):
+    def test_unset_zero_value_insertion_for_autoincrement_column_MSSQL(self, mock_session):
         mock_store = mock.Mock(SqlAlchemyStore)
         mock_store.db_type = MSSQL
-        SqlAlchemyStore._unset_zero_value_insertion_for_autoincrement_column(mock_store,mock_session)
+        SqlAlchemyStore._unset_zero_value_insertion_for_autoincrement_column(mock_store,
+                                                                             mock_session)
         mock_session.execute.assert_called_with("SET IDENTITY_INSERT experiments OFF;")


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
This patch fixes a setup issue with creating new MLflow instance with MS
SQL server.
 
## How is this patch tested?
 
Tested with MS Azure. Deployed as Docker image using Azure Kubernetes Services with Azure SQL database.
 
## Release Notes
 
Support using MS SQL Server database when creating new instances of MLflow. Setting that enables adding a `experiment_id = 0` for auto increment column.
 
### What component(s) does this PR affect?
 
- [ ] Serving

### How should the PR be classified in the release notes? Choose one:
 
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
