### PR TITLE
Log project backend for local runs with no environment

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -137,6 +137,7 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
             experiment_id=experiment_id, cluster_spec=backend_config)
 
     elif backend == "local" or backend is None:
+        tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND, "local")
         command_args = []
         command_separator = " "
         # If a docker_env attribute is defined in MLproject then it takes precedence over conda yaml
@@ -144,8 +145,6 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
         if project.docker_env:
             tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_ENV,
                                             "docker")
-            tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND,
-                                            "local")
             _validate_docker_env(project)
             _validate_docker_installation()
             image = _build_docker_image(work_dir=work_dir,
@@ -159,7 +158,6 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
         # to avoid failures due to multiple concurrent attempts to create the same conda env.
         elif use_conda:
             tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_ENV, "conda")
-            tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND, "local")
             command_separator = " && "
             conda_env_name = _get_or_create_conda_env(project.conda_env_path)
             command_args += _get_conda_command(conda_env_name)

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -10,9 +10,9 @@ import mlflow
 from mlflow.entities import ViewType
 from mlflow.projects import ExecutionException, _get_docker_image_uri
 from mlflow.store.tracking import file_store
-from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_DOCKER_IMAGE_URI, \
-    MLFLOW_DOCKER_IMAGE_ID
-
+from mlflow.utils.mlflow_tags import (
+    MLFLOW_PROJECT_ENV, MLFLOW_PROJECT_BACKEND, MLFLOW_DOCKER_IMAGE_URI, MLFLOW_DOCKER_IMAGE_ID,
+)
 from tests.projects.utils import TEST_DOCKER_PROJECT_DIR
 from tests.projects.utils import docker_example_base_image  # pylint: disable=unused-import
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
@@ -46,7 +46,10 @@ def test_docker_project_execution(
     run = mlflow_service.get_run(run_id)
     assert run.data.params == expected_params
     assert run.data.metrics == {"some_key": 3}
-    exact_expected_tags = {MLFLOW_PROJECT_ENV: "docker"}
+    exact_expected_tags = {
+        MLFLOW_PROJECT_ENV: "docker",
+        MLFLOW_PROJECT_BACKEND: "local",
+    }
     approx_expected_tags = {
         MLFLOW_DOCKER_IMAGE_URI: "docker-example",
         MLFLOW_DOCKER_IMAGE_ID: "sha256:",

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -18,7 +18,7 @@ from mlflow.store.tracking.file_store import FileStore
 from mlflow.utils import env
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_USER, MLFLOW_SOURCE_NAME, \
     MLFLOW_SOURCE_TYPE, MLFLOW_GIT_BRANCH, MLFLOW_GIT_REPO_URL, LEGACY_MLFLOW_GIT_BRANCH_NAME, \
-    LEGACY_MLFLOW_GIT_REPO_URL, MLFLOW_PROJECT_ENTRY_POINT
+    LEGACY_MLFLOW_GIT_REPO_URL, MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_PROJECT_BACKEND
 
 from tests.projects.utils import TEST_PROJECT_DIR, TEST_PROJECT_NAME, GIT_PROJECT_URI, \
     validate_exit_status, assert_dirs_equal
@@ -257,6 +257,7 @@ def test_run_local_git_repo(patch_user,  # pylint: disable=unused-argument
     assert "file:" in tags[MLFLOW_SOURCE_NAME]
     assert tags[MLFLOW_SOURCE_TYPE] == SourceType.to_string(SourceType.PROJECT)
     assert tags[MLFLOW_PROJECT_ENTRY_POINT] == "test_tracking"
+    assert tags[MLFLOW_PROJECT_BACKEND] == "local"
 
     if version == "master":
         assert tags[MLFLOW_GIT_BRANCH] == "master"

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -18,7 +18,8 @@ from mlflow.store.tracking.file_store import FileStore
 from mlflow.utils import env
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_USER, MLFLOW_SOURCE_NAME, \
     MLFLOW_SOURCE_TYPE, MLFLOW_GIT_BRANCH, MLFLOW_GIT_REPO_URL, LEGACY_MLFLOW_GIT_BRANCH_NAME, \
-    LEGACY_MLFLOW_GIT_REPO_URL, MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_PROJECT_BACKEND
+    LEGACY_MLFLOW_GIT_REPO_URL, MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_PROJECT_BACKEND, \
+    MLFLOW_PROJECT_ENV
 
 from tests.projects.utils import TEST_PROJECT_DIR, TEST_PROJECT_NAME, GIT_PROJECT_URI, \
     validate_exit_status, assert_dirs_equal
@@ -206,6 +207,21 @@ def test_use_conda(tracking_uri_mock):  # pylint: disable=unused-argument
         os.environ["PATH"] = old_path
         if conda_exe_path:
             os.environ["CONDA_EXE"] = conda_exe_path
+
+
+def test_expected_tags_logged_when_using_conda(
+        tracking_uri_mock):  # pylint: disable=unused-argument
+    with mock.patch.object(mlflow.tracking.MlflowClient, "set_tag") as tag_mock:
+        try:
+            mlflow.projects.run(TEST_PROJECT_DIR, use_conda=True)
+        finally:
+            tag_mock.assert_has_calls(
+                [
+                    mock.call(mock.ANY, MLFLOW_PROJECT_BACKEND, "local"),
+                    mock.call(mock.ANY, MLFLOW_PROJECT_ENV, "conda"),
+                ],
+                any_order=True,
+            )
 
 
 def test_is_valid_branch_name(local_git_repo):

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -14,7 +14,7 @@ from mlflow.projects import _project_spec
 from mlflow.utils.file_utils import path_to_local_sqlite_uri
 
 
-TEST_DIR = "tests"
+TEST_DIR = ".."
 TEST_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_project")
 TEST_DOCKER_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_docker_project")
 TEST_PROJECT_NAME = "example_project"

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -14,7 +14,7 @@ from mlflow.projects import _project_spec
 from mlflow.utils.file_utils import path_to_local_sqlite_uri
 
 
-TEST_DIR = ".."
+TEST_DIR = "tests"
 TEST_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_project")
 TEST_DOCKER_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_docker_project")
 TEST_PROJECT_NAME = "example_project"


### PR DESCRIPTION
## What changes are proposed in this pull request?

While reviewing #2202, I discovered that the `mlflow.project.backend` tag is not currently being set when using the `local` backend without a conda or docker environment. This PR fixes the issue and expands test coverage to ensure that the correct backend and environment tags are logged for the `docker`, `conda`, and `no environment` cases

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. *Small bug fix, no release note*

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [X] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
