### PR TITLE
Push filter function from Python to SQL

### DIFF
--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -152,6 +152,12 @@ class SqlRun(Base):
 
     @staticmethod
     def get_attribute_name(mlflow_attribute_name):
+        """
+        Resolves an MLflow attribute name to a `SqlRun` attribute name.
+        """
+        # Currently, MLflow Search attributes defined in `SearchUtils.VALID_SEARCH_ATTRIBUTE_KEYS`
+        # share the same names as their corresponding `SqlRun` attributes. Therefore, this function
+        # returns the same attribute name
         return mlflow_attribute_name
 
     def to_mlflow_entity(self):

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -150,6 +150,10 @@ class SqlRun(Base):
         PrimaryKeyConstraint('run_uuid', name='run_pk')
     )
 
+    @staticmethod
+    def get_attribute_name(mlflow_attribute_name):
+        return mlflow_attribute_name
+
     def to_mlflow_entity(self):
         """
         Convert DB model to corresponding MLflow entity.

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -583,22 +583,28 @@ class SqlAlchemyStore(AbstractStore):
                                   INVALID_PARAMETER_VALUE)
 
         stages = set(LifecycleStage.view_type_to_stages(run_view_type))
+
         with self.ManagedSessionMaker() as session:
             # Fetch the appropriate runs and eagerly load their summary metrics, params, and
             # tags. These run attributes are referenced during the invocation of
             # ``run.to_mlflow_entity()``, so eager loading helps avoid additional database queries
             # that are otherwise executed at attribute access time under a lazy loading model.
-            queried_runs = session \
-                .query(SqlRun) \
+            query = session.query(SqlRun)
+
+            parsed = SearchUtils.parse_search_filter(filter_string)
+            for s in _get_sqlalchemy_filter_clauses(parsed, session):
+                query = query.join(s)
+
+            queried_runs = query.distinct() \
                 .options(*self._get_eager_run_query_options()) \
                 .filter(
                     SqlRun.experiment_id.in_(experiment_ids),
-                    SqlRun.lifecycle_stage.in_(stages)) \
+                    SqlRun.lifecycle_stage.in_(stages),
+                    *_get_attributes_filtering_clauses(parsed)) \
                 .all()
             runs = [run.to_mlflow_entity() for run in queried_runs]
 
-        filtered = SearchUtils.filter(runs, filter_string)
-        sorted_runs = SearchUtils.sort(filtered, order_by)
+        sorted_runs = SearchUtils.sort(runs, order_by)
         runs, next_page_token = SearchUtils.paginate(sorted_runs, page_token, max_results)
         return runs, next_page_token
 
@@ -620,3 +626,77 @@ class SqlAlchemyStore(AbstractStore):
             raise e
         except Exception as e:
             raise MlflowException(e, INTERNAL_ERROR)
+
+    def update_artifacts_location(self, run_id, new_artifacts_location):
+        """
+        Update the location of artifacts for the specified run
+
+        :param run_id: String id for the run
+        :param new_artifact_location: String new artifact location
+
+        :return: None
+        """
+        with self.ManagedSessionMaker() as session:
+            run = session.query(SqlRun).filter_by(run_uuid=run_id).first()
+            run.artifact_uri = new_artifacts_location
+
+
+def _get_attributes_filtering_clauses(parsed):
+    clauses = []
+    for sql_statement in parsed:
+        key_type = sql_statement.get('type')
+        key_name = sql_statement.get('key')
+        value = sql_statement.get('value')
+        comparator = sql_statement.get('comparator')
+        if SearchUtils.is_attribute(key_type, comparator):
+            # validity of the comparator is checked in SearchUtils.parse_search_filter()
+            op = SearchUtils.filter_ops.get(comparator)
+            if op:
+                # key_name is guaranteed to be a valid searchable attribute of entities.RunInfo
+                # by the call to parse_search_filter
+                attribute_name = SqlRun.get_attribute_name(key_name)
+                clauses.append(op(getattr(SqlRun, attribute_name), value))
+    return clauses
+
+
+def _to_sqlalchemy_filtering_statement(sql_statement, session):
+    key_type = sql_statement.get('type')
+    key_name = sql_statement.get('key')
+    value = sql_statement.get('value')
+    comparator = sql_statement.get('comparator')
+
+    if SearchUtils.is_metric(key_type, comparator):
+        entity = SqlLatestMetric
+        value = float(value)
+    elif SearchUtils.is_param(key_type, comparator):
+        entity = SqlParam
+    elif SearchUtils.is_tag(key_type, comparator):
+        entity = SqlTag
+    elif SearchUtils.is_attribute(key_type, comparator):
+        return None
+    else:
+        raise MlflowException("Invalid search expression type '%s'" % key_type,
+                              error_code=INVALID_PARAMETER_VALUE)
+
+    # validity of the comparator is checked in SearchUtils.parse_search_filter()
+    op = SearchUtils.filter_ops.get(comparator)
+    if op:
+        return (
+            session
+            .query(entity)
+            .filter(entity.key == key_name, op(entity.value, value))
+            .subquery()
+        )
+    else:
+        return None
+
+
+def _get_sqlalchemy_filter_clauses(parsed, session):
+    """creates SqlAlchemy subqueries
+    that will be inner-joined to SQLRun to act as multi-clause filters."""
+    filters = []
+    for sql_statement in parsed:
+        filter_query = _to_sqlalchemy_filtering_statement(sql_statement, session)
+        if filter_query is not None:
+            filters.append(filter_query)
+    return filters

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -627,19 +627,6 @@ class SqlAlchemyStore(AbstractStore):
         except Exception as e:
             raise MlflowException(e, INTERNAL_ERROR)
 
-    def update_artifacts_location(self, run_id, new_artifacts_location):
-        """
-        Update the location of artifacts for the specified run
-
-        :param run_id: String id for the run
-        :param new_artifact_location: String new artifact location
-
-        :return: None
-        """
-        with self.ManagedSessionMaker() as session:
-            run = session.query(SqlRun).filter_by(run_uuid=run_id).first()
-            run.artifact_uri = new_artifacts_location
-
 
 def _get_attributes_filtering_clauses(parsed):
     clauses = []

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1,5 +1,7 @@
 import base64
 import json
+import operator
+
 import sqlparse
 from sqlparse.sql import Identifier, Token, Comparison, Statement
 from sqlparse.tokens import Token as TokenType
@@ -34,6 +36,15 @@ class SearchUtils(object):
                              + list(_ALTERNATE_ATTRIBUTE_IDENTIFIERS))
     STRING_VALUE_TYPES = set([TokenType.Literal.String.Single])
     NUMERIC_VALUE_TYPES = set([TokenType.Literal.Number.Integer, TokenType.Literal.Number.Float])
+
+    filter_ops = {
+        '>': operator.gt,
+        '>=': operator.ge,
+        '=': operator.eq,
+        '!=': operator.ne,
+        '<=': operator.le,
+        '<': operator.lt,
+    }
 
     @classmethod
     def _trim_ends(cls, string_value):
@@ -183,7 +194,7 @@ class SearchUtils(object):
         return [cls._get_comparison(si) for si in statement.tokens if isinstance(si, Comparison)]
 
     @classmethod
-    def _parse_search_filter(cls, filter_string):
+    def parse_search_filter(cls, filter_string):
         if not filter_string:
             return []
         try:
@@ -201,53 +212,68 @@ class SearchUtils(object):
         return SearchUtils._process_statement(parsed[0])
 
     @classmethod
-    def _does_run_match_clause(cls, run, sed):
-        key_type = sed.get('type')
-        key = sed.get('key')
-        value = sed.get('value')
-        comparator = sed.get('comparator')
+    def is_metric(cls, key_type, comparator):
         if key_type == cls._METRIC_IDENTIFIER:
             if comparator not in cls.VALID_METRIC_COMPARATORS:
                 raise MlflowException("Invalid comparator '%s' "
                                       "not one of '%s" % (comparator,
                                                           cls.VALID_METRIC_COMPARATORS),
                                       error_code=INVALID_PARAMETER_VALUE)
-            lhs = run.data.metrics.get(key, None)
-            value = float(value)
-        elif key_type == cls._PARAM_IDENTIFIER:
+            return True
+        return False
+
+    @classmethod
+    def is_param(cls, key_type, comparator):
+        if key_type == cls._PARAM_IDENTIFIER:
             if comparator not in cls.VALID_PARAM_COMPARATORS:
                 raise MlflowException("Invalid comparator '%s' "
                                       "not one of '%s'" % (comparator, cls.VALID_PARAM_COMPARATORS),
                                       error_code=INVALID_PARAMETER_VALUE)
-            lhs = run.data.params.get(key, None)
-        elif key_type == cls._TAG_IDENTIFIER:
+            return True
+        return False
+
+    @classmethod
+    def is_tag(cls, key_type, comparator):
+        if key_type == cls._TAG_IDENTIFIER:
             if comparator not in cls.VALID_TAG_COMPARATORS:
                 raise MlflowException("Invalid comparator '%s' "
                                       "not one of '%s" % (comparator, cls.VALID_TAG_COMPARATORS))
-            lhs = run.data.tags.get(key, None)
-        elif key_type == cls._ATTRIBUTE_IDENTIFIER:
+            return True
+        return False
+
+    @classmethod
+    def is_attribute(cls, key_type, comparator):
+        if key_type == cls._ATTRIBUTE_IDENTIFIER:
             if comparator not in cls.VALID_STRING_ATTRIBUTE_COMPARATORS:
                 raise MlflowException("Invalid comparator '{}' not one of "
                                       "'{}".format(comparator,
                                                    cls.VALID_STRING_ATTRIBUTE_COMPARATORS))
+            return True
+        return False
+
+    @classmethod
+    def _does_run_match_clause(cls, run, sed):
+        key_type = sed.get('type')
+        key = sed.get('key')
+        value = sed.get('value')
+        comparator = sed.get('comparator')
+
+        if cls.is_metric(key_type, comparator):
+            lhs = run.data.metrics.get(key, None)
+            value = float(value)
+        elif cls.is_param(key_type, comparator):
+            lhs = run.data.params.get(key, None)
+        elif cls.is_tag(key_type, comparator):
+            lhs = run.data.tags.get(key, None)
+        elif cls.is_attribute(key_type, comparator):
             lhs = getattr(run.info, key)
         else:
             raise MlflowException("Invalid search expression type '%s'" % key_type,
                                   error_code=INVALID_PARAMETER_VALUE)
         if lhs is None:
             return False
-        elif comparator == '>':
-            return lhs > value
-        elif comparator == '>=':
-            return lhs >= value
-        elif comparator == '=':
-            return lhs == value
-        elif comparator == '!=':
-            return lhs != value
-        elif comparator == '<=':
-            return lhs <= value
-        elif comparator == '<':
-            return lhs < value
+        if comparator in cls.filter_ops.keys():
+            return cls.filter_ops.get(comparator)(lhs, value)
         else:
             return False
 
@@ -256,7 +282,7 @@ class SearchUtils(object):
         """Filters a set of runs based on a search filter string."""
         if not filter_string:
             return runs
-        parsed = cls._parse_search_filter(filter_string)
+        parsed = cls.parse_search_filter(filter_string)
 
         def run_matches(run):
             return all([cls._does_run_match_clause(run, s) for s in parsed])

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1339,28 +1339,25 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                 fetched_run = store.get_run(run_id=run_id)
                 assert fetched_run.data.metrics == expected_metrics
 
-    def test_search_runs_returns_expected_results_with_large_experiment(self):
-        """
-        This case tests the SQLAlchemyStore implementation of the SearchRuns API to ensure
-        that search queries over an experiment containing many runs, each with a large number
-        of metrics, parameters, and tags, are performant and return the expected results.
-        """
+    def _generate_large_data(self, nb_runs=1000):
         experiment_id = self.store.create_experiment('test_experiment')
         run_ids = []
-        for _ in range(1000):
+        for _ in range(nb_runs):
             run_ids.append(self.store.create_run(
                 experiment_id=experiment_id,
                 start_time=time.time(),
                 tags=(),
                 user_id='Anderson').info.run_uuid)
 
+        current_run = 0
         metrics_list = []
         tags_list = []
         params_list = []
+        latest_metrics_list = []
         for run_id in run_ids:
             for i in range(100):
                 metric = {
-                    'key': 'mkey-%s' % i,
+                    'key': 'mkey_%s' % i,
                     'value': i,
                     'timestamp': i * 2,
                     'step': i * 3,
@@ -1369,27 +1366,78 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                 }
                 metrics_list.append(metric)
                 tag = {
-                    'key': "tkey-%s" % i,
-                    'value': "tval-%s" % i,
+                    'key': "tkey_%s" % i,
+                    'value': "tval_%s" % (current_run % 10),
                     'run_uuid': run_id,
                 }
                 tags_list.append(tag)
                 param = {
-                    'key': "pkey-%s" % i,
-                    'value': "pval-%s" % i,
+                    'key': "pkey_%s" % i,
+                    'value': "pval_%s" % ((current_run + 1) % 11),
                     'run_uuid': run_id,
                 }
                 params_list.append(param)
+            latest_metrics_list.append(
+                {
+                    'key': 'mkey_0',
+                    'value': current_run,
+                    'timestamp': 100 * 2,
+                    'step': 100 * 3,
+                    'is_nan': 0,
+                    'run_uuid': run_id,
+                }
+            )
+            current_run += 1
         metrics = pd.DataFrame(metrics_list)
         metrics.to_sql('metrics', self.store.engine, if_exists='append', index=False)
         params = pd.DataFrame(params_list)
         params.to_sql('params', self.store.engine, if_exists='append', index=False)
         tags = pd.DataFrame(tags_list)
         tags.to_sql('tags', self.store.engine, if_exists='append', index=False)
+        pd.DataFrame(latest_metrics_list).to_sql(
+            'latest_metrics', self.store.engine, if_exists='append', index=False)
+        return experiment_id, run_ids
+
+    def test_search_runs_returns_expected_results_with_large_experiment(self):
+        """
+        This case tests the SQLAlchemyStore implementation of the SearchRuns API to ensure
+        that search queries over an experiment containing many runs, each with a large number
+        of metrics, parameters, and tags, are performant and return the expected results.
+        """
+        experiment_id, run_ids = self._generate_large_data()
 
         run_results = self.store.search_runs([experiment_id], None, ViewType.ALL, max_results=100)
-        assert len(run_results) > 0
+        assert len(run_results) == 100
         assert set([run.info.run_id for run in run_results]).issubset(set(run_ids))
+
+    def test_search_runs_correctly_filters_large_data(self):
+        experiment_id, _ = self._generate_large_data(1000)
+
+        run_results = self.store.search_runs([experiment_id],
+                                             "metrics.mkey_0 < 26 and metrics.mkey_0 > 5 ",
+                                             ViewType.ALL, max_results=1000)
+        assert len(run_results) == 20
+
+        run_results = self.store.search_runs([experiment_id],
+                                             "metrics.mkey_0 < 26 and metrics.mkey_0 > 5 "
+                                             "and tags.tkey_0 = 'tval_0' ",
+                                             ViewType.ALL, max_results=1000)
+        assert len(run_results) == 2  # 20 runs between 9 and 26, 2 of which have a 0 tkey_0 value
+
+        run_results = self.store.search_runs([experiment_id],
+                                             "metrics.mkey_0 < 26 and metrics.mkey_0 > 5 "
+                                             "and tags.tkey_0 = 'tval_0' "
+                                             "and params.pkey_0 = 'pval_0'",
+                                             ViewType.ALL, max_results=1000)
+        assert len(run_results) == 1  # 2 runs on previous request, 1 of which has a 0 pkey_0 value
+
+    def test_get_attribute_name(self):
+        assert(models.SqlRun.get_attribute_name("artifact_uri") == "artifact_uri")
+        assert(models.SqlRun.get_attribute_name("status") == "status")
+
+        # we want this to break if a searchable attribute has been added
+        # and not referred to in this test
+        assert(len(entities.RunInfo.get_searchable_attributes()) == 2)
 
 
 class TestSqlAlchemyStoreSqliteMigratedDB(TestSqlAlchemyStoreSqlite):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1431,14 +1431,6 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                                              ViewType.ALL, max_results=1000)
         assert len(run_results) == 1  # 2 runs on previous request, 1 of which has a 0 pkey_0 value
 
-    def test_get_attribute_name(self):
-        assert(models.SqlRun.get_attribute_name("artifact_uri") == "artifact_uri")
-        assert(models.SqlRun.get_attribute_name("status") == "status")
-
-        # we want this to break if a searchable attribute has been added
-        # and not referred to in this test
-        assert(len(entities.RunInfo.get_searchable_attributes()) == 2)
-
 
 class TestSqlAlchemyStoreSqliteMigratedDB(TestSqlAlchemyStoreSqlite):
     """
@@ -1529,3 +1521,12 @@ class TestZeroValueInsertion(unittest.TestCase):
         SqlAlchemyStore._unset_zero_value_insertion_for_autoincrement_column(mock_store,
                                                                              mock_session)
         mock_session.execute.assert_called_with("SET IDENTITY_INSERT experiments OFF;")
+
+
+def test_get_attribute_name():
+    assert(models.SqlRun.get_attribute_name("artifact_uri") == "artifact_uri")
+    assert(models.SqlRun.get_attribute_name("status") == "status")
+
+    # we want this to break if a searchable attribute has been added
+    # and not referred to in this test
+    assert(len(entities.RunInfo.get_searchable_attributes()) == 2)

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -74,7 +74,7 @@ from mlflow.utils.search_utils import SearchUtils
                                  'value': 'RUNNING'}]),
 ])
 def test_filter(filter_string, parsed_filter):
-    assert SearchUtils._parse_search_filter(filter_string) == parsed_filter
+    assert SearchUtils.parse_search_filter(filter_string) == parsed_filter
 
 
 @pytest.mark.parametrize("filter_string, parsed_filter", [
@@ -85,7 +85,7 @@ def test_filter(filter_string, parsed_filter):
                                'key': 'm', 'value': "L'Hosp"}]),
 ])
 def test_correct_quote_trimming(filter_string, parsed_filter):
-    assert SearchUtils._parse_search_filter(filter_string) == parsed_filter
+    assert SearchUtils.parse_search_filter(filter_string) == parsed_filter
 
 
 @pytest.mark.parametrize("filter_string, error_message", [
@@ -117,7 +117,7 @@ def test_correct_quote_trimming(filter_string, parsed_filter):
 ])
 def test_error_filter(filter_string, error_message):
     with pytest.raises(MlflowException) as e:
-        SearchUtils._parse_search_filter(filter_string)
+        SearchUtils.parse_search_filter(filter_string)
     assert error_message in e.value.message
 
 
@@ -132,7 +132,7 @@ def test_error_filter(filter_string, error_message):
 ])
 def test_error_comparison_clauses(filter_string, error_message):
     with pytest.raises(MlflowException) as e:
-        SearchUtils._parse_search_filter(filter_string)
+        SearchUtils.parse_search_filter(filter_string)
     assert error_message in e.value.message
 
 
@@ -150,7 +150,7 @@ def test_error_comparison_clauses(filter_string, error_message):
 ])
 def test_bad_quotes(filter_string, error_message):
     with pytest.raises(MlflowException) as e:
-        SearchUtils._parse_search_filter(filter_string)
+        SearchUtils.parse_search_filter(filter_string)
     assert error_message in e.value.message
 
 
@@ -165,7 +165,7 @@ def test_bad_quotes(filter_string, error_message):
 ])
 def test_invalid_clauses(filter_string, error_message):
     with pytest.raises(MlflowException) as e:
-        SearchUtils._parse_search_filter(filter_string)
+        SearchUtils.parse_search_filter(filter_string)
     assert error_message in e.value.message
 
 


### PR DESCRIPTION
* Mutualize test data generation
* extract filtering string validity checks
* Check filtering on latest_metrics name of metrics changed to use an underscore, easier to use as filter keys
* Add sqlAlchemy filtering
* Don't join subqueries for SqlRun attributes filtering directly specify them as filters on the main query
* Mutualize switch on operators using a dict of operators
* Document the fact that key_name is a valid searchable attribute
* Add a field name conversion method from mlflow entity to SQLRun

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Further improve performance of search against SQL-backed stores by pushing filter logic down to SQL from Python

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
