### PR TITLE
Test compatibility with Anaconda distribution 2019.03

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,7 @@ script:
       ./travis/run-small-python-tests.sh && ./test-generate-protos.sh;
     else
       ./travis/run-large-python-tests.sh;
+      ./travis/test-anaconda-compatibility.sh;
     fi
 
 notifications:

--- a/travis/test-anaconda-compatibility-in-docker.sh
+++ b/travis/test-anaconda-compatibility-in-docker.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Test that mlflow installation does not modify (downgrade/upgrade/uninstall) packages from a
+# specific Anaconda distribution.
+# This script should run inside a continuumio/anaconda docker container with mlflow source
+# directory mounted at /mnt/mlflow.
+# See test-anaconda-compatibility.sh.
+
+set -euo pipefail
+
+. ~/.bashrc
+
+pip freeze > /tmp/before.txt
+pip install --upgrade-strategy only-if-needed -e /mnt/mlflow
+pip freeze > /tmp/after.txt
+diff /tmp/before.txt /tmp/after.txt > /tmp/diff.txt || true
+if [[ ! -z $(grep "<" /tmp/diff.txt) ]]; then
+  echo "MLflow installation modified the Anaconda distribution:\n" 1>&2
+  cat /tmp/diff.txt 1>&2
+  exit 1
+else
+  echo "MLflow installation did not modify the Anaconda distribution."
+  exit 0
+fi

--- a/travis/test-anaconda-compatibility-in-docker.sh
+++ b/travis/test-anaconda-compatibility-in-docker.sh
@@ -15,7 +15,7 @@ pip install --upgrade-strategy only-if-needed -e /mnt/mlflow
 pip freeze > /tmp/after.txt
 diff /tmp/before.txt /tmp/after.txt > /tmp/diff.txt || true
 if [[ ! -z $(grep "<" /tmp/diff.txt) ]]; then
-  echo "MLflow installation modified the Anaconda distribution:\n" 1>&2
+  echo "MLflow installation modified the Anaconda distribution:" 1>&2
   cat /tmp/diff.txt 1>&2
   exit 1
 else

--- a/travis/test-anaconda-compatibility.sh
+++ b/travis/test-anaconda-compatibility.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Test that mlflow installation does not modify (downgrade/upgrade/uninstall) packages from a
+# specific Anaconda distribution.
+
+set -e
+
+MLFLOW_DIR=$(cd "$(dirname ${BASH_SOURCE[0]})/.."; pwd)
+
+ANACONDA_VERSION=${1:-"anaconda3:2019.03"}
+docker run --rm -v "${MLFLOW_DIR}:/mnt/mlflow" continuumio/${ANACONDA_VERSION} \
+  bash /mnt/mlflow/travis/test-anaconda-compatibility-in-docker.sh

--- a/travis/test-anaconda-compatibility.sh
+++ b/travis/test-anaconda-compatibility.sh
@@ -3,10 +3,12 @@
 # Test that mlflow installation does not modify (downgrade/upgrade/uninstall) packages from a
 # specific Anaconda distribution.
 
-set -e
+set -eux
 
 MLFLOW_DIR=$(cd "$(dirname ${BASH_SOURCE[0]})/.."; pwd)
 
-ANACONDA_VERSION=${1:-"anaconda3:2019.03"}
+PYTHON_MAJOR_VERSION=$(python -c "import sys; print(sys.version_info[0])")
+DEFAULT_ANACONDA_VERSIONS=([2]="anaconda:2019.03" [3]="anaconda3:2019.03")
+ANACONDA_VERSION=${1:-${DEFAULT_ANACONDA_VERSIONS["$PYTHON_MAJOR_VERSION"]}}
 docker run --rm -v "${MLFLOW_DIR}:/mnt/mlflow" continuumio/${ANACONDA_VERSION} \
   bash /mnt/mlflow/travis/test-anaconda-compatibility-in-docker.sh


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Add a travis test to verify MLflow installation does not modify a specific Anaconda distribution. It is part of the large build.

Run `travis/test-anaconda-compatibility.sh anaconda3:4.4.0` to see what failures look like.
 
## How is this patch tested?
 
In Travis, it pulls the Anaconda docker file and tries to install MLflow dev there. Then verify the no existing packages from Anaconda were modified.
 
## Release Notes
 
### Is this a user-facing change? 

Not sure if we want to claim certain Anaconda distribution compatibility in the release notes.

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
