### PR TITLE
Fix models serve, models predict CLI commands against models:/ URIs

### DIFF
--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -5,6 +5,7 @@ import posixpath
 
 from mlflow.models import Model
 from mlflow.models.flavor_backend_registry import get_flavor_backend
+from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils import cli_args
@@ -137,9 +138,13 @@ def build_docker(model_uri, name, install_mlflow):
 
 def _get_flavor_backend(model_uri, **kwargs):
     with TempDir() as tmp:
-        local_path = _download_artifact_from_uri(posixpath.join(model_uri),
+        if ModelsArtifactRepository.is_models_uri(model_uri):
+            underlying_model_uri = ModelsArtifactRepository.get_underlying_uri(model_uri)
+        else:
+            underlying_model_uri = model_uri
+        local_path = _download_artifact_from_uri(posixpath.join(underlying_model_uri, "MLmodel"),
                                                  output_path=tmp.path())
-        model = Model.load(os.path.join(local_path, "MLmodel"))
+        model = Model.load(local_path)
     flavor_name, flavor_backend = get_flavor_backend(model, **kwargs)
     if flavor_backend is None:
         raise Exception("No suitable flavor backend was found for the model.")

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -137,9 +137,9 @@ def build_docker(model_uri, name, install_mlflow):
 
 def _get_flavor_backend(model_uri, **kwargs):
     with TempDir() as tmp:
-        local_path = _download_artifact_from_uri(posixpath.join(model_uri, "MLmodel"),
+        local_path = _download_artifact_from_uri(posixpath.join(model_uri),
                                                  output_path=tmp.path())
-        model = Model.load(local_path)
+        model = Model.load(os.path.join(local_path, "MLmodel"))
     flavor_name, flavor_backend = get_flavor_backend(model, **kwargs)
     if flavor_backend is None:
         raise Exception("No suitable flavor backend was found for the model.")

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -62,6 +62,9 @@ class ModelsArtifactRepository(ArtifactRepository):
         (name, version, stage) = ModelsArtifactRepository._parse_uri(uri)
         if stage is not None:
             latest = client.get_latest_versions(name, [stage])
+            if len(latest) == 0:
+                raise MlflowException("No versions of model with name '{name}' and "
+                                      "stage '{stage}' found".format(name=name, stage=stage))
             version = latest[0].version
         return client.get_model_version_download_uri(name, version)
 

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -126,6 +126,7 @@ def pyfunc_serve_and_score_model(
     """
     env = dict(os.environ)
     env.update(LC_ALL="en_US.UTF-8", LANG="en_US.UTF-8")
+    env.update(MLFLOW_TRACKING_URI=mlflow.get_tracking_uri())
     port = get_safe_port()
     scoring_cmd = ['mlflow', 'models', 'serve', '-m', model_uri, "-p", str(port)]
     if extra_args is not None:

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -26,6 +26,7 @@ from tests.models import test_pyfunc
 from tests.helper_functions import pyfunc_build_image, pyfunc_serve_from_docker_image, \
     pyfunc_serve_from_docker_image_with_env_override, \
     RestEndpoint, get_safe_port, pyfunc_serve_and_score_model
+from tests.projects.utils import tracking_uri_mock # pylint: disable=unused-import
 from mlflow.protos.databricks_pb2 import ErrorCode, MALFORMED_REQUEST
 from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON_SPLIT_ORIENTED, \
     CONTENT_TYPE_JSON, CONTENT_TYPE_CSV
@@ -127,12 +128,13 @@ def test_model_with_no_deployable_flavors_fails_pollitely():
         assert "No suitable flavor backend was found for the model." in stderr
 
 
-def test_serve_gunicorn_opts(iris_data, sk_model):
+def test_serve_gunicorn_opts(iris_data, sk_model,
+                             tracking_uri_mock): # pylint: disable=unused-argument
     if sys.platform == "win32":
         pytest.skip("This test requires gunicorn which is not available on windows.")
     with mlflow.start_run() as active_run:
-        mlflow.sklearn.log_model(sk_model, "model")
-        model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
+        mlflow.sklearn.log_model(sk_model, "model", registered_model_name="imlegit")
+        model_uri = "models:/{name}/{stage}".format(name="imlegit", stage="None")
 
     with TempDir() as tpm:
         output_file_path = tpm.path("stoudt")

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -223,7 +223,8 @@ def test_predict(iris_data, sk_model, tracking_uri_mock):  # pylint: disable=unu
                              universal_newlines=True,
                              stdin=subprocess.PIPE,
                              stdout=subprocess.PIPE,
-                             stderr=sys.stderr)
+                             stderr=sys.stderr,
+                             env=env_with_tracking_uri)
         with open(input_json_path, "r") as f:
             stdout, _ = p.communicate(f.read())
         assert 0 == p.wait()

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -134,33 +134,39 @@ def test_serve_gunicorn_opts(iris_data, sk_model,
         pytest.skip("This test requires gunicorn which is not available on windows.")
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model", registered_model_name="imlegit")
-        model_uri = "models:/{name}/{stage}".format(name="imlegit", stage="None")
+        run_id = active_run.info.run_id
 
-    with TempDir() as tpm:
-        output_file_path = tpm.path("stoudt")
-        with open(output_file_path, "w") as output_file:
-            x, _ = iris_data
-            scoring_response = pyfunc_serve_and_score_model(
-                model_uri, pd.DataFrame(x),
-                content_type=CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-                stdout=output_file,
-                extra_args=["-w", "3"])
-        with open(output_file_path, "r") as output_file:
-            stdout = output_file.read()
-    actual = pd.read_json(scoring_response.content, orient="records")
-    actual = actual[actual.columns[0]].values
-    expected = sk_model.predict(x)
-    assert all(expected == actual)
-    expected_command_pattern = re.compile((
-        "gunicorn.*-w 3.*mlflow.pyfunc.scoring_server.wsgi:app"))
-    assert expected_command_pattern.search(stdout) is not None
+    model_uris = [
+        "models:/{name}/{stage}".format(name="imlegit", stage="None"),
+        "runs:/{run_id}/model".format(run_id=run_id)
+    ]
+    for model_uri in model_uris:
+        with TempDir() as tpm:
+            output_file_path = tpm.path("stoudt")
+            with open(output_file_path, "w") as output_file:
+                x, _ = iris_data
+                scoring_response = pyfunc_serve_and_score_model(
+                    model_uri, pd.DataFrame(x),
+                    content_type=CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+                    stdout=output_file,
+                    extra_args=["-w", "3"])
+            with open(output_file_path, "r") as output_file:
+                stdout = output_file.read()
+        actual = pd.read_json(scoring_response.content, orient="records")
+        actual = actual[actual.columns[0]].values
+        expected = sk_model.predict(x)
+        assert all(expected == actual)
+        expected_command_pattern = re.compile((
+            "gunicorn.*-w 3.*mlflow.pyfunc.scoring_server.wsgi:app"))
+        assert expected_command_pattern.search(stdout) is not None
 
 
-def test_predict(iris_data, sk_model):
+def test_predict(iris_data, sk_model, tracking_uri_mock): # pylint: disable=unused-argument
     with TempDir(chdr=True) as tmp:
         with mlflow.start_run() as active_run:
-            mlflow.sklearn.log_model(sk_model, "model")
+            mlflow.sklearn.log_model(sk_model, "model", registered_model_name="impredicting")
             model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
+        model_registry_uri = "models:/{name}/{stage}".format(name="impredicting", stage="None")
         input_json_path = tmp.path("input.json")
         input_csv_path = tmp.path("input.csv")
         output_json_path = tmp.path("output.json")
@@ -168,9 +174,13 @@ def test_predict(iris_data, sk_model):
         pd.DataFrame(x).to_json(input_json_path, orient="split")
         pd.DataFrame(x).to_csv(input_csv_path, index=False)
 
-        # Test with no conda
-        p = subprocess.Popen(["mlflow", "models", "predict", "-m", model_uri, "-i", input_json_path,
-                              "-o", output_json_path, "--no-conda"], stderr=subprocess.PIPE)
+        # Test with no conda & model registry URI
+        env_with_tracking_uri = os.environ.copy()
+        env_with_tracking_uri.update(MLFLOW_TRACKING_URI=mlflow.get_tracking_uri())
+        p = subprocess.Popen(["mlflow", "models", "predict", "-m", model_registry_uri,
+                              "-i", input_json_path,
+                              "-o", output_json_path, "--no-conda"],
+                             stderr=subprocess.PIPE, env=env_with_tracking_uri)
         assert p.wait() == 0
         actual = pd.read_json(output_json_path, orient="records")
         actual = actual[actual.columns[0]].values
@@ -179,7 +189,7 @@ def test_predict(iris_data, sk_model):
 
         # With conda + --install-mlflow
         p = subprocess.Popen(["mlflow", "models", "predict", "-m", model_uri, "-i", input_json_path,
-                              "-o", output_json_path] + extra_options)
+                              "-o", output_json_path] + extra_options, env=env_with_tracking_uri)
         assert 0 == p.wait()
         actual = pd.read_json(output_json_path, orient="records")
         actual = actual[actual.columns[0]].values
@@ -188,7 +198,8 @@ def test_predict(iris_data, sk_model):
 
         # explicit json format with default orient (should be split)
         p = subprocess.Popen(["mlflow", "models", "predict", "-m", model_uri, "-i", input_json_path,
-                              "-o", output_json_path, "-t", "json"] + extra_options)
+                              "-o", output_json_path, "-t", "json"] + extra_options,
+                             env=env_with_tracking_uri)
         assert 0 == p.wait()
         actual = pd.read_json(output_json_path, orient="records")
         actual = actual[actual.columns[0]].values
@@ -198,7 +209,8 @@ def test_predict(iris_data, sk_model):
         # explicit json format with orient==split
         p = subprocess.Popen(["mlflow", "models", "predict", "-m", model_uri, "-i", input_json_path,
                               "-o", output_json_path, "-t", "json", "--json-format", "split"]
-                             + extra_options)
+                             + extra_options,
+                             env=env_with_tracking_uri)
         assert 0 == p.wait()
         actual = pd.read_json(output_json_path, orient="records")
         actual = actual[actual.columns[0]].values
@@ -225,7 +237,8 @@ def test_predict(iris_data, sk_model):
 
         # csv
         p = subprocess.Popen(["mlflow", "models", "predict", "-m", model_uri, "-i", input_csv_path,
-                              "-o", output_json_path, "-t", "csv"] + extra_options)
+                              "-o", output_json_path, "-t", "csv"] + extra_options,
+                             env=env_with_tracking_uri)
         assert 0 == p.wait()
         actual = pd.read_json(output_json_path, orient="records")
         actual = actual[actual.columns[0]].values

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -26,7 +26,7 @@ from tests.models import test_pyfunc
 from tests.helper_functions import pyfunc_build_image, pyfunc_serve_from_docker_image, \
     pyfunc_serve_from_docker_image_with_env_override, \
     RestEndpoint, get_safe_port, pyfunc_serve_and_score_model
-from tests.projects.utils import tracking_uri_mock # pylint: disable=unused-import
+from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 from mlflow.protos.databricks_pb2 import ErrorCode, MALFORMED_REQUEST
 from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON_SPLIT_ORIENTED, \
     CONTENT_TYPE_JSON, CONTENT_TYPE_CSV
@@ -129,7 +129,7 @@ def test_model_with_no_deployable_flavors_fails_pollitely():
 
 
 def test_serve_gunicorn_opts(iris_data, sk_model,
-                             tracking_uri_mock): # pylint: disable=unused-argument
+                             tracking_uri_mock):  # pylint: disable=unused-argument
     if sys.platform == "win32":
         pytest.skip("This test requires gunicorn which is not available on windows.")
     with mlflow.start_run() as active_run:
@@ -161,7 +161,7 @@ def test_serve_gunicorn_opts(iris_data, sk_model,
         assert expected_command_pattern.search(stdout) is not None
 
 
-def test_predict(iris_data, sk_model, tracking_uri_mock): # pylint: disable=unused-argument
+def test_predict(iris_data, sk_model, tracking_uri_mock):  # pylint: disable=unused-argument
     with TempDir(chdr=True) as tmp:
         with mlflow.start_run() as active_run:
             mlflow.sklearn.log_model(sk_model, "model", registered_model_name="impredicting")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes bug where we'd fail to download the full model locally prior to attempting to predict/serve with it when running MLflow `models` CLI commands (we previously only downloaded its MLmodel file). 

This prevented using the models CLI with `models:/` URIs exposed by the model registry, e.g. commands like `MLFLOW_TRACKING_URI=sqlite:////tmp/blah mlflow models serve -m models:/imcool/1` or `MLFLOW_TRACKING_URI=sqlite:////tmp/blah mlflow models prediction -m models:/imcool/Production` failed.

## How is this patch tested?

Updated tests in tests/models/test_cli.py

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed a bug that prevented using `mlflow models` CLI commands with models:/ URIs exposed by the model registry.

### What component(s) does this PR affect?

- [ ] UI
- [x] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [x] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
