### PR TITLE
Configure MLflow repository with Probot-stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,48 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 21
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 60
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - enhancement
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+unmarkComment: >
+   Thank you for interacting with this issue! Removing the stale label!
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+   This issue has not been interacted with for 60 days since it was marked as stale! As such, the
+   issue is now closed. If you have this issue or more information, please re-open the issue!
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -13,6 +13,7 @@ onlyLabels: []
 # Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
 exemptLabels:
   - enhancement
+  - will-fix
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false

--- a/mlflow/server/js/src/utils/FileUtils.js
+++ b/mlflow/server/js/src/utils/FileUtils.js
@@ -11,4 +11,4 @@ export const getExtension = (path) => {
 export const IMAGE_EXTENSIONS = new Set(['jpg', 'bmp', 'jpeg', 'png', 'gif', 'svg']);
 export const TEXT_EXTENSIONS = new Set(
   ['txt', 'log', 'py', 'js', 'yaml', 'yml', 'json', 'csv', 'tsv',
-    'md', 'rst', 'MLmodel', 'MLproject', 'jsonnet']);
+    'md', 'rst', 'mlmodel', 'mlproject', 'jsonnet']);


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Hey everyone!

As discussed, we want to be able to deal with older issues in a better way! [Probot](https://github.com/probot/stale) will go through issues and mark ones that have not been interacted with for a configured amount of time as stale. Some configurable number of days after an issue marked as stale has not been engaged with, Probot will close that issue due to a lack of activity. 

In this PR, I propose marking an issue as stale if it has not been interacted with for 3 weeks. The issue would then be closed if it has not been engaged with for 2 months after it has been marked as stale. We can make this more aggressive as we develop more processes around dealing with issues! Notably, issues marked as enhancement are ignored by Probot, since it's likely that those would have longer lifespans.

As discussed, this would increase the visibility of issues and encourage more progress on them. This, combined with eventual JIRA integration, should dramatically raise the visibility of issues.
 
## How is this patch tested?
 
Test in prod!
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
