### PR TITLE
New runs table column view

### DIFF
--- a/mlflow/server/js/package-lock.json
+++ b/mlflow/server/js/package-lock.json
@@ -14,6 +14,52 @@
         "turntable-camera-controller": "^3.0.0"
       }
     },
+    "@ag-grid-community/client-side-row-model": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/client-side-row-model/-/client-side-row-model-22.0.0.tgz",
+      "integrity": "sha512-qRV9zpdBEd8mgEiOdR17D3YhGGGmcNbkKlKK4xpfR5dSscgdkbC+zJ7RU+bYDITISjoLQ47yvLp5hs1nIywdJw==",
+      "requires": {
+        "@ag-grid-community/core": "~22.0.0"
+      }
+    },
+    "@ag-grid-community/core": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/core/-/core-22.0.0.tgz",
+      "integrity": "sha512-hHwUA2vMGcQWKHVwvu9QwCUPakaJ36fMIXfwnq4ZSNo0IkdpXxgWasfij7SI9povTz0CsrrlL4KGsV4mdOutXw=="
+    },
+    "@ag-grid-community/react": {
+      "version": "22.1.2",
+      "resolved": "https://registry.npmjs.org/@ag-grid-community/react/-/react-22.1.2.tgz",
+      "integrity": "sha512-rouYVp1NFq4hwBMmazMQ5sxcmwImcBOQC2YVn5/39uoP8+3UHTNcimMbKviAN+jMQgIHDlBTTBgjDAH9mMKmQg==",
+      "requires": {
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.12.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+          "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+        }
+      }
+    },
     "@ant-design/colors": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-3.2.2.tgz",

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@ag-grid-community/core": "22.0.0",
+    "@ag-grid-community/client-side-row-model": "22.0.0",
+    "@ag-grid-community/react": "^22.0.0",
     "antd": "^3.23.5",
     "bytes": "3.0.0",
     "classnames": "^2.2.6",
@@ -68,7 +71,7 @@
   },
   "scripts": {
     "start": "react-app-rewired start",
-    "build": "react-app-rewired build",
+    "build": "react-app-rewired --max_old_space_size=4096 build",
     "test": "react-app-rewired test --env=jsdom",
     "eject": "react-scripts eject",
     "lint": "eslint src",

--- a/mlflow/server/js/src/common/components/SearchTree.js
+++ b/mlflow/server/js/src/common/components/SearchTree.js
@@ -1,0 +1,197 @@
+/**
+ * This component consists of a checkbox tree select and a search input on top of which toggles and
+ * highlight tree nodes while user type in a search prefix.
+ */
+import React from 'react';
+import { Input, Tree } from 'antd';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+
+
+const { TreeNode } = Tree;
+const { Search } = Input;
+export const NodeShape = {
+  // display name of the node
+  title: PropTypes.string.isRequired,
+  // uniq key to identify this node
+  key: PropTypes.string.isRequired,
+  // an array of child nodes
+  children: PropTypes.arrayOf(PropTypes.object),
+};
+
+export class SearchTree extends React.Component {
+  static propTypes = {
+    // A forest of data nodes for rendering the checkbox tree view
+    data: PropTypes.arrayOf(PropTypes.shape(NodeShape)),
+    // Handler called when any node in the tree is checked/unchecked
+    onCheck: PropTypes.func,
+    // All keys checked
+    checkedKeys: PropTypes.array.isRequired,
+    // Handler called when user press ESC key in the search input
+    onSearchInputEscapeKeyPress: PropTypes.func.isRequired,
+  };
+
+  state = {
+    // Current expanded keys
+    expandedKeys: [],
+    // Current search input value
+    searchValue: '',
+    // Whether to automatically expand all parent node of current expanded keys
+    autoExpandParent: true,
+  };
+
+  handleExpand = (expandedKeys) => {
+    this.setState({
+      expandedKeys,
+      // we set autoExpandParent to false here because if it is true, we won't be able to toggle
+      // COLLAPSE any subtree having an expanded child node.
+      autoExpandParent: false,
+    });
+  };
+
+  handleSearch = (e) => {
+    const { value } = e.target;
+    const { data } = this.props;
+    const dataList = flattenDataToList(data);
+    const expandedKeys = _.uniq(
+      dataList
+        .map((item) =>
+          (item.title.toLowerCase().includes(value.toLowerCase())
+            ? getParentKey(item.key, data)
+            : null),
+        )
+        .filter((item) => !_.isEmpty(item)),
+    );
+    this.setState({
+      expandedKeys,
+      searchValue: value,
+      autoExpandParent: true,
+    });
+  };
+
+  handleSearchInputKeyUp = (e) => {
+    const { onSearchInputEscapeKeyPress } = this.props;
+    if (e.key === 'Escape' && onSearchInputEscapeKeyPress) {
+      this.setState({ searchValue: '' });
+      onSearchInputEscapeKeyPress();
+    }
+  };
+
+  handleCheck = (checkedKeys) => {
+    const { onCheck } = this.props;
+    if (onCheck) {
+      onCheck(checkedKeys, this.getAllKeys());
+    }
+  };
+
+  getAllKeys() {
+    const { data } = this.props;
+    const dataList = flattenDataToList(data);
+    return dataList.map((item) => item.key);
+  }
+
+  renderTreeNodes = (data) => {
+    const { searchValue } = this.state;
+    return data.map((item) => {
+      const index = item.title.toLowerCase().indexOf(searchValue.toLowerCase());
+      const beforeStr = item.title.substring(0, index);
+      const matchStr = item.title.substring(index, index + searchValue.length);
+      const afterStr = item.title.substring(index + searchValue.length);
+      const title =
+        index > -1 ? (
+          <span style={styles.treeNodeTextStyle}>
+            {beforeStr}
+            <span className='search-highlight' style={styles.searchHighlight}>{matchStr}</span>
+            {afterStr}
+          </span>
+        ) : (
+          <span style={styles.treeNodeTextStyle}>{item.title}</span>
+        );
+      if (item.children) {
+        return (
+          <TreeNode key={item.key} title={title}>
+            {this.renderTreeNodes(item.children)}
+          </TreeNode>
+        );
+      }
+      return <TreeNode key={item.key} title={title} />;
+    });
+  };
+
+  render() {
+    const { data, checkedKeys } = this.props;
+    const { expandedKeys, autoExpandParent, searchValue } = this.state;
+    return (
+      <div>
+        <Search
+          style={{ marginBottom: 8 }}
+          placeholder='Search'
+          value={searchValue}
+          onChange={this.handleSearch}
+          onKeyUp={this.handleSearchInputKeyUp}
+        />
+        <Tree
+          checkable
+          onCheck={this.handleCheck}
+          onExpand={this.handleExpand}
+          expandedKeys={expandedKeys}
+          autoExpandParent={autoExpandParent}
+          checkedKeys={checkedKeys}
+        >
+          {this.renderTreeNodes(data)}
+        </Tree>
+      </div>
+    );
+  }
+}
+
+/**
+ * Flatten all nodes in `data `to `dataList`
+ * @param {Array} data - tree shape data
+ * @param {Array} dataList - an array as an out parameter to collect the flattened nodes
+ * @returns {Array}
+ */
+export const flattenDataToList = (data, dataList = []) => {
+  for (let i = 0; i < data.length; i++) {
+    const node = data[i];
+    const { key, title } = node;
+    dataList.push({ key, title });
+    if (node.children) {
+      flattenDataToList(node.children, dataList);
+    }
+  }
+  return dataList;
+};
+
+/**
+ * Given a node's key and entire tree data, find the key of its parent node
+ * @param {string} key - key of the node to find parent for
+ * @param {Array} treeData - entire tree data
+ * @returns {string} parent key
+ */
+export const getParentKey = (key, treeData) => {
+  let parentKey;
+  for (let i = 0; i < treeData.length; i++) {
+    const node = treeData[i];
+    if (node.children) {
+      if (node.children.some(item => item.key === key)) {
+        parentKey = node.key;
+      } else {
+        parentKey = getParentKey(key, node.children);
+      }
+      if (parentKey) break;
+    }
+  }
+  return parentKey;
+};
+
+
+export const styles = {
+  treeNodeTextStyle: {
+    display: 'inline-block',
+    maxWidth: 100,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+  },
+  searchHighlight: { color: '#f50' },
+};

--- a/mlflow/server/js/src/common/components/SearchTree.test.js
+++ b/mlflow/server/js/src/common/components/SearchTree.test.js
@@ -1,0 +1,113 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { SearchTree, styles, getParentKey, flattenDataToList } from './SearchTree';
+import { Tree } from 'antd';
+
+const { TreeNode } = Tree;
+
+describe('SearchTree', () => {
+  let wrapper;
+  let instance;
+  let minimalProps;
+  let commonProps;
+
+  beforeEach(() => {
+    minimalProps = {
+      data: [],
+      onCheck: jest.fn(),
+      checkedKeys: [],
+      onSearchInputEscapeKeyPress: jest.fn(),
+    };
+
+    commonProps = {
+      ...minimalProps,
+      data: [
+        {
+          title: 'Date',
+          key: 'attributes-Date',
+        },
+        {
+          title: 'Parameters',
+          key: 'params',
+          children: [
+            {
+              title: 'p1',
+              key: 'params-p1',
+            },
+            {
+              title: 'p2',
+              key: 'params-p2',
+            },
+          ],
+        },
+        {
+          title: 'Metrics',
+          key: 'metrics',
+          children: [
+            {
+              title: 'm1',
+              key: 'metrics-m1',
+            },
+            {
+              title: 'm2',
+              key: 'metrics-m2',
+            },
+          ],
+        },
+      ],
+    };
+  });
+
+  test('should render with minimal props without exploding', () => {
+    wrapper = shallow(<SearchTree {...minimalProps} />);
+    expect(wrapper.length).toBe(1);
+  });
+
+  test('should render search tree properly', () => {
+    wrapper = shallow(<SearchTree {...commonProps} />);
+    const treeNodes = wrapper.find(TreeNode);
+    expect(treeNodes.length).toBe(7);
+  });
+
+  test('should highlight filter matched nodes correctly', () => {
+    wrapper = mount(<SearchTree {...commonProps} />);
+    instance = wrapper.instance();
+    instance.handleSearch({
+      target: {
+        value: 'p',
+      },
+    });
+    wrapper.update();
+    expect(wrapper.find({ style: styles.searchHighlight }).length).toBe(3);
+
+    instance.handleSearch({
+      target: {
+        value: 'p1',
+      },
+    });
+    wrapper.update();
+    expect(wrapper.find({ style: styles.searchHighlight }).length).toBe(1);
+  });
+
+  test('flattenDataToList', () => {
+    const { data } = commonProps;
+    expect(flattenDataToList(data)).toEqual([
+      { title: 'Date', key: 'attributes-Date' },
+      { title: 'Parameters', key: 'params' },
+      { title: 'p1', key: 'params-p1' },
+      { title: 'p2', key: 'params-p2' },
+      { title: 'Metrics', key: 'metrics' },
+      { title: 'm1', key: 'metrics-m1' },
+      { title: 'm2', key: 'metrics-m2' },
+    ]);
+  });
+
+  test('getParentKey', () => {
+    const { data } = commonProps;
+    expect(getParentKey('params-p1', data)).toBe('params');
+    expect(getParentKey('params-p2', data)).toBe('params');
+    expect(getParentKey('metrics-m1', data)).toBe('metrics');
+    expect(getParentKey('metrics-m2', data)).toBe('metrics');
+    expect(getParentKey('attributes-Date', data)).toBe(undefined);
+  });
+});

--- a/mlflow/server/js/src/common/components/ag-grid/RunsTableCustomHeader.js
+++ b/mlflow/server/js/src/common/components/ag-grid/RunsTableCustomHeader.js
@@ -1,0 +1,88 @@
+/**
+ * Custom header component
+ * https://www.ag-grid.com/javascript-grid-header-rendering/#react-header-rendering
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export class RunsTableCustomHeader extends React.Component {
+  /**
+   All `IHeaderParams` fields are available from ag-grid as well, add to propTypes when needed
+   export interface IHeaderParams {
+      column: Column;
+      displayName: string;
+      enableSorting: boolean;
+      enableMenu: boolean;
+      showColumnMenu: (source: HTMLElement) => void;
+      progressSort: (multiSort?: boolean) => void;
+      setSort: (sort: string, multiSort?: boolean) => void;
+      columnApi: ColumnApi;
+      api: GridApi;
+      context: any;
+      template: string;
+    }
+   */
+  static propTypes = {
+    /* props from `IHeaderParams` */
+    enableSorting: PropTypes.bool,
+    displayName: PropTypes.string,
+    /* custom props from `headerComponentParams` */
+    canonicalSortKey: PropTypes.string,
+    // Note(Zangr) using object in headerComponentParams will cause ag-grid error, like making
+    // `labelStyle` an object will cause rendering error.
+    // TODO(Zangr) investigate workaround to allow passing in object as custom props
+    style: PropTypes.string,
+    orderByAsc: PropTypes.bool,
+    orderByKey: PropTypes.string,
+    onSortBy: PropTypes.func,
+  };
+
+  static defaultProps = {
+    onSortBy: () => {},
+  };
+
+  render() {
+    const {
+      enableSorting,
+      canonicalSortKey,
+      displayName,
+      style = '{}',
+      orderByKey,
+      orderByAsc,
+      onSortBy,
+    } = this.props;
+
+    return (
+      <div
+        style={{ ...styles.headerLabelWrapper, ...JSON.parse(style) }}
+        onClick={enableSorting ? () => onSortBy(canonicalSortKey, !orderByAsc) : undefined}
+      >
+        {enableSorting && canonicalSortKey === orderByKey ? (
+          <SortByIcon orderByAsc={orderByAsc} />
+        ) : null}
+        <span>{displayName}</span>
+      </div>
+    );
+  }
+}
+
+export function SortByIcon({ orderByAsc }) {
+  return (
+    <span style={styles.headerSortIcon}>
+      <i className={`fa fa-long-arrow-alt-${orderByAsc ? 'up' : 'down'}`} />
+    </span>
+  );
+}
+SortByIcon.propTypes = { orderByAsc: PropTypes.bool };
+
+const styles = {
+  headerLabelWrapper: {
+    height: '100%',
+    width: '100%',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  headerSortIcon: {
+    marginRight: 4,
+  },
+};

--- a/mlflow/server/js/src/common/components/ag-grid/RunsTableCustomHeader.test.js
+++ b/mlflow/server/js/src/common/components/ag-grid/RunsTableCustomHeader.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { RunsTableCustomHeader, SortByIcon } from './RunsTableCustomHeader';
+
+describe('RunsTableCustomHeader', () => {
+  let wrapper;
+  let minimalProps;
+
+  beforeEach(() => {
+    minimalProps = {};
+  });
+
+  test('should render with minimal props without exploding', () => {
+    wrapper = shallow(<RunsTableCustomHeader {...minimalProps}/>);
+    expect(wrapper.length).toBe(1);
+  });
+
+  test('should render sorting icon correctly', () => {
+    const props = {
+      ...minimalProps,
+      enableSorting: true,
+      canonicalSortKey: 'user',
+      orderByKey: 'user',
+      orderByAsc: true,
+      onSortBy: jest.fn(),
+    };
+    wrapper = mount(<RunsTableCustomHeader {...props} />);
+    expect(wrapper.find(SortByIcon).length).toBe(1);
+    expect(wrapper.find(SortByIcon).prop('orderByAsc')).toBe(true);
+
+    // should not show sorting icon when sorting is disabled
+    props.enableSorting = false;
+    wrapper = mount(<RunsTableCustomHeader {...props} />);
+    expect(wrapper.find(SortByIcon).length).toBe(0);
+  });
+});

--- a/mlflow/server/js/src/common/utils.js
+++ b/mlflow/server/js/src/common/utils.js
@@ -9,3 +9,11 @@ export const shouldRender404 = (requests, requestIdsToCheck) => {
     return error && error.getErrorCode() === ErrorCodes.RESOURCE_DOES_NOT_EXIST;
   });
 };
+
+// TODO(Zangr) move to /experiment-tracking after folder refactor
+export const ColumnTypes = {
+  ATTRIBUTES: 'attributes',
+  PARAMS: 'params',
+  METRICS: 'metrics',
+  TAGS: 'tags',
+};

--- a/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView2.js
@@ -1,0 +1,502 @@
+/**
+ * Ag-grid based implementation of multi-column view with a bunch of new interactive features
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import { RunInfo } from '../sdk/MlflowMessages';
+import { Link } from 'react-router-dom';
+import Routes from '../Routes';
+import Utils from '../utils/Utils';
+
+import { AgGridReact } from '@ag-grid-community/react';
+import { Grid } from '@ag-grid-community/core';
+import { ClientSideRowModelModule } from '@ag-grid-community/client-side-row-model';
+import { RunsTableCustomHeader } from '../common/components/ag-grid/RunsTableCustomHeader';
+import '@ag-grid-community/core/dist/styles/ag-grid.css';
+import '@ag-grid-community/core/dist/styles/ag-theme-balham.css';
+import { ColumnTypes } from '../common/utils';
+import ExperimentViewUtil from './ExperimentViewUtil';
+import { LoadMoreBar } from './LoadMoreBar';
+import _ from 'lodash';
+import { Spinner } from './Spinner';
+import LocalStorageUtils from '../utils/LocalStorageUtils';
+import { AgGridPersistedState } from '../sdk/MlflowLocalStorageMessages';
+
+const PARAM_PREFIX = '$$$param$$$';
+const METRIC_PREFIX = '$$$metric$$$';
+const TAG_PREFIX = '$$$tag$$$';
+const MAX_PARAMS_COLS = 3;
+const MAX_METRICS_COLS = 3;
+const MAX_TAG_COLS = 3;
+const EMPTY_CELL_PLACEHOLDER = '-';
+
+export class ExperimentRunsTableMultiColumnView2 extends React.Component {
+  static propTypes = {
+    experimentId: PropTypes.number,
+    runInfos: PropTypes.arrayOf(RunInfo).isRequired,
+    // List of list of params in all the visible runs
+    paramsList: PropTypes.arrayOf(Array).isRequired,
+    // List of list of metrics in all the visible runs
+    metricsList: PropTypes.arrayOf(Array).isRequired,
+    paramKeyList: PropTypes.arrayOf(PropTypes.string),
+    metricKeyList: PropTypes.arrayOf(PropTypes.string),
+    visibleTagKeyList: PropTypes.arrayOf(PropTypes.string),
+    // List of tags dictionary in all the visible runs.
+    tagsList: PropTypes.arrayOf(Object).isRequired,
+    onSelectionChange: PropTypes.func.isRequired,
+    onExpand: PropTypes.func.isRequired,
+    onSortBy: PropTypes.func.isRequired,
+    orderByKey: PropTypes.string,
+    orderByAsc: PropTypes.bool,
+    runsSelected: PropTypes.object.isRequired,
+    runsExpanded: PropTypes.object.isRequired,
+    nextPageToken: PropTypes.string,
+    handleLoadMoreRuns: PropTypes.func.isRequired,
+    loadingMore: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool.isRequired,
+    categorizedUncheckedKeys: PropTypes.object.isRequired,
+  };
+
+  static defaultColDef = {
+    width: 100,
+    headerComponentParams: { menuIcon: 'fa-bars' },
+    resizable: true,
+    filter: true,
+    suppressMenu: true,
+    suppressMovable: true,
+  };
+
+  // A map of framework(React) specific custom components.
+  // Ideally we should minimize usage of framework cell renderer for better scrolling performance.
+  // More scrolling performance related discussion is available here:
+  // https://www.ag-grid.com/javascript-grid-performance/#3-create-fast-cell-renderers
+  static frameworkComponents = {
+    sourceCellRenderer: SourceCellRenderer,
+    versionCellRenderer: VersionCellRenderer,
+    dateCellRenderer: DateCellRenderer,
+    agColumnHeader: RunsTableCustomHeader,
+    loadingOverlayComponent: Spinner,
+  };
+
+  /**
+   * Returns a { name: value } map from a list of parameters/metrics/tags list
+   * @param list - all available parameter/metric/tag metadata objects
+   * @param keys - selected parameter/metric/tag keys
+   * @param prefix - category based string prefix to for the new key, we need this prefix to
+   * prevent name collision among parameters/metrics/tags
+   */
+  static getNameValueMapFromList(list, keys, prefix) {
+    const map = {};
+    // populate with default placeholder '-'
+    keys.forEach((key) => {
+      map[`${prefix}-${key}`] = EMPTY_CELL_PLACEHOLDER;
+    });
+    // override with existing value
+    list.forEach(({ key, value }) => {
+      if (value || _.isNumber(value)) {
+        map[`${prefix}-${key}`] = value;
+      }
+    });
+    return map;
+  }
+
+  static isFullWidthCell(rowNode) {
+    return rowNode.data.isFullWidth;
+  }
+
+  getLocalStore = () => LocalStorageUtils.getStoreForComponent(
+    "ExperimentRunsTableMultiColumnView2",
+    this.props.experimentId,
+  );
+
+  applyingRowSelectionFromProps = false;
+
+  getColumnDefs() {
+    const {
+      metricKeyList,
+      paramKeyList,
+      categorizedUncheckedKeys,
+      visibleTagKeyList,
+      orderByKey,
+      orderByAsc,
+      onSortBy,
+    } = this.props;
+    const commonSortOrderProps = { orderByKey, orderByAsc, onSortBy };
+
+    return [
+      ...[
+        {
+          headerName: 'Date',
+          field: 'startTime',
+          pinned: 'left',
+          width: 216,
+          cellRenderer: 'dateCellRenderer',
+          sortable: true,
+          checkboxSelection: true,
+          headerCheckboxSelection: true,
+          headerComponentParams: {
+            ...commonSortOrderProps,
+            canonicalSortKey: 'attributes.start_time',
+            style: JSON.stringify({ marginLeft: 18 }), // using object will cause ag-grid error
+          },
+        },
+        {
+          headerName: 'Run Name',
+          pinned: 'left',
+          field: 'runName',
+          sortable: true,
+          headerComponentParams: {
+            ...commonSortOrderProps,
+            canonicalSortKey: 'tags.`mlflow.runName`',
+          },
+        },
+        {
+          headerName: 'User',
+          field: 'user',
+          sortable: true,
+          headerComponentParams: {
+            ...commonSortOrderProps,
+            canonicalSortKey: 'tags.`mlflow.user`',
+          },
+        },
+        {
+          headerName: 'Source',
+          field: 'source',
+          cellRenderer: 'sourceCellRenderer',
+          sortable: true,
+          headerComponentParams: {
+            ...commonSortOrderProps,
+            canonicalSortKey: 'tags.`mlflow.source.name`',
+          },
+        },
+        {
+          headerName: 'Version',
+          field: 'version',
+          cellRenderer: 'versionCellRenderer',
+          sortable: true,
+          headerComponentParams: {
+            ...commonSortOrderProps,
+            canonicalSortKey: 'tags.`mlflow.source.git.commit`',
+          },
+        },
+      ].filter((c) => !categorizedUncheckedKeys[ColumnTypes.ATTRIBUTES].includes(c.headerName)),
+      {
+        headerName: 'Parameters',
+        children: paramKeyList.map((paramKey, i) => {
+          const columnKey = ExperimentViewUtil.makeCanonicalKey(ColumnTypes.PARAMS, paramKey);
+          return {
+            headerName: paramKey,
+            headerTooltip: paramKey,
+            field: `${PARAM_PREFIX}-${paramKey}`,
+            // `columnGroupShow` controls whether to show the column when the group is open/closed.
+            // Setting it to null means always show this column.
+            // Here we want to show the first 3 columns plus the current orderByKey column if it
+            // happens to be inside this column group.
+            columnGroupShow: i >= MAX_PARAMS_COLS && columnKey !== orderByKey ? 'open' : null,
+            sortable: true,
+            headerComponentParams: {
+              ...commonSortOrderProps,
+              canonicalSortKey: columnKey,
+            },
+          };
+        }),
+      },
+      {
+        headerName: 'Metrics',
+        children: metricKeyList.map((metricKey, i) => {
+          const columnKey = ExperimentViewUtil.makeCanonicalKey(ColumnTypes.METRICS, metricKey);
+          return {
+            headerName: metricKey,
+            headerTooltip: metricKey,
+            field: `${METRIC_PREFIX}-${metricKey}`,
+            // `columnGroupShow` controls whether to show the column when the group is open/closed.
+            // Setting it to null means always show this column.
+            // Here we want to show the first 3 columns plus the current orderByKey column if it
+            // happens to be inside this column group.
+            columnGroupShow: i >= MAX_METRICS_COLS && columnKey !== orderByKey ? 'open' : null,
+            sortable: true,
+            headerComponentParams: {
+              ...commonSortOrderProps,
+              canonicalSortKey: columnKey,
+            },
+          };
+        }),
+      },
+      {
+        headerName: 'Tags',
+        children: visibleTagKeyList.map((tagKey, i) => ({
+          headerName: tagKey,
+          headerTooltip: tagKey,
+          field: `${TAG_PREFIX}-${tagKey}`,
+          ...(i >= MAX_TAG_COLS ? { columnGroupShow: 'open' } : null),
+        })),
+      },
+    ];
+  }
+
+  // Only run based rows are selectable, other utility rows like "load more" row is not selectable
+  isRowSelectable = (rowNode) => rowNode.data && rowNode.data.runInfo;
+
+  getRowData() {
+    const {
+      runInfos,
+      paramsList,
+      metricsList,
+      paramKeyList,
+      metricKeyList,
+      tagsList,
+      runsExpanded,
+      onExpand,
+      nextPageToken,
+      loadingMore,
+      visibleTagKeyList,
+    } = this.props;
+    const { getNameValueMapFromList } = ExperimentRunsTableMultiColumnView2;
+    const mergedRows = ExperimentViewUtil.getRowRenderMetadata({
+      runInfos,
+      tagsList,
+      runsExpanded,
+    });
+
+    const runs = mergedRows.map(({ idx, isParent, hasExpander, expanderOpen, childrenIds }) => {
+      const tags = tagsList[idx];
+      const params = paramsList[idx];
+      const metrics = metricsList[idx];
+      const runInfo = runInfos[idx];
+
+      const user = Utils.getUser(runInfo, tags);
+      const queryParams = window.location && window.location.search ? window.location.search : '';
+      const startTime = runInfo.start_time;
+      const runName = Utils.getRunName(tags) || '-';
+      const visibleTags = Utils.getVisibleTagValues(tags).map(([key, value]) => ({ key, value }));
+
+      return {
+        runInfo,
+        startTime,
+        user,
+        runName,
+        tags,
+        queryParams,
+        isParent,
+        hasExpander,
+        expanderOpen,
+        childrenIds,
+        onExpand,
+        ...getNameValueMapFromList(params, paramKeyList, PARAM_PREFIX),
+        ...getNameValueMapFromList(metrics, metricKeyList, METRIC_PREFIX),
+        ...getNameValueMapFromList(visibleTags, visibleTagKeyList, TAG_PREFIX),
+      };
+    });
+
+    // Handle "Load more" row
+    if (nextPageToken || loadingMore) {
+      runs.push({
+        isFullWidth: true,
+        loadingMore,
+      });
+    }
+
+    return runs;
+  }
+
+  handleSelectionChange = (event) => {
+    // Avoid triggering event handlers while we are applying row selections from props
+    if (this.applyingRowSelectionFromProps) {
+      return;
+    }
+    const { onSelectionChange } = this.props;
+    if (onSelectionChange) {
+      const selectedRunUuids = [];
+      event.api.getSelectedRows().forEach(({ runInfo }) => {
+        if (runInfo) {
+          selectedRunUuids.push(runInfo.run_uuid);
+        }
+      });
+      // Do not trigger callback if the selection is not changed. This check helps improving
+      // rendering performance especially after applyRowSelectionFromProps where a large number of
+      // run selection event gets triggered because there is no batch select API.
+      if (!_.isEqual(selectedRunUuids, this.prevSelectRunUuids)) {
+        onSelectionChange(selectedRunUuids);
+        this.prevSelectRunUuids = selectedRunUuids;
+      }
+    }
+  };
+
+  handleGridReady = (params) => {
+    this.gridApi = params.api;
+    this.columnApi = params.columnApi;
+    this.applyRowSelectionFromProps();
+    this.handleColumnSizeRefit();
+    this.handleLoadingOverlay();
+  };
+
+  // There is no way in ag-grid to declaratively specify row selections. Thus, we have to use grid
+  // api to imperatively apply row selections per render. We don't want to trigger `selectionChange`
+  // event in this method.
+  applyRowSelectionFromProps() {
+    if (!this.gridApi) return;
+    const { runsSelected } = this.props;
+    const selectedRunsSet = new Set(Object.keys(runsSelected));
+
+    this.gridApi.deselectAll();
+    // ag-grid has no existing component prop or batch select API to handle row selection so we have
+    // to select rows with ag-grid API one by one. Currently, ag-grid batches selection value
+    // changes but still fires events per setSelected call.
+    // Like when we call:
+    // row1.setSelected(true);
+    // row2.setSelected(true);
+    // row3.setSelected(true);
+    // ag-grid will fire `selectionChange` event 3 times with the same selection [row1, row2, row3]
+    // So, we need to be aware of this and not re-render when selection stays the same.
+    this.gridApi.forEachNode((node) => {
+      const { runInfo } = node.data;
+      if (runInfo && selectedRunsSet.has(runInfo.getRunUuid())) {
+        node.setSelected(true);
+      }
+    });
+  }
+
+  handleColumnSizeRefit() {
+    if (!this.gridApi || !this.columnApi) return;
+    // Only re-fit columns into current viewport when there is no open column group. We are doing
+    // this because opened group can have arbitrary large number of child columns which will end
+    // up creating a lot of columns with extremely small width.
+    const columnGroupStates = this.columnApi.getColumnGroupState();
+    if (columnGroupStates.every((group) => !group.open)) {
+      this.gridApi.sizeColumnsToFit();
+    }
+  }
+
+  handleLoadingOverlay() {
+    if (!this.gridApi) return;
+    if (this.props.isLoading) {
+      this.gridApi.showLoadingOverlay();
+    } else {
+      this.gridApi.hideOverlay();
+    }
+  }
+
+  persistGridState = () => {
+    if (!this.columnApi) return;
+    this.getLocalStore().saveComponentState(new AgGridPersistedState({
+      columnGroupState: this.columnApi.getColumnGroupState(),
+    }));
+  };
+
+  restoreGridState() {
+    if (!this.columnApi) return;
+    const { columnGroupState } = this.getLocalStore().loadComponentState();
+    if (columnGroupState) {
+      this.columnApi.setColumnGroupState(columnGroupState);
+    }
+  }
+
+  componentDidUpdate() {
+    this.applyRowSelectionFromProps();
+    this.handleColumnSizeRefit();
+    this.handleLoadingOverlay();
+    this.restoreGridState();
+  }
+
+  render() {
+    const { handleLoadMoreRuns, loadingMore } = this.props;
+    const columnDefs = this.getColumnDefs();
+    const {
+      defaultColDef,
+      frameworkComponents,
+      isFullWidthCell,
+    } = ExperimentRunsTableMultiColumnView2;
+
+    return (
+      <div className='ag-theme-balham multi-column-view'>
+        <AgGridReact
+          defaultColDef={defaultColDef}
+          columnDefs={columnDefs}
+          rowData={this.getRowData()}
+          modules={[Grid, ClientSideRowModelModule]}
+          rowSelection='multiple'
+          onGridReady={this.handleGridReady}
+          onSelectionChanged={this.handleSelectionChange}
+          onColumnGroupOpened={this.persistGridState}
+          suppressRowClickSelection
+          suppressScrollOnNewData // retain scroll position after nested run toggling operations
+          enableCellTextSelection
+          frameworkComponents={frameworkComponents}
+          fullWidthCellRendererFramework={FullWidthCellRenderer}
+          fullWidthCellRendererParams={{ handleLoadMoreRuns, loadingMore }}
+          loadingOverlayComponent='loadingOverlayComponent'
+          loadingOverlayComponentParams={{ showImmediately: true }}
+          isFullWidthCell={isFullWidthCell}
+          isRowSelectable={this.isRowSelectable}
+        />
+      </div>
+    );
+  }
+}
+
+function FullWidthCellRenderer({ handleLoadMoreRuns, loadingMore }) {
+  return (
+    <div style={{ textAlign: 'center' }}>
+      <LoadMoreBar loadingMore={loadingMore} onLoadMore={handleLoadMoreRuns} />
+    </div>
+  );
+}
+FullWidthCellRenderer.propTypes = {
+  handleLoadMoreRuns: PropTypes.func,
+  loadingMore: PropTypes.bool,
+};
+
+function DateCellRenderer(props) {
+  const {
+    startTime,
+    runInfo,
+    isParent,
+    hasExpander,
+    expanderOpen,
+    childrenIds,
+    onExpand,
+  } = props.data;
+  return (
+    <div>
+      {hasExpander ? (
+        <div
+          onClick={() => {
+            onExpand(runInfo.run_uuid, childrenIds);
+          }}
+          key={'Expander-' + runInfo.run_uuid}
+          style={{ paddingRight: 8, display: 'inline' }}
+        >
+          <i
+            className={`ExperimentView-expander far fa-${expanderOpen ? 'minus' : 'plus'}-square`}
+          />
+        </div>
+      ) : (
+        <span style={{ paddingLeft: 18 }} />
+      )}
+      <Link
+        to={Routes.getRunPageRoute(runInfo.experiment_id, runInfo.run_uuid)}
+        style={{ paddingLeft: isParent ? 0 : 16 }}
+      >
+        {ExperimentViewUtil.getRunStatusIcon(runInfo.status)} {Utils.formatTimestamp(startTime)}
+      </Link>
+    </div>
+  );
+}
+DateCellRenderer.propTypes = { data: PropTypes.object };
+
+function SourceCellRenderer(props) {
+  const { tags, queryParams } = props.data;
+  const sourceType = Utils.renderSource(tags, queryParams);
+  return sourceType ? (
+    <React.Fragment>
+      {Utils.renderSourceTypeIcon(Utils.getSourceType(tags))}
+      {sourceType}
+    </React.Fragment>
+  ) : <React.Fragment>{EMPTY_CELL_PLACEHOLDER}</React.Fragment>;
+}
+SourceCellRenderer.propTypes = { data: PropTypes.object };
+
+function VersionCellRenderer(props) {
+  const { tags } = props.data;
+  return Utils.renderVersion(tags) || EMPTY_CELL_PLACEHOLDER;
+}

--- a/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView2.test.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView2.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { ExperimentRunsTableMultiColumnView2 } from './ExperimentRunsTableMultiColumnView2';
+import { ColumnTypes } from '../common/utils';
+
+describe('ExperimentRunsTableMultiColumnView2', () => {
+  let wrapper;
+  let instance;
+  let minimalProps;
+
+  beforeEach(() => {
+    minimalProps = {
+      runInfos: [],
+      paramsList: [],
+      metricsList: [],
+      paramKeyList: [],
+      metricKeyList: [],
+      visibleTagKeyList: [],
+      tagsList: [],
+      onSelectionChange: jest.fn(),
+      onExpand: jest.fn(),
+      onSortBy: jest.fn(),
+      runsSelected: {},
+      runsExpanded: {},
+      handleLoadMoreRuns: jest.fn(),
+      loadingMore: false,
+      isLoading: false,
+      categorizedUncheckedKeys: {
+        [ColumnTypes.ATTRIBUTES]: [],
+        [ColumnTypes.PARAMS]: [],
+        [ColumnTypes.METRICS]: [],
+        [ColumnTypes.TAGS]: [],
+      },
+    };
+  });
+
+  test('should render with minimal props without exploding', () => {
+    wrapper = shallow(<ExperimentRunsTableMultiColumnView2 {...minimalProps} />);
+    expect(wrapper.length).toBe(1);
+  });
+
+  test('should not refit column size if there is an open column group', () => {
+    wrapper = shallow(<ExperimentRunsTableMultiColumnView2 {...minimalProps} />);
+    instance = wrapper.instance();
+    instance.columnApi = {
+      getColumnGroupState: jest.fn(() => [{ open: true }]),
+    };
+    instance.gridApi = {
+      sizeColumnsToFit: jest.fn(),
+    };
+    instance.handleColumnSizeRefit();
+    expect(instance.gridApi.sizeColumnsToFit).not.toBeCalled();
+
+    instance.columnApi.getColumnGroupState = jest.fn(() => [{ open: false }]);
+    instance.handleColumnSizeRefit();
+    expect(instance.gridApi.sizeColumnsToFit).toBeCalled();
+  });
+});

--- a/mlflow/server/js/src/components/ExperimentView.css
+++ b/mlflow/server/js/src/components/ExperimentView.css
@@ -103,31 +103,21 @@
 }
 
 .ExperimentView-lifecycle-input {
-  width: 156px;
   padding-right: 8px;
 }
 
 .ExperimentView-lifecycle-button {
-  width: 100px;
+  width: 80px;
 }
 
 .ExperimentView-paramKeyFilter, .ExperimentView-metricKeyFilter, .ExperimentView-search-input, .ExperimentView-lifecycle-input {
   padding-right: 8px;
 }
 
-.ExperimentView-search-buttons {
-  float: right;
-  width: 100px;
-}
-
 .ExperimentView-search-buttons .btn {
   display: block;
   width: 100%;
   margin-bottom: 8px;
-}
-
-.ExperimentView-search-inputs {
-  margin-right: 104px;
 }
 
 .ExperimentView-search-controls .filter-label {
@@ -145,12 +135,11 @@
 }
 
 .search-button {
-  margin-right: 30px;
+  width: 120px;
 }
 
 .clear-button {
-  margin-bottom: 0;
-  height: 32px;
+  margin-left: 8px;
 }
 
 div.error-message {
@@ -281,6 +270,7 @@ span.error-message {
   flex: 1 1 auto;
   flex-direction: column;
   display: flex;
+  min-height: 800px;
 }
 
 .ExperimentView .ReactVirtualized__Table__row:hover {
@@ -296,4 +286,29 @@ span.error-message {
 .search-input-tooltip.ant-popover-placement-bottom > .ant-popover-content > .ant-popover-arrow {
   border-top-color: rgba(0, 0, 0, 0.75);
   border-left-color: rgba(0, 0, 0, 0.75);
+}
+
+.ExperimentView .ag-row-hover, .ExperimentView .ag-column-hover{
+  background-color: #f3fafd !important; /* TODO(Zangr) override specificity in a better way */
+}
+
+.ExperimentView .ag-row-hover .ag-column-hover {
+  background-color: #e8f6fd !important;
+}
+
+.ExperimentView .multi-column-view .load-more-button,
+.ExperimentView .multi-column-view .loading-more-wrapper {
+  height: 24px;
+  margin-top: 1px;
+}
+
+.ExperimentView .ag-header-cell .ag-react-container {
+  width: 100%;
+  height: 100%;
+}
+
+.ExperimentView .multi-column-view {
+  width: 100%;
+  height: 700px;
+  margin-bottom: 50px;
 }

--- a/mlflow/server/js/src/components/ExperimentView.test.js
+++ b/mlflow/server/js/src/components/ExperimentView.test.js
@@ -12,6 +12,7 @@ import {
   emptyState} from "../test-utils/ReduxStoreFixtures";
 import {getUUID} from "../Actions";
 import {Spinner} from "./Spinner";
+import { ExperimentViewPersistedState } from '../sdk/MlflowLocalStorageMessages';
 
 let onSearchSpy;
 
@@ -43,6 +44,7 @@ const getExperimentViewMock = () => {
     orderByAsc={false}
   />);
 };
+
 test(`Clearing filter state calls search handler with correct arguments`, () => {
   const wrapper = getExperimentViewMock();
   wrapper.instance().onClear();
@@ -54,17 +56,10 @@ test(`Clearing filter state calls search handler with correct arguments`, () => 
   expect(onSearchSpy.mock.calls[0][4]).toBe(null);
   expect(onSearchSpy.mock.calls[0][5]).toBe(true);
 });
-test('Entering filter input updates component state', () => {
+
+test('Entering search input updates component state', () => {
   const wrapper = getExperimentViewMock();
   wrapper.instance().setState = jest.fn();
-  // Test entering param filter input
-  wrapper.find('.ExperimentView-paramKeyFilter input').first().simulate(
-    'change', {target: {value: 'param name'}});
-  expect(wrapper.instance().setState).toBeCalledWith({paramKeyFilterInput: 'param name'});
-  // Test entering metric filter input
-  wrapper.find('.ExperimentView-metricKeyFilter input').first().simulate(
-    'change', {target: {value: 'metric name'}});
-  expect(wrapper.instance().setState).toBeCalledWith({metricKeyFilterInput: 'metric name'});
   // Test entering search input
   wrapper.find('.ExperimentView-search-input input').first().simulate(
     'change', {target: {value: 'search input string'}});
@@ -73,6 +68,10 @@ test('Entering filter input updates component state', () => {
 
 test("ExperimentView will show spinner if isLoading prop is true", () => {
   const wrapper = getExperimentViewMock();
+  const instance = wrapper.instance();
+  instance.setState({
+    persistedState: new ExperimentViewPersistedState({ showMultiColumns: false }).toJSON(),
+  });
   expect(wrapper.find(Spinner)).toHaveLength(1);
 });
 

--- a/mlflow/server/js/src/components/LoadMoreBar.js
+++ b/mlflow/server/js/src/components/LoadMoreBar.js
@@ -14,19 +14,17 @@ import PropTypes from 'prop-types';
 
 export class LoadMoreBar extends React.PureComponent {
   static propTypes = {
-    height: PropTypes.number.isRequired,
-    width: PropTypes.number.isRequired,
-    borderStyle: PropTypes.string.isRequired,
+    style: PropTypes.object,
     loadingMore: PropTypes.bool.isRequired,
     onLoadMore: PropTypes.func.isRequired,
   };
 
   render() {
-    const { height, width, borderStyle, loadingMore, onLoadMore } = this.props;
+    const { loadingMore, onLoadMore, style } = this.props;
     return (
       <div
         className='load-more-row'
-        style={{ ...styles.loadMoreRows, height, width, border: borderStyle }}
+        style={{ ...styles.loadMoreRows, ...style }}
       >
         {loadingMore ? (
           <div className='loading-more-wrapper' style={styles.loadingMoreWrapper}>
@@ -56,8 +54,6 @@ const styles = {
     justifyContent: 'center',
     alignItems: 'center',
     background: 'white',
-    position: 'absolute',
-    bottom: 20,
   },
   loadingMoreWrapper: {
     display: 'flex',

--- a/mlflow/server/js/src/components/LoadMoreBar.test.js
+++ b/mlflow/server/js/src/components/LoadMoreBar.test.js
@@ -8,9 +8,6 @@ describe('unit tests', () => {
 
   beforeEach(() => {
     mininumProps = {
-      height: 37,
-      width: 1000,
-      borderStyle: '',
       loadingMore: false,
       onLoadMore: jest.fn(),
     };

--- a/mlflow/server/js/src/components/RunsTableColumnSelectionDropdown.js
+++ b/mlflow/server/js/src/components/RunsTableColumnSelectionDropdown.js
@@ -26,7 +26,6 @@ export class RunsTableColumnSelectionDropdown extends React.Component {
   };
 
   handleCheck = (checkedKeys, allKeys) => {
-    console.log('checkedKeys', checkedKeys);
     const { onCheck } = this.props;
     if (onCheck) {
       onCheck(getCategorizedUncheckedKeys(checkedKeys, allKeys));

--- a/mlflow/server/js/src/components/RunsTableColumnSelectionDropdown.js
+++ b/mlflow/server/js/src/components/RunsTableColumnSelectionDropdown.js
@@ -1,0 +1,153 @@
+import React from 'react';
+import { Button, Dropdown, Icon, Menu } from 'antd';
+import { SearchTree } from '../common/components/SearchTree';
+import { ColumnTypes } from '../common/utils';
+import PropTypes from 'prop-types';
+import _ from 'lodash';
+import ExperimentViewUtil from './ExperimentViewUtil';
+
+export class RunsTableColumnSelectionDropdown extends React.Component {
+  static propTypes = {
+    paramKeyList: PropTypes.array,
+    metricKeyList: PropTypes.array,
+    visibleTagKeyList: PropTypes.array,
+    onCheck: PropTypes.func,
+    categorizedUncheckedKeys: PropTypes.object.isRequired,
+  };
+
+  static defaultProps = {
+    paramKeyList: [],
+    metricKeyList: [],
+    visibleTagKeyList: [],
+  };
+
+  state = {
+    menuVisible: false,
+  };
+
+  handleCheck = (checkedKeys, allKeys) => {
+    console.log('checkedKeys', checkedKeys);
+    const { onCheck } = this.props;
+    if (onCheck) {
+      onCheck(getCategorizedUncheckedKeys(checkedKeys, allKeys));
+    }
+  };
+
+  getData() {
+    const { paramKeyList, metricKeyList, visibleTagKeyList } = this.props;
+
+    // Attributes
+    const data = [
+      ...Object.values(ExperimentViewUtil.AttributeColumnLabels).map((text) => ({
+        key: `${ColumnTypes.ATTRIBUTES}-${text}`,
+        title: text,
+      })),
+    ];
+
+    // Parameters
+    if (paramKeyList.length > 0) {
+      data.push({
+        title: 'Parameters',
+        key: ColumnTypes.PARAMS,
+        children: paramKeyList.map((key) => ({ key: `${ColumnTypes.PARAMS}-${key}`, title: key })),
+      });
+    }
+
+    // Metrics
+    if (metricKeyList.length > 0) {
+      data.push({
+        title: 'Metrics',
+        key: ColumnTypes.METRICS,
+        children: metricKeyList.map((key) => ({
+          key: `${ColumnTypes.METRICS}-${key}`,
+          title: key,
+        })),
+      });
+    }
+
+    // Tags
+    if (visibleTagKeyList.length > 0) {
+      data.push({
+        title: 'Tags',
+        key: ColumnTypes.TAGS,
+        children: visibleTagKeyList.map((key) => ({
+          key: `${ColumnTypes.TAGS}-${key}`,
+          title: key,
+        })),
+      });
+    }
+
+    return data;
+  }
+
+  getCheckedKeys() {
+    const { paramKeyList, metricKeyList, visibleTagKeyList, categorizedUncheckedKeys } = this.props;
+    return [
+      ..._.difference(
+        Object.values(ExperimentViewUtil.AttributeColumnLabels),
+        categorizedUncheckedKeys[ColumnTypes.ATTRIBUTES],
+      ).map((key) => `${ColumnTypes.ATTRIBUTES}-${key}`),
+      ..._.difference(paramKeyList, categorizedUncheckedKeys[ColumnTypes.PARAMS])
+        .map((key) => `${ColumnTypes.PARAMS}-${key}`),
+      ..._.difference(metricKeyList, categorizedUncheckedKeys[ColumnTypes.METRICS])
+        .map((key) => `${ColumnTypes.METRICS}-${key}`),
+      ..._.difference(visibleTagKeyList, categorizedUncheckedKeys[ColumnTypes.TAGS])
+        .map((key) => `${ColumnTypes.TAGS}-${key}`),
+    ];
+  }
+
+  handleSearchInputEscapeKeyPress = () => {
+    this.setState({ menuVisible: false });
+  };
+
+  handleVisibleChange = (menuVisible) => {
+    this.setState({ menuVisible });
+  };
+
+  render() {
+    const { menuVisible } = this.state;
+    const content = (
+      <Menu style={{ maxHeight: 480, overflowY: 'scroll' }}>
+        <SearchTree
+          data={this.getData()}
+          onCheck={this.handleCheck}
+          checkedKeys={this.getCheckedKeys()}
+          onSearchInputEscapeKeyPress={this.handleSearchInputEscapeKeyPress}
+        />
+      </Menu>
+    );
+    return (
+      <Dropdown
+        overlay={content}
+        trigger={['click']}
+        visible={menuVisible}
+        onVisibleChange={this.handleVisibleChange}
+      >
+        <Button style={{ height: 34, display: 'flex', alignItems: 'center' }}>
+          <Icon type='setting' style={{ marginTop: 2 }} />
+          Columns
+        </Button>
+      </Dropdown>
+    );
+  }
+}
+
+function getCategorizedUncheckedKeys(checkedKeys, allKeys) {
+  const uncheckedKeys = _.difference(allKeys, checkedKeys);
+  const result = {
+    [ColumnTypes.ATTRIBUTES]: [],
+    [ColumnTypes.PARAMS]: [],
+    [ColumnTypes.METRICS]: [],
+    [ColumnTypes.TAGS]: [],
+  };
+  uncheckedKeys.forEach((key) => {
+    // split on first instance of '-' in case there are keys with '-'
+    const [columnType, rawKey] = key.split(/-(.+)/);
+    if (rawKey) {
+      result[columnType].push(rawKey);
+    } else if (columnType !== ColumnTypes.PARAMS && columnType !== ColumnTypes.METRICS) {
+      result[ColumnTypes.ATTRIBUTES].push(columnType);
+    }
+  });
+  return result;
+}

--- a/mlflow/server/js/src/components/RunsTableColumnSelectionDropdown.test.js
+++ b/mlflow/server/js/src/components/RunsTableColumnSelectionDropdown.test.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { RunsTableColumnSelectionDropdown } from './RunsTableColumnSelectionDropdown';
+import { ColumnTypes } from '../common/utils';
+import { SearchTree } from '../common/components/SearchTree';
+
+describe('RunsTableColumnSelectionDropdown', () => {
+  let wrapper;
+  let instance;
+  let minimalProps;
+  let commonProps;
+
+  beforeEach(() => {
+    minimalProps = {
+      paramKeyList: [],
+      metricKeyList: [],
+      visibleTagKeyList: [],
+      onCheck: jest.fn(),
+      categorizedUncheckedKeys: {
+        [ColumnTypes.ATTRIBUTES]: [],
+        [ColumnTypes.PARAMS]: [],
+        [ColumnTypes.METRICS]: [],
+        [ColumnTypes.TAGS]: [],
+      },
+    };
+
+    commonProps = {
+      ...minimalProps,
+      paramKeyList: ['p1', 'p2'],
+      metricKeyList: ['m1', 'm2'],
+      visibleTagKeyList: ['t1', 't2'],
+    };
+  });
+
+  test('should render with minimal props without exploding', () => {
+    wrapper = shallow(<RunsTableColumnSelectionDropdown {...minimalProps}/>);
+    expect(wrapper.length).toBe(1);
+  });
+
+  test('should render SearchTree with correct tree data', () => {
+    wrapper = mount(<RunsTableColumnSelectionDropdown {...commonProps}/>);
+    instance = wrapper.instance();
+    instance.setState({ menuVisible: true });
+    wrapper.update();
+    expect(wrapper.find(SearchTree).prop('data')).toEqual([
+      { key: 'attributes-Date', title: 'Date' },
+      { key: 'attributes-User', title: 'User' },
+      { key: 'attributes-Run Name', title: 'Run Name' },
+      { key: 'attributes-Source', title: 'Source' },
+      { key: 'attributes-Version', title: 'Version' },
+      {
+        title: 'Parameters',
+        key: 'params',
+        children: [
+          { key: 'params-p1', title: 'p1' },
+          { key: 'params-p2', title: 'p2' },
+        ],
+      },
+      {
+        title: 'Metrics',
+        key: 'metrics',
+        children: [
+          { key: 'metrics-m1', title: 'm1' },
+          { key: 'metrics-m2', title: 'm2' },
+        ],
+      },
+      {
+        title: 'Tags',
+        key: 'tags',
+        children: [
+          { key: 'tags-t1', title: 't1' },
+          { key: 'tags-t2', title: 't2' },
+        ],
+      },
+    ]);
+  });
+
+  test('should check all keys by default', () => {
+    wrapper = mount(<RunsTableColumnSelectionDropdown {...commonProps}/>);
+    instance = wrapper.instance();
+    instance.setState({ menuVisible: true });
+    wrapper.update();
+    expect(wrapper.find(SearchTree).prop('checkedKeys')).toEqual([
+      'attributes-Date',
+      'attributes-User',
+      'attributes-Run Name',
+      'attributes-Source',
+      'attributes-Version',
+      'params-p1',
+      'params-p2',
+      'metrics-m1',
+      'metrics-m2',
+      'tags-t1',
+      'tags-t2',
+    ]);
+  });
+
+  test('should not check keys marked as unchecked', () => {
+    const props = {
+      ...commonProps,
+      categorizedUncheckedKeys: {
+        [ColumnTypes.ATTRIBUTES]: ['User', 'Run Name', 'Source', 'Version'],
+        [ColumnTypes.PARAMS]: ['p1'],
+        [ColumnTypes.METRICS]: ['m1'],
+        [ColumnTypes.TAGS]: ['t1'],
+      },
+    };
+    wrapper = mount(<RunsTableColumnSelectionDropdown {...props}/>);
+    instance = wrapper.instance();
+    instance.setState({ menuVisible: true });
+    wrapper.update();
+    expect(wrapper.find(SearchTree).prop('checkedKeys')).toEqual(
+      ['attributes-Date', 'params-p2', 'metrics-m2', 'tags-t2'],
+    );
+  });
+});

--- a/mlflow/server/js/src/components/Spinner.css
+++ b/mlflow/server/js/src/components/Spinner.css
@@ -7,12 +7,11 @@
 
 .Spinner img {
     position: absolute;
-    top: 350px;
+    top: 50%;
     left: 50%;
     width: 80px;
     height: 80px;
     margin:-40px 0 0 -40px;
-    opacity: 0;
     -webkit-animation: spin 3s linear 1s infinite;
     -moz-animation: spin 3s linear 1s infinite;
     animation: spin 3s linear 1s infinite;

--- a/mlflow/server/js/src/sdk/MlflowLocalStorageMessages.js
+++ b/mlflow/server/js/src/sdk/MlflowLocalStorageMessages.js
@@ -15,6 +15,7 @@
  *    local storage.
  */
 import Immutable from "immutable";
+import { ColumnTypes } from '../common/utils';
 
 /**
  * This class wraps attributes of the ExperimentPage component's state that should be
@@ -44,9 +45,26 @@ export const ExperimentViewPersistedState = Immutable.Record({
   // Object mapping run UUIDs (strings) to booleans, where a boolean value of true indicates that
   // a run has been expanded (its child runs are visible).
   runsExpanded: {},
+  // If true, shows the multi-column table view instead of the compact table view.
+  showMultiColumns: true,
   // Arrays of "unbagged", or split-out metric and param keys (strings). We maintain these as lists
   // to help keep them ordered (i.e. splitting out a column shouldn't change the ordering of columns
   // that have already been split out)
   unbaggedMetrics: [],
   unbaggedParams: [],
+  // Unchecked keys in the columns dropdown
+  categorizedUncheckedKeys: {
+    [ColumnTypes.ATTRIBUTES]: [],
+    [ColumnTypes.PARAMS]: [],
+    [ColumnTypes.METRICS]: [],
+    [ColumnTypes.TAGS]: [],
+  },
 }, 'ExperimentViewPersistedState');
+
+/**
+ * This class wraps persisted states for AgGrid based table.
+ */
+export const AgGridPersistedState = Immutable.Record({
+  // column group open/close state
+  columnGroupState: [],
+});

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -448,10 +448,8 @@ class Utils {
     }
   }
 
-  static isMessageFromSameOrigin(messageEvent) {
-    // For Chrome, the origin property is in the event.originalEvent object.
-    const origin = messageEvent.origin || messageEvent.originalEvent.origin;
-    return window.location.origin === origin;
+  static isModelRegistryEnabled() {
+    return true;
   }
 }
 

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -7,6 +7,7 @@ import projectSvg from '../static/project.svg';
 import qs from 'qs';
 import { MLFLOW_INTERNAL_PREFIX } from './TagUtils';
 import { message } from 'antd';
+import _ from 'lodash';
 
 class Utils {
   /**
@@ -253,8 +254,8 @@ class Utils {
     const imageStyle = {
       height: '20px',
       position: 'relative',
-      top: '-1px',
-      marginRight: '2px',
+      top: '-3px',
+      marginRight: '4px',
     };
     if (sourceType === "NOTEBOOK") {
       return <img alt="" title="Notebook" style={imageStyle} src={notebookSvg} />;
@@ -426,6 +427,12 @@ class Utils {
     );
   }
 
+  static getVisibleTagKeyList(tagsList) {
+    return _.uniq(
+      _.flatMap(tagsList, (tags) => Utils.getVisibleTagValues(tags).map(([key]) => key)),
+    );
+  }
+
   static getAjaxUrl(relativeUrl) {
     if (process.env.USE_ABSOLUTE_AJAX_URLS === "true") {
       return '/' + relativeUrl;
@@ -441,8 +448,10 @@ class Utils {
     }
   }
 
-  static isModelRegistryEnabled() {
-    return true;
+  static isMessageFromSameOrigin(messageEvent) {
+    // For Chrome, the origin property is in the event.originalEvent object.
+    const origin = messageEvent.origin || messageEvent.originalEvent.origin;
+    return window.location.origin === origin;
   }
 }
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR implements a new runs table column view based on `ag-grid` with a series of features as listed below:
- Nested runs
- Serverside sorting
- Load more runs
- Column custom selection with a checkable tree dropdown
- Column resizing
- Column reordering
- Column pinning
- Column highlighting
- Column toggling
- Row selection batching with `Shift + Click`
- Cell `-` placeholder
- Table loading overlay
- Wire up the old compact view with the column selection tree dropdown

![new-multi-column-view](https://user-images.githubusercontent.com/6811562/71493782-6c432800-27f6-11ea-8b51-adfa08a04df4.gif)

## How is this patch tested?
Manual, Unit tests.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

This PR implements a new runs table column view based on `ag-grid` with a series of features 

### What component(s) does this PR affect?

- [x] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
