### PR TITLE
Pin TF version to 2.0.0

### DIFF
--- a/travis/run-large-python-tests.sh
+++ b/travis/run-large-python-tests.sh
@@ -37,7 +37,9 @@ pytest --verbose tests/azureml --large
 pytest --verbose tests/models --large
 pytest --verbose tests/xgboost --large
 pytest --verbose tests/lightgbm --large
-pip install 'tensorflow>=2.0.0'
+# TODO(smurching) Unpin TensorFlow dependency version once test failures with TF 2.1.0 have been
+# fixed
+pip install 'tensorflow==2.0.0'
 pytest --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
 pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
 pytest --verbose tests/keras --large


### PR DESCRIPTION
## What changes are proposed in this pull request?

A previous PR, https://github.com/mlflow/mlflow/pull/2277 to fix test failures caused by the TF 2.1.0 release is segfaulting during tests, so filing this PR to simply pin the TF version used in TF 2.x tests to 2.0.0 to unbreak the build for now.

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
