### PR TITLE
[R] Fix bug where mlflow_list_artifact throws when listing artifacts for a run without any logged

### DIFF
--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -354,7 +354,8 @@ mlflow_list_artifacts <- function(path = NULL, run_id = NULL, client = NULL) {
 
   message(glue::glue("Root URI: {uri}", uri = response$root_uri))
 
-  response$files %>%
+  files_list <- if (!is.null(response$files)) response$files else list()
+  files_list %>%
     purrr::transpose() %>%
     purrr::map(unlist) %>%
     tibble::as_tibble()
@@ -479,7 +480,7 @@ mlflow_log_artifact <- function(path, artifact_path = NULL, run_id = NULL, clien
              client = client
   )
 
-  mlflow_list_artifacts(run_id = run_id, path = artifact_path, client = client)
+  invisible(mlflow_list_artifacts(run_id = run_id, path = artifact_path, client = client))
 }
 
 #' Start Run

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -291,7 +291,7 @@ test_that("mlflow_log_artifact and mlflow_list_artifacts work", {
     dir.create(source_dir)
     file_path <- file.path(source_dir, "my-file")
     contents <- "File contents\n"
-    cat(contents, file=file_path, sep="")
+    cat(contents, file = file_path, sep = "")
     # Log file, file with path, directory with path argument
     mlflow_log_artifact(file_path)
     mlflow_log_artifact(file_path, "directory_for_file")
@@ -312,7 +312,7 @@ test_that("mlflow_log_artifact and mlflow_list_artifacts work", {
     artifact_list1 <- mlflow_list_artifacts("artifact_subdirectory")
     expect_equal(nrow(artifact_list1), 1)
     logged_file2 <- artifact_list1[artifact_list1$path ==
-      paste("artifact_subdirectory", "my-file", sep="/"), ]
+      paste("artifact_subdirectory", "my-file", sep = "/"), ]
     expect_equal(nrow(logged_file2), 1)
     expect_equal(logged_file2$is_dir, FALSE)
     expect_equal(strtoi(logged_file2$file_size), nchar(contents))
@@ -320,7 +320,7 @@ test_that("mlflow_log_artifact and mlflow_list_artifacts work", {
     artifact_list2 <- mlflow_list_artifacts("directory_for_file")
     expect_equal(nrow(artifact_list2), 1)
     logged_file3 <- artifact_list2[artifact_list2$path ==
-    paste("directory_for_file", "my-file", sep="/"), ]
+    paste("directory_for_file", "my-file", sep = "/"), ]
     expect_equal(nrow(logged_file3), 1)
     expect_equal(logged_file3$is_dir, FALSE)
     expect_equal(strtoi(logged_file3$file_size), nchar(contents))

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -281,6 +281,52 @@ test_that("mlflow_search_runs() works", {
   expect_equal(nrow(mlflow_search_runs(filter = "metrics.new_experiment_metric = 30")), 1)
 })
 
+test_that("mlflow_log_artifact and mlflow_list_artifacts work", {
+  with(mlflow_start_run(), {
+    # List artifacts for run without artifacts, result should be empty
+    empty_artifact_list <- mlflow_list_artifacts()
+    # Create some dummy artifact files/directories
+    expect_equal(nrow(empty_artifact_list), 0)
+    source_dir <- file.path(tempdir(), "temp-directory")
+    dir.create(source_dir)
+    file_path <- file.path(source_dir, "my-file")
+    contents <- "File contents\n"
+    cat(contents, file=file_path, sep="")
+    # Log file, file with path, directory with path argument
+    mlflow_log_artifact(file_path)
+    mlflow_log_artifact(file_path, "directory_for_file")
+    mlflow_log_artifact(source_dir, "artifact_subdirectory")
+    # Verify logged files
+    artifact_list0 <- mlflow_list_artifacts()
+    expect_equal(nrow(artifact_list0), 3)
+    logged_file0 <- artifact_list0[artifact_list0$path == "my-file", ]
+    expect_equal(nrow(logged_file0), 1)
+    expect_equal(logged_file0$is_dir, FALSE)
+    logged_file1 <- artifact_list0[artifact_list0$path == "directory_for_file", ]
+    expect_equal(nrow(logged_file1), 1)
+    expect_equal(logged_file1$is_dir, TRUE)
+    logged_dir0 <- artifact_list0[artifact_list0$path == "artifact_subdirectory", ]
+    expect_equal(nrow(logged_dir0), 1)
+    expect_equal(logged_dir0$is_dir, TRUE)
+    # Verify contents of logged directory
+    artifact_list1 <- mlflow_list_artifacts("artifact_subdirectory")
+    expect_equal(nrow(artifact_list1), 1)
+    logged_file2 <- artifact_list1[artifact_list1$path ==
+      paste("artifact_subdirectory", "my-file", sep="/"), ]
+    expect_equal(nrow(logged_file2), 1)
+    expect_equal(logged_file2$is_dir, FALSE)
+    expect_equal(strtoi(logged_file2$file_size), nchar(contents))
+    # Verify contents of file logged under directory
+    artifact_list2 <- mlflow_list_artifacts("directory_for_file")
+    expect_equal(nrow(artifact_list2), 1)
+    logged_file3 <- artifact_list2[artifact_list2$path ==
+    paste("directory_for_file", "my-file", sep="/"), ]
+    expect_equal(nrow(logged_file3), 1)
+    expect_equal(logged_file3$is_dir, FALSE)
+    expect_equal(strtoi(logged_file3$file_size), nchar(contents))
+  })
+})
+
 test_that("mlflow_list_run_infos() works", {
   mlflow_clear_test_dir("mlruns")
   expect_equal(nrow(mlflow_list_run_infos(experiment_id = "0")), 0)


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fix bug where `mlflow_list_artifact` throws when listing artifacts for a run without any artifacts logged (we now return an empty `tibble`), and adds regression test.
 
## How is this patch tested?
 
Adds own regression test.
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Fixed a bug where `mlflow_list_artifact` would throw when listing artifacts for a run without any artifacts logged (we now return an empty `tibble`).
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [x] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
