### PR TITLE
Improved error message for starting duplicate runs

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -106,8 +106,9 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False):
     # back compat for int experiment_id
     experiment_id = str(experiment_id) if isinstance(experiment_id, int) else experiment_id
     if len(_active_run_stack) > 0 and not nested:
-        raise Exception(("Run with UUID {} is already active. To start a nested " +
-                        "run, call start_run with nested=True").format(
+        raise Exception(("Run with UUID {} is already active. To start a new run, first end the " +
+                         "current run with end_run(). To start a nested " +
+                         "run, call start_run with nested=True").format(
             _active_run_stack[0].info.run_id))
     if run_id:
         existing_run_id = run_id

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -107,7 +107,7 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False):
     experiment_id = str(experiment_id) if isinstance(experiment_id, int) else experiment_id
     if len(_active_run_stack) > 0 and not nested:
         raise Exception(("Run with UUID {} is already active. To start a new run, first end the " +
-                         "current run with end_run(). To start a nested " +
+                         "current run with mlflow.end_run(). To start a nested " +
                          "run, call start_run with nested=True").format(
             _active_run_stack[0].info.run_id))
     if run_id:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Makes the error message thrown when attempting to start a new non-nested run while one is already active more descriptive.

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
