### PR TITLE
[Docs] Add back reference to fluent API

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -1,5 +1,5 @@
 """
-The ``mlflow`` module provides an API for starting and managing MLflow runs.
+The ``mlflow`` module provides a high-level "fluent" API for starting and managing MLflow runs.
 For example:
 
 .. code:: python
@@ -19,7 +19,7 @@ You can also use syntax like this:
 
 which automatically terminates the run at the end of the block.
 
-The tracking API is not currently threadsafe. Any concurrent callers to the tracking API must
+The fluent tracking API is not currently threadsafe. Any concurrent callers to the tracking API must
 implement mutual exclusion manually.
 
 For a lower level API, see the :py:mod:`mlflow.tracking` module.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds back references to a "fluent" API in the Python API docs, to make it easier to discover/Google for references to the fluent API

## How is this patch tested?

Existing docs lint tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [x] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
