### PR TITLE
Minor fix to make spark udf work with struct input in spark.

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -428,8 +428,8 @@ def spark_udf(spark, model_uri, result_type="double"):
         for x in args:
             if type(x) == pandas.DataFrame:
                 if len(args) != 1:
-                    raise Exception("If passing a StructType column, there should be only one input column, "
-                                    "but got %d" % len(args))
+                    raise Exception("If passing a StructType column, there should be only one "
+                                    "input column, but got %d" % len(args))
                 pdf = x
         else:
             # Explicitly pass order of columns to avoid lexicographic ordering (i.e., 10 < 2)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -425,13 +425,14 @@ def spark_udf(spark, model_uri, result_type="double"):
     def predict(*args):
         model = SparkModelCache.get_or_load(archive_path)
         schema = {str(i): arg for i, arg in enumerate(args)}
+        pdf = None
         for x in args:
             if type(x) == pandas.DataFrame:
                 if len(args) != 1:
                     raise Exception("If the input is DataFrame, there should be only one, "
                                     "got %d" % len(args))
                 pdf = x
-        else:
+        if pdf is None:
             # Explicitly pass order of columns to avoid lexicographic ordering (i.e., 10 < 2)
             columns = [str(i) for i, _ in enumerate(args)]
             pdf = pandas.DataFrame(schema, columns=columns)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -423,6 +423,9 @@ def spark_udf(spark, model_uri, result_type="double"):
         model = SparkModelCache.get_or_load(archive_path)
         schema = {str(i): arg for i, arg in enumerate(args)}
         if type(args[0]) == pandas.DataFrame:
+            if len(args) != 1:
+                raise Exception("If the input is DataFrame, there should be only one, "
+                                "got %d" % len(args))
             pdf = args[0]
         else:
             # Explicitly pass order of columns to avoid lexicographic ordering (i.e., 10 < 2)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -428,8 +428,8 @@ def spark_udf(spark, model_uri, result_type="double"):
         for x in args:
             if type(x) == pandas.DataFrame:
                 if len(args) != 1:
-                    raise Exception("If the input is DataFrame, there should be only one, "
-                                    "got %d" % len(args))
+                    raise Exception("If passing a StructType column, there should be only one input column, "
+                                    "but got %d" % len(args))
                 pdf = x
         else:
             # Explicitly pass order of columns to avoid lexicographic ordering (i.e., 10 < 2)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Struct input in  spark 3.0 will be passed as a single Dataframe. We should just use it as input in that case.
  
## How is this patch tested?
Manually.
 
## Release Notes
Spark udf can now be called with struct input if the underlying spark implementation supports it. 
The data is passed as a pandas DataFrame with column names corresponding to the struct.

### Is this a user-facing change? 
- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
  
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [x] Models 
- [x] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
