### PR TITLE
Enable logging pyspark ml params directly with log batch and log params.

### DIFF
--- a/mlflow/entities/param.py
+++ b/mlflow/entities/param.py
@@ -1,3 +1,5 @@
+import sys
+
 from mlflow.entities._mlflow_object import _MLflowObject
 from mlflow.protos.service_pb2 import Param as ProtoParam
 
@@ -6,14 +8,19 @@ class Param(_MLflowObject):
     """
     Parameter object.
     """
-
     def __init__(self, key, value):
+        if "pyspark.ml" in sys.modules:
+            import pyspark.ml.param
+            if isinstance(key, pyspark.ml.param.Param):
+                key = key.name
+                value = str(value)
         self._key = key
         self._value = value
 
     @property
     def key(self):
         """String key corresponding to the parameter name."""
+
         return self._key
 
     @property

--- a/mlflow/entities/param.py
+++ b/mlflow/entities/param.py
@@ -8,7 +8,7 @@ class Param(_MLflowObject):
     """
     Parameter object.
     """
-    
+
     def __init__(self, key, value):
         if "pyspark.ml" in sys.modules:
             import pyspark.ml.param

--- a/mlflow/entities/param.py
+++ b/mlflow/entities/param.py
@@ -8,6 +8,7 @@ class Param(_MLflowObject):
     """
     Parameter object.
     """
+    
     def __init__(self, key, value):
         if "pyspark.ml" in sys.modules:
             import pyspark.ml.param
@@ -20,7 +21,6 @@ class Param(_MLflowObject):
     @property
     def key(self):
         """String key corresponding to the parameter name."""
-
         return self._key
 
     @property

--- a/tests/entities/test_param.py
+++ b/tests/entities/test_param.py
@@ -26,10 +26,3 @@ class TestParam(unittest.TestCase):
 
         param3 = Param.from_dictionary(as_dict)
         self._check(param3, key, value)
-
-    def test_spark_integration(self):
-        from pyspark.ml.param import Param as SparkMLParam
-        key = SparkMLParam("parent", "name", "doc")
-        value = 123
-        param = Param(key, value)
-        self._check(param, "name", "123")

--- a/tests/entities/test_param.py
+++ b/tests/entities/test_param.py
@@ -26,3 +26,10 @@ class TestParam(unittest.TestCase):
 
         param3 = Param.from_dictionary(as_dict)
         self._check(param3, key, value)
+
+    def test_spark_integration(self):
+        from pyspark.ml.param import Param as SparkMLParam
+        key = SparkMLParam("parent", "name", "doc")
+        value = 123
+        param = Param(key, value)
+        self._check(param, "name", "123")

--- a/tests/spark/test_sparkml_param_integration.py
+++ b/tests/spark/test_sparkml_param_integration.py
@@ -1,0 +1,11 @@
+from mlflow.entities import Param
+from pyspark.ml.util import Identifiable
+from pyspark.ml.param import Param as SparkMLParam
+
+
+def test_spark_integration():
+    key = SparkMLParam(Identifiable(), "name", "doc")
+    value = 123
+    param = Param(key, value)
+    assert param.key == "name"
+    assert param.value == "123"


### PR DESCRIPTION
## What changes are proposed in this pull request?
Enable logging of spark ml params directly, e.g.
`mlflow.log_params(estimator.extractParamMap())`

## How is this patch tested?
Param unit test.

## Release Notes
n/a

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
MLflow Param class will recognize spark ml params as keys and will extract only the name attribute.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [x] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
