### PR TITLE
Support multi-column TensorFlow outputs

### DIFF
--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -21,7 +21,6 @@ import atexit
 import time
 import tempfile
 
-import numpy
 import pandas
 
 import mlflow
@@ -345,14 +344,12 @@ class _TFWrapper(object):
                     for tensor_column_name in self.input_tensor_mapping.keys()
             }
             raw_preds = self.tf_sess.run(self.output_tensors, feed_dict=feed_dict)
-            # Output tensors can be multidimensional (e.g., softmax), so return in DataFrame with
-            # columns tensor0_0, tensor0_1, ..., tensor0_n, tensor1_0, tensor1_1, ..., tensor1_n
             pred_df = pandas.DataFrame()
             for output_name, output_values in raw_preds.items():
                 if output_values.ndim == 1:
-                    output_values = numpy.expand_dims(output_values, axis=1)
-                for column in range(output_values.shape[1]):
-                    pred_df['{}_{}'.format(output_name, column)] = output_values[:, column]
+                    pred_df[output_name] = output_values
+                else:
+                    pred_df[output_name] = [value for value in output_values]
             return pred_df
 
 

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -60,10 +60,8 @@ def saved_tf_iris_model(tmpdir):
                                           hidden_units=[1])
     # Train the estimator and obtain expected predictions on the training dataset
     estimator.train(input_train, steps=10)
-    estimator_preds = np.array([s["predictions"] for s in estimator.predict(input_train)])
-    estimator_preds_df = pd.DataFrame(estimator_preds,
-                                      columns=["predictions_{}".format(column)
-                                               for column in range(estimator_preds.shape[1])])
+    estimator_preds = [s["predictions"] for s in estimator.predict(input_train)]
+    estimator_preds_df = pd.DataFrame({"predictions": estimator_preds})
 
     # Define a function for estimator inference
     feature_spec = {}
@@ -128,10 +126,8 @@ def saved_tf_categorical_model(tmpdir):
 
     # Train the estimator and obtain expected predictions on the training dataset
     estimator.train(input_fn=input_train, steps=10)
-    estimator_preds = np.array([s["predictions"] for s in estimator.predict(input_train)])
-    estimator_preds_df = pd.DataFrame(estimator_preds,
-                                      columns=["predictions_{}".format(column)
-                                               for column in range(estimator_preds.shape[1])])
+    estimator_preds = [s["predictions"] for s in estimator.predict(input_train)]
+    estimator_preds_df = pd.DataFrame({"predictions": estimator_preds})
 
     # Define a function for estimator inference
     feature_spec = {

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -60,8 +60,10 @@ def saved_tf_iris_model(tmpdir):
                                           hidden_units=[1])
     # Train the estimator and obtain expected predictions on the training dataset
     estimator.train(input_train, steps=10)
-    estimator_preds = np.array([s["predictions"] for s in estimator.predict(input_train)]).ravel()
-    estimator_preds_df = pd.DataFrame({"predictions": estimator_preds})
+    estimator_preds = np.array([s["predictions"] for s in estimator.predict(input_train)])
+    estimator_preds_df = pd.DataFrame(estimator_preds,
+                                      columns=["predictions_{}".format(column)
+                                               for column in range(estimator_preds.shape[1])])
 
     # Define a function for estimator inference
     feature_spec = {}
@@ -126,8 +128,10 @@ def saved_tf_categorical_model(tmpdir):
 
     # Train the estimator and obtain expected predictions on the training dataset
     estimator.train(input_fn=input_train, steps=10)
-    estimator_preds = np.array([s["predictions"] for s in estimator.predict(input_train)]).ravel()
-    estimator_preds_df = pd.DataFrame({"predictions": estimator_preds})
+    estimator_preds = np.array([s["predictions"] for s in estimator.predict(input_train)])
+    estimator_preds_df = pd.DataFrame(estimator_preds,
+                                      columns=["predictions_{}".format(column)
+                                               for column in range(estimator_preds.shape[1])])
 
     # Define a function for estimator inference
     feature_spec = {
@@ -268,7 +272,7 @@ def test_iris_model_can_be_loaded_and_evaluated_successfully(saved_tf_iris_model
             outputs_list = tf_sess.run(output_tensors, feed_dict=feed_dict)
             assert len(outputs_list) == 1
             outputs = outputs_list[0]
-            assert len(outputs.ravel()) == input_length
+            assert len(outputs) == input_length
 
     tf_graph_1 = tf.Graph()
     tf_sess_1 = tf.Session(graph=tf_graph_1)


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
This PR addresses https://github.com/mlflow/mlflow/issues/1066, changing the behavior of the TensorFlow model flavor to not automatically ravel its output during prediction. In the case of multi-column outputs, multiple columns are returned.

This is required for TensorFlow model compatibility with Spark UDFs with multi-column outputs. I've named the outputs _output_tensor0_0_, _output_tensor0_1_, ..., _output_tensor0_n_, which doesn't make a difference in the Spark UDF case (since they it is called with `withColumn`), but may for scoring server and SageMaker/Azure functionality.
 
## How is this patch tested?

I've modified the original tests with the expected output column names. Multi-column outputs are not explicitly tested, but if this if this design looks across the other deployment options, I can add the test.
 
(Details)
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users. 

TensorFlow models with multidimensional outputs (e.g., Softmax) will not be automatically raveled during prediction.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [x] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

Given that this changes output shapes, I am marking as a breaking change. Presumably users handled this manually when using SageMaker/Azure for scoring and reshaped the data client-side.
