### PR TITLE
[UI] Support deleting tags from the run view UI

### DIFF
--- a/mlflow/server/js/src/Actions.js
+++ b/mlflow/server/js/src/Actions.js
@@ -148,6 +148,17 @@ export const setTagApi = (runUuid, tagName, tagValue, id = getUUID()) => {
   };
 };
 
+export const DELETE_TAG_API = 'DELETE_TAG_API';
+export const deleteTagApi = (runUuid, tagName, id = getUUID()) => {
+  return {
+    type: DELETE_TAG_API,
+    payload: wrapDeferred(MlflowService.deleteTag, {
+      run_id: runUuid, key: tagName
+    }),
+    meta: { id: id, run_id: runUuid, key: tagName },
+  };
+};
+
 export const SET_EXPERIMENT_TAG_API = 'SET_EXPERIMENT_TAG_API';
 export const setExperimentTagApi = (experimentId, tagName, tagValue, id = getUUID()) => {
   return {

--- a/mlflow/server/js/src/components/EditableTagsTableView.js
+++ b/mlflow/server/js/src/components/EditableTagsTableView.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import Utils from '../utils/Utils';
 import PropTypes from 'prop-types';
 import { Form, Input, Button, message } from 'antd';
-import { getUUID, setTagApi } from '../Actions';
+import { getUUID, setTagApi, deleteTagApi } from '../Actions';
 import { EditableFormTable } from './tables/EditableFormTable';
 import _ from 'lodash';
 
@@ -13,6 +13,7 @@ export class EditableTagsTableView extends React.Component {
     tags: PropTypes.object.isRequired,
     form: PropTypes.object.isRequired,
     setTagApi: PropTypes.func.isRequired,
+    deleteTagApi: PropTypes.func.isRequired
   };
 
   state = { isRequestPending: false };
@@ -72,6 +73,15 @@ export class EditableTagsTableView extends React.Component {
       });
   };
 
+  handleDeleteTag = ({ name }) => {
+    const { runUuid, deleteTagApi: deleteTag } = this.props;
+    return deleteTag(runUuid, name, this.requestId)
+      .catch((ex) => {
+        console.error(ex);
+        message.error('Failed to delete tag. Error: ' + ex.getUserVisibleError());
+      });
+  };
+
   tagNameValidator = (rule, value, callback) => {
     const tagNamesSet = this.getTagNamesAsSet();
     callback(tagNamesSet.has(value) ? `Tag "${value}" already exists.` : undefined);
@@ -88,6 +98,7 @@ export class EditableTagsTableView extends React.Component {
           columns={this.tableColumns}
           data={this.getData()}
           onSaveEdit={this.handleSaveEdit}
+          onDelete={this.handleDeleteTag}
         />
         <div style={styles.addTagForm.wrapper}>
           <h2 style={styles.addTagForm.label}>Add Tag</h2>
@@ -131,6 +142,6 @@ const styles = {
   }
 };
 
-const mapDispatchToProps = { setTagApi };
+const mapDispatchToProps = { setTagApi, deleteTagApi };
 
 export default connect(undefined, mapDispatchToProps)(Form.create()(EditableTagsTableView));

--- a/mlflow/server/js/src/components/EditableTagsTableView.test.js
+++ b/mlflow/server/js/src/components/EditableTagsTableView.test.js
@@ -14,6 +14,7 @@ describe('unit tests', () => {
     // eslint-disable-next-line no-unused-vars
     form: { getFieldDecorator: jest.fn(opts => c => c) },
     setTagApi: () => {},
+    deleteTagApi: () => {}
   };
 
   test('should render with minimal props without exploding', () => {

--- a/mlflow/server/js/src/components/tables/EditableFormTable.js
+++ b/mlflow/server/js/src/components/tables/EditableFormTable.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table, Input, Form, Icon } from 'antd';
+import { Table, Input, Form, Icon, Popconfirm } from 'antd';
 import PropTypes from 'prop-types';
 
 import './EditableFormTable.css';
@@ -99,13 +99,28 @@ export class EditableTable extends React.Component {
             <a onClick={() => this.save(record.key)} style={{ marginRight: 10 }}>
               Save
             </a>
-            <a onClick={() => this.delete(record.key)} style={{ marginRight: 10 }}>Delete</a>
             <a onClick={() => this.cancel(record.key)}>Cancel</a>
           </span>
         ) : (
-          <a disabled={editingKey !== ''} onClick={() => this.edit(record.key)}>
-            <Icon type='edit' />
-          </a>
+          <span>
+            <a
+              disabled={editingKey !== ''}
+              onClick={() => this.edit(record.key)}
+              style={{ marginRight: 10 }}
+            >
+              <Icon type="edit" />
+            </a>
+            <Popconfirm
+              title="Are you sure you want to delete this tag？"
+              okText="Yes"
+              cancelText="No"
+              onConfirm={() => this.delete(record.key)}
+            >
+              <a disabled={editingKey !== ''}>
+                <Icon type="delete" />
+              </a>
+            </Popconfirm>
+          </span>
         );
       },
     },

--- a/mlflow/server/js/src/components/tables/EditableFormTable.js
+++ b/mlflow/server/js/src/components/tables/EditableFormTable.js
@@ -56,6 +56,7 @@ export class EditableTable extends React.Component {
     columns: PropTypes.arrayOf(Object).isRequired,
     data: PropTypes.arrayOf(Object).isRequired,
     onSaveEdit: PropTypes.func.isRequired,
+    onDelete: PropTypes.func.isRequired,
     form: PropTypes.object.isRequired,
   };
 
@@ -98,6 +99,7 @@ export class EditableTable extends React.Component {
             <a onClick={() => this.save(record.key)} style={{ marginRight: 10 }}>
               Save
             </a>
+            <a onClick={() => this.delete(record.key)} style={{ marginRight: 10 }}>Delete</a>
             <a onClick={() => this.cancel(record.key)}>Cancel</a>
           </span>
         ) : (
@@ -128,6 +130,16 @@ export class EditableTable extends React.Component {
       }
     });
   };
+
+  delete = (key) => {
+    const record = this.props.data.find((r) => r.key === key);
+    if (record) {
+      this.setState({ isRequestPending: true });
+      this.props.onDelete({ ...record }).then(() => {
+        this.setState({ editingKey: '', isRequestPending: false });
+      });
+    }
+  }
 
   edit = (key) => {
     this.setState({ editingKey: key });

--- a/mlflow/server/js/src/components/tables/EditableFormTable.test.js
+++ b/mlflow/server/js/src/components/tables/EditableFormTable.test.js
@@ -25,6 +25,7 @@ describe('unit tests', () => {
     // eslint-disable-next-line no-unused-vars
     form: { getFieldDecorator: jest.fn(opts => c => c) },
     onSaveEdit: () => {},
+    onDelete: () => {}
   };
 
   test('should render with minimal props without exploding', () => {

--- a/mlflow/server/js/src/reducers/Reducers.js
+++ b/mlflow/server/js/src/reducers/Reducers.js
@@ -14,6 +14,7 @@ import {
   LOAD_MORE_RUNS_API,
   SET_EXPERIMENT_TAG_API,
   SET_TAG_API,
+  DELETE_TAG_API,
   rejected,
 } from '../Actions';
 import { Experiment, Param, RunInfo, RunTag, ExperimentTag } from '../sdk/MlflowMessages';
@@ -185,6 +186,11 @@ const tagsByRunUuid = (state = {}, action) => {
     case fulfilled(SET_TAG_API): {
       const tag = { key: action.meta.key, value: action.meta.value };
       return amendTagsByRunUuid(state, [tag], action.meta.runUuid);
+    }
+    case fulfilled(DELETE_TAG_API): {
+      return Object.entries(state).reduce((newState, [runUuid, run]) => {
+        return {...newState, [runUuid]: _.omit(run, action.meta.key)};
+      }, {});
     }
     default:
       return state;

--- a/mlflow/server/js/src/sdk/MlflowService.js
+++ b/mlflow/server/js/src/sdk/MlflowService.js
@@ -277,6 +277,24 @@ export class MlflowService {
     });
   }
 
+    /**
+   * @param {DeleteTag} data: Immutable Record
+   * @param {function} success
+   * @param {function} error
+   * @return {Promise}
+   */
+  static deleteTag({ data, success, error }) {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/delete-tag'), {
+      type: 'POST',
+      contentType: 'application/json; charset=utf-8',
+      dataType: 'json',
+      data: JSON.stringify(data),
+      jsonp: false,
+      success: success,
+      error: error,
+    });
+  }
+
   /**
    * @param {SetExperimentTag} data: Immutable Record
    * @param {function} success


### PR DESCRIPTION
## What changes are proposed in this pull request?
Support deleting tags from the run view UI

![delete-tag](https://user-images.githubusercontent.com/17039389/66729871-229aa080-ee89-11e9-9a6a-7178175c0dfa.gif)
 
## How is this patch tested?
Manually tested

## Release Notes
 
### Is this a user-facing change? 

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
 
Run tags improvements. Adds the ability to delete tags from the run view UI.
 
### What component(s) does this PR affect?
 
- [x] UI
- [ ] CLI 
- [ ] API 
- [ ] REST-API 
- [ ] Examples 
- [ ] Docs
- [ ] Tracking
- [ ] Projects 
- [ ] Artifacts 
- [ ] Models 
- [ ] Scoring 
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:
 
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
