### PR TITLE
Added backendConfig tag for mlflow project

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -131,8 +131,10 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
     if backend == "databricks":
         tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND,
                                         "databricks")
-        tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND_CONFIG,
-                                        backend_config)
+        if (backend_config and type(backend_config) != dict
+                and os.path.splitext(backend_config)[-1] == ".json"):
+            tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND_CONFIG,
+                                            backend_config)
         from mlflow.projects.databricks import run_databricks
         return run_databricks(
             remote_run=active_run,
@@ -184,8 +186,10 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
         tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_ENV, "docker")
         tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND,
                                         "kubernetes")
-        tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND_CONFIG,
-                                        backend_config)
+        if (backend_config and type(backend_config) != dict
+                and os.path.splitext(backend_config)[-1] == ".json"):
+            tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND_CONFIG,
+                                            backend_config)
         _validate_docker_env(project)
         _validate_docker_installation()
         kube_config = _parse_kubernetes_config(backend_config)

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -46,6 +46,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, MLFLOW_GIT_COMMIT, MLFLOW_GIT_REPO_URL,
     MLFLOW_GIT_BRANCH, LEGACY_MLFLOW_GIT_REPO_URL, LEGACY_MLFLOW_GIT_BRANCH_NAME,
     MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_PARENT_RUN_ID, MLFLOW_PROJECT_BACKEND,
+    MLFLOW_PROJECT_BACKEND_CONFIG,
 )
 from mlflow.utils.uri import get_db_profile_from_uri, is_databricks_uri
 
@@ -130,6 +131,8 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
     if backend == "databricks":
         tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND,
                                         "databricks")
+        tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND_CONFIG,
+                                        backend_config)
         from mlflow.projects.databricks import run_databricks
         return run_databricks(
             remote_run=active_run,
@@ -181,6 +184,8 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
         tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_ENV, "docker")
         tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND,
                                         "kubernetes")
+        tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND_CONFIG,
+                                        backend_config)
         _validate_docker_env(project)
         _validate_docker_installation()
         kube_config = _parse_kubernetes_config(backend_config)

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -55,6 +55,7 @@ class RunView extends Component {
     const sourceVersion = Utils.getSourceVersion(tags);
     const entryPointName = Utils.getEntryPointName(tags);
     const backend = Utils.getBackend(tags);
+    const backendConfig = Utils.getBackendConfig(tags);
     if (Utils.getSourceType(tags) === "PROJECT") {
       runCommand = 'mlflow run ' + shellEscape(sourceName);
       if (sourceVersion && sourceVersion !== "latest") {
@@ -65,6 +66,9 @@ class RunView extends Component {
       }
       if (backend) {
         runCommand += ' -b ' + shellEscape(backend);
+      }
+      if (backendConfig) {
+        runCommand += ' -c ' + shellEscape(backendConfig);
       }
       Object.values(params).sort().forEach(p => {
         runCommand += ' -P ' + shellEscape(p.key + '=' + p.value);

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -36,6 +36,7 @@ class Utils {
   static gitCommitTag = 'mlflow.source.git.commit';
   static entryPointTag = 'mlflow.project.entryPoint';
   static backendTag = 'mlflow.project.backend';
+  static backendConfigTag = 'mlflow.project.backendConfig';
   static userTag = 'mlflow.user';
 
   static formatMetric(value) {
@@ -336,6 +337,14 @@ class Utils {
     const backendTag = runTags[Utils.backendTag];
     if (backendTag) {
       return backendTag.value;
+    }
+    return "";
+  }
+
+  static getBackendConfig(runTags) {
+    const backendConfigTag = runTags[Utils.backendConfigTag];
+    if (backendConfigTag) {
+      return backendConfigTag.value;
     }
     return "";
   }

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -25,6 +25,7 @@ MLFLOW_DATABRICKS_SHELL_JOB_ID = "mlflow.databricks.shellJobID"
 MLFLOW_DATABRICKS_SHELL_JOB_RUN_ID = "mlflow.databricks.shellJobRunID"
 
 MLFLOW_PROJECT_BACKEND = "mlflow.project.backend"
+MLFLOW_PROJECT_BACKEND_CONFIG = "mlflow.project.backendConfig"
 
 # The following legacy tags are deprecated and will be removed by MLflow 1.0.
 LEGACY_MLFLOW_GIT_BRANCH_NAME = "mlflow.gitBranchName"  # Replaced with mlflow.source.git.branch


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added a tag mlflow.project.backendConfig to store this information in the DB. Retrieve this tag in the UI to add the backend-config option in the run command.

## How is this patch tested?

Locally, checking that the backend config appears in the command in the UI

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added backend config in run command line in the ui.

### What component(s) does this PR affect?

- [X] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
