### PR TITLE
Fix dependency-installation bug in Java MLflow model scoring server

### DIFF
--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -75,7 +75,6 @@ def _get_mlflow_install_step(dockerfile_context_dir, mlflow_home):
             "RUN cp /opt/java/mlflow-scoring-{version}.pom /opt/java/pom.xml\n"
             "RUN cd /opt/java && mvn "
             "--batch-mode dependency:copy-dependencies -DoutputDirectory=/opt/java/jars\n"
-            ""
         ).format(version=mlflow.version.VERSION)
 
 

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -71,7 +71,11 @@ def _get_mlflow_install_step(dockerfile_context_dir, mlflow_home):
             "RUN mvn "
             " --batch-mode dependency:copy"
             " -Dartifact=org.mlflow:mlflow-scoring:{version}:jar"
-            " -DoutputDirectory=/opt/java/jars"
+            " -DoutputDirectory=/opt/java/jars\n"
+            "RUN cp /opt/java/mlflow-scoring-{version}.pom /opt/java/pom.xml\n"
+            "RUN cd /opt/java && mvn "
+            "--batch-mode dependency:copy-dependencies -DoutputDirectory=/opt/java/jars\n"
+            ""
         ).format(version=mlflow.version.VERSION)
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fixes a bug (#1906) where we currently don't install dependencies of the Java MLflow model scoring server within the docker image for the server
 
## How is this patch tested?
Manually verified that I was able to run an updated image built from this PR locally & on SageMaker
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Fixed a dependency-installation bug that prevented running the Java MLflow model scoring server against a docker image built via `mlflow sagemaker build-and-push-container`.
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [x] Models 
- [ ] Scoring 
- [x] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
