### PR TITLE
[UI] Fix a problem that image isn't shown when file path has special character

### DIFF
--- a/mlflow/server/js/package-lock.json
+++ b/mlflow/server/js/package-lock.json
@@ -3491,6 +3491,12 @@
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
       "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
     },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+      "dev": true
+    },
     "csscolorparser": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "babel-eslint": "8.2.2",
+    "css.escape": "^1.5.1",
     "enzyme": "3.5.0",
     "enzyme-adapter-react-16": "1.3.0",
     "eslint": "4.18.1",
@@ -64,8 +65,8 @@
     "eslint-plugin-react": "7.4.0",
     "eslint-plugin-standard": "3.0.1",
     "jest-localstorage-mock": "^2.3.0",
-    "react-app-rewired": "^1.5.2",
-    "react-app-rewire-define-plugin": "1.0.0"
+    "react-app-rewire-define-plugin": "1.0.0",
+    "react-app-rewired": "^1.5.2"
   },
   "scripts": {
     "start": "react-app-rewired start",

--- a/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
+++ b/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
@@ -13,7 +13,7 @@ class ShowArtifactImageView extends Component {
     return (
       <div className="image-outer-container">
         <div className="image-container"
-             style={{ backgroundImage: `url(${getSrc(path, runUuid)})` }}/>
+             style={{ backgroundImage: `url(${getSrc(path, runUuid, true)})` }}/>
       </div>
     );
   }

--- a/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.test.js
+++ b/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.test.js
@@ -1,0 +1,22 @@
+require('css.escape');
+import React from 'react';
+import { mount } from 'enzyme';
+import { getUUID } from '../../Actions';
+import ShowArtifactImageView from './ShowArtifactImageView';
+
+describe('<ShowArtifactImageView />', () => {
+  let wrapper;
+  let uuid = getUUID();
+
+  test('should render with image url ', () => {
+    const props = {runUuid: uuid, path: "test.jpg"}
+    wrapper = mount(<ShowArtifactImageView {...props} />);
+    expect(wrapper.find('.image-container').html().includes("style=\"background-image:")).toBeTruthy();
+  });
+
+  test('should render with image url when CSS special charactor', () => {
+    const props = {runUuid: uuid, path: "test( .jpg"}
+    wrapper = mount(<ShowArtifactImageView {...props} />);
+    expect(wrapper.find('.image-container').html().includes("style=\"background-image:")).toBeTruthy();
+  });
+});

--- a/mlflow/server/js/src/components/artifact-view-components/ShowArtifactPage.js
+++ b/mlflow/server/js/src/components/artifact-view-components/ShowArtifactPage.js
@@ -52,9 +52,13 @@ class ShowArtifactPage extends Component {
   }
 }
 
-export const getSrc = (path, runUuid) => {
+export const getSrc = (path, runUuid, CSSEscape=false) => {
   const basePath = "get-artifact";
-  return `${basePath}?path=${encodeURIComponent(path)}&run_uuid=${encodeURIComponent(runUuid)}`;
+  if(CSSEscape) {
+    return `${basePath}?path=${CSS.escape(path)}&run_uuid=${encodeURIComponent(runUuid)}`;
+  } else {
+    return `${basePath}?path=${encodeURIComponent(path)}&run_uuid=${encodeURIComponent(runUuid)}`;
+  }
 };
 
 

--- a/mlflow/server/js/src/components/artifact-view-components/ShowArtifactPage.test.js
+++ b/mlflow/server/js/src/components/artifact-view-components/ShowArtifactPage.test.js
@@ -1,0 +1,61 @@
+require('css.escape');
+import React from 'react';
+import { shallow } from 'enzyme';
+import { getUUID } from '../../Actions';
+import ShowArtifactPage, { getSrc } from './ShowArtifactPage';
+import ShowArtifactImageView from './ShowArtifactImageView';
+import ShowArtifactTextView from './ShowArtifactTextView';
+import ShowArtifactHtmlView from './ShowArtifactHtmlView';
+
+describe('#getSrc', () => {
+  let ret;
+  let expected;
+  let uuid = getUUID();
+
+  test('should return URI escaped value when no third argument given', () => {
+    ret = getSrc("test .jpg", uuid)
+    expected = "get-artifact?path=test%20.jpg&run_uuid=" + uuid;
+    expect(ret).toEqual(expected);
+  });
+
+  test('should return URI escaped value when third argument is false', () => {
+    ret = getSrc("test .jpg", uuid, false)
+    expected = "get-artifact?path=test%20.jpg&run_uuid=" + uuid;
+    expect(ret).toEqual(expected);
+  });
+
+  test('should return CSS escaped value when third argument is true', () => {
+    ret = getSrc("test .jpg", uuid, true)
+    expected = "get-artifact?path=test\\ \\.jpg&run_uuid=" + uuid;
+    expect(ret).toEqual(expected);
+  });
+});
+
+describe('<ShowArtifactPage />', () => {
+  let wrapper;
+  let uuid = getUUID();
+
+  test('should render ShowArtifactImageView when path is image path', () => {
+    const props = {runUuid: uuid, path: "huga.jpg"}
+    wrapper = shallow(<ShowArtifactPage {...props} />);
+    expect(wrapper.find(ShowArtifactImageView).length).toBe(1);
+  });
+
+  test('should render ShowArtifactImageView when path is image path includes special character', () => {
+    const props = {runUuid: uuid, path: "huga .jpg"}
+    wrapper = shallow(<ShowArtifactPage {...props} />);
+    expect(wrapper.find(ShowArtifactImageView).length).toBe(1);
+  });
+
+  test('should render ShowArtifactTextView when path is text path', () => {
+    const props = {runUuid: uuid, path: "huga.txt"}
+    wrapper = shallow(<ShowArtifactPage {...props} />);
+    expect(wrapper.find(ShowArtifactTextView).length).toBe(1);
+  });
+
+  test('should render ShowArtifactHtmlView when path is html path', () => {
+    const props = {runUuid: uuid, path: "huga.html"}
+    wrapper = shallow(<ShowArtifactPage {...props} />);
+    expect(wrapper.find(ShowArtifactHtmlView).length).toBe(1);
+  });
+});


### PR DESCRIPTION
## What changes are proposed in this pull request?
We encountered a problem that artifact image preview doesn't work when artifact file path has special character such as ' `(white space) and '('.
This PR try to fix that problem.

## How is this patch tested?
Manually.
Built js files and install mlflow on local machine by reference to [CONTRIBUTING guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#building-a-distributable-artifact).
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes