### PR TITLE
Avoid unnecessary copy from / to DFS when loading spark models.

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -239,7 +239,7 @@ class _HadoopFileSystem:
         """
         parsed_uri = urllib.parse.urlparse(src_uri)
         try:
-            if (src_uri == cls._fs().makeQualified(parsed_uri.path).toString()
+            if (src_uri == cls._fs().makeQualified(cls._remote_path(parsed_uri.path)).toString()
                     and cls._fs().exists(cls._remote_path(src_uri))):
                 print("FILE is already on DFS, skipping unnecessary copy.")
                 _logger.info("File '%s' is already on DFS, copy is not necessary.", src_uri)

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -233,7 +233,7 @@ class _HadoopFileSystem:
     @classmethod
     def _try_file_exists(cls, dfs_path):
         try:
-            return cls._fs().exists(dfs_path):
+            return cls._fs().exists(dfs_path)
         except Exception as ex:  # pylint: disable=broad-except
             _logger.warning(
                 "Unexpected exception '%s' while checking if model uri is visible on "

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -241,7 +241,7 @@ class _HadoopFileSystem:
             if parsed_uri.scheme and cls._fs().exists(cls._remote_path(src_uri)):
                 _logger.info("File '%s' already on DFS, copy is not necessary.", src_uri)
                 return src_uri
-        except:
+        except:  # pylint: disable=broad-except
             pass
         return cls.maybe_copy_from_local_file(_download_artifact_from_uri(src_uri), dst_path)
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -240,7 +240,7 @@ class _HadoopFileSystem:
         parsed_uri = urllib.parse.urlparse(src_uri)
         try:
             if parsed_uri.scheme and cls._fs().exists(cls._remote_path(src_uri)):
-                _logger.info("File '%s' already on DFS, copy is not necessary.", src_uri)
+                _logger.info("File '%s' is already on DFS, copy is not necessary.", src_uri)
                 return src_uri
         except Exception as ex:  # pylint: disable=broad-except
             _logger.warning("Unexpected exception '%s' while checking if model uri is visible on "

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -236,8 +236,8 @@ class _HadoopFileSystem:
             return cls._fs().exists(dfs_path)
         except Exception as ex:  # pylint: disable=broad-except
             _logger.warning(
-                "Unexpected exception '%s' while checking if model uri is visible on "
-                "DFS. Will attempt to upload the model to DFS.", ex)
+                "Unexpected exception while checking if model uri is visible on "
+                "DFS: ", ex)
         return False
 
     @classmethod

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -229,7 +229,6 @@ class _HadoopFileSystem:
         _logger.info("Copied SparkML model to %s", dst)
         return dst
 
-
     @classmethod
     def _try_file_exists(cls, dfs_path):
         try:

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -241,7 +241,7 @@ class _HadoopFileSystem:
             if parsed_uri.scheme and cls._fs().exists(cls._remote_path(src_uri)):
                 _logger.info("File '%s' already on DFS, copy is not necessary.", src_uri)
                 return src_uri
-        except:  # pylint: disable=broad-except
+        except:  # pylint: disable=W0702
             pass
         return cls.maybe_copy_from_local_file(_download_artifact_from_uri(src_uri), dst_path)
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -235,11 +235,19 @@ class _HadoopFileSystem:
 
         :return: If copied, return new target location, otherwise return source uri.
         """
-        if cls._fs().exists(cls._remote_path(src_uri)):
-            _logger.info("File '%s' already on DFS, copy is not necessary.", src_uri)
-            return src_uri
-        else:
-            return cls.maybe_copy_from_local_file(_download_artifact_from_uri(src_uri), dst_path)
+        import urllib
+        parsed_uri = urllib.parse.urlparse(src_uri)
+        try:
+            if parsed_uri.scheme and cls._fs().exists(cls._remote_path(src_uri)):
+                print(" ")
+                print("*** file already on dfs **")
+                print(" ")
+                _logger.info("File '%s' already on DFS, copy is not necessary.", src_uri)
+                return src_uri
+        except:
+            pass
+        raise Exception("file should be on dfs")
+        return cls.maybe_copy_from_local_file(_download_artifact_from_uri(src_uri), dst_path)
 
 
     @classmethod

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -252,7 +252,6 @@ class _HadoopFileSystem:
             # makeQualified throws if wrong schema / uri
             dfs_path = cls._fs().makeQualified(cls._remote_path(src_uri))
             if cls._try_file_exists(dfs_path):
-                print("FILE is already on DFS, skipping unnecessary copy.")
                 _logger.info("File '%s' is already on DFS, copy is not necessary.", src_uri)
                 return src_uri
         except Exception:  # pylint: disable=broad-except

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -235,7 +235,7 @@ class _HadoopFileSystem:
 
         :return: If copied, return new target location, otherwise return source uri.
         """
-        if cls._fs().exists(src_uri):
+        if cls._fs().exists(cls._remote_path(src_uri)):
             _logger.info("File '%s' already on DFS, copy is not necessary.", src_uri)
             return src_uri
         else:

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -239,16 +239,11 @@ class _HadoopFileSystem:
         parsed_uri = urllib.parse.urlparse(src_uri)
         try:
             if parsed_uri.scheme and cls._fs().exists(cls._remote_path(src_uri)):
-                print(" ")
-                print("*** file already on dfs **")
-                print(" ")
                 _logger.info("File '%s' already on DFS, copy is not necessary.", src_uri)
                 return src_uri
         except:
             pass
-        raise Exception("file should be on dfs")
         return cls.maybe_copy_from_local_file(_download_artifact_from_uri(src_uri), dst_path)
-
 
     @classmethod
     def delete(cls, path):
@@ -290,9 +285,9 @@ def _validate_model(spark_model):
             or not isinstance(spark_model, MLReadable) \
             or not isinstance(spark_model, MLWritable):
         raise MlflowException(
-                "Cannot serialize this model. MLFlow can only save descendants of pyspark.Model"
-                "that implement MLWritable and MLReadable.",
-                INVALID_PARAMETER_VALUE)
+            "Cannot serialize this model. MLFlow can only save descendants of pyspark.Model"
+            "that implement MLWritable and MLReadable.",
+            INVALID_PARAMETER_VALUE)
 
 
 def save_model(spark_model, path, mlflow_model=Model(), conda_env=None,
@@ -405,8 +400,9 @@ def load_model(model_uri, dfs_tmpdir=None):
     flavor_conf = model_conf.flavors[FLAVOR_NAME]
     model_uri = posixpath.join(model_uri, flavor_conf["model_data"])
     if RunsArtifactRepository.is_runs_uri(model_uri):
-        _logger.info("runs uri resolved as '%s'", model_uri)
+        runs_uri = model_uri
         model_uri = RunsArtifactRepository.get_underlying_uri(model_uri)
+        _logger.info("'%s' resolved as '%s'", runs_uri, model_uri)
     return _load_model(model_uri=model_uri, dfs_tmpdir=dfs_tmpdir)
 
 
@@ -424,7 +420,7 @@ def _load_pyfunc(path):
 
     spark = pyspark.sql.SparkSession._instantiatedSession
     if spark is None:
-        spark = pyspark.sql.SparkSession.builder.config("spark.python.worker.reuse", True)\
+        spark = pyspark.sql.SparkSession.builder.config("spark.python.worker.reuse", True) \
             .master("local[1]").getOrCreate()
     return _PyFuncModelWrapper(spark, _load_model(model_uri=path))
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -255,8 +255,8 @@ class _HadoopFileSystem:
                 _logger.info("File '%s' is already on DFS, copy is not necessary.", src_uri)
                 return src_uri
         except Exception:  # pylint: disable=broad-except
-            _logger.info("URI '%s' does not point to the current DFS.")
-        _logger.info("File '%s' not found on DFS. Will attempt to upload the file.")
+            _logger.info("URI '%s' does not point to the current DFS.", src_uri)
+        _logger.info("File '%s' not found on DFS. Will attempt to upload the file.", src_uri)
         return cls.maybe_copy_from_local_file(_download_artifact_from_uri(src_uri), dst_path)
 
     @classmethod

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -237,7 +237,7 @@ class _HadoopFileSystem:
         except Exception as ex:  # pylint: disable=broad-except
             _logger.warning(
                 "Unexpected exception while checking if model uri is visible on "
-                "DFS: ", ex)
+                "DFS: %s", ex)
         return False
 
     @classmethod

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -239,7 +239,8 @@ class _HadoopFileSystem:
         """
         parsed_uri = urllib.parse.urlparse(src_uri)
         try:
-            if parsed_uri.scheme and cls._fs().exists(cls._remote_path(src_uri)):
+            if (src_uri == cls._fs().makeQualified(parsed_uri.path).toString()
+                    and cls._fs().exists(cls._remote_path(src_uri))):
                 _logger.info("File '%s' is already on DFS, copy is not necessary.", src_uri)
                 return src_uri
         except Exception as ex:  # pylint: disable=broad-except

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -241,6 +241,7 @@ class _HadoopFileSystem:
         try:
             if (src_uri == cls._fs().makeQualified(parsed_uri.path).toString()
                     and cls._fs().exists(cls._remote_path(src_uri))):
+                print("FILE is already on DFS, skipping unnecessary copy.")
                 _logger.info("File '%s' is already on DFS, copy is not necessary.", src_uri)
                 return src_uri
         except Exception as ex:  # pylint: disable=broad-except

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -25,7 +25,6 @@ import os
 import yaml
 import logging
 import posixpath
-from six.moves import urllib
 
 import mlflow
 from mlflow import pyfunc, mleap

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -48,10 +48,10 @@ def _get_flavor_configuration_from_uri(model_uri, flavor_name):
     try:
         ml_model_file = _download_artifact_from_uri(
             artifact_uri=posixpath.join(model_uri, "MLmodel"))
-    except:
+    except Exception as ex:
         raise MlflowException(
-            "Failed to download an \"MLmodel\" model file from \"{model_uri}\"".format(
-                model_uri=model_uri),
+            "Failed to download an \"MLmodel\" model file from \"{model_uri}\": {ex}".format(
+                model_uri=model_uri, ex=ex),
             RESOURCE_DOES_NOT_EXIST)
     model_conf = Model.load(ml_model_file)
     if flavor_name not in model_conf.flavors:

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -5,7 +5,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 
 
 def _get_flavor_configuration(model_path, flavor_name):

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -1,8 +1,11 @@
 import os
+import posixpath
 
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 
 
 def _get_flavor_configuration(model_path, flavor_name):
@@ -19,14 +22,41 @@ def _get_flavor_configuration(model_path, flavor_name):
     model_configuration_path = os.path.join(model_path, "MLmodel")
     if not os.path.exists(model_configuration_path):
         raise MlflowException(
-                "Could not find an \"MLmodel\" configuration file at \"{model_path}\"".format(
-                    model_path=model_path),
-                RESOURCE_DOES_NOT_EXIST)
+            "Could not find an \"MLmodel\" configuration file at \"{model_path}\"".format(
+                model_path=model_path),
+            RESOURCE_DOES_NOT_EXIST)
 
     model_conf = Model.load(model_configuration_path)
     if flavor_name not in model_conf.flavors:
         raise MlflowException(
-                "Model does not have the \"{flavor_name}\" flavor".format(flavor_name=flavor_name),
-                RESOURCE_DOES_NOT_EXIST)
+            "Model does not have the \"{flavor_name}\" flavor".format(flavor_name=flavor_name),
+            RESOURCE_DOES_NOT_EXIST)
     conf = model_conf.flavors[flavor_name]
     return conf
+
+
+def _get_flavor_configuration_from_uri(model_uri, flavor_name):
+    """
+    Obtains the configuration for the specified flavor from the specified
+    MLflow model uri. If the model does not contain the specified flavor,
+    an exception will be thrown.
+
+    :param model_uri: The path to the root directory of the MLflow model for which to load
+                       the specified flavor configuration.
+    :param flavor_name: The name of the flavor configuration to load.
+    :return: The flavor configuration as a dictionary.
+    """
+    try:
+        ml_model_file = _download_artifact_from_uri(
+            artifact_uri=posixpath.join(model_uri, "MLmodel"))
+    except:
+        raise MlflowException(
+            "Could not find an \"MLmodel\" configuration file at \"{model_uri}\"".format(
+                model_uri=model_uri),
+            RESOURCE_DOES_NOT_EXIST)
+    model_conf = Model.load(ml_model_file)
+    if flavor_name not in model_conf.flavors:
+        raise MlflowException(
+            "Model does not have the \"{flavor_name}\" flavor".format(flavor_name=flavor_name),
+            RESOURCE_DOES_NOT_EXIST)
+    return model_conf.flavors[flavor_name]

--- a/mlflow/utils/model_utils.py
+++ b/mlflow/utils/model_utils.py
@@ -50,7 +50,7 @@ def _get_flavor_configuration_from_uri(model_uri, flavor_name):
             artifact_uri=posixpath.join(model_uri, "MLmodel"))
     except:
         raise MlflowException(
-            "Could not find an \"MLmodel\" configuration file at \"{model_uri}\"".format(
+            "Failed to download an \"MLmodel\" model file from \"{model_uri}\"".format(
                 model_uri=model_uri),
             RESOURCE_DOES_NOT_EXIST)
     model_conf = Model.load(ml_model_file)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Spark models are read in a distributed task from the associated DFS. Currently, MLflow will always copy the model locally first and subsequently upload it to a temporary DFS location. However, the model is often already stored on the same DFS and we can skip the unnecessary copying to improve model loading time.

## How is this patch tested?
Integration tests.

## Release Notes
N/A
### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
Spark models will load faster from DFS.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [x] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
