### PR TITLE
Artifact location was missing in mlflow.set_experiment

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -36,7 +36,7 @@ NUM_RUNS_PER_PAGE_PANDAS = 10000
 _logger = logging.getLogger(__name__)
 
 
-def set_experiment(experiment_name):
+def set_experiment(experiment_name, artifact_location=None):
     """
     Set given experiment as active experiment. If experiment does not exist, create an experiment
     with provided name.
@@ -48,7 +48,7 @@ def set_experiment(experiment_name):
     exp_id = experiment.experiment_id if experiment else None
     if exp_id is None:  # id can be 0
         print("INFO: '{}' does not exist. Creating a new experiment".format(experiment_name))
-        exp_id = client.create_experiment(experiment_name)
+        exp_id = client.create_experiment(experiment_name, artifact_location)
     elif experiment.lifecycle_stage == LifecycleStage.DELETED:
         raise MlflowException(
             "Cannot set a deleted experiment '%s' as the active experiment."


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Need to be able to set the artifact location for non existing experiments 
 
## How is this patch tested?
 
Tested with our MLFlow server
 
## Release Notes
 
### Is this a user-facing change? 

- [x ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [x ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [x ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
