### PR TITLE
[Docs] Streamline docs for getting started with hosted MLflow

### DIFF
--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -23,7 +23,20 @@ dependencies before calling other MLflow APIs.
 
 .. code:: r
 
-   install_mlflow()
+   install_mlflow(python_version = "3.6")
+
+Arguments
+---------
+
++-------------------------------+--------------------------------------+
+| Argument                      | Description                          |
++===============================+======================================+
+| ``python_version``            | Optional Python version to use       |
+|                               | within conda environment created for |
+|                               | installing the MLflow CLI. If        |
+|                               | unspecified, defaults to using       |
+|                               | Python 3.6                           |
++-------------------------------+--------------------------------------+
 
 Details
 -------
@@ -59,6 +72,8 @@ tracking server or store at the specified URI.
 
    mlflow_client(tracking_uri = NULL)
 
+.. _arguments-1:
+
 Arguments
 ---------
 
@@ -81,7 +96,7 @@ Creates an MLflow experiment and returns its id.
 
    mlflow_create_experiment(name, artifact_location = NULL, client = NULL)
 
-.. _arguments-1:
+.. _arguments-2:
 
 Arguments
 ---------
@@ -121,7 +136,7 @@ experiment are also deleted.
 
    mlflow_delete_experiment(experiment_id, client = NULL)
 
-.. _arguments-2:
+.. _arguments-3:
 
 Arguments
 ---------
@@ -154,7 +169,7 @@ Deletes the run with the specified ID.
 
    mlflow_delete_run(run_id, client = NULL)
 
-.. _arguments-3:
+.. _arguments-4:
 
 Arguments
 ---------
@@ -187,7 +202,7 @@ can be updated during a run and after a run completes.
 
    mlflow_delete_tag(key, run_id = NULL, client = NULL)
 
-.. _arguments-4:
+.. _arguments-5:
 
 Arguments
 ---------
@@ -223,7 +238,7 @@ if applicable, and return a local path for it.
 
    mlflow_download_artifacts(path, run_id = NULL, client = NULL)
 
-.. _arguments-5:
+.. _arguments-6:
 
 Arguments
 ---------
@@ -260,7 +275,7 @@ is not specified.
    mlflow_end_run(status = c("FINISHED", "FAILED", "KILLED"),
      end_time = NULL, run_id = NULL, client = NULL)
 
-.. _arguments-6:
+.. _arguments-7:
 
 Arguments
 ---------
@@ -302,7 +317,7 @@ Attempts to obtain the active experiment if both ``experiment_id`` and
    mlflow_get_experiment(experiment_id = NULL, name = NULL,
      client = NULL)
 
-.. _arguments-7:
+.. _arguments-8:
 
 Arguments
 ---------
@@ -338,7 +353,7 @@ Get a list of all values for the specified metric for a given run.
 
    mlflow_get_metric_history(metric_key, run_id = NULL, client = NULL)
 
-.. _arguments-8:
+.. _arguments-9:
 
 Arguments
 ---------
@@ -374,7 +389,7 @@ largest step.
 
    mlflow_get_run(run_id = NULL, client = NULL)
 
-.. _arguments-9:
+.. _arguments-10:
 
 Arguments
 ---------
@@ -419,7 +434,7 @@ Extracts the ID of the run or experiment.
    list(list("mlflow_id"), list("mlflow_run"))(object)
    list(list("mlflow_id"), list("mlflow_experiment"))(object)
 
-.. _arguments-10:
+.. _arguments-11:
 
 Arguments
 ---------
@@ -441,7 +456,7 @@ Gets a list of artifacts.
 
    mlflow_list_artifacts(path = NULL, run_id = NULL, client = NULL)
 
-.. _arguments-11:
+.. _arguments-12:
 
 Arguments
 ---------
@@ -478,7 +493,7 @@ Gets a list of all experiments.
    mlflow_list_experiments(view_type = c("ACTIVE_ONLY", "DELETED_ONLY",
      "ALL"), client = NULL)
 
-.. _arguments-12:
+.. _arguments-13:
 
 Arguments
 ---------
@@ -514,7 +529,7 @@ all runs under the specified experiment.
    mlflow_list_run_infos(run_view_type = c("ACTIVE_ONLY", "DELETED_ONLY",
      "ALL"), experiment_id = NULL, client = NULL)
 
-.. _arguments-13:
+.. _arguments-14:
 
 Arguments
 ---------
@@ -553,7 +568,7 @@ on MLflow model flavors.
 
    mlflow_load_flavor(flavor, model_path)
 
-.. _arguments-14:
+.. _arguments-15:
 
 Arguments
 ---------
@@ -584,7 +599,7 @@ searches for a flavor supported by R/MLflow.
 
    mlflow_load_model(model_uri, flavor = NULL, client = mlflow_client())
 
-.. _arguments-15:
+.. _arguments-16:
 
 Arguments
 ---------
@@ -642,7 +657,7 @@ Logs a specific file or directory as an artifact for a run.
    mlflow_log_artifact(path, artifact_path = NULL, run_id = NULL,
      client = NULL)
 
-.. _arguments-16:
+.. _arguments-17:
 
 Arguments
 ---------
@@ -697,7 +712,7 @@ request), partial data may be written.
    mlflow_log_batch(metrics = NULL, params = NULL, tags = NULL,
      run_id = NULL, client = NULL)
 
-.. _arguments-17:
+.. _arguments-18:
 
 Arguments
 ---------
@@ -751,7 +766,7 @@ historical metric values along two axes: timestamp and step.
    mlflow_log_metric(key, value, timestamp = NULL, step = NULL,
      run_id = NULL, client = NULL)
 
-.. _arguments-18:
+.. _arguments-19:
 
 Arguments
 ---------
@@ -800,7 +815,7 @@ model as an artifact within the active run.
 
    mlflow_log_model(model, artifact_path, ...)
 
-.. _arguments-19:
+.. _arguments-20:
 
 Arguments
 ---------
@@ -838,7 +853,7 @@ allowed to be logged only once.
 
    mlflow_log_param(key, value, run_id = NULL, client = NULL)
 
-.. _arguments-20:
+.. _arguments-21:
 
 Arguments
 ---------
@@ -877,7 +892,7 @@ multiple invocations of the same script with different parameters.
 
    mlflow_param(name, default = NULL, type = NULL, description = NULL)
 
-.. _arguments-21:
+.. _arguments-22:
 
 Arguments
 ---------
@@ -931,7 +946,7 @@ to be used by package authors to extend the supported MLflow models.
 
    mlflow_predict(model, data, ...)
 
-.. _arguments-22:
+.. _arguments-23:
 
 Arguments
 ---------
@@ -955,7 +970,7 @@ Renames an experiment.
 
    mlflow_rename_experiment(new_name, experiment_id = NULL, client = NULL)
 
-.. _arguments-23:
+.. _arguments-24:
 
 Arguments
 ---------
@@ -995,7 +1010,7 @@ restored.
 
    mlflow_restore_experiment(experiment_id, client = NULL)
 
-.. _arguments-24:
+.. _arguments-25:
 
 Arguments
 ---------
@@ -1036,7 +1051,7 @@ Restores the run with the specified ID.
 
    mlflow_restore_run(run_id, client = NULL)
 
-.. _arguments-25:
+.. _arguments-26:
 
 Arguments
 ---------
@@ -1075,7 +1090,7 @@ endpoint will be removed in a future version of mlflow.
    mlflow_rfunc_serve(model_uri, host = "127.0.0.1", port = 8090,
      daemonized = FALSE, browse = !daemonized, ...)
 
-.. _arguments-26:
+.. _arguments-27:
 
 Arguments
 ---------
@@ -1159,7 +1174,7 @@ https://www.mlflow.org/docs/latest/cli.html#mlflow-run for more info.
      backend = NULL, backend_config = NULL, no_conda = FALSE,
      storage_dir = NULL)
 
-.. _arguments-27:
+.. _arguments-28:
 
 Arguments
 ---------
@@ -1251,7 +1266,7 @@ model types.
      conda_env = NULL, ...)
    mlflow_save_model(model, path, ...)
 
-.. _arguments-28:
+.. _arguments-29:
 
 Arguments
 ---------
@@ -1279,7 +1294,7 @@ Metric and Param keys.
      "DELETED_ONLY", "ALL"), experiment_ids = NULL, order_by = list(),
      client = NULL)
 
-.. _arguments-29:
+.. _arguments-30:
 
 Arguments
 ---------
@@ -1329,7 +1344,7 @@ Wrapper for ``mlflow server``.
      host = "127.0.0.1", port = 5000, workers = 4,
      static_prefix = NULL)
 
-.. _arguments-30:
+.. _arguments-31:
 
 Arguments
 ---------
@@ -1369,7 +1384,7 @@ metadata that can be updated.
    mlflow_set_experiment_tag(key, value, experiment_id = NULL,
      client = NULL)
 
-.. _arguments-31:
+.. _arguments-32:
 
 Arguments
 ---------
@@ -1416,7 +1431,7 @@ provided name. Returns the ID of the active experiment.
    mlflow_set_experiment(experiment_name = NULL, experiment_id = NULL,
      artifact_location = NULL)
 
-.. _arguments-32:
+.. _arguments-33:
 
 Arguments
 ---------
@@ -1446,7 +1461,7 @@ run and after a run completes.
 
    mlflow_set_tag(key, value, run_id = NULL, client = NULL)
 
-.. _arguments-33:
+.. _arguments-34:
 
 Arguments
 ---------
@@ -1486,7 +1501,7 @@ experiments.
 
    mlflow_set_tracking_uri(uri)
 
-.. _arguments-34:
+.. _arguments-35:
 
 Arguments
 ---------
@@ -1509,7 +1524,7 @@ called via ``Rscript`` from the terminal or through the MLflow CLI.
 
    mlflow_source(uri)
 
-.. _arguments-35:
+.. _arguments-36:
 
 Arguments
 ---------
@@ -1536,7 +1551,7 @@ can be provided.
    mlflow_start_run(run_id = NULL, experiment_id = NULL,
      start_time = NULL, tags = NULL, client = NULL)
 
-.. _arguments-36:
+.. _arguments-37:
 
 Arguments
 ---------
@@ -1599,7 +1614,7 @@ Launches the MLflow user interface.
 
    mlflow_ui(client, ...)
 
-.. _arguments-37:
+.. _arguments-38:
 
 Arguments
 ---------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,11 +15,7 @@ programming language, since all functions are accessible through a :ref:`rest-ap
 and :ref:`CLI<cli>`. For convenience, the project also includes a :ref:`python-api`, :ref:`R-api`, 
 and :ref:`java_api`.
 
-Get started using the :ref:`quickstart`, reading about the :ref:`key concepts<concepts>`, or
-running `Python <https://docs.databricks.com/applications/mlflow/quick-start-python.html>`_ &
-`R quickstarts <https://docs.databricks.com/applications/mlflow/quick-start-r.html>`_ using hosted
-MLflow on `Databricks Community Edition <https://docs.databricks.com/getting-started/try-databricks.html#community-edition>`_.
-
+Get started using the :ref:`quickstart` or by reading about the :ref:`key concepts<concepts>`.
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -194,8 +194,9 @@ tracking server. To get access to a remote tracking server:
 - :ref:`Launch a tracking server <tracking_server>` on a remote machine.
 
 - Alternatively, sign up for `Databricks Community Edition <https://databricks.com/try-databricks>`_,
-  which comes bundled with a hosted, auto-updating tracking server that lies behind authentication.
-  Then, run ``databricks configure`` to create a credentials file for MLflow, specifying
+  which comes bundled with a hosted, auto-updating tracking server that lies behind authentication. Note that
+  Community Edition is intended for quick experimentation rather than production use cases.
+  After signing up, run ``databricks configure`` to create a credentials file for MLflow, specifying
   https://community.cloud.databricks.com as the host.
 
 You can then :ref:`log to the remote tracking server <logging_to_a_tracking_server>`, e.g. by

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -104,35 +104,6 @@ and view it at http://localhost:5000.
 .. note::
     If you see message ``[CRITICAL] WORKER TIMEOUT`` in the MLflow UI or error logs, try using ``http://localhost:5000`` instead of ``http://127.0.0.1:5000``.
 
-Logging to a Remote Tracking Server
------------------------------------
-To manage results centrally or share them across a team, you can configure MLflow to log to a remote
-tracking server. To get access to a remote tracking server:
-
-- :ref:`Launch a tracking server <tracking_server>` on a remote machine.
-
-- Alternatively, sign up for `Databricks Community Edition <https://databricks.com/try-databricks>`_,
-  which comes bundled with a hosted, auto-updating tracking server that lies behind authentication.
-  Then, run ``databricks configure`` to create a credentials file for MLflow, specifying
-  https://community.cloud.databricks.com as the host.
-
-
-To log to the remote server, add the following to the start of your program, where
-``remote_server_uri`` is a string like ``"http://your-remote-server-uri.com"`` or ``"databricks"``
-if running against Community Edition.
-
-  .. code-section::
-
-    .. code-block:: python
-
-        import mlflow
-        mlflow.set_tracking_uri(remote_server_uri)
-
-    .. code-block:: R
-
-        library(mlflow)
-        mlflow_set_tracking_uri(remote_server_uri)
-
 
 Running MLflow Projects
 -----------------------
@@ -212,3 +183,34 @@ which returns::
     {"predictions": [1, 0]}
 
 For more information, see :doc:`models`.
+
+
+Logging to a Remote Tracking Server
+-----------------------------------
+In the examples above, MLflow logs data to the local filesystem of the machine it's running on.
+To manage results centrally or share them across a team, you can configure MLflow to log to a remote
+tracking server. To get access to a remote tracking server:
+
+- :ref:`Launch a tracking server <tracking_server>` on a remote machine.
+
+- Alternatively, sign up for `Databricks Community Edition <https://databricks.com/try-databricks>`_,
+  which comes bundled with a hosted, auto-updating tracking server that lies behind authentication.
+  Then, run ``databricks configure`` to create a credentials file for MLflow, specifying
+  https://community.cloud.databricks.com as the host.
+
+
+To log to the remote server, add the following to the start of your program, where
+``remote_server_uri`` is a string like ``"http://your-remote-server-uri.com"`` or ``"databricks"``
+if running against Community Edition.
+
+  .. code-section::
+
+    .. code-block:: python
+
+        import mlflow
+        mlflow.set_tracking_uri(remote_server_uri)
+
+    .. code-block:: R
+
+        library(mlflow)
+        mlflow_set_tracking_uri(remote_server_uri)

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -3,14 +3,6 @@
 Quickstart
 ==========
 
-You can run the quickstart below:
-
-- On your laptop or other environment.
-- In a `Python <https://docs.databricks.com/applications/mlflow/quick-start-python.html>`_ or
-  `R notebook <https://docs.databricks.com/applications/mlflow/quick-start-r.html>`_ on
-  `Databricks Community Edition <https://docs.databricks.com/getting-started/try-databricks.html#community-edition>`_,
-  with hosted MLflow. With hosted MLflow you don't need to set up your own tracking server to track runs.
-
 Installing MLflow
 -----------------
 
@@ -94,8 +86,8 @@ as follows (this example is also included in ``quickstart/mlflow_tracking.py``):
 Viewing the Tracking UI
 -----------------------
 
-By default, wherever you run your program, the tracking API writes data into files into an ``mlruns`` directory.
-You can then run MLflow's Tracking UI:
+By default, wherever you run your program, the tracking API writes data into files into a local
+``./mlruns`` directory. You can then run MLflow's Tracking UI:
 
 .. code-section::
   
@@ -112,8 +104,14 @@ and view it at http://localhost:5000.
 .. note::
     If you see message ``[CRITICAL] WORKER TIMEOUT`` in the MLflow UI or error logs, try using ``http://localhost:5000`` instead of ``http://127.0.0.1:5000``.
 
-Alternatively, you can configure MLflow to :ref:`log runs to a remote server<tracking>` to manage
-your results centrally or share them across a team.
+Alternatively, you can:
+
+- Configure MLflow to :ref:`log runs to a remote server <tracking_server>` to manage
+  your results centrally or share them across a team.
+
+- `Configure MLflow <https://docs.databricks.com/applications/mlflow/logging-from-outside-databricks.html>`_
+  to log to the tracking server bundled with `Databricks Community Edition <https://databricks.com/try-databricks>`_,
+  which receives regular updates to and allows you to avoid running your own tracking server.
 
 Running MLflow Projects
 -----------------------

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -198,5 +198,28 @@ tracking server. To get access to a remote tracking server:
   Then, run ``databricks configure`` to create a credentials file for MLflow, specifying
   https://community.cloud.databricks.com as the host.
 
-You can then :ref:`log to the remote tracking server <logging_to_a_tracking_server>`,
-using ``"databricks"`` as your tracking URI if using Community Edition.
+You can then :ref:`log to the remote tracking server <logging_to_a_tracking_server>`, e.g. by
+adding the following to the start of your program:
+
+  .. code-section::
+
+    .. code-block:: python
+
+        import mlflow
+        # Set "databricks" as the tracking URI if running against Community Edition - otherwise,
+        # update this to your tracking server's URI
+        mlflow.set_tracking_uri("databricks")
+        # Note: on Databricks, the experiment name passed to set_experiment must be a valid path
+        # in the workspace
+        mlflow.set_experiment("/my-experiment")
+
+    .. code-block:: R
+
+        library(mlflow)
+        install_mlflow()
+        # Set "databricks" as the tracking URI if running against Community Edition - otherwise,
+        # update this to your tracking server's URI
+        mlflow_set_tracking_uri("databricks")
+        # Note: on Databricks, the experiment name passed to mlflow_set_experiment must be a
+        # valid path in the workspace
+        mlflow_set_experiment("/my-experiment")

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -185,6 +185,8 @@ which returns::
 For more information, see :doc:`models`.
 
 
+.. _quickstart_logging_to_remote_server:
+
 Logging to a Remote Tracking Server
 -----------------------------------
 In the examples above, MLflow logs data to the local filesystem of the machine it's running on.
@@ -194,7 +196,7 @@ tracking server. To get access to a remote tracking server:
 - :ref:`Launch a tracking server <tracking_server>` on a remote machine.
 
 - Alternatively, sign up for `Databricks Community Edition <https://databricks.com/try-databricks>`_,
-  which comes bundled with a hosted, auto-updating tracking server that lies behind authentication.
+  which comes bundled with a hosted tracking server.
   Then, run ``databricks configure`` to create a credentials file for MLflow, specifying
   https://community.cloud.databricks.com as the host.
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -213,7 +213,8 @@ adding the following to the start of your program:
         # update this to your tracking server's URI
         mlflow.set_tracking_uri("databricks")
         # Note: on Databricks, the experiment name passed to set_experiment must be a valid path
-        # in the workspace
+        # in the workspace, like '/Users/<your-username>/my-experiment'. See
+        # https://docs.databricks.com/user-guide/workspace.html for more info.
         mlflow.set_experiment("/my-experiment")
 
     .. code-block:: R
@@ -224,5 +225,6 @@ adding the following to the start of your program:
         # update this to your tracking server's URI
         mlflow_set_tracking_uri("databricks")
         # Note: on Databricks, the experiment name passed to mlflow_set_experiment must be a
-        # valid path in the workspace
+        # valid path in the workspace.  See https://docs.databricks.com/user-guide/workspace.html
+        # for more info.
         mlflow_set_experiment("/my-experiment")

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -104,14 +104,35 @@ and view it at http://localhost:5000.
 .. note::
     If you see message ``[CRITICAL] WORKER TIMEOUT`` in the MLflow UI or error logs, try using ``http://localhost:5000`` instead of ``http://127.0.0.1:5000``.
 
-Alternatively, you can:
+Logging to a Remote Tracking Server
+-----------------------------------
+To manage results centrally or share them across a team, you can configure MLflow to log to a remote
+tracking server. To get access to a remote tracking server:
 
-- Configure MLflow to :ref:`log runs to a remote server <tracking_server>` to manage
-  your results centrally or share them across a team.
+- :ref:`Launch a tracking server <tracking_server>` on a remote machine.
 
-- `Configure MLflow <https://docs.databricks.com/applications/mlflow/logging-from-outside-databricks.html>`_
-  to log to the tracking server bundled with `Databricks Community Edition <https://databricks.com/try-databricks>`_,
-  which receives regular updates to and allows you to avoid running your own tracking server.
+- Alternatively, sign up for `Databricks Community Edition <https://databricks.com/try-databricks>`_,
+  which comes bundled with a hosted, auto-updating tracking server that lies behind authentication.
+  Then, run ``databricks configure`` to create a credentials file for MLflow, specifying
+  https://community.cloud.databricks.com as the host.
+
+
+To log to the remote server, add the following to the start of your program, where
+``remote_server_uri`` is a string like ``"http://your-remote-server-uri.com"`` or ``"databricks"``
+if running against Community Edition.
+
+  .. code-section::
+
+    .. code-block:: python
+
+        import mlflow
+        mlflow.set_tracking_uri(remote_server_uri)
+
+    .. code-block:: R
+
+        library(mlflow)
+        mlflow_set_tracking_uri(remote_server_uri)
+
 
 Running MLflow Projects
 -----------------------

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -198,19 +198,5 @@ tracking server. To get access to a remote tracking server:
   Then, run ``databricks configure`` to create a credentials file for MLflow, specifying
   https://community.cloud.databricks.com as the host.
 
-
-To log to the remote server, add the following to the start of your program, where
-``remote_server_uri`` is a string like ``"http://your-remote-server-uri.com"`` or ``"databricks"``
-if running against Community Edition.
-
-  .. code-section::
-
-    .. code-block:: python
-
-        import mlflow
-        mlflow.set_tracking_uri(remote_server_uri)
-
-    .. code-block:: R
-
-        library(mlflow)
-        mlflow_set_tracking_uri(remote_server_uri)
+You can then :ref:`log to the remote tracking server <logging_to_a_tracking_server>`,
+using ``"databricks"`` as your tracking URI if using Community Edition.

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -536,6 +536,8 @@ You can then pass authentication headers to MLflow using these :ref:`environment
 Additionally, you should ensure that the ``--backend-store-uri`` (which defaults to the
 ``./mlruns`` directory) points to a persistent (non-ephemeral) disk or database connection.
 
+.. _logging_to_a_tracking_server:
+
 Logging to a Tracking Server
 ----------------------------
 
@@ -545,12 +547,25 @@ along with its scheme and port (for example, ``http://10.0.0.1:5000``) or call :
 The :py:func:`mlflow.start_run`, :py:func:`mlflow.log_param`, and :py:func:`mlflow.log_metric` calls 
 then make API requests to your remote tracking server.
 
-.. code-block:: py
+  .. code-section::
 
-    import mlflow
-    with mlflow.start_run():
-        mlflow.log_param("a", 1)
-        mlflow.log_metric("b", 2)
+    .. code-block:: python
+
+        import mlflow
+        remote_server_uri = "..." # set to your server URI
+        mlflow.set_tracking_uri(remote_server_uri)
+        with mlflow.start_run():
+            mlflow.log_param("a", 1)
+            mlflow.log_metric("b", 2)
+
+    .. code-block:: R
+
+        library(mlflow)
+        install_mlflow()
+        remote_server_uri = "..." # set to your server URI
+        mlflow_set_tracking_uri(remote_server_uri)
+        mlflow_log_param("a", "1")
+
 
 .. _tracking_auth:
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -72,6 +72,8 @@ There are different kinds of remote tracking URIs:
 - Database encoded as ``<dialect>+<driver>://<username>:<password>@<host>:<port>/<database>``. Mlflow supports the dialects ``mysql``, ``mssql``, ``sqlite``, and ``postgresql``. For more details, see `SQLAlchemy database uri <https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls>`_.
 - HTTP server (specified as ``https://my-server:5000``), which is a server hosting an :ref:`MLFlow tracking server <tracking_server>`.
 - Databricks workspace (specified as ``databricks`` or as ``databricks://<profileName>``, a `Databricks CLI profile <https://github.com/databricks/databricks-cli#installation>`_.
+  `See docs <http://docs.databricks.com/applications/mlflow/logging-from-outside-databricks.html>`_ on
+  logging to Databricks-hosted MLflow for more info.
 
 Logging Data to Runs
 ====================

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -554,6 +554,9 @@ then make API requests to your remote tracking server.
         import mlflow
         remote_server_uri = "..." # set to your server URI
         mlflow.set_tracking_uri(remote_server_uri)
+        # Note: on Databricks, the experiment name passed to mlflow_set_experiment must be a
+        # valid path in the workspace
+        mlflow.set_experiment("/my-experiment")
         with mlflow.start_run():
             mlflow.log_param("a", 1)
             mlflow.log_metric("b", 2)
@@ -564,6 +567,9 @@ then make API requests to your remote tracking server.
         install_mlflow()
         remote_server_uri = "..." # set to your server URI
         mlflow_set_tracking_uri(remote_server_uri)
+        # Note: on Databricks, the experiment name passed to mlflow_set_experiment must be a
+        # valid path in the workspace
+        mlflow_set_experiment("/my-experiment")
         mlflow_log_param("a", "1")
 
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -73,7 +73,9 @@ There are different kinds of remote tracking URIs:
 - HTTP server (specified as ``https://my-server:5000``), which is a server hosting an :ref:`MLFlow tracking server <tracking_server>`.
 - Databricks workspace (specified as ``databricks`` or as ``databricks://<profileName>``, a `Databricks CLI profile <https://github.com/databricks/databricks-cli#installation>`_.
   `See docs <http://docs.databricks.com/applications/mlflow/logging-from-outside-databricks.html>`_ on
-  logging to Databricks-hosted MLflow for more info.
+  logging to Databricks-hosted MLflow, or :ref:`the quickstart <quickstart_logging_to_remote_server>` to
+  easily get started with hosted MLflow on Databricks Community Edition.
+
 
 Logging Data to Runs
 ====================


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Follow up to #1785 - as per feedback from @mateiz, update the MLflow quickstart to mention logging to the hosted MLflow server on CE as an alternative to setting up your own tracking server, instead of encouraging users to run separate quickstart notebooks wholesale on a CE cluster.

After this PR, the quickstart user journey looks like:
1. Open docs (from google search or mlflow.org)
2. Click "quickstart" link from [docs index page](https://mlflow.org/docs/latest/index.html)
3. Run quickstart code snippets on laptop. At the bottom of the quickstart, we explain why users might want to log to a remote tracking server & how they can achieve this using hosted MLflow on CE.

We also update [this docs section](https://mlflow.org/docs/latest/tracking.html#logging-to-a-tracking-server) with more detailed (actually runnable) examples of how to log to a remote server, and update https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded to link to a soon-to-exist doc page explaining how to log to a Databricks-hosted tracking server.

## How is this patch tested?
Generated & viewed docs via `make html` from the `docs` subdirectory (`make livehtml` also generates docs & is faster, but doesn't render code blocks properly)
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Streamline docs for getting started with hosted MLflow & clarify instructions for logging to a remote tracking server.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [x] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
