### PR TITLE
[UI] Remove usage of state derived from component props in ExperimentView

### DIFF
--- a/mlflow/server/js/src/components/ExperimentPage.js
+++ b/mlflow/server/js/src/components/ExperimentPage.js
@@ -50,6 +50,7 @@ export class ExperimentPage extends Component {
     const orderBy = ExperimentPage.getOrderByExpr(orderByKey, orderByAsc);
     const viewType = lifecycleFilterToRunViewType(lifecycleFilter);
 
+    this.getExperimentRequestId = getUUID();
     this.props
       .getExperimentApi(experimentId, this.getExperimentRequestId)
       .catch((e) => {
@@ -80,6 +81,7 @@ export class ExperimentPage extends Component {
     const orderBy = ExperimentPage.getOrderByExpr(orderByKey, orderByAsc);
     const viewType = lifecycleFilterToRunViewType(lifecycleFilter);
     this.setState({ loadingMore: true });
+    this.loadMoreRunsRequestId = getUUID();
     this.props
       .loadMoreRunsApi(
         [experimentId],
@@ -162,6 +164,7 @@ export class ExperimentPage extends Component {
     });
 
     const orderBy = ExperimentPage.getOrderByExpr(orderByKey, orderByAsc);
+    this.searchRunsRequestId = getUUID();
     this.props
       .searchRunsApi(
         [this.props.experimentId],
@@ -262,6 +265,7 @@ export class ExperimentPage extends Component {
       nextPageToken={this.state.nextPageToken}
       handleLoadMoreRuns={this.handleLoadMoreRuns}
       loadingMore={this.state.loadingMore}
+      key={this.searchRunsRequestId}
     />;
   }
 

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -68,6 +68,9 @@ export class ExperimentView extends Component {
       persistedState: persistedState.toJSON(),
       showNotesEditor: false,
       showNotes: true,
+      searchInput: this.props.searchInput,
+      paramKeyFilterInput: this.props.paramKeyFilter.getFilterString(),
+      metricKeyFilterInput: this.props.metricKeyFilter.getFilterString(),
     };
   }
 
@@ -122,7 +125,7 @@ export class ExperimentView extends Component {
       // Text entered into the metric filter field
       metricKeyFilterInput: '',
       // Lifecycle stage of runs to display
-      lifecycleFilterInput: '',
+      lifecycleFilterInput: LIFECYCLE_FILTER.ACTIVE,
       // Text entered into the runs-search field
       searchInput: '',
       // String error message, if any, from an attempted search
@@ -179,29 +182,6 @@ export class ExperimentView extends Component {
     // Snapshot component state on unmounts to ensure we've captured component state in cases where
     // componentDidUpdate doesn't fire.
     this.snapshotComponentState();
-  }
-
-  static getDerivedStateFromProps(nextProps, prevState) {
-    // Compute the actual runs selected. (A run cannot be selected if it is not passed in as a
-    // prop)
-    const newRunsSelected = {};
-    nextProps.runInfos.forEach((rInfo) => {
-      const prevRunSelected = prevState.runsSelected[rInfo.run_uuid];
-      if (prevRunSelected) {
-        newRunsSelected[rInfo.run_uuid] = prevRunSelected;
-      }
-    });
-    const { searchInput, paramKeyFilter, metricKeyFilter, lifecycleFilter } = nextProps;
-    const paramKeyFilterInput = paramKeyFilter.getFilterString();
-    const metricKeyFilterInput = metricKeyFilter.getFilterString();
-    return {
-      ...prevState,
-      searchInput,
-      paramKeyFilterInput,
-      metricKeyFilterInput,
-      lifecycleFilterInput: lifecycleFilter,
-      runsSelected: newRunsSelected,
-    };
   }
 
   onDeleteRun() {


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Remove use of `getDerivedStateFromProps` from the ExperimentView component - this should unblock https://github.com/mlflow/mlflow/pull/1812, which upgrades the tracking UI to use react-scripts-v3 to allow the use of modern JS libraries that use ES6 syntax (e.g. the nteract IPython visualization library added in https://github.com/mlflow/mlflow/pull/1556).
 
## How is this patch tested?
 
Manually QA'd the different pages in the tracking UI:
* Search/filtering/setting lifecycle stage
* Viewing metric time-series, comparing metrics
* Scatter plot view for comparing metrics/params
* Parallel coordinates plot
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
