### PR TITLE
Update active_run() docs for accessing current run data

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -115,6 +115,15 @@ with no active run automatically starts a new one.
 
 :py:func:`mlflow.active_run` returns a :py:class:`mlflow.entities.Run` object corresponding to the
 currently active run, if any.
+***Note***: You cannot access currently-active run attributes
+(parameters, metrics, etc.) through the run returned by ``mlflow.active_run``. In order to access
+such attributes, use the :py:class:`mlflow.tracking.MlflowClient` as follows:
+
+.. code-block:: py
+
+    client = mlflow.tracking.MlflowClient()
+    data = client.get_run(mlflow.active_run().info.run_id).data
+
 
 :py:func:`mlflow.log_param` logs a single key-value param in the currently active run. The key and
 value are both strings. Use :py:func:`mlflow.log_params` to log multiple params at once.

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -115,7 +115,7 @@ with no active run automatically starts a new one.
 
 :py:func:`mlflow.active_run` returns a :py:class:`mlflow.entities.Run` object corresponding to the
 currently active run, if any.
-***Note***: You cannot access currently-active run attributes
+**Note**: You cannot access currently-active run attributes
 (parameters, metrics, etc.) through the run returned by ``mlflow.active_run``. In order to access
 such attributes, use the :py:class:`mlflow.tracking.MlflowClient` as follows:
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -173,7 +173,7 @@ atexit.register(end_run)
 def active_run():
     """Get the currently active ``Run``, or None if no such run exists.
 
-    ***Note***: You cannot access currently-active run attributes
+    **Note**: You cannot access currently-active run attributes
     (parameters, metrics, etc.) through the run returned by ``mlflow.active_run``. In order
     to access such attributes, use the :py:class:`mlflow.tracking.MlflowClient` as follows:
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -171,7 +171,17 @@ atexit.register(end_run)
 
 
 def active_run():
-    """Get the currently active ``Run``, or None if no such run exists."""
+    """Get the currently active ``Run``, or None if no such run exists.
+
+    ***Note***: You cannot access currently-active run attributes
+    (parameters, metrics, etc.) through the run returned by ``mlflow.active_run``. In order to access
+    such attributes, use the :py:class:`mlflow.tracking.MlflowClient` as follows:
+
+    .. code-block:: py
+
+        client = mlflow.tracking.MlflowClient()
+        data = client.get_run(mlflow.active_run().info.run_id).data
+    """
     return _active_run_stack[-1] if len(_active_run_stack) > 0 else None
 
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -174,8 +174,8 @@ def active_run():
     """Get the currently active ``Run``, or None if no such run exists.
 
     ***Note***: You cannot access currently-active run attributes
-    (parameters, metrics, etc.) through the run returned by ``mlflow.active_run``. In order to access
-    such attributes, use the :py:class:`mlflow.tracking.MlflowClient` as follows:
+    (parameters, metrics, etc.) through the run returned by ``mlflow.active_run``. In order
+    to access such attributes, use the :py:class:`mlflow.tracking.MlflowClient` as follows:
 
     .. code-block:: py
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

You cannot access current run data (params, metrics) via `active_run()`. This PR updates the docs to say so, and provides a small snippet in order to show users how to access current run attributes. 

Before:
![image](https://user-images.githubusercontent.com/39497939/69588980-39abd280-0f9f-11ea-81e6-c673f2b58b1e.png)

After:
![image](https://user-images.githubusercontent.com/39497939/69588910-fea99f00-0f9e-11ea-84f9-d4dac28dba61.png)


## How is this patch tested?

Manually.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [X] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
