### PR TITLE
Fix bug when environment run id overrides set_experiment

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -124,8 +124,9 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False):
                 _active_experiment_id != active_run_obj.info.experiment_id):
             raise MlflowException("Cannot start run with ID {} because active run ID "
                                   "does not match environment run ID. Make sure --experiment-name "
-                                  "or --experiment-id matches experiment set with set_experiment(), "
-                                  "or just use command-line arguments".format(existing_run_id))
+                                  "or --experiment-id matches experiment set with "
+                                  "set_experiment(), or just use command-line "
+                                  "arguments".format(existing_run_id))
         # Check to see if current run isn't deleted
         if active_run_obj.info.lifecycle_stage == LifecycleStage.DELETED:
             raise MlflowException("Cannot start run with ID {} because it is in the "

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -119,6 +119,14 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False):
     if existing_run_id:
         _validate_run_id(existing_run_id)
         active_run_obj = MlflowClient().get_run(existing_run_id)
+        # Check to see if experiment_id from environment matches experiment_id from set_experiment()
+        if (_active_experiment_id is not None and
+                _active_experiment_id != active_run_obj.info.experiment_id):
+            raise MlflowException("Cannot start run with ID {} because active run ID "
+                                  "does not match environment run ID. Make sure --experiment-name "
+                                  "or --experiment-id matches experiment set with set_experiment(), "
+                                  "or just use command-line arguments".format(existing_run_id))
+        # Check to see if current run isn't deleted
         if active_run_obj.info.lifecycle_stage == LifecycleStage.DELETED:
             raise MlflowException("Cannot start run with ID {} because it is in the "
                                   "deleted state.".format(existing_run_id))

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -16,9 +16,10 @@ from mlflow.store.abstract_store import PagedList
 from mlflow.tracking.client import MlflowClient
 import mlflow.tracking.fluent
 import mlflow.tracking.context.registry
-from mlflow.tracking.fluent import set_experiment, start_run, _get_experiment_id, _get_experiment_id_from_env, \
-    search_runs, _EXPERIMENT_NAME_ENV_VAR, _EXPERIMENT_ID_ENV_VAR, _RUN_ID_ENV_VAR, \
-    _get_paginated_runs, NUM_RUNS_PER_PAGE_PANDAS, SEARCH_MAX_RESULTS_PANDAS
+from mlflow.tracking.fluent import set_experiment, start_run, _get_experiment_id, \
+    _get_experiment_id_from_env, search_runs, _EXPERIMENT_NAME_ENV_VAR, \
+    _EXPERIMENT_ID_ENV_VAR, _RUN_ID_ENV_VAR, _get_paginated_runs,\
+    NUM_RUNS_PER_PAGE_PANDAS, SEARCH_MAX_RESULTS_PANDAS
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils import mlflow_tags
 

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -2,26 +2,30 @@ import os
 import random
 import uuid
 
-import pytest
 import mock
 import numpy as np
 import pandas as pd
+import pytest
 from six.moves import reload_module as reload
 
 import mlflow
-from mlflow.entities import LifecycleStage, SourceType, Run, RunInfo, RunData, RunStatus, Metric, \
-    Param, RunTag, ViewType
+import mlflow.tracking.context.registry
+import mlflow.tracking.fluent
+from mlflow.entities import (LifecycleStage, Metric, Param, Run, RunData,
+                             RunInfo, RunStatus, RunTag, SourceType, ViewType)
 from mlflow.exceptions import MlflowException
 from mlflow.store.abstract_store import PagedList
 from mlflow.tracking.client import MlflowClient
-import mlflow.tracking.fluent
-import mlflow.tracking.context.registry
-from mlflow.tracking.fluent import set_experiment, start_run, _get_experiment_id, \
-    _get_experiment_id_from_env, search_runs, _EXPERIMENT_NAME_ENV_VAR, \
-    _EXPERIMENT_ID_ENV_VAR, _RUN_ID_ENV_VAR, _get_paginated_runs, \
-    NUM_RUNS_PER_PAGE_PANDAS, SEARCH_MAX_RESULTS_PANDAS
-from mlflow.utils.file_utils import TempDir
+from mlflow.tracking.fluent import (_EXPERIMENT_ID_ENV_VAR,
+                                    _EXPERIMENT_NAME_ENV_VAR, _RUN_ID_ENV_VAR,
+                                    NUM_RUNS_PER_PAGE_PANDAS,
+                                    SEARCH_MAX_RESULTS_PANDAS,
+                                    _get_experiment_id,
+                                    _get_experiment_id_from_env,
+                                    _get_paginated_runs, search_runs,
+                                    set_experiment, start_run)
 from mlflow.utils import mlflow_tags
+from mlflow.utils.file_utils import TempDir
 
 
 class HelperEnv:

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -361,8 +361,8 @@ def test_start_run_existing_run_from_environment_with_set_environment(empty_acti
 
     with env_patch, mock.patch.object(MlflowClient, "get_run", return_value=mock_run):
         with pytest.raises(MlflowException):
-                set_experiment("test-run")
-                active_run = start_run()
+            set_experiment("test-run")
+            active_run = start_run()
 
 
 def test_start_run_existing_run_deleted(empty_active_run_stack):

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -18,7 +18,7 @@ import mlflow.tracking.fluent
 import mlflow.tracking.context.registry
 from mlflow.tracking.fluent import set_experiment, start_run, _get_experiment_id, \
     _get_experiment_id_from_env, search_runs, _EXPERIMENT_NAME_ENV_VAR, \
-    _EXPERIMENT_ID_ENV_VAR, _RUN_ID_ENV_VAR, _get_paginated_runs,\
+    _EXPERIMENT_ID_ENV_VAR, _RUN_ID_ENV_VAR, _get_paginated_runs, \
     NUM_RUNS_PER_PAGE_PANDAS, SEARCH_MAX_RESULTS_PANDAS
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils import mlflow_tags


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a check in `start_run()` to make sure `_active_experiment_id` isn't set by `set_experiment()` when a run id is supplied by the environment. The main reason this happens is when `--experiment-name` or `--experiment-id` is set from the CLI, it will create a run on that experiment. Afterwards, a user might assume they can also reference the run with `set_experiment()`, maybe providing a different name to override the CLI. Before, it would allow the user to use `set_experiment()` and it would create a new experiment from `set_experiment()`, however it would log results to the experiment set from CLI. Now, it will throw an `MlflowException` if both are set.

Addresses: https://github.com/mlflow/mlflow/issues/799
 
## How is this patch tested?
 
I tested it via the cli from the Ubuntu WSL terminal, and wrote a test in `test_fluent.py`
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Forces users to use CLI or fluent API, and can only use both if the experiment ids match.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [x] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
