### PR TITLE
Regenerate R docs with up-to-date version of roxygen2

### DIFF
--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -272,8 +272,12 @@ is not specified.
 
 .. code:: r
 
-   mlflow_end_run(status = c("FINISHED", "FAILED", "KILLED"),
-     end_time = NULL, run_id = NULL, client = NULL)
+   mlflow_end_run(
+     status = c("FINISHED", "FAILED", "KILLED"),
+     end_time = NULL,
+     run_id = NULL,
+     client = NULL
+   )
 
 .. _arguments-7:
 
@@ -314,8 +318,7 @@ Attempts to obtain the active experiment if both ``experiment_id`` and
 
 .. code:: r
 
-   mlflow_get_experiment(experiment_id = NULL, name = NULL,
-     client = NULL)
+   mlflow_get_experiment(experiment_id = NULL, name = NULL, client = NULL)
 
 .. _arguments-8:
 
@@ -439,11 +442,11 @@ Extracts the ID of the run or experiment.
 Arguments
 ---------
 
-========== ==================================================
-Argument   Description
-========== ==================================================
-``object`` An ``mlflow_run`` or ``mlflow_experiment`` object.
-========== ==================================================
++------------+----------------------------------------------------+
+| Argument   | Description                                        |
++============+====================================================+
+| ``object`` | An ``mlflow_run`` or ``mlflow_experiment`` object. |
++------------+----------------------------------------------------+
 
 ``mlflow_list_artifacts``
 =========================
@@ -490,8 +493,10 @@ Gets a list of all experiments.
 
 .. code:: r
 
-   mlflow_list_experiments(view_type = c("ACTIVE_ONLY", "DELETED_ONLY",
-     "ALL"), client = NULL)
+   mlflow_list_experiments(
+     view_type = c("ACTIVE_ONLY", "DELETED_ONLY", "ALL"),
+     client = NULL
+   )
 
 .. _arguments-13:
 
@@ -526,8 +531,11 @@ all runs under the specified experiment.
 
 .. code:: r
 
-   mlflow_list_run_infos(run_view_type = c("ACTIVE_ONLY", "DELETED_ONLY",
-     "ALL"), experiment_id = NULL, client = NULL)
+   mlflow_list_run_infos(
+     run_view_type = c("ACTIVE_ONLY", "DELETED_ONLY", "ALL"),
+     experiment_id = NULL,
+     client = NULL
+   )
 
 .. _arguments-14:
 
@@ -654,8 +662,7 @@ Logs a specific file or directory as an artifact for a run.
 
 .. code:: r
 
-   mlflow_log_artifact(path, artifact_path = NULL, run_id = NULL,
-     client = NULL)
+   mlflow_log_artifact(path, artifact_path = NULL, run_id = NULL, client = NULL)
 
 .. _arguments-17:
 
@@ -709,8 +716,13 @@ request), partial data may be written.
 
 .. code:: r
 
-   mlflow_log_batch(metrics = NULL, params = NULL, tags = NULL,
-     run_id = NULL, client = NULL)
+   mlflow_log_batch(
+     metrics = NULL,
+     params = NULL,
+     tags = NULL,
+     run_id = NULL,
+     client = NULL
+   )
 
 .. _arguments-18:
 
@@ -763,8 +775,14 @@ historical metric values along two axes: timestamp and step.
 
 .. code:: r
 
-   mlflow_log_metric(key, value, timestamp = NULL, step = NULL,
-     run_id = NULL, client = NULL)
+   mlflow_log_metric(
+     key,
+     value,
+     timestamp = NULL,
+     step = NULL,
+     run_id = NULL,
+     client = NULL
+   )
 
 .. _arguments-19:
 
@@ -951,13 +969,17 @@ to be used by package authors to extend the supported MLflow models.
 Arguments
 ---------
 
-========= ===================================================================
-Argument  Description
-========= ===================================================================
-``model`` The loaded MLflow model flavor.
-``data``  A data frame to perform scoring.
-``...``   Optional additional arguments passed to underlying predict methods.
-========= ===================================================================
++-----------------------------------+-----------------------------------+
+| Argument                          | Description                       |
++===================================+===================================+
+| ``model``                         | The loaded MLflow model flavor.   |
++-----------------------------------+-----------------------------------+
+| ``data``                          | A data frame to perform scoring.  |
++-----------------------------------+-----------------------------------+
+| ``...``                           | Optional additional arguments     |
+|                                   | passed to underlying predict      |
+|                                   | methods.                          |
++-----------------------------------+-----------------------------------+
 
 ``mlflow_rename_experiment``
 ============================
@@ -1087,8 +1109,14 @@ endpoint will be removed in a future version of mlflow.
 
 .. code:: r
 
-   mlflow_rfunc_serve(model_uri, host = "127.0.0.1", port = 8090,
-     daemonized = FALSE, browse = !daemonized, ...)
+   mlflow_rfunc_serve(
+     model_uri,
+     host = "127.0.0.1",
+     port = 8090,
+     daemonized = FALSE,
+     browse = !daemonized,
+     ...
+   )
 
 .. _arguments-27:
 
@@ -1169,10 +1197,18 @@ https://www.mlflow.org/docs/latest/cli.html#mlflow-run for more info.
 
 .. code:: r
 
-   mlflow_run(uri = ".", entry_point = NULL, version = NULL,
-     parameters = NULL, experiment_id = NULL, experiment_name = NULL,
-     backend = NULL, backend_config = NULL, no_conda = FALSE,
-     storage_dir = NULL)
+   mlflow_run(
+     uri = ".",
+     entry_point = NULL,
+     version = NULL,
+     parameters = NULL,
+     experiment_id = NULL,
+     experiment_name = NULL,
+     backend = NULL,
+     backend_config = NULL,
+     no_conda = FALSE,
+     storage_dir = NULL
+   )
 
 .. _arguments-28:
 
@@ -1262,8 +1298,7 @@ model types.
 .. code:: r
 
    list(list("mlflow_save_model"), list("crate"))(model, path, ...)
-   list(list("mlflow_save_model"), list("keras.engine.training.Model"))(model, path,
-     conda_env = NULL, ...)
+   list(list("mlflow_save_model"), list("keras.engine.training.Model"))(model, path, conda_env = NULL, ...)
    mlflow_save_model(model, path, ...)
 
 .. _arguments-29:
@@ -1271,14 +1306,20 @@ model types.
 Arguments
 ---------
 
-============= ==================================================================
-Argument      Description
-============= ==================================================================
-``model``     The model that will perform a prediction.
-``path``      Destination path where this MLflow compatible model will be saved.
-``...``       Optional additional arguments.
-``conda_env`` Path to Conda dependencies file.
-============= ==================================================================
++-----------------------------------+-----------------------------------+
+| Argument                          | Description                       |
++===================================+===================================+
+| ``model``                         | The model that will perform a     |
+|                                   | prediction.                       |
++-----------------------------------+-----------------------------------+
+| ``path``                          | Destination path where this       |
+|                                   | MLflow compatible model will be   |
+|                                   | saved.                            |
++-----------------------------------+-----------------------------------+
+| ``...``                           | Optional additional arguments.    |
++-----------------------------------+-----------------------------------+
+| ``conda_env``                     | Path to Conda dependencies file.  |
++-----------------------------------+-----------------------------------+
 
 ``mlflow_search_runs``
 ======================
@@ -1290,9 +1331,13 @@ Metric and Param keys.
 
 .. code:: r
 
-   mlflow_search_runs(filter = NULL, run_view_type = c("ACTIVE_ONLY",
-     "DELETED_ONLY", "ALL"), experiment_ids = NULL, order_by = list(),
-     client = NULL)
+   mlflow_search_runs(
+     filter = NULL,
+     run_view_type = c("ACTIVE_ONLY", "DELETED_ONLY", "ALL"),
+     experiment_ids = NULL,
+     order_by = list(),
+     client = NULL
+   )
 
 .. _arguments-30:
 
@@ -1340,9 +1385,14 @@ Wrapper for ``mlflow server``.
 
 .. code:: r
 
-   mlflow_server(file_store = "mlruns", default_artifact_root = NULL,
-     host = "127.0.0.1", port = 5000, workers = 4,
-     static_prefix = NULL)
+   mlflow_server(
+     file_store = "mlruns",
+     default_artifact_root = NULL,
+     host = "127.0.0.1",
+     port = 5000,
+     workers = 4,
+     static_prefix = NULL
+   )
 
 .. _arguments-31:
 
@@ -1381,8 +1431,7 @@ metadata that can be updated.
 
 .. code:: r
 
-   mlflow_set_experiment_tag(key, value, experiment_id = NULL,
-     client = NULL)
+   mlflow_set_experiment_tag(key, value, experiment_id = NULL, client = NULL)
 
 .. _arguments-32:
 
@@ -1428,8 +1477,11 @@ provided name. Returns the ID of the active experiment.
 
 .. code:: r
 
-   mlflow_set_experiment(experiment_name = NULL, experiment_id = NULL,
-     artifact_location = NULL)
+   mlflow_set_experiment(
+     experiment_name = NULL,
+     experiment_id = NULL,
+     artifact_location = NULL
+   )
 
 .. _arguments-33:
 
@@ -1506,11 +1558,11 @@ experiments.
 Arguments
 ---------
 
-======== ====================================
-Argument Description
-======== ====================================
-``uri``  The URI to the remote MLflow server.
-======== ====================================
++----------+--------------------------------------+
+| Argument | Description                          |
++==========+======================================+
+| ``uri``  | The URI to the remote MLflow server. |
++----------+--------------------------------------+
 
 ``mlflow_source``
 =================
@@ -1529,11 +1581,11 @@ called via ``Rscript`` from the terminal or through the MLflow CLI.
 Arguments
 ---------
 
-======== ========================================================
-Argument Description
-======== ========================================================
-``uri``  Path to an R script, can be a quoted or unquoted string.
-======== ========================================================
++----------+----------------------------------------------------------+
+| Argument | Description                                              |
++==========+==========================================================+
+| ``uri``  | Path to an R script, can be a quoted or unquoted string. |
++----------+----------------------------------------------------------+
 
 ``mlflow_start_run``
 ====================
@@ -1548,8 +1600,13 @@ can be provided.
 
 .. code:: r
 
-   mlflow_start_run(run_id = NULL, experiment_id = NULL,
-     start_time = NULL, tags = NULL, client = NULL)
+   mlflow_start_run(
+     run_id = NULL,
+     experiment_id = NULL,
+     start_time = NULL,
+     tags = NULL,
+     client = NULL
+   )
 
 .. _arguments-37:
 

--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -43,7 +43,7 @@ Imports:
   zeallot,
   tibble (>= 2.0.0),
   glue
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 Suggests: 
   covr,
   carrier,

--- a/mlflow/R/mlflow/man/mlflow_end_run.Rd
+++ b/mlflow/R/mlflow/man/mlflow_end_run.Rd
@@ -4,8 +4,12 @@
 \alias{mlflow_end_run}
 \title{End a Run}
 \usage{
-mlflow_end_run(status = c("FINISHED", "FAILED", "KILLED"),
-  end_time = NULL, run_id = NULL, client = NULL)
+mlflow_end_run(
+  status = c("FINISHED", "FAILED", "KILLED"),
+  end_time = NULL,
+  run_id = NULL,
+  client = NULL
+)
 }
 \arguments{
 \item{status}{Updated status of the run. Defaults to `FINISHED`. Can also be set to

--- a/mlflow/R/mlflow/man/mlflow_get_experiment.Rd
+++ b/mlflow/R/mlflow/man/mlflow_get_experiment.Rd
@@ -4,8 +4,7 @@
 \alias{mlflow_get_experiment}
 \title{Get Experiment}
 \usage{
-mlflow_get_experiment(experiment_id = NULL, name = NULL,
-  client = NULL)
+mlflow_get_experiment(experiment_id = NULL, name = NULL, client = NULL)
 }
 \arguments{
 \item{experiment_id}{ID of the experiment.}

--- a/mlflow/R/mlflow/man/mlflow_list_experiments.Rd
+++ b/mlflow/R/mlflow/man/mlflow_list_experiments.Rd
@@ -4,8 +4,10 @@
 \alias{mlflow_list_experiments}
 \title{List Experiments}
 \usage{
-mlflow_list_experiments(view_type = c("ACTIVE_ONLY", "DELETED_ONLY",
-  "ALL"), client = NULL)
+mlflow_list_experiments(
+  view_type = c("ACTIVE_ONLY", "DELETED_ONLY", "ALL"),
+  client = NULL
+)
 }
 \arguments{
 \item{view_type}{Qualifier for type of experiments to be returned. Defaults to `ACTIVE_ONLY`.}

--- a/mlflow/R/mlflow/man/mlflow_list_run_infos.Rd
+++ b/mlflow/R/mlflow/man/mlflow_list_run_infos.Rd
@@ -4,8 +4,11 @@
 \alias{mlflow_list_run_infos}
 \title{List Run Infos}
 \usage{
-mlflow_list_run_infos(run_view_type = c("ACTIVE_ONLY", "DELETED_ONLY",
-  "ALL"), experiment_id = NULL, client = NULL)
+mlflow_list_run_infos(
+  run_view_type = c("ACTIVE_ONLY", "DELETED_ONLY", "ALL"),
+  experiment_id = NULL,
+  client = NULL
+)
 }
 \arguments{
 \item{run_view_type}{Run view type.}

--- a/mlflow/R/mlflow/man/mlflow_load_model.Rd
+++ b/mlflow/R/mlflow/man/mlflow_load_model.Rd
@@ -30,8 +30,6 @@ The URI scheme must be supported by MLflow - i.e. there has to be an MLflow arti
                  - ``file:relative/path/to/local/model``
                  - ``s3://my_bucket/path/to/model``
                  - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
-                 - ``models:/<model_name>/<model_version>``
-                 - ``models:/<model_name>/<stage>``
 
  For more information about supported URI schemes, see the Artifacts Documentation at
  https://www.mlflow.org/docs/latest/tracking.html#artifact-stores.

--- a/mlflow/R/mlflow/man/mlflow_log_artifact.Rd
+++ b/mlflow/R/mlflow/man/mlflow_log_artifact.Rd
@@ -4,8 +4,7 @@
 \alias{mlflow_log_artifact}
 \title{Log Artifact}
 \usage{
-mlflow_log_artifact(path, artifact_path = NULL, run_id = NULL,
-  client = NULL)
+mlflow_log_artifact(path, artifact_path = NULL, run_id = NULL, client = NULL)
 }
 \arguments{
 \item{path}{The file or directory to log as an artifact.}

--- a/mlflow/R/mlflow/man/mlflow_log_batch.Rd
+++ b/mlflow/R/mlflow/man/mlflow_log_batch.Rd
@@ -4,8 +4,13 @@
 \alias{mlflow_log_batch}
 \title{Log Batch}
 \usage{
-mlflow_log_batch(metrics = NULL, params = NULL, tags = NULL,
-  run_id = NULL, client = NULL)
+mlflow_log_batch(
+  metrics = NULL,
+  params = NULL,
+  tags = NULL,
+  run_id = NULL,
+  client = NULL
+)
 }
 \arguments{
 \item{metrics}{A dataframe of metrics to log, containing the following columns: "key", "value",

--- a/mlflow/R/mlflow/man/mlflow_log_metric.Rd
+++ b/mlflow/R/mlflow/man/mlflow_log_metric.Rd
@@ -4,8 +4,14 @@
 \alias{mlflow_log_metric}
 \title{Log Metric}
 \usage{
-mlflow_log_metric(key, value, timestamp = NULL, step = NULL,
-  run_id = NULL, client = NULL)
+mlflow_log_metric(
+  key,
+  value,
+  timestamp = NULL,
+  step = NULL,
+  run_id = NULL,
+  client = NULL
+)
 }
 \arguments{
 \item{key}{Name of the metric.}

--- a/mlflow/R/mlflow/man/mlflow_rfunc_serve.Rd
+++ b/mlflow/R/mlflow/man/mlflow_rfunc_serve.Rd
@@ -4,8 +4,14 @@
 \alias{mlflow_rfunc_serve}
 \title{Serve an RFunc MLflow Model}
 \usage{
-mlflow_rfunc_serve(model_uri, host = "127.0.0.1", port = 8090,
-  daemonized = FALSE, browse = !daemonized, ...)
+mlflow_rfunc_serve(
+  model_uri,
+  host = "127.0.0.1",
+  port = 8090,
+  daemonized = FALSE,
+  browse = !daemonized,
+  ...
+)
 }
 \arguments{
 \item{model_uri}{The location, in URI format, of the MLflow model.}

--- a/mlflow/R/mlflow/man/mlflow_run.Rd
+++ b/mlflow/R/mlflow/man/mlflow_run.Rd
@@ -4,10 +4,18 @@
 \alias{mlflow_run}
 \title{Run an MLflow Project}
 \usage{
-mlflow_run(uri = ".", entry_point = NULL, version = NULL,
-  parameters = NULL, experiment_id = NULL, experiment_name = NULL,
-  backend = NULL, backend_config = NULL, no_conda = FALSE,
-  storage_dir = NULL)
+mlflow_run(
+  uri = ".",
+  entry_point = NULL,
+  version = NULL,
+  parameters = NULL,
+  experiment_id = NULL,
+  experiment_name = NULL,
+  backend = NULL,
+  backend_config = NULL,
+  no_conda = FALSE,
+  storage_dir = NULL
+)
 }
 \arguments{
 \item{uri}{A directory containing modeling scripts, defaults to the current directory.}

--- a/mlflow/R/mlflow/man/mlflow_save_model.Rd
+++ b/mlflow/R/mlflow/man/mlflow_save_model.Rd
@@ -8,8 +8,7 @@
 \usage{
 \method{mlflow_save_model}{crate}(model, path, ...)
 
-\method{mlflow_save_model}{keras.engine.training.Model}(model, path,
-  conda_env = NULL, ...)
+\method{mlflow_save_model}{keras.engine.training.Model}(model, path, conda_env = NULL, ...)
 
 mlflow_save_model(model, path, ...)
 }

--- a/mlflow/R/mlflow/man/mlflow_search_runs.Rd
+++ b/mlflow/R/mlflow/man/mlflow_search_runs.Rd
@@ -4,9 +4,13 @@
 \alias{mlflow_search_runs}
 \title{Search Runs}
 \usage{
-mlflow_search_runs(filter = NULL, run_view_type = c("ACTIVE_ONLY",
-  "DELETED_ONLY", "ALL"), experiment_ids = NULL, order_by = list(),
-  client = NULL)
+mlflow_search_runs(
+  filter = NULL,
+  run_view_type = c("ACTIVE_ONLY", "DELETED_ONLY", "ALL"),
+  experiment_ids = NULL,
+  order_by = list(),
+  client = NULL
+)
 }
 \arguments{
 \item{filter}{A filter expression over params, metrics, and tags, allowing returning a subset of runs.

--- a/mlflow/R/mlflow/man/mlflow_server.Rd
+++ b/mlflow/R/mlflow/man/mlflow_server.Rd
@@ -4,9 +4,14 @@
 \alias{mlflow_server}
 \title{Run MLflow Tracking Server}
 \usage{
-mlflow_server(file_store = "mlruns", default_artifact_root = NULL,
-  host = "127.0.0.1", port = 5000, workers = 4,
-  static_prefix = NULL)
+mlflow_server(
+  file_store = "mlruns",
+  default_artifact_root = NULL,
+  host = "127.0.0.1",
+  port = 5000,
+  workers = 4,
+  static_prefix = NULL
+)
 }
 \arguments{
 \item{file_store}{The root of the backing file store for experiment and run data.}

--- a/mlflow/R/mlflow/man/mlflow_set_experiment.Rd
+++ b/mlflow/R/mlflow/man/mlflow_set_experiment.Rd
@@ -4,8 +4,11 @@
 \alias{mlflow_set_experiment}
 \title{Set Experiment}
 \usage{
-mlflow_set_experiment(experiment_name = NULL, experiment_id = NULL,
-  artifact_location = NULL)
+mlflow_set_experiment(
+  experiment_name = NULL,
+  experiment_id = NULL,
+  artifact_location = NULL
+)
 }
 \arguments{
 \item{experiment_name}{Name of experiment to be activated.}

--- a/mlflow/R/mlflow/man/mlflow_set_experiment_tag.Rd
+++ b/mlflow/R/mlflow/man/mlflow_set_experiment_tag.Rd
@@ -4,8 +4,7 @@
 \alias{mlflow_set_experiment_tag}
 \title{Set Experiment Tag}
 \usage{
-mlflow_set_experiment_tag(key, value, experiment_id = NULL,
-  client = NULL)
+mlflow_set_experiment_tag(key, value, experiment_id = NULL, client = NULL)
 }
 \arguments{
 \item{key}{Name of the tag. All storage backends are guaranteed to support

--- a/mlflow/R/mlflow/man/mlflow_start_run.Rd
+++ b/mlflow/R/mlflow/man/mlflow_start_run.Rd
@@ -4,8 +4,13 @@
 \alias{mlflow_start_run}
 \title{Start Run}
 \usage{
-mlflow_start_run(run_id = NULL, experiment_id = NULL,
-  start_time = NULL, tags = NULL, client = NULL)
+mlflow_start_run(
+  run_id = NULL,
+  experiment_id = NULL,
+  start_time = NULL,
+  tags = NULL,
+  client = NULL
+)
 }
 \arguments{
 \item{run_id}{If specified, get the run with the specified UUID and log metrics


### PR DESCRIPTION
As of version 7.0.0, roxygen2 will put arguments on its own line in the usage section if calls are longer as described [in the release blog post](https://www.tidyverse.org/blog/2019/11/roxygen2-7-0-0/). This PR does nothing but re-generate the R documentation using 

```bash
cd docs
make rdocs
```
with roxygen 7.0.2.

## What changes are proposed in this pull request?

Using up-to-date version of the roxygen2 dependency for documenting the R package.

## How is this patch tested?

Inspecting the diff of the documentation output selectively and previewing the doc page with 
```bash
cd docs
make livehtml
```


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [x] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [x] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
