### PR TITLE
Solve race condition for directory creation

### DIFF
--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -1,4 +1,5 @@
 import codecs
+import errno
 import gzip
 import os
 import posixpath
@@ -99,11 +100,11 @@ def mkdir(root, name=None):  # noqa
     """
     target = os.path.join(root, name) if name is not None else root
     try:
-        if not exists(target):
-            os.makedirs(target)
-            return target
+        os.makedirs(target)
     except OSError as e:
-        raise e
+        if e.errno != errno.EEXIST:
+            raise e
+    return target
 
 
 def make_containing_dirs(path):

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -102,7 +102,7 @@ def mkdir(root, name=None):  # noqa
     try:
         os.makedirs(target)
     except OSError as e:
-        if e.errno != errno.EEXIST:
+        if e.errno != errno.EEXIST or not os.path.isdir(target):
             raise e
     return target
 

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -54,6 +54,15 @@ def test_mkdir(tmpdir):
     with pytest.raises(OSError):
         file_utils.mkdir("/   bad directory @ name ", "ouch")
 
+    # does not raise if directory exists already
+    file_utils.mkdir(temp_dir, new_dir_name)
+
+    # raises if it exists already but is a file
+    dummy_file_path = str(tmpdir.join("dummy_file"))
+    open(dummy_file_path, 'a').close()
+    with pytest.raises(OSError):
+        file_utils.mkdir(dummy_file_path)
+
 
 def test_make_tarfile(tmpdir):
     # Tar a local project


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR solves a race condition when creating the directory `mlruns` may cause Python programs running simultaneously to fail.

Concretely, the following error came up several times when a job scheduler launched several runs at simultaneously:
```
FileExistsError: [Errno 17] File exists: './mlruns'
```
Upon analysis, when trying to create the `mlruns` directory, [here](https://github.com/mlflow/mlflow/blob/e6764eb63dd66e8a809dcd422d547d091b74549a/mlflow/utils/file_utils.py#L102), 
```python
        if not exists(target):
            os.makedirs(target)
```
it looks like the filesystem was fast to check for the existence of the directory but slow to create it, and therefore all except one simultaneous runs failed on `os.makedirs()`.

To avoid this race condition, and be consistent the EAFP coding style (Easier to Ask for Forgiveness than Permission), this PR does not check for existence of the directory but inspects the exception, if any.

See https://stackoverflow.com/a/14364249 for a detailed discussion on StackOverflow.

## How is this patch tested?

-

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
