### PR TITLE
Push orderby and pagination to sql

### DIFF
--- a/mlflow/entities/run_info.py
+++ b/mlflow/entities/run_info.py
@@ -110,7 +110,7 @@ class RunInfo(_MLflowObject):
         """Start time of the run, in number of milliseconds since the UNIX epoch."""
         return self._start_time
 
-    @property
+    @orderable_attribute
     def end_time(self):
         """End time of the run, in number of milliseconds since the UNIX epoch."""
         return self._end_time

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -576,7 +576,6 @@ class SqlAlchemyStore(AbstractStore):
 
     def _search_runs(self, experiment_ids, filter_string, run_view_type, max_results, order_by_list,
                      page_token):
-        # TODO: push search query into backend database layer
         if max_results > SEARCH_MAX_RESULTS_THRESHOLD:
             raise MlflowException("Invalid value for request parameter max_results. It must be at "
                                   "most {}, but got value {}".format(SEARCH_MAX_RESULTS_THRESHOLD,
@@ -705,7 +704,7 @@ def get_orderby_clauses(order_by_list, session):
         for order_by_clause in order_by_list:
             (key_type, key, ascending) = SearchUtils.parse_order_by(order_by_clause)
             subquery = None
-            if key_type == SearchUtils.ATTRIBUTE_IDENTIFIER:
+            if SearchUtils.is_attribute(key_type):
                 order_value = getattr(SqlRun, key)
             else:
                 if SearchUtils.is_metric(key_type, '='):  # any valid comparator

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -740,14 +740,17 @@ def _get_orderby_clauses(order_by_list, session):
 
             # sqlite does not support NULLS LAST expression, so we sort first by
             # presence of the field (and is_nan for metrics), then by actual value
+            # As the subqueries are created independently and used later in the
+            # same main query, the CASE WHEN columns need to have unique names to
+            # avoid ambiguity
             if SearchUtils.is_metric(key_type, '='):
                 clauses.append(sql.case([
                     (subquery.c.is_nan.is_(True), 1),
                     (order_value.is_(None), 1)
-                ], else_=0).label(f'clause_{clause_id}'))
+                ], else_=0).label('clause_%s' % clause_id))
             else:  # other entities do not have an 'is_nan' field
                 clauses.append(sql.case([(order_value.is_(None), 1)], else_=0)
-                               .label(f'clause_{clause_id}'))
+                               .label('clause_%s' % clause_id))
 
             if ascending:
                 clauses.append(order_value)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -574,7 +574,7 @@ class SqlAlchemyStore(AbstractStore):
                     error_code=INVALID_STATE)
             session.delete(filtered_tags[0])
 
-    def _search_runs(self, experiment_ids, filter_string, run_view_type, max_results, order_by_list,
+    def _search_runs(self, experiment_ids, filter_string, run_view_type, max_results, order_by,
                      page_token):
 
         def compute_next_token(current_size):
@@ -599,7 +599,7 @@ class SqlAlchemyStore(AbstractStore):
             # ``run.to_mlflow_entity()``, so eager loading helps avoid additional database queries
             # that are otherwise executed at attribute access time under a lazy loading model.
             parsed_filters = SearchUtils.parse_search_filter(filter_string)
-            parsed_orderby, sorting_joins = get_orderby_clauses(order_by_list, session)
+            parsed_orderby, sorting_joins = get_orderby_clauses(order_by, session)
 
             query = session.query(SqlRun)
             for j in _get_sqlalchemy_filter_clauses(parsed_filters, session) + sorting_joins:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -599,7 +599,7 @@ class SqlAlchemyStore(AbstractStore):
             # ``run.to_mlflow_entity()``, so eager loading helps avoid additional database queries
             # that are otherwise executed at attribute access time under a lazy loading model.
             parsed_filters = SearchUtils.parse_search_filter(filter_string)
-            parsed_orderby, sorting_joins = get_orderby_clauses(order_by, session)
+            parsed_orderby, sorting_joins = _get_orderby_clauses(order_by, session)
 
             query = session.query(SqlRun)
             for j in _get_sqlalchemy_filter_clauses(parsed_filters, session) + sorting_joins:
@@ -701,7 +701,7 @@ def _get_sqlalchemy_filter_clauses(parsed, session):
     return filters
 
 
-def get_orderby_clauses(order_by_list, session):
+def _get_orderby_clauses(order_by_list, session):
     """Sorts a set of runs based on their natural ordering and an overriding set of order_bys.
     Runs are naturally ordered first by start time descending, then by run id for tie-breaking.
     """
@@ -714,16 +714,19 @@ def get_orderby_clauses(order_by_list, session):
     if order_by_list:
         for order_by_clause in order_by_list:
             (key_type, key, ascending) = SearchUtils.parse_order_by(order_by_clause)
-            subquery = None
             if SearchUtils.is_attribute(key_type, '='):
                 order_value = getattr(SqlRun, SqlRun.get_attribute_name(key))
             else:
                 if SearchUtils.is_metric(key_type, '='):  # any valid comparator
                     entity = SqlLatestMetric
+                    value_label = "latest_metrics_value"
+                    is_nan_value = "latest_metrics_is_nan"
                 elif SearchUtils.is_tag(key_type, '='):
                     entity = SqlTag
+                    value_label = "tags_value"
                 elif SearchUtils.is_param(key_type, '='):
                     entity = SqlParam
+                    value_label = "params_value"
                 else:
                     raise MlflowException("Invalid identifier type '%s'" % key_type,
                                           error_code=INVALID_PARAMETER_VALUE)
@@ -733,18 +736,18 @@ def get_orderby_clauses(order_by_list, session):
                 subquery = session \
                     .query(entity) \
                     .filter(entity.key == key) \
-                    .subquery()
+                    .subquery(with_labels=True)
+
                 ordering_joins.append(subquery)
-                order_value = subquery.c.value
+                order_value = getattr(subquery.c, value_label)
 
             # sqlite does not support NULLS LAST expression, so we sort first by
             # presence of the field (and is_nan for metrics), then by actual value
             if SearchUtils.is_metric(key_type, '='):
                 clauses.append(sql.case([
-                    (subquery.c.is_nan.is_(True), 1),
+                    (getattr(subquery.c, is_nan_value).is_(True), 1),
                     (order_value.is_(None), 1)
-                ],
-                    else_=0))
+                ], else_=0))
             else:  # other entities do not have an 'is_nan' field
                 clauses.append(sql.case([(order_value.is_(None), 1)], else_=0))
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -716,7 +716,7 @@ def get_orderby_clauses(order_by_list, session):
             (key_type, key, ascending) = SearchUtils.parse_order_by(order_by_clause)
             subquery = None
             if SearchUtils.is_attribute(key_type, '='):
-                order_value = getattr(SqlRun, key)
+                order_value = getattr(SqlRun, SqlRun.get_attribute_name(key))
             else:
                 if SearchUtils.is_metric(key_type, '='):  # any valid comparator
                     entity = SqlLatestMetric

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -310,7 +310,7 @@ class SqlAlchemyStore(AbstractStore):
             experiment.name = new_name
             self._save_to_db(objs=experiment, session=session)
 
-    def create_run(self, experiment_id, user_id, start_time, tags):
+    def create_run(self, experiment_id, user_id, start_time, tags, end_time = None):
         with self.ManagedSessionMaker() as session:
             experiment = self.get_experiment(experiment_id)
             self._check_experiment_is_active(experiment)
@@ -323,7 +323,7 @@ class SqlAlchemyStore(AbstractStore):
                          source_type=SourceType.to_string(SourceType.UNKNOWN),
                          source_name="", entry_point_name="",
                          user_id=user_id, status=RunStatus.to_string(RunStatus.RUNNING),
-                         start_time=start_time, end_time=None,
+                         start_time=start_time, end_time=end_time,
                          source_version="", lifecycle_stage=LifecycleStage.ACTIVE)
 
             tags_dict = {}

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -591,12 +591,10 @@ class SqlAlchemyStore(AbstractStore):
             # ``run.to_mlflow_entity()``, so eager loading helps avoid additional database queries
             # that are otherwise executed at attribute access time under a lazy loading model.
             parsed_filters = SearchUtils.parse_search_filter(filter_string)
-            parsed_orderby, joins = get_orderby_clauses(order_by_list, session)
+            parsed_orderby, sorting_joins = get_orderby_clauses(order_by_list, session)
 
             query = session.query(SqlRun)
-            for s in _get_sqlalchemy_filter_clauses(parsed_filters, session):
-                query = query.join(s)
-            for j in joins:
+            for j in _get_sqlalchemy_filter_clauses(parsed_filters, session) + sorting_joins:
                 query = query.join(j)
 
             queried_runs = query.distinct() \
@@ -699,39 +697,51 @@ def get_orderby_clauses(order_by_list, session):
     """
 
     clauses = []
-    ordering_joins = set()
+    ordering_joins = []
 
+    # contrary to filters, it is not easily feasible to separately handle sorting
+    # on attributes and on joined tables as we must keep all clauses in the same order
     if order_by_list:
         for order_by_clause in order_by_list:
             (key_type, key, ascending) = SearchUtils.parse_order_by(order_by_clause)
-            order_value = None
+            subquery = None
             if key_type == SearchUtils.ATTRIBUTE_IDENTIFIER:
-                # sqlite does not support NULLS LAST expression, so we sort
-                # first by presence of the field, then by actual value
                 order_value = getattr(SqlRun, key)
-                clauses.append(sql.case([(order_value.is_(None), 1)],
-                                        else_=0))
-            elif SearchUtils.is_metric(key_type, '<'):  # any valid comparator
+            else:
+                if SearchUtils.is_metric(key_type, '='):  # any valid comparator
+                    entity = SqlLatestMetric
+                elif SearchUtils.is_tag(key_type, '='):
+                    entity = SqlTag
+                elif SearchUtils.is_param(key_type, '='):
+                    entity = SqlParam
+                else:
+                    raise MlflowException("Invalid identifier type '%s'" % key_type,
+                                          error_code=INVALID_PARAMETER_VALUE)
+
                 # build a subquery first because we will join it in the main request so that the
                 # metric we want to sort on is available when we apply the sorting clause
                 subquery = session \
-                    .query(SqlLatestMetric) \
-                    .filter(SqlLatestMetric.key == key) \
+                    .query(entity) \
+                    .filter(entity.key == key) \
                     .subquery()
-                ordering_joins.add(subquery)
-
+                ordering_joins.append(subquery)
                 order_value = subquery.c.value
-                clauses.append(sql.case([
-                        (subquery.c.is_nan.is_(True), 1),
-                        (order_value.is_(None), 1)
-                        ],
-                        else_=0))
 
-            if order_value is not None:
-                if ascending:
-                    clauses.append(order_value)
-                else:
-                    clauses.append(order_value.desc())
+            # sqlite does not support NULLS LAST expression, so we sort first by
+            # presence of the field (and is_nan for metrics), then by actual value
+            if SearchUtils.is_metric(key_type, '='):
+                clauses.append(sql.case([
+                    (subquery.c.is_nan.is_(True), 1),
+                    (order_value.is_(None), 1)
+                ],
+                    else_=0))
+            else:  # other entities do not have an 'is_nan' field
+                clauses.append(sql.case([(order_value.is_(None), 1)], else_=0))
+
+            if ascending:
+                clauses.append(order_value)
+            else:
+                clauses.append(order_value.desc())
 
     clauses.append(SqlRun.start_time.desc())
     clauses.append(SqlRun.run_uuid)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -573,7 +573,7 @@ class SqlAlchemyStore(AbstractStore):
                     error_code=INVALID_STATE)
             session.delete(filtered_tags[0])
 
-    def _search_runs(self, experiment_ids, filter_string, run_view_type, max_results, order_by,
+    def _search_runs(self, experiment_ids, filter_string, run_view_type, max_results, order_by_list,
                      page_token):
         # TODO: push search query into backend database layer
         if max_results > SEARCH_MAX_RESULTS_THRESHOLD:
@@ -589,10 +589,11 @@ class SqlAlchemyStore(AbstractStore):
             # tags. These run attributes are referenced during the invocation of
             # ``run.to_mlflow_entity()``, so eager loading helps avoid additional database queries
             # that are otherwise executed at attribute access time under a lazy loading model.
-            query = session.query(SqlRun)
+            parsed_filters = SearchUtils.parse_search_filter(filter_string)
+            parsed_orderby = get_orderby_clauses(order_by_list)
 
-            parsed = SearchUtils.parse_search_filter(filter_string)
-            for s in _get_sqlalchemy_filter_clauses(parsed, session):
+            query = session.query(SqlRun)
+            for s in _get_sqlalchemy_filter_clauses(parsed_filters, session):
                 query = query.join(s)
 
             queried_runs = query.distinct() \
@@ -600,11 +601,12 @@ class SqlAlchemyStore(AbstractStore):
                 .filter(
                     SqlRun.experiment_id.in_(experiment_ids),
                     SqlRun.lifecycle_stage.in_(stages),
-                    *_get_attributes_filtering_clauses(parsed)) \
+                    *_get_attributes_filtering_clauses(parsed_filters)) \
+                .order_by(*parsed_orderby) \
                 .all()
-            runs = [run.to_mlflow_entity() for run in queried_runs]
+            sorted_runs = [run.to_mlflow_entity() for run in queried_runs]
 
-        sorted_runs = SearchUtils.sort(runs, order_by)
+        #sorted_runs = SearchUtils.sort(runs, order_by_list)
         runs, next_page_token = SearchUtils.paginate(sorted_runs, page_token, max_results)
         return runs, next_page_token
 
@@ -687,3 +689,34 @@ def _get_sqlalchemy_filter_clauses(parsed, session):
         if filter_query is not None:
             filters.append(filter_query)
     return filters
+
+
+def get_orderby_clauses(order_by_list):
+    """Sorts a set of runs based on their natural ordering and an overriding set of order_bys.
+    Runs are naturally ordered first by start time descending, then by run id for tie-breaking.
+    """
+    import sqlalchemy.sql.expression as sql
+
+    clauses = []
+    additional_joins = []
+
+    for order_by_clause in order_by_list:
+        (key_type, key, ascending) = SearchUtils.parse_order_by(order_by_clause)
+        order_key = None
+        if key_type == SearchUtils.ATTRIBUTE_IDENTIFIER:
+            # sqlite does not support NULLS LAST expression, so we sort
+            # first by presence of the field, then by actual value
+            order_key = getattr(SqlRun, key)
+            clauses.append(sql.case([(order_key.is_(None), 1)],
+                                    else_=0))
+
+        if order_key:
+
+            if ascending:
+                clauses.append(order_key)
+            else:
+                clauses.append(order_key.desc())
+
+    clauses.append(SqlRun.start_time.desc())
+    clauses.append(SqlRun.run_uuid)
+    return clauses

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -311,7 +311,7 @@ class SqlAlchemyStore(AbstractStore):
             experiment.name = new_name
             self._save_to_db(objs=experiment, session=session)
 
-    def create_run(self, experiment_id, user_id, start_time, tags, end_time = None):
+    def create_run(self, experiment_id, user_id, start_time, tags):
         with self.ManagedSessionMaker() as session:
             experiment = self.get_experiment(experiment_id)
             self._check_experiment_is_active(experiment)
@@ -324,7 +324,7 @@ class SqlAlchemyStore(AbstractStore):
                          source_type=SourceType.to_string(SourceType.UNKNOWN),
                          source_name="", entry_point_name="",
                          user_id=user_id, status=RunStatus.to_string(RunStatus.RUNNING),
-                         start_time=start_time, end_time=end_time,
+                         start_time=start_time, end_time=None,
                          source_version="", lifecycle_stage=LifecycleStage.ACTIVE)
 
             tags_dict = {}
@@ -704,7 +704,7 @@ def get_orderby_clauses(order_by_list, session):
         for order_by_clause in order_by_list:
             (key_type, key, ascending) = SearchUtils.parse_order_by(order_by_clause)
             subquery = None
-            if SearchUtils.is_attribute(key_type):
+            if SearchUtils.is_attribute(key_type, '='):
                 order_value = getattr(SqlRun, key)
             else:
                 if SearchUtils.is_metric(key_type, '='):  # any valid comparator

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -746,7 +746,8 @@ def _get_orderby_clauses(order_by_list, session):
                     (order_value.is_(None), 1)
                 ], else_=0).label(f'clause_{clause_id}'))
             else:  # other entities do not have an 'is_nan' field
-                clauses.append(sql.case([(order_value.is_(None), 1)], else_=0).label(f'clause_{clause_id}'))
+                clauses.append(sql.case([(order_value.is_(None), 1)], else_=0)
+                               .label(f'clause_{clause_id}'))
 
             if ascending:
                 clauses.append(order_value)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -702,20 +702,20 @@ def get_orderby_clauses(order_by_list):
 
     for order_by_clause in order_by_list:
         (key_type, key, ascending) = SearchUtils.parse_order_by(order_by_clause)
-        order_key = None
+        order_value = None
         if key_type == SearchUtils.ATTRIBUTE_IDENTIFIER:
             # sqlite does not support NULLS LAST expression, so we sort
             # first by presence of the field, then by actual value
-            order_key = getattr(SqlRun, key)
-            clauses.append(sql.case([(order_key.is_(None), 1)],
+            order_value = getattr(SqlRun, key)
+            clauses.append(sql.case([(order_value.is_(None), 1)],
                                     else_=0))
 
-        if order_key:
+        if order_value:
 
             if ascending:
-                clauses.append(order_key)
+                clauses.append(order_value)
             else:
-                clauses.append(order_key.desc())
+                clauses.append(order_value.desc())
 
     clauses.append(SqlRun.start_time.desc())
     clauses.append(SqlRun.run_uuid)

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -26,9 +26,9 @@ class SearchUtils(object):
     _ALTERNATE_PARAM_IDENTIFIERS = set(["parameters", "param", "params"])
     _TAG_IDENTIFIER = "tag"
     _ALTERNATE_TAG_IDENTIFIERS = set(["tags"])
-    ATTRIBUTE_IDENTIFIER = "attribute"
+    _ATTRIBUTE_IDENTIFIER = "attribute"
     _ALTERNATE_ATTRIBUTE_IDENTIFIERS = set(["attr", "attributes", "run"])
-    _IDENTIFIERS = [_METRIC_IDENTIFIER, _PARAM_IDENTIFIER, _TAG_IDENTIFIER, ATTRIBUTE_IDENTIFIER]
+    _IDENTIFIERS = [_METRIC_IDENTIFIER, _PARAM_IDENTIFIER, _TAG_IDENTIFIER, _ATTRIBUTE_IDENTIFIER]
     _VALID_IDENTIFIERS = set(_IDENTIFIERS
                              + list(_ALTERNATE_METRIC_IDENTIFIERS)
                              + list(_ALTERNATE_PARAM_IDENTIFIERS)
@@ -92,7 +92,7 @@ class SearchUtils(object):
         elif entity_type in cls._ALTERNATE_TAG_IDENTIFIERS:
             return cls._TAG_IDENTIFIER
         elif entity_type in cls._ALTERNATE_ATTRIBUTE_IDENTIFIERS:
-            return cls.ATTRIBUTE_IDENTIFIER
+            return cls._ATTRIBUTE_IDENTIFIER
         else:
             # one of ("metric", "parameter", "tag", or "attribute") since it a valid type
             return entity_type
@@ -108,7 +108,7 @@ class SearchUtils(object):
                                   error_code=INVALID_PARAMETER_VALUE)
         identifier = cls._valid_entity_type(entity_type)
         key = cls._trim_backticks(cls._strip_quotes(key))
-        if identifier == cls.ATTRIBUTE_IDENTIFIER and key not in valid_attributes:
+        if identifier == cls._ATTRIBUTE_IDENTIFIER and key not in valid_attributes:
             raise MlflowException("Invalid attribute key '{}' specified. Valid keys "
                                   " are '{}'".format(key, valid_attributes))
         return {"type": identifier, "key": key}
@@ -129,7 +129,7 @@ class SearchUtils(object):
                                   "{value}".format(identifier_type=identifier_type,
                                                    value=token.value),
                                   error_code=INVALID_PARAMETER_VALUE)
-        elif identifier_type == cls.ATTRIBUTE_IDENTIFIER:
+        elif identifier_type == cls._ATTRIBUTE_IDENTIFIER:
             if token.ttype in cls.STRING_VALUE_TYPES or isinstance(token, Identifier):
                 return cls._strip_quotes(token.value, expect_quoted_value=True)
             else:
@@ -243,7 +243,7 @@ class SearchUtils(object):
 
     @classmethod
     def is_attribute(cls, key_type, comparator):
-        if key_type == cls.ATTRIBUTE_IDENTIFIER:
+        if key_type == cls._ATTRIBUTE_IDENTIFIER:
             if comparator not in cls.VALID_STRING_ATTRIBUTE_COMPARATORS:
                 raise MlflowException("Invalid comparator '{}' not one of "
                                       "'{}".format(comparator,
@@ -325,7 +325,7 @@ class SearchUtils(object):
             sort_value = run.data.params.get(key)
         elif key_type == cls._TAG_IDENTIFIER:
             sort_value = run.data.tags.get(key)
-        elif key_type == cls.ATTRIBUTE_IDENTIFIER:
+        elif key_type == cls._ATTRIBUTE_IDENTIFIER:
             sort_value = getattr(run.info, key)
         else:
             raise MlflowException("Invalid order_by entity type '%s'" % key_type,

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -357,7 +357,7 @@ class SearchUtils(object):
         return runs
 
     @classmethod
-    def _parse_start_offset_from_page_token(cls, page_token):
+    def parse_start_offset_from_page_token(cls, page_token):
         # Note: the page_token is expected to be a base64-encoded JSON that looks like
         # { "offset": xxx }. However, this format is not stable, so it should not be
         # relied upon outside of this method.
@@ -393,7 +393,7 @@ class SearchUtils(object):
         return offset
 
     @classmethod
-    def _create_page_token(cls, offset):
+    def create_page_token(cls, offset):
         return base64.b64encode(json.dumps({"offset": offset}).encode("utf-8"))
 
     @classmethod
@@ -402,7 +402,7 @@ class SearchUtils(object):
         results limit. Returns a pair containing the set of paginated runs, followed by
         an optional next_page_token if there are further results that need to be returned.
         """
-        start_offset = cls._parse_start_offset_from_page_token(page_token)
+        start_offset = cls.parse_start_offset_from_page_token(page_token)
         final_offset = start_offset + max_results
 
         paginated_runs = runs[start_offset:final_offset]

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -26,9 +26,9 @@ class SearchUtils(object):
     _ALTERNATE_PARAM_IDENTIFIERS = set(["parameters", "param", "params"])
     _TAG_IDENTIFIER = "tag"
     _ALTERNATE_TAG_IDENTIFIERS = set(["tags"])
-    _ATTRIBUTE_IDENTIFIER = "attribute"
+    ATTRIBUTE_IDENTIFIER = "attribute"
     _ALTERNATE_ATTRIBUTE_IDENTIFIERS = set(["attr", "attributes", "run"])
-    _IDENTIFIERS = [_METRIC_IDENTIFIER, _PARAM_IDENTIFIER, _TAG_IDENTIFIER, _ATTRIBUTE_IDENTIFIER]
+    _IDENTIFIERS = [_METRIC_IDENTIFIER, _PARAM_IDENTIFIER, _TAG_IDENTIFIER, ATTRIBUTE_IDENTIFIER]
     _VALID_IDENTIFIERS = set(_IDENTIFIERS
                              + list(_ALTERNATE_METRIC_IDENTIFIERS)
                              + list(_ALTERNATE_PARAM_IDENTIFIERS)
@@ -92,7 +92,7 @@ class SearchUtils(object):
         elif entity_type in cls._ALTERNATE_TAG_IDENTIFIERS:
             return cls._TAG_IDENTIFIER
         elif entity_type in cls._ALTERNATE_ATTRIBUTE_IDENTIFIERS:
-            return cls._ATTRIBUTE_IDENTIFIER
+            return cls.ATTRIBUTE_IDENTIFIER
         else:
             # one of ("metric", "parameter", "tag", or "attribute") since it a valid type
             return entity_type
@@ -108,7 +108,7 @@ class SearchUtils(object):
                                   error_code=INVALID_PARAMETER_VALUE)
         identifier = cls._valid_entity_type(entity_type)
         key = cls._trim_backticks(cls._strip_quotes(key))
-        if identifier == cls._ATTRIBUTE_IDENTIFIER and key not in valid_attributes:
+        if identifier == cls.ATTRIBUTE_IDENTIFIER and key not in valid_attributes:
             raise MlflowException("Invalid attribute key '{}' specified. Valid keys "
                                   " are '{}'".format(key, valid_attributes))
         return {"type": identifier, "key": key}
@@ -129,7 +129,7 @@ class SearchUtils(object):
                                   "{value}".format(identifier_type=identifier_type,
                                                    value=token.value),
                                   error_code=INVALID_PARAMETER_VALUE)
-        elif identifier_type == cls._ATTRIBUTE_IDENTIFIER:
+        elif identifier_type == cls.ATTRIBUTE_IDENTIFIER:
             if token.ttype in cls.STRING_VALUE_TYPES or isinstance(token, Identifier):
                 return cls._strip_quotes(token.value, expect_quoted_value=True)
             else:
@@ -243,7 +243,7 @@ class SearchUtils(object):
 
     @classmethod
     def is_attribute(cls, key_type, comparator):
-        if key_type == cls._ATTRIBUTE_IDENTIFIER:
+        if key_type == cls.ATTRIBUTE_IDENTIFIER:
             if comparator not in cls.VALID_STRING_ATTRIBUTE_COMPARATORS:
                 raise MlflowException("Invalid comparator '{}' not one of "
                                       "'{}".format(comparator,
@@ -325,7 +325,7 @@ class SearchUtils(object):
             sort_value = run.data.params.get(key)
         elif key_type == cls._TAG_IDENTIFIER:
             sort_value = run.data.tags.get(key)
-        elif key_type == cls._ATTRIBUTE_IDENTIFIER:
+        elif key_type == cls.ATTRIBUTE_IDENTIFIER:
             sort_value = getattr(run.info, key)
         else:
             raise MlflowException("Invalid order_by entity type '%s'" % key_type,

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -408,7 +408,7 @@ class SearchUtils(object):
         paginated_runs = runs[start_offset:final_offset]
         next_page_token = None
         if final_offset < len(runs):
-            next_page_token = cls._create_page_token(final_offset)
+            next_page_token = cls.create_page_token(final_offset)
         return (paginated_runs, next_page_token)
 
     # Model Registry specific parser

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -290,7 +290,7 @@ class SearchUtils(object):
         return [run for run in runs if run_matches(run)]
 
     @classmethod
-    def _parse_order_by(cls, order_by):
+    def parse_order_by(cls, order_by):
         try:
             parsed = sqlparse.parse(order_by)
         except Exception:
@@ -349,7 +349,7 @@ class SearchUtils(object):
         # NB: We rely on the stability of Python's sort function, so that we can apply
         # the ordering conditions in reverse order.
         for order_by_clause in reversed(order_by_list):
-            (key_type, key, ascending) = cls._parse_order_by(order_by_clause)
+            (key_type, key, ascending) = cls.parse_order_by(order_by_clause)
             # pylint: disable=cell-var-from-loop
             runs = sorted(runs,
                           key=lambda run: cls._get_value_for_sort(run, key_type, key, ascending),

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1358,18 +1358,18 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         This JSON dump can be replicated by installing MLflow version 1.2.0 and executing the
         following code from the directory containing this test suite:
 
-        # >>> import json
-        # >>> import mlflow
-        # >>> from mlflow.tracking.client import MlflowClient
-        # >>> mlflow.set_tracking_uri(
-        # ...     "sqlite:///../../resources/db/db_version_7ac759974ad8_with_metrics.sql")
-        # >>> client = MlflowClient()
-        # >>> summary_metrics = {
-        # ...     run.info.run_id: run.data.metrics for run
-        # ...     in client.search_runs(experiment_ids="0")
-        # ... }
-        # >>> with open("dump.json", "w") as dump_file:
-        # >>>     json.dump(summary_metrics, dump_file, indent=4)
+        >>> import json
+        >>> import mlflow
+        >>> from mlflow.tracking.client import MlflowClient
+        >>> mlflow.set_tracking_uri(
+        ...     "sqlite:///../../resources/db/db_version_7ac759974ad8_with_metrics.sql")
+        >>> client = MlflowClient()
+        >>> summary_metrics = {
+        ...     run.info.run_id: run.data.metrics for run
+        ...     in client.search_runs(experiment_ids="0")
+        ... }
+        >>> with open("dump.json", "w") as dump_file:
+        >>>     json.dump(summary_metrics, dump_file, indent=4)
         """
         current_dir = os.path.dirname(os.path.abspath(__file__))
         db_resources_path = os.path.normpath(

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -842,7 +842,6 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         experiment_id = self.store.create_experiment('order_by_attributes')
 
         def create_run(start_time, end):
-
             return self.store.create_run(
                     experiment_id,
                     user_id="MrDuck",
@@ -1395,20 +1394,24 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
     def _generate_large_data(self, nb_runs=1000):
         experiment_id = self.store.create_experiment('test_experiment')
-        run_ids = []
-        for _ in range(nb_runs):
-            run_ids.append(self.store.create_run(
-                experiment_id=experiment_id,
-                start_time=time.time(),
-                tags=(),
-                user_id='Anderson').info.run_uuid)
 
         current_run = 0
+
+        run_ids = []
         metrics_list = []
         tags_list = []
         params_list = []
         latest_metrics_list = []
-        for run_id in run_ids:
+
+        for _ in range(nb_runs):
+            run_id = self.store.create_run(
+                experiment_id=experiment_id,
+                start_time=current_run,
+                tags=(),
+                user_id='Anderson').info.run_uuid
+
+            run_ids.append(run_id)
+
             for i in range(100):
                 metric = {
                     'key': 'mkey_%s' % i,
@@ -1486,17 +1489,6 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                                              "and params.pkey_0 = 'pval_0'",
                                              ViewType.ALL, max_results=5)
         assert len(run_results) == 1  # 2 runs on previous request, 1 of which has a 0 pkey_0 value
-
-    def test_get_attribute_name(self):
-        assert(models.SqlRun.get_attribute_name("artifact_uri") == "artifact_uri")
-        assert(models.SqlRun.get_attribute_name("status") == "status")
-        assert(models.SqlRun.get_attribute_name("start_time") == "start_time")
-        assert(models.SqlRun.get_attribute_name("end_time") == "end_time")
-
-        # we want this to break if a searchable or orderable attribute has been added
-        # and not referred to in this test
-        # searchable attibutes are also orderable
-        assert(len(entities.RunInfo.get_orderable_attributes()) == 4)
 
 
 class TestSqlAlchemyStoreSqliteMigratedDB(TestSqlAlchemyStoreSqlite):
@@ -1593,7 +1585,10 @@ class TestZeroValueInsertion(unittest.TestCase):
 def test_get_attribute_name():
     assert(models.SqlRun.get_attribute_name("artifact_uri") == "artifact_uri")
     assert(models.SqlRun.get_attribute_name("status") == "status")
+    assert(models.SqlRun.get_attribute_name("start_time") == "start_time")
+    assert(models.SqlRun.get_attribute_name("end_time") == "end_time")
 
-    # we want this to break if a searchable attribute has been added
+    # we want this to break if a searchable or orderable attribute has been added
     # and not referred to in this test
-    assert(len(entities.RunInfo.get_searchable_attributes()) == 2)
+    # searchable attibutes are also orderable
+    assert(len(entities.RunInfo.get_orderable_attributes()) == 4)

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1487,6 +1487,17 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                                              ViewType.ALL, max_results=5)
         assert len(run_results) == 1  # 2 runs on previous request, 1 of which has a 0 pkey_0 value
 
+    def test_get_attribute_name(self):
+        assert(models.SqlRun.get_attribute_name("artifact_uri") == "artifact_uri")
+        assert(models.SqlRun.get_attribute_name("status") == "status")
+        assert(models.SqlRun.get_attribute_name("start_time") == "start_time")
+        assert(models.SqlRun.get_attribute_name("end_time") == "end_time")
+
+        # we want this to break if a searchable or orderable attribute has been added
+        # and not referred to in this test
+        # searchable attibutes are also orderable
+        assert(len(entities.RunInfo.get_orderable_attributes()) == 4)
+
 
 class TestSqlAlchemyStoreSqliteMigratedDB(TestSqlAlchemyStoreSqlite):
     """

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -810,10 +810,6 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                          ["1", "2", "3", "4", "5", "6", "7"]):
             create_and_log_run(names)
 
-        import logging
-        logging.basicConfig()
-        #logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
-
         # asc/asc
         self.assertListEqual(["-inf/3", "-1000/4", "0/5", "0/6", "1000/7", "inf/2", "nan/1"],
                              self.get_ordered_runs(["metrics.x asc", "metrics.y asc"],

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -843,21 +843,21 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
     def test_order_by_attributes(self):
         experiment_id = self.store.create_experiment('order_by_attributes')
 
-        def create_runs(end_times):
-            start_time = 123
-            for end in end_times:
-                self.store.create_run(
+        def create_run(start_time, end):
+
+            return self.store.create_run(
                     experiment_id,
                     user_id="MrDuck",
                     start_time=start_time,
-                    end_time=end,
                     tags=[entities.RunTag(mlflow_tags.MLFLOW_RUN_NAME, end)]).info.run_id
-                start_time += 1
 
-        create_runs([234, None, 456, -123, 789, 123])
+        start_time = 123
+        for end in [234, None, 456, -123, 789, 123]:
+            run_id = create_run(start_time, end)
+            self.store.update_run_info(run_id, run_status=RunStatus.FINISHED, end_time=end)
+            start_time += 1
 
         # asc
-
         self.assertListEqual(["-123", "123", "234", "456", "789", None],
                              self.get_ordered_runs(["attribute.end_time asc"], experiment_id))
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -810,6 +810,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                          ["1", "2", "3", "4", "5", "6", "7"]):
             create_and_log_run(names)
 
+        import logging
+        logging.basicConfig()
+        #logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
+
         # asc/asc
         self.assertListEqual(["-inf/3", "-1000/4", "0/5", "0/6", "1000/7", "inf/2", "nan/1"],
                              self.get_ordered_runs(["metrics.x asc", "metrics.y asc"],
@@ -1358,18 +1362,18 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         This JSON dump can be replicated by installing MLflow version 1.2.0 and executing the
         following code from the directory containing this test suite:
 
-        >>> import json
-        >>> import mlflow
-        >>> from mlflow.tracking.client import MlflowClient
-        >>> mlflow.set_tracking_uri(
-        ...     "sqlite:///../../resources/db/db_version_7ac759974ad8_with_metrics.sql")
-        >>> client = MlflowClient()
-        >>> summary_metrics = {
-        ...     run.info.run_id: run.data.metrics for run
-        ...     in client.search_runs(experiment_ids="0")
-        ... }
-        >>> with open("dump.json", "w") as dump_file:
-        >>>     json.dump(summary_metrics, dump_file, indent=4)
+        # >>> import json
+        # >>> import mlflow
+        # >>> from mlflow.tracking.client import MlflowClient
+        # >>> mlflow.set_tracking_uri(
+        # ...     "sqlite:///../../resources/db/db_version_7ac759974ad8_with_metrics.sql")
+        # >>> client = MlflowClient()
+        # >>> summary_metrics = {
+        # ...     run.info.run_id: run.data.metrics for run
+        # ...     in client.search_runs(experiment_ids="0")
+        # ... }
+        # >>> with open("dump.json", "w") as dump_file:
+        # >>>     json.dump(summary_metrics, dump_file, indent=4)
         """
         current_dir = os.path.dirname(os.path.abspath(__file__))
         db_resources_path = os.path.normpath(

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1463,7 +1463,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         run_results = self.store.search_runs([experiment_id], None, ViewType.ALL, max_results=100)
         assert len(run_results) == 100
         # runs are sorted by desc start_time
-        self.assertListEqual([run.info.run_id for run in run_results], list(reversed(run_ids[900:])))
+        self.assertListEqual([run.info.run_id for run in run_results],
+                             list(reversed(run_ids[900:])))
 
     def test_search_runs_correctly_filters_large_data(self):
         experiment_id, _ = self._generate_large_data(1000)

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -322,7 +322,7 @@ def test_order_by_metric_with_nans_and_infs():
 ])
 def test_invalid_order_by(order_by, error_message):
     with pytest.raises(MlflowException) as e:
-        SearchUtils._parse_order_by(order_by)
+        SearchUtils.parse_order_by(order_by)
     assert error_message in e.value.message
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
The ordering and pagination of the requested runs is done in the SQL backend

## How is this patch tested?
Unit Tests
performance test on a dump of a real prod DB: 
- requests.post('....../runs/search', json='{"experiment_ids":["1"]}') 
------ ~14.5 s -> ~5.8s
- requests.post('....../runs/search', json='{"experiment_ids":["1"], "filter":"metrics.triplet_precision >= 0.87"}') ~0.11 s -> ~0.11s
- requests.post('....../runs/search', json='{"experiment_ids":["1"], "max_results": 10, "filter":"attribute.status = \'running\' "}') ~1.32s -> ~0.075s

## Release Notes
performance improvement in the search_runs endpoint


### Is this a user-facing change?
perf only
- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [x] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
