### PR TITLE
Wrapping TensorFlow/Keras autolog runs with try_mlflow_log()

### DIFF
--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -422,7 +422,7 @@ def autolog():
     @gorilla.patch(keras.Model)
     def fit(self, *args, **kwargs):
         if not mlflow.active_run():
-            mlflow.start_run()
+            try_mlflow_log(mlflow.start_run())
             auto_end_run = True
         else:
             auto_end_run = False
@@ -441,13 +441,13 @@ def autolog():
 
         result = original(self, *args, **kwargs)
         if auto_end_run:
-            mlflow.end_run()
+            try_mlflow_log(mlflow.end_run())
         return result
 
     @gorilla.patch(keras.Model)
     def fit_generator(self, *args, **kwargs):
         if not mlflow.active_run():
-            mlflow.start_run()
+            try_mlflow_log(mlflow.start_run())
             auto_end_run = True
         else:
             auto_end_run = False
@@ -466,7 +466,7 @@ def autolog():
 
         result = original(self, *args, **kwargs)
         if auto_end_run:
-            mlflow.end_run()
+            try_mlflow_log(mlflow.end_run())
         return result
 
     settings = gorilla.Settings(allow_hit=True, store_hit=True)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -422,7 +422,7 @@ def autolog():
     @gorilla.patch(keras.Model)
     def fit(self, *args, **kwargs):
         if not mlflow.active_run():
-            try_mlflow_log(mlflow.start_run())
+            try_mlflow_log(mlflow.start_run)
             auto_end_run = True
         else:
             auto_end_run = False
@@ -441,13 +441,13 @@ def autolog():
 
         result = original(self, *args, **kwargs)
         if auto_end_run:
-            try_mlflow_log(mlflow.end_run())
+            try_mlflow_log(mlflow.end_run)
         return result
 
     @gorilla.patch(keras.Model)
     def fit_generator(self, *args, **kwargs):
         if not mlflow.active_run():
-            try_mlflow_log(mlflow.start_run())
+            try_mlflow_log(mlflow.start_run)
             auto_end_run = True
         else:
             auto_end_run = False
@@ -466,7 +466,7 @@ def autolog():
 
         result = original(self, *args, **kwargs)
         if auto_end_run:
-            try_mlflow_log(mlflow.end_run())
+            try_mlflow_log(mlflow.end_run)
         return result
 
     settings = gorilla.Settings(allow_hit=True, store_hit=True)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -683,7 +683,7 @@ def autolog(every_n_iter=100):
     def fit(self, *args, **kwargs):
         global _AUTO_END_RUN
         if not mlflow.active_run():
-            mlflow.start_run()
+            try_mlflow_log(mlflow.start_run())
             _AUTO_END_RUN = True
 
         original = gorilla.get_original_attribute(tensorflow.keras.Model, 'fit')
@@ -703,7 +703,7 @@ def autolog(every_n_iter=100):
         shutil.rmtree(log_dir)
 
         if _AUTO_END_RUN:
-            mlflow.end_run()
+            try_mlflow_log(mlflow.end_run())
         _AUTO_END_RUN = False
         return result
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -583,7 +583,7 @@ def _log_event(event):
     Extracts metric information from the event protobuf
     """
     if not mlflow.active_run():
-        try_mlflow_log(mlflow.start_run())
+        try_mlflow_log(mlflow.start_run)
         global _AUTO_END_RUN
         _AUTO_END_RUN = True
     if event.WhichOneof('what') == 'summary':
@@ -683,7 +683,7 @@ def autolog(every_n_iter=100):
     def fit(self, *args, **kwargs):
         global _AUTO_END_RUN
         if not mlflow.active_run():
-            try_mlflow_log(mlflow.start_run())
+            try_mlflow_log(mlflow.start_run)
             _AUTO_END_RUN = True
 
         original = gorilla.get_original_attribute(tensorflow.keras.Model, 'fit')
@@ -703,7 +703,7 @@ def autolog(every_n_iter=100):
         shutil.rmtree(log_dir)
 
         if _AUTO_END_RUN:
-            try_mlflow_log(mlflow.end_run())
+            try_mlflow_log(mlflow.end_run)
         _AUTO_END_RUN = False
         return result
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -583,7 +583,7 @@ def _log_event(event):
     Extracts metric information from the event protobuf
     """
     if not mlflow.active_run():
-        mlflow.start_run()
+        try_mlflow_log(mlflow.start_run())
         global _AUTO_END_RUN
         _AUTO_END_RUN = True
     if event.WhichOneof('what') == 'summary':


### PR DESCRIPTION
## What changes are proposed in this pull request?

Applies the fix in #2095 comments (wrapping automatically started and ended runs with `try_mlflow_log()`) to hooks that exist in `tf.keras` and `keras`.

## How is this patch tested?

Manually.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
