### PR TITLE
Make kube-context config optional (default in-cluster)

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -474,7 +474,7 @@ You can run your MLflow Project on Kubernetes by following these steps:
    - ``kube-context``
      The `Kubernetes context
      <https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#context>`_
-     where MLflow will run the job.
+     where MLflow will run the job. If not provided, MLflow will assume it is running in a Kubernetes cluster.
    - ``repository-uri``
      The URI of the docker repository where the Project execution Docker image will be uploaded
      (pushed). Your Kubernetes cluster must have access to this repository in order to run your

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -474,7 +474,9 @@ You can run your MLflow Project on Kubernetes by following these steps:
    - ``kube-context``
      The `Kubernetes context
      <https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#context>`_
-     where MLflow will run the job. If not provided, MLflow will assume it is running in a Kubernetes cluster.
+     where MLflow will run the job. If not provided, MLflow will use the current context.
+     If no context is available, MLFlow will assume it is running in a Kubernetes cluster
+     and it will use the Kubernetes service account running the current pod ('in-cluster' configuration).
    - ``repository-uri``
      The URI of the docker repository where the Project execution Docker image will be uploaded
      (pushed). Your Kubernetes cluster must have access to this repository in order to run your

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -726,7 +726,7 @@ def _parse_kubernetes_config(backend_config):
             kube_job_template))
     if 'kube-context' not in backend_config.keys():
         _logger.debug("Could not find kube-context in backend_config."
-                      "Using current context or in-cluster config.")
+                      " Using current context or in-cluster config.")
     if 'repository-uri' not in backend_config.keys():
         raise ExecutionException("Could not find 'repository-uri' in backend_config.")
     return kube_config

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -199,7 +199,7 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
                 run_id=active_run.info.run_uuid,
                 experiment_id=active_run.info.experiment_id
             ),
-            kube_config['kube-context'],
+            kube_config.get('kube-context', None),
             kube_config['kube-job-template']
         )
         return submitted_run
@@ -725,7 +725,7 @@ def _parse_kubernetes_config(backend_config):
         raise ExecutionException("Could not find 'kube-job-template-path': {}".format(
             kube_job_template))
     if 'kube-context' not in backend_config.keys():
-        raise ExecutionException("Could not find kube-context in backend_config.")
+        _logger.info("Could not find kube-context in backend_config. Using in-cluster config.")
     if 'repository-uri' not in backend_config.keys():
         raise ExecutionException("Could not find 'repository-uri' in backend_config.")
     return kube_config

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -725,7 +725,8 @@ def _parse_kubernetes_config(backend_config):
         raise ExecutionException("Could not find 'kube-job-template-path': {}".format(
             kube_job_template))
     if 'kube-context' not in backend_config.keys():
-        _logger.info("Could not find kube-context in backend_config. Using in-cluster config.")
+        _logger.debug("Could not find kube-context in backend_config."
+                      "Using current context or in-cluster config.")
     if 'repository-uri' not in backend_config.keys():
         raise ExecutionException("Could not find 'repository-uri' in backend_config.")
     return kube_config

--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -48,7 +48,7 @@ def _get_run_command(entrypoint_command):
 
 
 def run_kubernetes_job(project_name, active_run, image_tag, image_digest, command, env_vars,
-                       kube_context, job_template=None):
+                       kube_context=None, job_template=None):
     job_template = _get_kubernetes_job_definition(project_name,
                                                   image_tag,
                                                   image_digest,
@@ -57,7 +57,10 @@ def run_kubernetes_job(project_name, active_run, image_tag, image_digest, comman
                                                   job_template)
     job_name = job_template['metadata']['name']
     job_namespace = job_template['metadata']['namespace']
-    kubernetes.config.load_kube_config(context=kube_context)
+    if not kube_context:
+        kubernetes.config.load_incluster_config()
+    else:
+        kubernetes.config.load_kube_config(context=kube_context)
     api_instance = kubernetes.client.BatchV1Api()
     api_instance.create_namespaced_job(namespace=job_namespace,
                                        body=job_template, pretty=True)

--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -3,8 +3,10 @@ import logging
 import docker
 import time
 from threading import RLock
-import kubernetes
 from datetime import datetime
+
+import kubernetes
+from kubernetes.config.config_exception import ConfigException
 
 from mlflow.exceptions import ExecutionException
 from mlflow.projects.submitted_run import SubmittedRun
@@ -47,6 +49,17 @@ def _get_run_command(entrypoint_command):
     return formatted_command
 
 
+def _load_kube_context(context=None):
+    try:
+        # trying to load either the context passed as arg or, if None,
+        # the one provided as env var `KUBECONFIG` or in `~/.kube/config`
+        kubernetes.config.load_kube_config(context=context)
+    except (IOError, ConfigException) as e:
+        _logger.debug('Error loading kube context "%s": %s', context, e)
+        _logger.info('No valid kube config found, using in-cluster configuration')
+        kubernetes.config.load_incluster_config()
+
+
 def run_kubernetes_job(project_name, active_run, image_tag, image_digest, command, env_vars,
                        kube_context=None, job_template=None):
     job_template = _get_kubernetes_job_definition(project_name,
@@ -57,10 +70,7 @@ def run_kubernetes_job(project_name, active_run, image_tag, image_digest, comman
                                                   job_template)
     job_name = job_template['metadata']['name']
     job_namespace = job_template['metadata']['namespace']
-    if not kube_context:
-        kubernetes.config.load_incluster_config()
-    else:
-        kubernetes.config.load_kube_config(context=kube_context)
+    _load_kube_context(context=kube_context)
     api_instance = kubernetes.client.BatchV1Api()
     api_instance.create_namespaced_job(namespace=job_namespace,
                                        body=job_template, pretty=True)

--- a/tests/projects/test_kubernetes.py
+++ b/tests/projects/test_kubernetes.py
@@ -95,6 +95,43 @@ def test_run_kubernetes_job():
             assert args[0][1]['context'] == kube_context
 
 
+def test_run_kubernetes_job_in_cluster():
+    active_run = mock.Mock()
+    project_name = "mlflow-docker-example"
+    image_tag = "image_tag"
+    image_digest = "5e74a5a"
+    command = ['python train.py --alpha 0.5 --l1-ratio 0.1']
+    env_vars = {'RUN_ID': '1'}
+    kube_context = None
+    job_template = yaml.safe_load("apiVersion: batch/v1\n"
+                                  "kind: Job\n"
+                                  "metadata:\n"
+                                  "  name: pi-with-ttl\n"
+                                  "  namespace: mlflow\n"
+                                  "spec:\n"
+                                  "  ttlSecondsAfterFinished: 100\n"
+                                  "  template:\n"
+                                  "    spec:\n"
+                                  "      containers:\n"
+                                  "      - name: pi\n"
+                                  "        image: perl\n"
+                                  "        command: ['perl',  '-Mbignum=bpi', '-wle']\n"
+                                  "      restartPolicy: Never\n")
+    with mock.patch("kubernetes.config.load_incluster_config") as kube_config_mock:
+        with mock.patch("kubernetes.client.BatchV1Api.create_namespaced_job") as kube_api_mock:
+            submitted_run_obj = kb.run_kubernetes_job(project_name=project_name,
+                                                      active_run=active_run, image_tag=image_tag,
+                                                      image_digest=image_digest, command=command,
+                                                      env_vars=env_vars, job_template=job_template,
+                                                      kube_context=kube_context)
+
+            assert submitted_run_obj._mlflow_run_id == active_run.info.run_id
+            assert submitted_run_obj._job_name.startswith(project_name)
+            assert submitted_run_obj._job_namespace == "mlflow"
+            assert kube_api_mock.call_count == 1
+            assert kube_config_mock.call_count == 1
+
+
 def test_push_image_to_registry():
     image_uri = "dockerhub_account/mlflow-kubernetes-example"
     with mock.patch("docker.from_env") as docker_mock:

--- a/tests/projects/test_kubernetes.py
+++ b/tests/projects/test_kubernetes.py
@@ -1,7 +1,10 @@
 import mock
 import yaml
 import pytest
+
 import kubernetes
+from kubernetes.config.config_exception import ConfigException
+
 from mlflow.projects import kubernetes as kb
 from mlflow.exceptions import ExecutionException
 from mlflow.entities import RunStatus
@@ -95,6 +98,49 @@ def test_run_kubernetes_job():
             assert args[0][1]['context'] == kube_context
 
 
+def test_run_kubernetes_job_current_kubecontext():
+    active_run = mock.Mock()
+    project_name = "mlflow-docker-example"
+    image_tag = "image_tag"
+    image_digest = "5e74a5a"
+    command = ['python train.py --alpha 0.5 --l1-ratio 0.1']
+    env_vars = {'RUN_ID': '1'}
+    kube_context = None
+
+    job_template = yaml.safe_load("apiVersion: batch/v1\n"
+                                  "kind: Job\n"
+                                  "metadata:\n"
+                                  "  name: pi-with-ttl\n"
+                                  "  namespace: mlflow\n"
+                                  "spec:\n"
+                                  "  ttlSecondsAfterFinished: 100\n"
+                                  "  template:\n"
+                                  "    spec:\n"
+                                  "      containers:\n"
+                                  "      - name: pi\n"
+                                  "        image: perl\n"
+                                  "        command: ['perl',  '-Mbignum=bpi', '-wle']\n"
+                                  "      restartPolicy: Never\n")
+    with mock.patch("kubernetes.config.load_kube_config") as kube_config_mock:
+        with mock.patch("kubernetes.config.load_incluster_config") as incluster_kube_config_mock:
+            with mock.patch("kubernetes.client.BatchV1Api.create_namespaced_job") as kube_api_mock:
+                submitted_run_obj = kb.run_kubernetes_job(project_name=project_name,
+                                                          active_run=active_run,
+                                                          image_tag=image_tag,
+                                                          image_digest=image_digest,
+                                                          command=command,
+                                                          env_vars=env_vars,
+                                                          job_template=job_template,
+                                                          kube_context=kube_context)
+
+                assert submitted_run_obj._mlflow_run_id == active_run.info.run_id
+                assert submitted_run_obj._job_name.startswith(project_name)
+                assert submitted_run_obj._job_namespace == "mlflow"
+                assert kube_api_mock.call_count == 1
+                assert kube_config_mock.call_count == 1
+                assert incluster_kube_config_mock.call_count == 0
+
+
 def test_run_kubernetes_job_in_cluster():
     active_run = mock.Mock()
     project_name = "mlflow-docker-example"
@@ -117,19 +163,25 @@ def test_run_kubernetes_job_in_cluster():
                                   "        image: perl\n"
                                   "        command: ['perl',  '-Mbignum=bpi', '-wle']\n"
                                   "      restartPolicy: Never\n")
-    with mock.patch("kubernetes.config.load_incluster_config") as kube_config_mock:
-        with mock.patch("kubernetes.client.BatchV1Api.create_namespaced_job") as kube_api_mock:
-            submitted_run_obj = kb.run_kubernetes_job(project_name=project_name,
-                                                      active_run=active_run, image_tag=image_tag,
-                                                      image_digest=image_digest, command=command,
-                                                      env_vars=env_vars, job_template=job_template,
-                                                      kube_context=kube_context)
+    with mock.patch("kubernetes.config.load_kube_config") as kube_config_mock:
+        kube_config_mock.side_effect = ConfigException()
+        with mock.patch("kubernetes.config.load_incluster_config") as incluster_kube_config_mock:
+            with mock.patch("kubernetes.client.BatchV1Api.create_namespaced_job") as kube_api_mock:
+                submitted_run_obj = kb.run_kubernetes_job(project_name=project_name,
+                                                          active_run=active_run,
+                                                          image_tag=image_tag,
+                                                          image_digest=image_digest,
+                                                          command=command,
+                                                          env_vars=env_vars,
+                                                          job_template=job_template,
+                                                          kube_context=kube_context)
 
-            assert submitted_run_obj._mlflow_run_id == active_run.info.run_id
-            assert submitted_run_obj._job_name.startswith(project_name)
-            assert submitted_run_obj._job_namespace == "mlflow"
-            assert kube_api_mock.call_count == 1
-            assert kube_config_mock.call_count == 1
+                assert submitted_run_obj._mlflow_run_id == active_run.info.run_id
+                assert submitted_run_obj._job_name.startswith(project_name)
+                assert submitted_run_obj._job_namespace == "mlflow"
+                assert kube_api_mock.call_count == 1
+                assert kube_config_mock.call_count == 1
+                assert incluster_kube_config_mock.call_count == 1
 
 
 def test_push_image_to_registry():


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make kube-context optional and default to the in-cluster configuration. This allows to run MLflow from within a Kubernetes cluster leveraging the role of the service account running it.

## How is this patch tested?

Unit tested and manually tested by running MLflow in a pod.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow projects can be scheduled from within a Kubernetes cluster.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [x] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
