### PR TITLE
Improve support for unicode characters

### DIFF
--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -3,7 +3,6 @@
 import os
 import yaml
 
-import six
 from six.moves import shlex_quote
 
 from mlflow import data

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -9,6 +9,7 @@ from six.moves import shlex_quote
 from mlflow import data
 from mlflow.exceptions import ExecutionException
 from mlflow.utils.file_utils import get_local_path_or_none
+from mlflow.utils.string_utils import is_string_type
 
 
 MLPROJECT_FILE_NAME = "mlproject"
@@ -85,7 +86,7 @@ class Project(object):
         ext_to_cmd = {".py": "python", ".sh": os.environ.get("SHELL", "bash")}
         if file_extension in ext_to_cmd:
             command = "%s %s" % (ext_to_cmd[file_extension], shlex_quote(entry_point))
-            if type(command) not in six.string_types:
+            if not is_string_type(command):
                 command = command.encode("utf-8")
             return EntryPoint(name=entry_point, parameters={}, command=command)
         elif file_extension == ".R":
@@ -159,7 +160,7 @@ class Parameter(object):
     """A parameter in an MLproject entry point."""
     def __init__(self, name, yaml_obj):
         self.name = name
-        if isinstance(yaml_obj, six.string_types):
+        if is_string_type(yaml_obj):
             self.type = yaml_obj
             self.default = None
         else:

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -159,7 +159,7 @@ class Parameter(object):
     """A parameter in an MLproject entry point."""
     def __init__(self, name, yaml_obj):
         self.name = name
-        if isinstance(yaml_obj, str):
+        if isinstance(yaml_obj, six.string_types):
             self.type = yaml_obj
             self.default = None
         else:

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -28,6 +28,7 @@ from mlflow.tracking._model_registry.registry import ModelRegistryStoreRegistry
 from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.validation import _validate_batch_log_api_req
+from mlflow.utils.string_utils import is_string_type
 
 _tracking_store = None
 _model_registry_store = None
@@ -120,7 +121,7 @@ def _get_request_message(request_message, flask_request=request):
     # above actually converts it to a string. Therefore, we check this condition
     # (which we can tell for sure because any proper request should be a dictionary),
     # and decode it a second time.
-    if isinstance(request_json, six.string_types):
+    if is_string_type(request_json):
         request_json = json.loads(request_json)
 
     # If request doesn't have json body then assume it's empty.

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -2,7 +2,6 @@
 import json
 import os
 import re
-import six
 
 from functools import wraps
 from flask import Response, request, send_file

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -4,7 +4,6 @@ import posixpath
 import sys
 
 import uuid
-import six
 
 from mlflow.entities import Experiment, Metric, Param, Run, RunData, RunInfo, RunStatus, RunTag, \
     ViewType, SourceType, ExperimentTag

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -24,6 +24,7 @@ from mlflow.utils.file_utils import (is_directory, list_subdirs, mkdir, exists, 
                                      write_to, append_to, make_containing_dirs, mv, get_parent_dir,
                                      list_all, local_file_uri_to_path, path_to_local_file_uri)
 from mlflow.utils.search_utils import SearchUtils
+from mlflow.utils.string_utils import is_string_type
 
 _TRACKING_DIR_ENV_VAR = "MLFLOW_TRACKING_DIR"
 
@@ -603,7 +604,7 @@ class FileStore(AbstractStore):
     def _writeable_value(self, tag_value):
         if tag_value is None:
             return ""
-        elif isinstance(tag_value, six.string_types):
+        elif is_string_type(tag_value):
             return tag_value
         else:
             return "%s" % tag_value

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -3,7 +3,6 @@ import uuid
 
 import math
 import posixpath
-import six
 import sqlalchemy
 
 from mlflow.entities.lifecycle_stage import LifecycleStage

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -22,6 +22,7 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_ALREA
 from mlflow.utils.uri import is_local_uri, extract_db_type_from_uri
 from mlflow.utils.file_utils import mkdir, local_file_uri_to_path
 from mlflow.utils.search_utils import SearchUtils
+from mlflow.utils.string_utils import is_string_type
 from mlflow.utils.validation import _validate_batch_log_limits, _validate_batch_log_data, \
     _validate_run_id, _validate_metric, _validate_experiment_tag, _validate_tag
 
@@ -141,7 +142,7 @@ class SqlAlchemyStore(AbstractStore):
         }
 
         def decorate(s):
-            if isinstance(s, six.string_types):
+            if is_string_type(s):
                 return "'{}'".format(s)
             else:
                 return "{}".format(s)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -3,6 +3,7 @@ import uuid
 
 import math
 import posixpath
+import six
 import sqlalchemy
 
 from mlflow.entities.lifecycle_stage import LifecycleStage
@@ -140,7 +141,7 @@ class SqlAlchemyStore(AbstractStore):
         }
 
         def decorate(s):
-            if isinstance(s, str):
+            if isinstance(s, six.string_types):
                 return "'{}'".format(s)
             else:
                 return "{}".format(s)

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -6,6 +6,7 @@ exposed in the :py:mod:`mlflow.tracking` module.
 
 import time
 import os
+import six
 from six import iteritems
 
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
@@ -333,7 +334,7 @@ class TrackingServiceClient(object):
             expressions. If the underlying tracking store supports pagination, the token for
             the next page may be obtained via the ``token`` attribute of the returned object.
         """
-        if isinstance(experiment_ids, int) or isinstance(experiment_ids, str):
+        if isinstance(experiment_ids, int) or isinstance(experiment_ids, six.string_types):
             experiment_ids = [experiment_ids]
         return self.store.search_runs(experiment_ids=experiment_ids, filter_string=filter_string,
                                       run_view_type=run_view_type, max_results=max_results,

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -16,6 +16,7 @@ from mlflow.utils.validation import _validate_param_name, _validate_tag_name, _v
 from mlflow.entities import Param, Metric, RunStatus, RunTag, ViewType, ExperimentTag
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.utils.mlflow_tags import MLFLOW_USER
+from mlflow.utils.string_utils import is_string_type
 
 
 class TrackingServiceClient(object):
@@ -334,7 +335,7 @@ class TrackingServiceClient(object):
             expressions. If the underlying tracking store supports pagination, the token for
             the next page may be obtained via the ``token`` attribute of the returned object.
         """
-        if isinstance(experiment_ids, int) or isinstance(experiment_ids, six.string_types):
+        if isinstance(experiment_ids, int) or is_string_type(experiment_ids):
             experiment_ids = [experiment_ids]
         return self.store.search_runs(experiment_ids=experiment_ids, filter_string=filter_string,
                                       run_view_type=run_view_type, max_results=max_results,

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -6,7 +6,6 @@ exposed in the :py:mod:`mlflow.tracking` module.
 
 import time
 import os
-import six
 from six import iteritems
 
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT

--- a/mlflow/utils/string_utils.py
+++ b/mlflow/utils/string_utils.py
@@ -8,3 +8,8 @@ def strip_suffix(original, suffix):
     if original.endswith(suffix) and suffix != '':
         return original[:-len(suffix)]
     return original
+
+
+def is_string_type(item):
+    import six
+    return isinstance(item, six.string_types)

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -4,6 +4,7 @@ Utilities for validating user inputs such as metric names and parameter names.
 import numbers
 import posixpath
 import re
+import six
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -196,7 +197,7 @@ def _validate_experiment_name(experiment_name):
     if experiment_name == "" or experiment_name is None:
         raise MlflowException("Invalid experiment name: '%s'" % experiment_name,
                               error_code=INVALID_PARAMETER_VALUE)
-    if not isinstance(experiment_name, str):
+    if not isinstance(experiment_name, six.string_types):
         raise MlflowException("Invalid experiment name: %s. Expects a string." % experiment_name,
                               error_code=INVALID_PARAMETER_VALUE)
 

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -9,6 +9,7 @@ import six
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.db.db_types import DATABASE_ENGINES
+from mlflow.utils.string_utils import is_string_type
 
 _VALID_PARAM_AND_METRIC_NAMES = re.compile(r"^[/\w.\- ]*$")
 
@@ -197,7 +198,8 @@ def _validate_experiment_name(experiment_name):
     if experiment_name == "" or experiment_name is None:
         raise MlflowException("Invalid experiment name: '%s'" % experiment_name,
                               error_code=INVALID_PARAMETER_VALUE)
-    if not isinstance(experiment_name, six.string_types):
+
+    if not is_string_type(experiment_name):
         raise MlflowException("Invalid experiment name: %s. Expects a string." % experiment_name,
                               error_code=INVALID_PARAMETER_VALUE)
 

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -4,7 +4,6 @@ Utilities for validating user inputs such as metric names and parameter names.
 import numbers
 import posixpath
 import re
-import six
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -40,6 +40,7 @@ def test_run_local_experiment_specification(experiment_name,
         [
             TEST_PROJECT_DIR,
             "-e", "greeter",
+            "-P", "name=test",
             "--experiment-name", experiment_name,
         ])
 
@@ -51,6 +52,7 @@ def test_run_local_experiment_specification(experiment_name,
         [
             TEST_PROJECT_DIR,
             "-e", "greeter",
+            "-P", "name=test",
             "--experiment-id", experiment_id,
         ])
 

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -34,7 +34,7 @@ def test_run_local_params(tracking_uri_mock):  # pylint: disable=unused-argument
     'test-experiment',
 ])
 def test_run_local_experiment_specification(experiment_name,
-                                            tracking_uri_mock): # pylint: disable=unused-argument
+                                            tracking_uri_mock):  # pylint: disable=unused-argument
     invoke_cli_runner(
         cli.run,
         [

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -9,6 +9,7 @@ from click.testing import CliRunner
 import pytest
 
 from mlflow import cli
+from mlflow.tracking.client import MlflowClient 
 from mlflow.utils import process
 from tests.integration.utils import invoke_cli_runner
 from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_URI, \
@@ -25,6 +26,33 @@ def test_run_local_params(tracking_uri_mock):  # pylint: disable=unused-argument
     invoke_cli_runner(cli.run, [TEST_PROJECT_DIR, "-e", "greeter", "-P",
                                 "greeting=hi", "-P", "name=%s" % name,
                                 "-P", "excitement=%s" % excitement_arg])
+
+
+@pytest.mark.large
+@pytest.mark.parametrize("experiment_name", [
+    b'test-experiment'.decode("utf-8"),
+    'test-experiment',
+])
+def test_run_local_experiment_specification(experiment_name, 
+                                            tracking_uri_mock): # pylint: disable=unused-argument
+    invoke_cli_runner(
+        cli.run, 
+        [
+            TEST_PROJECT_DIR, 
+            "-e", "greeter",
+            "--experiment-name", experiment_name,
+        ])
+
+    client = MlflowClient()
+    experiment_id = client.get_experiment_by_name(experiment_name).experiment_id
+
+    invoke_cli_runner(
+        cli.run, 
+        [
+            TEST_PROJECT_DIR, 
+            "-e", "greeter",
+            "--experiment-id", experiment_id,
+        ])
 
 
 @pytest.fixture(scope="module", autouse=True)

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -9,7 +9,7 @@ from click.testing import CliRunner
 import pytest
 
 from mlflow import cli
-from mlflow.tracking.client import MlflowClient 
+from mlflow.tracking.client import MlflowClient
 from mlflow.utils import process
 from tests.integration.utils import invoke_cli_runner
 from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_URI, \
@@ -33,12 +33,12 @@ def test_run_local_params(tracking_uri_mock):  # pylint: disable=unused-argument
     b'test-experiment'.decode("utf-8"),
     'test-experiment',
 ])
-def test_run_local_experiment_specification(experiment_name, 
+def test_run_local_experiment_specification(experiment_name,
                                             tracking_uri_mock): # pylint: disable=unused-argument
     invoke_cli_runner(
-        cli.run, 
+        cli.run,
         [
-            TEST_PROJECT_DIR, 
+            TEST_PROJECT_DIR,
             "-e", "greeter",
             "--experiment-name", experiment_name,
         ])
@@ -47,9 +47,9 @@ def test_run_local_experiment_specification(experiment_name,
     experiment_id = client.get_experiment_by_name(experiment_name).experiment_id
 
     invoke_cli_runner(
-        cli.run, 
+        cli.run,
         [
-            TEST_PROJECT_DIR, 
+            TEST_PROJECT_DIR,
             "-e", "greeter",
             "--experiment-id", experiment_id,
         ])

--- a/tests/utils/test_string_utils.py
+++ b/tests/utils/test_string_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from mlflow.utils.string_utils import strip_prefix, strip_suffix
+from mlflow.utils.string_utils import strip_prefix, strip_suffix, is_string_type
 
 
 @pytest.mark.parametrize("original,prefix,expected", [
@@ -21,3 +21,16 @@ def test_strip_prefix(original, prefix, expected):
 ])
 def test_strip_suffix(original, suffix, expected):
     assert strip_suffix(original, suffix) == expected
+
+
+def test_is_string_type():
+    assert is_string_type("validstring")
+    assert is_string_type("")
+    assert is_string_type((b'dog').decode("utf-8"))
+    assert not is_string_type(None)
+    assert not is_string_type(["teststring"])
+    assert not is_string_type([])
+    assert not is_string_type({})
+    assert not is_string_type({"test": "string"})
+    assert not is_string_type(12)
+    assert not is_string_type(12.7)

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -4,9 +4,11 @@ import pytest
 from mlflow.exceptions import MlflowException
 from mlflow.entities import Metric, Param, RunTag
 from mlflow.protos.databricks_pb2 import ErrorCode, INVALID_PARAMETER_VALUE
-from mlflow.utils.validation import _validate_metric_name, _validate_param_name, \
-    _validate_tag_name, _validate_run_id, _validate_batch_log_data, \
-    _validate_batch_log_limits, _validate_experiment_artifact_location, _validate_db_type_string
+from mlflow.utils.validation import (
+    _validate_metric_name, _validate_param_name, _validate_tag_name, _validate_run_id,
+    _validate_batch_log_data, _validate_batch_log_limits, _validate_experiment_artifact_location,
+    _validate_db_type_string, _validate_experiment_name
+)
 
 GOOD_METRIC_OR_PARAM_NAMES = [
     "a", "Ab-5_", "a/b/c", "a.b.c", ".a", "b.", "a..a/._./o_O/.e.", "a b/c d",
@@ -119,6 +121,15 @@ def test_validate_experiment_artifact_location():
     _validate_experiment_artifact_location(None)
     with pytest.raises(MlflowException):
         _validate_experiment_artifact_location('runs:/blah/bleh/blergh')
+
+
+def test_validate_experiment_name():
+    _validate_experiment_name("validstring")
+    bytestring = b'dog'
+    _validate_experiment_name(bytestring.decode("utf-8"))
+    for invalid_name in ["", 12, 12.7, None, {}, []]:
+        with pytest.raises(MlflowException):
+            _validate_experiment_name(invalid_name)
 
 
 def test_db_type():

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -125,7 +125,7 @@ def test_validate_experiment_artifact_location():
 
 def test_validate_experiment_name():
     _validate_experiment_name("validstring")
-    bytestring = b'dog'
+    bytestring = b'test byte string'
     _validate_experiment_name(bytestring.decode("utf-8"))
     for invalid_name in ["", 12, 12.7, None, {}, []]:
         with pytest.raises(MlflowException):


### PR DESCRIPTION
## What changes are proposed in this pull request?

In several MLflow APIs, we determine whether or not inputs are of string-like types by performing the following check: `isinstance(item, str)`. Unfortunately, this approach does not treat unicode strings properly.

This PR improves unicode compatibility by modifying these checks to read `isinstance(item, six.string_types)`, which encompasses both `unicode` and `str` types across Python 2 and 3. We already use this improved check in several locations throughout the MLflow API; this PR addresses remaining instances of brittle checks.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
