### PR TITLE
Optionally provide a custom image tag

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -423,6 +423,8 @@ You can run your MLflow Project on Kubernetes by following these steps:
      The URI of the docker repository where the Project execution Docker image will be uploaded
      (pushed). Your Kubernetes cluster must have access to this repository in order to run your
      MLflow Project.
+   - ``image-tag``
+     The tag used for the Project execution Docker image (Optional).
    - ``kube-job-template-path``
      The path to a YAML configuration file for your Kubernetes Job - a `Kubernetes Job Spec
      <https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#writing-a-job-spec>`_.

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -150,6 +150,7 @@ def _run(
             repository_uri=kube_config["repository-uri"],
             base_image=project.docker_env.get("image"),
             run_id=active_run.info.run_id,
+            tag=kube_config.get("image-tag"),
         )
         image_digest = kb.push_image_to_registry(image.tags[0])
         submitted_run = kb.run_kubernetes_job(

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -49,11 +49,11 @@ def validate_docker_env(project):
         )
 
 
-def build_docker_image(work_dir, repository_uri, base_image, run_id):
+def build_docker_image(work_dir, repository_uri, base_image, run_id, tag=None):
     """
     Build a docker image containing the project in `work_dir`, using the base image.
     """
-    image_uri = _get_docker_image_uri(repository_uri=repository_uri, work_dir=work_dir)
+    image_uri = _get_docker_image_uri(repository_uri=repository_uri, work_dir=work_dir, tag=tag)
     dockerfile = (
         "FROM {imagename}\n" "COPY {build_context_path}/ {workdir}\n" "WORKDIR {workdir}\n"
     ).format(
@@ -82,7 +82,7 @@ def build_docker_image(work_dir, repository_uri, base_image, run_id):
     return image
 
 
-def _get_docker_image_uri(repository_uri, work_dir):
+def _get_docker_image_uri(repository_uri, work_dir=None, tag=None):
     """
     Returns an appropriate Docker image URI for a project based on the git hash of the specified
     working directory.
@@ -92,9 +92,12 @@ def _get_docker_image_uri(repository_uri, work_dir):
     :param work_dir: Path to the working directory in which to search for a git commit hash
     """
     repository_uri = repository_uri if repository_uri else "docker-project"
-    # Optionally include first 7 digits of git SHA in tag name, if available.
-    git_commit = _get_git_commit(work_dir)
-    version_string = ":" + git_commit[:7] if git_commit else ""
+    if tag is not None:
+        version_string = ":" + tag
+    else:
+        # Optionally include first 7 digits of git SHA in tag name, if available.
+        git_commit = _get_git_commit(work_dir)
+        version_string = ":" + git_commit[:7] if git_commit else ""
     return repository_uri + version_string
 
 

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -126,6 +126,13 @@ def test_docker_image_uri_no_git(get_git_commit_mock):
     get_git_commit_mock.assert_called_with("my_workdir")
 
 
+@mock.patch("mlflow.projects.docker._get_git_commit")
+def test_docker_image_uri_custom_tag(get_git_commit_mock):
+    image_uri = _get_docker_image_uri("my_project", tag="foo")
+    assert image_uri == "my_project:foo"
+    get_git_commit_mock.assert_not_called()
+
+
 def test_docker_valid_project_backend_local():
     work_dir = "./examples/docker"
     project = _project_spec.load_project(work_dir)


### PR DESCRIPTION
## What changes are proposed in this pull request?

The proposed change aims at giving the user slightly more control on the Docker image produced.
In some circumstances it can be useful to be able to set a docker tag instead of relying on the default behaviour (commit sha1).

## How is this patch tested?

Manual and unit tests.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Optionally provide the image tag used for the Project execution docker image in the backend configuration file.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
