### PR TITLE
Added default value to alpha in sklearn_elasticnet_wine

### DIFF
--- a/examples/sklearn_elasticnet_wine/MLproject
+++ b/examples/sklearn_elasticnet_wine/MLproject
@@ -5,6 +5,6 @@ conda_env: conda.yaml
 entry_points:
   main:
     parameters:
-      alpha: float
+      alpha: {type: float, default: 0.5}
       l1_ratio: {type: float, default: 0.1}
     command: "python train.py {alpha} {l1_ratio}"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added default value to alpha in sklearn_elasticnet_wine to resolve the issue outlined in #2012. A small error I encountered while setting up remote execution. 

## How is this patch tested?

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
