### PR TITLE
Whitelisting columns

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
@@ -34868,6 +34868,60 @@ public final class Service {
      */
     com.google.protobuf.ByteString
         getPageTokenBytes();
+
+    /**
+     * <pre>
+     * These metrics, params and tags whitelist limit the fields returned by the search runs query
+     * A None whitelist will select all the fields
+     * </pre>
+     *
+     * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+     */
+    boolean hasMetricsWhitelist();
+    /**
+     * <pre>
+     * These metrics, params and tags whitelist limit the fields returned by the search runs query
+     * A None whitelist will select all the fields
+     * </pre>
+     *
+     * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+     */
+    org.mlflow.api.proto.Service.SearchRuns.WhiteList getMetricsWhitelist();
+    /**
+     * <pre>
+     * These metrics, params and tags whitelist limit the fields returned by the search runs query
+     * A None whitelist will select all the fields
+     * </pre>
+     *
+     * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+     */
+    org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder getMetricsWhitelistOrBuilder();
+
+    /**
+     * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+     */
+    boolean hasParamsWhitelist();
+    /**
+     * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+     */
+    org.mlflow.api.proto.Service.SearchRuns.WhiteList getParamsWhitelist();
+    /**
+     * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+     */
+    org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder getParamsWhitelistOrBuilder();
+
+    /**
+     * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+     */
+    boolean hasTagsWhitelist();
+    /**
+     * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+     */
+    org.mlflow.api.proto.Service.SearchRuns.WhiteList getTagsWhitelist();
+    /**
+     * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+     */
+    org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder getTagsWhitelistOrBuilder();
   }
   /**
    * Protobuf type {@code mlflow.SearchRuns}
@@ -34959,6 +35013,45 @@ public final class Service {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000008;
               pageToken_ = bs;
+              break;
+            }
+            case 66: {
+              org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000010) == 0x00000010)) {
+                subBuilder = metricsWhitelist_.toBuilder();
+              }
+              metricsWhitelist_ = input.readMessage(org.mlflow.api.proto.Service.SearchRuns.WhiteList.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(metricsWhitelist_);
+                metricsWhitelist_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000010;
+              break;
+            }
+            case 74: {
+              org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000020) == 0x00000020)) {
+                subBuilder = paramsWhitelist_.toBuilder();
+              }
+              paramsWhitelist_ = input.readMessage(org.mlflow.api.proto.Service.SearchRuns.WhiteList.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(paramsWhitelist_);
+                paramsWhitelist_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000020;
+              break;
+            }
+            case 82: {
+              org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder subBuilder = null;
+              if (((bitField0_ & 0x00000040) == 0x00000040)) {
+                subBuilder = tagsWhitelist_.toBuilder();
+              }
+              tagsWhitelist_ = input.readMessage(org.mlflow.api.proto.Service.SearchRuns.WhiteList.PARSER, extensionRegistry);
+              if (subBuilder != null) {
+                subBuilder.mergeFrom(tagsWhitelist_);
+                tagsWhitelist_ = subBuilder.buildPartial();
+              }
+              bitField0_ |= 0x00000040;
               break;
             }
             default: {
@@ -36061,6 +36154,619 @@ public final class Service {
 
     }
 
+    public interface WhiteListOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mlflow.SearchRuns.WhiteList)
+        com.google.protobuf.MessageOrBuilder {
+
+      /**
+       * <code>repeated string fields = 1;</code>
+       */
+      java.util.List<java.lang.String>
+          getFieldsList();
+      /**
+       * <code>repeated string fields = 1;</code>
+       */
+      int getFieldsCount();
+      /**
+       * <code>repeated string fields = 1;</code>
+       */
+      java.lang.String getFields(int index);
+      /**
+       * <code>repeated string fields = 1;</code>
+       */
+      com.google.protobuf.ByteString
+          getFieldsBytes(int index);
+    }
+    /**
+     * <pre>
+     * this whitelist message exists to be able to have an optional whitelist :
+     * no whitelist = all fields are available
+     * </pre>
+     *
+     * Protobuf type {@code mlflow.SearchRuns.WhiteList}
+     */
+    public  static final class WhiteList extends
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:mlflow.SearchRuns.WhiteList)
+        WhiteListOrBuilder {
+    private static final long serialVersionUID = 0L;
+      // Use WhiteList.newBuilder() to construct.
+      private WhiteList(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+        super(builder);
+      }
+      private WhiteList() {
+        fields_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+      }
+
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+      getUnknownFields() {
+        return this.unknownFields;
+      }
+      private WhiteList(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        int mutable_bitField0_ = 0;
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                com.google.protobuf.ByteString bs = input.readBytes();
+                if (!((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+                  fields_ = new com.google.protobuf.LazyStringArrayList();
+                  mutable_bitField0_ |= 0x00000001;
+                }
+                fields_.add(bs);
+                break;
+              }
+              default: {
+                if (!parseUnknownField(
+                    input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
+        } finally {
+          if (((mutable_bitField0_ & 0x00000001) == 0x00000001)) {
+            fields_ = fields_.getUnmodifiableView();
+          }
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_SearchRuns_WhiteList_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_SearchRuns_WhiteList_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.Service.SearchRuns.WhiteList.class, org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder.class);
+      }
+
+      public static final int FIELDS_FIELD_NUMBER = 1;
+      private com.google.protobuf.LazyStringList fields_;
+      /**
+       * <code>repeated string fields = 1;</code>
+       */
+      public com.google.protobuf.ProtocolStringList
+          getFieldsList() {
+        return fields_;
+      }
+      /**
+       * <code>repeated string fields = 1;</code>
+       */
+      public int getFieldsCount() {
+        return fields_.size();
+      }
+      /**
+       * <code>repeated string fields = 1;</code>
+       */
+      public java.lang.String getFields(int index) {
+        return fields_.get(index);
+      }
+      /**
+       * <code>repeated string fields = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getFieldsBytes(int index) {
+        return fields_.getByteString(index);
+      }
+
+      private byte memoizedIsInitialized = -1;
+      @java.lang.Override
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      @java.lang.Override
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        for (int i = 0; i < fields_.size(); i++) {
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 1, fields_.getRaw(i));
+        }
+        unknownFields.writeTo(output);
+      }
+
+      @java.lang.Override
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        {
+          int dataSize = 0;
+          for (int i = 0; i < fields_.size(); i++) {
+            dataSize += computeStringSizeNoTag(fields_.getRaw(i));
+          }
+          size += dataSize;
+          size += 1 * getFieldsList().size();
+        }
+        size += unknownFields.getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof org.mlflow.api.proto.Service.SearchRuns.WhiteList)) {
+          return super.equals(obj);
+        }
+        org.mlflow.api.proto.Service.SearchRuns.WhiteList other = (org.mlflow.api.proto.Service.SearchRuns.WhiteList) obj;
+
+        boolean result = true;
+        result = result && getFieldsList()
+            .equals(other.getFieldsList());
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        if (getFieldsCount() > 0) {
+          hash = (37 * hash) + FIELDS_FIELD_NUMBER;
+          hash = (53 * hash) + getFieldsList().hashCode();
+        }
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static org.mlflow.api.proto.Service.SearchRuns.WhiteList parseFrom(
+          java.nio.ByteBuffer data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.Service.SearchRuns.WhiteList parseFrom(
+          java.nio.ByteBuffer data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.SearchRuns.WhiteList parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.Service.SearchRuns.WhiteList parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.SearchRuns.WhiteList parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.Service.SearchRuns.WhiteList parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.SearchRuns.WhiteList parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.Service.SearchRuns.WhiteList parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.SearchRuns.WhiteList parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.Service.SearchRuns.WhiteList parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.SearchRuns.WhiteList parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.Service.SearchRuns.WhiteList parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+
+      @java.lang.Override
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+      public static Builder newBuilder(org.mlflow.api.proto.Service.SearchRuns.WhiteList prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+      @java.lang.Override
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE
+            ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * <pre>
+       * this whitelist message exists to be able to have an optional whitelist :
+       * no whitelist = all fields are available
+       * </pre>
+       *
+       * Protobuf type {@code mlflow.SearchRuns.WhiteList}
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mlflow.SearchRuns.WhiteList)
+          org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return org.mlflow.api.proto.Service.internal_static_mlflow_SearchRuns_WhiteList_descriptor;
+        }
+
+        @java.lang.Override
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return org.mlflow.api.proto.Service.internal_static_mlflow_SearchRuns_WhiteList_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  org.mlflow.api.proto.Service.SearchRuns.WhiteList.class, org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder.class);
+        }
+
+        // Construct using org.mlflow.api.proto.Service.SearchRuns.WhiteList.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
+          }
+        }
+        @java.lang.Override
+        public Builder clear() {
+          super.clear();
+          fields_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+          bitField0_ = (bitField0_ & ~0x00000001);
+          return this;
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return org.mlflow.api.proto.Service.internal_static_mlflow_SearchRuns_WhiteList_descriptor;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.Service.SearchRuns.WhiteList getDefaultInstanceForType() {
+          return org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance();
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.Service.SearchRuns.WhiteList build() {
+          org.mlflow.api.proto.Service.SearchRuns.WhiteList result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.Service.SearchRuns.WhiteList buildPartial() {
+          org.mlflow.api.proto.Service.SearchRuns.WhiteList result = new org.mlflow.api.proto.Service.SearchRuns.WhiteList(this);
+          int from_bitField0_ = bitField0_;
+          if (((bitField0_ & 0x00000001) == 0x00000001)) {
+            fields_ = fields_.getUnmodifiableView();
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.fields_ = fields_;
+          onBuilt();
+          return result;
+        }
+
+        @java.lang.Override
+        public Builder clone() {
+          return (Builder) super.clone();
+        }
+        @java.lang.Override
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return (Builder) super.setField(field, value);
+        }
+        @java.lang.Override
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return (Builder) super.clearField(field);
+        }
+        @java.lang.Override
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return (Builder) super.clearOneof(oneof);
+        }
+        @java.lang.Override
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, java.lang.Object value) {
+          return (Builder) super.setRepeatedField(field, index, value);
+        }
+        @java.lang.Override
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return (Builder) super.addRepeatedField(field, value);
+        }
+        @java.lang.Override
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof org.mlflow.api.proto.Service.SearchRuns.WhiteList) {
+            return mergeFrom((org.mlflow.api.proto.Service.SearchRuns.WhiteList)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(org.mlflow.api.proto.Service.SearchRuns.WhiteList other) {
+          if (other == org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance()) return this;
+          if (!other.fields_.isEmpty()) {
+            if (fields_.isEmpty()) {
+              fields_ = other.fields_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureFieldsIsMutable();
+              fields_.addAll(other.fields_);
+            }
+            onChanged();
+          }
+          this.mergeUnknownFields(other.unknownFields);
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          org.mlflow.api.proto.Service.SearchRuns.WhiteList parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (org.mlflow.api.proto.Service.SearchRuns.WhiteList) e.getUnfinishedMessage();
+            throw e.unwrapIOException();
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        private int bitField0_;
+
+        private com.google.protobuf.LazyStringList fields_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+        private void ensureFieldsIsMutable() {
+          if (!((bitField0_ & 0x00000001) == 0x00000001)) {
+            fields_ = new com.google.protobuf.LazyStringArrayList(fields_);
+            bitField0_ |= 0x00000001;
+           }
+        }
+        /**
+         * <code>repeated string fields = 1;</code>
+         */
+        public com.google.protobuf.ProtocolStringList
+            getFieldsList() {
+          return fields_.getUnmodifiableView();
+        }
+        /**
+         * <code>repeated string fields = 1;</code>
+         */
+        public int getFieldsCount() {
+          return fields_.size();
+        }
+        /**
+         * <code>repeated string fields = 1;</code>
+         */
+        public java.lang.String getFields(int index) {
+          return fields_.get(index);
+        }
+        /**
+         * <code>repeated string fields = 1;</code>
+         */
+        public com.google.protobuf.ByteString
+            getFieldsBytes(int index) {
+          return fields_.getByteString(index);
+        }
+        /**
+         * <code>repeated string fields = 1;</code>
+         */
+        public Builder setFields(
+            int index, java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureFieldsIsMutable();
+          fields_.set(index, value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string fields = 1;</code>
+         */
+        public Builder addFields(
+            java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureFieldsIsMutable();
+          fields_.add(value);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string fields = 1;</code>
+         */
+        public Builder addAllFields(
+            java.lang.Iterable<java.lang.String> values) {
+          ensureFieldsIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, fields_);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string fields = 1;</code>
+         */
+        public Builder clearFields() {
+          fields_ = com.google.protobuf.LazyStringArrayList.EMPTY;
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+          return this;
+        }
+        /**
+         * <code>repeated string fields = 1;</code>
+         */
+        public Builder addFieldsBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  ensureFieldsIsMutable();
+          fields_.add(value);
+          onChanged();
+          return this;
+        }
+        @java.lang.Override
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        @java.lang.Override
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
+
+        // @@protoc_insertion_point(builder_scope:mlflow.SearchRuns.WhiteList)
+      }
+
+      // @@protoc_insertion_point(class_scope:mlflow.SearchRuns.WhiteList)
+      private static final org.mlflow.api.proto.Service.SearchRuns.WhiteList DEFAULT_INSTANCE;
+      static {
+        DEFAULT_INSTANCE = new org.mlflow.api.proto.Service.SearchRuns.WhiteList();
+      }
+
+      public static org.mlflow.api.proto.Service.SearchRuns.WhiteList getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      @java.lang.Deprecated public static final com.google.protobuf.Parser<WhiteList>
+          PARSER = new com.google.protobuf.AbstractParser<WhiteList>() {
+        @java.lang.Override
+        public WhiteList parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new WhiteList(input, extensionRegistry);
+        }
+      };
+
+      public static com.google.protobuf.Parser<WhiteList> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<WhiteList> getParserForType() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.SearchRuns.WhiteList getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+
+    }
+
     private int bitField0_;
     public static final int EXPERIMENT_IDS_FIELD_NUMBER = 1;
     private com.google.protobuf.LazyStringList experimentIds_;
@@ -36332,6 +37038,84 @@ public final class Service {
       }
     }
 
+    public static final int METRICS_WHITELIST_FIELD_NUMBER = 8;
+    private org.mlflow.api.proto.Service.SearchRuns.WhiteList metricsWhitelist_;
+    /**
+     * <pre>
+     * These metrics, params and tags whitelist limit the fields returned by the search runs query
+     * A None whitelist will select all the fields
+     * </pre>
+     *
+     * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+     */
+    public boolean hasMetricsWhitelist() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <pre>
+     * These metrics, params and tags whitelist limit the fields returned by the search runs query
+     * A None whitelist will select all the fields
+     * </pre>
+     *
+     * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+     */
+    public org.mlflow.api.proto.Service.SearchRuns.WhiteList getMetricsWhitelist() {
+      return metricsWhitelist_ == null ? org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance() : metricsWhitelist_;
+    }
+    /**
+     * <pre>
+     * These metrics, params and tags whitelist limit the fields returned by the search runs query
+     * A None whitelist will select all the fields
+     * </pre>
+     *
+     * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+     */
+    public org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder getMetricsWhitelistOrBuilder() {
+      return metricsWhitelist_ == null ? org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance() : metricsWhitelist_;
+    }
+
+    public static final int PARAMS_WHITELIST_FIELD_NUMBER = 9;
+    private org.mlflow.api.proto.Service.SearchRuns.WhiteList paramsWhitelist_;
+    /**
+     * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+     */
+    public boolean hasParamsWhitelist() {
+      return ((bitField0_ & 0x00000020) == 0x00000020);
+    }
+    /**
+     * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+     */
+    public org.mlflow.api.proto.Service.SearchRuns.WhiteList getParamsWhitelist() {
+      return paramsWhitelist_ == null ? org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance() : paramsWhitelist_;
+    }
+    /**
+     * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+     */
+    public org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder getParamsWhitelistOrBuilder() {
+      return paramsWhitelist_ == null ? org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance() : paramsWhitelist_;
+    }
+
+    public static final int TAGS_WHITELIST_FIELD_NUMBER = 10;
+    private org.mlflow.api.proto.Service.SearchRuns.WhiteList tagsWhitelist_;
+    /**
+     * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+     */
+    public boolean hasTagsWhitelist() {
+      return ((bitField0_ & 0x00000040) == 0x00000040);
+    }
+    /**
+     * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+     */
+    public org.mlflow.api.proto.Service.SearchRuns.WhiteList getTagsWhitelist() {
+      return tagsWhitelist_ == null ? org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance() : tagsWhitelist_;
+    }
+    /**
+     * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+     */
+    public org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder getTagsWhitelistOrBuilder() {
+      return tagsWhitelist_ == null ? org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance() : tagsWhitelist_;
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -36363,6 +37147,15 @@ public final class Service {
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 7, pageToken_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        output.writeMessage(8, getMetricsWhitelist());
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        output.writeMessage(9, getParamsWhitelist());
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        output.writeMessage(10, getTagsWhitelist());
       }
       unknownFields.writeTo(output);
     }
@@ -36403,6 +37196,18 @@ public final class Service {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(7, pageToken_);
       }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(8, getMetricsWhitelist());
+      }
+      if (((bitField0_ & 0x00000020) == 0x00000020)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(9, getParamsWhitelist());
+      }
+      if (((bitField0_ & 0x00000040) == 0x00000040)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(10, getTagsWhitelist());
+      }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
       return size;
@@ -36442,6 +37247,21 @@ public final class Service {
         result = result && getPageToken()
             .equals(other.getPageToken());
       }
+      result = result && (hasMetricsWhitelist() == other.hasMetricsWhitelist());
+      if (hasMetricsWhitelist()) {
+        result = result && getMetricsWhitelist()
+            .equals(other.getMetricsWhitelist());
+      }
+      result = result && (hasParamsWhitelist() == other.hasParamsWhitelist());
+      if (hasParamsWhitelist()) {
+        result = result && getParamsWhitelist()
+            .equals(other.getParamsWhitelist());
+      }
+      result = result && (hasTagsWhitelist() == other.hasTagsWhitelist());
+      if (hasTagsWhitelist()) {
+        result = result && getTagsWhitelist()
+            .equals(other.getTagsWhitelist());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -36476,6 +37296,18 @@ public final class Service {
       if (hasPageToken()) {
         hash = (37 * hash) + PAGE_TOKEN_FIELD_NUMBER;
         hash = (53 * hash) + getPageToken().hashCode();
+      }
+      if (hasMetricsWhitelist()) {
+        hash = (37 * hash) + METRICS_WHITELIST_FIELD_NUMBER;
+        hash = (53 * hash) + getMetricsWhitelist().hashCode();
+      }
+      if (hasParamsWhitelist()) {
+        hash = (37 * hash) + PARAMS_WHITELIST_FIELD_NUMBER;
+        hash = (53 * hash) + getParamsWhitelist().hashCode();
+      }
+      if (hasTagsWhitelist()) {
+        hash = (37 * hash) + TAGS_WHITELIST_FIELD_NUMBER;
+        hash = (53 * hash) + getTagsWhitelist().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -36605,6 +37437,9 @@ public final class Service {
       private void maybeForceBuilderInitialization() {
         if (com.google.protobuf.GeneratedMessageV3
                 .alwaysUseFieldBuilders) {
+          getMetricsWhitelistFieldBuilder();
+          getParamsWhitelistFieldBuilder();
+          getTagsWhitelistFieldBuilder();
         }
       }
       @java.lang.Override
@@ -36622,6 +37457,24 @@ public final class Service {
         bitField0_ = (bitField0_ & ~0x00000010);
         pageToken_ = "";
         bitField0_ = (bitField0_ & ~0x00000020);
+        if (metricsWhitelistBuilder_ == null) {
+          metricsWhitelist_ = null;
+        } else {
+          metricsWhitelistBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000040);
+        if (paramsWhitelistBuilder_ == null) {
+          paramsWhitelist_ = null;
+        } else {
+          paramsWhitelistBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000080);
+        if (tagsWhitelistBuilder_ == null) {
+          tagsWhitelist_ = null;
+        } else {
+          tagsWhitelistBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000100);
         return this;
       }
 
@@ -36676,6 +37529,30 @@ public final class Service {
           to_bitField0_ |= 0x00000008;
         }
         result.pageToken_ = pageToken_;
+        if (((from_bitField0_ & 0x00000040) == 0x00000040)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        if (metricsWhitelistBuilder_ == null) {
+          result.metricsWhitelist_ = metricsWhitelist_;
+        } else {
+          result.metricsWhitelist_ = metricsWhitelistBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000080) == 0x00000080)) {
+          to_bitField0_ |= 0x00000020;
+        }
+        if (paramsWhitelistBuilder_ == null) {
+          result.paramsWhitelist_ = paramsWhitelist_;
+        } else {
+          result.paramsWhitelist_ = paramsWhitelistBuilder_.build();
+        }
+        if (((from_bitField0_ & 0x00000100) == 0x00000100)) {
+          to_bitField0_ |= 0x00000040;
+        }
+        if (tagsWhitelistBuilder_ == null) {
+          result.tagsWhitelist_ = tagsWhitelist_;
+        } else {
+          result.tagsWhitelist_ = tagsWhitelistBuilder_.build();
+        }
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -36760,6 +37637,15 @@ public final class Service {
           bitField0_ |= 0x00000020;
           pageToken_ = other.pageToken_;
           onChanged();
+        }
+        if (other.hasMetricsWhitelist()) {
+          mergeMetricsWhitelist(other.getMetricsWhitelist());
+        }
+        if (other.hasParamsWhitelist()) {
+          mergeParamsWhitelist(other.getParamsWhitelist());
+        }
+        if (other.hasTagsWhitelist()) {
+          mergeTagsWhitelist(other.getTagsWhitelist());
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -37400,6 +38286,405 @@ public final class Service {
         pageToken_ = value;
         onChanged();
         return this;
+      }
+
+      private org.mlflow.api.proto.Service.SearchRuns.WhiteList metricsWhitelist_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.mlflow.api.proto.Service.SearchRuns.WhiteList, org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder, org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder> metricsWhitelistBuilder_;
+      /**
+       * <pre>
+       * These metrics, params and tags whitelist limit the fields returned by the search runs query
+       * A None whitelist will select all the fields
+       * </pre>
+       *
+       * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+       */
+      public boolean hasMetricsWhitelist() {
+        return ((bitField0_ & 0x00000040) == 0x00000040);
+      }
+      /**
+       * <pre>
+       * These metrics, params and tags whitelist limit the fields returned by the search runs query
+       * A None whitelist will select all the fields
+       * </pre>
+       *
+       * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+       */
+      public org.mlflow.api.proto.Service.SearchRuns.WhiteList getMetricsWhitelist() {
+        if (metricsWhitelistBuilder_ == null) {
+          return metricsWhitelist_ == null ? org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance() : metricsWhitelist_;
+        } else {
+          return metricsWhitelistBuilder_.getMessage();
+        }
+      }
+      /**
+       * <pre>
+       * These metrics, params and tags whitelist limit the fields returned by the search runs query
+       * A None whitelist will select all the fields
+       * </pre>
+       *
+       * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+       */
+      public Builder setMetricsWhitelist(org.mlflow.api.proto.Service.SearchRuns.WhiteList value) {
+        if (metricsWhitelistBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          metricsWhitelist_ = value;
+          onChanged();
+        } else {
+          metricsWhitelistBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000040;
+        return this;
+      }
+      /**
+       * <pre>
+       * These metrics, params and tags whitelist limit the fields returned by the search runs query
+       * A None whitelist will select all the fields
+       * </pre>
+       *
+       * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+       */
+      public Builder setMetricsWhitelist(
+          org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder builderForValue) {
+        if (metricsWhitelistBuilder_ == null) {
+          metricsWhitelist_ = builderForValue.build();
+          onChanged();
+        } else {
+          metricsWhitelistBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000040;
+        return this;
+      }
+      /**
+       * <pre>
+       * These metrics, params and tags whitelist limit the fields returned by the search runs query
+       * A None whitelist will select all the fields
+       * </pre>
+       *
+       * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+       */
+      public Builder mergeMetricsWhitelist(org.mlflow.api.proto.Service.SearchRuns.WhiteList value) {
+        if (metricsWhitelistBuilder_ == null) {
+          if (((bitField0_ & 0x00000040) == 0x00000040) &&
+              metricsWhitelist_ != null &&
+              metricsWhitelist_ != org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance()) {
+            metricsWhitelist_ =
+              org.mlflow.api.proto.Service.SearchRuns.WhiteList.newBuilder(metricsWhitelist_).mergeFrom(value).buildPartial();
+          } else {
+            metricsWhitelist_ = value;
+          }
+          onChanged();
+        } else {
+          metricsWhitelistBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000040;
+        return this;
+      }
+      /**
+       * <pre>
+       * These metrics, params and tags whitelist limit the fields returned by the search runs query
+       * A None whitelist will select all the fields
+       * </pre>
+       *
+       * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+       */
+      public Builder clearMetricsWhitelist() {
+        if (metricsWhitelistBuilder_ == null) {
+          metricsWhitelist_ = null;
+          onChanged();
+        } else {
+          metricsWhitelistBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000040);
+        return this;
+      }
+      /**
+       * <pre>
+       * These metrics, params and tags whitelist limit the fields returned by the search runs query
+       * A None whitelist will select all the fields
+       * </pre>
+       *
+       * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+       */
+      public org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder getMetricsWhitelistBuilder() {
+        bitField0_ |= 0x00000040;
+        onChanged();
+        return getMetricsWhitelistFieldBuilder().getBuilder();
+      }
+      /**
+       * <pre>
+       * These metrics, params and tags whitelist limit the fields returned by the search runs query
+       * A None whitelist will select all the fields
+       * </pre>
+       *
+       * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+       */
+      public org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder getMetricsWhitelistOrBuilder() {
+        if (metricsWhitelistBuilder_ != null) {
+          return metricsWhitelistBuilder_.getMessageOrBuilder();
+        } else {
+          return metricsWhitelist_ == null ?
+              org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance() : metricsWhitelist_;
+        }
+      }
+      /**
+       * <pre>
+       * These metrics, params and tags whitelist limit the fields returned by the search runs query
+       * A None whitelist will select all the fields
+       * </pre>
+       *
+       * <code>optional .mlflow.SearchRuns.WhiteList metrics_whitelist = 8;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.mlflow.api.proto.Service.SearchRuns.WhiteList, org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder, org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder> 
+          getMetricsWhitelistFieldBuilder() {
+        if (metricsWhitelistBuilder_ == null) {
+          metricsWhitelistBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              org.mlflow.api.proto.Service.SearchRuns.WhiteList, org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder, org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder>(
+                  getMetricsWhitelist(),
+                  getParentForChildren(),
+                  isClean());
+          metricsWhitelist_ = null;
+        }
+        return metricsWhitelistBuilder_;
+      }
+
+      private org.mlflow.api.proto.Service.SearchRuns.WhiteList paramsWhitelist_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.mlflow.api.proto.Service.SearchRuns.WhiteList, org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder, org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder> paramsWhitelistBuilder_;
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+       */
+      public boolean hasParamsWhitelist() {
+        return ((bitField0_ & 0x00000080) == 0x00000080);
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+       */
+      public org.mlflow.api.proto.Service.SearchRuns.WhiteList getParamsWhitelist() {
+        if (paramsWhitelistBuilder_ == null) {
+          return paramsWhitelist_ == null ? org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance() : paramsWhitelist_;
+        } else {
+          return paramsWhitelistBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+       */
+      public Builder setParamsWhitelist(org.mlflow.api.proto.Service.SearchRuns.WhiteList value) {
+        if (paramsWhitelistBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          paramsWhitelist_ = value;
+          onChanged();
+        } else {
+          paramsWhitelistBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000080;
+        return this;
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+       */
+      public Builder setParamsWhitelist(
+          org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder builderForValue) {
+        if (paramsWhitelistBuilder_ == null) {
+          paramsWhitelist_ = builderForValue.build();
+          onChanged();
+        } else {
+          paramsWhitelistBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000080;
+        return this;
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+       */
+      public Builder mergeParamsWhitelist(org.mlflow.api.proto.Service.SearchRuns.WhiteList value) {
+        if (paramsWhitelistBuilder_ == null) {
+          if (((bitField0_ & 0x00000080) == 0x00000080) &&
+              paramsWhitelist_ != null &&
+              paramsWhitelist_ != org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance()) {
+            paramsWhitelist_ =
+              org.mlflow.api.proto.Service.SearchRuns.WhiteList.newBuilder(paramsWhitelist_).mergeFrom(value).buildPartial();
+          } else {
+            paramsWhitelist_ = value;
+          }
+          onChanged();
+        } else {
+          paramsWhitelistBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000080;
+        return this;
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+       */
+      public Builder clearParamsWhitelist() {
+        if (paramsWhitelistBuilder_ == null) {
+          paramsWhitelist_ = null;
+          onChanged();
+        } else {
+          paramsWhitelistBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000080);
+        return this;
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+       */
+      public org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder getParamsWhitelistBuilder() {
+        bitField0_ |= 0x00000080;
+        onChanged();
+        return getParamsWhitelistFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+       */
+      public org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder getParamsWhitelistOrBuilder() {
+        if (paramsWhitelistBuilder_ != null) {
+          return paramsWhitelistBuilder_.getMessageOrBuilder();
+        } else {
+          return paramsWhitelist_ == null ?
+              org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance() : paramsWhitelist_;
+        }
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList params_whitelist = 9;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.mlflow.api.proto.Service.SearchRuns.WhiteList, org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder, org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder> 
+          getParamsWhitelistFieldBuilder() {
+        if (paramsWhitelistBuilder_ == null) {
+          paramsWhitelistBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              org.mlflow.api.proto.Service.SearchRuns.WhiteList, org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder, org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder>(
+                  getParamsWhitelist(),
+                  getParentForChildren(),
+                  isClean());
+          paramsWhitelist_ = null;
+        }
+        return paramsWhitelistBuilder_;
+      }
+
+      private org.mlflow.api.proto.Service.SearchRuns.WhiteList tagsWhitelist_ = null;
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.mlflow.api.proto.Service.SearchRuns.WhiteList, org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder, org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder> tagsWhitelistBuilder_;
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+       */
+      public boolean hasTagsWhitelist() {
+        return ((bitField0_ & 0x00000100) == 0x00000100);
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+       */
+      public org.mlflow.api.proto.Service.SearchRuns.WhiteList getTagsWhitelist() {
+        if (tagsWhitelistBuilder_ == null) {
+          return tagsWhitelist_ == null ? org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance() : tagsWhitelist_;
+        } else {
+          return tagsWhitelistBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+       */
+      public Builder setTagsWhitelist(org.mlflow.api.proto.Service.SearchRuns.WhiteList value) {
+        if (tagsWhitelistBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          tagsWhitelist_ = value;
+          onChanged();
+        } else {
+          tagsWhitelistBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000100;
+        return this;
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+       */
+      public Builder setTagsWhitelist(
+          org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder builderForValue) {
+        if (tagsWhitelistBuilder_ == null) {
+          tagsWhitelist_ = builderForValue.build();
+          onChanged();
+        } else {
+          tagsWhitelistBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000100;
+        return this;
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+       */
+      public Builder mergeTagsWhitelist(org.mlflow.api.proto.Service.SearchRuns.WhiteList value) {
+        if (tagsWhitelistBuilder_ == null) {
+          if (((bitField0_ & 0x00000100) == 0x00000100) &&
+              tagsWhitelist_ != null &&
+              tagsWhitelist_ != org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance()) {
+            tagsWhitelist_ =
+              org.mlflow.api.proto.Service.SearchRuns.WhiteList.newBuilder(tagsWhitelist_).mergeFrom(value).buildPartial();
+          } else {
+            tagsWhitelist_ = value;
+          }
+          onChanged();
+        } else {
+          tagsWhitelistBuilder_.mergeFrom(value);
+        }
+        bitField0_ |= 0x00000100;
+        return this;
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+       */
+      public Builder clearTagsWhitelist() {
+        if (tagsWhitelistBuilder_ == null) {
+          tagsWhitelist_ = null;
+          onChanged();
+        } else {
+          tagsWhitelistBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000100);
+        return this;
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+       */
+      public org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder getTagsWhitelistBuilder() {
+        bitField0_ |= 0x00000100;
+        onChanged();
+        return getTagsWhitelistFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+       */
+      public org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder getTagsWhitelistOrBuilder() {
+        if (tagsWhitelistBuilder_ != null) {
+          return tagsWhitelistBuilder_.getMessageOrBuilder();
+        } else {
+          return tagsWhitelist_ == null ?
+              org.mlflow.api.proto.Service.SearchRuns.WhiteList.getDefaultInstance() : tagsWhitelist_;
+        }
+      }
+      /**
+       * <code>optional .mlflow.SearchRuns.WhiteList tags_whitelist = 10;</code>
+       */
+      private com.google.protobuf.SingleFieldBuilderV3<
+          org.mlflow.api.proto.Service.SearchRuns.WhiteList, org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder, org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder> 
+          getTagsWhitelistFieldBuilder() {
+        if (tagsWhitelistBuilder_ == null) {
+          tagsWhitelistBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+              org.mlflow.api.proto.Service.SearchRuns.WhiteList, org.mlflow.api.proto.Service.SearchRuns.WhiteList.Builder, org.mlflow.api.proto.Service.SearchRuns.WhiteListOrBuilder>(
+                  getTagsWhitelist(),
+                  getParentForChildren(),
+                  isClean());
+          tagsWhitelist_ = null;
+        }
+        return tagsWhitelistBuilder_;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -46558,6 +47843,11 @@ public final class Service {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_mlflow_SearchRuns_Response_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_SearchRuns_WhiteList_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_SearchRuns_WhiteList_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mlflow_ListArtifacts_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -46687,133 +47977,138 @@ public final class Service {
       "rpc.RPC[$this.Response]\"}\n\006GetRun\022\016\n\006run" +
       "_id\030\002 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\032$\n\010Response\022" +
       "\030\n\003run\030\001 \001(\0132\013.mlflow.Run:+\342?(\n&com.data" +
-      "bricks.rpc.RPC[$this.Response]\"\230\002\n\nSearc" +
+      "bricks.rpc.RPC[$this.Response]\"\334\003\n\nSearc" +
       "hRuns\022\026\n\016experiment_ids\030\001 \003(\t\022\016\n\006filter\030" +
       "\004 \001(\t\0224\n\rrun_view_type\030\003 \001(\0162\020.mlflow.Vi" +
       "ewType:\013ACTIVE_ONLY\022\031\n\013max_results\030\005 \001(\005" +
       ":\0041000\022\020\n\010order_by\030\006 \003(\t\022\022\n\npage_token\030\007" +
-      " \001(\t\032>\n\010Response\022\031\n\004runs\030\001 \003(\0132\013.mlflow." +
-      "Run\022\027\n\017next_page_token\030\002 \001(\t:+\342?(\n&com.d" +
-      "atabricks.rpc.RPC[$this.Response]\"\253\001\n\rLi" +
-      "stArtifacts\022\016\n\006run_id\030\003 \001(\t\022\020\n\010run_uuid\030" +
-      "\001 \001(\t\022\014\n\004path\030\002 \001(\t\032=\n\010Response\022\020\n\010root_" +
-      "uri\030\001 \001(\t\022\037\n\005files\030\002 \003(\0132\020.mlflow.FileIn" +
-      "fo:+\342?(\n&com.databricks.rpc.RPC[$this.Re" +
-      "sponse]\";\n\010FileInfo\022\014\n\004path\030\001 \001(\t\022\016\n\006is_" +
-      "dir\030\002 \001(\010\022\021\n\tfile_size\030\003 \001(\003\"\250\001\n\020GetMetr" +
-      "icHistory\022\016\n\006run_id\030\003 \001(\t\022\020\n\010run_uuid\030\001 " +
-      "\001(\t\022\030\n\nmetric_key\030\002 \001(\tB\004\370\206\031\001\032+\n\010Respons" +
-      "e\022\037\n\007metrics\030\001 \003(\0132\016.mlflow.Metric:+\342?(\n" +
-      "&com.databricks.rpc.RPC[$this.Response]\"" +
-      "\261\001\n\010LogBatch\022\016\n\006run_id\030\001 \001(\t\022\037\n\007metrics\030" +
-      "\002 \003(\0132\016.mlflow.Metric\022\035\n\006params\030\003 \003(\0132\r." +
-      "mlflow.Param\022\034\n\004tags\030\004 \003(\0132\016.mlflow.RunT" +
-      "ag\032\n\n\010Response:+\342?(\n&com.databricks.rpc." +
-      "RPC[$this.Response]\"\225\001\n\023GetExperimentByN" +
-      "ame\022\035\n\017experiment_name\030\001 \001(\tB\004\370\206\031\001\0322\n\010Re" +
-      "sponse\022&\n\nexperiment\030\001 \001(\0132\022.mlflow.Expe" +
-      "riment:+\342?(\n&com.databricks.rpc.RPC[$thi" +
-      "s.Response]*6\n\010ViewType\022\017\n\013ACTIVE_ONLY\020\001" +
-      "\022\020\n\014DELETED_ONLY\020\002\022\007\n\003ALL\020\003*I\n\nSourceTyp" +
-      "e\022\014\n\010NOTEBOOK\020\001\022\007\n\003JOB\020\002\022\013\n\007PROJECT\020\003\022\t\n" +
-      "\005LOCAL\020\004\022\014\n\007UNKNOWN\020\350\007*M\n\tRunStatus\022\013\n\007R" +
-      "UNNING\020\001\022\r\n\tSCHEDULED\020\002\022\014\n\010FINISHED\020\003\022\n\n" +
-      "\006FAILED\020\004\022\n\n\006KILLED\020\0052\300\035\n\rMlflowService\022" +
-      "\246\001\n\023getExperimentByName\022\033.mlflow.GetExpe" +
-      "rimentByName\032$.mlflow.GetExperimentByNam" +
-      "e.Response\"L\362\206\031H\n,\n\003GET\022\037/mlflow/experim" +
-      "ents/get-by-name\032\004\010\002\020\000\020\001*\026Get Experiment" +
-      " By Name\022\306\001\n\020createExperiment\022\030.mlflow.C" +
-      "reateExperiment\032!.mlflow.CreateExperimen" +
-      "t.Response\"u\362\206\031q\n(\n\004POST\022\032/mlflow/experi" +
-      "ments/create\032\004\010\002\020\000\n0\n\004POST\022\"/preview/mlf" +
-      "low/experiments/create\032\004\010\002\020\000\020\001*\021Create E" +
-      "xperiment\022\274\001\n\017listExperiments\022\027.mlflow.L" +
-      "istExperiments\032 .mlflow.ListExperiments." +
-      "Response\"n\362\206\031j\n%\n\003GET\022\030/mlflow/experimen" +
-      "ts/list\032\004\010\002\020\000\n-\n\003GET\022 /preview/mlflow/ex" +
-      "periments/list\032\004\010\002\020\000\020\001*\020List Experiments" +
-      "\022\262\001\n\rgetExperiment\022\025.mlflow.GetExperimen" +
-      "t\032\036.mlflow.GetExperiment.Response\"j\362\206\031f\n" +
-      "$\n\003GET\022\027/mlflow/experiments/get\032\004\010\002\020\000\n,\n" +
-      "\003GET\022\037/preview/mlflow/experiments/get\032\004\010" +
-      "\002\020\000\020\001*\016Get Experiment\022\306\001\n\020deleteExperime" +
-      "nt\022\030.mlflow.DeleteExperiment\032!.mlflow.De" +
-      "leteExperiment.Response\"u\362\206\031q\n(\n\004POST\022\032/" +
-      "mlflow/experiments/delete\032\004\010\002\020\000\n0\n\004POST\022" +
-      "\"/preview/mlflow/experiments/delete\032\004\010\002\020" +
-      "\000\020\001*\021Delete Experiment\022\314\001\n\021restoreExperi" +
-      "ment\022\031.mlflow.RestoreExperiment\032\".mlflow" +
-      ".RestoreExperiment.Response\"x\362\206\031t\n)\n\004POS" +
-      "T\022\033/mlflow/experiments/restore\032\004\010\002\020\000\n1\n\004" +
-      "POST\022#/preview/mlflow/experiments/restor" +
-      "e\032\004\010\002\020\000\020\001*\022Restore Experiment\022\306\001\n\020update" +
-      "Experiment\022\030.mlflow.UpdateExperiment\032!.m" +
-      "lflow.UpdateExperiment.Response\"u\362\206\031q\n(\n" +
-      "\004POST\022\032/mlflow/experiments/update\032\004\010\002\020\000\n" +
-      "0\n\004POST\022\"/preview/mlflow/experiments/upd" +
-      "ate\032\004\010\002\020\000\020\001*\021Update Experiment\022\234\001\n\tcreat" +
-      "eRun\022\021.mlflow.CreateRun\032\032.mlflow.CreateR" +
-      "un.Response\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/" +
-      "create\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/ru" +
-      "ns/create\032\004\010\002\020\000\020\001*\nCreate Run\022\234\001\n\tupdate" +
-      "Run\022\021.mlflow.UpdateRun\032\032.mlflow.UpdateRu" +
-      "n.Response\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/u" +
-      "pdate\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/run" +
-      "s/update\032\004\010\002\020\000\020\001*\nUpdate Run\022\234\001\n\tdeleteR" +
-      "un\022\021.mlflow.DeleteRun\032\032.mlflow.DeleteRun" +
-      ".Response\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/de" +
-      "lete\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/runs" +
-      "/delete\032\004\010\002\020\000\020\001*\nDelete Run\022\242\001\n\nrestoreR" +
-      "un\022\022.mlflow.RestoreRun\032\033.mlflow.RestoreR" +
-      "un.Response\"c\362\206\031_\n\"\n\004POST\022\024/mlflow/runs/" +
-      "restore\032\004\010\002\020\000\n*\n\004POST\022\034/preview/mlflow/r" +
-      "uns/restore\032\004\010\002\020\000\020\001*\013Restore Run\022\244\001\n\tlog" +
-      "Metric\022\021.mlflow.LogMetric\032\032.mlflow.LogMe" +
-      "tric.Response\"h\362\206\031d\n%\n\004POST\022\027/mlflow/run" +
-      "s/log-metric\032\004\010\002\020\000\n-\n\004POST\022\037/preview/mlf" +
-      "low/runs/log-metric\032\004\010\002\020\000\020\001*\nLog Metric\022" +
-      "\246\001\n\010logParam\022\020.mlflow.LogParam\032\031.mlflow." +
-      "LogParam.Response\"m\362\206\031i\n(\n\004POST\022\032/mlflow" +
-      "/runs/log-parameter\032\004\010\002\020\000\n0\n\004POST\022\"/prev" +
-      "iew/mlflow/runs/log-parameter\032\004\010\002\020\000\020\001*\tL" +
-      "og Param\022\341\001\n\020setExperimentTag\022\030.mlflow.S" +
-      "etExperimentTag\032!.mlflow.SetExperimentTa" +
-      "g.Response\"\217\001\362\206\031\212\001\n4\n\004POST\022&/mlflow/expe" +
-      "riments/set-experiment-tag\032\004\010\002\020\000\n<\n\004POST" +
-      "\022./preview/mlflow/experiments/set-experi" +
-      "ment-tag\032\004\010\002\020\000\020\001*\022Set Experiment Tag\022\222\001\n" +
-      "\006setTag\022\016.mlflow.SetTag\032\027.mlflow.SetTag." +
-      "Response\"_\362\206\031[\n\"\n\004POST\022\024/mlflow/runs/set" +
-      "-tag\032\004\010\002\020\000\n*\n\004POST\022\034/preview/mlflow/runs" +
-      "/set-tag\032\004\010\002\020\000\020\001*\007Set Tag\022\244\001\n\tdeleteTag\022" +
-      "\021.mlflow.DeleteTag\032\032.mlflow.DeleteTag.Re" +
-      "sponse\"h\362\206\031d\n%\n\004POST\022\027/mlflow/runs/delet" +
-      "e-tag\032\004\010\002\020\000\n-\n\004POST\022\037/preview/mlflow/run" +
-      "s/delete-tag\032\004\010\002\020\000\020\001*\nDelete Tag\022\210\001\n\006get" +
-      "Run\022\016.mlflow.GetRun\032\027.mlflow.GetRun.Resp" +
-      "onse\"U\362\206\031Q\n\035\n\003GET\022\020/mlflow/runs/get\032\004\010\002\020" +
-      "\000\n%\n\003GET\022\030/preview/mlflow/runs/get\032\004\010\002\020\000" +
-      "\020\001*\007Get Run\022\314\001\n\nsearchRuns\022\022.mlflow.Sear" +
-      "chRuns\032\033.mlflow.SearchRuns.Response\"\214\001\362\206" +
-      "\031\207\001\n!\n\004POST\022\023/mlflow/runs/search\032\004\010\002\020\000\n)" +
-      "\n\004POST\022\033/preview/mlflow/runs/search\032\004\010\002\020" +
-      "\000\n(\n\003GET\022\033/preview/mlflow/runs/search\032\004\010" +
-      "\002\020\000\020\001*\013Search Runs\022\260\001\n\rlistArtifacts\022\025.m" +
-      "lflow.ListArtifacts\032\036.mlflow.ListArtifac" +
-      "ts.Response\"h\362\206\031d\n#\n\003GET\022\026/mlflow/artifa" +
-      "cts/list\032\004\010\002\020\000\n+\n\003GET\022\036/preview/mlflow/a" +
-      "rtifacts/list\032\004\010\002\020\000\020\001*\016List Artifacts\022\307\001" +
-      "\n\020getMetricHistory\022\030.mlflow.GetMetricHis" +
-      "tory\032!.mlflow.GetMetricHistory.Response\"" +
-      "v\362\206\031r\n(\n\003GET\022\033/mlflow/metrics/get-histor" +
-      "y\032\004\010\002\020\000\n0\n\003GET\022#/preview/mlflow/metrics/" +
-      "get-history\032\004\010\002\020\000\020\001*\022Get Metric History\022" +
-      "\236\001\n\010logBatch\022\020.mlflow.LogBatch\032\031.mlflow." +
-      "LogBatch.Response\"e\362\206\031a\n$\n\004POST\022\026/mlflow" +
-      "/runs/log-batch\032\004\010\002\020\000\n,\n\004POST\022\036/preview/" +
-      "mlflow/runs/log-batch\032\004\010\002\020\000\020\001*\tLog Batch" +
-      "B\036\n\024org.mlflow.api.proto\220\001\001\342?\002\020\001"
+      " \001(\t\0227\n\021metrics_whitelist\030\010 \001(\0132\034.mlflow" +
+      ".SearchRuns.WhiteList\0226\n\020params_whitelis" +
+      "t\030\t \001(\0132\034.mlflow.SearchRuns.WhiteList\0224\n" +
+      "\016tags_whitelist\030\n \001(\0132\034.mlflow.SearchRun" +
+      "s.WhiteList\032>\n\010Response\022\031\n\004runs\030\001 \003(\0132\013." +
+      "mlflow.Run\022\027\n\017next_page_token\030\002 \001(\t\032\033\n\tW" +
+      "hiteList\022\016\n\006fields\030\001 \003(\t:+\342?(\n&com.datab" +
+      "ricks.rpc.RPC[$this.Response]\"\253\001\n\rListAr" +
+      "tifacts\022\016\n\006run_id\030\003 \001(\t\022\020\n\010run_uuid\030\001 \001(" +
+      "\t\022\014\n\004path\030\002 \001(\t\032=\n\010Response\022\020\n\010root_uri\030" +
+      "\001 \001(\t\022\037\n\005files\030\002 \003(\0132\020.mlflow.FileInfo:+" +
+      "\342?(\n&com.databricks.rpc.RPC[$this.Respon" +
+      "se]\";\n\010FileInfo\022\014\n\004path\030\001 \001(\t\022\016\n\006is_dir\030" +
+      "\002 \001(\010\022\021\n\tfile_size\030\003 \001(\003\"\250\001\n\020GetMetricHi" +
+      "story\022\016\n\006run_id\030\003 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022" +
+      "\030\n\nmetric_key\030\002 \001(\tB\004\370\206\031\001\032+\n\010Response\022\037\n" +
+      "\007metrics\030\001 \003(\0132\016.mlflow.Metric:+\342?(\n&com" +
+      ".databricks.rpc.RPC[$this.Response]\"\261\001\n\010" +
+      "LogBatch\022\016\n\006run_id\030\001 \001(\t\022\037\n\007metrics\030\002 \003(" +
+      "\0132\016.mlflow.Metric\022\035\n\006params\030\003 \003(\0132\r.mlfl" +
+      "ow.Param\022\034\n\004tags\030\004 \003(\0132\016.mlflow.RunTag\032\n" +
+      "\n\010Response:+\342?(\n&com.databricks.rpc.RPC[" +
+      "$this.Response]\"\225\001\n\023GetExperimentByName\022" +
+      "\035\n\017experiment_name\030\001 \001(\tB\004\370\206\031\001\0322\n\010Respon" +
+      "se\022&\n\nexperiment\030\001 \001(\0132\022.mlflow.Experime" +
+      "nt:+\342?(\n&com.databricks.rpc.RPC[$this.Re" +
+      "sponse]*6\n\010ViewType\022\017\n\013ACTIVE_ONLY\020\001\022\020\n\014" +
+      "DELETED_ONLY\020\002\022\007\n\003ALL\020\003*I\n\nSourceType\022\014\n" +
+      "\010NOTEBOOK\020\001\022\007\n\003JOB\020\002\022\013\n\007PROJECT\020\003\022\t\n\005LOC" +
+      "AL\020\004\022\014\n\007UNKNOWN\020\350\007*M\n\tRunStatus\022\013\n\007RUNNI" +
+      "NG\020\001\022\r\n\tSCHEDULED\020\002\022\014\n\010FINISHED\020\003\022\n\n\006FAI" +
+      "LED\020\004\022\n\n\006KILLED\020\0052\300\035\n\rMlflowService\022\246\001\n\023" +
+      "getExperimentByName\022\033.mlflow.GetExperime" +
+      "ntByName\032$.mlflow.GetExperimentByName.Re" +
+      "sponse\"L\362\206\031H\n,\n\003GET\022\037/mlflow/experiments" +
+      "/get-by-name\032\004\010\002\020\000\020\001*\026Get Experiment By " +
+      "Name\022\306\001\n\020createExperiment\022\030.mlflow.Creat" +
+      "eExperiment\032!.mlflow.CreateExperiment.Re" +
+      "sponse\"u\362\206\031q\n(\n\004POST\022\032/mlflow/experiment" +
+      "s/create\032\004\010\002\020\000\n0\n\004POST\022\"/preview/mlflow/" +
+      "experiments/create\032\004\010\002\020\000\020\001*\021Create Exper" +
+      "iment\022\274\001\n\017listExperiments\022\027.mlflow.ListE" +
+      "xperiments\032 .mlflow.ListExperiments.Resp" +
+      "onse\"n\362\206\031j\n%\n\003GET\022\030/mlflow/experiments/l" +
+      "ist\032\004\010\002\020\000\n-\n\003GET\022 /preview/mlflow/experi" +
+      "ments/list\032\004\010\002\020\000\020\001*\020List Experiments\022\262\001\n" +
+      "\rgetExperiment\022\025.mlflow.GetExperiment\032\036." +
+      "mlflow.GetExperiment.Response\"j\362\206\031f\n$\n\003G" +
+      "ET\022\027/mlflow/experiments/get\032\004\010\002\020\000\n,\n\003GET" +
+      "\022\037/preview/mlflow/experiments/get\032\004\010\002\020\000\020" +
+      "\001*\016Get Experiment\022\306\001\n\020deleteExperiment\022\030" +
+      ".mlflow.DeleteExperiment\032!.mlflow.Delete" +
+      "Experiment.Response\"u\362\206\031q\n(\n\004POST\022\032/mlfl" +
+      "ow/experiments/delete\032\004\010\002\020\000\n0\n\004POST\022\"/pr" +
+      "eview/mlflow/experiments/delete\032\004\010\002\020\000\020\001*" +
+      "\021Delete Experiment\022\314\001\n\021restoreExperiment" +
+      "\022\031.mlflow.RestoreExperiment\032\".mlflow.Res" +
+      "toreExperiment.Response\"x\362\206\031t\n)\n\004POST\022\033/" +
+      "mlflow/experiments/restore\032\004\010\002\020\000\n1\n\004POST" +
+      "\022#/preview/mlflow/experiments/restore\032\004\010" +
+      "\002\020\000\020\001*\022Restore Experiment\022\306\001\n\020updateExpe" +
+      "riment\022\030.mlflow.UpdateExperiment\032!.mlflo" +
+      "w.UpdateExperiment.Response\"u\362\206\031q\n(\n\004POS" +
+      "T\022\032/mlflow/experiments/update\032\004\010\002\020\000\n0\n\004P" +
+      "OST\022\"/preview/mlflow/experiments/update\032" +
+      "\004\010\002\020\000\020\001*\021Update Experiment\022\234\001\n\tcreateRun" +
+      "\022\021.mlflow.CreateRun\032\032.mlflow.CreateRun.R" +
+      "esponse\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/crea" +
+      "te\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/runs/c" +
+      "reate\032\004\010\002\020\000\020\001*\nCreate Run\022\234\001\n\tupdateRun\022" +
+      "\021.mlflow.UpdateRun\032\032.mlflow.UpdateRun.Re" +
+      "sponse\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/updat" +
+      "e\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/runs/up" +
+      "date\032\004\010\002\020\000\020\001*\nUpdate Run\022\234\001\n\tdeleteRun\022\021" +
+      ".mlflow.DeleteRun\032\032.mlflow.DeleteRun.Res" +
+      "ponse\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/delete" +
+      "\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/runs/del" +
+      "ete\032\004\010\002\020\000\020\001*\nDelete Run\022\242\001\n\nrestoreRun\022\022" +
+      ".mlflow.RestoreRun\032\033.mlflow.RestoreRun.R" +
+      "esponse\"c\362\206\031_\n\"\n\004POST\022\024/mlflow/runs/rest" +
+      "ore\032\004\010\002\020\000\n*\n\004POST\022\034/preview/mlflow/runs/" +
+      "restore\032\004\010\002\020\000\020\001*\013Restore Run\022\244\001\n\tlogMetr" +
+      "ic\022\021.mlflow.LogMetric\032\032.mlflow.LogMetric" +
+      ".Response\"h\362\206\031d\n%\n\004POST\022\027/mlflow/runs/lo" +
+      "g-metric\032\004\010\002\020\000\n-\n\004POST\022\037/preview/mlflow/" +
+      "runs/log-metric\032\004\010\002\020\000\020\001*\nLog Metric\022\246\001\n\010" +
+      "logParam\022\020.mlflow.LogParam\032\031.mlflow.LogP" +
+      "aram.Response\"m\362\206\031i\n(\n\004POST\022\032/mlflow/run" +
+      "s/log-parameter\032\004\010\002\020\000\n0\n\004POST\022\"/preview/" +
+      "mlflow/runs/log-parameter\032\004\010\002\020\000\020\001*\tLog P" +
+      "aram\022\341\001\n\020setExperimentTag\022\030.mlflow.SetEx" +
+      "perimentTag\032!.mlflow.SetExperimentTag.Re" +
+      "sponse\"\217\001\362\206\031\212\001\n4\n\004POST\022&/mlflow/experime" +
+      "nts/set-experiment-tag\032\004\010\002\020\000\n<\n\004POST\022./p" +
+      "review/mlflow/experiments/set-experiment" +
+      "-tag\032\004\010\002\020\000\020\001*\022Set Experiment Tag\022\222\001\n\006set" +
+      "Tag\022\016.mlflow.SetTag\032\027.mlflow.SetTag.Resp" +
+      "onse\"_\362\206\031[\n\"\n\004POST\022\024/mlflow/runs/set-tag" +
+      "\032\004\010\002\020\000\n*\n\004POST\022\034/preview/mlflow/runs/set" +
+      "-tag\032\004\010\002\020\000\020\001*\007Set Tag\022\244\001\n\tdeleteTag\022\021.ml" +
+      "flow.DeleteTag\032\032.mlflow.DeleteTag.Respon" +
+      "se\"h\362\206\031d\n%\n\004POST\022\027/mlflow/runs/delete-ta" +
+      "g\032\004\010\002\020\000\n-\n\004POST\022\037/preview/mlflow/runs/de" +
+      "lete-tag\032\004\010\002\020\000\020\001*\nDelete Tag\022\210\001\n\006getRun\022" +
+      "\016.mlflow.GetRun\032\027.mlflow.GetRun.Response" +
+      "\"U\362\206\031Q\n\035\n\003GET\022\020/mlflow/runs/get\032\004\010\002\020\000\n%\n" +
+      "\003GET\022\030/preview/mlflow/runs/get\032\004\010\002\020\000\020\001*\007" +
+      "Get Run\022\314\001\n\nsearchRuns\022\022.mlflow.SearchRu" +
+      "ns\032\033.mlflow.SearchRuns.Response\"\214\001\362\206\031\207\001\n" +
+      "!\n\004POST\022\023/mlflow/runs/search\032\004\010\002\020\000\n)\n\004PO" +
+      "ST\022\033/preview/mlflow/runs/search\032\004\010\002\020\000\n(\n" +
+      "\003GET\022\033/preview/mlflow/runs/search\032\004\010\002\020\000\020" +
+      "\001*\013Search Runs\022\260\001\n\rlistArtifacts\022\025.mlflo" +
+      "w.ListArtifacts\032\036.mlflow.ListArtifacts.R" +
+      "esponse\"h\362\206\031d\n#\n\003GET\022\026/mlflow/artifacts/" +
+      "list\032\004\010\002\020\000\n+\n\003GET\022\036/preview/mlflow/artif" +
+      "acts/list\032\004\010\002\020\000\020\001*\016List Artifacts\022\307\001\n\020ge" +
+      "tMetricHistory\022\030.mlflow.GetMetricHistory" +
+      "\032!.mlflow.GetMetricHistory.Response\"v\362\206\031" +
+      "r\n(\n\003GET\022\033/mlflow/metrics/get-history\032\004\010" +
+      "\002\020\000\n0\n\003GET\022#/preview/mlflow/metrics/get-" +
+      "history\032\004\010\002\020\000\020\001*\022Get Metric History\022\236\001\n\010" +
+      "logBatch\022\020.mlflow.LogBatch\032\031.mlflow.LogB" +
+      "atch.Response\"e\362\206\031a\n$\n\004POST\022\026/mlflow/run" +
+      "s/log-batch\032\004\010\002\020\000\n,\n\004POST\022\036/preview/mlfl" +
+      "ow/runs/log-batch\032\004\010\002\020\000\020\001*\tLog BatchB\036\n\024" +
+      "org.mlflow.api.proto\220\001\001\342?\002\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -47074,13 +48369,19 @@ public final class Service {
     internal_static_mlflow_SearchRuns_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_SearchRuns_descriptor,
-        new java.lang.String[] { "ExperimentIds", "Filter", "RunViewType", "MaxResults", "OrderBy", "PageToken", });
+        new java.lang.String[] { "ExperimentIds", "Filter", "RunViewType", "MaxResults", "OrderBy", "PageToken", "MetricsWhitelist", "ParamsWhitelist", "TagsWhitelist", });
     internal_static_mlflow_SearchRuns_Response_descriptor =
       internal_static_mlflow_SearchRuns_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_SearchRuns_Response_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_SearchRuns_Response_descriptor,
         new java.lang.String[] { "Runs", "NextPageToken", });
+    internal_static_mlflow_SearchRuns_WhiteList_descriptor =
+      internal_static_mlflow_SearchRuns_descriptor.getNestedTypes().get(1);
+    internal_static_mlflow_SearchRuns_WhiteList_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_SearchRuns_WhiteList_descriptor,
+        new java.lang.String[] { "Fields", });
     internal_static_mlflow_ListArtifacts_descriptor =
       getDescriptor().getMessageTypes().get(25);
     internal_static_mlflow_ListArtifacts_fieldAccessorTable = new

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -934,10 +934,22 @@ message SearchRuns {
 
   optional string page_token = 7;
 
+  // These metrics, params and tags whitelist limit the fields returned by the search runs query
+  // A None whitelist will select all the fields
+  optional WhiteList metrics_whitelist = 8;
+  optional WhiteList params_whitelist = 9;
+  optional WhiteList tags_whitelist = 10;
+
   message Response {
     // Runs that match the search criteria.
     repeated Run runs = 1;
     optional string next_page_token = 2;
+  }
+
+  // this whitelist message exists to be able to have an optional whitelist :
+  // no whitelist = all fields are available
+  message WhiteList  {
+    repeated string fields = 1;
   }
 }
 

--- a/mlflow/protos/service_pb2.py
+++ b/mlflow/protos/service_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\024org.mlflow.api.proto\220\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"H\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x04step\x18\x04 \x01(\x03:\x01\x30\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"+\n\rExperimentTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xcb\x01\n\x07RunInfo\x12\x0e\n\x06run_id\x18\x0f \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\xbb\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\x12#\n\x04tags\x18\x07 \x03(\x0b\x32\x15.mlflow.ExperimentTag\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x01\n\x0fListExperiments\x12#\n\tview_type\x18\x01 \x01(\x0e\x32\x10.mlflow.ViewType\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb0\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1aU\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12!\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfoB\x02\x18\x01:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x10UpdateExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xbe\x01\n\tUpdateRun\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tLogMetric\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\xf8\x86\x19\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\xf8\x86\x19\x01\x12\x0f\n\x04step\x18\x05 \x01(\x03:\x01\x30\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8d\x01\n\x08LogParam\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x90\x01\n\x10SetExperimentTag\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8b\x01\n\x06SetTag\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"m\n\tDeleteTag\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"}\n\x06GetRun\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x02\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\t\x12\x0e\n\x06\x66ilter\x18\x04 \x01(\t\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x12\x19\n\x0bmax_results\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12\x10\n\x08order_by\x18\x06 \x03(\t\x12\x12\n\npage_token\x18\x07 \x01(\t\x1a>\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xab\x01\n\rListArtifacts\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"\xa8\x01\n\x10GetMetricHistory\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb1\x01\n\x08LogBatch\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x1f\n\x07metrics\x18\x02 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x03 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x04 \x03(\x0b\x32\x0e.mlflow.RunTag\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x95\x01\n\x13GetExperimentByName\x12\x1d\n\x0f\x65xperiment_name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x32\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\xc0\x1d\n\rMlflowService\x12\xa6\x01\n\x13getExperimentByName\x12\x1b.mlflow.GetExperimentByName\x1a$.mlflow.GetExperimentByName.Response\"L\xf2\x86\x19H\n,\n\x03GET\x12\x1f/mlflow/experiments/get-by-name\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Get Experiment By Name\x12\xc6\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\xbc\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"n\xf2\x86\x19j\n%\n\x03GET\x12\x18/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\xb2\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"j\xf2\x86\x19\x66\n$\n\x03GET\x12\x17/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\xc6\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\xcc\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"x\xf2\x86\x19t\n)\n\x04POST\x12\x1b/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\n1\n\x04POST\x12#/preview/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12\xc6\x01\n\x10updateExperiment\x12\x18.mlflow.UpdateExperiment\x1a!.mlflow.UpdateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x11Update Experiment\x12\x9c\x01\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12\x9c\x01\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12\x9c\x01\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Run\x12\xa2\x01\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"c\xf2\x86\x19_\n\"\n\x04POST\x12\x14/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bRestore Run\x12\xa4\x01\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"h\xf2\x86\x19\x64\n%\n\x04POST\x12\x17/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12\xa6\x01\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"m\xf2\x86\x19i\n(\n\x04POST\x12\x1a/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12\xe1\x01\n\x10setExperimentTag\x12\x18.mlflow.SetExperimentTag\x1a!.mlflow.SetExperimentTag.Response\"\x8f\x01\xf2\x86\x19\x8a\x01\n4\n\x04POST\x12&/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\n<\n\x04POST\x12./preview/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Set Experiment Tag\x12\x92\x01\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\"_\xf2\x86\x19[\n\"\n\x04POST\x12\x14/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12\xa4\x01\n\tdeleteTag\x12\x11.mlflow.DeleteTag\x1a\x1a.mlflow.DeleteTag.Response\"h\xf2\x86\x19\x64\n%\n\x04POST\x12\x17/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\n-\n\x04POST\x12\x1f/preview/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Tag\x12\x88\x01\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"U\xf2\x86\x19Q\n\x1d\n\x03GET\x12\x10/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12\xcc\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"\x8c\x01\xf2\x86\x19\x87\x01\n!\n\x04POST\x12\x13/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\xb0\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"h\xf2\x86\x19\x64\n#\n\x03GET\x12\x16/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\xc7\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"v\xf2\x86\x19r\n(\n\x03GET\x12\x1b/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric History\x12\x9e\x01\n\x08logBatch\x12\x10.mlflow.LogBatch\x1a\x19.mlflow.LogBatch.Response\"e\xf2\x86\x19\x61\n$\n\x04POST\x12\x16/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\n,\n\x04POST\x12\x1e/preview/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog BatchB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"H\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x04step\x18\x04 \x01(\x03:\x01\x30\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"+\n\rExperimentTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xcb\x01\n\x07RunInfo\x12\x0e\n\x06run_id\x18\x0f \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\xbb\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\x12#\n\x04tags\x18\x07 \x03(\x0b\x32\x15.mlflow.ExperimentTag\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x01\n\x0fListExperiments\x12#\n\tview_type\x18\x01 \x01(\x0e\x32\x10.mlflow.ViewType\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb0\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1aU\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12!\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfoB\x02\x18\x01:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x10UpdateExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xbe\x01\n\tUpdateRun\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tLogMetric\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\xf8\x86\x19\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\xf8\x86\x19\x01\x12\x0f\n\x04step\x18\x05 \x01(\x03:\x01\x30\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8d\x01\n\x08LogParam\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x90\x01\n\x10SetExperimentTag\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8b\x01\n\x06SetTag\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"m\n\tDeleteTag\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"}\n\x06GetRun\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xdc\x03\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\t\x12\x0e\n\x06\x66ilter\x18\x04 \x01(\t\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x12\x19\n\x0bmax_results\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12\x10\n\x08order_by\x18\x06 \x03(\t\x12\x12\n\npage_token\x18\x07 \x01(\t\x12\x37\n\x11metrics_whitelist\x18\x08 \x01(\x0b\x32\x1c.mlflow.SearchRuns.WhiteList\x12\x36\n\x10params_whitelist\x18\t \x01(\x0b\x32\x1c.mlflow.SearchRuns.WhiteList\x12\x34\n\x0etags_whitelist\x18\n \x01(\x0b\x32\x1c.mlflow.SearchRuns.WhiteList\x1a>\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t\x1a\x1b\n\tWhiteList\x12\x0e\n\x06\x66ields\x18\x01 \x03(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xab\x01\n\rListArtifacts\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"\xa8\x01\n\x10GetMetricHistory\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb1\x01\n\x08LogBatch\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x1f\n\x07metrics\x18\x02 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x03 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x04 \x03(\x0b\x32\x0e.mlflow.RunTag\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x95\x01\n\x13GetExperimentByName\x12\x1d\n\x0f\x65xperiment_name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x32\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\xc0\x1d\n\rMlflowService\x12\xa6\x01\n\x13getExperimentByName\x12\x1b.mlflow.GetExperimentByName\x1a$.mlflow.GetExperimentByName.Response\"L\xf2\x86\x19H\n,\n\x03GET\x12\x1f/mlflow/experiments/get-by-name\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Get Experiment By Name\x12\xc6\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\xbc\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"n\xf2\x86\x19j\n%\n\x03GET\x12\x18/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\xb2\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"j\xf2\x86\x19\x66\n$\n\x03GET\x12\x17/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\xc6\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\xcc\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"x\xf2\x86\x19t\n)\n\x04POST\x12\x1b/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\n1\n\x04POST\x12#/preview/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12\xc6\x01\n\x10updateExperiment\x12\x18.mlflow.UpdateExperiment\x1a!.mlflow.UpdateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x11Update Experiment\x12\x9c\x01\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12\x9c\x01\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12\x9c\x01\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Run\x12\xa2\x01\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"c\xf2\x86\x19_\n\"\n\x04POST\x12\x14/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bRestore Run\x12\xa4\x01\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"h\xf2\x86\x19\x64\n%\n\x04POST\x12\x17/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12\xa6\x01\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"m\xf2\x86\x19i\n(\n\x04POST\x12\x1a/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12\xe1\x01\n\x10setExperimentTag\x12\x18.mlflow.SetExperimentTag\x1a!.mlflow.SetExperimentTag.Response\"\x8f\x01\xf2\x86\x19\x8a\x01\n4\n\x04POST\x12&/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\n<\n\x04POST\x12./preview/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Set Experiment Tag\x12\x92\x01\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\"_\xf2\x86\x19[\n\"\n\x04POST\x12\x14/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12\xa4\x01\n\tdeleteTag\x12\x11.mlflow.DeleteTag\x1a\x1a.mlflow.DeleteTag.Response\"h\xf2\x86\x19\x64\n%\n\x04POST\x12\x17/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\n-\n\x04POST\x12\x1f/preview/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Tag\x12\x88\x01\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"U\xf2\x86\x19Q\n\x1d\n\x03GET\x12\x10/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12\xcc\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"\x8c\x01\xf2\x86\x19\x87\x01\n!\n\x04POST\x12\x13/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\xb0\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"h\xf2\x86\x19\x64\n#\n\x03GET\x12\x16/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\xc7\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"v\xf2\x86\x19r\n(\n\x03GET\x12\x1b/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric History\x12\x9e\x01\n\x08logBatch\x12\x10.mlflow.LogBatch\x1a\x19.mlflow.LogBatch.Response\"e\xf2\x86\x19\x61\n$\n\x04POST\x12\x16/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\n,\n\x04POST\x12\x1e/preview/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog BatchB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -49,8 +49,8 @@ _VIEWTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4093,
-  serialized_end=4147,
+  serialized_start=4289,
+  serialized_end=4343,
 )
 _sym_db.RegisterEnumDescriptor(_VIEWTYPE)
 
@@ -84,8 +84,8 @@ _SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4149,
-  serialized_end=4222,
+  serialized_start=4345,
+  serialized_end=4418,
 )
 _sym_db.RegisterEnumDescriptor(_SOURCETYPE)
 
@@ -119,8 +119,8 @@ _RUNSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4224,
-  serialized_end=4301,
+  serialized_start=4420,
+  serialized_end=4497,
 )
 _sym_db.RegisterEnumDescriptor(_RUNSTATUS)
 
@@ -1657,8 +1657,38 @@ _SEARCHRUNS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3246,
-  serialized_end=3308,
+  serialized_start=3413,
+  serialized_end=3475,
+)
+
+_SEARCHRUNS_WHITELIST = _descriptor.Descriptor(
+  name='WhiteList',
+  full_name='mlflow.SearchRuns.WhiteList',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='fields', full_name='mlflow.SearchRuns.WhiteList.fields', index=0,
+      number=1, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto2',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3477,
+  serialized_end=3504,
 )
 
 _SEARCHRUNS = _descriptor.Descriptor(
@@ -1710,10 +1740,31 @@ _SEARCHRUNS = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='metrics_whitelist', full_name='mlflow.SearchRuns.metrics_whitelist', index=6,
+      number=8, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='params_whitelist', full_name='mlflow.SearchRuns.params_whitelist', index=7,
+      number=9, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='tags_whitelist', full_name='mlflow.SearchRuns.tags_whitelist', index=8,
+      number=10, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
-  nested_types=[_SEARCHRUNS_RESPONSE, ],
+  nested_types=[_SEARCHRUNS_RESPONSE, _SEARCHRUNS_WHITELIST, ],
   enum_types=[
   ],
   serialized_options=_b('\342?(\n&com.databricks.rpc.RPC[$this.Response]'),
@@ -1723,7 +1774,7 @@ _SEARCHRUNS = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=3073,
-  serialized_end=3353,
+  serialized_end=3549,
 )
 
 
@@ -1760,8 +1811,8 @@ _LISTARTIFACTS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3421,
-  serialized_end=3482,
+  serialized_start=3617,
+  serialized_end=3678,
 )
 
 _LISTARTIFACTS = _descriptor.Descriptor(
@@ -1804,8 +1855,8 @@ _LISTARTIFACTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3356,
-  serialized_end=3527,
+  serialized_start=3552,
+  serialized_end=3723,
 )
 
 
@@ -1849,8 +1900,8 @@ _FILEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3529,
-  serialized_end=3588,
+  serialized_start=3725,
+  serialized_end=3784,
 )
 
 
@@ -1880,8 +1931,8 @@ _GETMETRICHISTORY_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3671,
-  serialized_end=3714,
+  serialized_start=3867,
+  serialized_end=3910,
 )
 
 _GETMETRICHISTORY = _descriptor.Descriptor(
@@ -1924,8 +1975,8 @@ _GETMETRICHISTORY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3591,
-  serialized_end=3759,
+  serialized_start=3787,
+  serialized_end=3955,
 )
 
 
@@ -1999,8 +2050,8 @@ _LOGBATCH = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3762,
-  serialized_end=3939,
+  serialized_start=3958,
+  serialized_end=4135,
 )
 
 
@@ -2060,8 +2111,8 @@ _GETEXPERIMENTBYNAME = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3942,
-  serialized_end=4091,
+  serialized_start=4138,
+  serialized_end=4287,
 )
 
 _RUN.fields_by_name['info'].message_type = _RUNINFO
@@ -2098,7 +2149,11 @@ _GETRUN_RESPONSE.fields_by_name['run'].message_type = _RUN
 _GETRUN_RESPONSE.containing_type = _GETRUN
 _SEARCHRUNS_RESPONSE.fields_by_name['runs'].message_type = _RUN
 _SEARCHRUNS_RESPONSE.containing_type = _SEARCHRUNS
+_SEARCHRUNS_WHITELIST.containing_type = _SEARCHRUNS
 _SEARCHRUNS.fields_by_name['run_view_type'].enum_type = _VIEWTYPE
+_SEARCHRUNS.fields_by_name['metrics_whitelist'].message_type = _SEARCHRUNS_WHITELIST
+_SEARCHRUNS.fields_by_name['params_whitelist'].message_type = _SEARCHRUNS_WHITELIST
+_SEARCHRUNS.fields_by_name['tags_whitelist'].message_type = _SEARCHRUNS_WHITELIST
 _LISTARTIFACTS_RESPONSE.fields_by_name['files'].message_type = _FILEINFO
 _LISTARTIFACTS_RESPONSE.containing_type = _LISTARTIFACTS
 _GETMETRICHISTORY_RESPONSE.fields_by_name['metrics'].message_type = _METRIC
@@ -2448,12 +2503,20 @@ SearchRuns = _reflection.GeneratedProtocolMessageType('SearchRuns', (_message.Me
     # @@protoc_insertion_point(class_scope:mlflow.SearchRuns.Response)
     ))
   ,
+
+  WhiteList = _reflection.GeneratedProtocolMessageType('WhiteList', (_message.Message,), dict(
+    DESCRIPTOR = _SEARCHRUNS_WHITELIST,
+    __module__ = 'service_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.SearchRuns.WhiteList)
+    ))
+  ,
   DESCRIPTOR = _SEARCHRUNS,
   __module__ = 'service_pb2'
   # @@protoc_insertion_point(class_scope:mlflow.SearchRuns)
   ))
 _sym_db.RegisterMessage(SearchRuns)
 _sym_db.RegisterMessage(SearchRuns.Response)
+_sym_db.RegisterMessage(SearchRuns.WhiteList)
 
 ListArtifacts = _reflection.GeneratedProtocolMessageType('ListArtifacts', (_message.Message,), dict(
 
@@ -2574,8 +2637,8 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=4304,
-  serialized_end=8080,
+  serialized_start=4500,
+  serialized_end=8276,
   methods=[
   _descriptor.MethodDescriptor(
     name='getExperimentByName',

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -371,8 +371,16 @@ def _search_runs():
     experiment_ids = request_message.experiment_ids
     order_by = request_message.order_by
     page_token = request_message.page_token
+    metrics_whitelist = request_message.metrics_whitelist.fields\
+        if request_message.HasField("metrics_whitelist") else None
+    params_whitelist = request_message.params_whitelist.fields\
+        if request_message.HasField("params_whitelist") else None
+    tags_whitelist = request_message.tags_whitelist.fields\
+        if request_message.HasField("tags_whitelist") else None
     run_entities = _get_tracking_store().search_runs(experiment_ids, filter_string, run_view_type,
-                                                     max_results, order_by, page_token)
+                                                     max_results, order_by, page_token,
+                                                     metrics_whitelist, params_whitelist,
+                                                     tags_whitelist)
     response_message.runs.extend([r.to_proto() for r in run_entities])
     if run_entities.token:
         response_message.next_page_token = run_entities.token

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -206,7 +206,8 @@ class AbstractStore:
         pass
 
     def search_runs(self, experiment_ids, filter_string, run_view_type,
-                    max_results=SEARCH_MAX_RESULTS_DEFAULT, order_by=None, page_token=None):
+                    max_results=SEARCH_MAX_RESULTS_DEFAULT, order_by=None, page_token=None,
+                    metrics_whitelist=None, params_whitelist=None, tags_whitelist=None):
         """
         Return runs that match the given list of search expressions within the experiments.
 
@@ -219,6 +220,9 @@ class AbstractStore:
         :param order_by: List of order_by clauses.
         :param page_token: Token specifying the next page of results. It should be obtained from
             a ``search_runs`` call.
+        :param metrics_whitelist: white list of metrics, default to all (None)
+        :param params_whitelist: white list of params, default to all (None)
+        :param tags_whitelist: white list of tags, default to all (None)
 
         :return: A list of :py:class:`mlflow.entities.Run` objects that satisfy the search
             expressions. The pagination token for the next page can be obtained via the ``token``
@@ -226,12 +230,13 @@ class AbstractStore:
             and thus the returned token would not be meaningful in such cases.
         """
         runs, token = self._search_runs(experiment_ids, filter_string, run_view_type, max_results,
-                                        order_by, page_token)
+                                        order_by, page_token,
+                                        metrics_whitelist, params_whitelist, tags_whitelist)
         return PagedList(runs, token)
 
     @abstractmethod
     def _search_runs(self, experiment_ids, filter_string, run_view_type, max_results, order_by,
-                     page_token):
+                     page_token, metrics_whitelist, params_whitelist, tags_whitelist):
         """
         Return runs that match the given list of search expressions within the experiments, as
         well as a pagination token (indicating where the next page should start). Subclasses of

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -188,14 +188,17 @@ class RestStore(AbstractStore):
         return [Metric.from_proto(metric) for metric in response_proto.metrics]
 
     def _search_runs(self, experiment_ids, filter_string, run_view_type, max_results, order_by,
-                     page_token):
+                     page_token, metrics_whitelist, params_whitelist, tags_whitelist):
         experiment_ids = [str(experiment_id) for experiment_id in experiment_ids]
         sr = SearchRuns(experiment_ids=experiment_ids,
                         filter=filter_string,
                         run_view_type=ViewType.to_proto(run_view_type),
                         max_results=max_results,
                         order_by=order_by,
-                        page_token=page_token)
+                        page_token=page_token,
+                        metrics_whitelist=metrics_whitelist,
+                        params_whitelist=params_whitelist,
+                        tags_whitelist=tags_whitelist)
         req_body = message_to_json(sr)
         response_proto = self._call_endpoint(SearchRuns, req_body)
         runs = [Run.from_proto(proto_run) for proto_run in response_proto.runs]

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -315,7 +315,8 @@ class TrackingServiceClient(object):
         self.store.restore_run(run_id)
 
     def search_runs(self, experiment_ids, filter_string="", run_view_type=ViewType.ACTIVE_ONLY,
-                    max_results=SEARCH_MAX_RESULTS_DEFAULT, order_by=None, page_token=None):
+                    max_results=SEARCH_MAX_RESULTS_DEFAULT, order_by=None, page_token=None,
+                    metrics_whitelist=None, params_whitelist=None, tags_whitelist=None):
         """
         Search experiments that fit the search criteria.
 
@@ -329,6 +330,9 @@ class TrackingServiceClient(object):
                      The default ordering is to sort by ``start_time DESC``, then ``run_id``.
         :param page_token: Token specifying the next page of results. It should be obtained from
             a ``search_runs`` call.
+        :param metrics_whitelist: white list of metrics, default to all (None)
+        :param params_whitelist: white list of params, default to all (None)
+        :param tags_whitelist: white list of tags, default to all (None)
 
         :return: A list of :py:class:`mlflow.entities.Run` objects that satisfy the search
             expressions. If the underlying tracking store supports pagination, the token for
@@ -338,4 +342,7 @@ class TrackingServiceClient(object):
             experiment_ids = [experiment_ids]
         return self.store.search_runs(experiment_ids=experiment_ids, filter_string=filter_string,
                                       run_view_type=run_view_type, max_results=max_results,
-                                      order_by=order_by, page_token=page_token)
+                                      order_by=order_by, page_token=page_token,
+                                      metrics_whitelist=metrics_whitelist,
+                                      params_whitelist=params_whitelist,
+                                      tags_whitelist=tags_whitelist)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -307,7 +307,8 @@ class MlflowClient(object):
         self._tracking_client.restore_run(run_id)
 
     def search_runs(self, experiment_ids, filter_string="", run_view_type=ViewType.ACTIVE_ONLY,
-                    max_results=SEARCH_MAX_RESULTS_DEFAULT, order_by=None, page_token=None):
+                    max_results=SEARCH_MAX_RESULTS_DEFAULT, order_by=None, page_token=None,
+                    metrics_whitelist=None, params_whitelist=None, tags_whitelist=None):
         """
         Search experiments that fit the search criteria.
 
@@ -321,13 +322,18 @@ class MlflowClient(object):
                      The default ordering is to sort by ``start_time DESC``, then ``run_id``.
         :param page_token: Token specifying the next page of results. It should be obtained from
             a ``search_runs`` call.
+        :param metrics_whitelist: white list of metrics, default to all (None)
+        :param params_whitelist: white list of params, default to all (None)
+        :param tags_whitelist: white list of tags, default to all (None)
 
         :return: A list of :py:class:`mlflow.entities.Run` objects that satisfy the search
             expressions. If the underlying tracking store supports pagination, the token for
             the next page may be obtained via the ``token`` attribute of the returned object.
         """
         return self._tracking_client.search_runs(experiment_ids, filter_string, run_view_type,
-                                                 max_results, order_by, page_token)
+                                                 max_results, order_by, page_token,
+                                                 metrics_whitelist, params_whitelist,
+                                                 tags_whitelist)
 
     # Registry API
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -386,7 +386,8 @@ def get_artifact_uri(artifact_path=None):
 
 
 def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.ACTIVE_ONLY,
-                max_results=SEARCH_MAX_RESULTS_PANDAS, order_by=None):
+                max_results=SEARCH_MAX_RESULTS_PANDAS, order_by=None,
+                metrics_whitelist=None, params_whitelist=None, tags_whitelist=None):
     """
     Get a pandas DataFrame of runs that fit the search criteria.
 
@@ -399,6 +400,9 @@ def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.AC
     :param order_by: List of columns to order by (e.g., "metrics.rmse"). The ``order_by`` column
                      can contain an optional ``DESC`` or ``ASC`` value. The default is ``ASC``.
                      The default ordering is to sort by ``start_time DESC``, then ``run_id``.
+    :param metrics_whitelist: white list of metrics, default to all (None)
+    :param params_whitelist: white list of params, default to all (None)
+    :param tags_whitelist: white list of tags, default to all (None)
 
     :return: A pandas.DataFrame of runs, where each metric, parameter, and tag
         are expanded into their own columns named metrics.*, params.*, and tags.*
@@ -408,7 +412,7 @@ def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.AC
     if not experiment_ids:
         experiment_ids = _get_experiment_id()
     runs = _get_paginated_runs(experiment_ids, filter_string, run_view_type, max_results,
-                               order_by)
+                               order_by, metrics_whitelist, params_whitelist, tags_whitelist)
     info = {'run_id': [], 'experiment_id': [],
             'status': [], 'artifact_uri': [],
             'start_time': [], 'end_time': []}
@@ -470,17 +474,19 @@ def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.AC
 
 
 def _get_paginated_runs(experiment_ids, filter_string, run_view_type, max_results,
-                        order_by):
+                        order_by, metrics_whitelist, params_whitelist, tags_whitelist):
     all_runs = []
     next_page_token = None
     while(len(all_runs) < max_results):
         runs_to_get = max_results-len(all_runs)
         if runs_to_get < NUM_RUNS_PER_PAGE_PANDAS:
             runs = MlflowClient().search_runs(experiment_ids, filter_string, run_view_type,
-                                              runs_to_get, order_by, next_page_token)
+                                              runs_to_get, order_by, next_page_token,
+                                              metrics_whitelist, params_whitelist, tags_whitelist)
         else:
             runs = MlflowClient().search_runs(experiment_ids, filter_string, run_view_type,
-                                              NUM_RUNS_PER_PAGE_PANDAS, order_by, next_page_token)
+                                              NUM_RUNS_PER_PAGE_PANDAS, order_by, next_page_token,
+                                              metrics_whitelist, params_whitelist, tags_whitelist)
         all_runs.extend(runs)
         if hasattr(runs, 'token') and runs.token != '' and runs.token is not None:
             next_page_token = runs.token

--- a/tests/store/tracking/test_abstract_store.py
+++ b/tests/store/tracking/test_abstract_store.py
@@ -44,7 +44,7 @@ class AbstractStoreTestImpl(AbstractStore):
         raise NotImplementedError()
 
     def _search_runs(self, experiment_ids, filter_string, run_view_type, max_results, order_by,
-                     page_token):
+                     page_token, metrics_whitelist, params_whitelist, tags_whitelist):
         raise NotImplementedError()
 
     def log_batch(self, run_id, metrics, params, tags):
@@ -129,4 +129,5 @@ def test_search_runs():
             assert result[i] == runs[i]
         assert result.token == token
         store._search_runs.assert_called_once_with([experiment_id], None, view_type,
-                                                   SEARCH_MAX_RESULTS_DEFAULT, None, None)
+                                                   SEARCH_MAX_RESULTS_DEFAULT, None, None,
+                                                   None, None, None)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -78,7 +78,10 @@ def test_client_search_runs_defaults(mock_store):
                                                    run_view_type=ViewType.ACTIVE_ONLY,
                                                    max_results=SEARCH_MAX_RESULTS_DEFAULT,
                                                    order_by=None,
-                                                   page_token=None)
+                                                   page_token=None,
+                                                   metrics_whitelist=None,
+                                                   params_whitelist=None,
+                                                   tags_whitelist=None)
 
 
 def test_client_search_runs_filter(mock_store):
@@ -88,7 +91,10 @@ def test_client_search_runs_filter(mock_store):
                                                    run_view_type=ViewType.ACTIVE_ONLY,
                                                    max_results=SEARCH_MAX_RESULTS_DEFAULT,
                                                    order_by=None,
-                                                   page_token=None)
+                                                   page_token=None,
+                                                   metrics_whitelist=None,
+                                                   params_whitelist=None,
+                                                   tags_whitelist=None)
 
 
 def test_client_search_runs_view_type(mock_store):
@@ -98,7 +104,10 @@ def test_client_search_runs_view_type(mock_store):
                                                    run_view_type=ViewType.DELETED_ONLY,
                                                    max_results=SEARCH_MAX_RESULTS_DEFAULT,
                                                    order_by=None,
-                                                   page_token=None)
+                                                   page_token=None,
+                                                   metrics_whitelist=None,
+                                                   params_whitelist=None,
+                                                   tags_whitelist=None)
 
 
 def test_client_search_runs_max_results(mock_store):
@@ -108,7 +117,10 @@ def test_client_search_runs_max_results(mock_store):
                                                    run_view_type=ViewType.ALL,
                                                    max_results=2876,
                                                    order_by=None,
-                                                   page_token=None)
+                                                   page_token=None,
+                                                   metrics_whitelist=None,
+                                                   params_whitelist=None,
+                                                   tags_whitelist=None)
 
 
 def test_client_search_runs_int_experiment_id(mock_store):
@@ -118,7 +130,10 @@ def test_client_search_runs_int_experiment_id(mock_store):
                                                    run_view_type=ViewType.ACTIVE_ONLY,
                                                    max_results=SEARCH_MAX_RESULTS_DEFAULT,
                                                    order_by=None,
-                                                   page_token=None)
+                                                   page_token=None,
+                                                   metrics_whitelist=None,
+                                                   params_whitelist=None,
+                                                   tags_whitelist=None)
 
 
 def test_client_search_runs_string_experiment_id(mock_store):
@@ -128,7 +143,10 @@ def test_client_search_runs_string_experiment_id(mock_store):
                                                    run_view_type=ViewType.ACTIVE_ONLY,
                                                    max_results=SEARCH_MAX_RESULTS_DEFAULT,
                                                    order_by=None,
-                                                   page_token=None)
+                                                   page_token=None,
+                                                   metrics_whitelist=None,
+                                                   params_whitelist=None,
+                                                   tags_whitelist=None)
 
 
 def test_client_search_runs_order_by(mock_store):
@@ -138,7 +156,10 @@ def test_client_search_runs_order_by(mock_store):
                                                    run_view_type=ViewType.ACTIVE_ONLY,
                                                    max_results=SEARCH_MAX_RESULTS_DEFAULT,
                                                    order_by=["a", "b"],
-                                                   page_token=None)
+                                                   page_token=None,
+                                                   metrics_whitelist=None,
+                                                   params_whitelist=None,
+                                                   tags_whitelist=None)
 
 
 def test_client_search_runs_page_token(mock_store):
@@ -148,7 +169,10 @@ def test_client_search_runs_page_token(mock_store):
                                                    run_view_type=ViewType.ACTIVE_ONLY,
                                                    max_results=SEARCH_MAX_RESULTS_DEFAULT,
                                                    order_by=None,
-                                                   page_token="blah")
+                                                   page_token="blah",
+                                                   metrics_whitelist=None,
+                                                   params_whitelist=None,
+                                                   tags_whitelist=None)
 
 
 def test_client_registry_operations_raise_exception_with_unsupported_registry_store():

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -471,7 +471,8 @@ def test_search_runs_no_arguments():
     with experiment_id_patch, get_paginated_runs_patch:
         search_runs()
         mlflow.tracking.fluent._get_paginated_runs.assert_called_once_with(
-            mock_experiment_id, '', ViewType.ACTIVE_ONLY, SEARCH_MAX_RESULTS_PANDAS, None
+            mock_experiment_id, '', ViewType.ACTIVE_ONLY, SEARCH_MAX_RESULTS_PANDAS, None,
+            None, None, None
         )
 
 
@@ -485,7 +486,8 @@ def test_get_paginated_runs_lt_maxresults_onepage():
     max_results = 50
     with mock.patch("mlflow.tracking.fluent.NUM_RUNS_PER_PAGE_PANDAS", 10):
         with mock.patch.object(MlflowClient, "search_runs", return_value=tokenized_runs):
-            paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None)
+            paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None,
+                                                 None, None, None)
             MlflowClient.search_runs.assert_called_once()
             assert len(paginated_runs) == 5
 
@@ -502,7 +504,8 @@ def test_get_paginated_runs_lt_maxresults_multipage():
             MlflowClient.search_runs.side_effect = [tokenized_runs, tokenized_runs, no_token_runs]
             TOTAL_RUNS = 21
 
-            paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None)
+            paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None,
+                                                 None, None, None)
             assert len(paginated_runs) == TOTAL_RUNS
 
 
@@ -516,7 +519,8 @@ def test_get_paginated_runs_lt_maxresults_onepage_nonetoken():
     max_results = 50
     with mock.patch("mlflow.tracking.fluent.NUM_RUNS_PER_PAGE_PANDAS", 10):
         with mock.patch.object(MlflowClient, "search_runs", return_value=tokenized_runs):
-            paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None)
+            paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None,
+                                                 None, None, None)
             MlflowClient.search_runs.assert_called_once()
             assert len(paginated_runs) == 5
 
@@ -536,7 +540,8 @@ def test_get_paginated_runs_eq_maxresults_blanktoken():
     with mock.patch("mlflow.tracking.fluent.NUM_RUNS_PER_PAGE_PANDAS", 10):
         with mock.patch.object(MlflowClient, "search_runs"):
             MlflowClient.search_runs.side_effect = [tokenized_runs, no_token_runs]
-            paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None)
+            paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None,
+                                                 None, None, None)
             MlflowClient.search_runs.assert_called_once()
             assert len(paginated_runs) == 10
 
@@ -555,7 +560,8 @@ def test_get_paginated_runs_eq_maxresults_token():
     with mock.patch("mlflow.tracking.fluent.NUM_RUNS_PER_PAGE_PANDAS", 10):
         with mock.patch.object(MlflowClient, "search_runs"):
             MlflowClient.search_runs.side_effect = [tokenized_runs, blank_runs]
-            paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results, None)
+            paginated_runs = _get_paginated_runs([], "", ViewType.ACTIVE_ONLY, max_results,
+                                                 None, None, None, None)
             MlflowClient.search_runs.assert_called_once()
             assert len(paginated_runs) == 10
 
@@ -572,10 +578,14 @@ def test_get_paginated_runs_gt_maxresults_multipage():
     with mock.patch("mlflow.tracking.fluent.NUM_RUNS_PER_PAGE_PANDAS", 8):
         with mock.patch.object(MlflowClient, "search_runs"):
             MlflowClient.search_runs.side_effect = [full_page_runs, full_page_runs, partial_page]
-            paginated_runs = _get_paginated_runs([12], "", ViewType.ACTIVE_ONLY, max_results, None)
-            calls = [mock.call([12], "", ViewType.ACTIVE_ONLY, 8, None, None),
-                     mock.call([12], "", ViewType.ACTIVE_ONLY, 8, None, "abc"),
-                     mock.call([12], "", ViewType.ACTIVE_ONLY, 20 % 8, None, "abc")]
+            paginated_runs = _get_paginated_runs([12], "", ViewType.ACTIVE_ONLY, max_results, None,
+                                                 None, None, None)
+            calls = [mock.call([12], "", ViewType.ACTIVE_ONLY, 8, None, None,
+                               None, None, None),
+                     mock.call([12], "", ViewType.ACTIVE_ONLY, 8, None, "abc",
+                               None, None, None),
+                     mock.call([12], "", ViewType.ACTIVE_ONLY, 20 % 8, None, "abc",
+                               None, None, None)]
             MlflowClient.search_runs.assert_has_calls(calls)
             assert len(paginated_runs) == 20
 
@@ -590,9 +600,10 @@ def test_get_paginated_runs_gt_maxresults_onepage():
     max_results = 10
     with mock.patch("mlflow.tracking.fluent.NUM_RUNS_PER_PAGE_PANDAS", 20):
         with mock.patch.object(MlflowClient, "search_runs", return_value=tokenized_runs):
-            paginated_runs = _get_paginated_runs([123], "", ViewType.ACTIVE_ONLY, max_results, None)
+            paginated_runs = _get_paginated_runs([123], "", ViewType.ACTIVE_ONLY, max_results,
+                                                 None, None, None, None)
             MlflowClient.search_runs.assert_called_once_with(
-                [123], "", ViewType.ACTIVE_ONLY, max_results, None, None)
+                [123], "", ViewType.ACTIVE_ONLY, max_results, None, None, None, None, None)
             assert len(paginated_runs) == 10
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Introduce new whitelisting feature for tags, params and metrics in search_runs

This feature makes it possible to keep only some of the tags,
params and metrics in search_runs.

This is useful particularly in case of retrieving many runs but only few columns.

This commit is mostly split in 2 parts :
1. Adding tags_whitelist, metrics_whitelist, params_whitelist to the API as a non-breaking change : they default to None which mean keep all fields
2. Actually implement it in stores and in particular the sqlalchemy store

The second part is a bit subtle because the subquery loading strategy used in mlflow sqlalchemy store does not support filtering.
As a consequence I reimplemented a "disjoint_load" function that
is a simple implementation of subquery loading, adding the filtering functionality. I added many comments in it to explain how it works.
An additional change is removing the unneeded distinct in search_runs to avoid from_self from
propagating the column from ordering to the main fields of the main select. (it's not required to put fields from order by in select if the distinct keyword is not used h
ttps://dba.stackexchange.com/a/34970)

This change makes it possible to decrease the search_run time from 30s to 2s for an experiment with many runs (7000) and keeping only a few columns.

## How is this patch tested?

* adapted the existing tests
* added tests in sql alchemy store tests and file store tests to test the whitelisting


## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add tags_whitelist params_whitelist metrics_whitelist optional options in search_runs.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [x] API
- [x] REST-API
- [x] Examples
- [x] Docs
- [x] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [x] R
- [x] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
