### PR TITLE
Model registry: Fix client bug preventing description updates

### DIFF
--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -48,7 +48,7 @@ class ModelRegistryClient(object):
         """
         if new_name is None and description is None:
             raise MlflowException("Attempting to update registered model with no new field values.")
-        if new_name.strip() == "":
+        if new_name is not None and new_name.strip() == "":
             raise MlflowException("The new name must not be an empty string.")
         return self.store.update_registered_model(RegisteredModel(name), new_name, description)
 

--- a/tests/tracking/_model_registry/test_model_registry_client.py
+++ b/tests/tracking/_model_registry/test_model_registry_client.py
@@ -38,10 +38,25 @@ def test_create_registered_model(mock_store):
 
 def test_update_registered_model(mock_store):
     mock_store.update_registered_model.return_value = RegisteredModel("New Name")
-    result = newModelRegistryClient().update_registered_model("Model 1", "New Name",
-                                                              "New Description")
-    mock_store.update_registered_model.assert_called_once_with(ANY, "New Name", "New Description")
+    result = newModelRegistryClient().update_registered_model(
+        name="Model 1",
+        new_name="New Name",
+        description="New Description")
+    mock_store.update_registered_model.assert_called_with(ANY, "New Name", "New Description")
     assert result.name == "New Name"
+
+    mock_store.update_registered_model.return_value = RegisteredModel("New Name 2")
+    result2 = newModelRegistryClient().update_registered_model(
+        name="Model 1",
+        new_name="New Name 2")
+    mock_store.update_registered_model.assert_called_with(ANY, "New Name 2", ANY)
+    assert result2.name == "New Name 2"
+
+    result3 = newModelRegistryClient().update_registered_model(
+        name="Model 1",
+        description="New Description 2")
+    mock_store.update_registered_model.assert_called_with(ANY, ANY, "New Description 2")
+    assert result3.name == "New Name 2"
 
 
 def test_update_registered_model_validation_errors(mock_store):


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes a bug in `MlflowClient.update_registered_model` where specifying `description` without `new_name` leads to an attribute reference on a `NoneType`.

## How is this patch tested?

Augmentation of unit tests

## Release Notes

Use the same release note as the rest of the model registry features

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
