### PR TITLE
adding argument to pass existing client to mlflow_set_experiment()

### DIFF
--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -23,7 +23,20 @@ dependencies before calling other MLflow APIs.
 
 .. code:: r
 
-   install_mlflow()
+   install_mlflow(python_version = "3.6")
+
+Arguments
+---------
+
++-------------------------------+--------------------------------------+
+| Argument                      | Description                          |
++===============================+======================================+
+| ``python_version``            | Optional Python version to use       |
+|                               | within conda environment created for |
+|                               | installing the MLflow CLI. If        |
+|                               | unspecified, defaults to using       |
+|                               | Python 3.6                           |
++-------------------------------+--------------------------------------+
 
 Details
 -------
@@ -59,6 +72,8 @@ tracking server or store at the specified URI.
 
    mlflow_client(tracking_uri = NULL)
 
+.. _arguments-1:
+
 Arguments
 ---------
 
@@ -81,7 +96,7 @@ Creates an MLflow experiment and returns its id.
 
    mlflow_create_experiment(name, artifact_location = NULL, client = NULL)
 
-.. _arguments-1:
+.. _arguments-2:
 
 Arguments
 ---------
@@ -121,7 +136,7 @@ experiment are also deleted.
 
    mlflow_delete_experiment(experiment_id, client = NULL)
 
-.. _arguments-2:
+.. _arguments-3:
 
 Arguments
 ---------
@@ -154,7 +169,7 @@ Deletes the run with the specified ID.
 
    mlflow_delete_run(run_id, client = NULL)
 
-.. _arguments-3:
+.. _arguments-4:
 
 Arguments
 ---------
@@ -187,7 +202,7 @@ can be updated during a run and after a run completes.
 
    mlflow_delete_tag(key, run_id = NULL, client = NULL)
 
-.. _arguments-4:
+.. _arguments-5:
 
 Arguments
 ---------
@@ -223,7 +238,7 @@ if applicable, and return a local path for it.
 
    mlflow_download_artifacts(path, run_id = NULL, client = NULL)
 
-.. _arguments-5:
+.. _arguments-6:
 
 Arguments
 ---------
@@ -260,7 +275,7 @@ is not specified.
    mlflow_end_run(status = c("FINISHED", "FAILED", "KILLED"),
      end_time = NULL, run_id = NULL, client = NULL)
 
-.. _arguments-6:
+.. _arguments-7:
 
 Arguments
 ---------
@@ -302,7 +317,7 @@ Attempts to obtain the active experiment if both ``experiment_id`` and
    mlflow_get_experiment(experiment_id = NULL, name = NULL,
      client = NULL)
 
-.. _arguments-7:
+.. _arguments-8:
 
 Arguments
 ---------
@@ -338,7 +353,7 @@ Get a list of all values for the specified metric for a given run.
 
    mlflow_get_metric_history(metric_key, run_id = NULL, client = NULL)
 
-.. _arguments-8:
+.. _arguments-9:
 
 Arguments
 ---------
@@ -374,7 +389,7 @@ largest step.
 
    mlflow_get_run(run_id = NULL, client = NULL)
 
-.. _arguments-9:
+.. _arguments-10:
 
 Arguments
 ---------
@@ -419,7 +434,7 @@ Extracts the ID of the run or experiment.
    list(list("mlflow_id"), list("mlflow_run"))(object)
    list(list("mlflow_id"), list("mlflow_experiment"))(object)
 
-.. _arguments-10:
+.. _arguments-11:
 
 Arguments
 ---------
@@ -441,7 +456,7 @@ Gets a list of artifacts.
 
    mlflow_list_artifacts(path = NULL, run_id = NULL, client = NULL)
 
-.. _arguments-11:
+.. _arguments-12:
 
 Arguments
 ---------
@@ -478,7 +493,7 @@ Gets a list of all experiments.
    mlflow_list_experiments(view_type = c("ACTIVE_ONLY", "DELETED_ONLY",
      "ALL"), client = NULL)
 
-.. _arguments-12:
+.. _arguments-13:
 
 Arguments
 ---------
@@ -514,7 +529,7 @@ all runs under the specified experiment.
    mlflow_list_run_infos(run_view_type = c("ACTIVE_ONLY", "DELETED_ONLY",
      "ALL"), experiment_id = NULL, client = NULL)
 
-.. _arguments-13:
+.. _arguments-14:
 
 Arguments
 ---------
@@ -553,7 +568,7 @@ on MLflow model flavors.
 
    mlflow_load_flavor(flavor, model_path)
 
-.. _arguments-14:
+.. _arguments-15:
 
 Arguments
 ---------
@@ -584,7 +599,7 @@ searches for a flavor supported by R/MLflow.
 
    mlflow_load_model(model_uri, flavor = NULL, client = mlflow_client())
 
-.. _arguments-15:
+.. _arguments-16:
 
 Arguments
 ---------
@@ -642,7 +657,7 @@ Logs a specific file or directory as an artifact for a run.
    mlflow_log_artifact(path, artifact_path = NULL, run_id = NULL,
      client = NULL)
 
-.. _arguments-16:
+.. _arguments-17:
 
 Arguments
 ---------
@@ -697,7 +712,7 @@ request), partial data may be written.
    mlflow_log_batch(metrics = NULL, params = NULL, tags = NULL,
      run_id = NULL, client = NULL)
 
-.. _arguments-17:
+.. _arguments-18:
 
 Arguments
 ---------
@@ -751,7 +766,7 @@ historical metric values along two axes: timestamp and step.
    mlflow_log_metric(key, value, timestamp = NULL, step = NULL,
      run_id = NULL, client = NULL)
 
-.. _arguments-18:
+.. _arguments-19:
 
 Arguments
 ---------
@@ -800,7 +815,7 @@ model as an artifact within the active run.
 
    mlflow_log_model(model, artifact_path, ...)
 
-.. _arguments-19:
+.. _arguments-20:
 
 Arguments
 ---------
@@ -838,7 +853,7 @@ allowed to be logged only once.
 
    mlflow_log_param(key, value, run_id = NULL, client = NULL)
 
-.. _arguments-20:
+.. _arguments-21:
 
 Arguments
 ---------
@@ -877,7 +892,7 @@ multiple invocations of the same script with different parameters.
 
    mlflow_param(name, default = NULL, type = NULL, description = NULL)
 
-.. _arguments-21:
+.. _arguments-22:
 
 Arguments
 ---------
@@ -931,18 +946,21 @@ to be used by package authors to extend the supported MLflow models.
 
    mlflow_predict(model, data, ...)
 
-.. _arguments-22:
+.. _arguments-23:
 
 Arguments
 ---------
 
-========= ===================================================================
+=========
+===================================================================
 Argument  Description
-========= ===================================================================
+=========
+===================================================================
 ``model`` The loaded MLflow model flavor.
 ``data``  A data frame to perform scoring.
 ``...``   Optional additional arguments passed to underlying predict methods.
-========= ===================================================================
+=========
+===================================================================
 
 ``mlflow_rename_experiment``
 ============================
@@ -955,7 +973,7 @@ Renames an experiment.
 
    mlflow_rename_experiment(new_name, experiment_id = NULL, client = NULL)
 
-.. _arguments-23:
+.. _arguments-24:
 
 Arguments
 ---------
@@ -995,7 +1013,7 @@ restored.
 
    mlflow_restore_experiment(experiment_id, client = NULL)
 
-.. _arguments-24:
+.. _arguments-25:
 
 Arguments
 ---------
@@ -1036,7 +1054,7 @@ Restores the run with the specified ID.
 
    mlflow_restore_run(run_id, client = NULL)
 
-.. _arguments-25:
+.. _arguments-26:
 
 Arguments
 ---------
@@ -1075,7 +1093,7 @@ endpoint will be removed in a future version of mlflow.
    mlflow_rfunc_serve(model_uri, host = "127.0.0.1", port = 8090,
      daemonized = FALSE, browse = !daemonized, ...)
 
-.. _arguments-26:
+.. _arguments-27:
 
 Arguments
 ---------
@@ -1159,7 +1177,7 @@ https://www.mlflow.org/docs/latest/cli.html#mlflow-run for more info.
      backend = NULL, backend_config = NULL, no_conda = FALSE,
      storage_dir = NULL)
 
-.. _arguments-27:
+.. _arguments-28:
 
 Arguments
 ---------
@@ -1251,19 +1269,22 @@ model types.
      conda_env = NULL, ...)
    mlflow_save_model(model, path, ...)
 
-.. _arguments-28:
+.. _arguments-29:
 
 Arguments
 ---------
 
-============= ==================================================================
+=============
+==================================================================
 Argument      Description
-============= ==================================================================
+=============
+==================================================================
 ``model``     The model that will perform a prediction.
 ``path``      Destination path where this MLflow compatible model will be saved.
 ``...``       Optional additional arguments.
 ``conda_env`` Path to Conda dependencies file.
-============= ==================================================================
+=============
+==================================================================
 
 ``mlflow_search_runs``
 ======================
@@ -1279,7 +1300,7 @@ Metric and Param keys.
      "DELETED_ONLY", "ALL"), experiment_ids = NULL, order_by = list(),
      client = NULL)
 
-.. _arguments-29:
+.. _arguments-30:
 
 Arguments
 ---------
@@ -1329,7 +1350,7 @@ Wrapper for ``mlflow server``.
      host = "127.0.0.1", port = 5000, workers = 4,
      static_prefix = NULL)
 
-.. _arguments-30:
+.. _arguments-31:
 
 Arguments
 ---------
@@ -1369,7 +1390,7 @@ metadata that can be updated.
    mlflow_set_experiment_tag(key, value, experiment_id = NULL,
      client = NULL)
 
-.. _arguments-31:
+.. _arguments-32:
 
 Arguments
 ---------
@@ -1414,9 +1435,9 @@ provided name. Returns the ID of the active experiment.
 .. code:: r
 
    mlflow_set_experiment(experiment_name = NULL, experiment_id = NULL,
-     artifact_location = NULL)
+     client = NULL, artifact_location = NULL)
 
-.. _arguments-32:
+.. _arguments-33:
 
 Arguments
 ---------
@@ -1427,6 +1448,9 @@ Arguments
 | ``experiment_name``           | Name of experiment to be activated.  |
 +-------------------------------+--------------------------------------+
 | ``experiment_id``             | ID of experiment to be activated.    |
++-------------------------------+--------------------------------------+
+| ``client``                    | MLFlow client for tracking server    |
+|                               | where experiments are located.       |
 +-------------------------------+--------------------------------------+
 | ``artifact_location``         | Location where all artifacts for     |
 |                               | this experiment are stored. If not   |
@@ -1446,7 +1470,7 @@ run and after a run completes.
 
    mlflow_set_tag(key, value, run_id = NULL, client = NULL)
 
-.. _arguments-33:
+.. _arguments-34:
 
 Arguments
 ---------
@@ -1486,7 +1510,7 @@ experiments.
 
    mlflow_set_tracking_uri(uri)
 
-.. _arguments-34:
+.. _arguments-35:
 
 Arguments
 ---------
@@ -1509,7 +1533,7 @@ called via ``Rscript`` from the terminal or through the MLflow CLI.
 
    mlflow_source(uri)
 
-.. _arguments-35:
+.. _arguments-36:
 
 Arguments
 ---------
@@ -1536,7 +1560,7 @@ can be provided.
    mlflow_start_run(run_id = NULL, experiment_id = NULL,
      start_time = NULL, tags = NULL, client = NULL)
 
-.. _arguments-36:
+.. _arguments-37:
 
 Arguments
 ---------
@@ -1599,7 +1623,7 @@ Launches the MLflow user interface.
 
    mlflow_ui(client, ...)
 
-.. _arguments-37:
+.. _arguments-38:
 
 Arguments
 ---------

--- a/mlflow/R/mlflow/R/tracking-experiments.R
+++ b/mlflow/R/mlflow/R/tracking-experiments.R
@@ -190,10 +190,12 @@ mlflow_rename_experiment <- function(new_name, experiment_id = NULL, client = NU
 #'
 #' @param experiment_name Name of experiment to be activated.
 #' @param experiment_id ID of experiment to be activated.
+#' @param client MLFlow client for tracking server where experiments are located.
 #' @param artifact_location Location where all artifacts for this experiment are stored. If
 #'   not provided, the remote server will select an appropriate default.
 #' @export
-mlflow_set_experiment <- function(experiment_name = NULL, experiment_id = NULL, artifact_location = NULL) {
+mlflow_set_experiment <- function(experiment_name = NULL, experiment_id = NULL,
+                                  client = NULL, artifact_location = NULL) {
   if (!is.null(experiment_name) && !is.null(experiment_id)) {
     stop("Only one of `experiment_name` or `experiment_id` should be specified.",
          call. = FALSE
@@ -205,7 +207,7 @@ mlflow_set_experiment <- function(experiment_name = NULL, experiment_id = NULL, 
          call. = FALSE)
   }
 
-  client <- mlflow_client()
+  client <- resolve_client(client)
 
   final_experiment_id <- if (!is.null(experiment_name)) {
     tryCatch(

--- a/mlflow/R/mlflow/man/mlflow_set_experiment.Rd
+++ b/mlflow/R/mlflow/man/mlflow_set_experiment.Rd
@@ -5,12 +5,14 @@
 \title{Set Experiment}
 \usage{
 mlflow_set_experiment(experiment_name = NULL, experiment_id = NULL,
-  artifact_location = NULL)
+  client = NULL, artifact_location = NULL)
 }
 \arguments{
 \item{experiment_name}{Name of experiment to be activated.}
 
 \item{experiment_id}{ID of experiment to be activated.}
+
+\item{client}{MLFlow client for tracking server where experiments are located.}
 
 \item{artifact_location}{Location where all artifacts for this experiment are stored. If
 not provided, the remote server will select an appropriate default.}

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -17,11 +17,13 @@ test_that("mlflow_create/get_experiment() basic functionality (client)", {
 
   client <- mlflow_client()
 
-  experiment_1_id <- mlflow_create_experiment(client = client, "exp_name", "art_loc")
-  experiment_1a <- mlflow_get_experiment(client = client, experiment_id = experiment_1_id)
+  experiment_1_id_a <- mlflow_create_experiment(client = client, "exp_name", "art_loc")
+  experiment_1a <- mlflow_get_experiment(client = client, experiment_id = experiment_1_id_a)
   experiment_1b <- mlflow_get_experiment(client = client, name = "exp_name")
+  experiment_1_id_b <- mlflow_set_experiment(client = client, experiment_name = "exp_name")
 
   expect_identical(experiment_1a, experiment_1b)
+  expect_identical(experiment_1_id_a, experiment_1_id_b)
   expect_identical(experiment_1a$artifact_location, "art_loc")
   expect_identical(experiment_1a$name, "exp_name")
 })


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
I propose to change `mlflow_set_experiment()` in the R API to follow the conventions established in the rest of the R API. Currently, calls to `mlflow_set_experiment()` simply create a new MLFlow client and use that to set the active experiment. Elsewhere in the API, these functions accept a client as an argument and attempt to resolve it before performing the relevant operation.

For example:
```
mlflow_delete_experiment <- function(experiment_id, client = NULL) {
  if (identical(experiment_id, mlflow_get_active_experiment_id()))
    stop("Cannot delete an active experiment.", call. = FALSE)

  client <- resolve_client(client)
  mlflow_rest(
    "experiments", "delete",
    verb = "POST", client = client,
    data = list(experiment_id = experiment_id)

  )
  invisible(NULL)
}
```

This PR brings `mlflow_set_experiment()` in line with the other functions. The documentation was updated per the instructions in `CONTRIBUTING.rst` to reflect this change in the API.

## How is this patch tested?
 
I tested this by executing the R test suite per the instructions in `CONTRIBUTING.rst`. The tests threw two errors, but they were in namespaces that were unchanged by this commit:

```
1. Error: mlflow can read typed command line parameters (@test-params.R#6) 
2. Error: mlflow can launch the UI (@test-ui.R#6) 
```

I changed the existing tests for the MLFlow Experiments R API to ensure the correct experiment ID was still returned when a client was passed into the function, and those tests passed. 

## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Adding the ability to pass an existing client to `mlflow_set_experiment` in the R API
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [x] API 
- [ ] REST-API 
- [ ] Examples 
- [x] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [x] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
