### PR TITLE
Skip unnecessary gcs bucket metadata requests.

### DIFF
--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -35,7 +35,7 @@ def _fetch_gs(uri, local_path):
     from google.cloud import storage
     print("=== Downloading GCS file %s to local path %s ===" % (uri, os.path.abspath(local_path)))
     (bucket, gs_path) = parse_gs_uri(uri)
-    storage.Client().get_bucket(bucket).get_blob(gs_path).download_to_filename(local_path)
+    storage.Client().bucket(bucket).blob(gs_path).download_to_filename(local_path)
 
 
 def parse_s3_uri(uri):

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -41,7 +41,7 @@ class GCSArtifactRepository(ArtifactRepository):
             storage_client = self.gcs.Client()
         except DefaultCredentialsError:
             storage_client = self.gcs.Client.create_anonymous_client()
-        return storage_client.get_bucket(bucket)
+        return storage_client.bucket(bucket)
 
     def log_artifact(self, local_file, artifact_path=None):
         (bucket, dest_path) = self.parse_gcs_uri(self.artifact_uri)
@@ -101,4 +101,4 @@ class GCSArtifactRepository(ArtifactRepository):
         (bucket, remote_root_path) = self.parse_gcs_uri(self.artifact_uri)
         remote_full_path = posixpath.join(remote_root_path, remote_file_path)
         gcs_bucket = self._get_bucket(bucket)
-        gcs_bucket.get_blob(remote_full_path).download_to_filename(local_path)
+        gcs_bucket.blob(remote_full_path).download_to_filename(local_path)


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Use `bucket` and `blob` methods in gcs sdk rather than `get_bucket` and `get_blob` methods. This saves a handful of unnecessary api calls (since we don't use the bucket and blob metadata) and drops the iam permissions required to use the gcs artifact store: after this patch, users only require access to objects, not to the bucket itself.
 
## How is this patch tested?
 
Unit tests
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [x] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
