### PR TITLE
Fix search docs to reflect MLflow user tag support and start/end time ordering

### DIFF
--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -105,8 +105,6 @@ MLflow Tags
 
 You can search for MLflow tags by enclosing the tag name in double quotes or backticks. For example, to search for the name of an MLflow run, specify ``tags."mlflow.runName"`` or ``tags.`mlflow.runName```. 
 
-.. note:: Databricks does not support searching for a user with the tag ``tags."mlflow.user"``.
-
 .. rubric:: Examples
 
 .. code-block:: sql

--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -89,7 +89,6 @@ You can search using two run attributes contained in :py:class:`mlflow.entities.
   
   - The experiment ID is implicitly selected by the search API. 
   - A run's ``lifecycle_stage`` attribute is not allowed because it is already encoded as a part of the API's ``run_view_type`` field. To search for runs using ``run_id``, it is more efficient to use ``get_run`` APIs. 
-  - The ``start_time`` and ``end_time`` attributes are not supported.
   
 .. rubric:: Example
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix search docs to reflect MLflow user tag support and start/end time ordering

## How is this patch tested?

Unit tests for docs (yay!)

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [X] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
