### PR TITLE
Clarify MLflow Projects existing cluster restrictions

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -374,15 +374,26 @@ in the Databricks docs
 `Databricks on AWS <https://docs.databricks.com/applications/mlflow/index.html>`_). A brief overview
 of how to use the feature is as follows:
 
-Create a JSON file containing the 
-`cluster specification <https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster>`_
-for your run. Then, run your project using the command
+1. Create a JSON file containing the
+`new cluster specification <https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster>`_
+for your run. For example:
 
-.. code-block:: bash
+  .. code-block:: json
 
-  mlflow run <project_uri> -b databricks --backend-config <json-cluster-spec>
+    {
+      "spark_version": "5.5.x-scala2.11",
+      "node_type_id": "i3.xlarge",
+      "aws_attributes": {"availability": "ON_DEMAND"},
+      "num_workers": 4
+    }
 
-where ``<project_uri>`` is a Git repository URI or a folder.
+2. Run your project using the following command:
+
+  .. code-block:: bash
+
+    mlflow run <project_uri> -b databricks --backend-config <json-new-cluster-spec>
+
+  where ``<project_uri>`` is a Git repository URI or a folder.
 
 .. important::
 

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -374,10 +374,6 @@ in the Databricks docs
 `Databricks on AWS <https://docs.databricks.com/applications/mlflow/index.html>`_). A brief overview
 of how to use the feature is as follows:
 
-.. important::
-
-  Databricks execution for MLflow projects with Docker environments is *not* currently supported.
-
 Create a JSON file containing the 
 `cluster specification <https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster>`_
 for your run. Then, run your project using the command
@@ -387,6 +383,13 @@ for your run. Then, run your project using the command
   mlflow run <project_uri> -b databricks --backend-config <json-cluster-spec>
 
 where ``<project_uri>`` is a Git repository URI or a folder.
+
+.. important::
+
+  - Databricks execution for MLflow projects with Docker environments is *not* currently supported.
+
+  - You must use a *new cluster* specification when running an MLflow Project on Databricks. Running
+    Projects against existing clusters is not currently supported.
 
 .. _kubernetes_execution:
 

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -14,6 +14,7 @@ from mlflow import tracking
 from mlflow.entities import RunStatus
 from mlflow.exceptions import MlflowException
 from mlflow.projects.submitted_run import SubmittedRun
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.utils import rest_utils, file_utils, databricks_utils
 from mlflow.exceptions import ExecutionException
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_RUN_URL, MLFLOW_DATABRICKS_SHELL_JOB_ID, \
@@ -42,6 +43,14 @@ def before_run_validations(tracking_uri, backend_config):
     if backend_config is None:
         raise ExecutionException("Backend spec must be provided when launching MLflow project "
                                  "runs on Databricks.")
+    elif "existing_cluster_id" in backend_config:
+        raise MlflowException(
+            message=(
+                "MLflow Project runs on Databricks must provide a *new cluster* specification."
+                " Project execution against existing clusters is not currently supported. For more"
+                " information, see https://mlflow.org/docs/latest/projects.html"
+                "#run-an-mlflow-project-on-databricks"),
+            error_code=INVALID_PARAMETER_VALUE)
     if not is_databricks_uri(tracking_uri) and \
             not is_http_uri(tracking_uri):
         raise ExecutionException(

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -236,7 +236,7 @@ def test_run_databricks_cluster_spec_json(
 
 
 def test_run_databricks_throws_exception_when_spec_uses_existing_cluster(
-        tracking_uri_mock): # pylint: disable=unused-argument
+        tracking_uri_mock):  # pylint: disable=unused-argument
     with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
         existing_cluster_spec = {
             "existing_cluster_id": "1000-123456-clust1",

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -11,6 +11,7 @@ import pytest
 import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.projects.databricks import DatabricksJobRunner
+from mlflow.protos.databricks_pb2 import ErrorCode, INVALID_PARAMETER_VALUE
 from mlflow.entities import RunStatus
 from mlflow.projects import databricks, ExecutionException
 from mlflow.tracking import MlflowClient
@@ -232,6 +233,18 @@ def test_run_databricks_cluster_spec_json(
         runs_submit_args, _ = runs_submit_mock.call_args_list[0]
         req_body = runs_submit_args[0]
         assert req_body["new_cluster"] == cluster_spec
+
+
+def test_run_databricks_throws_exception_when_spec_uses_existing_cluster(
+        tracking_uri_mock): # pylint: disable=unused-argument
+    with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
+        existing_cluster_spec = {
+            "existing_cluster_id": "1000-123456-clust1",
+        }
+        with pytest.raises(MlflowException) as exc:
+            run_databricks_project(cluster_spec=existing_cluster_spec)
+        assert "execution against existing clusters is not currently supported" in str(exc)
+        assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
 def test_run_databricks_cancel(


### PR DESCRIPTION
## What changes are proposed in this pull request?

Addresses documentation shortcomings raised in #1842. Currently, MLflow projects cannot be executed against existing clusters. This PR adds a documentation warning noting the restriction.

## How is this patch tested?

Docs unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [X] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
