### PR TITLE
[UI] Prevent the x-axis range from changing when toggling scatter markers

### DIFF
--- a/mlflow/server/js/src/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/components/MetricsPlotView.js
@@ -54,8 +54,9 @@ export class MetricsPlotView extends React.Component {
         }),
         y: history.map((entry) => entry.value),
         type: 'scatter',
-        mode: isSingleHistory ? 'markers' : showPoint ? 'lines+markers' : 'lines',
+        mode: isSingleHistory ? 'markers' : 'lines+markers',
         line: { shape: 'spline', smoothing: lineSmoothness },
+        marker: {opacity: isSingleHistory || showPoint ? 1 : 0 }
       };
     });
     const props = { data };

--- a/mlflow/server/js/src/components/MetricsPlotView.test.js
+++ b/mlflow/server/js/src/components/MetricsPlotView.test.js
@@ -118,22 +118,24 @@ describe('unit tests', () => {
           x: [0, 1],
           y: [100, 200],
           type: 'scatter',
-          mode: 'lines',
+          mode: 'lines+markers',
           line: {
             shape: 'spline',
             smoothing: 0,
           },
+          "marker": {"opacity": 0},
         },
         {
           name: 'metric_1',
           x: [0, 1],
           y: [300, 400],
           type: 'scatter',
-          mode: 'lines',
+          mode: 'lines+markers',
           line: {
             shape: 'spline',
             smoothing: 0,
           },
+          "marker": {"opacity": 0},
         },
       ],
     });


### PR DESCRIPTION
## What changes are proposed in this pull request?

Prevent the x-axis range from changing when toggling scatter markers.

### Current:
![range-change](https://user-images.githubusercontent.com/17039389/67146566-65b0a580-f2c7-11e9-8daf-97ef0c3c2f34.gif)


### Proposed:
![after](https://user-images.githubusercontent.com/17039389/67146570-6ba68680-f2c7-11e9-804d-ce045d648ad1.gif)


## How is this patch tested?

Manually tested

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [x] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
