### PR TITLE
Improve error messages for stores that do not support the model registry

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -299,10 +299,6 @@ class MlflowClient(object):
 
     # Registry API
 
-    def verify_registry_client_available(self):
-        if self.registry_client is None:
-            raise Exception("Registry unavailable")
-
     # Registered Model Methods
 
     def create_registered_model(self, name):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -12,15 +12,6 @@ from mlflow.tracking._tracking_service import utils
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
 
 
-def with_registry_availability_check(f):
-    def check_availability(self, *args, **kwargs):
-        if self.registry_client is None:
-            raise Exception("REGISTRY DISABLED!")
-        else:
-           return f(self, *args, **kwargs)
-    return check_availability
-
-
 class MlflowClient(object):
     """
     Client of an MLflow Tracking Server that creates and manages experiments and runs, and of an
@@ -302,9 +293,12 @@ class MlflowClient(object):
 
     # Registry API
 
+    def verify_registry_client_available(self):
+        if self.registry_client is None:
+            raise Exception("Registry unavailable")
+
     # Registered Model Methods
 
-    @with_registry_availability_check
     def create_registered_model(self, name):
         """
         Create a new registered model in backend store.
@@ -313,6 +307,7 @@ class MlflowClient(object):
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
                  created by backend.
         """
+        self.verify_registry_client_available()
         return self.registry_client.create_registered_model(name)
 
     def update_registered_model(self, name, new_name=None, description=None):
@@ -325,6 +320,7 @@ class MlflowClient(object):
         :param description: (Optional) New description.
         :return: A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
+        self.verify_registry_client_available()
         return self.registry_client.update_registered_model(name, new_name, description)
 
     def delete_registered_model(self, name):
@@ -334,6 +330,7 @@ class MlflowClient(object):
 
         :param name: Name of the registered model to update.
         """
+        self.verify_registry_client_available()
         self.registry_client.delete_registered_model(name)
 
     def list_registered_models(self):
@@ -342,6 +339,7 @@ class MlflowClient(object):
 
         :return: List of :py:class:`mlflow.entities.registry.RegisteredModel` objects.
         """
+        self.verify_registry_client_available()
         return self.registry_client.list_registered_models()
 
     def get_registered_model_details(self, name):
@@ -349,6 +347,7 @@ class MlflowClient(object):
         :param name: Name of the registered model to update.
         :return: A single :py:class:`mlflow.entities.model_registry.RegisteredModelDetailed` object.
         """
+        self.verify_registry_client_available()
         return self.registry_client.get_registered_model_details(name)
 
     def get_latest_versions(self, name, stages=None):
@@ -361,6 +360,7 @@ class MlflowClient(object):
                        for ALL_STAGES.
         :return: List of `:py:class:`mlflow.entities.model_registry.ModelVersionDetailed` objects.
         """
+        self.verify_registry_client_available()
         return self.registry_client.get_latest_versions(name, stages)
 
     # Model Version Methods
@@ -375,6 +375,7 @@ class MlflowClient(object):
         :return: Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by
                  backend.
         """
+        self.verify_registry_client_available()
         return self.registry_client.create_model_version(name, source, run_id)
 
     def update_model_version(self, name, version, stage=None, description=None):
@@ -386,6 +387,7 @@ class MlflowClient(object):
         :param stage: New desired stage for this model version.
         :param description: New description.
         """
+        self.verify_registry_client_available()
         self.registry_client.update_model_version(name, version, stage, description)
 
     def delete_model_version(self, name, version):
@@ -395,6 +397,7 @@ class MlflowClient(object):
         :param name: Name of the containing registered model.
         :param version: Version number of the model version.
         """
+        self.verify_registry_client_available()
         self.registry_client.delete_model_version(name, version)
 
     def get_model_version_details(self, name, version):
@@ -403,6 +406,7 @@ class MlflowClient(object):
         :param version: Version number of the model version.
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersionDetailed` object.
         """
+        self.verify_registry_client_available()
         return self.registry_client.get_model_version_details(name, version)
 
     def get_model_version_download_uri(self, name, version):
@@ -413,6 +417,7 @@ class MlflowClient(object):
         :param version: Version number of the model version.
         :return: A single URI location that allows reads for downloading.
         """
+        self.verify_registry_client_available()
         return self.registry_client.get_model_version_download_uri(name, version)
 
     def search_model_versions(self, filter_string):
@@ -424,10 +429,12 @@ class MlflowClient(object):
                               ``run_id = '...'``.
         :return: PagedList of :py:class:`mlflow.entities.model_registry.ModelVersion` objects.
         """
+        self.verify_registry_client_available()
         return self.registry_client.search_model_versions(filter_string)
 
     def get_model_version_stages(self, name, version):
         """
         :return: A list of valid stages.
         """
+        self.verify_registry_client_available()
         return self.registry_client.get_model_version_stages(name, version)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -32,12 +32,18 @@ class MlflowClient(object):
         final_tracking_uri = tracking_uri or utils.get_tracking_uri()
         self.tracking_client = TrackingServiceClient(final_tracking_uri)
         try:
-            self.registry_client = ModelRegistryClient(registry_uri or final_tracking_uri)
+            self._registry_client = ModelRegistryClient(registry_uri or final_tracking_uri)
         except MlflowException as e:
             if "Unexpected URI" in e.message:
-                self.registry_client = None
+                self._registry_client = None
             else:
                 raise e
+
+    @property
+    def registry_client(self):
+        if self._registry_client is None:
+            raise Exception("Registry unavailable")
+        return self._registry_client
 
     # Tracking API
 
@@ -307,7 +313,6 @@ class MlflowClient(object):
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
                  created by backend.
         """
-        self.verify_registry_client_available()
         return self.registry_client.create_registered_model(name)
 
     def update_registered_model(self, name, new_name=None, description=None):
@@ -320,7 +325,6 @@ class MlflowClient(object):
         :param description: (Optional) New description.
         :return: A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
-        self.verify_registry_client_available()
         return self.registry_client.update_registered_model(name, new_name, description)
 
     def delete_registered_model(self, name):
@@ -330,7 +334,6 @@ class MlflowClient(object):
 
         :param name: Name of the registered model to update.
         """
-        self.verify_registry_client_available()
         self.registry_client.delete_registered_model(name)
 
     def list_registered_models(self):
@@ -339,7 +342,6 @@ class MlflowClient(object):
 
         :return: List of :py:class:`mlflow.entities.registry.RegisteredModel` objects.
         """
-        self.verify_registry_client_available()
         return self.registry_client.list_registered_models()
 
     def get_registered_model_details(self, name):
@@ -347,7 +349,6 @@ class MlflowClient(object):
         :param name: Name of the registered model to update.
         :return: A single :py:class:`mlflow.entities.model_registry.RegisteredModelDetailed` object.
         """
-        self.verify_registry_client_available()
         return self.registry_client.get_registered_model_details(name)
 
     def get_latest_versions(self, name, stages=None):
@@ -360,7 +361,6 @@ class MlflowClient(object):
                        for ALL_STAGES.
         :return: List of `:py:class:`mlflow.entities.model_registry.ModelVersionDetailed` objects.
         """
-        self.verify_registry_client_available()
         return self.registry_client.get_latest_versions(name, stages)
 
     # Model Version Methods
@@ -375,7 +375,6 @@ class MlflowClient(object):
         :return: Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by
                  backend.
         """
-        self.verify_registry_client_available()
         return self.registry_client.create_model_version(name, source, run_id)
 
     def update_model_version(self, name, version, stage=None, description=None):
@@ -387,7 +386,6 @@ class MlflowClient(object):
         :param stage: New desired stage for this model version.
         :param description: New description.
         """
-        self.verify_registry_client_available()
         self.registry_client.update_model_version(name, version, stage, description)
 
     def delete_model_version(self, name, version):
@@ -397,7 +395,6 @@ class MlflowClient(object):
         :param name: Name of the containing registered model.
         :param version: Version number of the model version.
         """
-        self.verify_registry_client_available()
         self.registry_client.delete_model_version(name, version)
 
     def get_model_version_details(self, name, version):
@@ -406,7 +403,6 @@ class MlflowClient(object):
         :param version: Version number of the model version.
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersionDetailed` object.
         """
-        self.verify_registry_client_available()
         return self.registry_client.get_model_version_details(name, version)
 
     def get_model_version_download_uri(self, name, version):
@@ -417,7 +413,6 @@ class MlflowClient(object):
         :param version: Version number of the model version.
         :return: A single URI location that allows reads for downloading.
         """
-        self.verify_registry_client_available()
         return self.registry_client.get_model_version_download_uri(name, version)
 
     def search_model_versions(self, filter_string):
@@ -429,12 +424,10 @@ class MlflowClient(object):
                               ``run_id = '...'``.
         :return: PagedList of :py:class:`mlflow.entities.model_registry.ModelVersion` objects.
         """
-        self.verify_registry_client_available()
         return self.registry_client.search_model_versions(filter_string)
 
     def get_model_version_stages(self, name, version):
         """
         :return: A list of valid stages.
         """
-        self.verify_registry_client_available()
         return self.registry_client.get_model_version_stages(name, version)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -12,6 +12,15 @@ from mlflow.tracking._tracking_service import utils
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
 
 
+def with_registry_availability_check(f):
+    def check_availability(self, *args, **kwargs):
+        if self.registry_client is None:
+            raise Exception("REGISTRY DISABLED!")
+        else:
+           return f(self, *args, **kwargs)
+    return check_availability
+
+
 class MlflowClient(object):
     """
     Client of an MLflow Tracking Server that creates and manages experiments and runs, and of an
@@ -295,6 +304,7 @@ class MlflowClient(object):
 
     # Registered Model Methods
 
+    @with_registry_availability_check
     def create_registered_model(self, name):
         """
         Create a new registered model in backend store.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -6,10 +6,10 @@ and is exposed in the :py:mod:`mlflow.tracking` module.
 
 from mlflow.entities import ViewType
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import FEATURE_DISABLED 
+from mlflow.protos.databricks_pb2 import FEATURE_DISABLED
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.tracking._model_registry.client import ModelRegistryClient
-from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException 
+from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.tracking._tracking_service import utils
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -37,7 +37,7 @@ class MlflowClient(object):
         # `MlflowClient` also references a `ModelRegistryClient` instance that is provided by the
         # `MlflowClient._get_registry_client()` method. This `ModelRegistryClient` is not explicitly
         # defined as an instance variable in the `MlflowClient` constructor; an instance variable
-        # is assigned lazily by `MlflowClient_get_registry_client()` and should not be referenced
+        # is assigned lazily by `MlflowClient._get_registry_client()` and should not be referenced
         # outside of the `MlflowClient._get_registry_client()` method
 
     def _get_registry_client(self):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -54,7 +54,7 @@ class MlflowClient(object):
                 raise MlflowException(
                     "Model Registry features are not supported by the store with URI:"
                     " '{uri}'. Stores with the following URI schemes are supported:"
-                    " {schemes}".format(uri=self._registry_uri, schemes=exc.supported_uri_schemes),
+                    " {schemes}.".format(uri=self._registry_uri, schemes=exc.supported_uri_schemes),
                     FEATURE_DISABLED)
         return registry_client
 
@@ -308,7 +308,7 @@ class MlflowClient(object):
             the next page may be obtained via the ``token`` attribute of the returned object.
         """
         return self._tracking_client.search_runs(experiment_ids, filter_string, run_view_type,
-                                                max_results, order_by, page_token)
+                                                 max_results, order_by, page_token)
 
     # Registry API
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -35,10 +35,10 @@ class MlflowClient(object):
         self._registry_uri = registry_uri or final_tracking_uri
         self._tracking_client = TrackingServiceClient(final_tracking_uri)
         # `MlflowClient` also references a `ModelRegistryClient` instance that is provided by the
-        # MlflowClient._get_registry_client() method. This `ModelRegistryClient` is not explicitly
+        # `MlflowClient._get_registry_client()` method. This `ModelRegistryClient` is not explicitly
         # defined as an instance variable in the `MlflowClient` constructor; an instance variable
         # is assigned lazily by `MlflowClient_get_registry_client()` and should not be referenced
-        # outside of the `MlflowClient._get_registry_client()` function.
+        # outside of the `MlflowClient._get_registry_client()` method
 
     def _get_registry_client(self):
         """

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -3,7 +3,18 @@ import entrypoints
 import warnings
 
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.utils.uri import get_uri_scheme
+
+
+class UnsupportedModelRegistryStoreURIException(MlflowException):
+    """Exception thrown when building a model registry store with an unsupported URI"""
+    def __init__(self, unsupported_uri, supported_uri_schemes):
+        message = "Unsupported URI '{}' for model registry store. Supported schemes are: {}".format(
+            unsupported_uri, supported_uri_schemes)
+        super(UnsupportedModelRegistryStoreURIException, self).__init__(
+            message, error_code=INVALID_PARAMETER_VALUE)
+        self.supported_uri_schemes = supported_uri_schemes
 
 
 class StoreRegistry:
@@ -59,7 +70,7 @@ class StoreRegistry:
         try:
             store_builder = self._registry[scheme]
         except KeyError:
-            raise MlflowException(
-                "Unexpected URI scheme '{}' for model registry store. "
-                "Valid schemes are: {}".format(store_uri, list(self._registry.keys())))
+            raise UnsupportedModelRegistryStoreURIException(
+                unsupported_uri=store_uri,
+                supported_uri_schemes=self._registry.keys())
         return store_builder

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -60,6 +60,6 @@ class StoreRegistry:
             store_builder = self._registry[scheme]
         except KeyError:
             raise MlflowException(
-                "Unexpected URI scheme '{}' for tracking store. "
+                "Unexpected URI scheme '{}' for model registry store. "
                 "Valid schemes are: {}".format(store_uri, list(self._registry.keys())))
         return store_builder

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -72,5 +72,5 @@ class StoreRegistry:
         except KeyError:
             raise UnsupportedModelRegistryStoreURIException(
                 unsupported_uri=store_uri,
-                supported_uri_schemes=self._registry.keys())
+                supported_uri_schemes=list(self._registry.keys()))
         return store_builder

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -1,11 +1,27 @@
 import mock
 import pytest
 
-from mlflow import register_model
+from mlflow import register_model, set_tracking_uri
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, RESOURCE_ALREADY_EXISTS
+from mlflow.protos.databricks_pb2 import (
+        ErrorCode, INTERNAL_ERROR, RESOURCE_ALREADY_EXISTS, FEATURE_DISABLED
+)
 from mlflow.tracking import MlflowClient
+from mlflow.utils.file_utils import TempDir
+
+
+def test_register_model_raises_exception_with_unsupported_registry_store():
+    """
+    This test case ensures that the `register_model` operation fails with an informative error 
+    message when the registry store URI refers to a store that does not support Model Registry 
+    features (e.g., FileStore).
+    """
+    with TempDir() as tmp:
+        set_tracking_uri(tmp.path())
+        with pytest.raises(MlflowException) as exc:
+            register_model(model_uri="runs:/1234/some_model", name="testmodel")
+            assert exc.value.error_code == ErrorCode.Name(FEATURE_DISABLED)
 
 
 def test_register_model_with_runs_uri():

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -13,8 +13,8 @@ from mlflow.utils.file_utils import TempDir
 
 def test_register_model_raises_exception_with_unsupported_registry_store():
     """
-    This test case ensures that the `register_model` operation fails with an informative error 
-    message when the registry store URI refers to a store that does not support Model Registry 
+    This test case ensures that the `register_model` operation fails with an informative error
+    message when the registry store URI refers to a store that does not support Model Registry
     features (e.g., FileStore).
     """
     with TempDir() as tmp:

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -1,14 +1,14 @@
 import mock
 import pytest
 
-from mlflow import register_model, set_tracking_uri, get_tracking_uri 
+from mlflow import register_model, set_tracking_uri, get_tracking_uri
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
         ErrorCode, INTERNAL_ERROR, RESOURCE_ALREADY_EXISTS, FEATURE_DISABLED
 )
 from mlflow.tracking import MlflowClient
-from mlflow.tracking._tracking_service.utils import is_tracking_uri_set 
+from mlflow.tracking._tracking_service.utils import is_tracking_uri_set
 from mlflow.utils.file_utils import TempDir
 
 

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -8,6 +8,7 @@ from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.tracking.file_store import FileStore
 from mlflow.store.tracking.rest_store import RestStore
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
 from mlflow.tracking._tracking_service.utils import _get_store, _TRACKING_URI_ENV_VAR, \
     _TRACKING_USERNAME_ENV_VAR, _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, \
@@ -278,6 +279,5 @@ def test_get_store_for_unregistered_scheme():
 
     tracking_store = TrackingStoreRegistry()
 
-    with pytest.raises(mlflow.exceptions.MlflowException,
-                       match="Unexpected URI scheme"):
+    with pytest.raises(UnsupportedModelRegistryStoreURIException):
         tracking_store.get_store("unknown-scheme://")

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2,8 +2,11 @@ import pytest
 import mock
 
 from mlflow.entities import SourceType, ViewType, RunTag
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import ErrorCode, FEATURE_DISABLED 
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.tracking import MlflowClient
+from mlflow.utils.file_utils import TempDir
 from mlflow.utils.mlflow_tags import MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, \
     MLFLOW_PARENT_RUN_ID, MLFLOW_GIT_COMMIT, MLFLOW_PROJECT_ENTRY_POINT
 
@@ -147,3 +150,18 @@ def test_client_search_runs_page_token(mock_store):
                                                    max_results=SEARCH_MAX_RESULTS_DEFAULT,
                                                    order_by=None,
                                                    page_token="blah")
+
+def test_client_registry_operations_raise_exception_with_unsupported_registry_store():
+    with TempDir() as tmp:
+        client = MlflowClient(registry_uri=tmp.path())
+        expected_failure_functions = [
+            client._get_registry_client,
+            lambda: client.create_registered_model("test"),
+            lambda: client.get_registered_model_details("test"),
+            lambda: client.create_model_version("test", "source", "run_id"), 
+            lambda: client.get_model_version_details("test", 1), 
+        ]
+        for func in expected_failure_functions:
+            with pytest.raises(MlflowException) as exc:
+                func() 
+            assert exc.value.error_code == ErrorCode.Name(FEATURE_DISABLED)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -3,7 +3,7 @@ import mock
 
 from mlflow.entities import SourceType, ViewType, RunTag
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import ErrorCode, FEATURE_DISABLED 
+from mlflow.protos.databricks_pb2 import ErrorCode, FEATURE_DISABLED
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.tracking import MlflowClient
 from mlflow.utils.file_utils import TempDir
@@ -163,10 +163,10 @@ def test_client_registry_operations_raise_exception_with_unsupported_registry_st
             client._get_registry_client,
             lambda: client.create_registered_model("test"),
             lambda: client.get_registered_model_details("test"),
-            lambda: client.create_model_version("test", "source", "run_id"), 
-            lambda: client.get_model_version_details("test", 1), 
+            lambda: client.create_model_version("test", "source", "run_id"),
+            lambda: client.get_model_version_details("test", 1),
         ]
         for func in expected_failure_functions:
             with pytest.raises(MlflowException) as exc:
-                func() 
+                func()
             assert exc.value.error_code == ErrorCode.Name(FEATURE_DISABLED)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -151,6 +151,7 @@ def test_client_search_runs_page_token(mock_store):
                                                    order_by=None,
                                                    page_token="blah")
 
+
 def test_client_registry_operations_raise_exception_with_unsupported_registry_store():
     """
     This test case ensures that Model Registry operations invoked on the `MlflowClient`

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -152,6 +152,11 @@ def test_client_search_runs_page_token(mock_store):
                                                    page_token="blah")
 
 def test_client_registry_operations_raise_exception_with_unsupported_registry_store():
+    """
+    This test case ensures that Model Registry operations invoked on the `MlflowClient`
+    fail with an informative error message when the registry store URI refers to a
+    store that does not support Model Registry features (e.g., FileStore).
+    """
     with TempDir() as tmp:
         client = MlflowClient(registry_uri=tmp.path())
         expected_failure_functions = [


### PR DESCRIPTION
## What changes are proposed in this pull request?

### Background

The default tracking store (`FileStore`) does not support model registry features. As a result, the `MlflowClient` that underlies most Model Registry API calls does not instantiate a `ModelRegistryClient`. This is expected behavior; however, the absence of this client and its capabilities currently surfaces in a pretty gnarly way; for example, here's what happens when you try to import mlflow and call `mlflow.register_model`:
```
> import mlflow
> mlflow.register_model("test", "test")
AttributeError                            Traceback (most recent call last)
<ipython-input-2-364635ef0b31> in <module>()
----> 1 mlflow.register_model("test", "test")

/Users/czumar/mlflow/mlflow/tracking/_model_registry/fluent.pyc in register_model(model_uri, name)
     22     client = MlflowClient()
     23     try:
---> 24         client.create_registered_model(name)
     25     except MlflowException as e:
     26         if e.error_code == ErrorCode.Name(RESOURCE_ALREADY_EXISTS):

/Users/czumar/mlflow/mlflow/tracking/client.py in create_registered_model(self, name)
    304                  created by backend.
    305         """
--> 306         return self.registry_client.create_registered_model(name)
    307
    308     def update_registered_model(self, name, new_name=None, description=None):

AttributeError: 'NoneType' object has no attribute 'create_registered_model'
```

This happens because `client` is `None. Similar behavior is produced by `MlflowClient.register_model()`, as well as other Model Registry API calls initiated from `MlflowClient`.

### Proposed changes

This PR makes it significantly easier to understand when / why Model Registry operations fail due to unsupported stores. Here are a couple of examples of behavior when this PR is applied:
```
> import mlflow
> mlflow.register_model("test", "test")
MlflowException                           Traceback (most recent call last)
<ipython-input-2-364635ef0b31> in <module>()
----> 1 mlflow.register_model("test", "test")

/Users/czumar/mlflow/mlflow/tracking/_model_registry/fluent.pyc in register_model(model_uri, name)
     27             eprint("Registered model %s already exists. Using it to create a new version." % name)
     28         else:
---> 29             raise e
     30
     31     if RunsArtifactRepository.is_runs_uri(model_uri):

MlflowException: Model Registry features are not supported by the store with URI: 'file:///Users/czumar/Documents/mlruns'. Stores with the following URI schemes are supported: ['sqlite', 'http', 'databricks', 'https', 'mysql', 'postgresql', 'mssql'].
```

```
> from mlflow.tracking.client import MlflowClient
> client = MlflowClient()
> client.get_model_version_details("test", 1)
MlflowException                           Traceback (most recent call last)
<ipython-input-5-47619719ce1d> in <module>()
----> 1 client.get_model_version_details("test", 1)

/Users/czumar/mlflow/mlflow/tracking/client.pyc in get_model_version_details(self, name, version)
    413         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersionDetailed` object.
    414         """
--> 415         return self._get_registry_client().get_model_version_details(name, version)
    416
    417     def get_model_version_download_uri(self, name, version):

/Users/czumar/mlflow/mlflow/tracking/client.pyc in _get_registry_client(self)
     56                     " '{uri}'. Stores with the following URI schemes are supported:"
     57                     " {schemes}.".format(uri=self._registry_uri, schemes=exc.supported_uri_schemes),
---> 58                     FEATURE_DISABLED)
     59         return registry_client
     60

MlflowException: Model Registry features are not supported by the store with URI: 'file:///Users/czumar/Documents/mlruns'. Stores with the following URI schemes are supported: ['sqlite', 'http', 'databricks', 'https', 'mysql', 'postgresql', 'mssql'].
```

## How is this patch tested?

Unit tests and manual tests

## Release Notes

Use model registry release note

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [X] Model Registry
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
