### PR TITLE
Add auto logging functionality for LightGBM flavor.

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -292,14 +292,14 @@ If early stopping is activated, metrics at the best iteration will be logged as 
 
 .. note::
   - This feature is experimental - the API and format of the logged data are subject to change.
-  - The `scikit-learn API <https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn>`_ is not supported.
+  - The `scikit-learn API <https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn>`__ is not supported.
 
 .. _xgboost.train: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
 .. _MLflow Model: https://mlflow.org/docs/latest/models.html
 
 
 LightGBM (experimental)
-----------------------
+-----------------------
 Call :py:func:`mlflow.lightgbm.autolog` before your training code to enable automatic logging of metrics and parameters.
 
 Autologging captures the following information:
@@ -314,7 +314,7 @@ If early stopping is activated, metrics at the best iteration will be logged as 
 
 .. note::
   - This feature is experimental - the API and format of the logged data are subject to change.
-  - The `scikit-learn API <https://lightgbm.readthedocs.io/en/latest/Python-API.html#scikit-learn-api>`_ is not supported.
+  - The `scikit-learn API <https://lightgbm.readthedocs.io/en/latest/Python-API.html#scikit-learn-api>`__ is not supported.
 
 .. _lightgbm.train: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html#lightgbm-train
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -292,11 +292,31 @@ If early stopping is activated, metrics at the best iteration will be logged as 
 
 .. note::
   - This feature is experimental - the API and format of the logged data are subject to change.
-  - The `scikit-learn API`_ is not supported.
+  - The `scikit-learn API <https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn>`_ is not supported.
 
 .. _xgboost.train: https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
 .. _MLflow Model: https://mlflow.org/docs/latest/models.html
-.. _scikit-learn API:  https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn
+
+
+LightGBM (experimental)
+----------------------
+Call :py:func:`mlflow.lightgbm.autolog` before your training code to enable automatic logging of metrics and parameters.
+
+Autologging captures the following information:
+
++-----------+------------------------+------------------------------+---------------+----------------------------------------------------------------------+
+| Framework | Metrics                | Parameters                   | Tags          | Artifacts                                                            |
++-----------+------------------------+------------------------------+---------------+----------------------------------------------------------------------+
+| LightGBM  | user-specified metrics | `lightgbm.train`_ parameters | --            | `MLflow Model`_ (LightGBM model) on training end; feature importance |
++-----------+------------------------+------------------------------+---------------+----------------------------------------------------------------------+
+
+If early stopping is activated, metrics at the best iteration will be logged as an extra step/iteration.
+
+.. note::
+  - This feature is experimental - the API and format of the logged data are subject to change.
+  - The `scikit-learn API <https://lightgbm.readthedocs.io/en/latest/Python-API.html#scikit-learn-api>`_ is not supported.
+
+.. _lightgbm.train: https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html#lightgbm-train
 
 .. _organizing_runs_in_experiments:
 

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -20,6 +20,11 @@ from __future__ import absolute_import
 
 import os
 import yaml
+import json
+import tempfile
+import shutil
+import inspect
+import gorilla
 
 import mlflow
 from mlflow import pyfunc
@@ -28,6 +33,9 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
+from mlflow.utils.annotations import experimental
+from mlflow.utils.autologging_utils import try_mlflow_log, log_fn_args_as_params
+
 
 FLAVOR_NAME = "lightgbm"
 
@@ -182,3 +190,111 @@ class _LGBModelWrapper:
 
     def predict(self, dataframe):
         return self.lgb_model.predict(dataframe)
+
+
+@experimental
+def autolog(importance_types=['split']):  # pylint: disable=W0102
+    """
+    Enables automatic logging from LightGBM to MLflow. Logs the following.
+    - parameters specified in `lightgbm.train`_.
+    - metrics on each iteration (if ``evals`` specified).
+    - metrics at the best iteration (if ``early_stopping_rounds`` specified).
+    - feature importance.
+    - trained model.
+    Note that the `scikit-learn API`_ is not supported.
+    :param importance_types: importance types to log.
+    """
+    import lightgbm
+
+    @gorilla.patch(lightgbm)
+    def train(*args, **kwargs):
+
+        def record_eval_results(eval_results):
+            """
+            Create a callback function that records evaluation results.
+            """
+            def callback(env):
+                res = {}
+                for data_name, eval_name, value, _ in env.evaluation_result_list:
+                    key = data_name + '-' + eval_name
+                    res[key] = value
+
+                eval_results.append(res)
+            return callback
+
+        if not mlflow.active_run():
+            try_mlflow_log(mlflow.start_run)
+            auto_end_run = True
+        else:
+            auto_end_run = False
+
+        original = gorilla.get_original_attribute(lightgbm, 'train')
+
+        # logging booster params separately via mlflow.log_params to extract key/value pairs
+        # and make it easier to compare them across runs.
+        params = args[0] if len(args) > 0 else kwargs['params']
+        try_mlflow_log(mlflow.log_params, params)
+
+        unlogged_params = ['params', 'train_set', 'valid_sets', 'valid_names', 'fobj', 'feval',
+                           'init_model', 'evals_result', 'learning_rates', 'callbacks']
+
+        log_fn_args_as_params(original, args, kwargs, unlogged_params)
+
+        all_arg_names = inspect.getargspec(original)[0]  # pylint: disable=W1505
+        num_pos_args = len(args)
+
+        # adding a callback that records evaluation results.
+        eval_results = []
+        callbacks_index = all_arg_names.index('callbacks')
+        callback = record_eval_results(eval_results)
+        if num_pos_args >= callbacks_index + 1:
+            tmp_list = list(args)
+            tmp_list[callbacks_index] += [callback]
+            args = tuple(tmp_list)
+        elif 'callbacks' in kwargs and kwargs['callbacks'] is not None:
+            kwargs['callbacks'] += [callback]
+        else:
+            kwargs['callbacks'] = [callback]
+
+        # training model
+        model = original(*args, **kwargs)
+
+        # logging metrics on each iteration.
+        for idx, metrics in enumerate(eval_results):
+            try_mlflow_log(mlflow.log_metrics, metrics, step=idx)
+
+        # If early_stopping_rounds is present, logging metrics at the best iteration
+        # as extra metrics with the max step + 1.
+        early_stopping_index = all_arg_names.index('early_stopping_rounds')
+        early_stopping = (num_pos_args >= early_stopping_index + 1 or
+                          'early_stopping_rounds' in kwargs)
+        if early_stopping:
+            extra_step = len(eval_results)
+            try_mlflow_log(mlflow.log_metric, 'stopped_iteration', len(eval_results))
+            try_mlflow_log(mlflow.log_metric, 'best_iteration', model.best_iteration)
+            # iteration starts from 1 in LightGBM.
+            try_mlflow_log(mlflow.log_metrics, eval_results[model.best_iteration - 1],
+                           step=extra_step)
+
+        # logging feature importance as artifacts.
+        for imp_type in importance_types:
+            features = model.feature_name()
+            importance = model.feature_importance(importance_type=imp_type)
+            imp = {ft: imp for ft, imp in zip(features, importance.tolist())}
+            tmpdir = tempfile.mkdtemp()
+            try:
+                filepath = os.path.join(tmpdir, 'feature_importance_{}.json'.format(imp_type))
+                with open(filepath, 'w') as f:
+                    json.dump(imp, f)
+                try_mlflow_log(mlflow.log_artifact, filepath)
+            finally:
+                shutil.rmtree(tmpdir)
+
+        try_mlflow_log(log_model, model, artifact_path='model')
+
+        if auto_end_run:
+            try_mlflow_log(mlflow.end_run)
+        return model
+
+    settings = gorilla.Settings(allow_hit=True, store_hit=True)
+    gorilla.apply(gorilla.Patch(lightgbm, 'train', train, settings=settings))

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -198,11 +198,13 @@ class _LGBModelWrapper:
 def autolog():
     """
     Enables automatic logging from LightGBM to MLflow. Logs the following.
+
     - parameters specified in `lightgbm.train`_.
-    - metrics on each iteration (if ``evals`` specified).
+    - metrics on each iteration (if ``valid_sets`` specified).
     - metrics at the best iteration (if ``early_stopping_rounds`` specified).
-    - feature importance.
+    - feature importance (both "split" and "gain").
     - trained model.
+
     Note that the `scikit-learn API`_ is not supported.
     """
     import lightgbm

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -195,7 +195,7 @@ class _LGBModelWrapper:
 
 
 @experimental
-def autolog(importance_types=['split']):  # pylint: disable=W0102
+def autolog():
     """
     Enables automatic logging from LightGBM to MLflow. Logs the following.
     - parameters specified in `lightgbm.train`_.
@@ -204,7 +204,6 @@ def autolog(importance_types=['split']):  # pylint: disable=W0102
     - feature importance.
     - trained model.
     Note that the `scikit-learn API`_ is not supported.
-    :param importance_types: importance types to log.
     """
     import lightgbm
 
@@ -280,7 +279,7 @@ def autolog(importance_types=['split']):  # pylint: disable=W0102
                            step=extra_step)
 
         # logging feature importance as artifacts.
-        for imp_type in importance_types:
+        for imp_type in ['split', 'gain']:
             features = model.feature_name()
             importance = model.feature_importance(importance_type=imp_type)
             imp = {ft: imp for ft, imp in zip(features, importance.tolist())}

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -12,6 +12,8 @@ LightGBM (native) format
 .. _lightgbm.Booster.save_model:
     https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.Booster.html
     #lightgbm.Booster.save_model
+.. _lightgbm.train:
+    https://lightgbm.readthedocs.io/en/latest/pythonapi/lightgbm.train.html#lightgbm-train
 .. _scikit-learn API:
     https://lightgbm.readthedocs.io/en/latest/Python-API.html#scikit-learn-api
 """

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -273,6 +273,7 @@ def autolog(importance_types=['split']):  # pylint: disable=W0102
         if early_stopping:
             extra_step = len(eval_results)
             try_mlflow_log(mlflow.log_metric, 'stopped_iteration', len(eval_results))
+            # best_iteration is set even if training does not stop early.
             try_mlflow_log(mlflow.log_metric, 'best_iteration', model.best_iteration)
             # iteration starts from 1 in LightGBM.
             try_mlflow_log(mlflow.log_metrics, eval_results[model.best_iteration - 1],

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -1,0 +1,270 @@
+import os
+import json
+import pytest
+import numpy as np
+import pandas as pd
+from sklearn import datasets
+import lightgbm as lgb
+
+import mlflow
+import mlflow.lightgbm
+
+client = mlflow.tracking.MlflowClient()
+
+
+def get_latest_run():
+    return client.get_run(client.list_run_infos(experiment_id='0')[0].run_id)
+
+
+@pytest.fixture(scope="session")
+def bst_params():
+    return {
+        'objective': 'multiclass',
+        'num_class': 3,
+    }
+
+
+@pytest.fixture(scope="session")
+def train_set():
+    iris = datasets.load_iris()
+    X = pd.DataFrame(iris.data[:, :2], columns=iris.feature_names[:2])
+    y = iris.target
+    # set free_raw_data False to use raw data later.
+    return lgb.Dataset(X, y, free_raw_data=False)
+
+
+@pytest.mark.large
+def test_lgb_autolog_ends_auto_created_run(bst_params, train_set):
+    mlflow.lightgbm.autolog()
+    lgb.train(bst_params, train_set)
+    assert mlflow.active_run() is None
+
+
+@pytest.mark.large
+def test_lgb_autolog_persists_manually_created_run(bst_params, train_set):
+    mlflow.lightgbm.autolog()
+    with mlflow.start_run() as run:
+        lgb.train(bst_params, train_set)
+        assert mlflow.active_run()
+        assert mlflow.active_run().info.run_id == run.info.run_id
+
+
+@pytest.mark.large
+def test_lgb_autolog_logs_default_params(bst_params, train_set):
+    mlflow.lightgbm.autolog()
+    lgb.train(bst_params, train_set)
+    run = get_latest_run()
+    params = run.data.params
+
+    expected_params = {
+        'num_boost_round': 100,
+        'feature_name': 'auto',
+        'categorical_feature': 'auto',
+        'verbose_eval': True,
+        'keep_training_booster': False
+    }
+    expected_params.update(bst_params)
+
+    for key, val in expected_params.items():
+        assert key in params
+        assert params[key] == str(val)
+
+    unlogged_params = ['params', 'train_set', 'valid_sets', 'valid_names', 'fobj', 'feval',
+                       'init_model', 'evals_result', 'learning_rates', 'callbacks']
+
+    for param in unlogged_params:
+        assert param not in params
+
+
+@pytest.mark.large
+def test_lgb_autolog_logs_specified_params(bst_params, train_set):
+    mlflow.lightgbm.autolog()
+    expected_params = {
+        'num_boost_round': 10,
+        'early_stopping_rounds': 5,
+        'verbose_eval': False,
+    }
+    lgb.train(bst_params, train_set, valid_sets=[train_set], **expected_params)
+    run = get_latest_run()
+    params = run.data.params
+
+    expected_params.update(bst_params)
+
+    for key, val in expected_params.items():
+        assert key in params
+        assert params[key] == str(val)
+
+    unlogged_params = ['params', 'train_set', 'valid_sets', 'valid_names', 'fobj', 'feval',
+                       'init_model', 'evals_result', 'learning_rates', 'callbacks']
+
+    for param in unlogged_params:
+        assert param not in params
+
+
+@pytest.mark.large
+def test_lgb_autolog_logs_metrics_with_validation_data(bst_params, train_set):
+    mlflow.lightgbm.autolog()
+    evals_result = {}
+    lgb.train(bst_params, train_set, num_boost_round=20, valid_sets=[train_set],
+              valid_names=['train'], evals_result=evals_result)
+    run = get_latest_run()
+    data = run.data
+
+    metric_key = 'train-multi_logloss'
+    metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
+    assert metric_key in data.metrics
+    assert len(metric_history) == 20
+    assert metric_history == evals_result['train']['multi_logloss']
+
+
+@pytest.mark.large
+def test_lgb_autolog_logs_metrics_with_multi_validation_data(bst_params, train_set):
+    mlflow.lightgbm.autolog()
+    evals_result = {}
+    # If we use [train_set, train_set] here, LightGBM ignores the first dataset.
+    # To avoid that, create a new Dataset object.
+    valid_sets = [train_set, lgb.Dataset(train_set.data)]
+    valid_names = ['train', 'valid']
+    lgb.train(bst_params, train_set, num_boost_round=20, valid_sets=valid_sets,
+              valid_names=valid_names, evals_result=evals_result)
+    run = get_latest_run()
+    data = run.data
+
+    for valid_name in valid_names:
+        metric_key = '{}-multi_logloss'.format(valid_name)
+        metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
+        assert metric_key in data.metrics
+        assert len(metric_history) == 20
+        assert metric_history == evals_result[valid_name]['multi_logloss']
+
+
+@pytest.mark.large
+def test_lgb_autolog_logs_metrics_with_multi_metrics(bst_params, train_set):
+    mlflow.lightgbm.autolog()
+    evals_result = {}
+    params = {'metric': ['multi_error', 'multi_logloss']}
+    params.update(bst_params)
+    valid_sets = [train_set]
+    valid_names = ['train']
+    lgb.train(params, train_set, num_boost_round=20, valid_sets=valid_sets,
+              valid_names=valid_names, evals_result=evals_result)
+    run = get_latest_run()
+    data = run.data
+
+    for metric_name in params['metric']:
+        metric_key = '{}-{}'.format(valid_names[0], metric_name)
+        metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
+        assert metric_key in data.metrics
+        assert len(metric_history) == 20
+        assert metric_history == evals_result['train'][metric_name]
+
+
+@pytest.mark.large
+def test_lgb_autolog_logs_metrics_with_multi_validation_data_and_metrics(bst_params, train_set):
+    mlflow.lightgbm.autolog()
+    evals_result = {}
+    params = {'metric': ['multi_error', 'multi_logloss']}
+    params.update(bst_params)
+    valid_sets = [train_set, lgb.Dataset(train_set.data)]
+    valid_names = ['train', 'valid']
+    lgb.train(params, train_set, num_boost_round=20, valid_sets=valid_sets,
+              valid_names=valid_names, evals_result=evals_result)
+    run = get_latest_run()
+    data = run.data
+
+    for valid_name in valid_names:
+        for metric_name in params['metric']:
+            metric_key = '{}-{}'.format(valid_name, metric_name)
+            metric_history = [x.value for x
+                              in client.get_metric_history(run.info.run_id, metric_key)]
+            assert metric_key in data.metrics
+            assert len(metric_history) == 20
+            assert metric_history == evals_result[valid_name][metric_name]
+
+
+@pytest.mark.large
+def test_lgb_autolog_logs_metrics_with_early_stopping(bst_params, train_set):
+    mlflow.lightgbm.autolog()
+    evals_result = {}
+    params = {'metric': ['multi_error', 'multi_logloss']}
+    params.update(bst_params)
+    valid_sets = [train_set, lgb.Dataset(train_set.data)]
+    valid_names = ['train', 'valid']
+    model = lgb.train(params, train_set, num_boost_round=20, early_stopping_rounds=5,
+                      valid_sets=valid_sets, valid_names=valid_names, evals_result=evals_result)
+    run = get_latest_run()
+    data = run.data
+
+    assert 'best_iteration' in data.metrics
+    assert int(data.metrics['best_iteration']) == model.best_iteration
+    assert 'stopped_iteration' in data.metrics
+    assert int(data.metrics['stopped_iteration']) == len(evals_result['train']['multi_logloss'])
+
+    for valid_name in valid_names:
+        for metric_name in params['metric']:
+            metric_key = '{}-{}'.format(valid_name, metric_name)
+            metric_history = [x.value for x
+                              in client.get_metric_history(run.info.run_id, metric_key)]
+            assert metric_key in data.metrics
+
+            best_metrics = evals_result[valid_name][metric_name][model.best_iteration - 1]
+            assert metric_history == evals_result[valid_name][metric_name] + [best_metrics]
+
+
+@pytest.mark.large
+def test_lgb_autolog_logs_feature_importance(bst_params, train_set):
+    mlflow.lightgbm.autolog()
+    model = lgb.train(bst_params, train_set, num_boost_round=20)
+    run = get_latest_run()
+    run_id = run.info.run_id
+    artifacts_dir = run.info.artifact_uri.replace('file://', '')
+    artifacts = [x.path for x in client.list_artifacts(run_id)]
+
+    importance_type = 'split'
+    filename = 'feature_importance_{}.json'.format(importance_type)
+    filepath = os.path.join(artifacts_dir, filename)
+    with open(filepath, 'r') as f:
+        loaded_imp = json.load(f)
+
+    features = model.feature_name()
+    importance = model.feature_importance(importance_type=importance_type)
+    imp = {ft: imp for ft, imp in zip(features, importance.tolist())}
+
+    assert filename in artifacts
+    assert loaded_imp == imp
+
+
+@pytest.mark.large
+def test_lgb_autolog_logs_specified_feature_importance(bst_params, train_set):
+    importance_types = ['split', 'gain']
+    mlflow.lightgbm.autolog(importance_types)
+    model = lgb.train(bst_params, train_set, num_boost_round=20)
+    run = get_latest_run()
+    run_id = run.info.run_id
+    artifacts_dir = run.info.artifact_uri.replace('file://', '')
+    artifacts = [x.path for x in client.list_artifacts(run_id)]
+
+    for imp_type in importance_types:
+        filename = 'feature_importance_{}.json'.format(imp_type)
+        filepath = os.path.join(artifacts_dir, filename)
+        with open(filepath, 'r') as f:
+            loaded_imp = json.load(f)
+
+        features = model.feature_name()
+        importance = model.feature_importance(importance_type=imp_type)
+        imp = {ft: imp for ft, imp in zip(features, importance.tolist())}
+
+        assert filename in artifacts
+        assert loaded_imp == imp
+
+
+@pytest.mark.large
+def test_lgb_autolog_loads_model_from_artifact(bst_params, train_set):
+    mlflow.lightgbm.autolog()
+    model = lgb.train(bst_params, train_set, num_boost_round=20)
+    run = get_latest_run()
+    run_id = run.info.run_id
+
+    loaded_model = mlflow.lightgbm.load_model('runs:/{}/model'.format(run_id))
+    np.testing.assert_array_almost_equal(model.predict(train_set.data),
+                                         loaded_model.predict(train_set.data))

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -36,7 +36,7 @@ def train_set():
 @pytest.mark.large
 def test_lgb_autolog_ends_auto_created_run(bst_params, train_set):
     mlflow.lightgbm.autolog()
-    lgb.train(bst_params, train_set)
+    lgb.train(bst_params, train_set, num_boost_round=1)
     assert mlflow.active_run() is None
 
 
@@ -44,7 +44,7 @@ def test_lgb_autolog_ends_auto_created_run(bst_params, train_set):
 def test_lgb_autolog_persists_manually_created_run(bst_params, train_set):
     mlflow.lightgbm.autolog()
     with mlflow.start_run() as run:
-        lgb.train(bst_params, train_set)
+        lgb.train(bst_params, train_set, num_boost_round=1)
         assert mlflow.active_run()
         assert mlflow.active_run().info.run_id == run.info.run_id
 
@@ -105,7 +105,7 @@ def test_lgb_autolog_logs_specified_params(bst_params, train_set):
 def test_lgb_autolog_logs_metrics_with_validation_data(bst_params, train_set):
     mlflow.lightgbm.autolog()
     evals_result = {}
-    lgb.train(bst_params, train_set, num_boost_round=20, valid_sets=[train_set],
+    lgb.train(bst_params, train_set, num_boost_round=10, valid_sets=[train_set],
               valid_names=['train'], evals_result=evals_result)
     run = get_latest_run()
     data = run.data
@@ -113,7 +113,7 @@ def test_lgb_autolog_logs_metrics_with_validation_data(bst_params, train_set):
     metric_key = 'train-multi_logloss'
     metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
     assert metric_key in data.metrics
-    assert len(metric_history) == 20
+    assert len(metric_history) == 10
     assert metric_history == evals_result['train']['multi_logloss']
 
 
@@ -125,7 +125,7 @@ def test_lgb_autolog_logs_metrics_with_multi_validation_data(bst_params, train_s
     # To avoid that, create a new Dataset object.
     valid_sets = [train_set, lgb.Dataset(train_set.data)]
     valid_names = ['train', 'valid']
-    lgb.train(bst_params, train_set, num_boost_round=20, valid_sets=valid_sets,
+    lgb.train(bst_params, train_set, num_boost_round=10, valid_sets=valid_sets,
               valid_names=valid_names, evals_result=evals_result)
     run = get_latest_run()
     data = run.data
@@ -134,7 +134,7 @@ def test_lgb_autolog_logs_metrics_with_multi_validation_data(bst_params, train_s
         metric_key = '{}-multi_logloss'.format(valid_name)
         metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
         assert metric_key in data.metrics
-        assert len(metric_history) == 20
+        assert len(metric_history) == 10
         assert metric_history == evals_result[valid_name]['multi_logloss']
 
 
@@ -146,7 +146,7 @@ def test_lgb_autolog_logs_metrics_with_multi_metrics(bst_params, train_set):
     params.update(bst_params)
     valid_sets = [train_set]
     valid_names = ['train']
-    lgb.train(params, train_set, num_boost_round=20, valid_sets=valid_sets,
+    lgb.train(params, train_set, num_boost_round=10, valid_sets=valid_sets,
               valid_names=valid_names, evals_result=evals_result)
     run = get_latest_run()
     data = run.data
@@ -155,7 +155,7 @@ def test_lgb_autolog_logs_metrics_with_multi_metrics(bst_params, train_set):
         metric_key = '{}-{}'.format(valid_names[0], metric_name)
         metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
         assert metric_key in data.metrics
-        assert len(metric_history) == 20
+        assert len(metric_history) == 10
         assert metric_history == evals_result['train'][metric_name]
 
 
@@ -167,7 +167,7 @@ def test_lgb_autolog_logs_metrics_with_multi_validation_data_and_metrics(bst_par
     params.update(bst_params)
     valid_sets = [train_set, lgb.Dataset(train_set.data)]
     valid_names = ['train', 'valid']
-    lgb.train(params, train_set, num_boost_round=20, valid_sets=valid_sets,
+    lgb.train(params, train_set, num_boost_round=10, valid_sets=valid_sets,
               valid_names=valid_names, evals_result=evals_result)
     run = get_latest_run()
     data = run.data
@@ -178,7 +178,7 @@ def test_lgb_autolog_logs_metrics_with_multi_validation_data_and_metrics(bst_par
             metric_history = [x.value for x
                               in client.get_metric_history(run.info.run_id, metric_key)]
             assert metric_key in data.metrics
-            assert len(metric_history) == 20
+            assert len(metric_history) == 10
             assert metric_history == evals_result[valid_name][metric_name]
 
 
@@ -190,7 +190,7 @@ def test_lgb_autolog_logs_metrics_with_early_stopping(bst_params, train_set):
     params.update(bst_params)
     valid_sets = [train_set, lgb.Dataset(train_set.data)]
     valid_names = ['train', 'valid']
-    model = lgb.train(params, train_set, num_boost_round=20, early_stopping_rounds=5,
+    model = lgb.train(params, train_set, num_boost_round=10, early_stopping_rounds=5,
                       valid_sets=valid_sets, valid_names=valid_names, evals_result=evals_result)
     run = get_latest_run()
     data = run.data
@@ -214,7 +214,7 @@ def test_lgb_autolog_logs_metrics_with_early_stopping(bst_params, train_set):
 @pytest.mark.large
 def test_lgb_autolog_logs_feature_importance(bst_params, train_set):
     mlflow.lightgbm.autolog()
-    model = lgb.train(bst_params, train_set, num_boost_round=20)
+    model = lgb.train(bst_params, train_set, num_boost_round=10)
     run = get_latest_run()
     run_id = run.info.run_id
     artifacts_dir = run.info.artifact_uri.replace('file://', '')
@@ -238,7 +238,7 @@ def test_lgb_autolog_logs_feature_importance(bst_params, train_set):
 def test_lgb_autolog_logs_specified_feature_importance(bst_params, train_set):
     importance_types = ['split', 'gain']
     mlflow.lightgbm.autolog(importance_types)
-    model = lgb.train(bst_params, train_set, num_boost_round=20)
+    model = lgb.train(bst_params, train_set, num_boost_round=10)
     run = get_latest_run()
     run_id = run.info.run_id
     artifacts_dir = run.info.artifact_uri.replace('file://', '')
@@ -261,7 +261,7 @@ def test_lgb_autolog_logs_specified_feature_importance(bst_params, train_set):
 @pytest.mark.large
 def test_lgb_autolog_loads_model_from_artifact(bst_params, train_set):
     mlflow.lightgbm.autolog()
-    model = lgb.train(bst_params, train_set, num_boost_round=20)
+    model = lgb.train(bst_params, train_set, num_boost_round=10)
     run = get_latest_run()
     run_id = run.info.run_id
 

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -220,31 +220,7 @@ def test_lgb_autolog_logs_feature_importance(bst_params, train_set):
     artifacts_dir = run.info.artifact_uri.replace('file://', '')
     artifacts = [x.path for x in client.list_artifacts(run_id)]
 
-    importance_type = 'split'
-    filename = 'feature_importance_{}.json'.format(importance_type)
-    filepath = os.path.join(artifacts_dir, filename)
-    with open(filepath, 'r') as f:
-        loaded_imp = json.load(f)
-
-    features = model.feature_name()
-    importance = model.feature_importance(importance_type=importance_type)
-    imp = {ft: imp for ft, imp in zip(features, importance.tolist())}
-
-    assert filename in artifacts
-    assert loaded_imp == imp
-
-
-@pytest.mark.large
-def test_lgb_autolog_logs_specified_feature_importance(bst_params, train_set):
-    importance_types = ['split', 'gain']
-    mlflow.lightgbm.autolog(importance_types)
-    model = lgb.train(bst_params, train_set, num_boost_round=10)
-    run = get_latest_run()
-    run_id = run.info.run_id
-    artifacts_dir = run.info.artifact_uri.replace('file://', '')
-    artifacts = [x.path for x in client.list_artifacts(run_id)]
-
-    for imp_type in importance_types:
+    for imp_type in ['split', 'gain']:
         filename = 'feature_importance_{}.json'.format(imp_type)
         filepath = os.path.join(artifacts_dir, filename)
         with open(filepath, 'r') as f:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add auto logging functionality for LightGBM flavor that logs the following:

- booster parameters
- metrics on each iteration
- best and stopped iteration (if early stopping activated)
- metrics at the best iteration  (if early stopping activated)
- feature importance (logged as an artifact in json format)
- trained model (logged as an artifact)

### Sample Code

```python
import lightgbm as lgb
from mlflow.lightgbm import autolog

from sklearn import datasets
from sklearn.model_selection import train_test_split

autolog()

X, y = datasets.load_iris(return_X_y=True)
X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
train_set = lgb.Dataset(X_train)
valid_set = lgb.Dataset(X_test)

params = {
    'objective': 'multiclass',
    'num_class': 3,
    'metric': 'multi_logloss',
    'random_state': 42,
}
model = lgb.train(params, train_set, early_stopping_rounds=10,
                  valid_sets=[train_set, valid_set], valid_names=['train', 'valid'])

```

![lgb-autolog-demo](https://user-images.githubusercontent.com/17039389/71988497-5d875700-3273-11ea-915e-5fbf79606833.gif)


## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [x] API
- [ ] REST-API
- [x] Examples
- [x] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [x] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
