### PR TITLE
Getting mlflow serving to work under windows.

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -668,7 +668,7 @@ def _invoke_mlflow_run_subprocess(
 
 def _get_conda_command(conda_env_name):
     #  Checking for newer conda versions
-    if 'CONDA_EXE' in os.environ or 'MLFLOW_CONDA_HOME' in os.environ:
+    if os.name != 'nt' and ('CONDA_EXE' in os.environ or 'MLFLOW_CONDA_HOME' in os.environ):
         conda_path = _get_conda_bin_executable("conda")
         activate_conda_env = ['source ' + os.path.dirname(conda_path) +
                               '/../etc/profile.d/conda.sh']
@@ -680,7 +680,7 @@ def _get_conda_command(conda_env_name):
         if os.name != "nt":
             return ["source %s %s 1>&2" % (activate_path, conda_env_name)]
         else:
-            return ["conda %s %s 1>&2" % (activate_path, conda_env_name)]
+            return ["conda activate %s" % (conda_env_name)]
     return activate_conda_env
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Getting mlflow serving working on windows

## How is this patch tested?

I can't run the shell script for the tests or the linter, as I don't have a linux machine to hand. I attempted to run the tests on windows using pytest directly, but I suspect people don't do this, and quite a lot of them failed. So I don't really have test verification. However the change is quite minor and should not touch any linux functionality.

I verified that the mlflow serving worked on windows 10 in powershell, using the guidelines outlined on page https://www.mlflow.org/docs/latest/tutorial.html
![image](https://user-images.githubusercontent.com/10985641/67041580-d6b45980-f11d-11e9-8aae-3fb115101281.png)
![image](https://user-images.githubusercontent.com/10985641/67041633-f481be80-f11d-11e9-8f7c-73799beddff3.png)


## Release Notes

### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The use of mlflow models serve should work under windows.

### What component(s) does this PR affect?

- [x] Serving

### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
