### PR TITLE
[cleanup] Move some misc methods to empty utils module

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -10,7 +10,6 @@ import json
 import yaml
 import os
 import sys
-import re
 import shutil
 from six.moves import urllib
 import subprocess
@@ -26,6 +25,11 @@ from mlflow.entities import RunStatus, SourceType
 from mlflow.exceptions import ExecutionException, MlflowException
 from mlflow.projects import _project_spec
 from mlflow.projects.submitted_run import LocalSubmittedRun, SubmittedRun
+from mlflow.projects.utils import (
+    _is_file_uri, _is_local_uri, _is_valid_branch_name, _is_zip_uri,
+    _get_git_repo_url, _parse_subdirectory, _expand_uri, _get_storage_dir,
+    _GIT_URI_REGEX,
+)
 from mlflow.tracking.context.default_context import _get_user
 from mlflow.tracking.context.git_context import _get_git_commit
 from mlflow.tracking.fluent import _get_experiment_id
@@ -45,10 +49,6 @@ from mlflow.utils.mlflow_tags import (
 )
 from mlflow.utils.uri import get_db_profile_from_uri, is_databricks_uri
 
-# TODO: this should be restricted to just Git repos and not S3 and stuff like that
-_GIT_URI_REGEX = re.compile(r"^[^/]*:")
-_FILE_URI_REGEX = re.compile(r"^file://.+")
-_ZIP_URI_REGEX = re.compile(r".+\.zip$")
 # Environment variable indicating a path to a conda installation. MLflow will default to running
 # "conda" if unset
 MLFLOW_CONDA_HOME = "MLFLOW_CONDA_HOME"
@@ -307,77 +307,6 @@ def _wait_for(submitted_run_obj):
         submitted_run_obj.cancel()
         _maybe_set_run_terminated(active_run, "FAILED")
         raise
-
-
-def _parse_subdirectory(uri):
-    # Parses a uri and returns the uri and subdirectory as separate values.
-    # Uses '#' as a delimiter.
-    subdirectory = ''
-    parsed_uri = uri
-    if '#' in uri:
-        subdirectory = uri[uri.find('#') + 1:]
-        parsed_uri = uri[:uri.find('#')]
-    if subdirectory and '.' in subdirectory:
-        raise ExecutionException("'.' is not allowed in project subdirectory paths.")
-    return parsed_uri, subdirectory
-
-
-def _get_storage_dir(storage_dir):
-    if storage_dir is not None and not os.path.exists(storage_dir):
-        os.makedirs(storage_dir)
-    return tempfile.mkdtemp(dir=storage_dir)
-
-
-def _get_git_repo_url(work_dir):
-    from git import Repo
-    from git.exc import GitCommandError, InvalidGitRepositoryError
-    try:
-        repo = Repo(work_dir, search_parent_directories=True)
-        remote_urls = [remote.url for remote in repo.remotes]
-        if len(remote_urls) == 0:
-            return None
-    except GitCommandError:
-        return None
-    except InvalidGitRepositoryError:
-        return None
-    return remote_urls[0]
-
-
-def _expand_uri(uri):
-    if _is_local_uri(uri):
-        return os.path.abspath(uri)
-    return uri
-
-
-def _is_file_uri(uri):
-    """Returns True if the passed-in URI is a file:// URI."""
-    return _FILE_URI_REGEX.match(uri)
-
-
-def _is_local_uri(uri):
-    """Returns True if the passed-in URI should be interpreted as a path on the local filesystem."""
-    return not _GIT_URI_REGEX.match(uri)
-
-
-def _is_zip_uri(uri):
-    """Returns True if the passed-in URI points to a ZIP file."""
-    return _ZIP_URI_REGEX.match(uri)
-
-
-def _is_valid_branch_name(work_dir, version):
-    """
-    Returns True if the ``version`` is the name of a branch in a Git project.
-    ``work_dir`` must be the working directory in a git repo.
-    """
-    if version is not None:
-        from git import Repo
-        from git.exc import GitCommandError
-        repo = Repo(work_dir, search_parent_directories=True)
-        try:
-            return repo.git.rev_parse("--verify", "refs/heads/%s" % version) != ''
-        except GitCommandError:
-            return False
-    return False
 
 
 def _fetch_project(uri, force_tempdir, version=None):

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -1,0 +1,82 @@
+import os
+import re
+import tempfile
+
+from mlflow.exceptions import ExecutionException
+
+
+# TODO: this should be restricted to just Git repos and not S3 and stuff like that
+_GIT_URI_REGEX = re.compile(r"^[^/]*:")
+_FILE_URI_REGEX = re.compile(r"^file://.+")
+_ZIP_URI_REGEX = re.compile(r".+\.zip$")
+
+
+def _parse_subdirectory(uri):
+    # Parses a uri and returns the uri and subdirectory as separate values.
+    # Uses '#' as a delimiter.
+    subdirectory = ''
+    parsed_uri = uri
+    if '#' in uri:
+        subdirectory = uri[uri.find('#') + 1:]
+        parsed_uri = uri[:uri.find('#')]
+    if subdirectory and '.' in subdirectory:
+        raise ExecutionException("'.' is not allowed in project subdirectory paths.")
+    return parsed_uri, subdirectory
+
+
+def _get_storage_dir(storage_dir):
+    if storage_dir is not None and not os.path.exists(storage_dir):
+        os.makedirs(storage_dir)
+    return tempfile.mkdtemp(dir=storage_dir)
+
+
+def _get_git_repo_url(work_dir):
+    from git import Repo
+    from git.exc import GitCommandError, InvalidGitRepositoryError
+    try:
+        repo = Repo(work_dir, search_parent_directories=True)
+        remote_urls = [remote.url for remote in repo.remotes]
+        if len(remote_urls) == 0:
+            return None
+    except GitCommandError:
+        return None
+    except InvalidGitRepositoryError:
+        return None
+    return remote_urls[0]
+
+
+def _expand_uri(uri):
+    if _is_local_uri(uri):
+        return os.path.abspath(uri)
+    return uri
+
+
+def _is_file_uri(uri):
+    """Returns True if the passed-in URI is a file:// URI."""
+    return _FILE_URI_REGEX.match(uri)
+
+
+def _is_local_uri(uri):
+    """Returns True if the passed-in URI should be interpreted as a path on the local filesystem."""
+    return not _GIT_URI_REGEX.match(uri)
+
+
+def _is_zip_uri(uri):
+    """Returns True if the passed-in URI points to a ZIP file."""
+    return _ZIP_URI_REGEX.match(uri)
+
+
+def _is_valid_branch_name(work_dir, version):
+    """
+    Returns True if the ``version`` is the name of a branch in a Git project.
+    ``work_dir`` must be the working directory in a git repo.
+    """
+    if version is not None:
+        from git import Repo
+        from git.exc import GitCommandError
+        repo = Repo(work_dir, search_parent_directories=True)
+        try:
+            return repo.git.rev_parse("--verify", "refs/heads/%s" % version) != ''
+        except GitCommandError:
+            return False
+    return False


### PR DESCRIPTION
## What changes are proposed in this pull request?

Code cleanup. There is an empty utils.py files in projects module, just put there some utils methods.

## How is this patch tested?

Unit tests

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
