### PR TITLE
Mark models CLI docker build tests as "release"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ matrix:
       install:
         - INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
       script:
-        - ./travis/run-large-python-tests.sh
+        - travis_wait 20 ./travis/run-large-python-tests.sh
     # Run Windows tests in the "large" test builder so that we don't spend Travis executor
     # time running Windows tests if Python 3 small tests fail.
     - os: windows
@@ -110,7 +110,7 @@ script:
     elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "Small" ]]; then
       ./travis/run-small-python-tests.sh && ./test-generate-protos.sh;
     else
-      ./travis/run-large-python-tests.sh;
+      travis_wait 20 ./travis/run-large-python-tests.sh;
     fi
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ matrix:
       install:
         - INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
       script:
-        - travis_wait 20 ./travis/run-large-python-tests.sh
+        - ./travis/run-large-python-tests.sh
     # Run Windows tests in the "large" test builder so that we don't spend Travis executor
     # time running Windows tests if Python 3 small tests fail.
     - os: windows
@@ -110,7 +110,7 @@ script:
     elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "Small" ]]; then
       ./travis/run-small-python-tests.sh && ./test-generate-protos.sh;
     else
-      travis_wait 20 ./travis/run-large-python-tests.sh;
+      ./travis/run-large-python-tests.sh;
     fi
 
 notifications:

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -231,7 +231,7 @@ def test_predict(iris_data, sk_model):
         assert all(expected == actual)
 
 
-@pytest.mark.large
+@pytest.mark.release
 def test_build_docker(iris_data, sk_model):
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model")
@@ -244,7 +244,7 @@ def test_build_docker(iris_data, sk_model):
     _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model)
 
 
-@pytest.mark.large
+@pytest.mark.release
 def test_build_docker_with_env_override(iris_data, sk_model):
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model")


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
There have been several instances of build failures due to timeouts associated with the `test_build_docker` and `test_build_docker_with_env_override` tests in the `mlflow/tests/models/test_cli.py` suite. We suspect that the Docker image build process is taking more than 10 minutes to complete on Travis; this contrasts significantly with locally-observed build times of around 2-3 minutes.

Accordingly, this PR marks the tests as `release` instead of `large` in order to remove them from the critical path to merging new changes. We will revisit this issue next week and assess whether or not long build times are still occurring.
 
## How is this patch tested?
 
Unit tests
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
