### PR TITLE
Suppress deprecation warnings when using mlflow.pyfunc.load_model()

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -260,7 +260,7 @@ def _load_model_env(path):
     return _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME).get(ENV, None)
 
 
-def load_model(model_uri, suppress_warnings=False):
+def load_model(model_uri, suppress_warnings=True):
     """
     Load a model stored in Python function format.
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
The default argument for suppress_warnings was changed from `False` to `True`. This is because we should only emit warnings about `load_pyfunc()` being deprecated when `load_pyfunc()` is being used, not `load_model()`.
 
## How is this patch tested?
 
Via Travis.
 
## Release Notes
 
### Is this a user-facing change? 

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [X] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [X] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
