### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -365,7 +365,7 @@ def _is_valid_branch_name(work_dir, version):
         from git.exc import GitCommandError
         repo = Repo(work_dir, search_parent_directories=True)
         try:
-            return repo.git.rev_parse("--verify", "refs/heads/%s" % version) is not ''
+            return repo.git.rev_parse("--verify", "refs/heads/%s" % version) != ''
         except GitCommandError:
             return False
     return False

--- a/mlflow/store/hdfs_artifact_repo.py
+++ b/mlflow/store/hdfs_artifact_repo.py
@@ -185,7 +185,7 @@ def _resolve_base_path(path, artifact_path):
 
 def _relative_path(base_dir, subdir_path, path_module):
     relative_path = path_module.relpath(subdir_path, base_dir)
-    return relative_path if relative_path is not '.' else None
+    return relative_path if relative_path != '.' else None
 
 
 def _relative_path_local(base_dir, subdir_path):

--- a/mlflow/utils/process.py
+++ b/mlflow/utils/process.py
@@ -34,7 +34,7 @@ def exec_cmd(cmd, throw_on_error=True, env=None, stream_output=False, cwd=None, 
                                  stdin=subprocess.PIPE, **kwargs)
         child.communicate(cmd_stdin)
         exit_code = child.wait()
-        if throw_on_error and exit_code is not 0:
+        if throw_on_error and exit_code != 0:
             raise ShellCommandException("Non-zero exitcode: %s" % (exit_code))
         return exit_code
     else:
@@ -43,7 +43,7 @@ def exec_cmd(cmd, throw_on_error=True, env=None, stream_output=False, cwd=None, 
             cwd=cwd, universal_newlines=True, **kwargs)
         (stdout, stderr) = child.communicate(cmd_stdin)
         exit_code = child.wait()
-        if throw_on_error and exit_code is not 0:
+        if throw_on_error and exit_code != 0:
             raise ShellCommandException("Non-zero exit code: %s\n\nSTDOUT:\n%s\n\nSTDERR:%s" %
                                         (exit_code, stdout, stderr))
         return exit_code, stdout, stderr

--- a/tests/store/test_dbfs_fuse_artifact_repo.py
+++ b/tests/store/test_dbfs_fuse_artifact_repo.py
@@ -112,7 +112,7 @@ class TestDbfsFuseArtifactRepository(object):
         assert artifacts[1].file_size is None
         assert artifacts[2].path == 'test.txt'
         assert artifacts[2].is_dir is False
-        assert artifacts[2].file_size is 23
+        assert artifacts[2].file_size == 23
 
     def test_download_artifacts(self, dbfs_fuse_artifact_repo, test_dir):
         dbfs_fuse_artifact_repo.log_artifacts(test_dir.strpath)

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -113,7 +113,7 @@ def test_numpy_encoder():
     test_number = numpy.int64(42)
     ne = NumpyEncoder()
     defaulted_val = ne.default(test_number)
-    assert defaulted_val is 42
+    assert defaulted_val == 42
 
 
 def test_numpy_encoder_fail():


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
(Please fill in changes proposed in this fix)
Use ==/!= to compare str, bytes, and int literals because identity is not the same thing as equality in Python.  These instances will raise SyntaxWarnings on Python >= 3.8 so it is best to fix them now.  https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8
 
## How is this patch tested?
 
[flake8](http://flake8.pycqa.org)
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
