### PR TITLE
Fix RestException bug that causes all server errors to be deserialized as INTERNAL_ERRORs

### DIFF
--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -56,11 +56,10 @@ class MlflowException(Exception):
 class RestException(MlflowException):
     """Exception thrown on non 200-level responses from the REST API"""
     def __init__(self, json):
-        error_code = json.get('error_code', INTERNAL_ERROR)
+        error_code = json.get('error_code', ErrorCode.Name(INTERNAL_ERROR))
         message = "%s: %s" % (error_code,
                               json['message'] if 'message' in json else "Response: " + str(json))
-
-        super(RestException, self).__init__(message, error_code=error_code)
+        super(RestException, self).__init__(message, error_code=ErrorCode.Value(error_code))
         self.json = json
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,6 +1,6 @@
 import json
 
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import MlflowException, RestException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, INVALID_STATE, \
     ENDPOINT_NOT_FOUND, INTERNAL_ERROR, RESOURCE_ALREADY_EXISTS, IO_ERROR
 
@@ -33,3 +33,11 @@ class TestMlflowException(object):
             == 500
         assert MlflowException('test', error_code=RESOURCE_ALREADY_EXISTS).get_http_status_code() \
             == 400
+
+
+def test_rest_exception():
+    mlflow_exception = MlflowException('test', error_code=RESOURCE_ALREADY_EXISTS)
+    json_exception = mlflow_exception.serialize_as_json()
+    deserialized_rest_exception = RestException(json.loads(json_exception))
+    assert deserialized_rest_exception.error_code == "RESOURCE_ALREADY_EXISTS"
+    assert "test" in deserialized_rest_exception.message

--- a/tests/utils/test_exception.py
+++ b/tests/utils/test_exception.py
@@ -1,5 +1,6 @@
 import json
 from mlflow.exceptions import ExecutionException, RestException
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode
 
 
 def test_execution_exception_string_repr():
@@ -28,7 +29,8 @@ def test_rest_exception_without_message():
 
 
 def test_rest_exception_error_code_and_no_message():
-    exc = RestException({"error_code": 2, "messages": "something important."})
+    exc = RestException({"error_code": ErrorCode.Name(RESOURCE_DOES_NOT_EXIST),
+                         "messages": "something important."})
     assert "something important." in str(exc)
-    assert "2" in str(exc)
+    assert "RESOURCE_DOES_NOT_EXIST" in str(exc)
     json.loads(exc.serialize_as_json())


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fixes a bug in the RestException constructor where we pass string-serialized ErrorCode values from JSON server responses (rather than the numeric enum value) to the parent MlflowException constructor. The MlflowException constructor handles this [by setting the error code to INTERNAL_ERROR](https://github.com/mlflow/mlflow/blob/05f18899df6db3364673d39910cc71bef4b95d27/mlflow/exceptions.py#L42), causing the client to incorrectly convert all non-INTERNAL_ERROR exceptions from the server (RESOURCE_DOES_NOT_EXIST, etc) into INTERNAL_ERRORS.

## How is this patch tested?
 
Added unit tests verifying that JSON-serialized MlflowExceptions can be deserialized by the RestException constructor
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix bug that caused all server errors to be deserialized as INTERNAL_ERRORs - MlflowExceptions thrown while making REST API Requests from the client should now have the correct value in their `error_code` attribute.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
