### PR TITLE
Investigate MLflow models test_cli timeouts when buildi…

### DIFF
--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -13,7 +13,7 @@ DISABLE_ENV_CREATION = "MLFLOW_DISABLE_ENV_CREATION"
 
 _DOCKERFILE_TEMPLATE = """
 # Build an image that can serve mlflow models.
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
          wget \

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -13,7 +13,7 @@ DISABLE_ENV_CREATION = "MLFLOW_DISABLE_ENV_CREATION"
 
 _DOCKERFILE_TEMPLATE = """
 # Build an image that can serve mlflow models.
-FROM ubuntu:18.04
+FROM ubuntu:16.04
 
 RUN apt-get -y update && apt-get install -y --no-install-recommends \
          wget \

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -278,7 +278,8 @@ def test_prepare_env_fails(sk_model):
 
     with TempDir(chdr=True):
         with mlflow.start_run() as active_run:
-            mlflow.sklearn.log_model(sk_model, "model", conda_env={"dependencies": ["mlflow-does-not-exist-dep==abc"]})
+            mlflow.sklearn.log_model(sk_model, "model",
+                                     conda_env={"dependencies": ["mlflow-does-not-exist-dep==abc"]})
             model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
 
         # Test with no conda

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -292,7 +292,7 @@ def test_prepare_env_fails(sk_model):
         assert p.wait() != 0
 
 
-@pytest.mark.release
+@pytest.mark.large
 def test_build_docker(iris_data, sk_model):
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model")
@@ -305,7 +305,7 @@ def test_build_docker(iris_data, sk_model):
     _validate_with_rest_endpoint(scoring_proc, host_port, df, x, sk_model)
 
 
-@pytest.mark.release
+@pytest.mark.large
 def test_build_docker_with_env_override(iris_data, sk_model):
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model")

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -278,17 +278,16 @@ def test_prepare_env_fails(sk_model):
 
     with TempDir(chdr=True):
         with mlflow.start_run() as active_run:
-            mlflow.sklearn.log_model(sk_model, "model", conda_env={"env": "Bad conda env"})
+            mlflow.sklearn.log_model(sk_model, "model", conda_env={"dependencies": ["mlflow-does-not-exist-dep==abc"]})
             model_uri = "runs:/{run_id}/model".format(run_id=active_run.info.run_id)
 
         # Test with no conda
         p = subprocess.Popen(["mlflow", "models", "prepare-env", "-m", model_uri,
-                              "--no-conda"], stderr=subprocess.PIPE)
+                              "--no-conda"])
         assert p.wait() == 0
 
         # With conda - should fail due to bad conda environment.
-        p = subprocess.Popen(["mlflow", "models", "prepare-env", "-m", model_uri],
-                             stderr=subprocess.PIPE)
+        p = subprocess.Popen(["mlflow", "models", "prepare-env", "-m", model_uri])
         assert p.wait() != 0
 
 

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -213,10 +213,7 @@ def test_transformer_model_export(spark_model_transformer, model_path, spark_cus
     assert "Cannot serialize this model" in e.value.message
 
 
-# TODO(czumar): Remark this test as "large" instead of "release" after SageMaker docker
-# container build issues have been debugged
-# @pytest.mark.large
-@pytest.mark.release
+@pytest.mark.large
 def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
     sparkm.save_model(spark_model_iris.model, path=model_path,
                       conda_env=spark_custom_env,
@@ -245,7 +242,7 @@ def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
             decimal=4)
 
 
-@pytest.mark.release
+@pytest.mark.large
 def test_sagemaker_docker_model_scoring_with_default_conda_env(spark_model_iris, model_path):
     sparkm.save_model(spark_model_iris.model, path=model_path, conda_env=None)
 

--- a/travis/run-large-python-tests.sh
+++ b/travis/run-large-python-tests.sh
@@ -6,16 +6,14 @@ err=0
 trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
+SAGEMAKER_OUT=$(mktemp)
+if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
+  echo "Sagemaker container build succeeded.";
+else
+  echo "Sagemaker container build failed, output:";
+  cat $SAGEMAKER_OUT;
+fi
 
-# TODO(czumar): Re-enable container building and associated SageMaker tests once the container
-# build process is no longer hanging
-# - SAGEMAKER_OUT=$(mktemp)
-# - if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
-#     echo "Sagemaker container build succeeded.";
-#   else
-#     echo "Sagemaker container build failed, output:";
-#     cat $SAGEMAKER_OUT;
-#   fi
 # NB: Also add --ignore'd tests to run-small-python-tests.sh
 pytest tests --large --ignore=tests/examples --ignore=tests/h2o --ignore=tests/keras \
   --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn \

--- a/travis/run-large-python-tests.sh
+++ b/travis/run-large-python-tests.sh
@@ -16,11 +16,11 @@ else
 fi
 
 # NB: Also add --ignore'd tests to run-small-python-tests.sh
-pytest tests --large --ignore=tests/examples --ignore=tests/h2o --ignore=tests/keras \
+time pytest tests --large --ignore=tests/examples --ignore=tests/h2o --ignore=tests/keras \
   --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn \
   --ignore=tests/spark --ignore=tests/tensorflow --ignore=tests/azureml --ignore=tests/onnx \
   --ignore=tests/keras_autolog --ignore=tests/tensorflow_autolog --ignore=tests/gluon \
-  --ignore=tests/gluon_autolog --ignore=tests/xgboost --ignore=tests/lightgbm
+  --ignore=tests/gluon_autolog --ignore=tests/xgboost --ignore=tests/lightgbm --ignore=tests/models
 # Run ML framework tests in their own Python processes to avoid OOM issues due to per-framework
 # overhead
 time pytest --verbose tests/h2o --large

--- a/travis/run-large-python-tests.sh
+++ b/travis/run-large-python-tests.sh
@@ -7,8 +7,9 @@ trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
 SAGEMAKER_OUT=$(mktemp)
-if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
+if time mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
   echo "Sagemaker container build succeeded.";
+  cat $SAGEMAKER_OUT;
 else
   echo "Sagemaker container build failed, output:";
   cat $SAGEMAKER_OUT;
@@ -22,25 +23,25 @@ pytest tests --large --ignore=tests/examples --ignore=tests/h2o --ignore=tests/k
   --ignore=tests/gluon_autolog --ignore=tests/xgboost --ignore=tests/lightgbm
 # Run ML framework tests in their own Python processes to avoid OOM issues due to per-framework
 # overhead
-pytest --verbose tests/h2o --large
-pytest --verbose tests/onnx --large
-pytest --verbose tests/pytorch --large
-pytest --verbose tests/pyfunc --large
-pytest --verbose tests/sagemaker --large
-pytest --verbose tests/sagemaker/mock --large
-pytest --verbose tests/sklearn --large
-pytest --verbose tests/spark --large
-pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
-pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
-pytest --verbose tests/azureml --large
-pytest --verbose tests/models --large
-pytest --verbose tests/xgboost --large
-pytest --verbose tests/lightgbm --large
-pip install 'tensorflow>=2.0.0'
-pytest --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
-pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
-pytest --verbose tests/keras --large
-pytest --verbose tests/keras_autolog --large
-pytest --verbose tests/gluon --large
-pytest --verbose tests/gluon_autolog --large
+time pytest --verbose tests/h2o --large
+time pytest --verbose tests/onnx --large
+time pytest --verbose tests/pytorch --large
+time pytest --verbose tests/pyfunc --large
+time pytest --verbose tests/sagemaker --large
+time pytest --verbose tests/sagemaker/mock --large
+time pytest --verbose tests/sklearn --large
+time pytest --verbose tests/spark --large
+time pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
+time pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
+time pytest --verbose tests/azureml --large
+time pytest --verbose tests/models --large
+time pytest --verbose tests/xgboost --large
+time pytest --verbose tests/lightgbm --large
+time pip install 'tensorflow>=2.0.0'
+time pytest --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
+time pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
+time pytest --verbose tests/keras --large
+time pytest --verbose tests/keras_autolog --large
+time pytest --verbose tests/gluon --large
+time pytest --verbose tests/gluon_autolog --large
 test $err = 0

--- a/travis/run-large-python-tests.sh
+++ b/travis/run-large-python-tests.sh
@@ -7,41 +7,41 @@ trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
 SAGEMAKER_OUT=$(mktemp)
-if time mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
+if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
   echo "Sagemaker container build succeeded.";
-  cat $SAGEMAKER_OUT;
+  # output the last few lines for the timing information (defaults to 10 lines)
 else
   echo "Sagemaker container build failed, output:";
   cat $SAGEMAKER_OUT;
 fi
 
 # NB: Also add --ignore'd tests to run-small-python-tests.sh
-time pytest tests --large --ignore=tests/examples --ignore=tests/h2o --ignore=tests/keras \
+pytest tests --large --ignore=tests/examples --ignore=tests/h2o --ignore=tests/keras \
   --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn \
   --ignore=tests/spark --ignore=tests/tensorflow --ignore=tests/azureml --ignore=tests/onnx \
   --ignore=tests/keras_autolog --ignore=tests/tensorflow_autolog --ignore=tests/gluon \
   --ignore=tests/gluon_autolog --ignore=tests/xgboost --ignore=tests/lightgbm --ignore=tests/models
 # Run ML framework tests in their own Python processes to avoid OOM issues due to per-framework
 # overhead
-time pytest --verbose tests/h2o --large
-time pytest --verbose tests/onnx --large
-time pytest --verbose tests/pytorch --large
-time pytest --verbose tests/pyfunc --large
-time pytest --verbose tests/sagemaker --large
-time pytest --verbose tests/sagemaker/mock --large
-time pytest --verbose tests/sklearn --large
-time pytest --verbose tests/spark --large
-time pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
-time pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
-time pytest --verbose tests/azureml --large
-time pytest --verbose tests/models --large
-time pytest --verbose tests/xgboost --large
-time pytest --verbose tests/lightgbm --large
-time pip install 'tensorflow>=2.0.0'
-time pytest --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
-time pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
-time pytest --verbose tests/keras --large
-time pytest --verbose tests/keras_autolog --large
-time pytest --verbose tests/gluon --large
-time pytest --verbose tests/gluon_autolog --large
+pytest --verbose tests/h2o --large
+pytest --verbose tests/onnx --large
+pytest --verbose tests/pytorch --large
+pytest --verbose tests/pyfunc --large
+pytest --verbose tests/sagemaker --large
+pytest --verbose tests/sagemaker/mock --large
+pytest --verbose tests/sklearn --large
+pytest --verbose tests/spark --large
+pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
+pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
+pytest --verbose tests/azureml --large
+pytest --verbose tests/models --large
+pytest --verbose tests/xgboost --large
+pytest --verbose tests/lightgbm --large
+pip install 'tensorflow>=2.0.0'
+pytest --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
+pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
+pytest --verbose tests/keras --large
+pytest --verbose tests/keras_autolog --large
+pytest --verbose tests/gluon --large
+pytest --verbose tests/gluon_autolog --large
 test $err = 0


### PR DESCRIPTION
## What changes are proposed in this pull request?

There are three major changes proposed in this pull request.
1. Re-add CLI docker build tests to "large"
2. Updated Ubuntu from 16.04 to 18.04
3. Removed duplicate run of `test/models` in run-large-python-tests.sh`

## How is this patch tested?
Integration tests were run several times because the tests would previously  transiently fail. So far, no run as failed yet.  

Secondly, I temporarily added timing information to `run-large-python-tests.sh` and demonstrated that docker requires approximately 5 minutes to build and the additional tests increase the total time by 5 minutes. In total, the large tests takes approximately 40 to 45 minutes now. 

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

The MLflow CLI will build a Docker image using the ubuntu:18.04 rather than ubuntu:16.04.

### What component(s) does this PR affect?

- [ ] UI
- [X ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
