### PR TITLE
Added support of viewfs for hdfs federation in artifact_repository_re…

### DIFF
--- a/mlflow/store/artifact/artifact_repository_registry.py
+++ b/mlflow/store/artifact/artifact_repository_registry.py
@@ -81,6 +81,7 @@ _artifact_repository_registry.register('ftp', FTPArtifactRepository)
 _artifact_repository_registry.register('sftp', SFTPArtifactRepository)
 _artifact_repository_registry.register('dbfs', dbfs_artifact_repo_factory)
 _artifact_repository_registry.register('hdfs', HdfsArtifactRepository)
+_artifact_repository_registry.register('viewfs', HdfsArtifactRepository)
 _artifact_repository_registry.register('runs', RunsArtifactRepository)
 
 _artifact_repository_registry.register_entrypoints()


### PR DESCRIPTION
…gistry

## What changes are proposed in this pull request?

Support artifact URI starting with viewfs:// to support hdfs namenode federation.

## How is this patch tested?

Locally, by creating an experiment with a path starting with viewfs://, and logging/listing artifacts.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
