### PR TITLE
test_examples use filesystem as backend.

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -8,8 +8,6 @@ from mlflow.utils.file_utils import path_to_local_file_uri
 from tests.integration.utils import invoke_cli_runner
 import pytest
 
-from tests.projects.utils import tracking_uri_mock
-
 EXAMPLES_DIR = 'examples'
 
 
@@ -21,9 +19,13 @@ EXAMPLES_DIR = 'examples'
     ('h2o', []),
     ('prophet', []),
 ])
-def test_mlflow_run_example(tracking_uri_mock, directory, params):
-    cli_run_list = [os.path.join(EXAMPLES_DIR, directory)] + params
-    invoke_cli_runner(cli.run, cli_run_list)
+def test_mlflow_run_example(tmpdir, directory, params):
+    os.environ['MLFLOW_TRACKING_URI'] = path_to_local_file_uri(str(tmpdir.join("mlruns")))
+    try:
+        cli_run_list = [os.path.join(EXAMPLES_DIR, directory)] + params
+        invoke_cli_runner(cli.run, cli_run_list)
+    finally:
+        del os.environ['MLFLOW_TRACKING_URI']
 
 
 @pytest.mark.large


### PR DESCRIPTION
## What changes are proposed in this pull request?

It uses filesystem backend instead of the SQL ones to execute test_examples. It is a workaround to https://github.com/mlflow/mlflow/issues/2122 in case a new SQL migration is introduce to master (migration will not be played). 
More info in the ticket about the root cause (version of MLFlow that executes the example is the latest released not the one built from sources)

## How is this patch tested?

Tests are now green after merge of https://github.com/mlflow/mlflow/pull/2110 and commit https://github.com/mlflow/mlflow/commit/fdcf3402123bccfa88b376a5efcf13be4a65fd2f

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
