### PR TITLE
Shell-escape entrypoint commands of Kubernetes jobs

### DIFF
--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -5,6 +5,7 @@ import time
 from threading import RLock
 import kubernetes
 from datetime import datetime
+from shlex import quote, split
 
 from mlflow.exceptions import ExecutionException
 from mlflow.projects.submitted_run import SubmittedRun
@@ -43,7 +44,7 @@ def _get_kubernetes_job_definition(project_name, image_tag, image_digest,
 def _get_run_command(entrypoint_command):
     formatted_command = []
     for cmd in entrypoint_command:
-        formatted_command = cmd.split(" ")
+        formatted_command.extend([quote(s) for s in split(cmd)])
     return formatted_command
 
 

--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -5,11 +5,16 @@ import time
 from threading import RLock
 import kubernetes
 from datetime import datetime
-from shlex import quote, split
 
 from mlflow.exceptions import ExecutionException
 from mlflow.projects.submitted_run import SubmittedRun
 from mlflow.entities import RunStatus
+
+from shlex import split
+try:
+    from shlex import quote
+except ImportError:
+    from pipes import quote
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -11,10 +11,7 @@ from mlflow.projects.submitted_run import SubmittedRun
 from mlflow.entities import RunStatus
 
 from shlex import split
-try:
-    from shlex import quote
-except ImportError:
-    from pipes import quote
+from six.moves import shlex_quote as quote
 
 _logger = logging.getLogger(__name__)
 

--- a/tests/projects/test_kubernetes.py
+++ b/tests/projects/test_kubernetes.py
@@ -11,9 +11,11 @@ def test_run_command_creation():  # pylint: disable=unused-argument
     """
     Tests command creation.
     """
-    command = ['python train.py --alpha 0.5 --l1-ratio 0.1']
+    command = ['python train.py --alpha 0.5 --l1-ratio 0.1', '--comment \'foo bar\'',
+               '--comment-bis "bar foo"']
     command = kb._get_run_command(command)
-    assert ['python', 'train.py', '--alpha', '0.5', '--l1-ratio', '0.1'] == command
+    assert ['python', 'train.py', '--alpha', '0.5', '--l1-ratio', '0.1', '--comment',
+            "'foo bar'", '--comment-bis', "'bar foo'"] == command
 
 
 def test_valid_kubernetes_job_spec():  # pylint: disable=unused-argument


### PR DESCRIPTION
## What changes are proposed in this pull request?

Entrypoint command arguments are not shell-escaped. As a result, they're passed to the Kubernetes job as individual arguments.

Example:
```
papermill '021 SP MLFlow keep prediction.ipynb' output.ipynb -k python3 --log-output
```

translates to
```yaml
 - command:
    - papermill
    - '021
    - SP
    - MLFlow
    - keep
    - prediction.ipynb'
    - output.ipynb
    - -k
    - python3
    - --log-output

```

## How is this patch tested?

Unit tested

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [x] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
