### PR TITLE
Fix note editor on the experiment page

### DIFF
--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -59,8 +59,8 @@ export class ExperimentView extends Component {
     this.removeBagged = this.removeBagged.bind(this);
     this.handleExposeNotesEditorClick = this.handleExposeNotesEditorClick.bind(this);
     this.renderNoteSection = this.renderNoteSection.bind(this);
-    this.handleNoteOnSubmit = this.handleNoteOnSubmit.bind(this);
-    this.handleNoteOnCancel = this.handleNoteOnCancel.bind(this);
+    this.handleSubmitEditNote = this.handleSubmitEditNote.bind(this);
+    this.handleCancelEditNote = this.handleCancelEditNote.bind(this);
     const store = ExperimentView.getLocalStore(this.props.experiment.experiment_id);
     const persistedState = new ExperimentViewPersistedState(store.loadComponentState());
     this.state = {
@@ -274,14 +274,15 @@ export class ExperimentView extends Component {
     }
   }
 
-  handleNoteOnSubmit(note) {
+  handleSubmitEditNote(note) {
     const { experiment_id } = this.props.experiment;
-    this.props.setExperimentTagApi(experiment_id, NOTE_CONTENT_TAG, note, getUUID())
-    .then(() => this.setState({showNotesEditor: false}));
+    this.props
+    .setExperimentTagApi(experiment_id, NOTE_CONTENT_TAG, note, getUUID())
+    .then(() => this.setState({ showNotesEditor: false }));
   }
 
-  handleNoteOnCancel() {
-    this.setState({showNotesEditor: false});
+  handleCancelEditNote() {
+    this.setState({showNoteEditor: false});
   }
 
   renderNoteSection(noteInfo) {
@@ -290,8 +291,8 @@ export class ExperimentView extends Component {
       return (
         <EditableNote
           defaultMarkdown={noteInfo && noteInfo.content}
-          onSubmit={this.handleNoteOnSubmit}
-          onCancel={this.handleNoteOnCancel}
+          onSubmit={this.handleSubmitEditNote}
+          onCancel={this.handleCancelEditNote}
           showEditor={showNotesEditor}
         />
       );
@@ -854,7 +855,7 @@ export const mapStateToProps = (state, ownProps) => {
 };
 
 const mapDispatchToProps = {
-  setExperimentTagApi
+  setExperimentTagApi,
 };
 
 const styles = {

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -283,7 +283,7 @@ export class ExperimentView extends Component {
         return <NoteEditorView
             experimentId={this.props.experiment.experiment_id}
             type={"experiment"}
-            noteInfo={noteInfo}
+            defaultMarkdown={noteInfo && noteInfo.content}
             submitCallback={this.handleSubmittedNote}
             cancelCallback={this.handleNoteEditorViewCancel}/>;
       } else if (noteInfo) {

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -265,8 +265,8 @@ export class ExperimentView extends Component {
   handleSubmitEditNote(note) {
     const { experiment_id } = this.props.experiment;
     this.props
-    .setExperimentTagApi(experiment_id, NOTE_CONTENT_TAG, note, getUUID())
-    .then(() => this.setState({ showNotesEditor: false }));
+      .setExperimentTagApi(experiment_id, NOTE_CONTENT_TAG, note, getUUID())
+      .then(() => this.setState({ showNotesEditor: false }));
   }
 
   handleCancelEditNote() {

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -25,13 +25,14 @@ import { NoteInfo, NOTE_CONTENT_TAG } from "../utils/NoteUtils";
 import LocalStorageUtils from "../utils/LocalStorageUtils";
 import { ExperimentViewPersistedState } from "../sdk/MlflowLocalStorageMessages";
 import { Icon, Popover, Descriptions } from 'antd';
+import { CollapsibleSection } from '../common/components/CollapsibleSection';
 import { EditableNote } from '../common/components/EditableNote';
 
+
 import Utils from '../utils/Utils';
-import {Spinner} from "./Spinner";
+import { Spinner } from "./Spinner";
 
 export const DEFAULT_EXPANDED_VALUE = false;
-const NOTES_KEY = 'notes';
 
 export class ExperimentView extends Component {
   constructor(props) {
@@ -57,7 +58,6 @@ export class ExperimentView extends Component {
     this.onExpand = this.onExpand.bind(this);
     this.addBagged = this.addBagged.bind(this);
     this.removeBagged = this.removeBagged.bind(this);
-    this.handleExposeNotesEditorClick = this.handleExposeNotesEditorClick.bind(this);
     this.renderNoteSection = this.renderNoteSection.bind(this);
     this.handleSubmitEditNote = this.handleSubmitEditNote.bind(this);
     this.handleCancelEditNote = this.handleCancelEditNote.bind(this);
@@ -262,18 +262,6 @@ export class ExperimentView extends Component {
       });
   }
 
-  handleExposeNotesEditorClick() {
-    this.setState({ showNotesEditor: true, showNotes: true });
-  }
-
-  returnOnClickFunction(notesKey) {
-    if (this.state.showNotesEditor) {
-      return undefined;
-    } else {
-      return () => this.onClickExpander(notesKey);
-    }
-  }
-
   handleSubmitEditNote(note) {
     const { experiment_id } = this.props.experiment;
     this.props
@@ -282,44 +270,32 @@ export class ExperimentView extends Component {
   }
 
   handleCancelEditNote() {
-    this.setState({showNoteEditor: false});
+    this.setState({showNotesEditor: false});
   }
 
+  startEditingDescription = (e) => {
+    e.stopPropagation();
+    this.setState({ showNotesEditor: true });
+  };
+
   renderNoteSection(noteInfo) {
-    const {showNotes, showNotesEditor} = this.state;
-    if (showNotes) {
-      return (
+    const { showNotesEditor } = this.state;
+
+    const editIcon = <a onClick={this.startEditingDescription}><Icon type='form' /></a>;
+
+    return (
+      <CollapsibleSection
+        title={<span>Notes {showNotesEditor ? null : editIcon}</span>}
+        forceOpen={showNotesEditor}
+      >
         <EditableNote
           defaultMarkdown={noteInfo && noteInfo.content}
           onSubmit={this.handleSubmitEditNote}
           onCancel={this.handleCancelEditNote}
           showEditor={showNotesEditor}
         />
-      );
-    }
-    return null;
-  }
-
-  onClickExpander(key) {
-    switch (key) {
-      case NOTES_KEY: {
-        this.setState({ showNotes: !this.state.showNotes });
-        return;
-      }
-      default:
-        return;
-    }
-  }
-
-  getExpanderClassName(key) {
-    switch (key) {
-      case NOTES_KEY: {
-        return this.state.showNotes ? 'fa-caret-down' : 'fa-caret-right';
-      }
-      default: {
-        return null;
-      }
-    }
+      </CollapsibleSection>
+    );
   }
 
   render() {
@@ -376,22 +352,6 @@ export class ExperimentView extends Component {
           <Descriptions.Item label='Artifact Location'>{artifact_location}</Descriptions.Item>
         </Descriptions>
         <div className="ExperimentView-info">
-          <h2 className="table-name">
-                <span className="metadata">
-                  <span
-                      onClick={this.returnOnClickFunction(NOTES_KEY)}
-                      className="metadata-header">
-                    <i className={`fa ${this.getExpanderClassName(NOTES_KEY)}`}/>{' '}Description:
-                  </span>
-                  {!this.state.showNotes || !this.state.showNotesEditor ?
-                      <a onClick={this.handleExposeNotesEditorClick} >
-                        <Icon type="form" />
-                      </a>
-                      :
-                      null
-                  }
-                </span>
-          </h2>
           {this.renderNoteSection(noteInfo)}
         </div>
         <div className="ExperimentView-runs runs-table-flex-container">


### PR DESCRIPTION
## What changes are proposed in this pull request?

#1972 updated `react-mde` and `NoteEditorView` on the experiment page doesn't work properly now. 
This PR fixes it.

## Before
![react-mde-before](https://user-images.githubusercontent.com/17039389/68398064-7c0b9c00-01b7-11ea-985e-76d07e953335.gif)



## After
![react-mde](https://user-images.githubusercontent.com/17039389/68397804-17504180-01b7-11ea-9f3e-2c9cf920967c.gif)


## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Note editor on the experiment page is updated.

### What component(s) does this PR affect?

- [x] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
