### PR TITLE
Use realistic timestamp values (in milliseconds, not seconds) in tests

### DIFF
--- a/tests/entities/test_metric.py
+++ b/tests/entities/test_metric.py
@@ -15,7 +15,7 @@ def _check(metric, key, value, timestamp, step):
 def test_creation_and_hydration():
     key = random_str()
     value = 10000
-    ts = int(time.time())
+    ts = int(1000 * time.time())
     step = random_int()
 
     metric = Metric(key, value, ts, step)

--- a/tests/store/test_sqlalchemy_store.py
+++ b/tests/store/test_sqlalchemy_store.py
@@ -420,8 +420,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         tkey = 'blahmetric'
         tval = 100.0
-        metric = entities.Metric(tkey, tval, int(time.time()), 0)
-        metric2 = entities.Metric(tkey, tval, int(time.time()) + 2, 0)
+        metric = entities.Metric(tkey, tval, int(1000 * time.time()), 0)
+        metric2 = entities.Metric(tkey, tval, int(1000 * time.time()) + 2, 0)
         nan_metric = entities.Metric("NaN", float("nan"), 0, 0)
         pos_inf_metric = entities.Metric("PosInf", float("inf"), 0, 0)
         neg_inf_metric = entities.Metric("NegInf", -float("inf"), 0, 0)
@@ -482,7 +482,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         tkey = 'blahmetric'
         tval = None
-        metric = entities.Metric(tkey, tval, int(time.time()), 0)
+        metric = entities.Metric(tkey, tval, int(1000 * time.time()), 0)
 
         warnings.simplefilter("ignore")
         with self.assertRaises(MlflowException) as exception_context, warnings.catch_warnings():


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Since the `timestamp` attribute of `Metric` expects milliseconds (_not seconds_) since the Unix epoch, that's what we should be using in tests, to avoid confusion.
 
## How is this patch tested?
 
This patch is tested by the existing tests that I am updating here
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 