### PR TITLE
Fix artifact image viewer to support animated GIF

### DIFF
--- a/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
+++ b/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
@@ -35,8 +35,19 @@ class ShowArtifactImageView extends Component {
     return getSrc(path, runUuid);
   };
 
+  isGif = () => {
+    return this.props.path.endsWith('.gif');
+  };
+
   fetchImage = () => {
     this.setState({ loading: true });
+
+    // gif
+    if (this.isGif()) {
+      return;
+    }
+
+    // static image
     const img = new Image();
     img.setAttribute('crossOrigin', 'anonymous');
     img.onload = () => {
@@ -52,64 +63,81 @@ class ShowArtifactImageView extends Component {
     img.src = this.getSrc();
   };
 
-  render() {
+  imageContainer = ({ children }) => (
+    <div className="image-outer-container">
+      <div className="image-container">{children}</div>
+    </div>
+  );
+
+  renderGif = () => {
+    const { loading } = this.state;
+    return (
+      <this.imageContainer>
+        <div style={{ display: loading ? 'block' : 'none' }}>Loading...</div>
+        <img
+          src={this.getSrc()}
+          onLoad={() => this.setState({ loading: false })}
+          style={{ height: '100%', display: loading ? 'none' : 'block' }}
+        />
+      </this.imageContainer>
+    );
+  };
+
+  renderStaticImage = () => {
     const { loading, dataURL, width, height } = this.state;
 
     if (loading) return <div>Loading...</div>;
 
     return (
-      <div className="image-outer-container">
-        <div className="image-container">
-          {
-            <Plot
-              data={[
+      <this.imageContainer>
+        {
+          <Plot
+            layout={{
+              width: width * (500 / height),
+              height: 500,
+              xaxis: { visible: false, range: [0, width] },
+              yaxis: { visible: false, range: [0, height], scaleanchor: 'x', scaleratio: 1 },
+              images: [
                 {
-                  x: [0, width],
-                  y: [0, height],
-                  type: 'scatter',
-                  mode: 'markers',
-                  marker: { opacity: 0, size: 0 },
-                  hoverinfo: 'none',
+                  source: dataURL,
+                  xref: 'x',
+                  yref: 'y',
+                  x: 0,
+                  y: 0,
+                  xanchor: 'left',
+                  yanchor: 'bottom',
+                  sizex: width,
+                  sizey: height,
                 },
-              ]}
-              layout={{
-                width: width * (500 / height),
-                height: 500,
-                xaxis: { visible: false, autorange: true },
-                yaxis: { visible: false, autorange: true, scaleanchor: 'x', scaleratio: 1 },
-                images: [
-                  {
-                    source: dataURL,
-                    xref: 'x',
-                    yref: 'y',
-                    x: 0,
-                    y: 0,
-                    xanchor: 'left',
-                    yanchor: 'bottom',
-                    sizex: width,
-                    sizey: height,
-                  },
-                ],
-                margin: { l: 0, r: 0, t: 0, b: 0 },
-              }}
-              config={{
-                displaylogo: false,
-                scrollZoom: true,
-                modeBarButtonsToRemove: [
-                  'hoverCompareCartesian',
-                  'hoverClosestCartesian',
-                  'lasso2d',
-                  'sendDataToCloud',
-                  'select2d',
-                  'toggleSpikelines',
-                ],
-              }}
-              useResizeHandler
-            />
-          }
-        </div>
-      </div>
+              ],
+              margin: { l: 0, r: 0, t: 0, b: 0 },
+            }}
+            config={{
+              displaylogo: false,
+              scrollZoom: true,
+              doubleClick: 'reset',
+              modeBarButtonsToRemove: [
+                'hoverCompareCartesian',
+                'hoverClosestCartesian',
+                'lasso2d',
+                'sendDataToCloud',
+                'select2d',
+                'toggleSpikelines',
+              ],
+            }}
+            useResizeHandler
+          />
+        }
+      </this.imageContainer>
     );
+  };
+
+  render() {
+    if (this.isGif()) {
+      return this.renderGif();
+    }
+
+    return this.renderStaticImage();
   }
 }
 

--- a/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
+++ b/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
@@ -21,11 +21,21 @@ class ShowArtifactImageView extends Component {
   };
 
   componentDidMount = () => {
+    // For a gif image, we don't have to do anything here because img tag fetches the image.
+    if (this.isGif()) {
+      return;
+    }
+
+    // For a static image, call fetchImage to load the image and convert it to data URI for plotly.
     this.fetchImage();
   };
 
   componentDidUpdate = prevProps => {
-    if (prevProps.path !== this.props.path) {
+    if (this.props.path !== prevProps.path || this.props.runUuid !== prevProps.runUuid) {
+      if (this.isGif()) {
+        return;
+      }
+
       this.fetchImage();
     }
   };
@@ -41,13 +51,6 @@ class ShowArtifactImageView extends Component {
 
   fetchImage = () => {
     this.setState({ loading: true });
-
-    // gif
-    if (this.isGif()) {
-      return;
-    }
-
-    // static image
     const img = new Image();
     img.setAttribute('crossOrigin', 'anonymous');
     img.onload = () => {
@@ -70,6 +73,7 @@ class ShowArtifactImageView extends Component {
         <div style={{ display: loading ? 'block' : 'none' }}>Loading...</div>
         <img
           src={this.getSrc()}
+          onLoadStart={() => this.setState({ loading: true })}
           onLoad={() => this.setState({ loading: false })}
           style={{ height: '100%', display: loading ? 'none' : 'block' }}
         />

--- a/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
+++ b/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
@@ -63,23 +63,17 @@ class ShowArtifactImageView extends Component {
     img.src = this.getSrc();
   };
 
-  imageContainer = ({ children }) => (
-    <div className="image-outer-container">
-      <div className="image-container">{children}</div>
-    </div>
-  );
-
   renderGif = () => {
     const { loading } = this.state;
     return (
-      <this.imageContainer>
+      <React.Fragment>
         <div style={{ display: loading ? 'block' : 'none' }}>Loading...</div>
         <img
           src={this.getSrc()}
           onLoad={() => this.setState({ loading: false })}
           style={{ height: '100%', display: loading ? 'none' : 'block' }}
         />
-      </this.imageContainer>
+      </React.Fragment>
     );
   };
 
@@ -89,55 +83,53 @@ class ShowArtifactImageView extends Component {
     if (loading) return <div>Loading...</div>;
 
     return (
-      <this.imageContainer>
-        {
-          <Plot
-            layout={{
-              width: width * (500 / height),
-              height: 500,
-              xaxis: { visible: false, range: [0, width] },
-              yaxis: { visible: false, range: [0, height], scaleanchor: 'x', scaleratio: 1 },
-              images: [
-                {
-                  source: dataURL,
-                  xref: 'x',
-                  yref: 'y',
-                  x: 0,
-                  y: 0,
-                  xanchor: 'left',
-                  yanchor: 'bottom',
-                  sizex: width,
-                  sizey: height,
-                },
-              ],
-              margin: { l: 0, r: 0, t: 0, b: 0 },
-            }}
-            config={{
-              displaylogo: false,
-              scrollZoom: true,
-              doubleClick: 'reset',
-              modeBarButtonsToRemove: [
-                'hoverCompareCartesian',
-                'hoverClosestCartesian',
-                'lasso2d',
-                'sendDataToCloud',
-                'select2d',
-                'toggleSpikelines',
-              ],
-            }}
-            useResizeHandler
-          />
-        }
-      </this.imageContainer>
+      <Plot
+        layout={{
+          width: width * (500 / height),
+          height: 500,
+          xaxis: { visible: false, range: [0, width] },
+          yaxis: { visible: false, range: [0, height], scaleanchor: 'x', scaleratio: 1 },
+          images: [
+            {
+              source: dataURL,
+              xref: 'x',
+              yref: 'y',
+              x: 0,
+              y: 0,
+              xanchor: 'left',
+              yanchor: 'bottom',
+              sizex: width,
+              sizey: height,
+            },
+          ],
+          margin: { l: 0, r: 0, t: 0, b: 0 },
+        }}
+        config={{
+          displaylogo: false,
+          scrollZoom: true,
+          doubleClick: 'reset',
+          modeBarButtonsToRemove: [
+            'hoverCompareCartesian',
+            'hoverClosestCartesian',
+            'lasso2d',
+            'sendDataToCloud',
+            'select2d',
+            'toggleSpikelines',
+          ],
+        }}
+        useResizeHandler
+      />
     );
   };
 
   render() {
-    if (this.isGif()) {
-      return this.renderGif();
-    }
-
-    return this.renderStaticImage();
+    return (
+      <div className="image-outer-container">
+        <div className="image-container">
+          {this.isGif() ? this.renderGif() : this.renderStaticImage()}
+        </div>
+      </div>
+    );
   }
 }
 

--- a/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
+++ b/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import './ShowArtifactImageView.css';
 import { getSrc } from './ShowArtifactPage';
 import Plot from 'react-plotly.js';
+import Utils from '../../utils/Utils';
 
 class ShowArtifactImageView extends Component {
   constructor(props) {
@@ -73,6 +74,7 @@ class ShowArtifactImageView extends Component {
         <div style={{ display: loading ? 'block' : 'none' }}>Loading...</div>
         <img
           src={this.getSrc()}
+          alt={Utils.baseName(this.props.path)}
           onLoadStart={() => this.setState({ loading: true })}
           onLoad={() => this.setState({ loading: false })}
           style={{ height: '100%', display: loading ? 'none' : 'block' }}

--- a/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.test.js
+++ b/mlflow/server/js/src/components/artifact-view-components/ShowArtifactImageView.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ShowArtifactImageView from './ShowArtifactImageView';
+
+describe('Render test', () => {
+  it('renders empty image container', () => {
+    const wrapper = shallow(<ShowArtifactImageView path="fakepath" runUuid="fakerunuuid" />);
+
+    wrapper.setState({ loading: false });
+
+    expect(wrapper.find('.image-outer-container')).toHaveLength(1);
+    expect(wrapper.find('.image-container')).toHaveLength(1);
+  });
+
+  it('renders gif image', () => {
+    const wrapper = shallow(<ShowArtifactImageView path="fake.gif" runUuid="fakerunuuid" />);
+
+    wrapper.setState({ loading: false });
+
+    expect(wrapper.find('img')).toHaveLength(1);
+  });
+
+  it('renders static image', () => {
+    const wrapper = shallow(<ShowArtifactImageView path="fake.png" runUuid="fakerunuuid" />);
+
+    wrapper.setState({ loading: false });
+
+    expect(wrapper.find('PlotlyComponent')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## What changes are proposed in this pull request?

As reported in this issue #2042, the artifact viewer doesn't display animated gifs due to this PR #1934. The cause is `plotly` displays animated gifs as a static image. This PR proposes to change how the artifact viewer handles images as follows:

- For a static image, use `plotly`.
- For a animated gif, use `img` tag so that the image can animate.


![handle-gif](https://user-images.githubusercontent.com/17039389/68524223-850b8300-0307-11ea-8003-a5eac3c26943.gif)

## How is this patch tested?

Manually tested

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [x] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
