### PR TITLE
Add yarn backend for MLflow project (#75)

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -344,6 +344,9 @@ Deployment Mode
     - You can also launch projects remotely on `Kubernetes <https://Kubernetes.io/>`_ clusters
       using the ``mlflow run`` CLI (see :ref:`kubernetes_execution`).
 
+    - You can also launch projects remotely on `Yarn <https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html>`_ clusters
+      using the ``mlflow run`` CLI (see :ref:`yarn_execution`).
+
 Environment
     By default, MLflow Projects are run in the environment specified by the project directory
     or the ``MLproject`` file (see :ref:`Specifying Project Environments <project-environments>`).
@@ -573,6 +576,94 @@ execution. Replaced fields are indicated using bracketed text.
 The ``container.name``, ``container.image``, and ``container.command`` fields are only replaced for
 the *first* container defined in the Job Spec. All subsequent container definitions are applied
 without modification.
+
+
+.. _yarn_execution:
+
+Run an MLflow Project on Yarn (experimental)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. important:: As an experimental feature, the API is subject to change.
+
+You can run MLflow Projects on Yarn.
+You can run any exemple having a conda.yaml file on yarn.
+
+
+To see this feature in action, you can also refer to
+`Any example <https://github.com/mlflow/mlflow/tree/master/examples>`_, which includes the required MLproject file, and a conda.yaml.
+You just need to add the required Yarn backend configuration (``yarn_conf.json``).
+
+How it works
+~~~~~~~~~~~~
+
+When you run an MLflow Project on Yarn, MLflow ship your conda env and your project folder to the yarn cluster and run
+the specified entry point using this env.
+
+
+Execution guide
+~~~~~~~~~~~~~~~
+
+You can run your MLflow Project on Yarn by following these steps:
+
+1. Create your project with the needed MLproject file and a conda.yaml describing the necessary environment.
+
+2. Create a backend configuration JSON file with the following entries:
+
+   - ``additional_files``
+     An array of strings that represents path to extra files that should be shipped to the cluster. (by default all your project and the conda env are shipped)
+   - ``num_cores``
+     The number of virtual cores to request.
+   - ``memory``
+     The amount of memory to request. Can be either a string with units (e.g. "5 GiB"), or numeric.
+     If numeric, specifies the amount of memory in MiB.
+   - ``queue``
+     The queue to submit the application to.
+   - ``hadoop_filesystems``
+      List of Hadoop file systems to acquire delegation tokens for.
+   - ``hadoop_conf_dir``
+     Path to directory containing hadoop configuration files in containers.
+     HADOOP_CONF_DIR environment variable will be set with this path in containers.
+
+  .. rubric:: Example Yarn backend configuration
+
+  .. code-block:: json
+
+    {
+        "additional_files": ["./notebooks/specialMessage.ipynb"],
+        "num_cores": 1,
+        "memory": 1024,
+        "queue": "default",
+        "hadoop_filesystems": "viewfs://prod-am6,viewfs://prod-pa4,viewfs://preprod-pa4",
+        "hadoop_conf_dir": "/etc/hadoop/conf"
+    }
+
+3. Create a MLproject file indicating your conda.yaml and your entrypoint:
+
+    .. code-block:: yaml
+
+      name: My Yarn Project
+
+      conda_env: conda.yaml
+
+      entry_points:
+          greet:
+              parameters:
+                  param1: {type: string, default: "param1"}
+                  param2: {type: string, default: "param2"}
+                  command: "python my_entrypoint --param1 {param1} --param2 {param2}"
+
+4. If necessary, obtain credentials to access your Yarn cluster.
+
+5. Run the Project using the MLflow Projects CLI or :py:func:`Python API <mlflow.projects.run>`,
+   specifying your Project URI and the path to your backend configuration file. For example:
+
+   .. code-block:: bash
+
+    mlflow run <project_uri> --backend yarn --backend-config examples/yarn/yarn_config.json
+             -e <entrypoint>
+
+   where ``<project_uri>`` is a Git repository URI or a folder.
+
 
 Iterating Quickly
 -----------------

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -202,7 +202,34 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
         )
         return submitted_run
 
-    supported_backends = ["local", "databricks", "kubernetes"]
+    elif backend == "yarn":
+        from mlflow.projects import yarn
+        entry_point_command = _get_entry_point_command(project, entry_point,
+                                                       parameters, storage_dir)
+        conda_env_name = _get_or_create_conda_env(project.conda_env_path)
+        yarn._validate_yarn_env(project)
+        tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_PROJECT_BACKEND, "yarn")
+        submitted_run = yarn.run_yarn_job(
+            remote_run=active_run,
+            work_dir=work_dir,
+            parameters=parameters,
+            experiment_id=experiment_id,
+            cluster_spec=backend_config,
+            conda_env_name=conda_env_name,
+            entry_point_command=entry_point_command[0],
+            run_env_vars=_get_run_env_vars(
+                run_id=active_run.info.run_uuid,
+                experiment_id=active_run.info.experiment_id
+            )
+        )
+
+        tracking.MlflowClient().set_tag(active_run.info.run_id,
+                                        yarn.YARN_APPLICATION_ID,
+                                        submitted_run._skein_app_id)
+
+        return submitted_run
+
+    supported_backends = ["local", "databricks", "kubernetes", "yarn"]
     raise ExecutionException("Got unsupported execution mode %s. Supported "
                              "values: %s" % (backend, supported_backends))
 

--- a/mlflow/projects/yarn.py
+++ b/mlflow/projects/yarn.py
@@ -1,0 +1,293 @@
+import time
+import logging
+import skein
+import os
+import tempfile
+import textwrap
+
+import conda_pack
+
+from mlflow.exceptions import ExecutionException
+from mlflow.projects.submitted_run import SubmittedRun
+from mlflow.entities import RunStatus
+from mlflow.utils import file_utils
+
+_logger = logging.getLogger(__name__)
+
+YARN_APPLICATION_ID = "yarn_application_id"
+
+# Configuration parameter names
+YARN_NUM_CORES = 'num_cores'
+YARN_MEMORY = 'memory'
+YARN_QUEUE = 'queue'
+YARN_HADOOP_FILESYSTEMS = 'hadoop_filesystems'
+YARN_HADOOP_CONF_DIR = 'hadoop_conf_dir'
+# Extra parameters to configure skein setup
+YARN_ENV = 'env'
+YARN_ADDITIONAL_FILES = 'additional_files'
+
+# default values for YARN related parameters
+yarn_cfg_defaults = {
+    YARN_NUM_CORES: 1,
+    YARN_MEMORY: "1 GiB",
+    YARN_QUEUE: "defautl",
+    YARN_HADOOP_FILESYSTEMS: '',
+    YARN_HADOOP_CONF_DIR: '',
+    YARN_ENV: {},
+    YARN_ADDITIONAL_FILES: []
+}
+
+
+def run_yarn_job(remote_run, work_dir, parameters, experiment_id, cluster_spec,
+                 conda_env_name, entry_point_command, run_env_vars):
+    env_params = _get_key_from_params(parameters, "env")
+    additional_files = _get_key_from_params(parameters, "additional_files")
+
+    yarn_config = _parse_yarn_config(cluster_spec, extra_params=parameters)
+
+    env = _merge_env_lists(env_params, yarn_config[YARN_ENV])
+    env.update(run_env_vars)
+    additional_files += yarn_config[YARN_ADDITIONAL_FILES]
+    zipped_project = _zip_project(work_dir)
+    additional_files.append(zipped_project)
+    packed_conda_env = _pack_conda_env(os.path.join(
+        os.environ["MLFLOW_CONDA_HOME"], "envs", conda_env_name))
+    additional_files.append(packed_conda_env)
+
+    try:
+        with skein.Client() as skein_client:
+            app_id = _submit(
+                skein_client=skein_client,
+                name="MLflow run for experiment {}".format(experiment_id),
+                num_cores=yarn_config[YARN_NUM_CORES],
+                memory=yarn_config[YARN_MEMORY],
+                queue=yarn_config[YARN_QUEUE],
+                hadoop_file_systems=yarn_config[YARN_HADOOP_FILESYSTEMS].split(','),
+                hadoop_conf_dir=yarn_config[YARN_HADOOP_CONF_DIR],
+                env_vars=env,
+                additional_files=additional_files,
+                entry_point_command=entry_point_command
+            )
+
+            _logger.info("YARN backend launched app_id : %s", app_id)
+            return YarnSubmittedRun(skein_app_id=app_id, mlflow_run_id=remote_run.info.run_id)
+    finally:
+        os.remove(zipped_project)
+        os.remove(packed_conda_env)
+
+
+def _submit(skein_client, entry_point_command, name="yarn_launcher",
+            num_cores=1, memory="1 GiB",
+            hadoop_file_systems=None, hadoop_conf_dir="", queue=None, env_vars=None,
+            additional_files=None, node_label=None, num_containers=1,
+            user=None):
+    service = _generate_skein_service(memory, num_cores, num_containers, env_vars, additional_files,
+                                      hadoop_conf_dir, entry_point_command)
+
+    spec = skein.ApplicationSpec(
+        name=name,
+        file_systems=hadoop_file_systems,
+        services={name: service},
+        acls=skein.model.ACLs(
+            enable=True,
+            ui_users=['*'],
+            view_users=['*']
+        )
+    )
+
+    if user:
+        spec.user = user
+
+    if queue:
+        spec.queue = queue
+
+    if node_label:
+        service.node_label = node_label
+
+    return skein_client.submit(spec)
+
+
+def _generate_skein_service(memory, num_cores, num_containers, env_vars, additional_files,
+                            hadoop_conf_dir, entry_point_command):
+    env = dict(env_vars) if env_vars else dict()
+    env.update(
+        {
+            'SKEIN_CONFIG': './.skein',
+            "GIT_PYTHON_REFRESH": "quiet"
+        }
+    )
+    dict_files_to_upload = {os.path.basename(path): os.path.abspath(path)
+                            for path in additional_files}
+
+    script = textwrap.dedent("""
+                 set -x
+                 env
+                 export HADOOP_CONF_DIR=%s
+                 export PATH=$(pwd)/conda_env.zip/bin:$PATH
+                 export LD_LIBRARY_PATH=$(pwd)/conda_env.zip/lib
+                 cd project.zip
+                 %s
+             """ % (hadoop_conf_dir, entry_point_command))
+
+    return skein.Service(
+        resources=skein.model.Resources(memory, num_cores),
+        instances=num_containers,
+        files=dict_files_to_upload,
+        env=env,
+        script=script
+    )
+
+
+def _zip_project(project_dir):
+    """
+    Zip a project directory into an archive in a temp dir .
+
+    :param project_dir: Path to a directory containing an MLflow project to upload to DBFS (e.g.
+                        a directory containing an MLproject file).
+    """
+    temp_tarfile_dir = tempfile.mkdtemp()
+    zip_filename = os.path.join(temp_tarfile_dir, "project.zip")
+    file_utils.make_zipfile(zip_filename, project_dir)
+    return zip_filename
+
+
+def _pack_conda_env(conda_env_name):
+    temp_tarfile_dir = tempfile.mkdtemp()
+    conda_pack_filename = os.path.join(temp_tarfile_dir, "conda_env.zip")
+    conda_pack.pack(prefix=conda_env_name, output=conda_pack_filename)
+    return conda_pack_filename
+
+
+def _validate_yarn_env(project):
+    if not project.name:
+        raise ExecutionException("Project name in MLProject must be specified when "
+                                 "using Yarn backend.")
+
+
+def _merge_env_lists(env_params, env_yarn_cfg):
+    env = dict(value.split('=') for value in env_params)
+    env.update(dict(value.split('=') for value in env_yarn_cfg))
+    return env
+
+
+def _get_key_from_params(params, key, remove_key=True):
+    if key not in params:
+        return []
+
+    values = params[key].split(',')
+    if remove_key:
+        del params[key]
+
+    return values
+
+
+def _parse_yarn_config(backend_config, extra_params=None):
+    """
+    Parses configuration for yarn backend and returns a dictionary
+    with all needed values. In case values are not found in ``backend_config``
+    dict passed, it is filled with the default values.
+    """
+
+    extra_params = extra_params or {}
+    if not backend_config:
+        raise ExecutionException("Backend_config file not found.")
+    yarn_config = backend_config.copy()
+
+    for cfg_key in [YARN_NUM_CORES, YARN_MEMORY, YARN_QUEUE,
+                    YARN_HADOOP_FILESYSTEMS, YARN_HADOOP_CONF_DIR,
+                    YARN_ENV, YARN_ADDITIONAL_FILES]:
+        if cfg_key not in yarn_config.keys():
+            yarn_config[cfg_key] = extra_params.get(cfg_key,
+                                                    yarn_cfg_defaults[cfg_key])
+    return yarn_config
+
+
+def _format_app_report(report):
+    attrs = [
+        "queue",
+        "start_time",
+        "finish_time",
+        "final_status",
+        "tracking_url",
+        "user"
+    ]
+    return os.linesep + os.linesep.join(
+        "{:>16}: {}".format(attr, getattr(report, attr) or '') for attr in attrs)
+
+
+def _get_application_logs(skein_client, app_id, wait_for_nb_logs=None, log_tries=15):
+    for ind in range(log_tries):
+        try:
+            logs = skein_client.application_logs(app_id)
+            nb_keys = len(logs.keys())
+            _logger.info("Got %s/%s log files", nb_keys, wait_for_nb_logs)
+            if not wait_for_nb_logs or nb_keys == wait_for_nb_logs:
+                return logs
+        except (skein.exceptions.ConnectionError, skein.exceptions.TimeoutError) as ex:
+            _logger.exception("Cannot collect logs (attempt %s/%s) due to exception: %s",
+                              ind + 1, log_tries, ex)
+        time.sleep(3)
+    return None
+
+
+class YarnSubmittedRun(SubmittedRun):
+    """
+    Instance of SubmittedRun corresponding to a Yarn Job launched through skein to run an MLflow
+    project.
+    :param skein_app_id: ID of the submitted Skein Application.
+    :param mlflow_run_id: ID of the MLflow project run.
+    """
+
+    POLL_STATUS_INTERNAL_SECS = 30
+
+    def __init__(self, skein_app_id, mlflow_run_id):
+        super(YarnSubmittedRun, self).__init__()
+        self._skein_app_id = skein_app_id
+        self._mlflow_run_id = mlflow_run_id
+
+    @property
+    def run_id(self):
+        return self._mlflow_run_id
+
+    def wait(self):
+        status = skein.model.FinalStatus.UNDEFINED
+        state = None
+
+        with skein.Client() as skein_client:
+            while True:
+                app_report = skein_client.application_report(self._skein_app_id)
+                if state != app_report.state:
+                    _logger.info(_format_app_report(app_report))
+
+                if app_report.final_status == skein.model.FinalStatus.FAILED:
+                    _logger.info("YARN Application %s has failed", self._skein_app_id)
+
+                if app_report.final_status != skein.model.FinalStatus.UNDEFINED:
+                    break
+
+                state = app_report.state
+                time.sleep(self.POLL_STATUS_INTERNAL_SECS)
+
+        return status == skein.model.FinalStatus.SUCCEEDED
+
+    def cancel(self):
+        with skein.Client() as skein_client:
+            skein_client.kill_application(self._skein_app_id)
+
+    def get_status(self):
+        with skein.Client() as skein_client:
+            app_report = skein_client.application_report(self._skein_app_id)
+            return self._translate_to_runstate(app_report.state)
+
+    def _translate_to_runstate(self, app_state):
+        if app_state == skein.model.FinalStatus.SUCCEEDED:
+            return RunStatus.FINISHED
+        elif app_state == skein.model.FinalStatus.KILLED:
+            return RunStatus.KILLED
+        elif app_state == skein.model.FinalStatus.FAILED:
+            return RunStatus.FAILED
+        elif app_state == skein.model.FinalStatus.UNDEFINED:
+            return RunStatus.RUNNING
+
+        raise ExecutionException("YARN Application %s has invalid status: %s"
+                                 % (self._skein_app_id, app_state))

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
+import zipfile
 
 from six.moves.urllib.request import pathname2url
 from six.moves.urllib.parse import unquote
@@ -281,6 +282,24 @@ def make_tarfile(output_filename, source_dir, archive_name, custom_filter=None):
             gzipped_tar.write(tar.read())
     finally:
         os.remove(unzipped_filename)
+
+
+def make_zipfile(archive_name, source_dir):
+    with zipfile.ZipFile(archive_name, 'w', zipfile.ZIP_DEFLATED) as zip_file:
+        for root, _, files in os.walk(source_dir):
+            for file in files:
+                zip_file.write(
+                    os.path.join(root, file),
+                    os.path.join(
+                        "",
+                        os.path.relpath(root, source_dir),
+                        file
+                    )
+                    if root != source_dir
+                    else os.path.join(
+                        "",
+                        file
+                    ))
 
 
 def _copy_project(src_path, dst_path=""):

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,9 @@ setup(
         'sqlparse',
         'sqlalchemy',
         'gorilla',
+        'skein',
         'prometheus-flask-exporter',
+        'conda-pack',
     ],
     extras_require={
         'extras':[

--- a/tests/projects/test_yarn.py
+++ b/tests/projects/test_yarn.py
@@ -1,0 +1,88 @@
+import pytest
+import textwrap
+
+import skein
+
+from mlflow.projects import _project_spec
+from mlflow.exceptions import ExecutionException
+from mlflow.projects.yarn import _validate_yarn_env, _generate_skein_service, \
+    _get_key_from_params, _parse_yarn_config
+from tests.projects.utils import TEST_YARN_PROJECT_DIR
+
+
+def test_valid_project_backend_yarn():
+    project = _project_spec.load_project(TEST_YARN_PROJECT_DIR)
+    _validate_yarn_env(project)
+
+
+def test_invalid_project_backend_yarn():
+    project = _project_spec.load_project(TEST_YARN_PROJECT_DIR)
+    project.name = None
+    with pytest.raises(ExecutionException):
+        _validate_yarn_env(project)
+
+
+def test_get_key_from_params():
+    extra_params = {
+        'env': 'ENV1=ENV1,ENV2=ENV2',
+        'additional_files': '/user/myfile1.py,/user/myfile2.py'
+    }
+    env = _get_key_from_params(extra_params, 'env')
+    additional_files = _get_key_from_params(extra_params, 'additional_files')
+    empty_param = _get_key_from_params(extra_params, 'no_key')
+    assert env == ['ENV1=ENV1', 'ENV2=ENV2']
+    assert additional_files == ['/user/myfile1.py', '/user/myfile2.py']
+    assert empty_param == []
+
+
+def test_generate_skein_service():
+    expected_command = textwrap.dedent("""
+                 set -x
+                 env
+                 export HADOOP_CONF_DIR=/etc/hadoop/conf
+                 export PATH=$(pwd)/conda_env.zip/bin:$PATH
+                 export LD_LIBRARY_PATH=$(pwd)/conda_env.zip/lib
+                 cd project.zip
+                 python train.py
+             """)
+    expected_files = {
+        'test.py': skein.model.File('test.py')
+    }
+
+    service = _generate_skein_service("1 GiB", 1, 1, {"ENV": "ENV"}, ["test.py"],
+                                      "/etc/hadoop/conf", "python train.py")
+
+    assert service.instances == 1
+    assert service.env['ENV'] == 'ENV'
+    assert service.script == expected_command
+    assert service.resources == skein.model.Resources("1 GiB", 1)
+    assert service.files == expected_files
+
+
+def test_parse_yarn_config():
+    backend_config = {
+        "additional_files": ["./notebooks/specialMessage.ipynb"],
+        "num_cores": 12,
+        "memory": 2048,
+        "queue": "default",
+        "hadoop_filesystems": "viewfs://filesystem",
+        "hadoop_conf_dir": "/etc/hadoop/conf"
+    }
+    expected_backend_config = {
+        "additional_files": ["./notebooks/specialMessage.ipynb"],
+        "num_cores": 12,
+        "memory": 2048,
+        "queue": "default",
+        "hadoop_filesystems": "viewfs://filesystem",
+        "hadoop_conf_dir": "/etc/hadoop/conf",
+        "env": {}
+    }
+    yarn_config = _parse_yarn_config(backend_config)
+    assert yarn_config == expected_backend_config
+
+    extra_params = {
+        'env': 'env'
+    }
+    yarn_config = _parse_yarn_config(backend_config, extra_params)
+    expected_backend_config['env'] = 'env'
+    assert yarn_config == expected_backend_config

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -17,6 +17,7 @@ from mlflow.utils.file_utils import path_to_local_sqlite_uri
 TEST_DIR = "tests"
 TEST_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_project")
 TEST_DOCKER_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_docker_project")
+TEST_YARN_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_yarn_project")
 TEST_PROJECT_NAME = "example_project"
 TEST_NO_SPEC_PROJECT_DIR = os.path.join(TEST_DIR, "resources", "example_project_no_spec")
 GIT_PROJECT_URI = "https://github.com/mlflow/mlflow-example"

--- a/tests/resources/example_yarn_project/MLproject
+++ b/tests/resources/example_yarn_project/MLproject
@@ -1,0 +1,12 @@
+name: Example yarn project
+
+conda_env: conda.yaml
+
+entry_points:
+  main:
+    command: "echo 'Main entry point'"
+  greeter:
+    parameters:
+      greeting: {type: string, default: "hi"}
+      name: string
+    command: "python greeter.py {greeting} {name}"

--- a/tests/resources/example_yarn_project/conda.yaml
+++ b/tests/resources/example_yarn_project/conda.yaml
@@ -1,0 +1,10 @@
+# Adding a comment here to distinguish the hash of this conda.yaml from the hashes of existing
+# conda.yaml files in the test environment.
+name: tutorial
+channels:
+  - defaults
+dependencies:
+  - python=3.6
+  - pip:
+    - -e ../../../
+    - psutil

--- a/tests/resources/example_yarn_project/greeter.py
+++ b/tests/resources/example_yarn_project/greeter.py
@@ -1,0 +1,16 @@
+"""
+Example program helping verify functionality for passing parameters other than those required in
+the MLproject file.
+"""
+import argparse
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("greeting", help="Greeting to use", type=str)
+    parser.add_argument("name", help="Name of person to greet", type=str)
+    parser.add_argument("--excitement", help="Excitement level (int) of greeting", type=int)
+    args = parser.parse_args()
+    greeting = [args.greeting, args.name]
+    if args.excitement is not None:
+        greeting.append("!" * args.excitement)
+    print(" ".join(greeting))

--- a/tests/resources/example_yarn_project/yarn_config.json
+++ b/tests/resources/example_yarn_project/yarn_config.json
@@ -1,0 +1,9 @@
+
+{
+  "additional_files": [],
+  "num_cores": 1,
+  "memory": 1024,
+  "queue": "default",
+  "hadoop_filesystems": "viewfs://root",
+  "hadoop_conf_dir": "/etc/hadoop/conf"
+}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Added yarn backend to launch MLflow projects on Yarn.

## How is this patch tested?

With unit tests and by launching run with --backend yarn option in the command line

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Added yarn backend to launch runs on yarn when using MLflow project. This can be used by using --backend yarn option in the mlflow run command line.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [X] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
