### PR TITLE
Travis CI: Drop dist trusty because it is EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: python
 
-dist: trusty
-
 services:
   - docker
 

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -74,7 +74,7 @@ def test_model_save_load(h2o_iris_model, model_path):
             h2o_model.predict(h2o_iris_model.inference_data).as_data_frame())
 
     # Loading pyfunc model
-    pyfunc_loaded = mlflow.pyfunc.load_pyfunc(model_path)
+    pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
     assert all(
             pyfunc_loaded.predict(h2o_iris_model.inference_data.as_data_frame()) ==
             h2o_model.predict(h2o_iris_model.inference_data).as_data_frame())

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -65,7 +65,7 @@ def test_model_save_load(sklearn_knn_model, iris_data, tmpdir, model_path):
     assert model_config.__dict__ == reloaded_model_config.__dict__
     assert mlflow.pyfunc.FLAVOR_NAME in reloaded_model_config.flavors
     assert mlflow.pyfunc.PY_VERSION in reloaded_model_config.flavors[mlflow.pyfunc.FLAVOR_NAME]
-    reloaded_model = mlflow.pyfunc.load_pyfunc(model_path)
+    reloaded_model = mlflow.pyfunc.load_model(model_path)
     np.testing.assert_array_equal(
         sklearn_knn_model.predict(iris_data[0]), reloaded_model.predict(iris_data[0]))
 
@@ -88,7 +88,7 @@ def test_model_log_load(sklearn_knn_model, iris_data, tmpdir):
     model_config = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
     assert mlflow.pyfunc.FLAVOR_NAME in model_config.flavors
     assert mlflow.pyfunc.PY_VERSION in model_config.flavors[mlflow.pyfunc.FLAVOR_NAME]
-    reloaded_model = mlflow.pyfunc.load_pyfunc(pyfunc_model_path)
+    reloaded_model = mlflow.pyfunc.load_model(pyfunc_model_path)
     np.testing.assert_array_equal(
         sklearn_knn_model.predict(iris_data[0]), reloaded_model.predict(iris_data[0]))
 
@@ -111,7 +111,7 @@ def test_model_log_load_no_active_run(sklearn_knn_model, iris_data, tmpdir):
     model_config = Model.load(os.path.join(pyfunc_model_path, "MLmodel"))
     assert mlflow.pyfunc.FLAVOR_NAME in model_config.flavors
     assert mlflow.pyfunc.PY_VERSION in model_config.flavors[mlflow.pyfunc.FLAVOR_NAME]
-    reloaded_model = mlflow.pyfunc.load_pyfunc(pyfunc_model_path)
+    reloaded_model = mlflow.pyfunc.load_model(pyfunc_model_path)
     np.testing.assert_array_equal(
         sklearn_knn_model.predict(iris_data[0]), reloaded_model.predict(iris_data[0]))
     mlflow.end_run()

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -241,7 +241,7 @@ def test_save_and_load_model(sequential_model, model_path, data, sequential_pred
     np.testing.assert_array_equal(_predict(sequential_model_loaded, data), sequential_predicted)
 
     # Loading pyfunc model
-    pyfunc_loaded = mlflow.pyfunc.load_pyfunc(model_path)
+    pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
     np.testing.assert_array_almost_equal(
         pyfunc_loaded.predict(data[0]).values[:, 0], sequential_predicted, decimal=4)
 
@@ -496,7 +496,7 @@ def test_load_pyfunc_loads_torch_model_using_pickle_module_specified_at_save_tim
     with mock.patch("importlib.import_module") as import_mock,\
             mock.patch("torch.load") as torch_load_mock:
         import_mock.side_effect = track_module_imports
-        pyfunc.load_pyfunc(model_path)
+        pyfunc.load_model(model_path)
 
     torch_load_mock.assert_called_with(mock.ANY, pickle_module=custom_pickle_module)
     assert custom_pickle_module.__name__ in imported_modules
@@ -528,7 +528,7 @@ def test_load_model_loads_torch_model_using_pickle_module_specified_at_save_time
     with mock.patch("importlib.import_module") as import_mock,\
             mock.patch("torch.load") as torch_load_mock:
         import_mock.side_effect = track_module_imports
-        pyfunc.load_pyfunc(model_uri=model_uri)
+        pyfunc.load_model(model_uri=model_uri)
 
     torch_load_mock.assert_called_with(mock.ANY, pickle_module=custom_pickle_module)
     assert custom_pickle_module.__name__ in imported_modules
@@ -559,7 +559,7 @@ def test_load_pyfunc_succeeds_when_data_is_model_file_instead_of_directory(
         model_data_path, mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME)
     model_conf.save(model_conf_path)
 
-    loaded_pyfunc = pyfunc.load_pyfunc(model_path)
+    loaded_pyfunc = pyfunc.load_model(model_path)
 
     np.testing.assert_array_almost_equal(
         loaded_pyfunc.predict(data[0]),
@@ -596,7 +596,7 @@ def test_load_model_succeeds_when_data_is_model_file_instead_of_directory(
         model_data_path, mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME)
     model_conf.save(model_conf_path)
 
-    loaded_pyfunc = pyfunc.load_pyfunc(model_path)
+    loaded_pyfunc = pyfunc.load_model(model_path)
 
     np.testing.assert_array_almost_equal(
         loaded_pyfunc.predict(data[0]),


### PR DESCRIPTION
https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

## What changes are proposed in this pull request?
 
Travis CI: Drop dist trusty because it has reached its End of Life.

(Please fill in changes proposed in this fix)
 
## How is this patch tested?
 
Travis CI
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
Travis CI: Drop dist trusty because it is EOL

### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python
- [ ] Testing - Continuous Integration

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
