### PR TITLE
Add backend parameter to mlflow run command in RunView

### DIFF
--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -54,6 +54,7 @@ class RunView extends Component {
     const sourceName = Utils.getSourceName(tags);
     const sourceVersion = Utils.getSourceVersion(tags);
     const entryPointName = Utils.getEntryPointName(tags);
+    const backend = Utils.getBackend(tags);
     if (Utils.getSourceType(tags) === "PROJECT") {
       runCommand = 'mlflow run ' + shellEscape(sourceName);
       if (sourceVersion && sourceVersion !== "latest") {
@@ -61,6 +62,9 @@ class RunView extends Component {
       }
       if (entryPointName && entryPointName !== "main") {
         runCommand += ' -e ' + shellEscape(entryPointName);
+      }
+      if (backend) {
+        runCommand += ' -b ' + shellEscape(backend);
       }
       Object.values(params).sort().forEach(p => {
         runCommand += ' -P ' + shellEscape(p.key + '=' + p.value);

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -35,6 +35,7 @@ class Utils {
   static sourceTypeTag = 'mlflow.source.type';
   static gitCommitTag = 'mlflow.source.git.commit';
   static entryPointTag = 'mlflow.project.entryPoint';
+  static backendTag = 'mlflow.project.backend';
   static userTag = 'mlflow.user';
 
   static formatMetric(value) {
@@ -327,6 +328,14 @@ class Utils {
     const entryPointTag = runTags[Utils.entryPointTag];
     if (entryPointTag) {
       return entryPointTag.value;
+    }
+    return "";
+  }
+
+  static getBackend(runTags) {
+    const backendTag = runTags[Utils.backendTag];
+    if (backendTag) {
+      return backendTag.value;
     }
     return "";
   }


### PR DESCRIPTION
## What changes are proposed in this pull request?

When using MLflow project, the command used to launch a run is displayed in the run view in the UI. But if we used the command with a backend, the backend parameter does not appear. The proposed change is to add this parameter to the command in the run view so the command can be reused.

I have a question about this, we don't log the backend config in the tag so we can't add it to this view, should we add a tag mlflow.project.backend-config to be able to retrieve it and display it ?

## How is this patch tested?

Locally, checking in the UI that the -b parameter appear.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add backend parameter to mlflow run command in RunView.

### What component(s) does this PR affect?

- [X] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
