### PR TITLE
Add hdfs support for path parameters

### DIFF
--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -6,13 +6,18 @@ import re
 from six.moves import urllib
 
 from mlflow.utils import process
+from mlflow.store.artifact.hdfs_artifact_repo import HdfsArtifactRepository
 
 DBFS_PREFIX = "dbfs:/"
 S3_PREFIX = "s3://"
 GS_PREFIX = "gs://"
+VIEWFS_PREFIX = "viewfs://"
+HDFS_PREFIX = "hdfs://"
 DBFS_REGEX = re.compile("^%s" % re.escape(DBFS_PREFIX))
 S3_REGEX = re.compile("^%s" % re.escape(S3_PREFIX))
 GS_REGEX = re.compile("^%s" % re.escape(GS_PREFIX))
+VIEWFS_REGEX = re.compile("^%s" % re.escape(VIEWFS_PREFIX))
+HDFS_REGEX = re.compile("^%s" % re.escape(HDFS_PREFIX))
 
 
 class DownloadException(Exception):
@@ -27,33 +32,31 @@ def _fetch_dbfs(uri, local_path):
 def _fetch_s3(uri, local_path):
     import boto3
     print("=== Downloading S3 object %s to local path %s ===" % (uri, os.path.abspath(local_path)))
-    (bucket, s3_path) = parse_s3_uri(uri)
+    (bucket, s3_path) = parse_simple_uri(uri, ["s3"])
     boto3.client('s3').download_file(bucket, s3_path, local_path)
 
 
 def _fetch_gs(uri, local_path):
     from google.cloud import storage
     print("=== Downloading GCS file %s to local path %s ===" % (uri, os.path.abspath(local_path)))
-    (bucket, gs_path) = parse_gs_uri(uri)
+    (bucket, gs_path) = parse_simple_uri(uri, ["gs"])
     storage.Client().bucket(bucket).blob(gs_path).download_to_filename(local_path)
 
 
-def parse_s3_uri(uri):
-    """Parse an S3 URI, returning (bucket, path)"""
-    parsed = urllib.parse.urlparse(uri)
-    if parsed.scheme != "s3":
-        raise Exception("Not an S3 URI: %s" % uri)
-    path = parsed.path
-    if path.startswith('/'):
-        path = path[1:]
-    return parsed.netloc, path
+def _fetch_hdfs(uri, local_path):
+    print(
+        "=== Downloading HDFS file %s to local path %s ===" %
+        (uri, os.path.abspath(local_path))
+    )
+    parse_simple_uri(uri, ["hdfs", "viewfs"])
+    hdfs = HdfsArtifactRepository("/".join(uri.split('/')[:-1]))
+    hdfs.download_artifacts(uri.split('/')[-1], local_path, create_tmp_dir=False)
 
 
-def parse_gs_uri(uri):
-    """Parse an GCS URI, returning (bucket, path)"""
+def parse_simple_uri(uri, scheme):
     parsed = urllib.parse.urlparse(uri)
-    if parsed.scheme != "gs":
-        raise Exception("Not a GCS URI: %s" % uri)
+    if parsed.scheme not in scheme:
+        raise Exception("Not an %s URI: %s" % (str(scheme).upper(), uri))
     path = parsed.path
     if path.startswith('/'):
         path = path[1:]
@@ -72,6 +75,9 @@ def download_uri(uri, output_path):
         _fetch_s3(uri, output_path)
     elif GS_REGEX.match(uri):
         _fetch_gs(uri, output_path)
+    elif VIEWFS_REGEX.match(uri) or HDFS_REGEX.match(uri):
+        _fetch_hdfs(uri, output_path)
     else:
-        raise DownloadException("`uri` must be a DBFS (%s), S3 (%s), or GCS (%s) URI, got "
-                                "%s" % (DBFS_PREFIX, S3_PREFIX, GS_PREFIX, uri))
+        raise DownloadException("`uri` must be a DBFS (%s), S3 (%s), HDFS (%s), VIEWFS (%s), "
+                                "or GCS (%s) URI, got %s" % (DBFS_PREFIX, S3_PREFIX, HDFS_PREFIX,
+                                                             VIEWFS_PREFIX, GS_PREFIX, uri))

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -6,8 +6,7 @@ import re
 from six.moves import urllib
 
 from mlflow.utils import process
-from mlflow.store.artifact.hdfs_artifact_repo import hdfs_system, _resolve_connection_params,\
-    _download_hdfs_file
+from mlflow.store.artifact.hdfs_artifact_repo import HdfsArtifactRepository
 
 DBFS_PREFIX = "dbfs:/"
 S3_PREFIX = "s3://"
@@ -47,10 +46,8 @@ def _fetch_gs(uri, local_path):
 def _fetch_hdfs(uri, local_path):
     print("=== Downloading HDFS file %s to local path %s ===" % (uri, os.path.abspath(local_path)))
     parse_simple_uri(uri, ["hdfs", "viewfs"])
-    host, port, path = _resolve_connection_params(uri)
-    with hdfs_system(host=host, port=port) as hdfs:
-        local_path = os.path.join(local_path, os.path.normpath(uri.split('/')[-1]))
-        _download_hdfs_file(hdfs, path, local_path)
+    hdfs_repo = HdfsArtifactRepository(uri)
+    hdfs_repo._download_file(uri, local_path)
 
 
 def parse_simple_uri(uri, scheme):

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -6,7 +6,8 @@ import re
 from six.moves import urllib
 
 from mlflow.utils import process
-from mlflow.store.artifact.hdfs_artifact_repo import HdfsArtifactRepository
+from mlflow.store.artifact.hdfs_artifact_repo import hdfs_system, _resolve_connection_params,\
+    _download_hdfs_file
 
 DBFS_PREFIX = "dbfs:/"
 S3_PREFIX = "s3://"
@@ -44,13 +45,12 @@ def _fetch_gs(uri, local_path):
 
 
 def _fetch_hdfs(uri, local_path):
-    print(
-        "=== Downloading HDFS file %s to local path %s ===" %
-        (uri, os.path.abspath(local_path))
-    )
+    print("=== Downloading HDFS file %s to local path %s ===" % (uri, os.path.abspath(local_path)))
     parse_simple_uri(uri, ["hdfs", "viewfs"])
-    hdfs = HdfsArtifactRepository("/".join(uri.split('/')[:-1]))
-    hdfs.download_artifacts(uri.split('/')[-1], local_path, create_tmp_dir=False)
+    host, port, path = _resolve_connection_params(uri)
+    with hdfs_system(host=host, port=port) as hdfs:
+        local_path = os.path.join(local_path, os.path.normpath(uri.split('/')[-1]))
+        _download_hdfs_file(hdfs, path, local_path)
 
 
 def parse_simple_uri(uri, scheme):

--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -145,7 +145,12 @@ class HdfsArtifactRepository(ArtifactRepository):
             return local_dir
 
     def _download_file(self, remote_file_path, local_path):
-        raise MlflowException('This is not implemented. Should never be called.')
+        _, _, path = _resolve_connection_params(remote_file_path)
+        if path.endswith('/'):
+            path = path[:-1]
+        with hdfs_system(host=self.host, port=self.port) as hdfs:
+            local_path = os.path.join(local_path, os.path.normpath(path.split('/')[-1]))
+            _download_hdfs_file(hdfs, path, local_path)
 
 
 @contextmanager

--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from six.moves import urllib
 
 from mlflow.entities import FileInfo
-from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.utils.file_utils import mkdir, relative_path_to_artifact_path
 

--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -103,7 +103,7 @@ class HdfsArtifactRepository(ArtifactRepository):
             else:
                 yield hdfs_path, False, hdfs.info(hdfs_path).get("size")
 
-    def download_artifacts(self, artifact_path, dst_path=None, create_tmp_dir=True):
+    def download_artifacts(self, artifact_path, dst_path=None):
         """
             Download an artifact file or directory to a local directory/file if applicable, and
             return a local path for it.
@@ -123,10 +123,7 @@ class HdfsArtifactRepository(ArtifactRepository):
         """
 
         hdfs_base_path = _resolve_base_path(self.path, artifact_path)
-        if create_tmp_dir:
-            local_dir = _tmp_dir(dst_path)
-        else:
-            local_dir = dst_path
+        local_dir = _tmp_dir(dst_path)
 
         with hdfs_system(host=self.host, port=self.port) as hdfs:
 

--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -103,7 +103,7 @@ class HdfsArtifactRepository(ArtifactRepository):
             else:
                 yield hdfs_path, False, hdfs.info(hdfs_path).get("size")
 
-    def download_artifacts(self, artifact_path, dst_path=None):
+    def download_artifacts(self, artifact_path, dst_path=None, create_tmp_dir=True):
         """
             Download an artifact file or directory to a local directory/file if applicable, and
             return a local path for it.
@@ -123,7 +123,10 @@ class HdfsArtifactRepository(ArtifactRepository):
         """
 
         hdfs_base_path = _resolve_base_path(self.path, artifact_path)
-        local_dir = _tmp_dir(dst_path)
+        if create_tmp_dir:
+            local_dir = _tmp_dir(dst_path)
+        else:
+            local_dir = dst_path
 
         with hdfs_system(host=self.host, port=self.port) as hdfs:
 

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -29,7 +29,7 @@ class S3ArtifactRepository(ArtifactRepository):
         return boto3.client('s3', endpoint_url=s3_endpoint_url)
 
     def log_artifact(self, local_file, artifact_path=None):
-        (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)
+        (bucket, dest_path) = data.parse_simple_uri(self.artifact_uri, ["s3"])
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
         dest_path = posixpath.join(
@@ -38,7 +38,7 @@ class S3ArtifactRepository(ArtifactRepository):
         s3_client.upload_file(local_file, bucket, dest_path)
 
     def log_artifacts(self, local_dir, artifact_path=None):
-        (bucket, dest_path) = data.parse_s3_uri(self.artifact_uri)
+        (bucket, dest_path) = data.parse_simple_uri(self.artifact_uri, ["s3"])
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
         s3_client = self._get_s3_client()
@@ -56,7 +56,7 @@ class S3ArtifactRepository(ArtifactRepository):
                         posixpath.join(upload_path, f))
 
     def list_artifacts(self, path=None):
-        (bucket, artifact_path) = data.parse_s3_uri(self.artifact_uri)
+        (bucket, artifact_path) = data.parse_simple_uri(self.artifact_uri, ["s3"])
         dest_path = artifact_path
         if path:
             dest_path = posixpath.join(dest_path, path)
@@ -96,7 +96,7 @@ class S3ArtifactRepository(ArtifactRepository):
                     artifact_path=artifact_path, object_path=listed_object_path))
 
     def _download_file(self, remote_file_path, local_path):
-        (bucket, s3_root_path) = data.parse_s3_uri(self.artifact_uri)
+        (bucket, s3_root_path) = data.parse_simple_uri(self.artifact_uri, ["s3"])
         s3_full_path = posixpath.join(s3_root_path, remote_file_path)
         s3_client = self._get_s3_client()
         s3_client.download_file(bucket, s3_full_path, local_path)

--- a/tests/data/test_data.py
+++ b/tests/data/test_data.py
@@ -31,6 +31,8 @@ def test_is_uri():
     assert is_uri("gs://some/gs/path")
     assert is_uri("dbfs:/some/dbfs/path")
     assert is_uri("file://some/local/path")
+    assert is_uri("hdfs://some/hdfs/path")
+    assert is_uri("viewfs://some/viewfs/path")
     assert not is_uri("/tmp/some/local/path")
 
 
@@ -38,7 +40,9 @@ def test_download_uri():
     # Verify downloading from DBFS & S3 urls calls the corresponding helper functions
     prefix_to_mock = {"dbfs:/": "mlflow.data._fetch_dbfs",
                       "s3://": "mlflow.data._fetch_s3",
-                      "gs://": "mlflow.data._fetch_gs"}
+                      "gs://": "mlflow.data._fetch_gs",
+                      "hdfs://": "mlflow.data._fetch_hdfs",
+                      "viewfs://": "mlflow.data._fetch_hdfs"}
     for prefix, fn_name in prefix_to_mock.items():
         with mock.patch(fn_name) as mocked_fn, temp_directory() as dst_dir:
             download_uri(uri=os.path.join(prefix, "some/path"),

--- a/tests/store/artifact/test_hdfs_artifact_repo.py
+++ b/tests/store/artifact/test_hdfs_artifact_repo.py
@@ -191,3 +191,18 @@ def test_download_artifacts():
                             os.path.join(tmp_dir.path(), artifact_path))
         with open(os.path.join(tmp_dir.path(), artifact_path), "rb") as fd:
             assert expected_data == fd.read()
+
+
+@mock.patch('pyarrow.hdfs.HadoopFileSystem', spec=HadoopFileSystem)
+def test_download_file(hdfs_system_mock):
+    expected_data = b"hello"
+    artifact_paths = ["hdfs://host/test.txt", "hdfs://host/test.txt/"]
+    hdfs_system_mock.return_value.open = mock_open(read_data=expected_data)
+
+    for artifact_path in artifact_paths:
+        hdfs_repo = HdfsArtifactRepository(artifact_path)
+        with TempDir() as tmp_dir:
+            hdfs_repo._download_file(artifact_path,
+                                     tmp_dir.path())
+            with open(os.path.join(tmp_dir.path(), 'test.txt'), "rb") as fd:
+                assert expected_data == fd.read()


### PR DESCRIPTION
## What changes are proposed in this pull request?

In a MLproject file, when a parameter has a path type and is an hdfs uri, the artifact will be downloaded from hdfs.

## How is this patch tested?

With unit test and by creating an MLflow project that tries to download a file from hdfs.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added support of hdfs for path parameters in MLflow project.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [X] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
