### PR TITLE
Marking Model Registry APIs, utilities, and entity classes as experimental.

### DIFF
--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -1,7 +1,6 @@
 from mlflow.entities.model_registry import RegisteredModel
 from mlflow.entities.model_registry._model_registry_entity import _ModelRegistryEntity
 from mlflow.protos.model_registry_pb2 import ModelVersion as ProtoModelVersion
-from mlflow.utils import experimental
 
 
 class ModelVersion(_ModelRegistryEntity):

--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -7,7 +7,9 @@ from mlflow.utils import experimental
 @experimental
 class ModelVersion(_ModelRegistryEntity):
     """
-    MLflow entity for Model Version
+    MLflow entity for Model Version.
+    A model version is uniquely identified using underlying
+    :py:class:`mlflow.entities.model_registry.RegisteredModel` and version number.
     """
     def __init__(self, registered_model, version):
         """

--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -1,9 +1,14 @@
 from mlflow.entities.model_registry import RegisteredModel
 from mlflow.entities.model_registry._model_registry_entity import _ModelRegistryEntity
 from mlflow.protos.model_registry_pb2 import ModelVersion as ProtoModelVersion
+from mlflow.utils import experimental
 
 
+@experimental
 class ModelVersion(_ModelRegistryEntity):
+    """
+    MLflow entity for Model Version
+    """
     def __init__(self, registered_model, version):
         """
         Construct a :py:class:`mlflow.entities.model_registry.RegisteredModel` instance

--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -4,9 +4,9 @@ from mlflow.protos.model_registry_pb2 import ModelVersion as ProtoModelVersion
 from mlflow.utils import experimental
 
 
-@experimental
 class ModelVersion(_ModelRegistryEntity):
     """
+    Note:: Experimental: This entity may change or be removed in a future release without warning.
     MLflow entity for Model Version.
     A model version is uniquely identified using underlying
     :py:class:`mlflow.entities.model_registry.RegisteredModel` and version number.

--- a/mlflow/entities/model_registry/model_version_detailed.py
+++ b/mlflow/entities/model_registry/model_version_detailed.py
@@ -2,7 +2,6 @@ from mlflow.entities.model_registry import RegisteredModel
 from mlflow.entities.model_registry.model_version import ModelVersion
 from mlflow.entities.model_registry.model_version_status import ModelVersionStatus
 from mlflow.protos.model_registry_pb2 import ModelVersionDetailed as ProtoModelVersionDetailed
-from mlflow.utils import experimental
 
 
 class ModelVersionDetailed(ModelVersion):

--- a/mlflow/entities/model_registry/model_version_detailed.py
+++ b/mlflow/entities/model_registry/model_version_detailed.py
@@ -8,7 +8,9 @@ from mlflow.utils import experimental
 @experimental
 class ModelVersionDetailed(ModelVersion):
     """
-    MLflow entity for Model Version Detailed
+    MLflow entity for Model Version Detailed.
+    Provides additional metadata data for model version in addition to information in
+    :py:class:`mlflow.entities.model_registry.ModelVersion`.
     """
 
     def __init__(self, registered_model, version, creation_timestamp, last_updated_timestamp=None,

--- a/mlflow/entities/model_registry/model_version_detailed.py
+++ b/mlflow/entities/model_registry/model_version_detailed.py
@@ -2,9 +2,15 @@ from mlflow.entities.model_registry import RegisteredModel
 from mlflow.entities.model_registry.model_version import ModelVersion
 from mlflow.entities.model_registry.model_version_status import ModelVersionStatus
 from mlflow.protos.model_registry_pb2 import ModelVersionDetailed as ProtoModelVersionDetailed
+from mlflow.utils import experimental
 
 
+@experimental
 class ModelVersionDetailed(ModelVersion):
+    """
+    MLflow entity for Model Version Detailed
+    """
+
     def __init__(self, registered_model, version, creation_timestamp, last_updated_timestamp=None,
                  description=None, user_id=None, current_stage=None, source=None, run_id=None,
                  status=None, status_message=None):

--- a/mlflow/entities/model_registry/model_version_detailed.py
+++ b/mlflow/entities/model_registry/model_version_detailed.py
@@ -5,9 +5,9 @@ from mlflow.protos.model_registry_pb2 import ModelVersionDetailed as ProtoModelV
 from mlflow.utils import experimental
 
 
-@experimental
 class ModelVersionDetailed(ModelVersion):
     """
+    Note:: Experimental: This entity may change or be removed in a future release without warning.
     MLflow entity for Model Version Detailed.
     Provides additional metadata data for model version in addition to information in
     :py:class:`mlflow.entities.model_registry.ModelVersion`.

--- a/mlflow/entities/model_registry/registered_model.py
+++ b/mlflow/entities/model_registry/registered_model.py
@@ -1,8 +1,14 @@
 from mlflow.entities.model_registry._model_registry_entity import _ModelRegistryEntity
 from mlflow.protos.model_registry_pb2 import RegisteredModel as ProtoRegisteredModel
+from mlflow.utils import experimental
 
 
+@experimental
 class RegisteredModel(_ModelRegistryEntity):
+    """
+    MLflow entity for Registered Model
+    """
+
     def __init__(self, name):
         """
         Construct a :py:class:`mlflow.entities.model_registry.RegisteredModel`

--- a/mlflow/entities/model_registry/registered_model.py
+++ b/mlflow/entities/model_registry/registered_model.py
@@ -1,6 +1,5 @@
 from mlflow.entities.model_registry._model_registry_entity import _ModelRegistryEntity
 from mlflow.protos.model_registry_pb2 import RegisteredModel as ProtoRegisteredModel
-from mlflow.utils import experimental
 
 
 class RegisteredModel(_ModelRegistryEntity):

--- a/mlflow/entities/model_registry/registered_model.py
+++ b/mlflow/entities/model_registry/registered_model.py
@@ -6,7 +6,8 @@ from mlflow.utils import experimental
 @experimental
 class RegisteredModel(_ModelRegistryEntity):
     """
-    MLflow entity for Registered Model
+    MLflow entity for Registered Model.
+    A registered model entity is uniquely identified by it's name.
     """
 
     def __init__(self, name):

--- a/mlflow/entities/model_registry/registered_model.py
+++ b/mlflow/entities/model_registry/registered_model.py
@@ -3,11 +3,11 @@ from mlflow.protos.model_registry_pb2 import RegisteredModel as ProtoRegisteredM
 from mlflow.utils import experimental
 
 
-@experimental
 class RegisteredModel(_ModelRegistryEntity):
     """
+    Note:: Experimental: This entity may change or be removed in a future release without warning.
     MLflow entity for Registered Model.
-    A registered model entity is uniquely identified by it's name.
+    A registered model entity is uniquely identified by its name.
     """
 
     def __init__(self, name):

--- a/mlflow/entities/model_registry/registered_model_detailed.py
+++ b/mlflow/entities/model_registry/registered_model_detailed.py
@@ -4,9 +4,9 @@ from mlflow.protos.model_registry_pb2 import RegisteredModelDetailed as ProtoReg
 from mlflow.utils import experimental
 
 
-@experimental
 class RegisteredModelDetailed(RegisteredModel):
     """
+    Note:: Experimental: This entity may change or be removed in a future release without warning.
     MLflow entity for Registered Model Detailed.
     Provides additional metadata data for registered model in addition to information in
     :py:class:`mlflow.entities.model_registry.RegisteredModel`.

--- a/mlflow/entities/model_registry/registered_model_detailed.py
+++ b/mlflow/entities/model_registry/registered_model_detailed.py
@@ -1,7 +1,6 @@
 from mlflow.entities.model_registry.model_version_detailed import ModelVersionDetailed
 from mlflow.entities.model_registry.registered_model import RegisteredModel
 from mlflow.protos.model_registry_pb2 import RegisteredModelDetailed as ProtoRegisteredModelDetailed
-from mlflow.utils import experimental
 
 
 class RegisteredModelDetailed(RegisteredModel):

--- a/mlflow/entities/model_registry/registered_model_detailed.py
+++ b/mlflow/entities/model_registry/registered_model_detailed.py
@@ -1,10 +1,15 @@
 from mlflow.entities.model_registry.model_version_detailed import ModelVersionDetailed
 from mlflow.entities.model_registry.registered_model import RegisteredModel
 from mlflow.protos.model_registry_pb2 import RegisteredModelDetailed as ProtoRegisteredModelDetailed
+from mlflow.utils import experimental
 
 
+@experimental
 class RegisteredModelDetailed(RegisteredModel):
-    # __init__ method to initialize fields
+    """
+    MLflow entity for Registered Model Detailed
+    """
+
     def __init__(self, name, creation_timestamp, last_updated_timestamp=None, description=None,
                  latest_versions=None):
         # Constructor is called only from within the system by various backend stores.

--- a/mlflow/entities/model_registry/registered_model_detailed.py
+++ b/mlflow/entities/model_registry/registered_model_detailed.py
@@ -7,14 +7,15 @@ from mlflow.utils import experimental
 @experimental
 class RegisteredModelDetailed(RegisteredModel):
     """
-    MLflow entity for Registered Model Detailed
+    MLflow entity for Registered Model Detailed.
+    Provides additional metadata data for registered model in addition to information in
+    :py:class:`mlflow.entities.model_registry.RegisteredModel`.
     """
 
     def __init__(self, name, creation_timestamp, last_updated_timestamp=None, description=None,
                  latest_versions=None):
         # Constructor is called only from within the system by various backend stores.
         super(RegisteredModelDetailed, self).__init__(name)
-        self._name = name
         self._creation_time = creation_timestamp
         self._last_updated_timestamp = last_updated_timestamp
         self._description = description

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -126,9 +126,10 @@ def log_model(h2o_model, artifact_path, conda_env=None, registered_model_name=No
                                 ]
                             ]
                         }
-    :param registered_model_name: If given, create a model version under ``registered_model_name``,
-                                  also creating a registered model if one with the given name does
-                                  not exist.
+    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+                                  future release without warning. If given, create a model
+                                  version under ``registered_model_name``, also creating a
+                                  registered model if one with the given name does not exist.
     :param kwargs: kwargs to pass to ``h2o.save_model`` method.
     """
     Model.log(artifact_path=artifact_path, flavor=mlflow.h2o,

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -126,7 +126,7 @@ def log_model(h2o_model, artifact_path, conda_env=None, registered_model_name=No
                                 ]
                             ]
                         }
-    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+    :param registered_model_name: Note:: Experimental: This argument may change or be removed in a
                                   future release without warning. If given, create a model
                                   version under ``registered_model_name``, also creating a
                                   registered model if one with the given name does not exist.

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -212,9 +212,10 @@ def log_model(keras_model, artifact_path, conda_env=None, custom_objects=None, k
     :param keras_module: Keras module to be used to save / load the model
                          (``keras`` or ``tf.keras``). If not provided, MLflow will
                          attempt to infer the Keras module based on the given model.
-    :param registered_model_name: If given, create a model version under ``registered_model_name``,
-                                  also creating a registered model if one with the given name does
-                                  not exist.
+    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+                                  future release without warning. If given, create a model
+                                  version under ``registered_model_name``, also creating a
+                                  registered model if one with the given name does not exist.
     :param kwargs: kwargs to pass to ``keras_model.save`` method.
 
     >>> from keras import Dense, layers

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -212,7 +212,7 @@ def log_model(keras_model, artifact_path, conda_env=None, custom_objects=None, k
     :param keras_module: Keras module to be used to save / load the model
                          (``keras`` or ``tf.keras``). If not provided, MLflow will
                          attempt to infer the Keras module based on the given model.
-    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+    :param registered_model_name: Note:: Experimental: This argument may change or be removed in a
                                   future release without warning. If given, create a model
                                   version under ``registered_model_name``, also creating a
                                   registered model if one with the given name does not exist.

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -36,9 +36,10 @@ def log_model(spark_model, sample_input, artifact_path, registered_model_name=No
     :param sample_input: Sample PySpark DataFrame input that the model can evaluate. This is
                          required by MLeap for data schema inference.
     :param artifact_path: Run-relative artifact path.
-    :param registered_model_name: If given, create a model version under ``registered_model_name``,
-                                  also creating a registered model if one with the given name does
-                                  not exist.
+    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+                                  future release without warning. If given, create a model
+                                  version under ``registered_model_name``, also creating a
+                                  registered model if one with the given name does not exist.
 
     >>> import mlflow
     >>> import mlflow.mleap

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -36,7 +36,7 @@ def log_model(spark_model, sample_input, artifact_path, registered_model_name=No
     :param sample_input: Sample PySpark DataFrame input that the model can evaluate. This is
                          required by MLeap for data schema inference.
     :param artifact_path: Run-relative artifact path.
-    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+    :param registered_model_name: Note:: Experimental: This argument may change or be removed in a
                                   future release without warning. If given, create a model
                                   version under ``registered_model_name``, also creating a
                                   registered model if one with the given name does not exist.

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -68,8 +68,8 @@ class Model(object):
         :param flavor: Flavor module to save the model with. The module must have
                        the ``save_model`` function that will persist the model as a valid
                        MLflow model.
-        :param registered_model_name: Note:: Experimental: This method may change or be removed in a
-                                      future release without warning. If given, create a model
+        :param registered_model_name: Note:: Experimental: This argument may change or be removed
+                                      in a future release without warning. If given, create a model
                                       version under ``registered_model_name``, also creating a
                                       registered model if one with the given name does not exist.
         :param kwargs: Extra args passed to the model flavor.

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -68,9 +68,10 @@ class Model(object):
         :param flavor: Flavor module to save the model with. The module must have
                        the ``save_model`` function that will persist the model as a valid
                        MLflow model.
-        :param registered_model_name: If given, create a model version under
-                                      ``registered_model_name``, also creating a registered model
-                                      if one with the given name does not exist.
+        :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+                                      future release without warning. If given, create a model
+                                      version under ``registered_model_name``, also creating a
+                                      registered model if one with the given name does not exist.
         :param kwargs: Extra args passed to the model flavor.
         """
         with TempDir() as tmp:

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -232,7 +232,7 @@ def log_model(onnx_model, artifact_path, conda_env=None, registered_model_name=N
                                 'onnxruntime=0.3.0'
                             ]
                         }
-    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+    :param registered_model_name: Note:: Experimental: This argument may change or be removed in a
                                   future release without warning. If given, create a model
                                   version under ``registered_model_name``, also creating a
                                   registered model if one with the given name does not exist.

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -232,9 +232,10 @@ def log_model(onnx_model, artifact_path, conda_env=None, registered_model_name=N
                                 'onnxruntime=0.3.0'
                             ]
                         }
-    :param registered_model_name: If given, create a model version under ``registered_model_name``,
-                                  also creating a registered model if one with the given name does
-                                  not exist.
+    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+                                  future release without warning. If given, create a model
+                                  version under ``registered_model_name``, also creating a
+                                  registered model if one with the given name does not exist.
     """
     Model.log(artifact_path=artifact_path, flavor=mlflow.onnx,
               onnx_model=onnx_model, conda_env=conda_env,

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -664,9 +664,10 @@ def log_model(artifact_path, loader_module=None, data_path=None, code_path=None,
                       path via ``context.artifacts["my_file"]``.
 
                       If ``None``, no artifacts are added to the model.
-    :param registered_model_name: If given, create a model version under ``registered_model_name``,
-                                  also creating a registered model if one with the given name does
-                                  not exist.
+    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+                                  future release without warning. If given, create a model
+                                  version under ``registered_model_name``, also creating a
+                                  registered model if one with the given name does not exist.
     """
     return Model.log(artifact_path=artifact_path,
                      flavor=mlflow.pyfunc,

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -664,7 +664,7 @@ def log_model(artifact_path, loader_module=None, data_path=None, code_path=None,
                       path via ``context.artifacts["my_file"]``.
 
                       If ``None``, no artifacts are added to the model.
-    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+    :param registered_model_name: Note:: Experimental: This argument may change or be removed in a
                                   future release without warning. If given, create a model
                                   version under ``registered_model_name``, also creating a
                                   registered model if one with the given name does not exist.

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -101,9 +101,10 @@ def log_model(pytorch_model, artifact_path, conda_env=None, code_paths=None,
                           ``pytorch_model``. This is passed as the ``pickle_module`` parameter
                           to ``torch.save()``. By default, this module is also used to
                           deserialize ("unpickle") the PyTorch model at load time.
-    :param registered_model_name: If given, create a model version under ``registered_model_name``,
-                                  also creating a registered model if one with the given name does
-                                  not exist.
+    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+                                  future release without warning. If given, create a model
+                                  version under ``registered_model_name``, also creating a
+                                  registered model if one with the given name does not exist.
     :param kwargs: kwargs to pass to ``torch.save`` method.
 
     >>> import torch

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -101,7 +101,7 @@ def log_model(pytorch_model, artifact_path, conda_env=None, code_paths=None,
                           ``pytorch_model``. This is passed as the ``pickle_module`` parameter
                           to ``torch.save()``. By default, this module is also used to
                           deserialize ("unpickle") the PyTorch model at load time.
-    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+    :param registered_model_name: Note:: Experimental: This argument may change or be removed in a
                                   future release without warning. If given, create a model
                                   version under ``registered_model_name``, also creating a
                                   registered model if one with the given name does not exist.

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -173,9 +173,10 @@ def log_model(sk_model, artifact_path, conda_env=None,
                                  format, ``mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE``,
                                  provides better cross-system compatibility by identifying and
                                  packaging code dependencies with the serialized model.
-    :param registered_model_name: If given, create a model version under ``registered_model_name``,
-                                  also creating a registered model if one with the given name does
-                                  not exist.
+    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+                                  future release without warning. If given, create a model
+                                  version under ``registered_model_name``, also creating a
+                                  registered model if one with the given name does not exist.
 
     >>> import mlflow
     >>> import mlflow.sklearn

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -173,7 +173,7 @@ def log_model(sk_model, artifact_path, conda_env=None,
                                  format, ``mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE``,
                                  provides better cross-system compatibility by identifying and
                                  packaging code dependencies with the serialized model.
-    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+    :param registered_model_name: Note:: Experimental: This argument may change or be removed in a
                                   future release without warning. If given, create a model
                                   version under ``registered_model_name``, also creating a
                                   registered model if one with the given name does not exist.

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -94,7 +94,7 @@ def log_model(spark_model, artifact_path, conda_env=None, dfs_tmpdir=None,
     :param sample_input: A sample input used to add the MLeap flavor to the model.
                          This must be a PySpark DataFrame that the model can evaluate. If
                          ``sample_input`` is ``None``, the MLeap flavor is not added.
-    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+    :param registered_model_name: Note:: Experimental: This argument may change or be removed in a
                                   future release without warning. If given, create a model
                                   version under ``registered_model_name``, also creating a
                                   registered model if one with the given name does not exist.

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -94,9 +94,10 @@ def log_model(spark_model, artifact_path, conda_env=None, dfs_tmpdir=None,
     :param sample_input: A sample input used to add the MLeap flavor to the model.
                          This must be a PySpark DataFrame that the model can evaluate. If
                          ``sample_input`` is ``None``, the MLeap flavor is not added.
-    :param registered_model_name: If given, create a model version under ``registered_model_name``,
-                                  also creating a registered model if one with the given name does
-                                  not exist.
+    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+                                  future release without warning. If given, create a model
+                                  version under ``registered_model_name``, also creating a
+                                  registered model if one with the given name does not exist.
 
     >>> from pyspark.ml import Pipeline
     >>> from pyspark.ml.classification import LogisticRegression

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -4,9 +4,9 @@ from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
 from mlflow.utils import experimental
 
 
-@experimental
 class AbstractStore:
     """
+    Note:: Experimental: This entity may change or be removed in a future release without warning.
     Abstract class that defines API interfaces for storing Model Registry metadata.
     """
 

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -1,8 +1,10 @@
 from abc import abstractmethod, ABCMeta
 
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
+from mlflow.utils import experimental
 
 
+@experimental
 class AbstractStore:
     """
     Abstract class that defines API interfaces for storing Model Registry metadata.

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod, ABCMeta
 
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
-from mlflow.utils import experimental
 
 
 class AbstractStore:

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -15,9 +15,9 @@ _PATH_PREFIX = "/api/2.0"
 _METHOD_TO_INFO = extract_api_info_for_service(ModelRegistryService, _PATH_PREFIX)
 
 
-@experimental
 class RestStore(AbstractStore):
     """
+    Note:: Experimental: This entity may change or be removed in a future release without warning.
     Client for a remote model registry server accessed via REST API calls
 
     :param get_host_creds: Method to be invoked prior to every REST request to get the

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -7,7 +7,6 @@ from mlflow.protos.model_registry_pb2 import ModelRegistryService, CreateRegiste
     GetModelVersionStages
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry.abstract_store import AbstractStore
-from mlflow.utils import experimental
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import call_endpoint, extract_api_info_for_service
 

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -7,6 +7,7 @@ from mlflow.protos.model_registry_pb2 import ModelRegistryService, CreateRegiste
     GetModelVersionStages
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry.abstract_store import AbstractStore
+from mlflow.utils import experimental
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import call_endpoint, extract_api_info_for_service
 
@@ -14,6 +15,7 @@ _PATH_PREFIX = "/api/2.0"
 _METHOD_TO_INFO = extract_api_info_for_service(ModelRegistryService, _PATH_PREFIX)
 
 
+@experimental
 class RestStore(AbstractStore):
     """
     Client for a remote model registry server accessed via REST API calls

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -13,6 +13,7 @@ from mlflow.store.db.base_sql_model import Base
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry.abstract_store import AbstractStore
 from mlflow.store.model_registry.dbmodels.models import SqlRegisteredModel, SqlModelVersion
+from mlflow.utils import experimental
 from mlflow.utils.search_utils import SearchUtils
 from mlflow.utils.uri import extract_db_type_from_uri
 
@@ -27,6 +28,7 @@ _logger = logging.getLogger(__name__)
 sqlalchemy.orm.configure_mappers()
 
 
+@experimental
 class SqlAlchemyStore(AbstractStore):
     """
     SQLAlchemy compliant backend store for tracking meta data for MLflow entities. MLflow

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -28,9 +28,9 @@ _logger = logging.getLogger(__name__)
 sqlalchemy.orm.configure_mappers()
 
 
-@experimental
 class SqlAlchemyStore(AbstractStore):
     """
+    Note:: Experimental: This entity may change or be removed in a future release without warning.
     SQLAlchemy compliant backend store for tracking meta data for MLflow entities. MLflow
     supports the database dialects ``mysql``, ``mssql``, ``sqlite``, and ``postgresql``.
     As specified in the

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -13,7 +13,6 @@ from mlflow.store.db.base_sql_model import Base
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry.abstract_store import AbstractStore
 from mlflow.store.model_registry.dbmodels.models import SqlRegisteredModel, SqlModelVersion
-from mlflow.utils import experimental
 from mlflow.utils.search_utils import SearchUtils
 from mlflow.utils.uri import extract_db_type_from_uri
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -114,7 +114,7 @@ def log_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, arti
                                 'tensorflow=1.8.0'
                             ]
                         }
-    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+    :param registered_model_name: Note:: Experimental: This argument may change or be removed in a
                                   future release without warning. If given, create a model
                                   version under ``registered_model_name``, also creating a
                                   registered model if one with the given name does not exist.

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -114,9 +114,10 @@ def log_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_def_key, arti
                                 'tensorflow=1.8.0'
                             ]
                         }
-    :param registered_model_name: If given, create a model version under ``registered_model_name``,
-                                  also creating a registered model if one with the given name does
-                                  not exist.
+    :param registered_model_name: Note:: Experimental: This method may change or be removed in a
+                                  future release without warning. If given, create a model
+                                  version under ``registered_model_name``, also creating a
+                                  registered model if one with the given name does not exist.
     """
     return Model.log(artifact_path=artifact_path, flavor=mlflow.tensorflow,
                      tf_saved_model_dir=tf_saved_model_dir, tf_meta_graph_tags=tf_meta_graph_tags,

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -2,9 +2,11 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, ErrorCode
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.tracking import MlflowClient
+from mlflow.utils import experimental
 from mlflow.utils.logging_utils import eprint
 
 
+@experimental
 def register_model(model_uri, name):
     """
     Create a new model version in model registry for the model files specified by ``model_uri``.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -10,6 +10,7 @@ from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.tracking._model_registry.client import ModelRegistryClient
 from mlflow.tracking._tracking_service import utils
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
+from mlflow.utils import experimental
 
 
 class MlflowClient(object):
@@ -295,6 +296,7 @@ class MlflowClient(object):
 
     # Registered Model Methods
 
+    @experimental
     def create_registered_model(self, name):
         """
         Create a new registered model in backend store.
@@ -305,6 +307,7 @@ class MlflowClient(object):
         """
         return self.registry_client.create_registered_model(name)
 
+    @experimental
     def update_registered_model(self, name, new_name=None, description=None):
         """
         Updates metadata for RegisteredModel entity. Either ``new_name`` or ``description`` should
@@ -317,6 +320,7 @@ class MlflowClient(object):
         """
         return self.registry_client.update_registered_model(name, new_name, description)
 
+    @experimental
     def delete_registered_model(self, name):
         """
         Delete registered model.
@@ -326,6 +330,7 @@ class MlflowClient(object):
         """
         self.registry_client.delete_registered_model(name)
 
+    @experimental
     def list_registered_models(self):
         """
         List of all registered models.
@@ -341,6 +346,7 @@ class MlflowClient(object):
         """
         return self.registry_client.get_registered_model_details(name)
 
+    @experimental
     def get_latest_versions(self, name, stages=None):
         """
         Latest version models for each requests stage. If no ``stages`` provided, returns the
@@ -355,6 +361,7 @@ class MlflowClient(object):
 
     # Model Version Methods
 
+    @experimental
     def create_model_version(self, name, source, run_id):
         """
         Create a new model version from given source or run ID.
@@ -367,6 +374,7 @@ class MlflowClient(object):
         """
         return self.registry_client.create_model_version(name, source, run_id)
 
+    @experimental
     def update_model_version(self, name, version, stage=None, description=None):
         """
         Update metadata associated with a model version in backend.
@@ -378,6 +386,7 @@ class MlflowClient(object):
         """
         self.registry_client.update_model_version(name, version, stage, description)
 
+    @experimental
     def delete_model_version(self, name, version):
         """
         Delete model version in backend.
@@ -387,6 +396,7 @@ class MlflowClient(object):
         """
         self.registry_client.delete_model_version(name, version)
 
+    @experimental
     def get_model_version_details(self, name, version):
         """
         :param name: Name of the containing registered model.
@@ -395,6 +405,7 @@ class MlflowClient(object):
         """
         return self.registry_client.get_model_version_details(name, version)
 
+    @experimental
     def get_model_version_download_uri(self, name, version):
         """
         Get the download location in Model Registry for this model version.
@@ -405,6 +416,7 @@ class MlflowClient(object):
         """
         return self.registry_client.get_model_version_download_uri(name, version)
 
+    @experimental
     def search_model_versions(self, filter_string):
         """
         Search for model versions in backend that satisfy the filter criteria.
@@ -416,6 +428,7 @@ class MlflowClient(object):
         """
         return self.registry_client.search_model_versions(filter_string)
 
+    @experimental
     def get_model_version_stages(self, name, version):
         """
         :return: A list of valid stages.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Marking the following as `experimental`
- Python fluent and client APIs for Model Registry
- `registered_model_name` argument for `mlflow.XXX.log_model`
- Model Registry entity classes
- Model Registry stores APIs

[**NOTE**: Will mark REST API as experiment in a different PR, which can be independently reverted]

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
