### PR TITLE
Add missing import in search docs

### DIFF
--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -156,6 +156,7 @@ with 10 layers and had a prediction accuracy of 94.5% or higher, use:
 .. code-block:: py
 
   from mlflow.tracking.client import MlflowClient
+  from mlflow.entities import ViewType
 
   query = "params.model = 'CNN' and params.layers = '10' and metrics.'prediction accuracy' >= 0.945"
   runs = MlflowClient().search_runs(["3", "4", "17"], query, ViewType.ACTIVE_ONLY)
@@ -165,6 +166,7 @@ To search all known experiments for any MLflow runs created using the Inception 
 .. code-block:: py
 
   from mlflow.tracking.client import MlflowClient
+  from mlflow.entities import ViewType
 
   all_experiments = [exp.experiment_id for exp in MlflowClient().list_experiments()]
   runs = MlflowClient().search_runs(all_experiments, "params.model = 'Inception'", ViewType.ALL)


### PR DESCRIPTION
## What changes are proposed in this pull request?

In Python example for using search import of ViewType was missing, I've added it.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [x] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
