### PR TITLE
Add killed status constraint

### DIFF
--- a/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
+++ b/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
@@ -1,0 +1,52 @@
+"""Update run status constraint with killed
+
+Revision ID: cfd24bdc0731
+Revises: 89d4b8295536
+Create Date: 2019-10-11 15:55:10.853449
+
+"""
+from alembic import op, context
+from mlflow.store.tracking.dbmodels.models import SqlRun
+from mlflow.entities import RunStatus
+
+# revision identifiers, used by Alembic.
+revision = 'cfd24bdc0731'
+down_revision = '2b4d017a5e9b'
+branch_labels = None
+depends_on = None
+
+
+new_run_status = [
+    RunStatus.to_string(RunStatus.SCHEDULED),
+    RunStatus.to_string(RunStatus.FAILED),
+    RunStatus.to_string(RunStatus.FINISHED),
+    RunStatus.to_string(RunStatus.RUNNING),
+    RunStatus.to_string(RunStatus.KILLED)
+]
+
+previous_run_status = [
+    RunStatus.to_string(RunStatus.SCHEDULED),
+    RunStatus.to_string(RunStatus.FAILED),
+    RunStatus.to_string(RunStatus.FINISHED),
+    RunStatus.to_string(RunStatus.RUNNING)
+]
+
+
+def _is_backend_sqlite():
+    return context.get_bind().engine.url.get_backend_name() == 'sqlite'
+
+
+def upgrade():
+    with op.batch_alter_table("runs") as batch_op:
+        if not _is_backend_sqlite():
+            batch_op.drop_constraint(constraint_name='status', type_='check')
+            batch_op.create_check_constraint(constraint_name='status',
+                                             condition=SqlRun.status.in_(new_run_status))
+
+
+def downgrade():
+    with op.batch_alter_table("runs") as batch_op:
+        if not _is_backend_sqlite():
+            batch_op.drop_constraint(constraint_name='status', type_='check')
+            batch_op.create_check_constraint(constraint_name='status',
+                                             condition=SqlRun.status.in_(previous_run_status))

--- a/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
+++ b/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
@@ -53,14 +53,22 @@ def get_check_constraints():
 def upgrade():
     if _has_check_constraints():
         with op.batch_alter_table("runs", table_args=get_check_constraints()) as batch_op:
+            # Update the "status" constraint via the SqlAlchemy `Enum` type. Specify
+            # `native_enum=False` to create a check constraint rather than a
+            # database-backend-dependent enum (see https://docs.sqlalchemy.org/en/13/core/
+            # type_basics.html#sqlalchemy.types.Enum.params.native_enum)
             batch_op.alter_column("status",
                                   type_=Enum(*new_run_status, create_constraint=True,
-                                             constraint_name="status"))
+                                             constraint_name="status", native_enum=False))
 
 
 def downgrade():
     if _has_check_constraints():
         with op.batch_alter_table("runs", table_args=get_check_constraints()) as batch_op:
+            # Update the "status" constraint via the SqlAlchemy `Enum` construct. Specify
+            # `native_enum=False` to create a check constraint rather than a
+            # database-backend-dependent enum (see https://docs.sqlalchemy.org/en/13/core/
+            # type_basics.html#sqlalchemy.types.Enum.params.native_enum)
             batch_op.alter_column("status",
                                   type_=Enum(*previous_run_status, create_constraint=True,
-                                             constraint_name="status"))
+                                             constraint_name="status", native_enum=False))

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -22,7 +22,8 @@ RunStatusTypes = [
     RunStatus.to_string(RunStatus.SCHEDULED),
     RunStatus.to_string(RunStatus.FAILED),
     RunStatus.to_string(RunStatus.FINISHED),
-    RunStatus.to_string(RunStatus.RUNNING)
+    RunStatus.to_string(RunStatus.RUNNING),
+    RunStatus.to_string(RunStatus.KILLED)
 ]
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -59,7 +59,7 @@ CREATE TABLE runs (
 	source_name VARCHAR(500), 
 	entry_point_name VARCHAR(50), 
 	user_id VARCHAR(256), 
-	status VARCHAR(20), 
+	status VARCHAR(9),
 	start_time BIGINT, 
 	end_time BIGINT, 
 	source_version VARCHAR(50), 
@@ -69,8 +69,8 @@ CREATE TABLE runs (
 	CONSTRAINT run_pk PRIMARY KEY (run_uuid), 
 	FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id), 
 	CONSTRAINT source_type CHECK (source_type IN ('NOTEBOOK', 'JOB', 'LOCAL', 'UNKNOWN', 'PROJECT')), 
-	CONSTRAINT status CHECK (status IN ('SCHEDULED', 'FAILED', 'FINISHED', 'RUNNING')), 
-	CONSTRAINT runs_lifecycle_stage CHECK (lifecycle_stage IN ('active', 'deleted'))
+	CONSTRAINT runs_lifecycle_stage CHECK (lifecycle_stage IN ('active', 'deleted')),
+	CHECK (status IN ('SCHEDULED', 'FAILED', 'FINISHED', 'RUNNING', 'KILLED'))
 )
 
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1555,6 +1555,13 @@ class TestSqlAlchemyStoreMysqlDb(TestSqlAlchemyStoreSqlite):
             self.store.log_param(run.info.run_id, entities.Param("pkey-%s" % i, "pval-%s" % i))
             self.store.set_tag(run.info.run_id, entities.RunTag("tkey-%s" % i, "tval-%s" % i))
 
+    def test_set_status_scheduled(self):
+        """
+        Constraints are not tested by sqlite. Use mysql to test it
+        """
+        run = self._run_factory()
+        self.store.update_run_info(run.info.run_id, 'KILLED', 10)
+
 
 @mock.patch('sqlalchemy.orm.session.Session', spec=True)
 class TestZeroValueInsertion(unittest.TestCase):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add KILLED in the RunStatus constraint in DB schema. MariaDB enforces these constraint. It is currently not possible to set the KILLED status to a run if we use MariaDB as a backend.

## How is this patch tested?

* Test DB migration
* Add a test that sets this status in the 'release' tests that run using MySQL: sqlite does not enforce this constraint. So this kind of bug cannot be detected with the unittests.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
