### PR TITLE
Added optional prometheus exporter

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -234,8 +234,10 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
               help="Additional command line options forwarded to gunicorn processes.")
 @click.option("--waitress-opts", default=None,
               help="Additional command line options for waitress-serve.")
+@click.option("--activate-prometheus", default=False, is_flag=True,
+              help="Activate prometheus exporter to expose metrics on /metrics endpoint.")
 def server(backend_store_uri, default_artifact_root, host, port,
-           workers, static_prefix, gunicorn_opts, waitress_opts):
+           workers, static_prefix, gunicorn_opts, waitress_opts, activate_prometheus):
     """
     Run the MLflow tracking server.
 
@@ -268,7 +270,7 @@ def server(backend_store_uri, default_artifact_root, host, port,
 
     try:
         _run_server(backend_store_uri, default_artifact_root, host, port,
-                    static_prefix, workers, gunicorn_opts, waitress_opts)
+                    static_prefix, workers, gunicorn_opts, waitress_opts, activate_prometheus)
     except ShellCommandException:
         eprint("Running the mlflow server failed. Please see the logs above for details.")
         sys.exit(1)

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -234,10 +234,12 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
               help="Additional command line options forwarded to gunicorn processes.")
 @click.option("--waitress-opts", default=None,
               help="Additional command line options for waitress-serve.")
-@click.option("--activate-prometheus", default=False, is_flag=True,
-              help="Activate prometheus exporter to expose metrics on /metrics endpoint.")
+@click.option("--expose-prometheus", default=False, is_flag=True,
+              help="Activate prometheus exporter to expose metrics on /metrics endpoint."
+                   "You need to set the environment variable 'prometheus_multiproc_dir' "
+                   "to point to a directory where the metrics will be stored.")
 def server(backend_store_uri, default_artifact_root, host, port,
-           workers, static_prefix, gunicorn_opts, waitress_opts, activate_prometheus):
+           workers, static_prefix, gunicorn_opts, waitress_opts, expose_prometheus):
     """
     Run the MLflow tracking server.
 
@@ -270,7 +272,7 @@ def server(backend_store_uri, default_artifact_root, host, port,
 
     try:
         _run_server(backend_store_uri, default_artifact_root, host, port,
-                    static_prefix, workers, gunicorn_opts, waitress_opts, activate_prometheus)
+                    static_prefix, workers, gunicorn_opts, waitress_opts, expose_prometheus)
     except ShellCommandException:
         eprint("Running the mlflow server failed. Please see the logs above for details.")
         sys.exit(1)

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -234,10 +234,10 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
               help="Additional command line options forwarded to gunicorn processes.")
 @click.option("--waitress-opts", default=None,
               help="Additional command line options for waitress-serve.")
-@click.option("--expose-prometheus", default=False, is_flag=True,
-              help="Activate prometheus exporter to expose metrics on /metrics endpoint."
-                   "You need to set the environment variable 'prometheus_multiproc_dir' "
-                   "to point to a directory where the metrics will be stored.")
+@click.option("--expose-prometheus", default=None,
+              help="Path to the directory where metrics will be stored. If the directory"
+                   "doesn't exist, it will be created."
+                   "Activate prometheus exporter to expose metrics on /metrics endpoint.")
 def server(backend_store_uri, default_artifact_root, host, port,
            workers, static_prefix, gunicorn_opts, waitress_opts, expose_prometheus):
     """

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -12,7 +12,7 @@ from mlflow.utils.process import exec_cmd
 # the cli and the forked gunicorn processes.
 BACKEND_STORE_URI_ENV_VAR = "_MLFLOW_SERVER_FILE_STORE"
 ARTIFACT_ROOT_ENV_VAR = "_MLFLOW_SERVER_ARTIFACT_ROOT"
-PROMETHEUS_EXPORTER_ENV_VAR = "_MLFLOW_ACTIVATE_PROMETHEUS_EXPORTER"
+PROMETHEUS_EXPORTER_ENV_VAR = "_MLFLOW_EXPOSE_PROMETHEUS_METRICS"
 
 REL_STATIC_DIR = "js/build"
 
@@ -65,7 +65,7 @@ def _build_gunicorn_command(gunicorn_opts, host, port, workers):
 
 
 def _run_server(file_store_path, default_artifact_root, host, port, static_prefix=None,
-                workers=None, gunicorn_opts=None, waitress_opts=None, activate_prometheus=False):
+                workers=None, gunicorn_opts=None, waitress_opts=None, expose_prometheus=False):
     """
     Run the MLflow server, wrapping it in gunicorn or waitress on windows
     :param static_prefix: If set, the index.html asset will be served from the path static_prefix.
@@ -80,7 +80,7 @@ def _run_server(file_store_path, default_artifact_root, host, port, static_prefi
     if static_prefix:
         env_map[STATIC_PREFIX_ENV_VAR] = static_prefix
 
-    if activate_prometheus:
+    if expose_prometheus:
         env_map[PROMETHEUS_EXPORTER_ENV_VAR] = '1'
 
     # TODO: eventually may want waitress on non-win32

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -6,7 +6,6 @@ from flask import Flask, send_from_directory
 
 from mlflow.server import handlers
 from mlflow.server.handlers import get_artifact_handler, STATIC_PREFIX_ENV_VAR, _add_static_prefix
-from mlflow.server.prometheus_exporter import activate_prometheus_exporter
 from mlflow.utils.process import exec_cmd
 
 # NB: These are intenrnal environment variables used for communication between
@@ -25,6 +24,7 @@ for http_path, handler, methods in handlers.get_endpoints():
     app.add_url_rule(http_path, handler.__name__, handler, methods=methods)
 
 if os.getenv(PROMETHEUS_EXPORTER_ENV_VAR):
+    from mlflow.server.prometheus_exporter import activate_prometheus_exporter
     activate_prometheus_exporter(app)
 
 

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -25,7 +25,9 @@ for http_path, handler, methods in handlers.get_endpoints():
 
 if os.getenv(PROMETHEUS_EXPORTER_ENV_VAR):
     from mlflow.server.prometheus_exporter import activate_prometheus_exporter
-    os.makedirs(os.getenv(PROMETHEUS_EXPORTER_ENV_VAR), exist_ok=True)
+    prometheus_metrics_path = os.getenv(PROMETHEUS_EXPORTER_ENV_VAR)
+    if not os.path.exists(prometheus_metrics_path):
+        os.makedirs(prometheus_metrics_path)
     activate_prometheus_exporter(app)
 
 

--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -1,0 +1,23 @@
+from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
+from flask import request
+
+
+def activate_prometheus_exporter(app):
+    metrics = GunicornInternalPrometheusMetrics(app, export_defaults=False)
+
+    endpoint = app.view_functions
+    histogram = metrics.histogram('mlflow_requests_by_status_and_path',
+                                  'Request latencies and count by status and path',
+                                  labels={'status': lambda r: r.status_code,
+                                          'path': lambda: change_path_for_metric(request.path)})
+    for func_name, func in endpoint.items():
+        if func_name in ["_search_runs", "_log_metric", "_log_param", "_set_tag", "_create_run"]:
+            app.view_functions[func_name] = histogram(func)
+
+    return app
+
+
+def change_path_for_metric(path):
+    if 'mlflow/' in path:
+        path = path.split('mlflow/')[-1]
+    return path.replace('/', '_')

--- a/mlflow/server/prometheus_exporter.py
+++ b/mlflow/server/prometheus_exporter.py
@@ -18,6 +18,11 @@ def activate_prometheus_exporter(app):
 
 
 def change_path_for_metric(path):
+    """
+    Replace the '/' in the metric path by '_' so grafana can correctly use it.
+    :param path: path of the metric (example: runs/search)
+    :return: path with '_' instead of '/'
+    """
     if 'mlflow/' in path:
         path = path.split('mlflow/')[-1]
     return path.replace('/', '_')

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'sqlparse',
         'sqlalchemy',
         'gorilla',
+        'prometheus-flask-exporter',
     ],
     extras_require={
         'extras':[


### PR DESCRIPTION
## What changes are proposed in this pull request?

A new parameter to the `mlflow server` cli allowing to activate a prometheus exporter which expose metrics on the /metrics endpoint.
The following metrics are exported for the search_run, create_run, log_param, log_metric and set_tag endpoints:
- Total number of calls
- Buckets with the response time of each call.

## How is this patch tested?

Locally, by trying to launch the server with or without the argument `--activate-prometheus`, and by checking that metrics are indeed available on /metrics endpoint.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
A prometheus exporter exposing metrics on /metrics can be activated using --activate-parameter argument of the mlfllow server cli.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
