### PR TITLE
Remove autologging support for tf.keras.fit_generator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
         - export NOT_CRAN=true
         - cd mlflow/R/mlflow
         - Rscript -e 'install.packages("devtools")'
-        - Rscript -e 'devtools::install_deps(dependencies = TRUE, upgrade = "always")'
+        - Rscript -e 'devtools::install_deps(dependencies = TRUE, upgrade = FALSE)'
         - cd ../../..
       install:
         - source ./travis/install-common-deps.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-dist: trusty
+dist: xenial
 
 services:
   - docker

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -250,7 +250,7 @@ Autologging captures the following information:
 Note that autologging for ``tf.keras`` is handled by :py:func:`mlflow.tensorflow.autolog`, not :py:func:`mlflow.keras.autolog`.
 
 If no active run exists when ``autolog()`` captures data, MLflow will automatically create a run to log information to.
-Once training ends via calls to ``tf.estimator.train()``, ``tf.keras.fit()``, ``tf.keras.fit_generator()``, ``keras.fit()`` or ``keras.fit_generator()``,
+Once training ends via calls to ``tf.estimator.train()``, ``tf.keras.fit()``, ``keras.fit()`` or ``keras.fit_generator()``,
 or once ``tf.estimator`` models are exported via ``tf.estimator.export_saved_model()``, MLflow will automatically end that run.
 
 If a run exists when ``autolog()`` captures data, MLflow will log to that run and not automatically end that run after training.

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -151,9 +151,6 @@ def create_tf_estimator_model(dir, export):
 
     train = pd.read_csv(os.path.join(os.path.dirname(__file__), "iris_training.csv"),
                         names=CSV_COLUMN_NAMES, header=0)
-    test = pd.read_csv(os.path.join(os.path.dirname(__file__), "iris_test.csv"),
-                       names=CSV_COLUMN_NAMES, header=0)
-
     train_y = train.pop('Species')
 
     def input_fn(features, labels, training=True, batch_size=256):

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -61,72 +61,46 @@ def create_tf_keras_model():
 
 
 @pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_tf_keras_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels,
-                                                fit_variant):
+def test_tf_keras_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels):
     mlflow.tensorflow.autolog()
 
     data = random_train_data
     labels = random_one_hot_labels
 
     model = create_tf_keras_model()
-
-    if fit_variant == 'fit_generator':
-        def generator():
-            while True:
-                yield data, labels
-        model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
-    else:
-        model.fit(data, labels, epochs=10)
+    model.fit(data, labels, epochs=10)
 
     assert mlflow.active_run() is None
 
 
 @pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_tf_keras_autolog_persists_manually_created_run(random_train_data, random_one_hot_labels,
-                                                        fit_variant):
+def test_tf_keras_autolog_persists_manually_created_run(random_train_data, random_one_hot_labels):
     mlflow.tensorflow.autolog()
     with mlflow.start_run() as run:
         data = random_train_data
         labels = random_one_hot_labels
 
         model = create_tf_keras_model()
-
-        if fit_variant == 'fit_generator':
-            def generator():
-                while True:
-                    yield data, labels
-            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
-        else:
-            model.fit(data, labels, epochs=10)
+        model.fit(data, labels, epochs=10)
 
         assert mlflow.active_run()
         assert mlflow.active_run().info.run_id == run.info.run_id
 
 
 @pytest.fixture
-def tf_keras_random_data_run(random_train_data, random_one_hot_labels, manual_run, fit_variant):
+def tf_keras_random_data_run(random_train_data, random_one_hot_labels, manual_run):
     mlflow.tensorflow.autolog(every_n_iter=5)
 
     data = random_train_data
     labels = random_one_hot_labels
 
     model = create_tf_keras_model()
-
-    if fit_variant == 'fit_generator':
-        def generator():
-            while True:
-                yield data, labels
-        model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
-    else:
-        model.fit(data, labels, epochs=10, steps_per_epoch=1)
+    model.fit(data, labels, epochs=10, steps_per_epoch=1)
 
     return client.get_run(client.list_run_infos(experiment_id='0')[0].run_id)
 
 
 @pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
 def test_tf_keras_autolog_logs_expected_data(tf_keras_random_data_run):
     data = tf_keras_random_data_run.data
     assert 'accuracy' in data.metrics
@@ -162,7 +136,6 @@ def test_tf_keras_autolog_logs_expected_data(tf_keras_random_data_run):
 
 
 @pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
 def test_tf_keras_autolog_model_can_load_from_artifact(tf_keras_random_data_run, random_train_data):
     artifacts = client.list_artifacts(tf_keras_random_data_run.info.run_id)
     artifacts = map(lambda x: x.path, artifacts)
@@ -175,7 +148,6 @@ def test_tf_keras_autolog_model_can_load_from_artifact(tf_keras_random_data_run,
 
 def create_tf_estimator_model(dir, export):
     CSV_COLUMN_NAMES = ['SepalLength', 'SepalWidth', 'PetalLength', 'PetalWidth', 'Species']
-    SPECIES = ['Setosa', 'Versicolor', 'Virginica']
 
     train = pd.read_csv(os.path.join(os.path.dirname(__file__), "iris_training.csv"),
                         names=CSV_COLUMN_NAMES, header=0)
@@ -183,7 +155,6 @@ def create_tf_estimator_model(dir, export):
                        names=CSV_COLUMN_NAMES, header=0)
 
     train_y = train.pop('Species')
-    test_y = test.pop('Species')
 
     def input_fn(features, labels, training=True, batch_size=256):
         """An input function for training or evaluating"""

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -61,9 +61,7 @@ def create_tf_keras_model():
 
 
 @pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_tf_keras_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels,
-                                                fit_variant):
+def test_tf_keras_autolog_ends_auto_created_run(random_train_data, random_one_hot_labels):
     mlflow.tensorflow.autolog()
 
     data = random_train_data
@@ -77,9 +75,7 @@ def test_tf_keras_autolog_ends_auto_created_run(random_train_data, random_one_ho
 
 
 @pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_tf_keras_autolog_persists_manually_created_run(random_train_data, random_one_hot_labels,
-                                                        fit_variant):
+def test_tf_keras_autolog_persists_manually_created_run(random_train_data, random_one_hot_labels):
     mlflow.tensorflow.autolog()
     with mlflow.start_run() as run:
         data = random_train_data
@@ -94,27 +90,19 @@ def test_tf_keras_autolog_persists_manually_created_run(random_train_data, rando
 
 
 @pytest.fixture
-def tf_keras_random_data_run(random_train_data, random_one_hot_labels, manual_run, fit_variant):
+def tf_keras_random_data_run(random_train_data, random_one_hot_labels, manual_run):
     mlflow.tensorflow.autolog(every_n_iter=5)
 
     data = random_train_data
     labels = random_one_hot_labels
 
     model = create_tf_keras_model()
-
-    if fit_variant == 'fit_generator':
-        def generator():
-            while True:
-                yield data, labels
-        model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
-    else:
-        model.fit(data, labels, epochs=10, steps_per_epoch=1)
+    model.fit(data, labels, epochs=10, steps_per_epoch=1)
 
     return client.get_run(client.list_run_infos(experiment_id='0')[0].run_id)
 
 
 @pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
 def test_tf_keras_autolog_logs_expected_data(tf_keras_random_data_run):
     data = tf_keras_random_data_run.data
     assert 'epoch_acc' in data.metrics
@@ -143,7 +131,6 @@ def test_tf_keras_autolog_logs_expected_data(tf_keras_random_data_run):
 
 
 @pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
 def test_tf_keras_autolog_model_can_load_from_artifact(tf_keras_random_data_run, random_train_data):
     artifacts = client.list_artifacts(tf_keras_random_data_run.info.run_id)
     artifacts = map(lambda x: x.path, artifacts)
@@ -191,15 +178,10 @@ def test_tf_core_autolog_logs_scalars(tf_core_random_tensors):
 
 def create_tf_estimator_model(dir, export):
     CSV_COLUMN_NAMES = ['SepalLength', 'SepalWidth', 'PetalLength', 'PetalWidth', 'Species']
-    SPECIES = ['Setosa', 'Versicolor', 'Virginica']
 
     train = pd.read_csv(os.path.join(os.path.dirname(__file__), "iris_training.csv"),
                         names=CSV_COLUMN_NAMES, header=0)
-    test = pd.read_csv(os.path.join(os.path.dirname(__file__), "iris_test.csv"),
-                       names=CSV_COLUMN_NAMES, header=0)
-
     train_y = train.pop('Species')
-    test_y = test.pop('Species')
 
     def input_fn(features, labels, training=True, batch_size=256):
         """An input function for training or evaluating"""

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -4,6 +4,7 @@ set -ex
 sudo mkdir -p /travis-install
 sudo chown travis /travis-install
 which java
+rm -rf /usr/local/lib/jvm/openjdk11
 sudo apt install openjdk-8-jdk
 which java
 java -version

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -4,7 +4,7 @@ set -ex
 sudo mkdir -p /travis-install
 sudo chown travis /travis-install
 sudo apt install openjdk-8-jdk
-sudo update-alternatives --config java
+export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
 java -version
 # (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)
 # We do this conditionally because it saves us some downloading if the

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -3,6 +3,7 @@
 set -ex
 sudo mkdir -p /travis-install
 sudo chown travis /travis-install
+sudo apt install openjdk-8-jdk
 # (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)
 # We do this conditionally because it saves us some downloading if the
 # version is the same.

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -4,6 +4,8 @@ set -ex
 sudo mkdir -p /travis-install
 sudo chown travis /travis-install
 sudo apt install openjdk-8-jdk
+sudo update-alternatives --config java
+java -version
 # (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)
 # We do this conditionally because it saves us some downloading if the
 # version is the same.

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -3,8 +3,9 @@
 set -ex
 sudo mkdir -p /travis-install
 sudo chown travis /travis-install
+which java
 sudo apt install openjdk-8-jdk
-export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
+which java
 java -version
 # (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)
 # We do this conditionally because it saves us some downloading if the

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -6,6 +6,7 @@ sudo chown travis /travis-install
 which java
 sudo rm -rf /usr/local/lib/jvm/openjdk11
 sudo apt install openjdk-8-jdk
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 hash -r
 which java
 java -version

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -6,6 +6,7 @@ sudo chown travis /travis-install
 which java
 sudo rm -rf /usr/local/lib/jvm/openjdk11
 sudo apt install openjdk-8-jdk
+hash -r
 which java
 java -version
 # (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -4,7 +4,7 @@ set -ex
 sudo mkdir -p /travis-install
 sudo chown travis /travis-install
 which java
-rm -rf /usr/local/lib/jvm/openjdk11
+sudo rm -rf /usr/local/lib/jvm/openjdk11
 sudo apt install openjdk-8-jdk
 which java
 java -version

--- a/travis/test-spark-autologging.sh
+++ b/travis/test-spark-autologging.sh
@@ -6,7 +6,7 @@ set -ex
 
 # Build Java package
 pushd mlflow/java/spark
-mvn package -DskipTests
+mvn package -q -DskipTests
 popd
 
 # Install PySpark 3.0 preview & run tests. For faster local iteration, you can also simply download
@@ -16,7 +16,7 @@ popd
 TEMPDIR=$(mktemp -d)
 pushd $TEMPDIR
 wget https://archive.apache.org/dist/spark/spark-3.0.0-preview/spark-3.0.0-preview-bin-hadoop2.7.tgz -O /tmp/spark.tgz
-tar -xvf /tmp/spark.tgz
+tar -xf /tmp/spark.tgz
 pip install -e spark-3.0.0-preview-bin-hadoop2.7/python
 popd
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

``tf.keras.Model.fit_generator`` has been deprecated in TF 2.1.0, as per the [release notes](https://github.com/tensorflow/tensorflow/releases/tag/v2.1.0):

> Note that Model.fit_generator, Model.evaluate_generator, and Model.predict_generator are deprecated endpoints. They are subsumed by Model.fit, Model.evaluate, and Model.predict which now support generators and Sequences.

In particular, the tf.keras implementation of `fit_generator` now simply calls `fit`, which breaks our autologging support.

This PR circumvents the issue by removing autologging support for `fit_generator` entirely, which seems reasonable as:
* TF autologging is experimental
* `fit_generator` is not as commonly-used an API as `fit`
* User code that uses `fit_generator` with autologging will still run normally (just not autolog anything)
* Users of `fit_generator` with autologging have a workaround (replace `fit_generator` with `fit`).

## How is this patch tested?
Existing tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Removes autologging support for `tf.keras.Model.fit_generator`

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
