### PR TITLE
Fix empty tag value on edit

### DIFF
--- a/mlflow/server/js/src/components/tables/EditableFormTable.js
+++ b/mlflow/server/js/src/components/tables/EditableFormTable.js
@@ -38,7 +38,7 @@ class EditableCell extends React.Component {
               <Form.Item style={{ margin: 0 }}>
                 {getFieldDecorator(dataIndex, {
                   rules: [],
-                  defaultMarkdown: record[dataIndex],
+                  initialValue: record[dataIndex],
                 })(<Input onKeyDown={this.handleKeyPress} />)}
               </Form.Item>
             ) : (


### PR DESCRIPTION
## What changes are proposed in this pull request?

When editing tags, the initial value of the input box is is set to empty. This PR proposes to fix it (resolves #2104 ).

### Before
![before](https://user-images.githubusercontent.com/17039389/68979907-42373700-0842-11ea-974f-ec16ee9f356e.gif)


### After
![after](https://user-images.githubusercontent.com/17039389/68979904-3e0b1980-0842-11ea-80da-d625c2d41072.gif)


## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
