### PR TITLE
Fix spark model load from model repository.

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -35,6 +35,7 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
+from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.uri import is_local_uri
 from mlflow.utils.model_utils import _get_flavor_configuration_from_uri
@@ -422,6 +423,10 @@ def load_model(model_uri, dfs_tmpdir=None):
     if RunsArtifactRepository.is_runs_uri(model_uri):
         runs_uri = model_uri
         model_uri = RunsArtifactRepository.get_underlying_uri(model_uri)
+        _logger.info("'%s' resolved as '%s'", runs_uri, model_uri)
+    elif ModelsArtifactRepository.is_models_uri(model_uri):
+        runs_uri = model_uri
+        model_uri = ModelsArtifactRepository.get_underlying_uri(model_uri)
         _logger.info("'%s' resolved as '%s'", runs_uri, model_uri)
     flavor_conf = _get_flavor_configuration_from_uri(model_uri, FLAVOR_NAME)
     model_uri = posixpath.join(model_uri, flavor_conf["model_data"])


### PR DESCRIPTION
## What changes are proposed in this pull request?
When loading spark models from a uri, mlflow attempts to load the MLmodel file first by adding /MLflow to the model uri. This does not work if model uri is model repository one (models:/...) because model repository does not behave as  a standard artifact repository and rejects the resulting uri as invalid.

This PR fixes this issue by resolving the model repository uri to the underlying URI first.

## How is this patch tested?
Integration tests.


## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
Fix loading of spark models from model repository uris (models:/.)
 
### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [x] Models
- [x] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
