### PR TITLE
Strip "dev" suffix from PySpark versions

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -51,7 +51,12 @@ _logger = logging.getLogger(__name__)
 def get_default_conda_env():
     """
     :return: The default Conda environment for MLflow Models produced by calls to
-             :func:`save_model()` and :func:`log_model()`.
+             :func:`save_model()` and :func:`log_model()`. This Conda environment
+             contains the current version of PySpark that is installed on the caller's
+             system. ``dev`` versions of PySpark are replaced with stable versions in
+             the resulting Conda environment (e.g., if you are running PySpark version
+             ``2.4.5.dev0``, invoking this method produces a Conda environment with a
+             dependency on PySpark version ``2.4.5``).
     """
     import pyspark
     # Strip the suffix from `dev` versions of PySpark, which are not

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -56,7 +56,7 @@ def get_default_conda_env():
     import pyspark
     # Strip the suffix from `dev` versions of PySpark, which are not
     # available for installation from Anaconda or PyPI
-    pyspark_version = re.sub(r"\.dev.*", "", pyspark.__version__)
+    pyspark_version = re.sub(r"dev.*", "", pyspark.__version__).rstrip(".")
 
     return _mlflow_conda_env(
         additional_conda_deps=[

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -25,6 +25,7 @@ import os
 import yaml
 import logging
 import posixpath
+import re
 
 import mlflow
 from mlflow import pyfunc, mleap
@@ -53,10 +54,13 @@ def get_default_conda_env():
              :func:`save_model()` and :func:`log_model()`.
     """
     import pyspark
+    # Strip the suffix from `dev` versions of PySpark, which are not
+    # available for installation from Anaconda or PyPI
+    pyspark_version = re.sub(r"\.dev.*", "", pyspark.__version__)
 
     return _mlflow_conda_env(
         additional_conda_deps=[
-            "pyspark={}".format(pyspark.__version__),
+            "pyspark={}".format(pyspark_version),
         ],
         additional_pip_deps=None,
         additional_conda_channels=None)

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -61,7 +61,7 @@ def get_default_conda_env():
     import pyspark
     # Strip the suffix from `dev` versions of PySpark, which are not
     # available for installation from Anaconda or PyPI
-    pyspark_version = re.sub(r"dev.*", "", pyspark.__version__).rstrip(".")
+    pyspark_version = re.sub(r"(\.?)dev.*", "", pyspark.__version__)
 
     return _mlflow_conda_env(
         additional_conda_deps=[

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -487,6 +487,34 @@ def test_sparkml_model_log_without_specified_conda_env_uses_default_env_with_exp
 
 
 @pytest.mark.large
+def test_default_conda_env_strips_dev_suffix_from_pyspark_version(spark_model_iris, model_path):
+    mock_version_standard = mock.PropertyMock(return_value="2.4.0")
+    with mock.patch("pyspark.__version__", new_callable=mock_version_standard):
+        default_conda_env_standard = sparkm.get_default_conda_env()
+
+    for dev_version in ["2.4.0.dev0", "2.4.0.dev", "2.4.0.dev1", "2.4.0.dev.a", "2.4.0.devb"]:
+        mock_version_dev = mock.PropertyMock(return_value=dev_version)
+        with mock.patch("pyspark.__version__", new_callable=mock_version_dev):
+            default_conda_env_dev = sparkm.get_default_conda_env()
+            assert(default_conda_env_dev == default_conda_env_standard)
+
+            with mlflow.start_run():
+                sparkm.log_model(
+                    spark_model=spark_model_iris.model, artifact_path="model", conda_env=None)
+                model_uri = "runs:/{run_id}/{artifact_path}".format(
+                    run_id=mlflow.active_run().info.run_id,
+                    artifact_path="model")
+
+            model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+            pyfunc_conf = _get_flavor_configuration(
+                model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+            conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+            with open(conda_env_path, "r") as f:
+                persisted_conda_env_dev = yaml.safe_load(f)
+            assert(persisted_conda_env_dev == default_conda_env_standard)
+
+
+@pytest.mark.large
 def test_mleap_model_log(spark_model_iris):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -492,7 +492,7 @@ def test_default_conda_env_strips_dev_suffix_from_pyspark_version(spark_model_ir
     with mock.patch("pyspark.__version__", new_callable=mock_version_standard):
         default_conda_env_standard = sparkm.get_default_conda_env()
 
-    for dev_version in ["2.4.0.dev0", "2.4.0.dev", "2.4.0.dev1", "2.4.0.dev.a", "2.4.0.devb"]:
+    for dev_version in ["2.4.0.dev0", "2.4.0.dev", "2.4.0.dev1", "2.4.0dev.a", "2.4.0.devb"]:
         mock_version_dev = mock.PropertyMock(return_value=dev_version)
         with mock.patch("pyspark.__version__", new_callable=mock_version_dev):
             default_conda_env_dev = sparkm.get_default_conda_env()
@@ -512,6 +512,11 @@ def test_default_conda_env_strips_dev_suffix_from_pyspark_version(spark_model_ir
             with open(conda_env_path, "r") as f:
                 persisted_conda_env_dev = yaml.safe_load(f)
             assert(persisted_conda_env_dev == default_conda_env_standard)
+
+    for unaffected_version in ["2.0", "2.3.4", "2"]:
+        mock_version = mock.PropertyMock(return_value=unaffected_version)
+        with mock.patch("pyspark.__version__", new_callable=mock_version):
+            assert unaffected_version in yaml.safe_dump(sparkm.get_default_conda_env())
 
 
 @pytest.mark.large


### PR DESCRIPTION
## What changes are proposed in this pull request?

Dev versions of PySpark are used by default on certain platforms (e.g., Databricks). Dev versions of PySpark are not available on Anaconda; as a result, Conda environments generated for SparkML models saved with MLflow on Databricks contain an uninstallable PySpark version dependency. When a model with such an invalid dependency is served, the serving process fails.

## How is this patch tested?

Unit tests

## Release Notes

"dev" versions of PySpark are now replaced with stable versions when saving SparkML models with MLflow.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [X] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
