### PR TITLE
Expose mlflow.tracking.is_tracking_uri_set()

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -61,6 +61,7 @@ set_tracking_uri = tracking.set_tracking_uri
 get_experiment = mlflow.tracking.fluent.get_experiment
 get_experiment_by_name = mlflow.tracking.fluent.get_experiment_by_name
 get_tracking_uri = tracking.get_tracking_uri
+is_tracking_uri_set = tracking.is_tracking_uri_set
 create_experiment = mlflow.tracking.fluent.create_experiment
 set_experiment = mlflow.tracking.fluent.set_experiment
 log_params = mlflow.tracking.fluent.log_params

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -61,7 +61,6 @@ set_tracking_uri = tracking.set_tracking_uri
 get_experiment = mlflow.tracking.fluent.get_experiment
 get_experiment_by_name = mlflow.tracking.fluent.get_experiment_by_name
 get_tracking_uri = tracking.get_tracking_uri
-is_tracking_uri_set = tracking.is_tracking_uri_set
 create_experiment = mlflow.tracking.fluent.create_experiment
 set_experiment = mlflow.tracking.fluent.set_experiment
 log_params = mlflow.tracking.fluent.log_params

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -7,10 +7,10 @@ For a higher level API for managing an "active run", use the :py:mod:`mlflow` mo
 
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking._tracking_service.utils import (
-    set_tracking_uri, 
+    set_tracking_uri,
     get_tracking_uri,
     is_tracking_uri_set,
-    _get_store, 
+    _get_store,
     _TRACKING_URI_ENV_VAR
 )
 from mlflow.tracking.fluent import _EXPERIMENT_ID_ENV_VAR, _EXPERIMENT_NAME_ENV_VAR, \

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -6,8 +6,13 @@ For a higher level API for managing an "active run", use the :py:mod:`mlflow` mo
 """
 
 from mlflow.tracking.client import MlflowClient
-from mlflow.tracking._tracking_service.utils import set_tracking_uri, get_tracking_uri, \
-    _get_store, _TRACKING_URI_ENV_VAR
+from mlflow.tracking._tracking_service.utils import (
+    set_tracking_uri, 
+    get_tracking_uri,
+    is_tracking_uri_set,
+    _get_store, 
+    _TRACKING_URI_ENV_VAR
+)
 from mlflow.tracking.fluent import _EXPERIMENT_ID_ENV_VAR, _EXPERIMENT_NAME_ENV_VAR, \
     _RUN_ID_ENV_VAR
 
@@ -15,6 +20,7 @@ __all__ = [
     "MlflowClient",
     "get_tracking_uri",
     "set_tracking_uri",
+    "is_tracking_uri_set",
     "_get_store",
     "_EXPERIMENT_ID_ENV_VAR",
     "_RUN_ID_ENV_VAR",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes:
https://github.com/mlflow/mlflow/issues/2005

## How is this patch tested?

On our Criteo Mlflow server

## Release Notes

### Is this a user-facing change?

- [] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Exposed `mlflow.tracking.is_tracking_uri_set()` to determine whether or not the tracking URI is set via environment variable or `set_tracking_uri`. This is distinct from `get_tracking_uri`, which will return a default value if the URI is not set.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
