### PR TITLE
Require docker python dependency version 4.0.0 or greater

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,11 +45,10 @@ setup(
         'pyyaml',
         'querystring_parser',
         'simplejson',
-        'docker>=3.6.0',
+        'docker>=4.0.0',
         'entrypoints',
         'sqlparse',
         'sqlalchemy',
-        'docker>=3.6.0',
         'gorilla',
     ],
     extras_require={


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Change `setup.py` to require a `docker` python library version of 4.0.0 or greater. This fixes #1672.
 
## How is this patch tested?
 
Manual testing
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

This is a minor change that does not warrant a release note; it is user-facing.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [X] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
