### PR TITLE
Remove runs from MLflow server GetExperiment responses

### DIFF
--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -53,8 +53,7 @@ service MlflowService {
     };
   }
 
-  // Get metadata for an experiment and a list of runs for the experiment.
-  // This method works on deleted experiments.
+  // Get metadata for an experiment. This method works on deleted experiments.
   rpc getExperiment (GetExperiment) returns (GetExperiment.Response) {
     option (rpc) = {
       endpoints: [{

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -159,9 +159,6 @@ def _get_experiment():
     response_message = GetExperiment.Response()
     experiment = _get_store().get_experiment(request_message.experiment_id).to_proto()
     response_message.experiment.MergeFrom(experiment)
-    run_info_entities = _get_store().list_run_infos(request_message.experiment_id,
-                                                    run_view_type=ViewType.ACTIVE_ONLY)
-    response_message.runs.extend([r.to_proto() for r in run_info_entities])
     response = Response(mimetype='application/json')
     response.set_data(message_to_json(response_message))
     return response


### PR DESCRIPTION
## What changes are proposed in this pull request?

The `runs` field in the `GetExperiment` RPC response has been deprecated; users are encouraged to use the more powerful `Search Runs` API to fetch runs instead (see #1647).

Currently, the MLflow REST server still populates this field with all of the runs associated with a given experiment. This adds unnecessary latency when viewing runs in the UI because the run view fetches the run's associated experiment, thereby fetching every run in the experiment.

Accordingly, this PR removes the `runs` field from `GetExperiment` responses returned by the MLflow REST server.
 
## How is this patch tested?
 
Manual testing, existing unit tests
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
The MLflow REST server no longer populates the `GetExperiment.Response.runs` field when responding to `Get Experiment` requests. This field was deprecated in MLflow 1.1. Please use the `Search Runs` API to fetch runs for a particular experiment instead.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [X] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
