### PR TITLE
Fix encoding of metric names in MLflow UI URLs

### DIFF
--- a/mlflow/server/js/src/Actions.js
+++ b/mlflow/server/js/src/Actions.js
@@ -131,7 +131,7 @@ export const getMetricHistoryApi = (runUuid, metricKey, id = getUUID()) => {
   return {
     type: GET_METRIC_HISTORY_API,
     payload: wrapDeferred(MlflowService.getMetricHistory, {
-      run_uuid: runUuid, metric_key: metricKey
+      run_uuid: runUuid, metric_key: decodeURIComponent(metricKey)
     }),
     meta: { id: id, runUuid: runUuid, key: metricKey },
   };

--- a/mlflow/server/js/src/Routes.js
+++ b/mlflow/server/js/src/Routes.js
@@ -16,7 +16,8 @@ class Routes {
   static runPageRoute = "/experiments/:experimentId/runs/:runUuid";
 
   static getMetricPageRoute(runUuids, metricKey, experimentId, plotMetricKeys) {
-    return `/metric/${encodeURIComponent(metricKey)}?runs=${JSON.stringify(runUuids)}&experiment=${experimentId}` +
+    return `/metric/${encodeURIComponent(metricKey)}?runs=${JSON.stringify(runUuids)}&` +
+      `experiment=${experimentId}` +
       `&plot_metric_keys=${JSON.stringify(plotMetricKeys || [metricKey])}`;
   }
 

--- a/mlflow/server/js/src/Routes.js
+++ b/mlflow/server/js/src/Routes.js
@@ -16,7 +16,7 @@ class Routes {
   static runPageRoute = "/experiments/:experimentId/runs/:runUuid";
 
   static getMetricPageRoute(runUuids, metricKey, experimentId, plotMetricKeys) {
-    return `/metric/${metricKey}?runs=${JSON.stringify(runUuids)}&experiment=${experimentId}` +
+    return `/metric/${encodeURIComponent(metricKey)}?runs=${JSON.stringify(runUuids)}&experiment=${experimentId}` +
       `&plot_metric_keys=${JSON.stringify(plotMetricKeys || [metricKey])}`;
   }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Prior to this PR, viewing metrics with names like "steps/sec" in the MLflow UI would break as we include the metric names as part of the URL (specifically the URL hash) and our underlying JS router framework (react-router) interprets forward-slashes (e.g. the "/" in "steps/sec") as path separators when trying to determine the component to render for a given URL hash. This PR fixes the behavior by URI-encoding metric names before including them in the URL, taking care to decode them before using them in `GetMetricHistory` API requests

## How is this patch tested?

Manual tests. This doesn't seem to change the behavior (or URLs) of metrics without URI-escaped characters in their names, e.g. on Chrome the metric name "Mean Squared Error" still results in a URL like http://localhost:3000/#/metric/Mean%20Square%20Error?runs=[%2227d6086ee1b544a79fa93d31ff3ff60e%22]&experiment=0&plot_metric_keys=[%22Mean%20Square%20Error%22] (note the spaces are replaced by "%20" by the browser).

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where viewing metrics containing forward-slashes in the name would break the MLflow UI

### What component(s) does this PR affect?

- [x] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
