### PR TITLE
Clarify client's access to artifact store

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -411,13 +411,15 @@ default location to store artifacts for all runs in this experiment. Additional,
 is a property on :py:class:`mlflow.entities.RunInfo` to indicate location where all artifacts for
 this run are stored.
 
-Use ``--default-artifact-root`` (defaults to local ``./mlruns`` directory) to configure default
-location to server's artifact store. This will be used as artifact location for newly-created
+Use ``--default-artifact-root`` (defaults to client's local ``./mlruns`` directory) to configure the default
+artifact location for the server's future experiments. This will be used as artifact location for newly-created
 experiments that do not specify one. Once you create an experiment, ``--default-artifact-root``
 is no longer relevant to that experiment.
 
+A client will connect to the artifact location directly, regardless whether it was configured via the server or via the client. Therefore both, server and client, need connectivity and authentication for the artifact location.
+
 To allow the server and clients to access the artifact location, you should configure your cloud
-provider credentials as normal. For example, for S3, you can set the ``AWS_ACCESS_KEY_ID``
+provider credentials as normal, on both server and client side. For example, for S3, you can set the ``AWS_ACCESS_KEY_ID``
 and ``AWS_SECRET_ACCESS_KEY`` environment variables, use an IAM role, or configure a default
 profile in ``~/.aws/credentials``.
 See `Set up AWS Credentials and Region for Development <https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/setup-credentials.html>`_ for more info.
@@ -454,6 +456,8 @@ For example, if you have a Minio server at 1.2.3.4 on port 9000:
 .. code-block:: bash
 
   export MLFLOW_S3_ENDPOINT_URL=http://1.2.3.4:9000
+  
+on both, tracking server and client.
 
 Azure Blob Storage
 ^^^^^^^^^^^^^^^^^^

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -411,8 +411,7 @@ default location to store artifacts for all runs in this experiment. Additional,
 is a property on :py:class:`mlflow.entities.RunInfo` to indicate location where all artifacts for
 this run are stored.
 
-Use ``--default-artifact-root`` (defaults to client's local ``./mlruns`` directory) to configure the default
-artifact location for the server's future experiments. This will be used as artifact location for newly-created
+Use ``--default-artifact-root`` (defaults to client's local ``./mlruns`` directory) to configure the default artifact location for the server. This will be used as artifact location for newly-created
 experiments that do not specify one. Once you create an experiment, ``--default-artifact-root``
 is no longer relevant to that experiment.
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Doc update to clarify that client needs direct access to artifact store.

Hopefully addresses #2044 #2045 

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [X] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
