### PR TITLE
Allows specifying docker run command through the MLproject file

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -145,7 +145,10 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
                                         repository_uri=project.name,
                                         base_image=project.docker_env.get('image'),
                                         run_id=active_run.info.run_id)
-            command += _get_docker_command(image=image, active_run=active_run, options=project.docker_env.get('options'))
+            command += _get_docker_command(
+                    image=image,
+                    active_run=active_run,
+                    options=project.docker_env.get('options'))
         # Synchronously create a conda environment (even though this may take some time)
         # to avoid failures due to multiple concurrent attempts to create the same conda env.
         elif use_conda:

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -145,7 +145,7 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
                                         repository_uri=project.name,
                                         base_image=project.docker_env.get('image'),
                                         run_id=active_run.info.run_id)
-            command += _get_docker_command(image=image, active_run=active_run)
+            command += _get_docker_command(image=image, active_run=active_run, options=project.docker_env.get('options'))
         # Synchronously create a conda environment (even though this may take some time)
         # to avoid failures due to multiple concurrent attempts to create the same conda env.
         elif use_conda:
@@ -699,7 +699,7 @@ def _get_local_uri_or_none(uri):
         return None, None
 
 
-def _get_docker_command(image, active_run):
+def _get_docker_command(image, active_run, options=[]):
     docker_path = "docker"
     cmd = [docker_path, "run", "--rm"]
     env_vars = _get_run_env_vars(run_id=active_run.info.run_id,
@@ -736,6 +736,8 @@ def _get_docker_command(image, active_run):
 
     for key, value in env_vars.items():
         cmd += ["-e", "{key}={value}".format(key=key, value=value)]
+    for opt in options:
+        cmd += ["{flag}".format(flag=opt['flag']), "{value}".format(value=opt['value'])]
     cmd += [image.tags[0]]
     return cmd
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR proposes a way to allow the user to specify any ```docker run``` option to be used after executing the ```mlflow run``` command. The options are written in the MLproject file under the ```docker_env.options``` as an array of dictionary containing a flag and value key.

An example use case is when the user prefer to mount their training-data instead of inserting them to their image or downloading them after the container was created (Issue #1441)

Example MLproject:

```
name: my_project

docker_env:
  image: "test-mlflow"
  options:
    - flag : "--mount"
      value : "source=my-volume,=/mlflow/projects/code/data"
    - flag : "-w"
      value : "/mlflow/projects/code/src/"
    - flag : "--network"
      value : "host"

entry_points:
  main:
    command: "./run.sh"
```
 
## How is this patch tested?
 
Manual testing
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
This feature adds an optional ```options``` key under the ```docker_env``` of MLproject file which will be used when executing the ```mlflow run``` command.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [x] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
