### PR TITLE
[LINT] Remove fix option for ESLint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ matrix:
       script:
         - cd mlflow/server/js
         - npm i
-        - ./lint.sh
+        - npm run lint
         - npm test -- --coverage
     - stage: large
     - language: python

--- a/mlflow/server/js/lint.sh
+++ b/mlflow/server/js/lint.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-./node_modules/.bin/eslint src --fix
+./node_modules/.bin/eslint src

--- a/mlflow/server/js/lint.sh
+++ b/mlflow/server/js/lint.sh
@@ -1,2 +1,0 @@
-#!/usr/bin/env bash
-./node_modules/.bin/eslint src

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -71,7 +71,8 @@
     "build": "react-app-rewired build",
     "test": "react-app-rewired test --env=jsdom",
     "eject": "react-scripts eject",
-    "lint": "react-scripts run lint"
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix"
   },
   "homepage": "static-files",
   "jest": {


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR propses to remove `--fix` option from `server/js/lint.sh` ([link](https://github.com/mlflow/mlflow/blob/master/mlflow/server/js/lint.sh#L2)) because with `--fix` option, `eslint` exits with 0 if all the detected violations are **fixable**. This behavior might allow code that violates the lint rules to pass the CI tests.

## How is this patch tested?

Tested on this PR #2035 

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
