### PR TITLE
Fix mlflow_list_artifacts() for the general case (R package)

### DIFF
--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -355,6 +355,12 @@ mlflow_list_artifacts <- function(path = NULL, run_id = NULL, client = NULL) {
   message(glue::glue("Root URI: {uri}", uri = response$root_uri))
 
   files_list <- if (!is.null(response$files)) response$files else list()
+  files_list <- purrr::map(files_list, function(file_info) {
+    if (is.null(file_info$file_size)) {
+      file_info$file_size <- NA
+    }
+    file_info
+  })
   files_list %>%
     purrr::transpose() %>%
     purrr::map(unlist) %>%

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -289,17 +289,24 @@ test_that("mlflow_log_artifact and mlflow_list_artifacts work", {
     expect_equal(nrow(empty_artifact_list), 0)
     source_dir <- file.path(tempdir(), "temp-directory")
     dir.create(source_dir)
-    file_path <- file.path(source_dir, "my-file")
+    ## file 1
+    file_path1 <- file.path(source_dir, "a-my-file")
     contents <- "File contents\n"
-    cat(contents, file = file_path, sep = "")
+    cat(contents, file = file_path1, sep = "")
+    ## file 2
+    file_path2 <- file.path(source_dir, "a-my-file-2")
+    contents <- "File contents\n"
+    cat(contents, file = file_path2, sep = "")
+
     # Log file, file with path, directory with path argument
-    mlflow_log_artifact(file_path)
-    mlflow_log_artifact(file_path, "directory_for_file")
+    mlflow_log_artifact(file_path1)
+    mlflow_log_artifact(file_path2)
+    mlflow_log_artifact(file_path1, "directory_for_file")
     mlflow_log_artifact(source_dir, "artifact_subdirectory")
     # Verify logged files
     artifact_list0 <- mlflow_list_artifacts()
-    expect_equal(nrow(artifact_list0), 3)
-    logged_file0 <- artifact_list0[artifact_list0$path == "my-file", ]
+    expect_equal(nrow(artifact_list0), 4)
+    logged_file0 <- artifact_list0[artifact_list0$path == "a-my-file", ]
     expect_equal(nrow(logged_file0), 1)
     expect_equal(logged_file0$is_dir, FALSE)
     logged_file1 <- artifact_list0[artifact_list0$path == "directory_for_file", ]
@@ -310,9 +317,9 @@ test_that("mlflow_log_artifact and mlflow_list_artifacts work", {
     expect_equal(logged_dir0$is_dir, TRUE)
     # Verify contents of logged directory
     artifact_list1 <- mlflow_list_artifacts("artifact_subdirectory")
-    expect_equal(nrow(artifact_list1), 1)
+    expect_equal(nrow(artifact_list1), 2)
     logged_file2 <- artifact_list1[artifact_list1$path ==
-      paste("artifact_subdirectory", "my-file", sep = "/"), ]
+      paste("artifact_subdirectory", "a-my-file", sep = "/"), ]
     expect_equal(nrow(logged_file2), 1)
     expect_equal(logged_file2$is_dir, FALSE)
     expect_equal(strtoi(logged_file2$file_size), nchar(contents))
@@ -320,7 +327,7 @@ test_that("mlflow_log_artifact and mlflow_list_artifacts work", {
     artifact_list2 <- mlflow_list_artifacts("directory_for_file")
     expect_equal(nrow(artifact_list2), 1)
     logged_file3 <- artifact_list2[artifact_list2$path ==
-    paste("directory_for_file", "my-file", sep = "/"), ]
+    paste("directory_for_file", "a-my-file", sep = "/"), ]
     expect_equal(nrow(logged_file3), 1)
     expect_equal(logged_file3$is_dir, FALSE)
     expect_equal(strtoi(logged_file3$file_size), nchar(contents))


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make `mlflow_list_artifacts()` work for the general case. More concretely, for cases where: 
- there is at least one directory in the artifacts directory that is not the first when sorting all names alphabetically and
- at least two other files in the artifact directory.


**Details**

As per the [documentation for the REST API to list artifacts](https://mlflow.org/docs/latest/rest-api.html#list-artifacts) and the specific [file info](https://mlflow.org/docs/latest/rest-api.html#mlflowfileinfo), the file size is unset for directories in the REST response, which is not accounted for in `mlflow_list_artifacts()` in the R API, specifically not in https://github.com/mlflow/mlflow/blob/master/mlflow/R/mlflow/R/tracking-experiments.R#L43-L46. For the reader's convenience, I c/p the code linked above:

```r
files_list %>%
    purrr::transpose() %>%
    purrr::map(unlist) %>%
    tibble::as_tibble()
```

As the file size is not set for directories, `as_tibble()` won't work in general because the column `file_size` will be shorter than the other columns if there was at least one directory and the above will fail like this:

```
Error: Tibble columns must have consistent lengths, only values of length one are recycled:
* Length 2: Column `file_size`
* Length 4: Columns `path`, `is_dir`
```

The problem has not occurred so far in the tests (tests/testthat/test/tracking-runs) because the first file (alphabetically) was a directory without file information and `purrr::transpose()` only uses the name of the first element that should be transposed, so the file_size was subsequentially omitted. Also, the problem does not occur if there is only one directory because as the above error message says: "values of length one are recycled".

## How is this patch tested?

Adapted unit tests and locally in project.


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [x] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
