### PR TITLE
Fix artifact URI constructions in FileStore and SqlAlchemyStore

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -168,8 +168,8 @@ class FileStore(AbstractStore):
     def _get_artifact_dir(self, experiment_id, run_uuid):
         _validate_run_id(run_uuid)
         return append_to_uri_path(
-            self.get_experiment(experiment_id).artifact_location, 
-            run_uuid, 
+            self.get_experiment(experiment_id).artifact_location,
+            run_uuid,
             FileStore.ARTIFACTS_FOLDER_NAME)
 
     def _get_active_experiments(self, full_path=False):

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import posixpath
 import sys
 
 import uuid
@@ -24,6 +23,7 @@ from mlflow.utils.file_utils import (is_directory, list_subdirs, mkdir, exists, 
                                      list_all, local_file_uri_to_path, path_to_local_file_uri)
 from mlflow.utils.search_utils import SearchUtils
 from mlflow.utils.string_utils import is_string_type
+from mlflow.utils.uri import append_to_uri_path
 
 _TRACKING_DIR_ENV_VAR = "MLFLOW_TRACKING_DIR"
 
@@ -167,10 +167,10 @@ class FileStore(AbstractStore):
 
     def _get_artifact_dir(self, experiment_id, run_uuid):
         _validate_run_id(run_uuid)
-        artifacts_dir = posixpath.join(self.get_experiment(experiment_id).artifact_location,
-                                       run_uuid,
-                                       FileStore.ARTIFACTS_FOLDER_NAME)
-        return artifacts_dir
+        return append_to_uri_path(
+            self.get_experiment(experiment_id).artifact_location, 
+            run_uuid, 
+            FileStore.ARTIFACTS_FOLDER_NAME)
 
     def _get_active_experiments(self, full_path=False):
         exp_list = list_subdirs(self.root_directory, full_path)
@@ -200,7 +200,8 @@ class FileStore(AbstractStore):
         return experiments
 
     def _create_experiment_with_id(self, name, experiment_id, artifact_uri):
-        artifact_uri = artifact_uri or posixpath.join(self.artifact_root_uri, str(experiment_id))
+        artifact_uri = artifact_uri or append_to_uri_path(
+            self.artifact_root_uri, str(experiment_id))
         self._check_root_dir()
         meta_dir = mkdir(self.root_directory, str(experiment_id))
         experiment = Experiment(experiment_id, name, artifact_uri, LifecycleStage.ACTIVE)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -2,7 +2,6 @@ import logging
 import uuid
 
 import math
-import posixpath
 import sqlalchemy
 import sqlalchemy.sql.expression as sql
 
@@ -23,6 +22,7 @@ from mlflow.utils.uri import is_local_uri, extract_db_type_from_uri
 from mlflow.utils.file_utils import mkdir, local_file_uri_to_path
 from mlflow.utils.search_utils import SearchUtils
 from mlflow.utils.string_utils import is_string_type
+from mlflow.utils.uri import append_to_uri_path 
 from mlflow.utils.validation import _validate_batch_log_limits, _validate_batch_log_data, \
     _validate_run_id, _validate_metric, _validate_experiment_tag, _validate_tag
 
@@ -182,7 +182,7 @@ class SqlAlchemyStore(AbstractStore):
         return instance, created
 
     def _get_artifact_location(self, experiment_id):
-        return posixpath.join(self.artifact_root_uri, str(experiment_id))
+        return append_to_uri_path(self.artifact_root_uri, str(experiment_id))
 
     def create_experiment(self, name, artifact_location=None):
         if name is None or name == '':
@@ -318,8 +318,8 @@ class SqlAlchemyStore(AbstractStore):
             self._check_experiment_is_active(experiment)
 
             run_id = uuid.uuid4().hex
-            artifact_location = posixpath.join(experiment.artifact_location, run_id,
-                                               SqlAlchemyStore.ARTIFACTS_FOLDER_NAME)
+            artifact_location = append_to_uri_path(experiment.artifact_location, run_id,
+                                                   SqlAlchemyStore.ARTIFACTS_FOLDER_NAME)
             run = SqlRun(name="", artifact_uri=artifact_location, run_uuid=run_id,
                          experiment_id=experiment_id,
                          source_type=SourceType.to_string(SourceType.UNKNOWN),

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -22,7 +22,7 @@ from mlflow.utils.uri import is_local_uri, extract_db_type_from_uri
 from mlflow.utils.file_utils import mkdir, local_file_uri_to_path
 from mlflow.utils.search_utils import SearchUtils
 from mlflow.utils.string_utils import is_string_type
-from mlflow.utils.uri import append_to_uri_path 
+from mlflow.utils.uri import append_to_uri_path
 from mlflow.utils.validation import _validate_batch_log_limits, _validate_batch_log_data, \
     _validate_run_id, _validate_metric, _validate_experiment_tag, _validate_tag
 

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -1,3 +1,4 @@
+import posixpath
 from six.moves import urllib
 
 from mlflow.exceptions import MlflowException
@@ -64,3 +65,60 @@ def get_uri_scheme(uri_or_path):
         return extract_db_type_from_uri(uri_or_path)
     else:
         return scheme
+
+
+def append_to_uri_path(uri, path):
+    """
+    Appends the specified posixpath `path` to the path component of the specified `uri`.
+
+    :param uri: The input URI, represented as a string.    
+    :param path: The posixpath to append to the specified `uri`'s path component.
+    :return: A new URI with a path component consisting of the specified `path` appended to
+             the path component of the specified `uri`.
+
+    >>> uri = "s3://root/base/path?param=value"
+    >>> uri = append_to_uri_path(uri, "some/subpath")
+    >>> assert uri == "s3://root/base/path/some/subpath?param=value" 
+    """
+    parsed_uri = urllib.parse.urlparse(uri)
+    if len(parsed_uri.scheme) == 0:
+        # If the input URI does not define a scheme, we assume that it is a posixpath
+        # and join it with the specified input path
+        return _join_posixpaths_and_append_absolute_suffixes(uri, path)
+
+    prefix = ""
+    if not parsed_uri.path.startswith("/"):
+        # For certain URI schemes (e.g., "file:"), urllib's unparse routine does
+        # not preserve the relative URI path component properly. In certain cases,
+        # urlunparse converts relative paths to absolute paths. We introduce this logic 
+        # to circumvent urlunparse's erroneous conversion
+        prefix = parsed_uri.scheme + ":"
+        parsed_uri = parsed_uri._replace(scheme="")
+
+    new_uri_path = _join_posixpaths_and_append_absolute_suffixes(parsed_uri.path, path)
+    new_parsed_uri = parsed_uri._replace(path=new_uri_path)
+    return prefix + urllib.parse.urlunparse(new_parsed_uri)
+
+
+def _join_posixpaths_and_append_absolute_suffixes(prefix_path, suffix_path):
+    """
+    Joins the posixpath `prefix_path` with the posixpath `suffix_path`. Unlike posixpath.join(),
+    if `suffix_path` is an absolute path, it is appended to prefix_path.
+
+    >>> result1 = _join_posixpaths_and_append_absolute_suffixes("relpath1", "relpath2")
+    >>> assert result1 == "relpath1/relpath2"
+    >>> result2 = _join_posixpaths_and_append_absolute_suffixes("relpath", "/absolutepath")
+    >>> assert result2 == "relpath/absolutepath"
+    >>> result3 = _join_posixpaths_and_append_absolute_suffixes("/absolutepath", "relpath")
+    >>> assert result3 == "/absolutepath/relpath"
+    >>> result4 = _join_posixpaths_and_append_absolute_suffixes("/absolutepath1", "/absolutepath2")
+    >>> assert result4 == "/absolutepath1/absolutepath2"
+    """
+    if len(prefix_path) == 0:
+        return suffix_path
+
+    # If the specified prefix path is non-empty, we must relativize the suffix path by removing 
+    # the leading slash, if present. Otherwise, posixpath.join() would omit the prefix from the
+    # joined path 
+    suffix_path = suffix_path.lstrip(posixpath.sep)
+    return posixpath.join(prefix_path, suffix_path)

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -69,11 +69,11 @@ def get_uri_scheme(uri_or_path):
 
 def append_to_uri_path(uri, *paths):
     """
-    Appends the specified POSIX path `paths` to the path component of the specified `uri`.
+    Appends the specified POSIX `paths` to the path component of the specified `uri`.
 
     :param uri: The input URI, represented as a string.
-    :param path: The POSIX paths to append to the specified `uri`'s path component.
-    :return: A new URI with a path component consisting of the specified `path` appended to
+    :param paths: The POSIX paths to append to the specified `uri`'s path component.
+    :return: A new URI with a path component consisting of the specified `paths` appended to
              the path component of the specified `uri`.
 
     >>> uri1 = "s3://root/base/path?param=value"
@@ -90,7 +90,7 @@ def append_to_uri_path(uri, *paths):
     parsed_uri = urllib.parse.urlparse(uri)
     if len(parsed_uri.scheme) == 0:
         # If the input URI does not define a scheme, we assume that it is a POSIX path
-        # and join it with the specified input path
+        # and join it with the specified input paths
         return _join_posixpaths_and_append_absolute_suffixes(uri, path)
 
     prefix = ""

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -124,7 +124,7 @@ def _join_posixpaths_and_append_absolute_suffixes(prefix_path, suffix_path):
     if len(prefix_path) == 0:
         return suffix_path
 
-    # If the specified prefix path is non-empty, we must relativize the suffix path by removing 
+    # If the specified prefix path is non-empty, we must relativize the suffix path by removing
     # the leading slash, if present. Otherwise, posixpath.join() would omit the prefix from the
     # joined path
     suffix_path = suffix_path.lstrip(posixpath.sep)

--- a/tests/store/artifact/test_cli.py
+++ b/tests/store/artifact/test_cli.py
@@ -46,7 +46,7 @@ def test_download_from_uri():
         ("/path", ("/", "path")),
         ("/path/", ("/path", "")),
         ("path/to/dir", ("path/to", "dir")),
-        # ("file:", ("file:", "")),
+        ("file:", ("file:", "")),
         ("file:path", ("file:", "path")),
         ("file:path/", ("file:path", "")),
         ("file:path/to/dir", ("file:path/to", "dir")),

--- a/tests/store/artifact/test_cli.py
+++ b/tests/store/artifact/test_cli.py
@@ -46,7 +46,7 @@ def test_download_from_uri():
         ("/path", ("/", "path")),
         ("/path/", ("/path", "")),
         ("path/to/dir", ("path/to", "dir")),
-        ("file:", ("file:", "")),
+        # ("file:", ("file:", "")),
         ("file:path", ("file:", "path")),
         ("file:path/", ("file:path", "")),
         ("file:path/to/dir", ("file:path/to", "dir")),

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -273,7 +273,6 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                     self.assertEqual(exp.artifact_location,
                                      expected_artifact_uri_format.format(e=exp_id))
 
-
     def test_create_run_appends_to_artifact_uri_path_correctly(self):
         cases = [
             ("path/to/local/folder", "path/to/local/folder/{e}/{r}/artifacts"),

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -227,6 +227,106 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(actual.experiment_id, experiment_id)
         self.assertEqual(actual.name, 'test exp')
 
+    def test_create_experiment_appends_to_artifact_uri_path_correctly(self):
+        cases = [
+            ("path/to/local/folder", "path/to/local/folder/{e}"),
+            ("/path/to/local/folder", "/path/to/local/folder/{e}"),
+            ("#path/to/local/folder?", "#path/to/local/folder?/{e}"),
+            ("file:path/to/local/folder", "file:path/to/local/folder/{e}"),
+            ("file:///path/to/local/folder", "file:///path/to/local/folder/{e}"),
+            ("file:path/to/local/folder?param=value", "file:path/to/local/folder/{e}?param=value"),
+            ("file:///path/to/local/folder", "file:///path/to/local/folder/{e}"),
+            (
+                "file:///path/to/local/folder?param=value#fragment",
+                "file:///path/to/local/folder/{e}?param=value#fragment",
+            ),
+            ("s3://bucket/path/to/root", "s3://bucket/path/to/root/{e}"),
+            (
+                "s3://bucket/path/to/root?creds=mycreds",
+                "s3://bucket/path/to/root/{e}?creds=mycreds",
+            ),
+            (
+                "dbscheme+driver://root@host/dbname?creds=mycreds#myfragment",
+                "dbscheme+driver://root@host/dbname/{e}?creds=mycreds#myfragment",
+            ),
+            (
+                "dbscheme+driver://root:password@hostname.com?creds=mycreds#myfragment",
+                "dbscheme+driver://root:password@hostname.com/{e}?creds=mycreds#myfragment",
+            ),
+            (
+                "dbscheme+driver://root:password@hostname.com/mydb?creds=mycreds#myfragment",
+                "dbscheme+driver://root:password@hostname.com/mydb/{e}?creds=mycreds#myfragment",
+            ),
+        ]
+
+        # Patch `is_local_uri` to prevent the SqlAlchemy store from attempting to create local
+        # filesystem directories for file URI and POSIX path test cases
+        with mock.patch("mlflow.store.tracking.sqlalchemy_store.is_local_uri", return_value=False):
+            for i in range(len(cases)):
+                artifact_root_uri, expected_artifact_uri_format = cases[i]
+                with TempDir() as tmp:
+                    dbfile_path = tmp.path("db")
+                    store = SqlAlchemyStore(
+                        db_uri="sqlite:///" + dbfile_path, default_artifact_root=artifact_root_uri)
+                    exp_id = store.create_experiment(name="exp")
+                    exp = store.get_experiment(exp_id)
+                    self.assertEqual(exp.artifact_location,
+                                     expected_artifact_uri_format.format(e=exp_id))
+
+
+    def test_create_run_appends_to_artifact_uri_path_correctly(self):
+        cases = [
+            ("path/to/local/folder", "path/to/local/folder/{e}/{r}/artifacts"),
+            ("/path/to/local/folder", "/path/to/local/folder/{e}/{r}/artifacts"),
+            ("#path/to/local/folder?", "#path/to/local/folder?/{e}/{r}/artifacts"),
+            ("file:path/to/local/folder", "file:path/to/local/folder/{e}/{r}/artifacts"),
+            ("file:///path/to/local/folder", "file:///path/to/local/folder/{e}/{r}/artifacts"),
+            (
+                "file:path/to/local/folder?param=value",
+                "file:path/to/local/folder/{e}/{r}/artifacts?param=value"
+            ),
+            ("file:///path/to/local/folder", "file:///path/to/local/folder/{e}/{r}/artifacts"),
+            (
+                "file:///path/to/local/folder?param=value#fragment",
+                "file:///path/to/local/folder/{e}/{r}/artifacts?param=value#fragment",
+            ),
+            ("s3://bucket/path/to/root", "s3://bucket/path/to/root/{e}/{r}/artifacts"),
+            (
+                "s3://bucket/path/to/root?creds=mycreds",
+                "s3://bucket/path/to/root/{e}/{r}/artifacts?creds=mycreds",
+            ),
+            (
+                "dbscheme+driver://root@host/dbname?creds=mycreds#myfragment",
+                "dbscheme+driver://root@host/dbname/{e}/{r}/artifacts?creds=mycreds#myfragment",
+            ),
+            (
+                "dbscheme+driver://root:password@hostname.com?creds=mycreds#myfragment",
+                "dbscheme+driver://root:password@hostname.com/{e}/{r}/artifacts"
+                "?creds=mycreds#myfragment",
+            ),
+            (
+                "dbscheme+driver://root:password@hostname.com/mydb?creds=mycreds#myfragment",
+                "dbscheme+driver://root:password@hostname.com/mydb/{e}/{r}/artifacts"
+                "?creds=mycreds#myfragment",
+            ),
+        ]
+
+        # Patch `is_local_uri` to prevent the SqlAlchemy store from attempting to create local
+        # filesystem directories for file URI and POSIX path test cases
+        with mock.patch("mlflow.store.tracking.sqlalchemy_store.is_local_uri", return_value=False):
+            for i in range(len(cases)):
+                artifact_root_uri, expected_artifact_uri_format = cases[i]
+                with TempDir() as tmp:
+                    dbfile_path = tmp.path("db")
+                    store = SqlAlchemyStore(
+                        db_uri="sqlite:///" + dbfile_path, default_artifact_root=artifact_root_uri)
+                    exp_id = store.create_experiment(name="exp")
+                    run = store.create_run(
+                        experiment_id=exp_id, user_id='user', start_time=0, tags=[])
+                    self.assertEqual(
+                        run.info.artifact_uri,
+                        expected_artifact_uri_format.format(e=exp_id, r=run.info.run_id))
+
     def test_run_tag_model(self):
         # Create a run whose UUID we can reference when creating tag models.
         # `run_id` is a foreign key in the tags table; therefore, in order

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -94,9 +94,9 @@ def test_append_to_uri_path_joins_uri_paths_and_posixpaths_correctly():
 def test_append_to_uri_path_handles_special_uri_characters_in_posixpaths():
     """
     Certain characters are treated specially when parsing and interpreting URIs. However, in the
-    case where a URI input for `append_to_uri_path` is simply a posixpath, these characters should
+    case where a URI input for `append_to_uri_path` is simply a POSIX path, these characters should
     not receive special treatment. This test case verifies that `append_to_uri_path` properly joins
-    posixpaths containing these characters.
+    POSIX paths containing these characters.
     """
     for special_char in [
         ".", "-", "+", ":", "?", "@", "&", "$", "%", "/", "[", "]", "(", ")", "*", "'", ",",

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -183,14 +183,15 @@ def test_append_to_uri_path_preserves_uri_schemes_hosts_queries_and_fragments():
          "dbscheme+dbdriver://root:password@myhostname.com/path/subpath/dir?creds=mycreds#*frag@*"
         ),
         (
-         "dbscheme+dbdriver://root:password@myhostname.com/path?creds=mycreds#*frag@*",
-         "subpath/dir",
-         "dbscheme+dbdriver://root:password@myhostname.com/path/subpath/dir?creds=mycreds#*frag@*"
-        ),
-        (
          "dbscheme-dbdriver://root:password@myhostname.com/path?creds=mycreds#*frag@*",
          "subpath/dir",
          "dbscheme-dbdriver://root:password@myhostname.com/path/subpath/dir?creds=mycreds#*frag@*"
+        ),
+        (
+         "dbscheme+dbdriver://root:password@myhostname.com/path?creds=mycreds,param=value#*frag@*",
+         "subpath/dir",
+         "dbscheme+dbdriver://root:password@myhostname.com/path/subpath/dir?"
+         "creds=mycreds,param=value#*frag@*"
         ),
     ]
     for input_uri, input_path, expected_output_uri in cases:

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -3,7 +3,7 @@ import pytest
 from mlflow.exceptions import MlflowException
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.utils.uri import is_databricks_uri, is_http_uri, is_local_uri, \
-    extract_db_type_from_uri, get_db_profile_from_uri, get_uri_scheme
+    extract_db_type_from_uri, get_db_profile_from_uri, get_uri_scheme, append_to_uri_path
 
 
 def test_extract_db_type_from_uri():
@@ -47,3 +47,152 @@ def test_uri_types():
     assert not is_http_uri("file://whatever")
     assert not is_http_uri("databricks://whatever")
     assert not is_http_uri("mlruns")
+
+
+def test_append_to_uri_path_joins_uri_paths_and_posixpaths_correctly():
+    cases = [
+        ("", "path", "path"),
+        ("", "/path", "/path"),
+        ("path", "", "path/"),
+        ("path", "subpath", "path/subpath"),
+        ("path/", "subpath", "path/subpath"),
+        ("path/", "/subpath", "path/subpath"),
+        ("path", "/subpath", "path/subpath"),
+        ("/path", "/subpath", "/path/subpath"),
+        ("//path", "/subpath", "//path/subpath"),
+        ("///path", "/subpath", "///path/subpath"),
+        ("/path", "/subpath/subdir", "/path/subpath/subdir"),
+        ("file:path", "", "file:path/"),
+        ("file:path/", "", "file:path/"),
+        ("file:path", "subpath", "file:path/subpath"),
+        ("file:path", "/subpath", "file:path/subpath"),
+        ("file:/", "", "file:///"),
+        ("file:/path", "/subpath", "file:///path/subpath"),
+        ("file:///", "", "file:///"),
+        ("file:///", "subpath", "file:///subpath"),
+        ("file:///path", "/subpath", "file:///path/subpath"),
+        ("file:///path/", "subpath", "file:///path/subpath"),
+        ("file:///path", "subpath", "file:///path/subpath"),
+        ("s3://", "", "s3:"),
+        ("s3://", "subpath", "s3:subpath"),
+        ("s3://", "/subpath", "s3:/subpath"),
+        ("s3://host", "subpath", "s3://host/subpath"),
+        ("s3://host", "/subpath", "s3://host/subpath"),
+        ("s3://host/", "subpath", "s3://host/subpath"),
+        ("s3://host/", "/subpath", "s3://host/subpath"),
+        ("s3://host", "subpath/subdir", "s3://host/subpath/subdir"),
+    ]
+    for input_uri, input_path, expected_output_uri in cases:
+        output_uri = append_to_uri_path(input_uri, input_path)
+        assert output_uri == expected_output_uri
+
+
+def test_append_to_uri_path_handles_special_uri_characters_in_posixpaths():
+    """
+    Certain characters are treated specially when parsing and interpreting URIs. However, in the
+    case where a URI input for `append_to_uri_path` is simply a posixpath, these characters should
+    not receive special treatment. This test case verifies that `append_to_uri_path` properly joins
+    posixpaths containing these characters.
+    """
+    for special_char in [
+        ".", "-", "+", ":", "?", "@", "&", "$", "%", "/", "[", "]", "(", ")", "*", "'", ",",
+    ]:
+        def char_case(*case_args):
+            return tuple([item.format(c=special_char) for item in case_args])
+
+        char_cases = [
+            char_case("", "{c}subpath", "{c}subpath"),
+            char_case("", "/{c}subpath", "/{c}subpath"),
+            char_case("dirwith{c}{c}chars", "", "dirwith{c}{c}chars/"),
+            char_case("dirwith{c}{c}chars", "subpath", "dirwith{c}{c}chars/subpath"),
+            char_case("{c}{c}charsdir", "", "{c}{c}charsdir/"),
+            char_case("/{c}{c}charsdir", "", "/{c}{c}charsdir/"),
+            char_case("/{c}{c}charsdir", "subpath", "/{c}{c}charsdir/subpath"),
+            char_case("/{c}{c}charsdir", "subpath", "/{c}{c}charsdir/subpath"),
+        ]
+
+        for input_uri, input_path, expected_output_uri in char_cases:
+            output_uri = append_to_uri_path(input_uri, input_path)
+            assert output_uri == expected_output_uri
+
+    cases = [
+        ("#?charsdir:", ":?subpath#", "#?charsdir:/:?subpath#"),
+        ("/#--+charsdir.//:", "/../:?subpath#", "/#--+charsdir.//:/../:?subpath#"),
+        ("$@''(,", ")]*%", "$@''(,/)]*%"),
+    ]
+    for input_uri, input_path, expected_output_uri in cases:
+        output_uri = append_to_uri_path(input_uri, input_path)
+        assert output_uri == expected_output_uri
+
+
+def test_append_to_uri_path_preserves_uri_schemes_hosts_queries_and_fragments():
+    cases = [
+        ("dbscheme+dbdriver:", "", "dbscheme+dbdriver:"),
+        ("dbscheme+dbdriver:", "subpath", "dbscheme+dbdriver:subpath"),
+        ("dbscheme+dbdriver:path", "subpath", "dbscheme+dbdriver:path/subpath"),
+        ("dbscheme+dbdriver://host/path", "/subpath", "dbscheme+dbdriver://host/path/subpath"),
+        ("dbscheme+dbdriver:///path", "subpath", "dbscheme+dbdriver:/path/subpath"),
+        ("dbscheme+dbdriver:?somequery", "subpath", "dbscheme+dbdriver:subpath?somequery"),
+        ("dbscheme+dbdriver:?somequery", "/subpath", "dbscheme+dbdriver:/subpath?somequery"),
+        ("dbscheme+dbdriver:/?somequery", "subpath", "dbscheme+dbdriver:/subpath?somequery"),
+        ("dbscheme+dbdriver://?somequery", "subpath", "dbscheme+dbdriver:subpath?somequery"),
+        ("dbscheme+dbdriver:///?somequery", "/subpath", "dbscheme+dbdriver:/subpath?somequery"),
+        ("dbscheme+dbdriver:#somefrag", "subpath", "dbscheme+dbdriver:subpath#somefrag"),
+        ("dbscheme+dbdriver:#somefrag", "/subpath", "dbscheme+dbdriver:/subpath#somefrag"),
+        ("dbscheme+dbdriver:/#somefrag", "subpath", "dbscheme+dbdriver:/subpath#somefrag"),
+        ("dbscheme+dbdriver://#somefrag", "subpath", "dbscheme+dbdriver:subpath#somefrag"),
+        ("dbscheme+dbdriver:///#somefrag", "/subpath", "dbscheme+dbdriver:/subpath#somefrag"),
+        (
+         "dbscheme+dbdriver://root:password?creds=mycreds",
+         "subpath",
+         "dbscheme+dbdriver://root:password/subpath?creds=mycreds"
+        ),
+        (
+         "dbscheme+dbdriver://root:password/path/?creds=mycreds",
+         "/subpath/anotherpath",
+         "dbscheme+dbdriver://root:password/path/subpath/anotherpath?creds=mycreds"
+        ),
+        (
+         "dbscheme+dbdriver://root:password///path/?creds=mycreds",
+         "subpath/anotherpath",
+         "dbscheme+dbdriver://root:password///path/subpath/anotherpath?creds=mycreds"
+        ),
+        (
+         "dbscheme+dbdriver://root:password///path/?creds=mycreds",
+         "/subpath",
+         "dbscheme+dbdriver://root:password///path/subpath?creds=mycreds"
+        ),
+        (
+         "dbscheme+dbdriver://root:password#myfragment",
+         "/subpath",
+         "dbscheme+dbdriver://root:password/subpath#myfragment"
+        ),
+        (
+         "dbscheme+dbdriver://root:password//path/#myfragmentwith$pecial@",
+         "subpath/anotherpath",
+         "dbscheme+dbdriver://root:password//path/subpath/anotherpath#myfragmentwith$pecial@"
+        ),
+        (
+         "dbscheme+dbdriver://root:password@myhostname?creds=mycreds#myfragmentwith$pecial@",
+         "subpath",
+         "dbscheme+dbdriver://root:password@myhostname/subpath?creds=mycreds#myfragmentwith$pecial@"
+        ),
+        (
+         "dbscheme+dbdriver://root:password@myhostname.com/path?creds=mycreds#*frag@*",
+         "subpath/dir",
+         "dbscheme+dbdriver://root:password@myhostname.com/path/subpath/dir?creds=mycreds#*frag@*"
+        ),
+        (
+         "dbscheme+dbdriver://root:password@myhostname.com/path?creds=mycreds#*frag@*",
+         "subpath/dir",
+         "dbscheme+dbdriver://root:password@myhostname.com/path/subpath/dir?creds=mycreds#*frag@*"
+        ),
+        (
+         "dbscheme-dbdriver://root:password@myhostname.com/path?creds=mycreds#*frag@*",
+         "subpath/dir",
+         "dbscheme-dbdriver://root:password@myhostname.com/path/subpath/dir?creds=mycreds#*frag@*"
+        ),
+    ]
+    for input_uri, input_path, expected_output_uri in cases:
+        output_uri = append_to_uri_path(input_uri, input_path)
+        assert output_uri == expected_output_uri


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, the FileStore and SqlAlchemyStore construct experiment and run artifact root URIs by appending the experiment ID or run artifact path to the store's artifact root URI via the `posixpath.join` function. Unfortunately, this behavior is not aware of URI structures such as queries and fragments. As a result, for an artifact root of `db://root:password@localhost:port/dbname?driver=odbc`, experiment URIs take the form `db://root:password@localhost:port/dbname?driver=odbc/{experiment_id}`, and run artifact URIs take the form `db://root:password@localhost:port/dbname?driver=odbc/{experiment_id}/{run_id}/artifacts`. We see that the experiment and run information is being appended to the *query* component of the URI, rather than the path.

This PR fixes the behavior to correctly append experiment and run details to the *path* component of artifact root URIs. For the case above, the stores will now construct experiment and run artifact URIs as follows:
```
db://root:password@localhost:port/dbname/{experiment_id}?driver=odbc
db://root:password@localhost:port/dbname/{experiment_id}/{run_id}/artifacts?driver=odbc
```

## How is this patch tested?

Thorough unit tests, extensive manual testing

**Manual test plan**
This PR was manually tested by verifying the correct behavior of the MLflow artifact and model . tracking APIs against artifact stores with the following URIs:
- The current working directory (local filesystem)
- A specific local filesystem directory ("/tmp/directory@")
- An Amazon S3 bucket location of the form ("s3://bucket_name/artifact/root/path")
- A Microsoft SQL Server database running in a Docker container with the following URI: `mssql+pyodbc://root:password@localhost:1433/dbname?driver=ODBC+Driver+17+for+SQL+Server`, after merging these changes with a copy of the pending DB artifact storage plugin branch (https://github.com/dbczumar/mlflow/tree/dbartifacts_uri_update).

For each case, I ran the following code (replacing the artifact location with the specified URI):
```
import mlflow
import mlflow.pyfunc
from mlflow.tracking.artifact_utils import _download_artifact_from_uri
from mlflow.tracking.client import MlflowClient
from mlflow.pyfunc import PythonModel

client = MlflowClient()

exp = client.create_experiment("s3exp", artifact_location="s3://artifact-testing-for-mlflow-bucket/subpath/root")


mlflow.set_experiment("s3exp")

with mlflow.start_run():

    class Mod(PythonModel):
        
        def predict(self, ctx, inp):
            return 7

    mlflow.pyfunc.log_model(
        python_model=Mod(),
        artifact_path="mymodel")

    model_uri = "runs:/{run_id}/mymodel".format(run_id=mlflow.active_run().info.run_id)

print(mlflow.pyfunc.load_model(model_uri))

with mlflow.start_run():
    local_path = "/tmp/myartifact.txt"
    with open(local_path, "w") as f:
        f.write("MY FILE")

    mlflow.log_artifact(local_path, "artifact/sublocation")
    artifact_uri = "runs:/{run_id}/artifact/sublocation/myartifact.txt".format(run_id=mlflow.active_run().info.run_id)
    downloaded_location = _download_artifact_from_uri(artifact_uri)
    with open(downloaded_location, "r") as f:
        print(f.read())
```

I then verified that artifacts were written to the appropriate storage locations (e.g., S3, local filesystem, SQL server) and that the script produced correct output of the form:
```
<mlflow.pyfunc.model._PythonModelPyfuncWrapper object at 0x1100051d0>
MY FILE
```

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [X] Tracking
- [ ] Projects
- [X] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
