### PR TITLE
Add autologging functionality for XGBoost flavor

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -255,9 +255,9 @@ or once ``tf.estimator`` models are exported via ``tf.estimator.export_saved_mod
 
 If a run exists when ``autolog()`` captures data, MLflow will log to that run and not automatically end that run after training.
 
-**Note** Parameters not explicitly passed by users (parameters that use default values) while using ``keras.Model.fit_generator()`` are not currently automatically logged.
-
-**Note**: this feature is experimental - the API and format of the logged data are subject to change.
+.. note::
+  - Parameters not explicitly passed by users (parameters that use default values) while using ``keras.Model.fit_generator()`` are not currently automatically logged.
+  - his feature is experimental - the API and format of the logged data are subject to change.
 
 
 Gluon (experimental)
@@ -273,7 +273,8 @@ Autologging captures the following information:
 | Gluon            | Training loss; validation loss; user-specified metrics | Number of layers; optimizer name; learning rate; epsilon | --            | `MLflow Model <https://mlflow.org/docs/latest/models.html>`_ (Gluon model); on training end                                   |
 +------------------+--------------------------------------------------------+----------------------------------------------------------+---------------+-------------------------------------------------------------------------------------------------------------------------------+
 
-**Note**: this feature is experimental - the API and format of the logged data are subject to change.
+.. note::
+  This feature is experimental - the API and format of the logged data are subject to change.
 
 XGBoost (experimental)
 ----------------------

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -218,11 +218,20 @@ Here is an example plot of the :ref:`quick start tutorial <quickstart>` with the
   X-axis relative time - graphs the time relative to the first metric logged, for each run
 
 
-Automatic Logging from TensorFlow and Keras (experimental)
-==================================================================
+Automatic Logging
+=================
+
+Automatic logging allows you to log metrics and parameters without the need for explicit log statements.
+
+.. contents:: In this section:
+  :local:
+  :depth: 1
+
+TensorFlow and Keras (experimental)
+-----------------------------------
 Call :py:func:`mlflow.tensorflow.autolog` or :py:func:`mlflow.keras.autolog` before your training code to enable automatic logging of metrics and parameters without the need for explicit
 log statements. See example usages with `Keras <https://github.com/mlflow/mlflow/tree/master/examples/keras>`_ and
-`TensorFlow <https://github.com/mlflow/mlflow/tree/master/examples/tensorflow>`_. 
+`TensorFlow <https://github.com/mlflow/mlflow/tree/master/examples/tensorflow>`_.
 
 Autologging captures the following information:
 
@@ -238,7 +247,7 @@ Autologging captures the following information:
 | TensorFlow Core  | All ``tf.summary.scalar`` calls                        | --                                                           | --            | --                                                                                                                                               |
 +------------------+--------------------------------------------------------+--------------------------------------------------------------+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------+
 
-Note that autologging for ``tf.keras`` is handled by :py:func:`mlflow.tensorflow.autolog`, not :py:func:`mlflow.keras.autolog`. 
+Note that autologging for ``tf.keras`` is handled by :py:func:`mlflow.tensorflow.autolog`, not :py:func:`mlflow.keras.autolog`.
 
 If no active run exists when ``autolog()`` captures data, MLflow will automatically create a run to log information to.
 Once training ends via calls to ``tf.estimator.train()``, ``tf.keras.fit()``, ``tf.keras.fit_generator()``, ``keras.fit()`` or ``keras.fit_generator()``,
@@ -251,8 +260,8 @@ If a run exists when ``autolog()`` captures data, MLflow will log to that run an
 **Note**: this feature is experimental - the API and format of the logged data are subject to change.
 
 
-Automatic Logging from Gluon (experimental)
-==================================================================
+Gluon (experimental)
+--------------------
 Call :py:func:`mlflow.gluon.autolog` before your training code to enable automatic logging of metrics and parameters without the need for explicit
 log statements. See example usages with `Gluon <https://github.com/mlflow/mlflow/tree/master/examples/gluon>`_ .
 
@@ -266,6 +275,27 @@ Autologging captures the following information:
 
 **Note**: this feature is experimental - the API and format of the logged data are subject to change.
 
+XGBoost (experimental)
+----------------------
+Call :py:func:`mlflow.xgboost.autolog` before your training code to enable automatic logging of metrics and parameters without the need for explicit log statements.
+
+Autologging captures the following information:
+
++-----------+------------------------+-----------------------------+---------------+---------------------------------------------------------------------+
+| Framework | Metrics                | Parameters                  | Tags          | Artifacts                                                           |
++-----------+------------------------+-----------------------------+---------------+---------------------------------------------------------------------+
+| XGBoost   | user-specified metrics | `xgboost.train`_ parameters | --            | `MLflow Model`_ (XGBoost model) on training end; feature importance |
++-----------+------------------------+-----------------------------+---------------+---------------------------------------------------------------------+
+
+If early stopping is activated, metrics at the best iteration will be logged as an extra step/iteration.
+
+.. note::
+  - This feature is experimental - the API and format of the logged data are subject to change.
+  - The `scikit-learn API`_ is not supported.
+
+.. _xgboost.train: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
+.. _MLflow Model: https://mlflow.org/docs/latest/models.html
+.. _scikit-learn API:  https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn
 
 .. _organizing_runs_in_experiments:
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -221,16 +221,16 @@ Here is an example plot of the :ref:`quick start tutorial <quickstart>` with the
 Automatic Logging
 =================
 
-Automatic logging allows you to log metrics and parameters without the need for explicit log statements.
+Automatic logging allows you to log metrics, parameters, and models without the need for explicit
+log statements, and is currently supported for:
 
-.. contents:: In this section:
+.. contents::
   :local:
   :depth: 1
 
 TensorFlow and Keras (experimental)
 -----------------------------------
-Call :py:func:`mlflow.tensorflow.autolog` or :py:func:`mlflow.keras.autolog` before your training code to enable automatic logging of metrics and parameters without the need for explicit
-log statements. See example usages with `Keras <https://github.com/mlflow/mlflow/tree/master/examples/keras>`_ and
+Call :py:func:`mlflow.tensorflow.autolog` or :py:func:`mlflow.keras.autolog` before your training code to enable automatic logging of metrics and parameters. See example usages with `Keras <https://github.com/mlflow/mlflow/tree/master/examples/keras>`_ and
 `TensorFlow <https://github.com/mlflow/mlflow/tree/master/examples/tensorflow>`_.
 
 Autologging captures the following information:
@@ -257,13 +257,13 @@ If a run exists when ``autolog()`` captures data, MLflow will log to that run an
 
 .. note::
   - Parameters not explicitly passed by users (parameters that use default values) while using ``keras.Model.fit_generator()`` are not currently automatically logged.
-  - his feature is experimental - the API and format of the logged data are subject to change.
+  - This feature is experimental - the API and format of the logged data are subject to change.
 
 
 Gluon (experimental)
 --------------------
-Call :py:func:`mlflow.gluon.autolog` before your training code to enable automatic logging of metrics and parameters without the need for explicit
-log statements. See example usages with `Gluon <https://github.com/mlflow/mlflow/tree/master/examples/gluon>`_ .
+Call :py:func:`mlflow.gluon.autolog` before your training code to enable automatic logging of metrics and parameters.
+See example usages with `Gluon <https://github.com/mlflow/mlflow/tree/master/examples/gluon>`_ .
 
 Autologging captures the following information:
 
@@ -278,7 +278,7 @@ Autologging captures the following information:
 
 XGBoost (experimental)
 ----------------------
-Call :py:func:`mlflow.xgboost.autolog` before your training code to enable automatic logging of metrics and parameters without the need for explicit log statements.
+Call :py:func:`mlflow.xgboost.autolog` before your training code to enable automatic logging of metrics and parameters.
 
 Autologging captures the following information:
 

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -75,7 +75,7 @@ def log_fn_args_as_params(fn, args, kwargs, unlogged=[], unpacked=[]):  # pylint
                      in zip(all_param_names[:len(args)], args)
                      if param_name not in unlogged)
 
-    # Unpack dict parameters if unpack is not empty.
+    # Unpack dict parameters
     for param_name in unpacked:
         popped = args_dict.pop(param_name)
         args_dict = {**args_dict, **popped}

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -46,14 +46,13 @@ def get_unspecified_default_args(user_args, user_kwargs, all_param_names, all_de
             if name not in user_specified_arg_names}
 
 
-def log_fn_args_as_params(fn, args, kwargs, unlogged=[], unpacked=[]):  # pylint: disable=W0102
+def log_fn_args_as_params(fn, args, kwargs, unlogged=[]):  # pylint: disable=W0102
     """
     Log parameters explicitly passed to a function.
     :param fn: function whose parameters are to be logged
     :param args: arguments explicitly passed into fn
     :param kwargs: kwargs explicitly passed into fn
     :param unlogged: parameters not to be logged
-    :param unpacked: dict parameters to be unpacked
     :return: None
     """
     # all_default_values has length n, corresponding to values of the
@@ -74,21 +73,10 @@ def log_fn_args_as_params(fn, args, kwargs, unlogged=[], unpacked=[]):  # pylint
     args_dict = dict((param_name, param_val) for param_name, param_val
                      in zip(all_param_names[:len(args)], args)
                      if param_name not in unlogged)
-
-    # Unpack dict parameters
-    for param_name in unpacked:
-        popped = args_dict.pop(param_name)
-        args_dict = {**args_dict, **popped}
-
     if len(args_dict.keys()) > 0:
         try_mlflow_log(mlflow.log_params, args_dict)
 
     # Logging the kwargs passed by the user
     for param_name in kwargs:
-        if param_name in unlogged:
-            continue
-
-        if param_name in unpacked:
-            try_mlflow_log(mlflow.log_params, kwargs[param_name])
-        else:
+        if param_name not in unlogged:
             try_mlflow_log(mlflow.log_param, param_name, kwargs[param_name])

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -249,15 +249,15 @@ def autolog(importance_types=['weight']):  # pylint: disable=W0102
 
         model = original(*args, **kwargs)
 
-        # checking if the 'early_stopping_rounds' argument of train() is set.
+        # checking if the 'early_stopping_rounds' argument of train() is present.
         early_stopping_index = all_arg_names.index('early_stopping_rounds')
-        has_early_stopping = (num_pos_args >= early_stopping_index + 1 or
-                              'early_stopping_rounds' in kwargs)
+        early_stopping = (num_pos_args >= early_stopping_index + 1 or
+                          'early_stopping_rounds' in kwargs)
 
-        # if 'early_stopping_rounds' is set, the output model has
+        # if 'early_stopping_rounds' is present, the output model has
         # 'best_score', 'best_iteration', and 'best_ntree_limit'
         # even if early stopping didn't occur.
-        if has_early_stopping:
+        if early_stopping:
             attrs = ['best_score', 'best_iteration', 'best_ntree_limit']
             try_mlflow_log(mlflow.log_metrics, {attr: getattr(model, attr) for attr in attrs})
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -211,12 +211,6 @@ def autolog():
             try_mlflow_log(mlflow.log_metrics, dict(env.evaluation_result_list),
                            step=env.iteration)
 
-        if not mlflow.active_run():
-            try_mlflow_log(mlflow.start_run)
-            auto_end_run = True
-        else:
-            auto_end_run = False
-
         def get_feature_importance(model, importance_type):
             score = model.get_score(importance_type=importance_type)
             return [(fn, score[fn] if fn in score else 0) for fn in model.feature_names]
@@ -227,6 +221,12 @@ def autolog():
                 csv_out.writerow(header)
                 for row in data:
                     csv_out.writerow(row)
+
+        if not mlflow.active_run():
+            try_mlflow_log(mlflow.start_run)
+            auto_end_run = True
+        else:
+            auto_end_run = False
 
         original = gorilla.get_original_attribute(xgboost, 'train')
         unlogged_params = ['dtrain', 'evals', 'obj', 'feval', 'evals_result',
@@ -252,7 +252,7 @@ def autolog():
         # checking if the 'early_stopping_rounds' argument of train() is set.
         early_stopping_index = all_arg_names.index('early_stopping_rounds')
         has_early_stopping = num_pos_args >= early_stopping_index + 1 or \
-                             'early_stopping_rounds' in kwargs
+        'early_stopping_rounds' in kwargs
 
         # if 'early_stopping_rounds' is set, the output model has
         # 'best_score', 'best_iteration', and 'best_ntree_limit'

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -198,13 +198,15 @@ class _XGBModelWrapper:
 @experimental
 def autolog(importance_types=['weight']):  # pylint: disable=W0102
     """
-    Enables autologging from XGBoost to MLflow. Logs the following.
+    Enables automatic logging from XGBoost to MLflow. Logs the following.
 
     - parameters specified in `xgboost.train`_.
     - metrics on each iteration (if ``evals`` specified).
     - metrics at the best iteration (if ``early_stopping_rounds`` specified).
     - feature importance.
     - trained model.
+
+    Note that the `scikit-learn API`_ is not supported.
 
     :param importance_types: importance types to log.
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -271,6 +271,8 @@ def autolog(importance_types=['weight']):  # pylint: disable=W0102
                           'early_stopping_rounds' in kwargs)
         if early_stopping:
             extra_step = len(eval_results)
+            try_mlflow_log(mlflow.log_metric, 'stopped_iteration', len(eval_results) - 1)
+            try_mlflow_log(mlflow.log_metric, 'best_iteration', model.best_iteration)
             try_mlflow_log(mlflow.log_metrics, eval_results[model.best_iteration],
                            step=extra_step)
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -195,7 +195,7 @@ class _XGBModelWrapper:
 
 
 @experimental
-def autolog(importance_types=['weight']):
+def autolog(importance_types=['weight']):  # pylint: disable=W0102
     """
     Enables autologging from XGBoost to MLflow. Logs the following.
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -245,9 +245,8 @@ def autolog():
         # 'best_score', 'best_iteration', and 'best_ntree_limit'
         # even if early stopping didn't occur.
         if has_early_stopping:
-            try_mlflow_log(mlflow.log_metric, 'best_score', model.best_score)
-            try_mlflow_log(mlflow.log_metric, 'best_iteration', model.best_iteration)
-            try_mlflow_log(mlflow.log_metric, 'best_ntree_limit', model.best_iteration)
+            attrs = ['best_score', 'best_iteration', 'best_ntree_limit']
+            try_mlflow_log(mlflow.log_metrics, {attr: getattr(model, attr) for attr in attrs})
 
         try_mlflow_log(log_model, model, artifact_path='model')
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -231,7 +231,7 @@ def autolog(importance_types=['weight']):
                            'xgb_model', 'callbacks', 'learning_rates']
         log_fn_args_as_params(original, args, kwargs, unlogged_params)
 
-        all_arg_names = inspect.getargspec(original)[0]
+        all_arg_names = inspect.getargspec(original)[0]  # pylint: disable=W1505
         num_pos_args = len(args)
 
         # checking if the 'callbacks' argument of train() is set.

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -228,7 +228,13 @@ def autolog(importance_types=['weight']):  # pylint: disable=W0102
             auto_end_run = False
 
         original = gorilla.get_original_attribute(xgboost, 'train')
-        unlogged_params = ['dtrain', 'evals', 'obj', 'feval', 'evals_result',
+
+        # Logging `params` separately via mlflow.log_params to extract key/value pairs
+        # and make it easier to compare them across runs.
+        params = args[0] if len(args) > 0 else kwargs['params']
+        try_mlflow_log(mlflow.log_params, params)
+
+        unlogged_params = ['params', 'dtrain', 'evals', 'obj', 'feval', 'evals_result',
                            'xgb_model', 'callbacks', 'learning_rates']
         log_fn_args_as_params(original, args, kwargs, unlogged_params)
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -214,6 +214,8 @@ def autolog(importance_types=['weight']):  # pylint: disable=W0102
     @gorilla.patch(xgboost)
     def train(*args, **kwargs):
 
+        # TODO (harupy): Add asynchronous logging to prevent the API request overhead
+        # from slowing down training.
         def mlflow_callback(env):
             """
             Callback for auto-logging metrics on each iteration.

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -221,9 +221,10 @@ def autolog():
             score = model.get_score(importance_type=importance_type)
             return [(fn, score[fn] if fn in score else 0) for fn in model.feature_names]
 
-        def save_as_csv(data, save_path):
+        def save_as_csv(data, header, save_path):
             with open(save_path, 'w') as f:
                 csv_out = csv.writer(f)
+                csv_out.writerow(header)
                 for row in data:
                     csv_out.writerow(row)
 
@@ -266,7 +267,7 @@ def autolog():
             fi = get_feature_importance(model, importance_type=fi_type)
             filename = 'feature_importance_{}.csv'.format(fi_type)
             filepath = os.path.join(tempfile.mkdtemp(), filename)
-            save_as_csv(fi, filepath)
+            save_as_csv(fi, ['feature', 'importance'], filepath)
             try_mlflow_log(mlflow.log_artifact, filepath)
 
         try_mlflow_log(log_model, model, artifact_path='model')

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -230,8 +230,7 @@ def autolog(importance_types=['weight']):  # pylint: disable=W0102
         original = gorilla.get_original_attribute(xgboost, 'train')
         unlogged_params = ['dtrain', 'evals', 'obj', 'feval', 'evals_result',
                            'xgb_model', 'callbacks', 'learning_rates']
-        unpacked_params = ['params']
-        log_fn_args_as_params(original, args, kwargs, unlogged_params, unpacked_params)
+        log_fn_args_as_params(original, args, kwargs, unlogged_params)
 
         all_arg_names = inspect.getargspec(original)[0]  # pylint: disable=W1505
         num_pos_args = len(args)

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -230,7 +230,8 @@ def autolog(importance_types=['weight']):  # pylint: disable=W0102
         original = gorilla.get_original_attribute(xgboost, 'train')
         unlogged_params = ['dtrain', 'evals', 'obj', 'feval', 'evals_result',
                            'xgb_model', 'callbacks', 'learning_rates']
-        log_fn_args_as_params(original, args, kwargs, unlogged_params)
+        unpacked_params = ['params']
+        log_fn_args_as_params(original, args, kwargs, unlogged_params, unpacked_params)
 
         all_arg_names = inspect.getargspec(original)[0]  # pylint: disable=W1505
         num_pos_args = len(args)

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -20,6 +20,7 @@ XGBoost (native) format
 from __future__ import absolute_import
 
 import os
+import shutil
 import json
 import yaml
 import tempfile
@@ -271,11 +272,15 @@ def autolog(importance_types=['weight']):  # pylint: disable=W0102
         # logging feature importance as artifacts.
         for imp_type in importance_types:
             imp = model.get_score(importance_type=imp_type)
-            filename = 'feature_importance_{}.json'.format(imp_type)
-            filepath = os.path.join(tempfile.mkdtemp(), filename)
-            with open(filepath, 'w') as f:
-                json.dump(imp, f)
-            try_mlflow_log(mlflow.log_artifact, filepath)
+
+            tmpdir = tempfile.mkdtemp()
+            try:
+                filepath = os.path.join(tmpdir, 'feature_importance_{}.json'.format(imp_type))
+                with open(filepath, 'w') as f:
+                    json.dump(imp, f)
+                try_mlflow_log(mlflow.log_artifact, filepath)
+            finally:
+                shutil.rmtree(tmpdir)
 
         try_mlflow_log(log_model, model, artifact_path='model')
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -251,8 +251,8 @@ def autolog():
 
         # checking if the 'early_stopping_rounds' argument of train() is set.
         early_stopping_index = all_arg_names.index('early_stopping_rounds')
-        has_early_stopping = num_pos_args >= early_stopping_index + 1 or \
-        'early_stopping_rounds' in kwargs
+        has_early_stopping = (num_pos_args >= early_stopping_index + 1 or
+                              'early_stopping_rounds' in kwargs)
 
         # if 'early_stopping_rounds' is set, the output model has
         # 'best_score', 'best_iteration', and 'best_ntree_limit'

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -201,7 +201,8 @@ def autolog(importance_types=['weight']):
 
     - parameters specified in `xgboost.train`_.
     - metrics on each iteration (if ``evals`` specified).
-    - ``best_iteration``, ``best_ntree_limit``, and ``best_score`` (if ``early_stopping_rounds`` specified).
+    - ``best_iteration``, ``best_ntree_limit``, and ``best_score``
+      (if ``early_stopping_rounds`` specified).
     - feature importance.
     - trained model.
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -260,7 +260,7 @@ def autolog(importance_types=['weight']):  # pylint: disable=W0102
 
         # logging metrics on each iteration.
         for idx, metrics in enumerate(eval_results):
-            try_mlflow_log(mlflow.log_metrics, metrics, step=idx + 1)
+            try_mlflow_log(mlflow.log_metrics, metrics, step=idx)
 
         # If early_stopping_rounds is present, logging metrics at the best iteration
         # as extra metrics with the max step + 1.
@@ -268,9 +268,9 @@ def autolog(importance_types=['weight']):  # pylint: disable=W0102
         early_stopping = (num_pos_args >= early_stopping_index + 1 or
                           'early_stopping_rounds' in kwargs)
         if early_stopping:
-            num_steps = len(eval_results)
-            best_iter = model.best_iteration
-            try_mlflow_log(mlflow.log_metrics, eval_results[best_iter - 1], step=num_steps + 1)
+            extra_step = len(eval_results)
+            try_mlflow_log(mlflow.log_metrics, eval_results[model.best_iteration],
+                           step=extra_step)
 
         # logging feature importance as artifacts.
         for imp_type in importance_types:

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -1,0 +1,194 @@
+import os
+import json
+import pytest
+import numpy as np
+import pandas as pd
+from sklearn import datasets
+import xgboost as xgb
+
+import mlflow
+import mlflow.xgboost
+
+client = mlflow.tracking.MlflowClient()
+
+
+def get_latest_run():
+    return client.get_run(client.list_run_infos(experiment_id='0')[0].run_id)
+
+
+@pytest.fixture(scope="session")
+def bst_params():
+    return {
+        'objective': 'multi:softprob',
+        'num_class': 3,
+        'eval_metric': 'mlogloss',
+    }
+
+
+@pytest.fixture(scope="session")
+def dtrain():
+    iris = datasets.load_iris()
+    X = pd.DataFrame(iris.data[:, :2], columns=iris.feature_names[:2])
+    y = iris.target
+    return xgb.DMatrix(X, y)
+
+
+@pytest.mark.large
+def test_xgb_autolog_ends_auto_created_run(bst_params, dtrain):
+    mlflow.xgboost.autolog()
+    xgb.train(bst_params, dtrain)
+    assert mlflow.active_run() is None
+
+
+@pytest.mark.large
+def test_xgb_autolog_persists_manually_created_run(bst_params, dtrain):
+    mlflow.xgboost.autolog()
+    with mlflow.start_run() as run:
+        xgb.train(bst_params, dtrain)
+        assert mlflow.active_run()
+        assert mlflow.active_run().info.run_id == run.info.run_id
+
+
+@pytest.mark.large
+def test_xgb_autolog_logs_default_params(bst_params, dtrain):
+    mlflow.xgboost.autolog()
+    xgb.train(bst_params, dtrain)
+    run = get_latest_run()
+    params = run.data.params
+
+    expected_params = {
+        'params': bst_params,
+        'num_boost_round': 10,
+        'maximize': False,
+        'early_stopping_rounds': None,
+        'verbose_eval': True,
+    }
+
+    for key, val in expected_params.items():
+        assert key in params
+        assert params[key] == str(val)
+
+    unlogged_params = ['dtrain', 'evals', 'obj', 'feval', 'evals_result',
+                       'xgb_model', 'callbacks', 'learning_rates']
+
+    for param in unlogged_params:
+        assert param not in params
+
+
+@pytest.mark.large
+def test_xgb_autolog_logs_specified_params(bst_params, dtrain):
+    mlflow.xgboost.autolog()
+    expected_params = {
+        'num_boost_round': 20,
+        'early_stopping_rounds': 5,
+        'verbose_eval': False,
+    }
+    xgb.train(bst_params, dtrain, evals=[(dtrain, 'train')], **expected_params)
+    run = get_latest_run()
+    params = run.data.params
+
+    expected_params.update({'params': bst_params})
+
+    for key, val in expected_params.items():
+        assert key in params
+        assert params[key] == str(val)
+
+    unlogged_params = ['dtrain', 'evals', 'obj', 'feval', 'evals_result',
+                       'xgb_model', 'callbacks', 'learning_rates']
+
+    for param in unlogged_params:
+        assert param not in params
+
+
+@pytest.mark.large
+def test_xgb_autolog_logs_metrics_with_validation_data(bst_params, dtrain):
+    mlflow.xgboost.autolog()
+    evals_result = {}
+    xgb.train(bst_params, dtrain, num_boost_round=20,
+              evals=[(dtrain, 'train')], evals_result=evals_result)
+    run = get_latest_run()
+    data = run.data
+
+    metric_key = 'train-mlogloss'
+    metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
+    assert metric_key in data.metrics
+    assert len(metric_history) == 20
+    assert metric_history == evals_result['train']['mlogloss']
+
+    # these metrics should not be logged because early_stopping_rounds wasn't specified.
+    attrs = ['best_iteration', 'best_ntree_limit', 'best_score']
+
+    for attr in attrs:
+        assert attr not in data.metrics
+
+
+@pytest.mark.large
+def test_xgb_autolog_logs_metrics_with_early_stopping(bst_params, dtrain):
+    mlflow.xgboost.autolog()
+    evals_result = {}
+    model = xgb.train(bst_params, dtrain, num_boost_round=20, early_stopping_rounds=5,
+                      evals=[(dtrain, 'train')], evals_result=evals_result)
+    run = get_latest_run()
+    data = run.data
+
+    metric_key = 'train-mlogloss'
+    metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
+    assert metric_key in data.metrics
+    assert len(metric_history) == 20
+    assert metric_history == evals_result['train']['mlogloss']
+
+    attrs = ['best_iteration', 'best_ntree_limit', 'best_score']
+
+    for attr in attrs:
+        assert attr in data.metrics
+        assert data.metrics[attr] == getattr(model, attr)
+
+
+@pytest.mark.large
+def test_xgb_autolog_logs_feature_importance(bst_params, dtrain):
+    mlflow.xgboost.autolog()
+    model = xgb.train(bst_params, dtrain)
+    run = get_latest_run()
+    run_id = run.info.run_id
+    artifacts_dir = run.info.artifact_uri.replace('file://', '')
+    artifacts = [x.path for x in client.list_artifacts(run_id)]
+
+    importance_type = 'weight'
+    filename = 'feature_importance_{}.json'.format(importance_type)
+    filepath = os.path.join(artifacts_dir, filename)
+    with open(filepath, 'r') as f:
+        loaded_imp = json.load(f)
+
+    assert filename in artifacts
+    assert loaded_imp == model.get_score(importance_type=importance_type)
+
+
+@pytest.mark.large
+def test_xgb_autolog_logs_specified_feature_importance(bst_params, dtrain):
+    importance_types = ['weight', 'total_gain']
+    mlflow.xgboost.autolog(importance_types)
+    model = xgb.train(bst_params, dtrain)
+    run = get_latest_run()
+    run_id = run.info.run_id
+    artifacts_dir = run.info.artifact_uri.replace('file://', '')
+    artifacts = [x.path for x in client.list_artifacts(run_id)]
+
+    for imp_type in importance_types:
+        filename = 'feature_importance_{}.json'.format(imp_type)
+        filepath = os.path.join(artifacts_dir, filename)
+        with open(filepath, 'r') as f:
+            loaded_imp = json.load(f)
+
+        assert filename in artifacts
+        assert loaded_imp == model.get_score(importance_type=imp_type)
+
+
+@pytest.mark.large
+def test_xgb_autolog_loads_model_from_artifact(bst_params, dtrain):
+    mlflow.xgboost.autolog()
+    model = xgb.train(bst_params, dtrain)
+    run = get_latest_run()
+    run_id = run.info.run_id
+
+    loaded_model = mlflow.xgboost.load_model('runs:/{}/model'.format(run_id))
+    np.testing.assert_array_almost_equal(model.predict(dtrain), loaded_model.predict(dtrain))

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -21,7 +21,6 @@ def bst_params():
     return {
         'objective': 'multi:softprob',
         'num_class': 3,
-        'eval_metric': 'mlogloss',
     }
 
 
@@ -109,27 +108,90 @@ def test_xgb_autolog_logs_metrics_with_validation_data(bst_params, dtrain):
     run = get_latest_run()
     data = run.data
 
-    metric_key = 'train-mlogloss'
+    metric_key = 'train-merror'
     metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
     assert metric_key in data.metrics
     assert len(metric_history) == 20
-    assert metric_history == evals_result['train']['mlogloss']
+    assert metric_history == evals_result['train']['merror']
+
+
+@pytest.mark.large
+def test_xgb_autolog_logs_metrics_with_multi_validation_data(bst_params, dtrain):
+    mlflow.xgboost.autolog()
+    evals_result = {}
+    evals = [(dtrain, 'train'), (dtrain, 'valid')]
+    xgb.train(bst_params, dtrain, num_boost_round=20, evals=evals, evals_result=evals_result)
+    run = get_latest_run()
+    data = run.data
+
+    for eval_name in ['train', 'valid']:
+        metric_key = '{}-merror'.format(eval_name)
+        metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
+        assert metric_key in data.metrics
+        assert len(metric_history) == 20
+        assert metric_history == evals_result[eval_name]['merror']
+
+
+@pytest.mark.large
+def test_xgb_autolog_logs_metrics_with_multi_metrics(bst_params, dtrain):
+    mlflow.xgboost.autolog()
+    evals_result = {}
+    params = {'eval_metric': ['merror', 'mlogloss']}
+    params.update(bst_params)
+    xgb.train(params, dtrain, num_boost_round=20,
+              evals=[(dtrain, 'train')], evals_result=evals_result)
+    run = get_latest_run()
+    data = run.data
+
+    for metric_name in params['eval_metric']:
+        metric_key = 'train-{}'.format(metric_name)
+        metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
+        assert metric_key in data.metrics
+        assert len(metric_history) == 20
+        assert metric_history == evals_result['train'][metric_name]
+
+
+@pytest.mark.large
+def test_xgb_autolog_logs_metrics_with_multi_validation_data_and_metrics(bst_params, dtrain):
+    mlflow.xgboost.autolog()
+    evals_result = {}
+    params = {'eval_metric': ['merror', 'mlogloss']}
+    params.update(bst_params)
+    evals = [(dtrain, 'train'), (dtrain, 'valid')]
+    xgb.train(params, dtrain, num_boost_round=20, evals=evals, evals_result=evals_result)
+    run = get_latest_run()
+    data = run.data
+
+    for eval_name in [e[1] for e in evals]:
+        for metric_name in params['eval_metric']:
+            metric_key = '{}-{}'.format(eval_name, metric_name)
+            metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
+            assert metric_key in data.metrics
+            assert len(metric_history) == 20
+            assert metric_history == evals_result[eval_name][metric_name]
 
 
 @pytest.mark.large
 def test_xgb_autolog_logs_metrics_with_early_stopping(bst_params, dtrain):
     mlflow.xgboost.autolog()
     evals_result = {}
-    model = xgb.train(bst_params, dtrain, num_boost_round=20, early_stopping_rounds=5,
-                      evals=[(dtrain, 'train')], evals_result=evals_result)
+    params = {'eval_metric': ['merror', 'mlogloss']}
+    params.update(bst_params)
+    evals = [(dtrain, 'train'), (dtrain, 'valid')]
+    model = xgb.train(params, dtrain, num_boost_round=20, early_stopping_rounds=5,
+                      evals=evals, evals_result=evals_result)
     run = get_latest_run()
     data = run.data
 
-    metric_key = 'train-mlogloss'
-    metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
-    assert metric_key in data.metrics
-    assert len(metric_history) == 20 + 1
-    assert metric_history == evals_result['train']['mlogloss'] + [model.best_score]
+    for eval_name in [e[1] for e in evals]:
+        for metric_name in params['eval_metric']:
+            metric_key = '{}-{}'.format(eval_name, metric_name)
+            metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
+            assert metric_key in data.metrics
+            assert len(metric_history) == 20 + 1
+
+            best_metrics = evals_result[eval_name][metric_name][model.best_iteration]
+            assert metric_history == evals_result[eval_name][metric_name] + [best_metrics]
 
 
 @pytest.mark.large

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -165,7 +165,8 @@ def test_xgb_autolog_logs_metrics_with_multi_validation_data_and_metrics(bst_par
     for eval_name in [e[1] for e in evals]:
         for metric_name in params['eval_metric']:
             metric_key = '{}-{}'.format(eval_name, metric_name)
-            metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
+            metric_history = [x.value for x
+                              in client.get_metric_history(run.info.run_id, metric_key)]
             assert metric_key in data.metrics
             assert len(metric_history) == 20
             assert metric_history == evals_result[eval_name][metric_name]
@@ -186,7 +187,8 @@ def test_xgb_autolog_logs_metrics_with_early_stopping(bst_params, dtrain):
     for eval_name in [e[1] for e in evals]:
         for metric_name in params['eval_metric']:
             metric_key = '{}-{}'.format(eval_name, metric_name)
-            metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
+            metric_history = [x.value for x
+                              in client.get_metric_history(run.info.run_id, metric_key)]
             assert metric_key in data.metrics
             assert len(metric_history) == 20 + 1
 

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -57,7 +57,7 @@ def test_xgb_autolog_logs_default_params(bst_params, dtrain):
     params = run.data.params
 
     expected_params = {
-        'params': bst_params,
+        **bst_params,
         'num_boost_round': 10,
         'maximize': False,
         'early_stopping_rounds': None,
@@ -87,7 +87,7 @@ def test_xgb_autolog_logs_specified_params(bst_params, dtrain):
     run = get_latest_run()
     params = run.data.params
 
-    expected_params.update({'params': bst_params})
+    expected_params.update(bst_params)
 
     for key, val in expected_params.items():
         assert key in params

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -124,7 +124,7 @@ def test_xgb_autolog_logs_metrics_with_multi_validation_data(bst_params, dtrain)
     run = get_latest_run()
     data = run.data
 
-    for eval_name in ['train', 'valid']:
+    for eval_name in [e[1] for e in evals]:
         metric_key = '{}-merror'.format(eval_name)
         metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
         assert metric_key in data.metrics

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -115,12 +115,6 @@ def test_xgb_autolog_logs_metrics_with_validation_data(bst_params, dtrain):
     assert len(metric_history) == 20
     assert metric_history == evals_result['train']['mlogloss']
 
-    # these metrics should not be logged because early_stopping_rounds wasn't specified.
-    attrs = ['best_iteration', 'best_ntree_limit', 'best_score']
-
-    for attr in attrs:
-        assert attr not in data.metrics
-
 
 @pytest.mark.large
 def test_xgb_autolog_logs_metrics_with_early_stopping(bst_params, dtrain):
@@ -134,14 +128,8 @@ def test_xgb_autolog_logs_metrics_with_early_stopping(bst_params, dtrain):
     metric_key = 'train-mlogloss'
     metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
     assert metric_key in data.metrics
-    assert len(metric_history) == 20
-    assert metric_history == evals_result['train']['mlogloss']
-
-    attrs = ['best_iteration', 'best_ntree_limit', 'best_score']
-
-    for attr in attrs:
-        assert attr in data.metrics
-        assert data.metrics[attr] == getattr(model, attr)
+    assert len(metric_history) == 20 + 1
+    assert metric_history == evals_result['train']['mlogloss'] + [model.best_score]
 
 
 @pytest.mark.large

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -57,12 +57,12 @@ def test_xgb_autolog_logs_default_params(bst_params, dtrain):
     params = run.data.params
 
     expected_params = {
-        **bst_params,
         'num_boost_round': 10,
         'maximize': False,
         'early_stopping_rounds': None,
         'verbose_eval': True,
     }
+    expected_params.update(bst_params)
 
     for key, val in expected_params.items():
         assert key in params

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -184,6 +184,11 @@ def test_xgb_autolog_logs_metrics_with_early_stopping(bst_params, dtrain):
     run = get_latest_run()
     data = run.data
 
+    assert 'best_iteration' in data.metrics
+    assert int(data.metrics['best_iteration']) == model.best_iteration
+    assert 'stopped_iteration' in data.metrics
+    assert int(data.metrics['stopped_iteration']) == len(evals_result['train']['merror']) - 1
+
     for eval_name in [e[1] for e in evals]:
         for metric_name in params['eval_metric']:
             metric_key = '{}-{}'.format(eval_name, metric_name)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add autologging functionality that logs the following  for XGBoost flavor

- booster parameters
- metrics on each iteration
- feature importance (logged as artifacts in json)
- trained model (logged as an artifact)
- best_score, best_iteration, and best_ntree_limit (if early stopping is set)


Sample code

```python
import xgboost as xgb
from mlflow.xgboost import autolog

from sklearn import datasets
from sklearn.model_selection import train_test_split

autolog()

X, y = datasets.load_iris(return_X_y=True)
X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
dtrain = xgb.DMatrix(X_train, label=y_train)
dtest = xgb.DMatrix(X_test, label=y_test)

# train model
params = {
    'objective': 'multi:softprob',
    'num_class': 3,
    'eval_metric': 'mlogloss',
    'seed': 42,
}
model = xgb.train(params, dtrain, evals=[(dtest, 'test')], early_stopping_rounds=10)
```

and the output

![Dec-27-2019 14-21-38](https://user-images.githubusercontent.com/17039389/71502572-48461c00-28b4-11ea-943d-e556c620bce9.gif)



## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [x] API
- [ ] REST-API
- [x] Examples
- [x] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [x] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
