### PR TITLE
Remove recharts from dependencies

### DIFF
--- a/mlflow/server/js/package-lock.json
+++ b/mlflow/server/js/package-lock.json
@@ -3737,11 +3737,6 @@
         "d3-timer": "1"
       }
     },
-    "d3-format": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.3.0.tgz",
-      "integrity": "sha512-ycfLEIzHVZC3rOvuBOKVyQXSiUyCDjeAPIj9n/wugrr+s5AcTQC2Bz6aKkubG7rQaQF0SGW/OV4UEJB9nfioFg=="
-    },
     "d3-hierarchy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz",
@@ -3765,39 +3760,12 @@
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.6.tgz",
       "integrity": "sha512-NUgeo9G+ENQCQ1LsRr2qJg3MQ4DJvxcDNCiohdJGHt5gRhBW6orIB5m5FJ9kK3HNL8g9F4ERVoBzcEwQBfXWVA=="
     },
-    "d3-scale": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.6.tgz",
-      "integrity": "sha1-vOGdqA06DPQiyVQ64zIghiILNO0=",
-      "requires": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-color": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
-      }
-    },
     "d3-shape": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.2.0.tgz",
       "integrity": "sha1-RdAVOPBkuv0F6j1tLLdI/YxB93c=",
       "requires": {
         "d3-path": "1"
-      }
-    },
-    "d3-time": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.0.8.tgz",
-      "integrity": "sha512-YRZkNhphZh3KcnBfitvF3c6E0JOFGikHZ4YqD+Lzv83ZHn1/u6yGenRU1m+KAk9J1GnZMnKcrtfvSktlA1DXNQ=="
-    },
-    "d3-time-format": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.1.1.tgz",
-      "integrity": "sha512-8kAkymq2WMfzW7e+s/IUNAtN/y3gZXGRrdGfo6R8NKPAA85UBTxZg5E61bR6nLwjPjj4d3zywSQe1CkYLPFyrw==",
-      "requires": {
-        "d3-time": "1"
       }
     },
     "d3-timer": {
@@ -16513,14 +16481,6 @@
         "prop-types": "^15.6.0"
       }
     },
-    "react-resize-detector": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-1.1.0.tgz",
-      "integrity": "sha512-68KVcQlhcWQGXMAie82YueCa4f4yqwEoiQbVyYlSgJEin1zMtNBLLeU/+6FLNf1TTgjwSfpbMTJTw/uU0HNgtQ==",
-      "requires": {
-        "prop-types": "^15.5.10"
-      }
-    },
     "react-router": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.2.0.tgz",
@@ -16729,17 +16689,6 @@
         "resize-observer-polyfill": "^1.5.0"
       }
     },
-    "react-smooth": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-1.0.0.tgz",
-      "integrity": "sha1-sp2+vd3bBtIbWwiWIWf7nqwYl9g=",
-      "requires": {
-        "lodash": "~4.17.4",
-        "prop-types": "^15.6.0",
-        "raf": "^3.2.0",
-        "react-transition-group": "^2.2.1"
-      }
-    },
     "react-sticky": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/react-sticky/-/react-sticky-6.0.2.tgz",
@@ -16867,41 +16816,6 @@
         "readable-stream": "^2.0.2",
         "set-immediate-shim": "^1.0.1"
       }
-    },
-    "recharts": {
-      "version": "1.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-1.0.0-beta.10.tgz",
-      "integrity": "sha1-080V32t4edWWjaPJQrX82vJQT+E=",
-      "requires": {
-        "classnames": "2.2.5",
-        "core-js": "2.5.1",
-        "d3-interpolate": "^1.1.5",
-        "d3-scale": "1.0.6",
-        "d3-shape": "1.2.0",
-        "lodash": "~4.17.4",
-        "prop-types": "^15.6.0",
-        "react-resize-detector": "1.1.0",
-        "react-smooth": "1.0.0",
-        "recharts-scale": "0.3.2",
-        "reduce-css-calc": "1.3.0"
-      },
-      "dependencies": {
-        "classnames": {
-          "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz",
-          "integrity": "sha1-+zgB1FNGdknvNgPH1hoCvRKb3m0="
-        },
-        "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
-        }
-      }
-    },
-    "recharts-scale": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.3.2.tgz",
-      "integrity": "sha1-2sdiFxSkdl0VLLKtvDDHO4MSCMk="
     },
     "recursive-readdir": {
       "version": "2.2.1",

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -38,7 +38,6 @@
     "react-sticky": "6.0.2",
     "react-treebeard": "2.1.0",
     "react-virtualized": "9.21.0",
-    "recharts": "1.0.0-beta.10",
     "redux": "3.7.2",
     "redux-promise-middleware": "5.0.0",
     "redux-thunk": "^2.3.0",

--- a/mlflow/server/js/src/components/MetricView.css
+++ b/mlflow/server/js/src/components/MetricView.css
@@ -7,20 +7,6 @@ div.MetricView h1 {
   margin-bottom: 24px;
 }
 
-
-div.MetricView .recharts-tooltip-item-name {
-  max-width: 100px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  display: inline-block;
-  vertical-align: bottom;
-}
-
-div.MetricView .recharts-tooltip-item-value, .recharts-tooltip-item-separator {
-  display: inline-block;
-  margin-left: 4px;
-}
-
 .metrics-plot-container {
   display: flex;
   width: 100%;
@@ -37,7 +23,7 @@ div.MetricView .recharts-tooltip-item-value, .recharts-tooltip-item-separator {
   display: block;
 }
 
-.metrics-plot-container .plot-controls .metrics-select input[type=text] {
+.metrics-plot-container .plot-controls .metrics-select input[type='text'] {
   padding: 0;
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Remove `recharts` from the dependencies because it's no longer used (got replaced by `plotly`).

## How is this patch tested?
Manually tested
 
## Release Notes
 
### Is this a user-facing change? 

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
 
### What component(s) does this PR affect?
 
- [ ] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
