### PR TITLE
Slightly strengthen issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -5,12 +5,9 @@ labels: 'bug'
 title: "[BUG]"
 ---
 Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
-for information on what types of issues we address.
+for information on what types of issues we address. For help with debugging your code, please refer to [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
 
-For help with debugging your code, please refer to [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
-
-  
-Please do not delete this template unless you are sure your issue is outside its scope.
+Please fill in this template and do not delete it unless you are sure your issue is outside its scope.
 
 ### System information
 - **Have I written custom code (as opposed to using a stock example script provided in MLflow)**:

--- a/.github/ISSUE_TEMPLATE/doc_fix_template.md
+++ b/.github/ISSUE_TEMPLATE/doc_fix_template.md
@@ -7,7 +7,7 @@ title: "[DOC-FIX]"
 Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
 for information on what types of issues we address.
   
-Please do not delete this template unless you are sure your issue is outside its scope.
+Please fill in this template and do not delete it unless you are sure your issue is outside its scope.
 
 ### URL(s) with the issue:
 

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -7,7 +7,7 @@ title: "[FR]"
 Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
 for information on what types of issues we address.
   
-Please do not delete this template unless you are sure your issue is outside its scope.
+Please fill in this template and do not delete it unless you are sure your issue is outside its scope.
 
 -------
 ## Guidelines

--- a/.github/ISSUE_TEMPLATE/installation_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue_template.md
@@ -7,7 +7,7 @@ title: "[SETUP-BUG]"
 Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
 for information on what types of issues we address.
   
-Please do not delete this template unless you are sure your issue is outside its scope.
+Please fill in this template and do not delete it unless you are sure your issue is outside its scope.
 
 ### System information
 - **OS Platform and Distribution (e.g., Linux Ubuntu 16.04)**:


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
A considerable number of issues are not using the templates as intended - some delete the template, some add minimal information at the top instead of filling in the questions.
This is a small PR to make it slightly clearer that the questions in the template should be answered, if the template is being used.
 
## How is this patch tested?

N/A
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
