### PR TITLE
Keras and TF Keras autologging: Log params at the beginning of training

### DIFF
--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -381,7 +381,7 @@ def autolog():
         Records available logs after each epoch.
         Records model structural information as params after training finishes.
         """
-        def on_train_begin(self, logs=None): # pylint: disable=unused-argument
+        def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
             try_mlflow_log(mlflow.log_param, 'num_layers', len(self.model.layers))
             try_mlflow_log(mlflow.log_param, 'optimizer_name', type(self.model.optimizer).__name__)
             if hasattr(self.model.optimizer, 'lr'):

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -395,16 +395,17 @@ def autolog():
                     else keras.backend.eval(self.model.optimizer.epsilon)
                 try_mlflow_log(mlflow.log_param, 'epsilon', epsilon)
 
+            sum_list = []
+            self.model.summary(print_fn=sum_list.append)
+            summary = '\n'.join(sum_list)
+            try_mlflow_log(mlflow.set_tag, 'summary', summary)
+
         def on_epoch_end(self, epoch, logs=None):
             if not logs:
                 return
             try_mlflow_log(mlflow.log_metrics, logs, step=epoch)
 
         def on_train_end(self, logs=None):
-            sum_list = []
-            self.model.summary(print_fn=sum_list.append)
-            summary = '\n'.join(sum_list)
-            try_mlflow_log(mlflow.set_tag, 'summary', summary)
             try_mlflow_log(log_model, self.model, artifact_path='model')
 
     @gorilla.patch(keras.Model)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -381,13 +381,7 @@ def autolog():
         Records available logs after each epoch.
         Records model structural information as params after training finishes.
         """
-
-        def on_epoch_end(self, epoch, logs=None):
-            if not logs:
-                return
-            try_mlflow_log(mlflow.log_metrics, logs, step=epoch)
-
-        def on_train_end(self, logs=None):
+        def on_train_begin(self, logs=None): # pylint: disable=unused-argument
             try_mlflow_log(mlflow.log_param, 'num_layers', len(self.model.layers))
             try_mlflow_log(mlflow.log_param, 'optimizer_name', type(self.model.optimizer).__name__)
             if hasattr(self.model.optimizer, 'lr'):
@@ -400,6 +394,13 @@ def autolog():
                     type(self.model.optimizer.epsilon) is float \
                     else keras.backend.eval(self.model.optimizer.epsilon)
                 try_mlflow_log(mlflow.log_param, 'epsilon', epsilon)
+
+        def on_epoch_end(self, epoch, logs=None):
+            if not logs:
+                return
+            try_mlflow_log(mlflow.log_metrics, logs, step=epoch)
+
+        def on_train_end(self, logs=None):
             sum_list = []
             self.model.summary(print_fn=sum_list.append)
             summary = '\n'.join(sum_list)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -473,14 +473,15 @@ class __MLflowTfKerasCallback(Callback):
                 else tensorflow.keras.backend.eval(opt._epsilon)
             try_mlflow_log(mlflow.log_param, 'epsilon', epsilon)
 
+        sum_list = []
+        self.model.summary(print_fn=sum_list.append)
+        summary = '\n'.join(sum_list)
+        try_mlflow_log(mlflow.set_tag, 'summary', summary)
+
     def on_epoch_end(self, epoch, logs=None):
         pass
 
     def on_train_end(self, logs=None):  # pylint: disable=unused-argument
-        tmp_list = []
-        self.model.summary(print_fn=tmp_list.append)
-        summary = '\n'.join(tmp_list)
-        try_mlflow_log(mlflow.set_tag, 'summary', summary)
         try_mlflow_log(mlflow.keras.log_model, self.model, artifact_path='model')
 
 
@@ -504,15 +505,16 @@ class __MLflowTfKeras2Callback(Callback):
         for attribute in config:
             try_mlflow_log(mlflow.log_param, "opt_" + attribute, config[attribute])
 
+        sum_list = []
+        self.model.summary(print_fn=sum_list.append)
+        summary = '\n'.join(sum_list)
+        try_mlflow_log(mlflow.set_tag, 'summary', summary)
+
     def on_epoch_end(self, epoch, logs=None):
         if (epoch-1) % _LOG_EVERY_N_STEPS == 0:
             try_mlflow_log(mlflow.log_metrics, logs, step=epoch)
 
     def on_train_end(self, logs=None):  # pylint: disable=unused-argument
-        tmp_list = []
-        self.model.summary(print_fn=tmp_list.append)
-        summary = '\n'.join(tmp_list)
-        try_mlflow_log(mlflow.set_tag, 'summary', summary)
         try_mlflow_log(mlflow.keras.log_model, self.model, artifact_path='model')
 
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -460,10 +460,7 @@ class __MLflowTfKerasCallback(Callback):
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
-    def on_epoch_end(self, epoch, logs=None):
-        pass
-
-    def on_train_end(self, logs=None):  # pylint: disable=unused-argument
+    def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
         opt = self.model.optimizer
         if hasattr(opt, 'optimizer'):
             opt = opt.optimizer
@@ -475,6 +472,11 @@ class __MLflowTfKerasCallback(Callback):
             epsilon = opt._epsilon if type(opt._epsilon) is float \
                 else tensorflow.keras.backend.eval(opt._epsilon)
             try_mlflow_log(mlflow.log_param, 'epsilon', epsilon)
+
+    def on_epoch_end(self, epoch, logs=None):
+        pass
+
+    def on_train_end(self, logs=None):  # pylint: disable=unused-argument
         tmp_list = []
         self.model.summary(print_fn=tmp_list.append)
         summary = '\n'.join(tmp_list)
@@ -497,15 +499,16 @@ class __MLflowTfKeras2Callback(Callback):
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
+    def on_train_begin(self, logs=None): # pylint: disable=unused-argument
+        config = self.model.optimizer.get_config()
+        for attribute in config:
+            try_mlflow_log(mlflow.log_param, "opt_" + attribute, config[attribute])
+
     def on_epoch_end(self, epoch, logs=None):
         if (epoch-1) % _LOG_EVERY_N_STEPS == 0:
             try_mlflow_log(mlflow.log_metrics, logs, step=epoch)
 
     def on_train_end(self, logs=None):  # pylint: disable=unused-argument
-        opt = self.model.optimizer
-        config = opt.get_config()
-        for attribute in config:
-            try_mlflow_log(mlflow.log_param, "opt_" + attribute, config[attribute])
         tmp_list = []
         self.model.summary(print_fn=tmp_list.append)
         summary = '\n'.join(tmp_list)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -499,7 +499,7 @@ class __MLflowTfKeras2Callback(Callback):
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
-    def on_train_begin(self, logs=None): # pylint: disable=unused-argument
+    def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
         config = self.model.optimizer.get_config()
         for attribute in config:
             try_mlflow_log(mlflow.log_param, "opt_" + attribute, config[attribute])


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR modifies Keras autologging behavior to log parameters at the beginning of the run. This is especially useful for longer runs that may not complete for several hours.

## How is this patch tested?

Existing unit tests

## Release Notes

Keras autologging functionality now logs model parameters at the beginning of the run. Previously, these parameters were logged at the end of the run.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [X] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
