### PR TITLE
fix bug that causes MLflow artifact preview to not preview MLmodel files

### DIFF
--- a/mlflow/server/js/src/utils/FileUtils.js
+++ b/mlflow/server/js/src/utils/FileUtils.js
@@ -11,4 +11,4 @@ export const getExtension = (path) => {
 export const IMAGE_EXTENSIONS = new Set(['jpg', 'bmp', 'jpeg', 'png', 'gif', 'svg']);
 export const TEXT_EXTENSIONS = new Set(
   ['txt', 'log', 'py', 'js', 'yaml', 'yml', 'json', 'csv', 'tsv',
-    'md', 'rst', 'MLmodel', 'MLproject', 'jsonnet']);
+    'md', 'rst', 'mlmodel', 'mlproject', 'jsonnet']);


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
MLmodel files were not being previewed as text files. This is because when we normalized artifact preview to work with upper case file extensions, we failed to actually convert existing uppercase files to lower case so that the check works correctly. 

![image](https://user-images.githubusercontent.com/52183359/64462566-ba9cb180-d0b5-11e9-810b-e10409fcaee3.png)

 
## How is this patch tested?
 
Manual testing.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
