### PR TITLE
Add automatic run ending in TensorFlow/Keras autologging

### DIFF
--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -381,8 +381,6 @@ def autolog():
         Records available logs after each epoch.
         Records model structural information as params after training finishes.
         """
-        def __init__(self):
-            pass
 
         def on_epoch_end(self, epoch, logs=None):
             if not logs:
@@ -407,7 +405,6 @@ def autolog():
             summary = '\n'.join(sum_list)
             try_mlflow_log(mlflow.set_tag, 'summary', summary)
             try_mlflow_log(log_model, self.model, artifact_path='model')
-
 
     @gorilla.patch(keras.Model)
     def fit(self, *args, **kwargs):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -451,8 +451,10 @@ class __MLflowTfKerasCallback(Callback):
         Records model structural information as params after training finishes.
     """
     def __init__(self):
+        self.auto_end_run = False
         if mlflow.active_run() is None:
             mlflow.start_run()
+            self.auto_end_run = True
 
     def __enter__(self):
         pass
@@ -480,6 +482,8 @@ class __MLflowTfKerasCallback(Callback):
         summary = '\n'.join(l)
         try_mlflow_log(mlflow.set_tag, 'summary', summary)
         try_mlflow_log(mlflow.keras.log_model, self.model, artifact_path='model')
+        if self.auto_end_run:
+            mlflow.end_run()
 
 
 class __MLflowTfKeras2Callback(Callback):
@@ -488,8 +492,10 @@ class __MLflowTfKeras2Callback(Callback):
         Records model structural information as params after training finishes.
     """
     def __init__(self):
+        self.auto_end_run = False
         if mlflow.active_run() is None:
             mlflow.start_run()
+            self.auto_end_run = True
 
     def __enter__(self):
         pass
@@ -511,6 +517,8 @@ class __MLflowTfKeras2Callback(Callback):
         summary = '\n'.join(l)
         try_mlflow_log(mlflow.set_tag, 'summary', summary)
         try_mlflow_log(mlflow.keras.log_model, self.model, artifact_path='model')
+        if self.auto_end_run:
+            mlflow.end_run()
 
 
 def _log_artifacts_with_warning(**kwargs):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -644,10 +644,16 @@ def autolog(every_n_iter=100):
         original = gorilla.get_original_attribute(tensorflow.estimator.Estimator,
                                                   'export_saved_model')
         serialized = original(self, *args, **kwargs)
+        if not mlflow.active_run():
+            end_run = True
+        else:
+            end_run = False
         try_mlflow_log(log_model, tf_saved_model_dir=serialized.decode('utf-8'),
                        tf_meta_graph_tags=[tag_constants.SERVING],
                        tf_signature_def_key='predict',
                        artifact_path='model')
+        if end_run:
+            mlflow.end_run()
         return serialized
 
     @gorilla.patch(tensorflow.estimator.Estimator)
@@ -655,10 +661,16 @@ def autolog(every_n_iter=100):
         original = gorilla.get_original_attribute(tensorflow.estimator.Estimator,
                                                   'export_savedmodel')
         serialized = original(self, *args, **kwargs)
+        if not mlflow.active_run():
+            auto_end_run = True
+        else:
+            auto_end_run = False
         try_mlflow_log(log_model, tf_saved_model_dir=serialized.decode('utf-8'),
                        tf_meta_graph_tags=[tag_constants.SERVING],
                        tf_signature_def_key='predict',
                        artifact_path='model')
+        if auto_end_run:
+            mlflow.end_run()
         return serialized
 
     @gorilla.patch(tensorflow.keras.Model)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -645,14 +645,14 @@ def autolog(every_n_iter=100):
                                                   'export_saved_model')
         serialized = original(self, *args, **kwargs)
         if not mlflow.active_run():
-            end_run = True
+            auto_end_run = True
         else:
-            end_run = False
+            auto_end_run = False
         try_mlflow_log(log_model, tf_saved_model_dir=serialized.decode('utf-8'),
                        tf_meta_graph_tags=[tag_constants.SERVING],
                        tf_signature_def_key='predict',
                        artifact_path='model')
-        if end_run:
+        if auto_end_run:
             mlflow.end_run()
         return serialized
 

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -20,20 +20,22 @@ def fit_variant():
     return "fit"
 
 
-@pytest.fixture
-def keras_random_data_run(random_train_data, fit_variant):
-    mlflow.keras.autolog()
+@pytest.fixture()
+def random_one_hot_labels():
+    n, n_class = (1000, 10)
+    classes = np.random.randint(0, n_class, n)
+    labels = np.zeros((n, n_class))
+    labels[np.arange(n), classes] = 1
+    return labels
 
-    def random_one_hot_labels(shape):
-        n, n_class = shape
-        classes = np.random.randint(0, n_class, n)
-        labels = np.zeros((n, n_class))
-        labels[np.arange(n), classes] = 1
-        return labels
+
+@pytest.fixture
+def keras_random_data_run(random_train_data, fit_variant, random_one_hot_labels):
+    mlflow.keras.autolog()
 
     with mlflow.start_run() as run:
         data = random_train_data
-        labels = random_one_hot_labels((1000, 10))
+        labels = random_one_hot_labels
 
         model = keras.Sequential()
 
@@ -82,11 +84,60 @@ def test_keras_autolog_model_can_load_from_artifact(keras_random_data_run, rando
 
 
 @pytest.mark.large
-def test_autolog_ends_auto_created_run():
-    pass
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+def test_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels, fit_variant):
+    mlflow.keras.autolog()
+
+    data = random_train_data
+    labels = random_one_hot_labels
+
+    model = keras.Sequential()
+
+    model.add(layers.Dense(64, activation='relu', input_shape=(32,)))
+    model.add(layers.Dense(64, activation='relu'))
+    model.add(layers.Dense(10, activation='softmax'))
+
+    model.compile(optimizer=keras.optimizers.Adam(lr=0.001, epsilon=1e-07),
+                  loss='categorical_crossentropy',
+                  metrics=['accuracy'])
+
+    if fit_variant == 'fit_generator':
+        def generator():
+            while True:
+                yield data, labels
+        model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
+    else:
+        model.fit(data, labels, epochs=10)
+
+    assert mlflow.active_run() is None
 
 
 @pytest.mark.large
-def test_autolog_persists_manually_created_run():
-    pass
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+def test_autolog_persists_manually_created_run(random_train_data, random_one_hot_labels, fit_variant):
+    mlflow.keras.autolog()
+
+    with mlflow.start_run() as run:
+        data = random_train_data
+        labels = random_one_hot_labels
+
+        model = keras.Sequential()
+
+        model.add(layers.Dense(64, activation='relu', input_shape=(32,)))
+        model.add(layers.Dense(64, activation='relu'))
+        model.add(layers.Dense(10, activation='softmax'))
+
+        model.compile(optimizer=keras.optimizers.Adam(lr=0.001, epsilon=1e-07),
+                      loss='categorical_crossentropy',
+                      metrics=['accuracy'])
+
+        if fit_variant == 'fit_generator':
+            def generator():
+                while True:
+                    yield data, labels
+            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
+        else:
+            model.fit(data, labels, epochs=10)
+
+    return client.get_run(run.info.run_id)
 

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -79,3 +79,14 @@ def test_keras_autolog_model_can_load_from_artifact(keras_random_data_run, rando
     model = mlflow.keras.load_model("runs:/" + keras_random_data_run.info.run_id +
                                     "/model")
     model.predict(random_train_data)
+
+
+@pytest.mark.large
+def test_autolog_ends_self_created_run():
+    pass
+
+
+@pytest.mark.large
+def test_autolog_persists_manually_created_run():
+    pass
+

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -82,7 +82,7 @@ def test_keras_autolog_model_can_load_from_artifact(keras_random_data_run, rando
 
 
 @pytest.mark.large
-def test_autolog_ends_self_created_run():
+def test_autolog_ends_auto_created_run():
     pass
 
 

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -113,7 +113,8 @@ def test_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels,
 
 @pytest.mark.large
 @pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_autolog_persists_manually_created_run(random_train_data, random_one_hot_labels, fit_variant):
+def test_autolog_persists_manually_created_run(random_train_data,
+                                               random_one_hot_labels, fit_variant):
     mlflow.keras.autolog()
 
     with mlflow.start_run() as run:
@@ -139,4 +140,3 @@ def test_autolog_persists_manually_created_run(random_train_data, random_one_hot
             model.fit(data, labels, epochs=10)
 
         assert mlflow.active_run().info.run_id == run.info.run_id
-

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -5,7 +5,6 @@ import keras.layers as layers
 
 import mlflow
 import mlflow.keras
-from distutils.version import LooseVersion
 
 client = mlflow.tracking.MlflowClient()
 
@@ -139,5 +138,5 @@ def test_autolog_persists_manually_created_run(random_train_data, random_one_hot
         else:
             model.fit(data, labels, epochs=10)
 
-    return client.get_run(run.info.run_id)
+        assert mlflow.active_run().info.run_id == run.info.run_id
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -172,3 +172,13 @@ def duplicate_autolog_tf_estimator_run():
 def test_duplicate_autolog_second_overrides(duplicate_autolog_tf_estimator_run):
     metrics = client.get_metric_history(duplicate_autolog_tf_estimator_run.info.run_id, 'loss')
     assert all((x.step - 1) % 4 == 0 for x in metrics)
+
+
+@pytest.mark.large
+def test_autolog_ends_self_created_run():
+    pass
+
+
+@pytest.mark.large
+def test_autolog_persists_manually_created_run():
+    pass

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -142,6 +142,7 @@ def tf_estimator():
 
     shutil.rmtree(dir)
 
+
 @pytest.fixture
 def tf_estimator_random_data_run():
     mlflow.tensorflow.autolog()

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -31,19 +31,21 @@ def random_train_data():
 
 
 @pytest.fixture
-def tf_keras_random_data_run(random_train_data):
-    mlflow.tensorflow.autolog(every_n_iter=5)
+def random_one_hot_labels():
+    n, n_class = (1000, 10)
+    classes = np.random.randint(0, n_class, n)
+    labels = np.zeros((n, n_class))
+    labels[np.arange(n), classes] = 1
+    return labels
 
-    def random_one_hot_labels(shape):
-        n, n_class = shape
-        classes = np.random.randint(0, n_class, n)
-        labels = np.zeros((n, n_class))
-        labels[np.arange(n), classes] = 1
-        return labels
+
+@pytest.fixture
+def tf_keras_random_data_run(random_train_data, random_one_hot_labels):
+    mlflow.tensorflow.autolog(every_n_iter=5)
 
     with mlflow.start_run() as run:
         data = random_train_data
-        labels = random_one_hot_labels((1000, 10))
+        labels = random_one_hot_labels
 
         model = tf.keras.Sequential()
 
@@ -184,6 +186,7 @@ def test_keras_autolog_persists_manually_created_run():
     pass
 
 
+# These two do not need to test for export_savedmodel, but does need to test export_saved_model
 @pytest.mark.large
 def test_estimator_autolog_ends_auto_created_run():
     pass

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -175,10 +175,20 @@ def test_duplicate_autolog_second_overrides(duplicate_autolog_tf_estimator_run):
 
 
 @pytest.mark.large
-def test_autolog_ends_self_created_run():
+def test_keras_autolog_ends_auto_created_run():
     pass
 
 
 @pytest.mark.large
-def test_autolog_persists_manually_created_run():
+def test_keras_autolog_persists_manually_created_run():
+    pass
+
+
+@pytest.mark.large
+def test_estimator_autolog_ends_auto_created_run():
+    pass
+
+
+@pytest.mark.large
+def test_estimator_autolog_ends_auto_created_run():
     pass

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -205,10 +205,20 @@ def test_duplicate_autolog_second_overrides(duplicate_autolog_tf_estimator_run):
 
 
 @pytest.mark.large
-def test_autolog_ends_self_created_run():
+def test_keras_autolog_ends_auto_created_run():
     pass
 
 
 @pytest.mark.large
-def test_autolog_persists_manually_created_run():
+def test_keras_autolog_persists_manually_created_run():
+    pass
+
+
+@pytest.mark.large
+def test_estimator_autolog_ends_auto_created_run():
+    pass
+
+
+@pytest.mark.large
+def test_estimator_autolog_ends_auto_created_run():
     pass

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -122,57 +122,59 @@ def test_tf_core_autolog_logs_scalars(tf_core_random_tensors):
     assert mlflow.active_run() is None
 
 
+def tf_estimator():
+    dir = tempfile.mkdtemp()
+    CSV_COLUMN_NAMES = ['SepalLength', 'SepalWidth', 'PetalLength', 'PetalWidth', 'Species']
+    SPECIES = ['Setosa', 'Versicolor', 'Virginica']
+
+    train = pd.read_csv(os.path.join(os.path.dirname(__file__), "iris_training.csv"),
+                        names=CSV_COLUMN_NAMES, header=0)
+    test = pd.read_csv(os.path.join(os.path.dirname(__file__), "iris_test.csv"),
+                       names=CSV_COLUMN_NAMES, header=0)
+
+    train_y = train.pop('Species')
+    test_y = test.pop('Species')
+
+    def input_fn(features, labels, training=True, batch_size=256):
+        """An input function for training or evaluating"""
+        # Convert the inputs to a Dataset.
+        dataset = tf.data.Dataset.from_tensor_slices((dict(features), labels))
+
+        # Shuffle and repeat if you are in training mode.
+        if training:
+            dataset = dataset.shuffle(1000).repeat()
+
+        return dataset.batch(batch_size)
+
+    my_feature_columns = []
+    for key in train.keys():
+        my_feature_columns.append(tf.feature_column.numeric_column(key=key))
+
+    feature_spec = {}
+    for feature in CSV_COLUMN_NAMES:
+        feature_spec[feature] = tf.placeholder(dtype="float", name=feature, shape=[150])
+
+    receiver_fn = tf.estimator.export.build_raw_serving_input_receiver_fn(feature_spec)
+
+    classifier = tf.estimator.DNNClassifier(
+        feature_columns=my_feature_columns,
+        # Two hidden layers of 10 nodes each.
+        hidden_units=[30, 10],
+        # The model must choose between 3 classes.
+        n_classes=3,
+        model_dir=dir)
+
+    classifier.train(
+        input_fn=lambda: input_fn(train, train_y, training=True),
+        steps=500)
+    classifier.export_saved_model(dir, receiver_fn)
+    shutil.rmtree(dir)
+
 @pytest.fixture
 def tf_estimator_random_data_run():
     mlflow.tensorflow.autolog()
     with mlflow.start_run() as run:
-        dir = tempfile.mkdtemp()
-        CSV_COLUMN_NAMES = ['SepalLength', 'SepalWidth', 'PetalLength', 'PetalWidth', 'Species']
-        SPECIES = ['Setosa', 'Versicolor', 'Virginica']
-
-        train = pd.read_csv(os.path.join(os.path.dirname(__file__), "iris_training.csv"),
-                            names=CSV_COLUMN_NAMES, header=0)
-        test = pd.read_csv(os.path.join(os.path.dirname(__file__), "iris_test.csv"),
-                           names=CSV_COLUMN_NAMES, header=0)
-
-        train_y = train.pop('Species')
-        test_y = test.pop('Species')
-
-        def input_fn(features, labels, training=True, batch_size=256):
-            """An input function for training or evaluating"""
-            # Convert the inputs to a Dataset.
-            dataset = tf.data.Dataset.from_tensor_slices((dict(features), labels))
-
-            # Shuffle and repeat if you are in training mode.
-            if training:
-                dataset = dataset.shuffle(1000).repeat()
-
-            return dataset.batch(batch_size)
-
-        my_feature_columns = []
-        for key in train.keys():
-            my_feature_columns.append(tf.feature_column.numeric_column(key=key))
-
-        feature_spec = {}
-        for feature in CSV_COLUMN_NAMES:
-            feature_spec[feature] = tf.placeholder(dtype="float", name=feature, shape=[150])
-
-        receiver_fn = tf.estimator.export.build_raw_serving_input_receiver_fn(feature_spec)
-
-        classifier = tf.estimator.DNNClassifier(
-            feature_columns=my_feature_columns,
-            # Two hidden layers of 10 nodes each.
-            hidden_units=[30, 10],
-            # The model must choose between 3 classes.
-            n_classes=3,
-            model_dir=dir)
-
-        classifier.train(
-            input_fn=lambda: input_fn(train, train_y, training=True),
-            steps=500)
-        classifier.export_saved_model(dir, receiver_fn)
-
-    shutil.rmtree(dir)
+        tf_estimator()
     return client.get_run(run.info.run_id)
 
 
@@ -251,12 +253,16 @@ def test_keras_autolog_persists_manually_created_run(random_train_data, random_o
         assert mlflow.active_run().info.run_id == run.info.run_id
 
 
-# These need to test for export_savedmodel and export_saved_model
 @pytest.mark.large
 def test_estimator_autolog_ends_auto_created_run():
-    pass
+    mlflow.tensorflow.autolog()
+    tf_estimator()
+    assert mlflow.active_run() is None
 
 
 @pytest.mark.large
-def test_estimator_autolog_ends_auto_created_run():
-    pass
+def test_estimator_autolog_persists_manually_created_run():
+    mlflow.tensorflow.autolog()
+    with mlflow.start_run() as run:
+        tf_estimator()
+        assert mlflow.active_run().info.run_id == run.info.run_id

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -170,6 +170,7 @@ def tf_estimator():
     classifier.export_saved_model(dir, receiver_fn)
     shutil.rmtree(dir)
 
+
 @pytest.fixture
 def tf_estimator_random_data_run():
     mlflow.tensorflow.autolog()

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -31,19 +31,21 @@ def random_train_data():
 
 
 @pytest.fixture
-def tf_keras_random_data_run(random_train_data):
-    mlflow.tensorflow.autolog(every_n_iter=5)
+def random_one_hot_labels():
+    n, n_class = (1000, 10)
+    classes = np.random.randint(0, n_class, n)
+    labels = np.zeros((n, n_class))
+    labels[np.arange(n), classes] = 1
+    return labels
 
-    def random_one_hot_labels(shape):
-        n, n_class = shape
-        classes = np.random.randint(0, n_class, n)
-        labels = np.zeros((n, n_class))
-        labels[np.arange(n), classes] = 1
-        return labels
+
+@pytest.fixture
+def tf_keras_random_data_run(random_train_data, random_one_hot_labels):
+    mlflow.tensorflow.autolog(every_n_iter=5)
 
     with mlflow.start_run() as run:
         data = random_train_data
-        labels = random_one_hot_labels((1000, 10))
+        labels = random_one_hot_labels
 
         model = tf.keras.Sequential()
 
@@ -214,6 +216,7 @@ def test_keras_autolog_persists_manually_created_run():
     pass
 
 
+# These need to test for export_savedmodel and export_saved_model
 @pytest.mark.large
 def test_estimator_autolog_ends_auto_created_run():
     pass

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -207,13 +207,48 @@ def test_duplicate_autolog_second_overrides(duplicate_autolog_tf_estimator_run):
 
 
 @pytest.mark.large
-def test_keras_autolog_ends_auto_created_run():
-    pass
+def test_keras_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels):
+    mlflow.tensorflow.autolog(every_n_iter=5)
+
+    data = random_train_data
+    labels = random_one_hot_labels
+
+    model = tf.keras.Sequential()
+
+    model.add(layers.Dense(64, activation='relu', input_shape=(32,)))
+    model.add(layers.Dense(64, activation='relu'))
+    model.add(layers.Dense(10, activation='softmax'))
+
+    model.compile(optimizer=tf.train.AdamOptimizer(0.001),
+                  loss='categorical_crossentropy',
+                  metrics=['accuracy'])
+
+    model.fit(data, labels, epochs=10)
+
+    assert mlflow.active_run() is None
 
 
 @pytest.mark.large
-def test_keras_autolog_persists_manually_created_run():
-    pass
+def test_keras_autolog_persists_manually_created_run(random_train_data, random_one_hot_labels):
+    mlflow.tensorflow.autolog(every_n_iter=5)
+
+    with mlflow.start_run() as run:
+        data = random_train_data
+        labels = random_one_hot_labels
+
+        model = tf.keras.Sequential()
+
+        model.add(layers.Dense(64, activation='relu', input_shape=(32,)))
+        model.add(layers.Dense(64, activation='relu'))
+        model.add(layers.Dense(10, activation='softmax'))
+
+        model.compile(optimizer=tf.train.AdamOptimizer(0.001),
+                      loss='categorical_crossentropy',
+                      metrics=['accuracy'])
+
+        model.fit(data, labels, epochs=10)
+
+        assert mlflow.active_run().info.run_id == run.info.run_id
 
 
 # These need to test for export_savedmodel and export_saved_model

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -202,3 +202,13 @@ def duplicate_autolog_tf_estimator_run():
 def test_duplicate_autolog_second_overrides(duplicate_autolog_tf_estimator_run):
     metrics = client.get_metric_history(duplicate_autolog_tf_estimator_run.info.run_id, 'loss')
     assert all((x.step - 1) % 4 == 0 for x in metrics)
+
+
+@pytest.mark.large
+def test_autolog_ends_self_created_run():
+    pass
+
+
+@pytest.mark.large
+def test_autolog_persists_manually_created_run():
+    pass


### PR DESCRIPTION
Previously, invoking autolog without an active run would keep the run open indefinitely, which might have not been clear to users of `autolog()`. This PR changes the logic of `autolog()` such that if there is no run active when anything is logged via autologging, a run is automatically created and is automatically closed after 
- a Keras or tf.Keras model calls `fit()`
- a TensorFlow.Estimator model calls `export_saved_model()` or `export_savedmodel()`.

`autolog()` will persist active runs that are manually created by other methods.

## How is this patch tested?

Keras, TensorFlow.Keras (versions 1.X and 2.0):
- Tests that checks `autolog()` does not persist automatically created runs after calling `fit()`
- Tests that checks `autolog()` persists manually created runs after calling `fit()`

TensorFlow.Estimator (versions 1.X and 2.0):
- Same as above, but `fit()` is replaced with `export_saved_model()`

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Keras and tf.Keras autologging now automatically ends runs after calling `fit()`, and TensorFlow.estimator autologging after `export_saved_model()` or `export_savedmodel()`.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
