### PR TITLE
Cap train_loss at null_train_loss

### DIFF
--- a/examples/hyperparam/search_gpyopt.py
+++ b/examples/hyperparam/search_gpyopt.py
@@ -109,7 +109,7 @@ def run(training_data, max_runs, batch_size, max_p, epochs, metric, gpy_model, g
                 metrics = training_run.data.metrics
 
                 # cap the loss at the loss of the null model
-                train_loss = min(null_valid_loss,
+                train_loss = min(null_train_loss,
                                  metrics["train_{}".format(metric)])
                 valid_loss = min(null_valid_loss,
                                  metrics["val_{}".format(metric)])


### PR DESCRIPTION
Cap `train_loss` at `null_train_loss` instead of `null_valid_loss`.

## What changes are proposed in this pull request?

Cap `train_loss` at `null_train_loss` instead of `null_valid_loss`. Seems more reasonable, since `null_train_loss` is supplied anyway.

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [x] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
