### PR TITLE
[UI] Display "Loading..." when the artifact image viewer is loading an image

### DIFF
--- a/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
+++ b/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
@@ -12,7 +12,6 @@ class ShowArtifactImageView extends Component {
       width: 0,
       height: 0,
       dataURL: '',
-      prevPath: props.path,
     };
   }
 
@@ -20,16 +19,6 @@ class ShowArtifactImageView extends Component {
     runUuid: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired,
   };
-
-  static getDerivedStateFromProps(props, state) {
-    if (props.path !== state.prevPath) {
-      return {
-        loading: true,
-        prevPath: props.path,
-      };
-    }
-    return null;
-  }
 
   componentDidMount = () => {
     this.fetchImage();
@@ -47,6 +36,7 @@ class ShowArtifactImageView extends Component {
   };
 
   fetchImage = () => {
+    this.setState({ loading: true });
     const img = new Image();
     img.setAttribute('crossOrigin', 'anonymous');
     img.onload = () => {

--- a/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
+++ b/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
@@ -5,42 +5,67 @@ import { getSrc } from './ShowArtifactPage';
 import Plot from 'react-plotly.js';
 
 class ShowArtifactImageView extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      loading: true,
+      width: 0,
+      height: 0,
+      dataURL: '',
+      prevPath: props.path,
+    };
+  }
+
   static propTypes = {
     runUuid: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired,
   };
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      width: 0,
-      height: 0,
-    };
+  static getDerivedStateFromProps(props, state) {
+    if (props.path !== state.prevPath) {
+      return {
+        loading: true,
+        prevPath: props.path,
+      };
+    }
+    return null;
   }
+
+  componentDidMount = () => {
+    this.fetchImage();
+  };
+
+  componentDidUpdate = prevProps => {
+    if (prevProps.path !== this.props.path) {
+      this.fetchImage();
+    }
+  };
 
   getSrc = () => {
     const { path, runUuid } = this.props;
     return getSrc(path, runUuid);
   };
 
-  resize = () => {
+  fetchImage = () => {
     const img = new Image();
+    img.setAttribute('crossOrigin', 'anonymous');
+    img.onload = () => {
+      const { width, height } = img;
+      const canvas = document.createElement('canvas');
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext('2d');
+      ctx.drawImage(img, 0, 0);
+      const dataURL = canvas.toDataURL('image/png');
+      this.setState({ loading: false, dataURL, width, height });
+    };
     img.src = this.getSrc();
-    img.onload = () => this.setState({ width: img.width, height: img.height });
-  };
-
-  componentDidMount = () => {
-    this.resize();
-  };
-
-  componentDidUpdate = prevProps => {
-    if (prevProps.path !== this.props.path) {
-      this.resize();
-    }
   };
 
   render() {
-    const { width, height } = this.state;
+    const { loading, dataURL, width, height } = this.state;
+
+    if (loading) return <div>Loading...</div>;
 
     return (
       <div className="image-outer-container">
@@ -64,7 +89,7 @@ class ShowArtifactImageView extends Component {
                 yaxis: { visible: false, autorange: true, scaleanchor: 'x', scaleratio: 1 },
                 images: [
                   {
-                    source: this.getSrc(),
+                    source: dataURL,
                     xref: 'x',
                     yref: 'y',
                     x: 0,


### PR DESCRIPTION
## What changes are proposed in this pull request?
Display "Loading..." when the artifact image viewer is loading an image to display.

![loading-message](https://user-images.githubusercontent.com/17039389/67139605-1057a280-f28d-11e9-8d72-021f895a09cb.gif)


## How is this patch tested?

Manually tested

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

#1934 

### What component(s) does this PR affect?

- [x] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
