### PR TITLE
Added reatelimit (429s) retries to Java rest client.

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
@@ -30,11 +30,57 @@ import org.mlflow.tracking.creds.MlflowHostCredsProvider;
 class MlflowHttpCaller {
   private static final Logger logger = LoggerFactory.getLogger(MlflowHttpCaller.class);
   private static final String BASE_API_PATH = "api/2.0/preview/mlflow";
-  private HttpClient httpClient;
+  protected HttpClient httpClient;
   private final MlflowHostCredsProvider hostCredsProvider;
+  private final int maxRateLimitIntervalMillis;
+  private final int rateLimitRetrySleepInitMillis;
 
   MlflowHttpCaller(MlflowHostCredsProvider hostCredsProvider) {
+    this(hostCredsProvider, 60000);
+  }
+
+  MlflowHttpCaller(MlflowHostCredsProvider hostCredsProvider, int maxRateLimitIntervalSeconds) {
+    this(hostCredsProvider, maxRateLimitIntervalSeconds, 1000);
+  }
+
+  MlflowHttpCaller(MlflowHostCredsProvider hostCredsProvider,
+                   int maxRateLimitIntervalSeconds,
+                   int rateLimitRetrySleepInitMs) {
     this.hostCredsProvider = hostCredsProvider;
+    this.maxRateLimitIntervalMillis = maxRateLimitIntervalSeconds;
+    this.rateLimitRetrySleepInitMillis = rateLimitRetrySleepInitMs;
+  }
+
+  MlflowHttpCaller(MlflowHostCredsProvider hostCredsProvider,
+                   int maxRateLimitIntervalSeconds,
+                   int rateLimitRetrySleepInitMs,
+                   HttpClient client) {
+    this(hostCredsProvider, maxRateLimitIntervalSeconds, rateLimitRetrySleepInitMs);
+    this.httpClient = client;
+  }
+
+
+  HttpResponse executeRequest(HttpRequestBase request) throws IOException {
+    HttpResponse response = httpClient.execute(request);
+    int timeLeft = maxRateLimitIntervalMillis;
+    int sleepFor = rateLimitRetrySleepInitMillis;
+    while (response.getStatusLine().getStatusCode() == 429 && timeLeft > 0) {
+      timeLeft -= sleepFor;
+      logger.warn("Request returned with status code 429 (Rate limit exceeded). Retrying after "
+                  + sleepFor
+                  + " milliseconds. Will continue to retry 429s for up to "
+                  + timeLeft
+                  + " milliseconds.");
+      try {
+        Thread.sleep(sleepFor);
+      } catch (InterruptedException e) {
+        logger.warn("interrupted while waiting for retry.");
+      }
+      sleepFor = Math.min(timeLeft, 2 * sleepFor);
+      response = httpClient.execute(request);
+    }
+    checkError(response);
+    return response;
   }
 
   String get(String path) {
@@ -42,8 +88,7 @@ class MlflowHttpCaller {
     HttpGet request = new HttpGet();
     fillRequestSettings(request, path);
     try {
-      HttpResponse response = httpClient.execute(request);
-      checkError(response);
+      HttpResponse response = executeRequest(request);
       String responseJosn = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
       logger.debug("Response: " + responseJosn);
       return responseJosn;
@@ -58,8 +103,7 @@ class MlflowHttpCaller {
     HttpGet request = new HttpGet();
     fillRequestSettings(request, path);
     try {
-      HttpResponse response = httpClient.execute(request);
-      checkError(response);
+      HttpResponse response = executeRequest(request);
       byte[] bytes = EntityUtils.toByteArray(response.getEntity());
       logger.debug("response: #bytes=" + bytes.length);
       return bytes;
@@ -75,8 +119,7 @@ class MlflowHttpCaller {
     request.setEntity(new StringEntity(json, StandardCharsets.UTF_8));
     request.setHeader("Content-Type", "application/json");
     try {
-      HttpResponse response = httpClient.execute(request);
-      checkError(response);
+      HttpResponse response = executeRequest(request);
       String responseJson = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
       logger.debug("Response: " + responseJson);
       return responseJson;

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/HttpCallerTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/HttpCallerTest.java
@@ -1,0 +1,101 @@
+package org.mlflow.tracking;
+
+
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.mlflow.tracking.creds.BasicMlflowHostCreds;
+import org.mlflow.tracking.creds.MlflowHostCreds;
+import org.mlflow.tracking.creds.MlflowHostCredsProvider;
+import org.testng.Assert;
+import org.testng.annotations.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.Mockito.*;
+
+public class HttpCallerTest {
+
+  static CloseableHttpClient client = mock(CloseableHttpClient.class);
+
+  static CloseableHttpResponse response429 = mock(CloseableHttpResponse.class);
+  static CloseableHttpResponse response200 = mock(CloseableHttpResponse.class);
+  static StatusLine statusLine200 = mock(StatusLine.class);
+  static HttpEntity entity200 = mock(HttpEntity.class);
+  static HttpEntity entity429 = mock(HttpEntity.class);
+  static String expectedResponseText = "expected response text.";
+  static StatusLine statusLine429 = mock(StatusLine.class);
+
+  MlflowHttpCaller caller = new MlflowHttpCaller(new MlflowHostCredsProvider() {
+    @Override
+    public MlflowHostCreds getHostCreds() {
+      return new BasicMlflowHostCreds("http://some/host");
+    }
+
+    @Override
+    public void refresh() {
+      // pass
+    }
+  }, 4, 1, client);
+
+  @BeforeSuite
+  public void beforeAll() throws IOException {
+    when(statusLine200.getStatusCode()).thenReturn(200);
+    when(statusLine429.getStatusCode()).thenReturn(429);
+    when(response200.getStatusLine()).thenReturn(statusLine200);
+    when(entity200.getContent())
+            .thenReturn(
+                    new ByteArrayInputStream(expectedResponseText.getBytes(StandardCharsets.UTF_8)))
+            .thenReturn(new ByteArrayInputStream(expectedResponseText.getBytes(StandardCharsets.UTF_8)));
+    when(entity429.getContent())
+            .thenReturn(
+                    new ByteArrayInputStream(expectedResponseText.getBytes(StandardCharsets.UTF_8)))
+            .thenReturn(new ByteArrayInputStream(expectedResponseText.getBytes(StandardCharsets.UTF_8)));
+    when(response200.getEntity()).thenReturn(entity200);
+    when(response429.getStatusLine()).thenReturn(statusLine429);
+    when(response429.getEntity()).thenReturn(entity429);
+  }
+
+  @Test
+  public void testMultipleRetries() throws IOException {
+    when(client.execute(any(HttpUriRequest.class)))
+            .thenReturn(response429) // sleep for 1 ms
+            .thenReturn(response429) // sleep for 2 ms
+            .thenReturn(response429) // sleep for 4 - 3 == 1ms
+            .thenReturn(response200);// last response before timing out
+    Assert.assertEquals(expectedResponseText, caller.get("some/path"));
+
+    when(client.execute(any(HttpUriRequest.class)))
+            .thenReturn(response429) // sleep for 1 ms
+            .thenReturn(response429) // sleep for 2 ms
+            .thenReturn(response429) // sleep for 4 - 3 == 1ms
+            .thenReturn(response200);// last response before timing out
+    Assert.assertEquals(expectedResponseText, caller.post("some/path", "{\"attr\":\"val\"}"));
+  }
+
+  @Test
+  public void testMaxRetryIntervalFor429s() throws IOException {
+    when(client.execute(any(HttpUriRequest.class)))
+            .thenReturn(response429) // sleep for 1 ms
+            .thenReturn(response429) // sleep for 2 ms
+            .thenReturn(response429) // sleep for 4 - 3 == 1ms
+            .thenReturn(response429) // last response before timing out
+            .thenReturn(response200);// should never be returned;
+    MlflowHttpException ex = Assert.expectThrows(MlflowHttpException.class,
+            () -> caller.get("some/path"));
+    Assert.assertEquals(429, ex.getStatusCode());
+    when(client.execute(any(HttpUriRequest.class)))
+            .thenReturn(response429) // sleep for 1 ms
+            .thenReturn(response429) // sleep for 2 ms
+            .thenReturn(response429) // sleep for 4 - 3 == 1ms
+            .thenReturn(response429) // last response before timing out
+            .thenReturn(response200);// should never be returned;
+    ex = Assert.expectThrows(MlflowHttpException.class,
+            () -> caller.post("some/path", "{\"attr\":\"val\"}"));
+    Assert.assertEquals(429, ex.getStatusCode());
+  }
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?
 Retry 429s (rate limit exceeded) in Java rest client.
 
## How is this patch tested?
 Added a unit test.
 
## Release Notes
 Java client will now retry status code 429 (rate limit exceeded) with an exponential backoff.

### Is this a user-facing change? 
- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [x] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
