### PR TITLE
Add support for specifying dependent libraries in Databricks backend specification

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -157,6 +157,7 @@ class DatabricksJobRunner(object):
                  `Runs Get <https://docs.databricks.com/api/latest/jobs.html#runs-get>`_ API.
         """
         # Make jobs API request to launch run.
+        extra_libraries = cluster_spec.pop("libraries", [])
         req_body_json = {
             'run_name': 'MLflow Run for %s' % project_uri,
             'new_cluster': cluster_spec,
@@ -167,7 +168,8 @@ class DatabricksJobRunner(object):
             # NB: We use <= on the version specifier to allow running projects on pre-release
             # versions, where we will select the most up-to-date mlflow version available.
             # Also note, that we escape this so '<' is not treated as a shell pipe.
-            "libraries": [{"pypi": {"package": "'mlflow<=%s'" % VERSION}}],
+            "libraries": [{"pypi": {"package": "'mlflow<=%s'" % VERSION}},
+                          *extra_libraries],
         }
         run_submit_res = self._jobs_runs_submit(req_body_json)
         databricks_run_id = run_submit_res["run_id"]


### PR DESCRIPTION


## What changes are proposed in this pull request?
 
This commit adds a simple extension to the backend specification for
the databricks backend that allows users to pass additional dependent
library configurations to the job.  This allows mlflow to tacitly
support use cases where an entry point requires libraries to available
on the worker nodes of a databricks cluster, and aligns `mlflow run` more
closely with mlflow-tracked databricks notebooks. 

## How is this patch tested?
 
I did not add specific tests, as the functionality is provided by databricks.  I confirmed it has the expected functionality when run against the databricks API
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Databricks backend specification has been extended to accept an additional key 'libraries' which contains a list of databricks [Library](https://docs.databricks.com/dev-tools/api/latest/libraries.html#library) specifications
 
### What component(s) does this PR affect?
 
- [ ] UI
- [x] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
