### PR TITLE
Make detection of MLproject files case insensitive

### DIFF
--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -11,14 +11,21 @@ from mlflow.exceptions import ExecutionException
 from mlflow.utils.file_utils import get_local_path_or_none
 
 
-MLPROJECT_FILE_NAME = "MLproject"
+MLPROJECT_FILE_NAME = "mlproject"
 DEFAULT_CONDA_FILE_NAME = "conda.yaml"
 
 
+def _find_mlproject(directory):
+    filenames = os.listdir(directory)
+    for filename in filenames:
+        if filename.lower() == MLPROJECT_FILE_NAME:
+            return os.path.join(directory, filename)
+    return None
+
 def load_project(directory):
-    mlproject_path = os.path.join(directory, MLPROJECT_FILE_NAME)
+    mlproject_path = _find_mlproject(directory)
     # TODO: Validate structure of YAML loaded from the file
-    if os.path.exists(mlproject_path):
+    if mlproject_path is not None:
         with open(mlproject_path) as mlproject_file:
             yaml_obj = yaml.safe_load(mlproject_file.read())
     else:

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -22,6 +22,7 @@ def _find_mlproject(directory):
             return os.path.join(directory, filename)
     return None
 
+
 def load_project(directory):
     mlproject_path = _find_mlproject(directory)
     # TODO: Validate structure of YAML loaded from the file

--- a/tests/projects/test_project_spec.py
+++ b/tests/projects/test_project_spec.py
@@ -39,12 +39,12 @@ def test_project_get_unspecified_entry_point():
         project.get_entry_point("my_program.scala")
 
 
-@pytest.mark.parametrize("mlproject, conda_env_path, conda_env_contents", [
-    (None, None, ""),
-    ("key: value", "conda.yaml", "hi"),
-    ("conda_env: some-env.yaml", "some-env.yaml", "hi")
+@pytest.mark.parametrize("mlproject, conda_env_path, conda_env_contents, mlproject_path", [
+    (None, None, "", None),
+    ("key: value", "conda.yaml", "hi", "MLproject"),
+    ("conda_env: some-env.yaml", "some-env.yaml", "hi", "mlproject")
 ])
-def test_load_project(tmpdir, mlproject, conda_env_path, conda_env_contents):
+def test_load_project(tmpdir, mlproject, conda_env_path, conda_env_contents, mlproject_path):
     """
     Test that we can load a project with various combinations of an MLproject / conda.yaml file
     :param mlproject: Contents of MLproject file. If None, no MLproject file will be written
@@ -54,7 +54,7 @@ def test_load_project(tmpdir, mlproject, conda_env_path, conda_env_contents):
                                not None)
     """
     if mlproject:
-        tmpdir.join("MLproject").write(mlproject)
+        tmpdir.join(mlproject_path).write(mlproject)
     if conda_env_path:
         tmpdir.join(conda_env_path).write(conda_env_contents)
     project = _project_spec.load_project(tmpdir.strpath)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make detection of MLproject files case insensitive- if a user's on a case-sensitive filename and has two filenames in the same directory that, when lowercased, are equal to 'mlproject', we'll simply pick one of them (we expect this to be very uncommon).

## How is this patch tested?

New unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug where detection of MLproject files was sensitive to the case of the filename - we now recognize filenames like "mlproject", "Mlproject", etc.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [x] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
