### PR TITLE
Use relative path for model version link in case there is a url prefix

### DIFF
--- a/mlflow/server/js/src/model-registry/routes.js
+++ b/mlflow/server/js/src/model-registry/routes.js
@@ -12,5 +12,5 @@ export const getModelVersionPageURL = (modelName, version) => {
     const parentOrigin = window.parent.location.origin;
     return `${parentOrigin}/#mlflow${modelRoute}`;
   }
-  return `/#${modelRoute}`;
+  return `./#${modelRoute}`; // issue-2213 use relative path in case there is a url prefix
 };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use relative path for model version link in case there is a url prefix.
Fixed Issue: https://github.com/mlflow/mlflow/issues/2213

## How is this patch tested?

Manual test

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Use relative path for model version link in case there is a url prefix


### What component(s) does this PR affect?

- [x] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
