### PR TITLE
Add note about active run instantiation side effect in fluent APIs

### DIFF
--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -64,6 +64,8 @@ class Model(object):
         """
         Log model using supplied flavor module.
 
+        Note: If no run is active, it will instantiate a run to obtain a run_id.
+
         :param artifact_path: Run relative path identifying the model.
         :param flavor: Flavor module to save the model with. The module must have
                        the ``save_model`` function that will persist the model as a valid

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -62,9 +62,7 @@ class Model(object):
     @classmethod
     def log(cls, artifact_path, flavor, registered_model_name=None, **kwargs):
         """
-        Log model using supplied flavor module.
-
-        Note: If no run is active, this method will create a new active run.
+        Log model using supplied flavor module. If no run is active, this method will create a new active run.
 
         :param artifact_path: Run relative path identifying the model.
         :param flavor: Flavor module to save the model with. The module must have

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -64,7 +64,7 @@ class Model(object):
         """
         Log model using supplied flavor module.
 
-        Note: If no run is active, it will instantiate a run to obtain a run_id.
+        Note: If no run is active, this method will create a new active run.
 
         :param artifact_path: Run relative path identifying the model.
         :param flavor: Flavor module to save the model with. The module must have

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -62,7 +62,8 @@ class Model(object):
     @classmethod
     def log(cls, artifact_path, flavor, registered_model_name=None, **kwargs):
         """
-        Log model using supplied flavor module. If no run is active, this method will create a new active run.
+        Log model using supplied flavor module. If no run is active, this method will create a new
+        active run.
 
         :param artifact_path: Run relative path identifying the model.
         :param flavor: Flavor module to save the model with. The module must have

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -78,6 +78,8 @@ def log_model(spark_model, artifact_path, conda_env=None, dfs_tmpdir=None,
     Log a Spark MLlib model as an MLflow artifact for the current run. This uses the
     MLlib persistence format and produces an MLflow Model with the Spark flavor.
 
+    Note: If no run is active, it will instantiate a run to obtain a run_id.
+
     :param spark_model: Spark model to be saved - MLFlow can only save descendants of
                         pyspark.ml.Model which implement MLReadable and MLWritable.
     :param artifact_path: Run relative artifact path.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -204,7 +204,8 @@ def get_run(run_id):
 
 def log_param(key, value):
     """
-    Log a parameter under the current run. If no run is active, this method will create a new active run.
+    Log a parameter under the current run. If no run is active, this method will create
+    a new active run.
 
     :param key: Parameter name (string)
     :param value: Parameter value (string, but will be string-ified if not)
@@ -215,7 +216,8 @@ def log_param(key, value):
 
 def set_tag(key, value):
     """
-    Set a tag under the current run. If no run is active, this method will create a new active run.
+    Set a tag under the current run. If no run is active, this method will create a
+    new active run.
 
     :param key: Tag name (string)
     :param value: Tag value (string, but will be string-ified if not)
@@ -226,7 +228,8 @@ def set_tag(key, value):
 
 def delete_tag(key):
     """
-    Delete a tag from a run. This is irreversible. If no run is active, this method will create a new active run.
+    Delete a tag from a run. This is irreversible. If no run is active, this method
+    will create a new active run.
 
     :param key: Name of the tag
     """
@@ -236,7 +239,8 @@ def delete_tag(key):
 
 def log_metric(key, value, step=None):
     """
-    Log a metric under the current run. If no run is active, this method will create a new active run.
+    Log a metric under the current run. If no run is active, this method will create
+    a new active run.
 
     :param key: Metric name (string).
     :param value: Metric value (float). Note that some special values such as +/- Infinity may be
@@ -250,7 +254,8 @@ def log_metric(key, value, step=None):
 
 def log_metrics(metrics, step=None):
     """
-    Log multiple metrics for the current run. If no run is active, this method will create a new active run.
+    Log multiple metrics for the current run. If no run is active, this method will create a new
+    active run.
 
     :param metrics: Dictionary of metric_name: String -> value: Float. Note that some special values
                     such as +/- Infinity may be replaced by other values depending on the store.
@@ -268,7 +273,8 @@ def log_metrics(metrics, step=None):
 
 def log_params(params):
     """
-    Log a batch of params for the current run. If no run is active, this method will create a new active run.
+    Log a batch of params for the current run. If no run is active, this method will create a
+    new active run.
 
     :param params: Dictionary of param_name: String -> value: (String, but will be string-ified if
                    not)
@@ -281,7 +287,8 @@ def log_params(params):
 
 def set_tags(tags):
     """
-    Log a batch of tags for the current run. If no run is active, this method will create a new active run.
+    Log a batch of tags for the current run. If no run is active, this method will create a
+    new active run.
 
     :param tags: Dictionary of tag_name: String -> value: (String, but will be string-ified if
                  not)
@@ -294,8 +301,8 @@ def set_tags(tags):
 
 def log_artifact(local_path, artifact_path=None):
     """
-    Log a local file or directory as an artifact of the currently active run. If no run is active,
-    this method will create a new active run.
+    Log a local file or directory as an artifact of the currently active run. If no run is
+    active, this method will create a new active run.
 
     :param local_path: Path to the file to write.
     :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
@@ -306,8 +313,8 @@ def log_artifact(local_path, artifact_path=None):
 
 def log_artifacts(local_dir, artifact_path=None):
     """
-    Log all the contents of a local directory as artifacts of the run. If no run is active, this
-    method will create a new active run.
+    Log all the contents of a local directory as artifacts of the run. If no run is active,
+    this method will create a new active run.
 
     :param local_dir: Path to the directory of files to write.
     :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -388,7 +388,7 @@ def get_artifact_uri(artifact_path=None):
     If `path` is not specified, the artifact root URI of the currently active
     run will be returned; calls to ``log_artifact`` and ``log_artifacts`` write
     artifact(s) to subdirectories of the artifact root URI.
-    
+
     **Note:** If no run is active, it will instantiate a new run.
 
     :param artifact_path: The run-relative artifact path for which to obtain an absolute URI.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -204,9 +204,7 @@ def get_run(run_id):
 
 def log_param(key, value):
     """
-    Log a parameter under the current run, creating a run if necessary.
-
-    **Note:** If no run is active, it will instantiate a new run.
+    Log a parameter under the current run. If no run is active, this method will create a new active run.
 
     :param key: Parameter name (string)
     :param value: Parameter value (string, but will be string-ified if not)
@@ -217,9 +215,7 @@ def log_param(key, value):
 
 def set_tag(key, value):
     """
-    Set a tag under the current run, creating a run if necessary.
-
-    **Note:** If no run is active, it will instantiate a new run.
+    Set a tag under the current run. If no run is active, this method will create a new active run.
 
     :param key: Tag name (string)
     :param value: Tag value (string, but will be string-ified if not)
@@ -230,9 +226,7 @@ def set_tag(key, value):
 
 def delete_tag(key):
     """
-    Delete a tag from a run. This is irreversible.
-
-    **Note:** If no run is active, it will instantiate a new run.
+    Delete a tag from a run. This is irreversible. If no run is active, this method will create a new active run.
 
     :param key: Name of the tag
     """
@@ -242,9 +236,7 @@ def delete_tag(key):
 
 def log_metric(key, value, step=None):
     """
-    Log a metric under the current run, creating a run if necessary.
-
-    **Note:** If no run is active, it will instantiate a new run.
+    Log a metric under the current run. If no run is active, this method will create a new active run.
 
     :param key: Metric name (string).
     :param value: Metric value (float). Note that some special values such as +/- Infinity may be
@@ -258,9 +250,7 @@ def log_metric(key, value, step=None):
 
 def log_metrics(metrics, step=None):
     """
-    Log multiple metrics for the current run, starting a run if no runs are active.
-
-    **Note:** If no run is active, it will instantiate a new run.
+    Log multiple metrics for the current run. If no run is active, this method will create a new active run.
 
     :param metrics: Dictionary of metric_name: String -> value: Float. Note that some special values
                     such as +/- Infinity may be replaced by other values depending on the store.
@@ -278,9 +268,7 @@ def log_metrics(metrics, step=None):
 
 def log_params(params):
     """
-    Log a batch of params for the current run, starting a run if no runs are active.
-
-    **Note:** If no run is active, it will instantiate a new run.
+    Log a batch of params for the current run. If no run is active, this method will create a new active run.
 
     :param params: Dictionary of param_name: String -> value: (String, but will be string-ified if
                    not)
@@ -293,9 +281,7 @@ def log_params(params):
 
 def set_tags(tags):
     """
-    Log a batch of tags for the current run, starting a run if no runs are active.
-
-    **Note:** If no run is active, it will instantiate a new run.
+    Log a batch of tags for the current run. If no run is active, this method will create a new active run.
 
     :param tags: Dictionary of tag_name: String -> value: (String, but will be string-ified if
                  not)
@@ -308,9 +294,8 @@ def set_tags(tags):
 
 def log_artifact(local_path, artifact_path=None):
     """
-    Log a local file or directory as an artifact of the currently active run.
-
-    **Note:** If no run is active, it will instantiate a new run.
+    Log a local file or directory as an artifact of the currently active run. If no run is active,
+    this method will create a new active run.
 
     :param local_path: Path to the file to write.
     :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
@@ -321,9 +306,8 @@ def log_artifact(local_path, artifact_path=None):
 
 def log_artifacts(local_dir, artifact_path=None):
     """
-    Log all the contents of a local directory as artifacts of the run.
-
-    **Note:** If no run is active, it will instantiate a new run.
+    Log all the contents of a local directory as artifacts of the run. If no run is active, this
+    method will create a new active run.
 
     :param local_dir: Path to the directory of files to write.
     :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
@@ -389,7 +373,7 @@ def get_artifact_uri(artifact_path=None):
     run will be returned; calls to ``log_artifact`` and ``log_artifacts`` write
     artifact(s) to subdirectories of the artifact root URI.
 
-    **Note:** If no run is active, it will instantiate a new run.
+    If no run is active, this method will create a new active run.
 
     :param artifact_path: The run-relative artifact path for which to obtain an absolute URI.
                           For example, "path/to/artifact". If unspecified, the artifact root URI

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -206,6 +206,8 @@ def log_param(key, value):
     """
     Log a parameter under the current run, creating a run if necessary.
 
+    **Note:** If no run is active, it will instantiate a new run.
+
     :param key: Parameter name (string)
     :param value: Parameter value (string, but will be string-ified if not)
     """
@@ -216,6 +218,8 @@ def log_param(key, value):
 def set_tag(key, value):
     """
     Set a tag under the current run, creating a run if necessary.
+
+    **Note:** If no run is active, it will instantiate a new run.
 
     :param key: Tag name (string)
     :param value: Tag value (string, but will be string-ified if not)
@@ -228,6 +232,8 @@ def delete_tag(key):
     """
     Delete a tag from a run. This is irreversible.
 
+    **Note:** If no run is active, it will instantiate a new run.
+
     :param key: Name of the tag
     """
     run_id = _get_or_start_run().info.run_id
@@ -237,6 +243,8 @@ def delete_tag(key):
 def log_metric(key, value, step=None):
     """
     Log a metric under the current run, creating a run if necessary.
+
+    **Note:** If no run is active, it will instantiate a new run.
 
     :param key: Metric name (string).
     :param value: Metric value (float). Note that some special values such as +/- Infinity may be
@@ -251,6 +259,8 @@ def log_metric(key, value, step=None):
 def log_metrics(metrics, step=None):
     """
     Log multiple metrics for the current run, starting a run if no runs are active.
+
+    **Note:** If no run is active, it will instantiate a new run.
 
     :param metrics: Dictionary of metric_name: String -> value: Float. Note that some special values
                     such as +/- Infinity may be replaced by other values depending on the store.
@@ -270,6 +280,8 @@ def log_params(params):
     """
     Log a batch of params for the current run, starting a run if no runs are active.
 
+    **Note:** If no run is active, it will instantiate a new run.
+
     :param params: Dictionary of param_name: String -> value: (String, but will be string-ified if
                    not)
     :returns: None
@@ -282,6 +294,8 @@ def log_params(params):
 def set_tags(tags):
     """
     Log a batch of tags for the current run, starting a run if no runs are active.
+
+    **Note:** If no run is active, it will instantiate a new run.
 
     :param tags: Dictionary of tag_name: String -> value: (String, but will be string-ified if
                  not)
@@ -296,6 +310,8 @@ def log_artifact(local_path, artifact_path=None):
     """
     Log a local file or directory as an artifact of the currently active run.
 
+    **Note:** If no run is active, it will instantiate a new run.
+
     :param local_path: Path to the file to write.
     :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
     """
@@ -306,6 +322,8 @@ def log_artifact(local_path, artifact_path=None):
 def log_artifacts(local_dir, artifact_path=None):
     """
     Log all the contents of a local directory as artifacts of the run.
+
+    **Note:** If no run is active, it will instantiate a new run.
 
     :param local_dir: Path to the directory of files to write.
     :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
@@ -370,6 +388,8 @@ def get_artifact_uri(artifact_path=None):
     If `path` is not specified, the artifact root URI of the currently active
     run will be returned; calls to ``log_artifact`` and ``log_artifacts`` write
     artifact(s) to subdirectories of the artifact root URI.
+    
+    **Note:** If no run is active, it will instantiate a new run.
 
     :param artifact_path: The run-relative artifact path for which to obtain an absolute URI.
                           For example, "path/to/artifact". If unspecified, the artifact root URI


### PR DESCRIPTION
# What changes are proposed in this pull request?

In some APIs such as `get_artifact_uri`, the function starts an active
run if no there is no active run. This should be considered a
side-effect because these it is not apparent that these functions would
instantiate the active run.

As a short-term solution, I have updated the documentation in
functions that have this behavior.

## How is this patch tested?

Standard automated tests

## Release Notes

- Only updated documentation. There should be no code change as part of this PR.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [X ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
