### PR TITLE
Fix download of artifacts with HdfsArtifactRepository

### DIFF
--- a/mlflow/store/hdfs_artifact_repo.py
+++ b/mlflow/store/hdfs_artifact_repo.py
@@ -208,7 +208,8 @@ def _tmp_dir(local_path):
 def _download_hdfs_file(hdfs, remote_file_path, local_file_path):
     # Ensure all required directories exist. Without doing this nested files can't be downloaded.
     dirs = os.path.dirname(local_file_path)
-    os.makedirs(dirs)
+    if not os.path.exists(dirs):
+        os.makedirs(dirs)
     with open(local_file_path, 'wb') as f:
         f.write(hdfs.open(remote_file_path, 'rb').read())
 


### PR DESCRIPTION
A regression has been introduced in the master branch that breaks the download of artifacts in mlflow
The root cause is that the tmpdir used to download artifacts is created twice. This code protects the creation of the folder.

## What changes are proposed in this pull request?
 
Fix the creation of the temporary folder + add unit test
 
## How is this patch tested?
 
* Unit test
* Using the python api (instantiate hdfsArtifactRepository on a existing run + download an artifact)
* Download artifacts from the server UI
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [X] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
