### PR TITLE
Speed up Travis build in common cases by moving correlated tests into "large" stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,14 @@ matrix:
         - ./lint.sh
         - npm test -- --coverage
     - stage: large
+    - language: python
+      python: 2.7
+      install:
+        - INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
+      script:
+        - ./travis/run-large-python-tests.sh
+    # Run Windows tests in the "large" test builder so that we don't spend Travis executor
+    # time running Windows tests if Python 3 small tests fail.
     - os: windows
       name: "Windows"
       language: sh
@@ -73,18 +81,14 @@ matrix:
         - pip install -e .
       script:
         - pytest --verbose --ignore=tests/h2o --ignore=tests/keras --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn  --ignore=tests/spark --ignore=tests/tensorflow --ignore=tests/keras_autolog --ignore=tests/tensorflow_autolog --ignore tests/azureml --ignore tests/onnx --ignore tests/projects tests
+    # Run small Python 2.7 tests in the "large" test builder so that we don't spend Travis executor
+    # time running Python 2.7 tests if Python 3 small tests fail.
     - language: python
       python: 2.7
       install:
         - INSTALL_SMALL_PYTHON_DEPS=true source ./travis/install-common-deps.sh
       script:
         - ./travis/run-small-python-tests.sh
-    - language: python
-      python: 2.7
-      install:
-        - INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
-      script:
-        - ./travis/run-large-python-tests.sh
 
 # Travis runs an extra top-level job for each build stage - depending on the build stage, we either
 # run small or large Python tests below.

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,24 +16,6 @@ matrix:
         - pip install -r ./travis/lint-requirements.txt
       script:
         - ./lint.sh
-    - language: python
-      python: 2.7
-      install:
-        - INSTALL_SMALL_PYTHON_DEPS=true source ./travis/install-common-deps.sh
-      script:
-        - ./travis/run-small-python-tests.sh
-    - os: windows
-      name: "Windows"
-      language: sh
-      before_install:
-        - cinst -y python3
-      install:
-        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
-        - pip install -r dev-requirements.txt
-        - pip install -r travis/small-requirements.txt
-        - pip install -e .
-      script:
-        - pytest --verbose --ignore=tests/h2o --ignore=tests/keras --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn  --ignore=tests/spark --ignore=tests/tensorflow --ignore=tests/keras_autolog --ignore=tests/tensorflow_autolog --ignore tests/azureml --ignore tests/onnx --ignore tests/projects tests
     - language: r
       name: "R"
       cache: packages
@@ -79,6 +61,24 @@ matrix:
         - ./lint.sh
         - npm test -- --coverage
     - stage: large
+    - os: windows
+      name: "Windows"
+      language: sh
+      before_install:
+        - cinst -y python3
+      install:
+        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+        - pip install -r dev-requirements.txt
+        - pip install -r travis/small-requirements.txt
+        - pip install -e .
+      script:
+        - pytest --verbose --ignore=tests/h2o --ignore=tests/keras --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn  --ignore=tests/spark --ignore=tests/tensorflow --ignore=tests/keras_autolog --ignore=tests/tensorflow_autolog --ignore tests/azureml --ignore tests/onnx --ignore tests/projects tests
+    - language: python
+      python: 2.7
+      install:
+        - INSTALL_SMALL_PYTHON_DEPS=true source ./travis/install-common-deps.sh
+      script:
+        - ./travis/run-small-python-tests.sh
     - language: python
       python: 2.7
       install:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Some reordering of Travis build stages, given the fact that we seem to have ~6 or 7ish travis build executors. In particular we:

* Move Python 2 unit tests to large tests, so that we don’t waste Travis executor time running Python 2 tests if Python 3 tests fail.
* Move windows tests to be large tests for the same reason


## How is this patch tested?
Existing tests + manually verifying that the expected build stages still run
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
