### PR TITLE
Fixing TensorFlow estimator autolog test names

### DIFF
--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -46,7 +46,7 @@ def create_model():
 
 @pytest.mark.large
 @pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels, fit_variant):
+def test_keras_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels, fit_variant):
     mlflow.keras.autolog()
 
     data = random_train_data
@@ -67,8 +67,8 @@ def test_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels,
 
 @pytest.mark.large
 @pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_autolog_persists_manually_created_run(random_train_data,
-                                               random_one_hot_labels, fit_variant):
+def test_keras_autolog_persists_manually_created_run(random_train_data,
+                                                     random_one_hot_labels, fit_variant):
     mlflow.keras.autolog()
 
     with mlflow.start_run() as run:

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -209,7 +209,7 @@ def create_tf_estimator_model(dir, export):
 
 @pytest.mark.large
 @pytest.mark.parametrize('export', [True, False])
-def test_tf_keras_autolog_ends_auto_created_run(tmpdir, export):
+def test_tf_estimator_autolog_ends_auto_created_run(tmpdir, export):
     dir = tmpdir.mkdir("test")
     mlflow.tensorflow.autolog()
     create_tf_estimator_model(str(dir), export)
@@ -218,7 +218,7 @@ def test_tf_keras_autolog_ends_auto_created_run(tmpdir, export):
 
 @pytest.mark.large
 @pytest.mark.parametrize('export', [True, False])
-def test_tf_keras_autolog_persists_manually_created_run(tmpdir, export):
+def test_tf_estimator_autolog_persists_manually_created_run(tmpdir, export):
     dir = tmpdir.mkdir("test")
     with mlflow.start_run() as run:
         create_tf_estimator_model(str(dir), export)

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -228,7 +228,7 @@ def create_tf_estimator_model(dir, export):
 
 @pytest.mark.large
 @pytest.mark.parametrize('export', [True, False])
-def test_tf_keras_autolog_ends_auto_created_run(tmpdir, export):
+def test_tf_estimator_autolog_ends_auto_created_run(tmpdir, export):
     dir = tmpdir.mkdir("test")
     mlflow.tensorflow.autolog()
     create_tf_estimator_model(str(dir), export)
@@ -237,7 +237,7 @@ def test_tf_keras_autolog_ends_auto_created_run(tmpdir, export):
 
 @pytest.mark.large
 @pytest.mark.parametrize('export', [True, False])
-def test_tf_keras_autolog_persists_manually_created_run(tmpdir, export):
+def test_tf_estimator_autolog_persists_manually_created_run(tmpdir, export):
     dir = tmpdir.mkdir("test")
     with mlflow.start_run() as run:
         create_tf_estimator_model(str(dir), export)


### PR DESCRIPTION
## What changes are proposed in this pull request?

A few tests for autologging with `tf.estimator` were incorrectly named, causing some of the tests in the suite not to be run since the names were the same as other tests in the suite.

Also renamed some `keras` tests to make them more specific.

## How is this patch tested?

Manually

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
