### PR TITLE
[mlflow/R] Retry 429s in R's res client.

### DIFF
--- a/mlflow/R/mlflow/R/tracking-rest.R
+++ b/mlflow/R/mlflow/R/tracking-rest.R
@@ -74,15 +74,17 @@ mlflow_rest <- function( ..., client, query = NULL, data = NULL, verb = "GET", v
     },
     stop("Verb '", verb, "' is unsupported.", call. = FALSE)
   )
-  sleep <- 1
-  time_left <- max_rate_limit_interval
-  response <- get_response()
-
+  sleep_for <<- 1
+  time_left <<- max_rate_limit_interval
+  response <<- get_response()
   while (response$status_code == 429 && time_left > 0) {
-    Sys.sleep(sleep)
-    time_left <- time_left - sleep
-    sleep <- min(time_left, sleep*2)
-    response <- get_response()
+    time_left <<- time_left - sleep_for
+    warning(paste("Request returned with status code 429 (Rate limit exceeded). Retrying after ",
+                  sleep_for, " seconds. Will continue to retry 429s for up to ", time_left,
+                  " second.", sep = ""))
+    Sys.sleep(sleep_for)
+    sleep_for <<- min(time_left, sleep_for * 2)
+    response <<- get_response()
   }
 
   if (response$status_code != 200) {

--- a/mlflow/R/mlflow/R/tracking-rest.R
+++ b/mlflow/R/mlflow/R/tracking-rest.R
@@ -46,7 +46,8 @@ get_rest_config <- function(host_creds) {
 }
 
 #' @importFrom httr GET POST add_headers config content
-mlflow_rest <- function( ..., client, query = NULL, data = NULL, verb = "GET", version = "2.0") {
+mlflow_rest <- function( ..., client, query = NULL, data = NULL, verb = "GET", version = "2.0",
+                         max_rate_limit_interval=60) {
   host_creds <- client$get_host_creds()
   rest_config <- get_rest_config(host_creds)
   args <- list(...)
@@ -55,25 +56,35 @@ mlflow_rest <- function( ..., client, query = NULL, data = NULL, verb = "GET", v
     mlflow_rest_path(version),
     paste(args, collapse = "/")
   )
-
-  response <- switch(
+  req_headers <- do.call(add_headers, rest_config$headers)
+  get_response <- switch(
     verb,
-    GET = GET(
-      api_url,
-      query = query,
-      mlflow_rest_timeout(),
-      config = rest_config$config,
-      do.call(add_headers, rest_config$headers)),
-    POST = POST(
-      api_url,
-      body = if (is.null(data)) NULL else rapply(data, as.character, how = "replace"),
-      encode = "json",
-      mlflow_rest_timeout(),
-      config = rest_config$config,
-      do.call(add_headers, rest_config$headers)
-    ),
+    GET = function() {
+      GET( api_url, query = query, mlflow_rest_timeout(), config = rest_config$config,
+           req_headers)
+    },
+    POST = function(){
+      POST( api_url,
+            body = if (is.null(data)) NULL else rapply(data, as.character, how = "replace"),
+            encode = "json",
+            mlflow_rest_timeout(),
+            config = rest_config$config,
+            req_headers
+      )
+    },
     stop("Verb '", verb, "' is unsupported.", call. = FALSE)
   )
+  sleep <- 1
+  time_left <- max_rate_limit_interval
+  response <- get_response()
+
+  while (response$status_code == 429 && time_left > 0) {
+    Sys.sleep(sleep)
+    time_left <- time_left - sleep
+    sleep <- min(time_left, sleep*2)
+    response <- get_response()
+  }
+
   if (response$status_code != 200) {
     message_body <- tryCatch(
       paste(content(response, "parsed", type = "application/json"), collapse = "; "),

--- a/mlflow/R/mlflow/tests/testthat/test-rest.R
+++ b/mlflow/R/mlflow/tests/testthat/test-rest.R
@@ -65,7 +65,6 @@ test_that("429s are retried", {
       ), class = "response"
     )
   }
-  print("A")
   responses <- list(new_response(429), new_response(429), new_response(200))
   with_mock(.env = "httr", GET = function(...) {
     res <- responses[[next_id]]
@@ -96,5 +95,4 @@ test_that("429s are retried", {
       TRUE
     })
   })
-  print("B")
 })

--- a/mlflow/R/mlflow/tests/testthat/test-rest.R
+++ b/mlflow/R/mlflow/tests/testthat/test-rest.R
@@ -1,5 +1,8 @@
 context("rest")
 
+library(withr)
+
+
 test_that("user-agent header is set", {
   config <- list()
   config$insecure <- FALSE
@@ -48,4 +51,34 @@ test_that("insecure is used", {
   rest_config <- mlflow:::get_rest_config(config)
 
   expect_equal(rest_config$config, httr::config(ssl_verifypeer = 0, ssl_verifyhost = 0))
+})
+
+
+test_that("429s are retried", {
+  responses = list(list(status_code = 429), list(status_code = 429), list(status_code = 200))
+  next_id <- 1
+  client <- client1 <- mlflow:::mlflow_client("local")
+  with_mock(GET = function(...) {
+    res <- responses[[next_id]]
+    next_id <- next_id
+    res
+  }, {
+    tryCatch({
+      mlflow_rest(client, max_rate_limit_interval=0)
+      stop("The rest call should have returned 429 and the function should have thrown.")
+    })
+    x <- mlflow_rest(client, max_rate_limit_interval=2)
+    expect_equal(200, x$status_code)
+    next_id <- 1
+    x <- mlflow_rest(client, max_rate_limit_interval=2)
+    expect_equal(200, x$status_code)
+    next_id <- 1
+    x <- mlflow_rest(client, max_rate_limit_interval=3)
+    expect_equal(200, x$status_code)
+    next_id <- 1
+    tryCatch({
+      mlflow_rest(client, max_rate_limit_interval=1)
+      stop("The rest call should have returned 429 and the function should have thrown.")
+    })
+  })
 })


### PR DESCRIPTION
## What changes are proposed in this pull request?
Similarly to other clients, R should retry 429s.
 
## How is this patch tested?
Unit test.
 
## Release Notes
 Rest client in R will now retry 429 codes (rate limit exceeded) with an exponential backoff.
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [x] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
