### PR TITLE
[CLI] Add 'models prepare-env' command to explicitly prepare model environments

### DIFF
--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -130,6 +130,14 @@ class FlavorBackend(object):
         """
         pass
 
+    def prepare_env(self, model_uri):
+        """
+        Performs any preparation necessary to predict or serve the model, for example
+        downloading dependencies or initializing a conda environment. After preparation,
+        calling predict or serve should be fast.
+        """
+        pass
+
     @abstractmethod
     def can_score_model(self):
         """

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -91,6 +91,20 @@ def predict(model_uri, input_path, output_path, content_type, json_format, no_co
                                                                       json_format=json_format)
 
 
+@commands.command("prepare-env")
+@cli_args.MODEL_URI
+@cli_args.NO_CONDA
+@cli_args.INSTALL_MLFLOW
+def prepare_env(model_uri, no_conda, install_mlflow):
+    """
+    Performs any preparation necessary to predict or serve the model, for example
+    downloading dependencies or initializing a conda environment. After preparation,
+    calling predict or serve should be fast.
+    """
+    return _get_flavor_backend(model_uri, no_conda=no_conda,
+                               install_mlflow=install_mlflow).prepare_env(model_uri=model_uri)
+
+
 @commands.command("build-docker")
 @cli_args.MODEL_URI
 @click.option("--name", "-n", default="mlflow-pyfunc-servable",

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -7,7 +7,7 @@ from mlflow.models import Model
 from mlflow.models.flavor_backend_registry import get_flavor_backend
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.file_utils import TempDir
-from mlflow.utils import cli_args, experimental
+from mlflow.utils import cli_args
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -7,7 +7,7 @@ from mlflow.models import Model
 from mlflow.models.flavor_backend_registry import get_flavor_backend
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.file_utils import TempDir
-from mlflow.utils import cli_args
+from mlflow.utils import cli_args, experimental
 
 _logger = logging.getLogger(__name__)
 
@@ -97,9 +97,11 @@ def predict(model_uri, input_path, output_path, content_type, json_format, no_co
 @cli_args.INSTALL_MLFLOW
 def prepare_env(model_uri, no_conda, install_mlflow):
     """
-    Performs any preparation necessary to predict or serve the model, for example
+    **EXPERIMENTAL**: Performs any preparation necessary to predict or serve the model, for example
     downloading dependencies or initializing a conda environment. After preparation,
     calling predict or serve should be fast.
+
+    This method is experimental and may be removed in a future release without warning.
     """
     return _get_flavor_backend(model_uri, no_conda=no_conda,
                                install_mlflow=install_mlflow).prepare_env(model_uri=model_uri)

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -30,9 +30,6 @@ class PyFuncBackend(FlavorBackend):
 
     def prepare_env(self, model_uri):
         local_path = _download_artifact_from_uri(model_uri)
-        # NB: Absolute windows paths do not work with mlflow apis, use file uri to ensure
-        # platform compatibility.
-        local_uri = path_to_local_file_uri(local_path)
         if self._no_conda or ENV not in self._config:
             return 0
         conda_env_path = os.path.join(local_path, self._config[ENV])

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -28,6 +28,17 @@ class PyFuncBackend(FlavorBackend):
         self._no_conda = no_conda
         self._install_mlflow = install_mlflow
 
+    def prepare_env(self, model_uri):
+        local_path = _download_artifact_from_uri(model_uri)
+        # NB: Absolute windows paths do not work with mlflow apis, use file uri to ensure
+        # platform compatibility.
+        local_uri = path_to_local_file_uri(local_path)
+        if self._no_conda or ENV not in self._config:
+            return 0
+        conda_env_path = os.path.join(local_path, self._config[ENV])
+        command = 'python -c ""'
+        return _execute_in_conda_env(conda_env_path, command, self._install_mlflow)
+
     def predict(self, model_uri, input_path, output_path, content_type, json_format, ):
         """
         Generate predictions using generic python model saved with MLflow.

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -231,11 +231,11 @@ def test_predict(iris_data, sk_model):
         assert all(expected == actual)
 
 
-def test_prepare_env_passes(iris_data, sk_model):
+def test_prepare_env_passes(sk_model):
     if no_conda:
         pytest.skip("This test requires conda.")
 
-    with TempDir(chdr=True) as tmp:
+    with TempDir(chdr=True):
         with mlflow.start_run() as active_run:
             mlflow.sklearn.log_model(sk_model, "model")
             model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
@@ -256,11 +256,11 @@ def test_prepare_env_passes(iris_data, sk_model):
         assert p.wait() == 0
 
 
-def test_prepare_env_fails(iris_data, sk_model):
+def test_prepare_env_fails(sk_model):
     if no_conda:
         pytest.skip("This test requires conda.")
 
-    with TempDir(chdr=True) as tmp:
+    with TempDir(chdr=True):
         with mlflow.start_run() as active_run:
             mlflow.sklearn.log_model(sk_model, "model", conda_env={"env": "Bad conda env"})
             model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -70,7 +70,7 @@ def test_predict_with_old_mlflow_in_conda_and_with_orient_records(iris_data):
         output_json_path = tmp.path("output.json")
         test_model_path = tmp.path("test_model")
         test_model_conda_path = tmp.path("conda.yml")
-        # create env with odl mlflow!
+        # create env with old mlflow!
         _mlflow_conda_env(path=test_model_conda_path,
                           additional_pip_deps=["mlflow=={}".format(test_pyfunc.MLFLOW_VERSION)])
         pyfunc.save_model(path=test_model_path,
@@ -229,6 +229,51 @@ def test_predict(iris_data, sk_model):
         actual = actual[actual.columns[0]].values
         expected = sk_model.predict(x)
         assert all(expected == actual)
+
+
+def test_prepare_env_passes(iris_data, sk_model):
+    if no_conda:
+        pytest.skip("This test requires conda.")
+
+    with TempDir(chdr=True) as tmp:
+        with mlflow.start_run() as active_run:
+            mlflow.sklearn.log_model(sk_model, "model")
+            model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
+
+        # Test with no conda
+        p = subprocess.Popen(["mlflow", "models", "prepare-env", "-m", model_uri,
+                              "--no-conda"], stderr=subprocess.PIPE)
+        assert p.wait() == 0
+
+        # With conda
+        p = subprocess.Popen(["mlflow", "models", "prepare-env", "-m", model_uri],
+                             stderr=subprocess.PIPE)
+        assert p.wait() == 0
+
+        # Should be idempotent
+        p = subprocess.Popen(["mlflow", "models", "prepare-env", "-m", model_uri],
+                             stderr=subprocess.PIPE)
+        assert p.wait() == 0
+
+
+def test_prepare_env_fails(iris_data, sk_model):
+    if no_conda:
+        pytest.skip("This test requires conda.")
+
+    with TempDir(chdr=True) as tmp:
+        with mlflow.start_run() as active_run:
+            mlflow.sklearn.log_model(sk_model, "model", conda_env={"env": "Bad conda env"})
+            model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
+
+        # Test with no conda
+        p = subprocess.Popen(["mlflow", "models", "prepare-env", "-m", model_uri,
+                              "--no-conda"], stderr=subprocess.PIPE)
+        assert p.wait() == 0
+
+        # With conda - should fail due to bad conda environment.
+        p = subprocess.Popen(["mlflow", "models", "prepare-env", "-m", model_uri],
+                             stderr=subprocess.PIPE)
+        assert p.wait() != 0
 
 
 @pytest.mark.release


### PR DESCRIPTION
## What changes are proposed in this pull request?

Users may now call `mlflow models prepare-env -m <model-uri>` prior to calling `mlflow models predict` or `mlflow models serve`. This will download the model file and create the conda environment, if one is specified.

This method allows a programmatic distinction between configuration errors (such as invalid model URI or invalid conda env) versus user errors (such as the model raising an exception).

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added `mlflow models prepare-env` command to do any preparation necessary to initialize an environment. This allows distinguishing configuration and user errors during predict/serve time.

### What component(s) does this PR affect?

- [x] CLI
- [x] Models

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
