### PR TITLE
Azure ML authentication with service principal ID

### DIFF
--- a/mlflow/azureml/cli.py
+++ b/mlflow/azureml/cli.py
@@ -44,10 +44,14 @@ def commands():
                     " key-value pairs, to associate with the Azure Container Image and the Azure"
                     " Model that are created. These tags are added to a set of default tags"
                     " that include the model path, the model run id (if specified), and more."))
-@click.option("--service-principal", is_flag=True, help="Authenticate to the workspace through a service principal")
-@click.option("--tenant-id", default=None, help="Tenant Id of the Azure subscription.")
-@click.option("--user-id", "-u", default=None, help="User Id of the azure application.")
-@click.option("--password", "-p", default=None, help="Password of the azure application")
+@click.option("--service-principal", is_flag=True,
+              help="Authenticate to the workspace through a service principal")
+@click.option("--tenant-id", default=None,
+              help="Tenant Id of the Azure subscription.")
+@click.option("--user-id", "-u", default=None,
+              help="User Id of the azure application.")
+@click.option("--password", "-p", default=None,
+              help="Password of the azure application")
 @experimental
 def build_image(model_uri, workspace_name, subscription_id, image_name, model_name,
                 mlflow_home, description, tags, service_principal, tenant_id, user_id, password):
@@ -70,7 +74,8 @@ def build_image(model_uri, workspace_name, subscription_id, image_name, model_na
     auth = None
 
     if(service_principal):
-      auth = ServicePrincipalAuthentication(tenant_id=tenant_id, service_principal_id=user_id, service_principal_password=password)
+        auth = ServicePrincipalAuthentication(tenant_id=tenant_id, service_principal_id=user_id,
+                                              service_principal_password=password)
 
     workspace = Workspace.get(name=workspace_name, subscription_id=subscription_id, auth=auth)
     if tags is not None:

--- a/mlflow/azureml/cli.py
+++ b/mlflow/azureml/cli.py
@@ -44,9 +44,13 @@ def commands():
                     " key-value pairs, to associate with the Azure Container Image and the Azure"
                     " Model that are created. These tags are added to a set of default tags"
                     " that include the model path, the model run id (if specified), and more."))
+@click.option("--service-principal", is_flag=True, help="Authenticate to the workspace through a service principal")
+@click.option("--tenant-id", default=None, help="Tenant Id of the Azure subscription.")
+@click.option("--user-id", "-u", default=None, help="User Id of the azure application.")
+@click.option("--password", "-p", default=None, help="Password of the azure application")
 @experimental
 def build_image(model_uri, workspace_name, subscription_id, image_name, model_name,
-                mlflow_home, description, tags):
+                mlflow_home, description, tags, service_principal, tenant_id, user_id, password):
     """
     Register an MLflow model with Azure ML and build an Azure ML ContainerImage for deployment.
     The resulting image can be deployed as a web service to Azure Container Instances (ACI) or
@@ -61,8 +65,14 @@ def build_image(model_uri, workspace_name, subscription_id, image_name, model_na
     # upon command invocation.
     # pylint: disable=import-error
     from azureml.core import Workspace
+    from azureml.core.authentication import ServicePrincipalAuthentication
 
-    workspace = Workspace.get(name=workspace_name, subscription_id=subscription_id)
+    auth = None
+
+    if(service_principal):
+      auth = ServicePrincipalAuthentication(tenant_id=tenant_id, service_principal_id=user_id, service_principal_password=password)
+
+    workspace = Workspace.get(name=workspace_name, subscription_id=subscription_id, auth=auth)
     if tags is not None:
         tags = json.loads(tags)
     mlflow.azureml.build_image(


### PR DESCRIPTION
Added the authentication through service principal in an azure machine learning workspace in order to be able to authenticate 
for CI/CD

## What changes are proposed in this pull request?

I have added a way to authenticate directly to the Azure Machine Learning Workspace without the interactive login. 
It uses a service principal authentication in order to directly log into azure subscription and the workspace.
It is an option that can be enable. So, it only extends the actual method of the cli `mlflow azureml build-image`.

## How is this patch tested?

I have create a workspace in one of the multiples subscritptions that I had.
I also have created an application to log into the workspace and finally run the command.
I checked that the image was succesfully created.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added support in the CLI to log with an active directory application in order to create the image inside the azure machine learning workspace.

### What component(s) does this PR affect?

- [ ] UI
- [x] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
