### PR TITLE
Add TypeError check to call_endpoint validation

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -108,7 +108,7 @@ class DatabricksJobRunner(object):
             json={"path": "/%s" % dbfs_path})
         try:
             json_response_obj = json.loads(response.text)
-        except ValueError:
+        except (ValueError, TypeError):
             raise MlflowException(
                 "API request to check existence of file at DBFS path %s failed with status code "
                 "%s. Response body: %s" % (dbfs_path, response.status_code, response.text))

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -108,7 +108,7 @@ class DatabricksJobRunner(object):
             json={"path": "/%s" % dbfs_path})
         try:
             json_response_obj = json.loads(response.text)
-        except (ValueError, TypeError):
+        except Exception:  # pylint: disable=broad-except
             raise MlflowException(
                 "API request to check existence of file at DBFS path %s failed with status code "
                 "%s. Response body: %s" % (dbfs_path, response.status_code, response.text))

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -84,7 +84,7 @@ def _can_parse_as_json(string):
     try:
         json.loads(string)
         return True
-    except (ValueError, TypeError):
+    except Exception:  # pylint: disable=broad-except
         return False
 
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -84,7 +84,7 @@ def _can_parse_as_json(string):
     try:
         json.loads(string)
         return True
-    except ValueError:
+    except (ValueError, TypeError):
         return False
 
 
@@ -99,11 +99,12 @@ def http_request_safe(host_creds, endpoint, **kwargs):
 def verify_rest_response(response, endpoint):
     """Verify the return code and raise exception if the request was not successful."""
     if response.status_code != 200:
-        base_msg = "API request to endpoint %s failed with error code " \
-                   "%s != 200" % (endpoint, response.status_code)
         if _can_parse_as_json(response.text):
             raise RestException(json.loads(response.text))
-        raise MlflowException("%s. Response body: '%s'" % (base_msg, response.text))
+        else:
+            base_msg = "API request to endpoint %s failed with error code " \
+                       "%s != 200" % (endpoint, response.status_code)
+            raise MlflowException("%s. Response body: '%s'" % (base_msg, response.text))
     return response
 
 

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import os
 import random
-from unittest import mock
+import mock
 
 import requests
 import string

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 
 import os
 import random
+from unittest import mock
+
 import requests
 import string
 import time
@@ -255,3 +257,16 @@ class safe_edit_yaml(object):
 
     def __exit__(self, *args):
         write_yaml(self._root, self._file_name, self._original, overwrite=True)
+
+
+def create_mock_response(status_code, text):
+    """
+    Create a mock resposne object with the status_code and text
+
+    :param status_code int HTTP status code
+    :param text message from the response
+    """
+    response = mock.MagicMock()
+    response.status_code = status_code
+    response.text = text
+    return response

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -263,8 +263,9 @@ def create_mock_response(status_code, text):
     """
     Create a mock resposne object with the status_code and text
 
-    :param status_code int HTTP status code
-    :param text message from the response
+    :param: status_code int HTTP status code
+    :param: text message from the response
+    :reutrn: mock HTTP Response
     """
     response = mock.MagicMock()
     response.status_code = status_code

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -154,24 +154,24 @@ def test_upload_existing_project_to_dbfs(dbfs_path_exists_mock):  # pylint: disa
         assert upload_to_dbfs_mock.call_count == 0
 
 
-@mock.patch("mlflow.utils.rest_utils.http_request")
-@pytest.mark.parametrize("response", [
-    helper_functions.create_mock_response(400, "Error message but not a JSON string"),
-    helper_functions.create_mock_response(400, ""),
-    helper_functions.create_mock_response(400, None)
-])
-def test_dbfs_path_exists_error_response_handling(http_request_mock, response):
-    # given a well formed DatabricksJobRunner
-    # note: databricks_profile is None needed because clients using profile are mocked
-    job_runner = DatabricksJobRunner(databricks_profile=None)
-
-    # when the http request to validate the dbfs path returns a 400 response with an
-    # error message that is either well-formed JSON or not
-    http_request_mock.return_value = response
-
-    # then _dbfs_path_exists should return a MlflowException
-    with pytest.raises(MlflowException):
-        job_runner._dbfs_path_exists('some/path')
+# @mock.patch("mlflow.utils.rest_utils.http_request")
+# @pytest.mark.parametrize("response", [
+#     helper_functions.create_mock_response(400, "Error message but not a JSON string"),
+#     helper_functions.create_mock_response(400, ""),
+#     helper_functions.create_mock_response(400, None)
+# ])
+# def test_dbfs_path_exists_error_response_handling(http_request_mock, response):
+#     # given a well formed DatabricksJobRunner
+#     # note: databricks_profile is None needed because clients using profile are mocked
+#     job_runner = DatabricksJobRunner(databricks_profile=None)
+#
+#     # when the http request to validate the dbfs path returns a 400 response with an
+#     # error message that is either well-formed JSON or not
+#     http_request_mock.return_value = response
+#
+#     # then _dbfs_path_exists should return a MlflowException
+#     with pytest.raises(MlflowException):
+#         job_runner._dbfs_path_exists('some/path')
 
 
 def test_run_databricks_validations(

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -21,7 +21,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_RUN_URL, \
     MLFLOW_DATABRICKS_SHELL_JOB_RUN_ID, \
     MLFLOW_DATABRICKS_WEBAPP_URL
 from mlflow.utils.rest_utils import _DEFAULT_HEADERS
-# from tests import helper_functions
+from tests import helper_functions
 
 from tests.projects.utils import validate_exit_status, TEST_PROJECT_DIR
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
@@ -154,24 +154,24 @@ def test_upload_existing_project_to_dbfs(dbfs_path_exists_mock):  # pylint: disa
         assert upload_to_dbfs_mock.call_count == 0
 
 
-# @mock.patch("mlflow.utils.rest_utils.http_request")
-# @pytest.mark.parametrize("response", [
-#     helper_functions.create_mock_response(400, "Error message but not a JSON string"),
-#     helper_functions.create_mock_response(400, ""),
-#     helper_functions.create_mock_response(400, None)
-# ])
-# def test_dbfs_path_exists_error_response_handling(http_request_mock, response):
-#     # given a well formed DatabricksJobRunner
-#     # note: databricks_profile is None needed because clients using profile are mocked
-#     job_runner = DatabricksJobRunner(databricks_profile=None)
-#
-#     # when the http request to validate the dbfs path returns a 400 response with an
-#     # error message that is either well-formed JSON or not
-#     http_request_mock.return_value = response
-#
-#     # then _dbfs_path_exists should return a MlflowException
-#     with pytest.raises(MlflowException):
-#         job_runner._dbfs_path_exists('some/path')
+@pytest.mark.parametrize("response_mock", [
+    helper_functions.create_mock_response(400, "Error message but not a JSON string"),
+    helper_functions.create_mock_response(400, ""),
+    helper_functions.create_mock_response(400, None)
+])
+def test_dbfs_path_exists_error_response_handling(response_mock):
+    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
+        # given a well formed DatabricksJobRunner
+        # note: databricks_profile is None needed because clients using profile are mocked
+        job_runner = DatabricksJobRunner(databricks_profile=None)
+
+        # when the http request to validate the dbfs path returns a 400 response with an
+        # error message that is either well-formed JSON or not
+        http_request_mock.return_value = response_mock
+
+        # then _dbfs_path_exists should return a MlflowException
+        with pytest.raises(MlflowException):
+            job_runner._dbfs_path_exists('some/path')
 
 
 def test_run_databricks_validations(

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -21,7 +21,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_RUN_URL, \
     MLFLOW_DATABRICKS_SHELL_JOB_RUN_ID, \
     MLFLOW_DATABRICKS_WEBAPP_URL
 from mlflow.utils.rest_utils import _DEFAULT_HEADERS
-
+from tests import helper_functions
 
 from tests.projects.utils import validate_exit_status, TEST_PROJECT_DIR
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
@@ -30,7 +30,7 @@ from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-imp
 @pytest.fixture()
 def runs_cancel_mock():
     """Mocks the Jobs Runs Cancel API request"""
-    with mock.patch("mlflow.projects.databricks.DatabricksJobRunner.jobs_runs_cancel")\
+    with mock.patch("mlflow.projects.databricks.DatabricksJobRunner.jobs_runs_cancel") \
             as runs_cancel_mock:
         runs_cancel_mock.return_value = None
         yield runs_cancel_mock
@@ -39,7 +39,7 @@ def runs_cancel_mock():
 @pytest.fixture()
 def runs_submit_mock():
     """Mocks the Jobs Runs Submit API request"""
-    with mock.patch("mlflow.projects.databricks.DatabricksJobRunner._jobs_runs_submit")\
+    with mock.patch("mlflow.projects.databricks.DatabricksJobRunner._jobs_runs_submit") \
             as runs_submit_mock:
         runs_submit_mock.return_value = {"run_id": "-1"}
         yield runs_submit_mock
@@ -48,7 +48,7 @@ def runs_submit_mock():
 @pytest.fixture()
 def runs_get_mock():
     """Mocks the Jobs Runs Get API request"""
-    with mock.patch("mlflow.projects.databricks.DatabricksJobRunner.jobs_runs_get")\
+    with mock.patch("mlflow.projects.databricks.DatabricksJobRunner.jobs_runs_get") \
             as runs_get_mock:
         yield runs_get_mock
 
@@ -80,7 +80,7 @@ def upload_to_dbfs_mock(dbfs_root_mock):
 
 @pytest.fixture()
 def dbfs_path_exists_mock(dbfs_root_mock):  # pylint: disable=unused-argument
-    with mock.patch("mlflow.projects.databricks.DatabricksJobRunner._dbfs_path_exists")\
+    with mock.patch("mlflow.projects.databricks.DatabricksJobRunner._dbfs_path_exists") \
             as path_exists_mock:
         yield path_exists_mock
 
@@ -145,13 +145,33 @@ def test_upload_project_to_dbfs(
 
 def test_upload_existing_project_to_dbfs(dbfs_path_exists_mock):  # pylint: disable=unused-argument
     # Check that we don't upload the project if it already exists on DBFS
-    with mock.patch("mlflow.projects.databricks.DatabricksJobRunner._upload_to_dbfs")\
+    with mock.patch("mlflow.projects.databricks.DatabricksJobRunner._upload_to_dbfs") \
             as upload_to_dbfs_mock:
         dbfs_path_exists_mock.return_value = True
         runner = DatabricksJobRunner(databricks_profile="DEFAULT")
         runner._upload_project_to_dbfs(
             project_dir=TEST_PROJECT_DIR, experiment_id=FileStore.DEFAULT_EXPERIMENT_ID)
         assert upload_to_dbfs_mock.call_count == 0
+
+
+@mock.patch("mlflow.utils.rest_utils.http_request")
+@pytest.mark.parametrize("response", [
+    helper_functions.create_mock_response(400, "Error message but not a JSON string"),
+    helper_functions.create_mock_response(400, ""),
+    helper_functions.create_mock_response(400, None)
+])
+def test_dbfs_path_exists_error_response_handling(http_request_mock, response):
+    # given a well formed DatabricksJobRunner
+    # note: databricks_profile is None needed because clients using profile are mocked
+    job_runner = DatabricksJobRunner(databricks_profile=None)
+
+    # when the http request to validate the dbfs path returns a 400 response with an
+    # error message that is either well-formed JSON or not
+    http_request_mock.return_value = response
+
+    # then _dbfs_path_exists should return a MlflowException
+    with pytest.raises(MlflowException):
+        job_runner._dbfs_path_exists('some/path')
 
 
 def test_run_databricks_validations(
@@ -290,6 +310,7 @@ class MockProfileConfigProvider:
                    MockProfileConfigProvider)
 def test_databricks_http_request_integration(get_config, request):
     """Confirms that the databricks http request params can in fact be used as an HTTP request"""
+
     def confirm_request_params(**kwargs):
         headers = dict(_DEFAULT_HEADERS)
         headers['Authorization'] = 'Basic dXNlcjpwYXNz'
@@ -304,6 +325,7 @@ def test_databricks_http_request_integration(get_config, request):
         http_response.status_code = 200
         http_response.text = '{"OK": "woo"}'
         return http_response
+
     request.side_effect = confirm_request_params
     get_config.return_value = \
         DatabricksConfig("host", "user", "pass", None, insecure=False)

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -160,13 +160,16 @@ def test_upload_existing_project_to_dbfs(dbfs_path_exists_mock):  # pylint: disa
     helper_functions.create_mock_response(400, None)
 ])
 def test_dbfs_path_exists_error_response_handling(response_mock):
-    with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
+    with mock.patch("mlflow.utils.databricks_utils.get_databricks_host_creds") \
+         as get_databricks_host_creds_mock, \
+         mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
         # given a well formed DatabricksJobRunner
         # note: databricks_profile is None needed because clients using profile are mocked
         job_runner = DatabricksJobRunner(databricks_profile=None)
 
         # when the http request to validate the dbfs path returns a 400 response with an
         # error message that is either well-formed JSON or not
+        get_databricks_host_creds_mock.return_value = None
         http_request_mock.return_value = response_mock
 
         # then _dbfs_path_exists should return a MlflowException

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -21,7 +21,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_RUN_URL, \
     MLFLOW_DATABRICKS_SHELL_JOB_RUN_ID, \
     MLFLOW_DATABRICKS_WEBAPP_URL
 from mlflow.utils.rest_utils import _DEFAULT_HEADERS
-from tests import helper_functions
+# from tests import helper_functions
 
 from tests.projects.utils import validate_exit_status, TEST_PROJECT_DIR
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -5,12 +5,9 @@ import numpy
 import pytest
 
 from mlflow.exceptions import MlflowException, RestException
-from mlflow.protos.service_pb2 import GetRun
 from mlflow.pyfunc.scoring_server import NumpyEncoder
 from mlflow.utils.rest_utils import http_request, http_request_safe, \
-    MlflowHostCreds, _DEFAULT_HEADERS, call_endpoint
-from tests import helper_functions
-
+    MlflowHostCreds, _DEFAULT_HEADERS
 
 # @mock.patch('requests.request')
 # def test_well_formed_json_error_response(request):

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -9,13 +9,7 @@ from mlflow.protos.service_pb2 import GetRun
 from mlflow.pyfunc.scoring_server import NumpyEncoder
 from mlflow.utils.rest_utils import http_request, http_request_safe, \
     MlflowHostCreds, _DEFAULT_HEADERS, call_endpoint
-
-
-def _create_mock_response(status_code, text):
-    response = mock.MagicMock()
-    response.status_code = status_code
-    response.text = text
-    return response
+from tests import helper_functions
 
 
 @mock.patch('requests.request')
@@ -33,9 +27,9 @@ def test_well_formed_json_error_response(request):
 
 @mock.patch('requests.request')
 @pytest.mark.parametrize("response", [
-    _create_mock_response(400, "Error message but not a JSON string"),  # response text is not json
-    _create_mock_response(400, ""),  # response text is empty
-    _create_mock_response(400, None)  # response text is None
+    helper_functions.create_mock_response(400, "Error message but not a JSON string"),
+    helper_functions.create_mock_response(400, ""),
+    helper_functions.create_mock_response(400, None)
 ])
 def test_malformed_json_error_response(request, response):
     host_only = MlflowHostCreds("http://my-host")

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -7,34 +7,37 @@ import pytest
 from mlflow.exceptions import MlflowException, RestException
 from mlflow.pyfunc.scoring_server import NumpyEncoder
 from mlflow.utils.rest_utils import http_request, http_request_safe, \
-    MlflowHostCreds, _DEFAULT_HEADERS
+    MlflowHostCreds, _DEFAULT_HEADERS, call_endpoint
+from mlflow.protos.service_pb2 import GetRun
+from tests import helper_functions
 
-# @mock.patch('requests.request')
-# def test_well_formed_json_error_response(request):
-#     host_only = MlflowHostCreds("http://my-host")
-#     response = mock.MagicMock()
-#     response.status_code = 400
-#     response.text = "{}"  # well-formed JSON error response
-#     request.return_value = response
-#
-#     response_proto = GetRun.Response()
-#     with pytest.raises(RestException):
-#         call_endpoint(host_only, '/my/endpoint', 'GET', "", response_proto)
-#
-#
-# @mock.patch('requests.request')
-# @pytest.mark.parametrize("response", [
-#     helper_functions.create_mock_response(400, "Error message but not a JSON string"),
-#     helper_functions.create_mock_response(400, ""),
-#     helper_functions.create_mock_response(400, None)
-# ])
-# def test_malformed_json_error_response(request, response):
-#     host_only = MlflowHostCreds("http://my-host")
-#     request.return_value = response
-#
-#     response_proto = GetRun.Response()
-#     with pytest.raises(MlflowException):
-#         call_endpoint(host_only, '/my/endpoint', 'GET', "", response_proto)
+
+def test_well_formed_json_error_response():
+    with mock.patch('requests.request') as request_mock:
+        host_only = MlflowHostCreds("http://my-host")
+        response_mock = mock.MagicMock()
+        response_mock.status_code = 400
+        response_mock.text = "{}"  # well-formed JSON error response
+        request_mock.return_value = response_mock
+
+        response_proto = GetRun.Response()
+        with pytest.raises(RestException):
+            call_endpoint(host_only, '/my/endpoint', 'GET', "", response_proto)
+
+
+@pytest.mark.parametrize("response_mock", [
+    helper_functions.create_mock_response(400, "Error message but not a JSON string"),
+    helper_functions.create_mock_response(400, ""),
+    helper_functions.create_mock_response(400, None)
+])
+def test_malformed_json_error_response(response_mock):
+    with mock.patch('requests.request') as request_mock:
+        host_only = MlflowHostCreds("http://my-host")
+        request_mock.return_value = response_mock
+
+        response_proto = GetRun.Response()
+        with pytest.raises(MlflowException):
+            call_endpoint(host_only, '/my/endpoint', 'GET', "", response_proto)
 
 
 @mock.patch('requests.request')

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -12,32 +12,32 @@ from mlflow.utils.rest_utils import http_request, http_request_safe, \
 from tests import helper_functions
 
 
-@mock.patch('requests.request')
-def test_well_formed_json_error_response(request):
-    host_only = MlflowHostCreds("http://my-host")
-    response = mock.MagicMock()
-    response.status_code = 400
-    response.text = "{}"  # well-formed JSON error response
-    request.return_value = response
-
-    response_proto = GetRun.Response()
-    with pytest.raises(RestException):
-        call_endpoint(host_only, '/my/endpoint', 'GET', "", response_proto)
-
-
-@mock.patch('requests.request')
-@pytest.mark.parametrize("response", [
-    helper_functions.create_mock_response(400, "Error message but not a JSON string"),
-    helper_functions.create_mock_response(400, ""),
-    helper_functions.create_mock_response(400, None)
-])
-def test_malformed_json_error_response(request, response):
-    host_only = MlflowHostCreds("http://my-host")
-    request.return_value = response
-
-    response_proto = GetRun.Response()
-    with pytest.raises(MlflowException):
-        call_endpoint(host_only, '/my/endpoint', 'GET', "", response_proto)
+# @mock.patch('requests.request')
+# def test_well_formed_json_error_response(request):
+#     host_only = MlflowHostCreds("http://my-host")
+#     response = mock.MagicMock()
+#     response.status_code = 400
+#     response.text = "{}"  # well-formed JSON error response
+#     request.return_value = response
+#
+#     response_proto = GetRun.Response()
+#     with pytest.raises(RestException):
+#         call_endpoint(host_only, '/my/endpoint', 'GET', "", response_proto)
+#
+#
+# @mock.patch('requests.request')
+# @pytest.mark.parametrize("response", [
+#     helper_functions.create_mock_response(400, "Error message but not a JSON string"),
+#     helper_functions.create_mock_response(400, ""),
+#     helper_functions.create_mock_response(400, None)
+# ])
+# def test_malformed_json_error_response(request, response):
+#     host_only = MlflowHostCreds("http://my-host")
+#     request.return_value = response
+#
+#     response_proto = GetRun.Response()
+#     with pytest.raises(MlflowException):
+#         call_endpoint(host_only, '/my/endpoint', 'GET', "", response_proto)
 
 
 @mock.patch('requests.request')

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -4,14 +4,11 @@ import mock
 import numpy
 import pytest
 
+from mlflow.exceptions import MlflowException, RestException
+from mlflow.protos.service_pb2 import GetRun
+from mlflow.pyfunc.scoring_server import NumpyEncoder
 from mlflow.utils.rest_utils import http_request, http_request_safe, \
     MlflowHostCreds, _DEFAULT_HEADERS, call_endpoint
-from mlflow.pyfunc.scoring_server import NumpyEncoder
-from mlflow.exceptions import MlflowException, RestException
-from mlflow.protos.service_pb2 import CreateExperiment, MlflowService, GetExperiment, \
-    GetRun, SearchRuns, ListExperiments, GetMetricHistory, LogMetric, LogParam, SetTag, \
-    UpdateRun, CreateRun, DeleteRun, RestoreRun, DeleteExperiment, RestoreExperiment, \
-    UpdateExperiment, LogBatch, DeleteTag, SetExperimentTag, GetExperimentByName
 
 
 def _create_mock_response(status_code, text):


### PR DESCRIPTION
## What changes are proposed in this pull request?

When an HTTP request is executed, it tries to parse an error response as
JSON. This check only handles ValueError. `json.loads` can throw both
ValueError and TypeError. Therefore, I have added addition logic and
tests to safeguard against the behavior

## How is this patch tested?

I wrote several new unit tests to validate the JSON.loads behavior. 

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [x] CLI
- [ ] API
- [x] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
