### PR TITLE
Fixing link to Conda installation instructions.

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -503,11 +503,13 @@ def _get_or_create_conda_env(conda_env_path, env_id=None):
         process.exec_cmd([conda_path, "--help"], throw_on_error=False)
     except EnvironmentError:
         raise ExecutionException("Could not find Conda executable at {0}. "
-                                 "Ensure Conda is installed as per the instructions "
-                                 "at https://conda.io/docs/user-guide/install/index.html. You can "
-                                 "also configure MLflow to look for a specific Conda executable "
-                                 "by setting the {1} environment variable to the path of the Conda "
-                                 "executable".format(conda_path, MLFLOW_CONDA_HOME))
+                                 "Ensure Conda is installed as per the instructions at "
+                                 "https://conda.io/projects/conda/en/latest/"
+                                 "user-guide/install/index.html. "
+                                 "You can also configure MLflow to look for a specific "
+                                 "Conda executable by setting the {1} environment variable "
+                                 "to the path of the Conda executable"
+                                 .format(conda_path, MLFLOW_CONDA_HOME))
     (_, stdout, _) = process.exec_cmd([conda_path, "env", "list", "--json"])
     env_names = [os.path.basename(env) for env in json.loads(stdout)['envs']]
     project_env_name = _get_conda_env_name(conda_env_path, env_id)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes link to conda installation instructions in message that appears
when conda executable can't be found.

## How is this patch tested?

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ x] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
