### PR TITLE
Move URI helper methods to utils.uri module

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -9,24 +9,22 @@ import click
 from click import UsageError
 
 import mlflow.azureml.cli
-import mlflow.projects as projects
+import mlflow.db
 import mlflow.experiments
 import mlflow.models.cli
-
-import mlflow.sagemaker.cli
+import mlflow.projects as projects
 import mlflow.runs
+import mlflow.sagemaker.cli
+import mlflow.store.artifact.cli
 import mlflow.store.db.utils
-import mlflow.db
-
-from mlflow.utils.uri import _is_local_uri
-from mlflow.utils.logging_utils import eprint
-from mlflow.utils.process import ShellCommandException
-from mlflow.utils import cli_args
+from mlflow import tracking
 from mlflow.server import _run_server
 from mlflow.server.handlers import _get_store
 from mlflow.store.tracking import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
-from mlflow import tracking
-import mlflow.store.artifact.cli
+from mlflow.utils import cli_args
+from mlflow.utils.logging_utils import eprint
+from mlflow.utils.process import ShellCommandException
+from mlflow.utils.uri import _is_local_uri
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -18,7 +18,7 @@ import mlflow.runs
 import mlflow.store.db.utils
 import mlflow.db
 
-from mlflow.tracking.utils import _is_local_uri
+from mlflow.utils.uri import _is_local_uri
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.process import ShellCommandException
 from mlflow.utils import cli_args

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -24,7 +24,7 @@ from mlflow.store.tracking import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 from mlflow.utils import cli_args
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.process import ShellCommandException
-from mlflow.utils.uri import _is_local_uri
+from mlflow.utils.uri import is_local_uri
 
 _logger = logging.getLogger(__name__)
 
@@ -178,7 +178,7 @@ def ui(backend_store_uri, default_artifact_root, port):
         backend_store_uri = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 
     if not default_artifact_root:
-        if _is_local_uri(backend_store_uri):
+        if is_local_uri(backend_store_uri):
             default_artifact_root = backend_store_uri
         else:
             default_artifact_root = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
@@ -252,7 +252,7 @@ def server(backend_store_uri, default_artifact_root, host, port,
         backend_store_uri = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 
     if not default_artifact_root:
-        if _is_local_uri(backend_store_uri):
+        if is_local_uri(backend_store_uri):
             default_artifact_root = backend_store_uri
         else:
             eprint("Option 'default-artifact-root' is required, when backend store is not "

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -932,7 +932,7 @@ def _get_docker_tracking_cmd_and_envs(tracking_uri):
     if local_path is not None:
         cmds = ["-v", "%s:%s" % (local_path, _MLFLOW_DOCKER_TRACKING_DIR_PATH)]
         env_vars[tracking._TRACKING_URI_ENV_VAR] = container_tracking_uri
-    if utils.uri._is_databricks_uri(tracking_uri):
+    if utils.uri.is_databricks_uri(tracking_uri):
         db_profile = utils.uri.get_db_profile_from_uri(tracking_uri)
         config = databricks_utils.get_databricks_host_creds(db_profile)
         # We set these via environment variables so that only the current profile is exposed, rather

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -21,6 +21,7 @@ import docker
 
 import mlflow.tracking as tracking
 import mlflow.tracking.fluent as fluent
+import mlflow.utils.uri
 from mlflow.projects.submitted_run import LocalSubmittedRun, SubmittedRun
 from mlflow.projects import _project_spec
 from mlflow.exceptions import ExecutionException, MlflowException
@@ -934,8 +935,8 @@ def _get_docker_tracking_cmd_and_envs(tracking_uri):
     if local_path is not None:
         cmds = ["-v", "%s:%s" % (local_path, _MLFLOW_DOCKER_TRACKING_DIR_PATH)]
         env_vars[tracking._TRACKING_URI_ENV_VAR] = container_tracking_uri
-    if tracking.utils._is_databricks_uri(tracking_uri):
-        db_profile = mlflow.tracking.utils.get_db_profile_from_uri(tracking_uri)
+    if mlflow.utils.uri._is_databricks_uri(tracking_uri):
+        db_profile = mlflow.utils.uri.get_db_profile_from_uri(tracking_uri)
         config = databricks_utils.get_databricks_host_creds(db_profile)
         # We set these via environment variables so that only the current profile is exposed, rather
         # than all profiles in ~/.databrickscfg; maybe better would be to mount the necessary

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -19,33 +19,30 @@ import logging
 import posixpath
 import docker
 
+import mlflow.projects.databricks
 import mlflow.tracking as tracking
 import mlflow.tracking.fluent as fluent
-import mlflow.utils.uri
-from mlflow.projects.submitted_run import LocalSubmittedRun, SubmittedRun
-from mlflow.projects import _project_spec
-from mlflow.exceptions import ExecutionException, MlflowException
+from mlflow import utils
 from mlflow.entities import RunStatus, SourceType
-from mlflow.tracking.fluent import _get_experiment_id
+from mlflow.exceptions import ExecutionException, MlflowException
+from mlflow.projects import _project_spec
+from mlflow.projects.submitted_run import LocalSubmittedRun, SubmittedRun
 from mlflow.tracking.context.default_context import _get_user
 from mlflow.tracking.context.git_context import _get_git_commit
-import mlflow.projects.databricks
-from mlflow.utils import process
-
-from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
-from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
+from mlflow.tracking.fluent import _get_experiment_id
+from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.artifact.azure_blob_artifact_repo import AzureBlobArtifactRepository
 from mlflow.store.artifact.gcs_artifact_repo import GCSArtifactRepository
 from mlflow.store.artifact.hdfs_artifact_repo import HdfsArtifactRepository
-from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
-
+from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
+from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
+from mlflow.utils import databricks_utils, file_utils, process
 from mlflow.utils.file_utils import path_to_local_sqlite_uri, path_to_local_file_uri
 from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_DOCKER_IMAGE_URI, \
     MLFLOW_DOCKER_IMAGE_ID, MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, \
     MLFLOW_GIT_COMMIT, MLFLOW_GIT_REPO_URL, MLFLOW_GIT_BRANCH, LEGACY_MLFLOW_GIT_REPO_URL, \
     LEGACY_MLFLOW_GIT_BRANCH_NAME, MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_PARENT_RUN_ID, \
     MLFLOW_PROJECT_BACKEND
-from mlflow.utils import databricks_utils, file_utils
 
 # TODO: this should be restricted to just Git repos and not S3 and stuff like that
 _GIT_URI_REGEX = re.compile(r"^[^/]*:")
@@ -935,8 +932,8 @@ def _get_docker_tracking_cmd_and_envs(tracking_uri):
     if local_path is not None:
         cmds = ["-v", "%s:%s" % (local_path, _MLFLOW_DOCKER_TRACKING_DIR_PATH)]
         env_vars[tracking._TRACKING_URI_ENV_VAR] = container_tracking_uri
-    if mlflow.utils.uri._is_databricks_uri(tracking_uri):
-        db_profile = mlflow.utils.uri.get_db_profile_from_uri(tracking_uri)
+    if utils.uri._is_databricks_uri(tracking_uri):
+        db_profile = utils.uri.get_db_profile_from_uri(tracking_uri)
         config = databricks_utils.get_databricks_host_creds(db_profile)
         # We set these via environment variables so that only the current profile is exposed, rather
         # than all profiles in ~/.databrickscfg; maybe better would be to mount the necessary

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -22,7 +22,6 @@ import docker
 import mlflow.projects.databricks
 import mlflow.tracking as tracking
 import mlflow.tracking.fluent as fluent
-from mlflow import utils
 from mlflow.entities import RunStatus, SourceType
 from mlflow.exceptions import ExecutionException, MlflowException
 from mlflow.projects import _project_spec
@@ -43,6 +42,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_DOCKER_IMAGE_URI
     MLFLOW_GIT_COMMIT, MLFLOW_GIT_REPO_URL, MLFLOW_GIT_BRANCH, LEGACY_MLFLOW_GIT_REPO_URL, \
     LEGACY_MLFLOW_GIT_BRANCH_NAME, MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_PARENT_RUN_ID, \
     MLFLOW_PROJECT_BACKEND
+from mlflow.utils.uri import get_db_profile_from_uri, is_databricks_uri
 
 # TODO: this should be restricted to just Git repos and not S3 and stuff like that
 _GIT_URI_REGEX = re.compile(r"^[^/]*:")
@@ -932,8 +932,8 @@ def _get_docker_tracking_cmd_and_envs(tracking_uri):
     if local_path is not None:
         cmds = ["-v", "%s:%s" % (local_path, _MLFLOW_DOCKER_TRACKING_DIR_PATH)]
         env_vars[tracking._TRACKING_URI_ENV_VAR] = container_tracking_uri
-    if utils.uri.is_databricks_uri(tracking_uri):
-        db_profile = utils.uri.get_db_profile_from_uri(tracking_uri)
+    if is_databricks_uri(tracking_uri):
+        db_profile = get_db_profile_from_uri(tracking_uri)
         config = databricks_utils.get_databricks_host_creds(db_profile)
         # We set these via environment variables so that only the current profile is exposed, rather
         # than all profiles in ~/.databrickscfg; maybe better would be to mount the necessary

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -9,7 +9,7 @@ import logging
 
 from six.moves import shlex_quote
 
-from mlflow import tracking, utils
+from mlflow import tracking
 from mlflow.entities import RunStatus
 from mlflow.exceptions import MlflowException
 from mlflow.projects.submitted_run import SubmittedRun
@@ -17,6 +17,7 @@ from mlflow.utils import rest_utils, file_utils, databricks_utils
 from mlflow.exceptions import ExecutionException
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_RUN_URL, MLFLOW_DATABRICKS_SHELL_JOB_ID, \
     MLFLOW_DATABRICKS_SHELL_JOB_RUN_ID, MLFLOW_DATABRICKS_WEBAPP_URL
+from mlflow.utils.uri import get_db_profile_from_uri, is_databricks_uri, is_http_uri
 from mlflow.version import VERSION
 
 # Base directory within driver container for storing files related to MLflow
@@ -40,8 +41,8 @@ def before_run_validations(tracking_uri, backend_config):
     if backend_config is None:
         raise ExecutionException("Backend spec must be provided when launching MLflow project "
                                  "runs on Databricks.")
-    if not utils.uri.is_databricks_uri(tracking_uri) and \
-            not utils.uri.is_http_uri(tracking_uri):
+    if not is_databricks_uri(tracking_uri) and \
+            not is_http_uri(tracking_uri):
         raise ExecutionException(
             "When running on Databricks, the MLflow tracking URI must be of the form "
             "'databricks' or 'databricks://profile', or a remote HTTP URI accessible to both the "
@@ -270,7 +271,7 @@ def run_databricks(remote_run, uri, entry_point, work_dir, parameters, experimen
     Run the project at the specified URI on Databricks, returning a ``SubmittedRun`` that can be
     used to query the run's status or wait for the resulting Databricks Job run to terminate.
     """
-    profile = utils.uri.get_db_profile_from_uri(tracking.get_tracking_uri())
+    profile = get_db_profile_from_uri(tracking.get_tracking_uri())
     run_id = remote_run.info.run_id
     db_job_runner = DatabricksJobRunner(databricks_profile=profile)
     db_run_id = db_job_runner.run_databricks(

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -9,13 +9,12 @@ import logging
 
 from six.moves import shlex_quote
 
-import mlflow.utils.uri
+from mlflow import tracking, utils
 from mlflow.entities import RunStatus
 from mlflow.exceptions import MlflowException
 from mlflow.projects.submitted_run import SubmittedRun
 from mlflow.utils import rest_utils, file_utils, databricks_utils
 from mlflow.exceptions import ExecutionException
-from mlflow import tracking
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_RUN_URL, MLFLOW_DATABRICKS_SHELL_JOB_ID, \
     MLFLOW_DATABRICKS_SHELL_JOB_RUN_ID, MLFLOW_DATABRICKS_WEBAPP_URL
 from mlflow.version import VERSION
@@ -41,8 +40,8 @@ def before_run_validations(tracking_uri, backend_config):
     if backend_config is None:
         raise ExecutionException("Backend spec must be provided when launching MLflow project "
                                  "runs on Databricks.")
-    if not mlflow.utils.uri._is_databricks_uri(tracking_uri) and \
-            not mlflow.utils.uri._is_http_uri(tracking_uri):
+    if not utils.uri._is_databricks_uri(tracking_uri) and \
+            not utils.uri._is_http_uri(tracking_uri):
         raise ExecutionException(
             "When running on Databricks, the MLflow tracking URI must be of the form "
             "'databricks' or 'databricks://profile', or a remote HTTP URI accessible to both the "
@@ -271,7 +270,7 @@ def run_databricks(remote_run, uri, entry_point, work_dir, parameters, experimen
     Run the project at the specified URI on Databricks, returning a ``SubmittedRun`` that can be
     used to query the run's status or wait for the resulting Databricks Job run to terminate.
     """
-    profile = mlflow.utils.uri.get_db_profile_from_uri(tracking.get_tracking_uri())
+    profile = utils.uri.get_db_profile_from_uri(tracking.get_tracking_uri())
     run_id = remote_run.info.run_id
     db_job_runner = DatabricksJobRunner(databricks_profile=profile)
     db_run_id = db_job_runner.run_databricks(

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -9,6 +9,7 @@ import logging
 
 from six.moves import shlex_quote
 
+import mlflow.utils.uri
 from mlflow.entities import RunStatus
 from mlflow.exceptions import MlflowException
 from mlflow.projects.submitted_run import SubmittedRun
@@ -40,8 +41,8 @@ def before_run_validations(tracking_uri, backend_config):
     if backend_config is None:
         raise ExecutionException("Backend spec must be provided when launching MLflow project "
                                  "runs on Databricks.")
-    if not tracking.utils._is_databricks_uri(tracking_uri) and \
-            not tracking.utils._is_http_uri(tracking_uri):
+    if not mlflow.utils.uri._is_databricks_uri(tracking_uri) and \
+            not mlflow.utils.uri._is_http_uri(tracking_uri):
         raise ExecutionException(
             "When running on Databricks, the MLflow tracking URI must be of the form "
             "'databricks' or 'databricks://profile', or a remote HTTP URI accessible to both the "
@@ -270,7 +271,7 @@ def run_databricks(remote_run, uri, entry_point, work_dir, parameters, experimen
     Run the project at the specified URI on Databricks, returning a ``SubmittedRun`` that can be
     used to query the run's status or wait for the resulting Databricks Job run to terminate.
     """
-    profile = tracking.utils.get_db_profile_from_uri(tracking.get_tracking_uri())
+    profile = mlflow.utils.uri.get_db_profile_from_uri(tracking.get_tracking_uri())
     run_id = remote_run.info.run_id
     db_job_runner = DatabricksJobRunner(databricks_profile=profile)
     db_run_id = db_job_runner.run_databricks(

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -40,8 +40,8 @@ def before_run_validations(tracking_uri, backend_config):
     if backend_config is None:
         raise ExecutionException("Backend spec must be provided when launching MLflow project "
                                  "runs on Databricks.")
-    if not utils.uri._is_databricks_uri(tracking_uri) and \
-            not utils.uri._is_http_uri(tracking_uri):
+    if not utils.uri.is_databricks_uri(tracking_uri) and \
+            not utils.uri.is_http_uri(tracking_uri):
         raise ExecutionException(
             "When running on Databricks, the MLflow tracking URI must be of the form "
             "'databricks' or 'databricks://profile', or a remote HTTP URI accessible to both the "

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -26,6 +26,7 @@ import yaml
 import logging
 
 import mlflow
+import mlflow.utils.uri
 from mlflow import pyfunc, mleap
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
@@ -122,7 +123,7 @@ def log_model(spark_model, artifact_path, conda_env=None, dfs_tmpdir=None,
     # writing to `file:/uri` will write to the local filesystem from each executor, which will
     # be incorrect on multi-node clusters - to avoid such issues we just use the Model.log() path
     # here.
-    if mlflow.tracking.utils._is_local_uri(run_root_artifact_uri):
+    if mlflow.utils.uri._is_local_uri(run_root_artifact_uri):
         return Model.log(artifact_path=artifact_path, flavor=mlflow.spark, spark_model=spark_model,
                          conda_env=conda_env, dfs_tmpdir=dfs_tmpdir,
                          sample_input=sample_input)

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -26,7 +26,6 @@ import yaml
 import logging
 
 import mlflow
-import mlflow.utils.uri
 from mlflow import pyfunc, mleap
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
@@ -35,6 +34,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.utils.file_utils import TempDir
+from mlflow.utils.uri import _is_local_uri
 
 FLAVOR_NAME = "spark"
 
@@ -123,7 +123,7 @@ def log_model(spark_model, artifact_path, conda_env=None, dfs_tmpdir=None,
     # writing to `file:/uri` will write to the local filesystem from each executor, which will
     # be incorrect on multi-node clusters - to avoid such issues we just use the Model.log() path
     # here.
-    if mlflow.utils.uri._is_local_uri(run_root_artifact_uri):
+    if _is_local_uri(run_root_artifact_uri):
         return Model.log(artifact_path=artifact_path, flavor=mlflow.spark, spark_model=spark_model,
                          conda_env=conda_env, dfs_tmpdir=dfs_tmpdir,
                          sample_input=sample_input)

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -34,7 +34,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.utils.file_utils import TempDir
-from mlflow.utils.uri import _is_local_uri
+from mlflow.utils.uri import is_local_uri
 
 FLAVOR_NAME = "spark"
 
@@ -123,7 +123,7 @@ def log_model(spark_model, artifact_path, conda_env=None, dfs_tmpdir=None,
     # writing to `file:/uri` will write to the local filesystem from each executor, which will
     # be incorrect on multi-node clusters - to avoid such issues we just use the Model.log() path
     # here.
-    if _is_local_uri(run_root_artifact_uri):
+    if is_local_uri(run_root_artifact_uri):
         return Model.log(artifact_path=artifact_path, flavor=mlflow.spark, spark_model=spark_model,
                          conda_env=conda_env, dfs_tmpdir=dfs_tmpdir,
                          sample_input=sample_input)

--- a/mlflow/store/artifact/artifact_repository_registry.py
+++ b/mlflow/store/artifact/artifact_repository_registry.py
@@ -12,7 +12,7 @@ from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from mlflow.store.artifact.sftp_artifact_repo import SFTPArtifactRepository
 
-from mlflow.utils import get_uri_scheme
+from mlflow.utils.uri import get_uri_scheme
 
 
 class ArtifactRepositoryRegistry:

--- a/mlflow/store/artifact/cli.py
+++ b/mlflow/store/artifact/cli.py
@@ -119,5 +119,6 @@ def download_artifacts(run_id, artifact_path, artifact_uri):
     artifact_location = artifact_repo.download_artifacts(artifact_path)
     print(artifact_location)
 
+
 if __name__ == '__main__':
     commands()

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -19,7 +19,7 @@ from mlflow.entities import ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_ALREADY_EXISTS, \
     INVALID_STATE, RESOURCE_DOES_NOT_EXIST, INTERNAL_ERROR
-from mlflow.utils.uri import _is_local_uri, extract_db_type_from_uri
+from mlflow.utils.uri import is_local_uri, extract_db_type_from_uri
 from mlflow.utils.file_utils import mkdir, local_file_uri_to_path
 from mlflow.utils.search_utils import SearchUtils
 from mlflow.utils.validation import _validate_batch_log_limits, _validate_batch_log_data, \
@@ -101,7 +101,7 @@ class SqlAlchemyStore(AbstractStore):
         self.ManagedSessionMaker = self._get_managed_session_maker(SessionMaker)
         SqlAlchemyStore._verify_schema(self.engine)
 
-        if _is_local_uri(default_artifact_root):
+        if is_local_uri(default_artifact_root):
             mkdir(local_file_uri_to_path(default_artifact_root))
 
         if len(self.list_experiments()) == 0:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -19,7 +19,7 @@ from mlflow.entities import ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_ALREADY_EXISTS, \
     INVALID_STATE, RESOURCE_DOES_NOT_EXIST, INTERNAL_ERROR
-from mlflow.tracking.utils import _is_local_uri
+from mlflow.utils.uri import _is_local_uri
 from mlflow.utils import extract_db_type_from_uri
 from mlflow.utils.file_utils import mkdir, local_file_uri_to_path
 from mlflow.utils.search_utils import SearchUtils

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -19,8 +19,7 @@ from mlflow.entities import ViewType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_ALREADY_EXISTS, \
     INVALID_STATE, RESOURCE_DOES_NOT_EXIST, INTERNAL_ERROR
-from mlflow.utils.uri import _is_local_uri
-from mlflow.utils import extract_db_type_from_uri
+from mlflow.utils.uri import _is_local_uri, extract_db_type_from_uri
 from mlflow.utils.file_utils import mkdir, local_file_uri_to_path
 from mlflow.utils.search_utils import SearchUtils
 from mlflow.utils.validation import _validate_batch_log_limits, _validate_batch_log_data, \

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -3,7 +3,7 @@ import warnings
 import entrypoints
 
 from mlflow.exceptions import MlflowException
-from mlflow.utils import get_uri_scheme
+from mlflow.utils.uri import get_uri_scheme
 
 
 class TrackingStoreRegistry:

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -1,13 +1,10 @@
 from sys import version_info
 
 from mlflow.utils.annotations import deprecated, experimental, keyword_only
-from mlflow.utils.validation import _validate_db_type_string
 
 PYTHON_VERSION = "{major}.{minor}.{micro}".format(major=version_info.major,
                                                   minor=version_info.minor,
                                                   micro=version_info.micro)
-_INVALID_DB_URI_MSG = "Please refer to https://mlflow.org/docs/latest/tracking.html#storage for " \
-                      "format specifications."
 
 
 def get_major_minor_py_version(py_version):

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -1,7 +1,6 @@
 from sys import version_info
 
 from mlflow.utils.annotations import deprecated, experimental, keyword_only
-from mlflow.utils.uri import extract_db_type_from_uri
 from mlflow.utils.validation import _validate_db_type_string
 
 PYTHON_VERSION = "{major}.{minor}.{micro}".format(major=version_info.major,

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -1,12 +1,7 @@
 from sys import version_info
 
-from six.moves import urllib
-
-from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-
-from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.utils.annotations import deprecated, experimental, keyword_only
+from mlflow.utils.uri import extract_db_type_from_uri
 from mlflow.utils.validation import _validate_db_type_string
 
 PYTHON_VERSION = "{major}.{minor}.{micro}".format(major=version_info.major,
@@ -14,27 +9,6 @@ PYTHON_VERSION = "{major}.{minor}.{micro}".format(major=version_info.major,
                                                   micro=version_info.micro)
 _INVALID_DB_URI_MSG = "Please refer to https://mlflow.org/docs/latest/tracking.html#storage for " \
                       "format specifications."
-
-
-def extract_db_type_from_uri(db_uri):
-    """
-    Parse the specified DB URI to extract the database type. Confirm the database type is
-    supported. If a driver is specified, confirm it passes a plausible regex.
-    """
-    scheme = urllib.parse.urlparse(db_uri).scheme
-    scheme_plus_count = scheme.count('+')
-
-    if scheme_plus_count == 0:
-        db_type = scheme
-    elif scheme_plus_count == 1:
-        db_type, _ = scheme.split('+')
-    else:
-        error_msg = "Invalid database URI: '%s'. %s" % (db_uri, _INVALID_DB_URI_MSG)
-        raise MlflowException(error_msg, INVALID_PARAMETER_VALUE)
-
-    _validate_db_type_string(db_type)
-
-    return db_type
 
 
 def get_major_minor_py_version(py_version):
@@ -69,11 +43,3 @@ def get_unique_resource_id(max_length=None):
     if max_length is not None:
         unique_id = unique_id[:int(max_length)]
     return unique_id
-
-
-def get_uri_scheme(uri_or_path):
-    scheme = urllib.parse.urlparse(uri_or_path).scheme
-    if any([scheme.lower().startswith(db) for db in DATABASE_ENGINES]):
-        return extract_db_type_from_uri(uri_or_path)
-    else:
-        return scheme

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -1,0 +1,61 @@
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.store.db.db_types import DATABASE_ENGINES
+from mlflow.utils import _INVALID_DB_URI_MSG, _validate_db_type_string
+
+
+def _is_local_uri(uri):
+    """Returns true if this is a local file path (/foo or file:/foo)."""
+    scheme = urllib.parse.urlparse(uri).scheme
+    return uri != 'databricks' and (scheme == '' or scheme == 'file')
+
+
+def _is_http_uri(uri):
+    scheme = urllib.parse.urlparse(uri).scheme
+    return scheme == 'http' or scheme == 'https'
+
+
+def _is_databricks_uri(uri):
+    """Databricks URIs look like 'databricks' (default profile) or 'databricks://profile'"""
+    scheme = urllib.parse.urlparse(uri).scheme
+    return scheme == 'databricks' or uri == 'databricks'
+
+
+def get_db_profile_from_uri(uri):
+    """
+    Get the Databricks profile specified by the tracking URI (if any), otherwise
+    returns None.
+    """
+    parsed_uri = urllib.parse.urlparse(uri)
+    if parsed_uri.scheme == "databricks":
+        return parsed_uri.netloc
+    return None
+
+
+def extract_db_type_from_uri(db_uri):
+    """
+    Parse the specified DB URI to extract the database type. Confirm the database type is
+    supported. If a driver is specified, confirm it passes a plausible regex.
+    """
+    scheme = urllib.parse.urlparse(db_uri).scheme
+    scheme_plus_count = scheme.count('+')
+
+    if scheme_plus_count == 0:
+        db_type = scheme
+    elif scheme_plus_count == 1:
+        db_type, _ = scheme.split('+')
+    else:
+        error_msg = "Invalid database URI: '%s'. %s" % (db_uri, _INVALID_DB_URI_MSG)
+        raise MlflowException(error_msg, INVALID_PARAMETER_VALUE)
+
+    _validate_db_type_string(db_type)
+
+    return db_type
+
+
+def get_uri_scheme(uri_or_path):
+    scheme = urllib.parse.urlparse(uri_or_path).scheme
+    if any([scheme.lower().startswith(db) for db in DATABASE_ENGINES]):
+        return extract_db_type_from_uri(uri_or_path)
+    else:
+        return scheme

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -3,7 +3,10 @@ from six.moves import urllib
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.db.db_types import DATABASE_ENGINES
-from mlflow.utils import _INVALID_DB_URI_MSG, _validate_db_type_string
+from mlflow.utils.validation import _validate_db_type_string
+
+_INVALID_DB_URI_MSG = "Please refer to https://mlflow.org/docs/latest/tracking.html#storage for " \
+                      "format specifications."
 
 
 def is_local_uri(uri):

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -1,21 +1,23 @@
+from six.moves import urllib
+
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.utils import _INVALID_DB_URI_MSG, _validate_db_type_string
 
 
-def _is_local_uri(uri):
+def is_local_uri(uri):
     """Returns true if this is a local file path (/foo or file:/foo)."""
     scheme = urllib.parse.urlparse(uri).scheme
     return uri != 'databricks' and (scheme == '' or scheme == 'file')
 
 
-def _is_http_uri(uri):
+def is_http_uri(uri):
     scheme = urllib.parse.urlparse(uri).scheme
     return scheme == 'http' or scheme == 'https'
 
 
-def _is_databricks_uri(uri):
+def is_databricks_uri(uri):
     """Databricks URIs look like 'databricks' (default profile) or 'databricks://profile'"""
     scheme = urllib.parse.urlparse(uri).scheme
     return scheme == 'databricks' or uri == 'databricks'

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -27,8 +27,9 @@ from mlflow.store.db.db_types import MYSQL, MSSQL
 from mlflow import entities
 from mlflow.exceptions import MlflowException
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
-from mlflow.utils import extract_db_type_from_uri, mlflow_tags
+from mlflow.utils import mlflow_tags
 from mlflow.utils.file_utils import TempDir
+from mlflow.utils.uri import extract_db_type_from_uri
 from tests.resources.db.initial_models import Base as InitialBase
 from tests.integration.utils import invoke_cli_runner
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -22,6 +22,8 @@ from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_USER, MLFLOW_S
     MLFLOW_SOURCE_TYPE
 from mlflow.tracking.fluent import _RUN_ID_ENV_VAR
 
+from tests.projects.utils import tracking_uri_mock
+
 
 def test_create_experiment(tracking_uri_mock):
     with pytest.raises(TypeError):

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -22,8 +22,6 @@ from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_USER, MLFLOW_S
     MLFLOW_SOURCE_TYPE
 from mlflow.tracking.fluent import _RUN_ID_ENV_VAR
 
-from tests.projects.utils import tracking_uri_mock
-
 
 def test_create_experiment(tracking_uri_mock):
     with pytest.raises(TypeError):
@@ -484,31 +482,6 @@ def test_log_artifact(tracking_uri_mock):
         assert len(dir_comparison.right_only) == 0
         assert len(dir_comparison.diff_files) == 0
         assert len(dir_comparison.funny_files) == 0
-
-
-def test_uri_types():
-    from mlflow.tracking import utils
-    assert utils._is_local_uri("mlruns")
-    assert utils._is_local_uri("./mlruns")
-    assert utils._is_local_uri("file:///foo/mlruns")
-    assert utils._is_local_uri("file:foo/mlruns")
-    assert not utils._is_local_uri("https://whatever")
-    assert not utils._is_local_uri("http://whatever")
-    assert not utils._is_local_uri("databricks")
-    assert not utils._is_local_uri("databricks:whatever")
-    assert not utils._is_local_uri("databricks://whatever")
-
-    assert utils._is_databricks_uri("databricks")
-    assert utils._is_databricks_uri("databricks:whatever")
-    assert utils._is_databricks_uri("databricks://whatever")
-    assert not utils._is_databricks_uri("mlruns")
-    assert not utils._is_databricks_uri("http://whatever")
-
-    assert utils._is_http_uri("http://whatever")
-    assert utils._is_http_uri("https://whatever")
-    assert not utils._is_http_uri("file://whatever")
-    assert not utils._is_http_uri("databricks://whatever")
-    assert not utils._is_http_uri("mlruns")
 
 
 def test_with_startrun():

--- a/tests/tracking/test_utils.py
+++ b/tests/tracking/test_utils.py
@@ -10,8 +10,7 @@ from mlflow.store.tracking.rest_store import RestStore
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.tracking.registry import TrackingStoreRegistry
 from mlflow.tracking.utils import _get_store, _TRACKING_URI_ENV_VAR, _TRACKING_USERNAME_ENV_VAR, \
-    _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, _TRACKING_INSECURE_TLS_ENV_VAR, \
-    get_db_profile_from_uri
+    _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, _TRACKING_INSECURE_TLS_ENV_VAR
 
 
 def test_get_store_file_store(tmp_wkdir):
@@ -280,7 +279,3 @@ def test_get_store_for_unregistered_scheme():
     with pytest.raises(mlflow.exceptions.MlflowException,
                        match="Unexpected URI scheme"):
         tracking_store.get_store("unknown-scheme://")
-
-
-def test_get_db_profile_from_uri_casing():
-    assert get_db_profile_from_uri('databricks://aAbB') == 'aAbB'

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -2,7 +2,7 @@ import pytest
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.db.db_types import DATABASE_ENGINES
-from mlflow.utils.uri import _is_databricks_uri, _is_http_uri, _is_local_uri, \
+from mlflow.utils.uri import is_databricks_uri, is_http_uri, is_local_uri, \
     extract_db_type_from_uri, get_db_profile_from_uri, get_uri_scheme
 
 
@@ -26,24 +26,24 @@ def test_get_db_profile_from_uri_casing():
 
 
 def test_uri_types():
-    assert _is_local_uri("mlruns")
-    assert _is_local_uri("./mlruns")
-    assert _is_local_uri("file:///foo/mlruns")
-    assert _is_local_uri("file:foo/mlruns")
-    assert not _is_local_uri("https://whatever")
-    assert not _is_local_uri("http://whatever")
-    assert not _is_local_uri("databricks")
-    assert not _is_local_uri("databricks:whatever")
-    assert not _is_local_uri("databricks://whatever")
+    assert is_local_uri("mlruns")
+    assert is_local_uri("./mlruns")
+    assert is_local_uri("file:///foo/mlruns")
+    assert is_local_uri("file:foo/mlruns")
+    assert not is_local_uri("https://whatever")
+    assert not is_local_uri("http://whatever")
+    assert not is_local_uri("databricks")
+    assert not is_local_uri("databricks:whatever")
+    assert not is_local_uri("databricks://whatever")
 
-    assert _is_databricks_uri("databricks")
-    assert _is_databricks_uri("databricks:whatever")
-    assert _is_databricks_uri("databricks://whatever")
-    assert not _is_databricks_uri("mlruns")
-    assert not _is_databricks_uri("http://whatever")
+    assert is_databricks_uri("databricks")
+    assert is_databricks_uri("databricks:whatever")
+    assert is_databricks_uri("databricks://whatever")
+    assert not is_databricks_uri("mlruns")
+    assert not is_databricks_uri("http://whatever")
 
-    assert _is_http_uri("http://whatever")
-    assert _is_http_uri("https://whatever")
-    assert not _is_http_uri("file://whatever")
-    assert not _is_http_uri("databricks://whatever")
-    assert not _is_http_uri("mlruns")
+    assert is_http_uri("http://whatever")
+    assert is_http_uri("https://whatever")
+    assert not is_http_uri("file://whatever")
+    assert not is_http_uri("databricks://whatever")
+    assert not is_http_uri("mlruns")

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -2,9 +2,8 @@ import pytest
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.db.db_types import DATABASE_ENGINES
-from mlflow.utils import extract_db_type_from_uri
 from mlflow.utils.uri import _is_databricks_uri, _is_http_uri, _is_local_uri, \
-    get_db_profile_from_uri, get_uri_scheme
+    extract_db_type_from_uri, get_db_profile_from_uri, get_uri_scheme
 
 
 def test_extract_db_type_from_uri():

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -1,0 +1,50 @@
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.store.db.db_types import DATABASE_ENGINES
+from mlflow.utils import extract_db_type_from_uri
+from mlflow.utils.uri import _is_databricks_uri, _is_http_uri, _is_local_uri, \
+    get_db_profile_from_uri, get_uri_scheme
+
+
+def test_extract_db_type_from_uri():
+    uri = "{}://username:password@host:port/database"
+    for legit_db in DATABASE_ENGINES:
+        assert legit_db == extract_db_type_from_uri(uri.format(legit_db))
+        assert legit_db == get_uri_scheme(uri.format(legit_db))
+
+        with_driver = legit_db + "+driver-string"
+        assert legit_db == extract_db_type_from_uri(uri.format(with_driver))
+        assert legit_db == get_uri_scheme(uri.format(with_driver))
+
+    for unsupported_db in ["a", "aa", "sql"]:
+        with pytest.raises(MlflowException):
+            extract_db_type_from_uri(unsupported_db)
+
+
+def test_get_db_profile_from_uri_casing():
+    assert get_db_profile_from_uri('databricks://aAbB') == 'aAbB'
+
+
+def test_uri_types():
+    assert _is_local_uri("mlruns")
+    assert _is_local_uri("./mlruns")
+    assert _is_local_uri("file:///foo/mlruns")
+    assert _is_local_uri("file:foo/mlruns")
+    assert not _is_local_uri("https://whatever")
+    assert not _is_local_uri("http://whatever")
+    assert not _is_local_uri("databricks")
+    assert not _is_local_uri("databricks:whatever")
+    assert not _is_local_uri("databricks://whatever")
+
+    assert _is_databricks_uri("databricks")
+    assert _is_databricks_uri("databricks:whatever")
+    assert _is_databricks_uri("databricks://whatever")
+    assert not _is_databricks_uri("mlruns")
+    assert not _is_databricks_uri("http://whatever")
+
+    assert _is_http_uri("http://whatever")
+    assert _is_http_uri("https://whatever")
+    assert not _is_http_uri("file://whatever")
+    assert not _is_http_uri("databricks://whatever")
+    assert not _is_http_uri("mlruns")

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -1,8 +1,6 @@
 import pytest
 
-from mlflow.exceptions import MlflowException
-from mlflow.store.db.db_types import DATABASE_ENGINES
-from mlflow.utils import get_unique_resource_id, extract_db_type_from_uri, get_uri_scheme
+from mlflow.utils import get_unique_resource_id
 
 
 def test_get_unique_resource_id_respects_max_length():
@@ -17,18 +15,3 @@ def test_get_unique_resource_id_with_invalid_max_length_throws_exception():
 
     with pytest.raises(ValueError):
         get_unique_resource_id(max_length=0)
-
-
-def test_extract_db_type_from_uri():
-    uri = "{}://username:password@host:port/database"
-    for legit_db in DATABASE_ENGINES:
-        assert legit_db == extract_db_type_from_uri(uri.format(legit_db))
-        assert legit_db == get_uri_scheme(uri.format(legit_db))
-
-        with_driver = legit_db + "+driver-string"
-        assert legit_db == extract_db_type_from_uri(uri.format(with_driver))
-        assert legit_db == get_uri_scheme(uri.format(with_driver))
-
-    for unsupported_db in ["a", "aa", "sql"]:
-        with pytest.raises(MlflowException):
-            extract_db_type_from_uri(unsupported_db)


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Consolidate these methods that aren't just used by tracking to `utils.uri`.
 
## How is this patch tested?
 
Unit tests
 
## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Helper methods for dealing with URIs have been consolidated into the `utils.uri` module. These are internal methods (undocumented) but the change could break existing user code.
 
### What component(s) does this PR affect?
 
- [X] API 
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
