### PR TITLE
Add run status in mlflow ui

### DIFF
--- a/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableCompactView.js
@@ -13,7 +13,7 @@ import { LoadMoreBar } from './LoadMoreBar';
 
 import 'react-virtualized/styles.css';
 
-export const NUM_RUN_METADATA_COLS = 8;
+export const NUM_RUN_METADATA_COLS = 9;
 const TABLE_HEADER_HEIGHT = 40;
 const UNBAGGED_COL_WIDTH = 125;
 const BAGGED_COL_WIDTH = 250;
@@ -403,6 +403,7 @@ class ExperimentRunsTableCompactView extends React.Component {
               const runMetadataColWidths = [
                 30, // checkbox column width
                 20, // expander column width
+                35, // 'Status' column width
                 180, // 'Date' column width
                 120, // 'user' column width
                 120, // 'Run Name' column width

--- a/mlflow/server/js/src/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/components/ExperimentViewUtil.js
@@ -39,6 +39,31 @@ export default class ExperimentViewUtil {
   };
 
   /**
+  * Returns an icon depending on run status.
+  */
+  static getRunStatusIcon(status) {
+    switch (status) {
+      case 'FAILED':
+      case 'KILLED':
+        return (
+            <i className="far fa-times-circle" style={{color: '#DB1905'}}/>
+        );
+      case 'FINISHED':
+        return (
+            <i className="far fa-check-circle" style={{color: '#10B36B'}}/>
+        );
+      case 'SCHEDULED':
+        return (
+            <i className="far fa-clock" style={{color: '#258BD2'}}/>
+        );
+      default:
+        return (
+            <i/>
+        );
+    }
+  }
+
+  /**
    * Returns table cells describing run metadata (i.e. not params/metrics) comprising part of
    * the display row for a run.
    */
@@ -48,9 +73,13 @@ export default class ExperimentViewUtil {
     const queryParams = window.location && window.location.search ? window.location.search : "";
     const sourceType = Utils.renderSource(tags, queryParams);
     const startTime = runInfo.start_time;
+    const status = runInfo.status;
     const runName = Utils.getRunName(tags);
     const childLeftMargin = isParent ? {} : {paddingLeft: '16px'};
     return [
+      <CellComponent key="meta-status" className="run-table-container" title={status}>
+        {ExperimentViewUtil.getRunStatusIcon(status)}
+      </CellComponent>,
       <CellComponent
         key="meta-link"
         className="run-table-container"
@@ -140,6 +169,7 @@ export default class ExperimentViewUtil {
         </CellComponent>);
     };
     return [
+      getHeaderCell("status", <span></span>, null),
       getHeaderCell("start_time", <span>{"Date"}</span>, "attributes.start_time"),
       getHeaderCell("user_id", <span>{"User"}</span>, "tags.`mlflow.user`"),
       getHeaderCell("run_name", <span>{"Run Name"}</span>, "tags.`mlflow.runName`"),

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -90,6 +90,10 @@ class RunView extends Component {
     this.setState({ showNoteEditor: true });
   };
 
+  static getRunStatusDisplayName(status) {
+    return status !== "RUNNING" ? status : "UNFINISHED";
+  }
+
   render() {
     const { runUuid, run, params, tags, latestMetrics, getMetricPagePath } = this.props;
     const { showNoteEditor } = this.state;
@@ -97,6 +101,7 @@ class RunView extends Component {
     const startTime = run.getStartTime() ? Utils.formatTimestamp(run.getStartTime()) : '(unknown)';
     const duration =
       run.getStartTime() && run.getEndTime() ? run.getEndTime() - run.getStartTime() : null;
+    const status = RunView.getRunStatusDisplayName(run.getStatus());
     const queryParams = window.location && window.location.search ?
       window.location.search : "";
     const tableStyles = {
@@ -162,6 +167,7 @@ class RunView extends Component {
           {duration !== null ? (
             <Descriptions.Item label='Duration'>{Utils.formatDuration(duration)}</Descriptions.Item>
           ) : null}
+          <Descriptions.Item label='Status'>{status}</Descriptions.Item>
           {tags['mlflow.parentRunId'] !== undefined ? (
             <Descriptions.Item label='Parent Run'>
               <Link to={Routes.getRunPageRoute(this.props.experimentId,


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Add run status to mlflow ui (https://github.com/mlflow/mlflow/issues/1380)

In Experiments runs table view and Run view.

![image](https://user-images.githubusercontent.com/5285727/72344459-90957480-36d1-11ea-9d08-d8a2f40cf418.png)
![image](https://user-images.githubusercontent.com/5285727/72344502-ad31ac80-36d1-11ea-8814-670628a40721.png)
 
## How is this patch tested?
 
Manually 
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
