### PR TITLE
Retry 429s in REST Client 

### DIFF
--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -21,10 +21,11 @@ _DEFAULT_HEADERS = {
 def http_request(host_creds, endpoint, retries=3, retry_interval=3,
                  max_rate_limit_interval=60, **kwargs):
     """
-    Makes an HTTP request with the specified method to the specified hostname/endpoint. Retries
-    up to `retries` times if a request fails with a server error (e.g. error code 500), waiting
-    `retry_interval` seconds between successive retries. Parses the API response (assumed to be
-    JSON) into a Python object and returns it.
+    Makes an HTTP request with the specified method to the specified hostname/endpoint. Ratelimit
+    error code (429) will be retried with an exponential back off (1, 2, 4, ... seconds) for at most
+    `max_rate_limit_interval` seconds.  Internal errors (500s) will be retried up to `retries` times,
+    waiting `retry_interval` seconds between successive retries. Parses the API response
+    (assumed to be JSON) into a Python object and returns it.
 
     :param host_creds: A :py:class:`mlflow.rest_utils.MlflowHostCreds` object containing
         hostname and optional authentication.

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -23,8 +23,8 @@ def http_request(host_creds, endpoint, retries=3, retry_interval=3,
     """
     Makes an HTTP request with the specified method to the specified hostname/endpoint. Ratelimit
     error code (429) will be retried with an exponential back off (1, 2, 4, ... seconds) for at most
-    `max_rate_limit_interval` seconds.  Internal errors (500s) will be retried up to `retries` times,
-    waiting `retry_interval` seconds between successive retries. Parses the API response
+    `max_rate_limit_interval` seconds.  Internal errors (500s) will be retried up to `retries` times
+    , waiting `retry_interval` seconds between successive retries. Parses the API response
     (assumed to be JSON) into a Python object and returns it.
 
     :param host_creds: A :py:class:`mlflow.rest_utils.MlflowHostCreds` object containing


### PR DESCRIPTION
## What changes are proposed in this pull request?
 In order to correctly handle ratelimits in the rets api, the client should retry status code 429.
We already have a logic for retrying internal errors, however, the rate limit is somewhat different from internal error and so I put the logic for retrying 429s below the logic for retrying 500s. In this way, the rate limit has the same effect (assuming the request eventually gets through) as a slow down in connection speed. 
 
## How is this patch tested?
 Added a unit tets.
 
## Release Notes
The REST client will retry rate limited status code (429) with an exponential backoff. 

### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [x] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
