### PR TITLE
Add autodetection of job environments to Java client

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
@@ -53,6 +53,7 @@ public class DatabricksContext {
     return tags;
   }
 
+
   public boolean isInDatabricksNotebook() {
     return configProvider.get("notebookId") != null;
   }
@@ -77,7 +78,7 @@ public class DatabricksContext {
   }
 
   /**
-   * Should only be called if isInDatabricksNotebook() is true.
+   * Should only be called if isInDatabricksNotebook() is true or if isInDatabricksJob() is true.
    */
   private String getWebappUrl() {
     if (!isInDatabricksNotebook()) {
@@ -86,6 +87,22 @@ public class DatabricksContext {
       );
     };
     return configProvider.get("host");
+  }
+
+  public boolean isInDatabricksJob() {
+    return configProvider.get("jobId") != null;
+  }
+
+  public String getJobId() {
+    return configProvider.get("jobId");
+  }
+
+  public String getJobRunId() {
+    return configProvider.get("idInJob");
+  }
+
+  public String getJobType() {
+    return configProvider.get("getJobType");
   }
 
   public static Map<String, String> getConfigProviderIfAvailable(String className) {

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
@@ -32,13 +32,13 @@ public class DatabricksContext {
   }
 
   public Map<String, String> getTags() {
-    Map<String, String> tags = new HashMap<>();
     if (isInDatabricksNotebook()) {
-      tags.putAll(getTagsForDatabricksNotebook());
+      return getTagsForDatabricksNotebook();
     } else if (isInDatabricksJob()) {
-      tags.putAll(getTagsForDatabricksJob());
+      return getTagsForDatabricksJob();
+    } else {
+      return new HashMap<>();
     }
-    return tags;
   }
 
   public boolean isInDatabricksNotebook() {

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
@@ -79,7 +79,7 @@ public class DatabricksContext {
     return configProvider.get("notebookId");
   }
 
-  public boolean isInDatabricksJob() {
+  private boolean isInDatabricksJob() {
     return configProvider.get("jobId") != null;
   }
 
@@ -87,28 +87,25 @@ public class DatabricksContext {
    * Should only be called if isInDatabricksJob() is true.
    */
   private Map<String, String> getTagsForDatabricksJob() {
-    return null;
-  }
-
-  /**
-   * Should only be called if isInDatabricksJob() is true.
-   */
-  public String getJobId() {
-    return configProvider.get("jobId");
-  }
-
-  /**
-   * Should only be called if isInDatabricksJob() is true.
-   */
-  public String getJobRunId() {
-    return configProvider.get("idInJob");
-  }
-
-  /**
-   * Should only be called if isInDatabricksJob() is true.
-   */
-  public String getJobType() {
-    return configProvider.get("getJobType");
+    Map<String, String> tagsForJob = new HashMap<>();
+    String jobId = configProvider.get("jobId");
+    String jobRunId = configProvider.get("idInJob");
+    String jobType = configProvider.get("jobType");
+    String webappUrl = configProvider.get("host");
+    if (jobId != null && jobRunId != null) {
+      tagsForJob.put(MlflowTagConstants.DATABRICKS_JOB_ID, jobId);
+      tagsForJob.put(MlflowTagConstants.DATABRICKS_JOB_RUN_ID, jobRunId);
+      tagsForJob.put(MlflowTagConstants.SOURCE_TYPE, "JOB");
+      tagsForJob.put(MlflowTagConstants.SOURCE_NAME,
+                          String.format("job/%s/run/%s", jobId, jobRunId));
+    }
+    if (jobType != null) {
+      tagsForJob.put(MlflowTagConstants.DATABRICKS_JOB_TYPE, jobType);
+    }
+    if (webappUrl != null) {
+      tagsForJob.put(MlflowTagConstants.DATABRICKS_WEBAPP_URL, webappUrl);
+    }
+    return tagsForJob;
   }
 
   public static Map<String, String> getConfigProviderIfAvailable(String className) {

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
@@ -89,7 +89,7 @@ public class DatabricksContext {
   private Map<String, String> getTagsForDatabricksJob() {
     Map<String, String> tagsForJob = new HashMap<>();
     String jobId = configProvider.get("jobId");
-    String jobRunId = configProvider.get("idInJob");
+    String jobRunId = configProvider.get("jobRunId");
     String jobType = configProvider.get("jobType");
     String webappUrl = configProvider.get("host");
     if (jobId != null && jobRunId != null) {

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
@@ -93,14 +93,23 @@ public class DatabricksContext {
     return configProvider.get("jobId") != null;
   }
 
+  /**
+   * Should only be called if isInDatabricksJob() is true.
+   */
   public String getJobId() {
     return configProvider.get("jobId");
   }
 
+  /**
+   * Should only be called if isInDatabricksJob() is true.
+   */
   public String getJobRunId() {
     return configProvider.get("idInJob");
   }
 
+  /**
+   * Should only be called if isInDatabricksJob() is true.
+   */
   public String getJobType() {
     return configProvider.get("getJobType");
   }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
@@ -33,26 +33,13 @@ public class DatabricksContext {
 
   public Map<String, String> getTags() {
     Map<String, String> tags = new HashMap<>();
-    if (!isInDatabricksNotebook()) {
-      return tags;
-    }
-    String notebookId = getNotebookId();
-    if (notebookId != null) {
-      tags.put(MlflowTagConstants.DATABRICKS_NOTEBOOK_ID, notebookId);
-    }
-    String notebookPath = getNotebookPath();
-    if (notebookPath != null) {
-      tags.put(MlflowTagConstants.SOURCE_NAME, notebookPath);
-      tags.put(MlflowTagConstants.DATABRICKS_NOTEBOOK_PATH, notebookPath);
-      tags.put(MlflowTagConstants.SOURCE_TYPE, "NOTEBOOK");
-    }
-    String webappUrl = getWebappUrl();
-    if (webappUrl != null) {
-      tags.put(MlflowTagConstants.DATABRICKS_WEBAPP_URL, webappUrl);
+    if (isInDatabricksNotebook()) {
+      tags.putAll(getTagsForDatabricksNotebook());
+    } else if (isInDatabricksJob()) {
+      tags.putAll(getTagsForDatabricksJob());
     }
     return tags;
   }
-
 
   public boolean isInDatabricksNotebook() {
     return configProvider.get("notebookId") != null;
@@ -61,36 +48,46 @@ public class DatabricksContext {
   /**
    * Should only be called if isInDatabricksNotebook() is true.
    */
-  public String getNotebookId() {
-    return configProvider.get("notebookId");
+  private Map<String, String> getTagsForDatabricksNotebook() {
+    Map<String, String> tagsForNotebook = new HashMap<>();
+    String notebookId = getNotebookId();
+    if (notebookId != null) {
+      tagsForNotebook.put(MlflowTagConstants.DATABRICKS_NOTEBOOK_ID, notebookId);
+    }
+    String notebookPath = configProvider.get("notebookPath");
+    if (notebookPath != null) {
+      tagsForNotebook.put(MlflowTagConstants.SOURCE_NAME, notebookPath);
+      tagsForNotebook.put(MlflowTagConstants.DATABRICKS_NOTEBOOK_PATH, notebookPath);
+      tagsForNotebook.put(MlflowTagConstants.SOURCE_TYPE, "NOTEBOOK");
+    }
+    String webappUrl = configProvider.get("host");
+    if (webappUrl != null) {
+      tagsForNotebook.put(MlflowTagConstants.DATABRICKS_WEBAPP_URL, webappUrl);
+    }
+    return tagsForNotebook;
   }
 
   /**
    * Should only be called if isInDatabricksNotebook() is true.
    */
-  private String getNotebookPath() {
+  public String getNotebookId() {
     if (!isInDatabricksNotebook()) {
       throw new IllegalArgumentException(
         "getNotebookPath() should not be called when isInDatabricksNotebook() is false"
       );
-    };
-    return configProvider.get("notebookPath");
-  }
-
-  /**
-   * Should only be called if isInDatabricksNotebook() is true or if isInDatabricksJob() is true.
-   */
-  private String getWebappUrl() {
-    if (!isInDatabricksNotebook()) {
-      throw new IllegalArgumentException(
-        "getWebappUrl() should not be called when isInDatabricksNotebook() is false"
-      );
-    };
-    return configProvider.get("host");
+    }
+    return configProvider.get("notebookId");
   }
 
   public boolean isInDatabricksJob() {
     return configProvider.get("jobId") != null;
+  }
+
+  /**
+   * Should only be called if isInDatabricksJob() is true.
+   */
+  private Map<String, String> getTagsForDatabricksJob() {
+    return null;
   }
 
   /**

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/DatabricksContext.java
@@ -97,7 +97,7 @@ public class DatabricksContext {
       tagsForJob.put(MlflowTagConstants.DATABRICKS_JOB_RUN_ID, jobRunId);
       tagsForJob.put(MlflowTagConstants.SOURCE_TYPE, "JOB");
       tagsForJob.put(MlflowTagConstants.SOURCE_NAME,
-                          String.format("job/%s/run/%s", jobId, jobRunId));
+                          String.format("jobs/%s/run/%s", jobId, jobRunId));
     }
     if (jobType != null) {
       tagsForJob.put(MlflowTagConstants.DATABRICKS_JOB_TYPE, jobType);

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/MlflowTagConstants.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/utils/MlflowTagConstants.java
@@ -8,5 +8,10 @@ public class MlflowTagConstants {
   public static final String SOURCE_NAME = "mlflow.source.name";
   public static final String DATABRICKS_NOTEBOOK_ID = "mlflow.databricks.notebookID";
   public static final String DATABRICKS_NOTEBOOK_PATH = "mlflow.databricks.notebookPath";
+  // The JOB_ID, JOB_RUN_ID, and JOB_TYPE tags are used for automatically recording Job 
+  // information when MLflow Tracking APIs are used within a Databricks Job
+  public static final String DATABRICKS_JOB_ID = "mlflow.databricks.jobID";
+  public static final String DATABRICKS_JOB_RUN_ID = "mlflow.databricks.jobRunID";
+  public static final String DATABRICKS_JOB_TYPE = "mlflow.databricks.jobType";
   public static final String DATABRICKS_WEBAPP_URL = "mlflow.databricks.webappURL";
 }

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/utils/DatabricksContextTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/utils/DatabricksContextTest.java
@@ -101,7 +101,7 @@ public class DatabricksContextTest {
         MlflowTagConstants.DATABRICKS_JOB_RUN_ID, "5",
         MlflowTagConstants.DATABRICKS_JOB_TYPE, "notebook",
         MlflowTagConstants.SOURCE_TYPE, "JOB",
-        MlflowTagConstants.SOURCE_NAME, "job/70/run/5");
+        MlflowTagConstants.SOURCE_NAME, "jobs/70/run/5");
       baseMap.put("jobId", "70");
       baseMap.put("jobRunId", "5");
       baseMap.put("jobType", "notebook");

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/utils/DatabricksContextTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/utils/DatabricksContextTest.java
@@ -103,7 +103,7 @@ public class DatabricksContextTest {
         MlflowTagConstants.SOURCE_TYPE, "JOB",
         MlflowTagConstants.SOURCE_NAME, "job/70/run/5");
       baseMap.put("jobId", "70");
-      baseMap.put("idInJob", "5");
+      baseMap.put("jobRunId", "5");
       baseMap.put("jobType", "notebook");
       DatabricksContext context = DatabricksContext.createIfAvailable(MyDynamicProvider.class.getName());
       Assert.assertEquals(context.getTags(), expectedTags);
@@ -117,7 +117,7 @@ public class DatabricksContextTest {
         MlflowTagConstants.SOURCE_TYPE, "JOB",
         MlflowTagConstants.SOURCE_NAME, "jobs/70/run/5");
       baseMap.put("jobId", "70");
-      baseMap.put("idInJob", "5");
+      baseMap.put("jobRunId", "5");
       DatabricksContext context = DatabricksContext.createIfAvailable(MyDynamicProvider.class.getName());
       Assert.assertEquals(context.getTags(), expectedTags);
     }

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/utils/DatabricksContextTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/utils/DatabricksContextTest.java
@@ -115,7 +115,7 @@ public class DatabricksContextTest {
         MlflowTagConstants.DATABRICKS_JOB_ID, "70",
         MlflowTagConstants.DATABRICKS_JOB_RUN_ID, "5",
         MlflowTagConstants.SOURCE_TYPE, "JOB",
-        MlflowTagConstants.SOURCE_NAME, "job/70/run/5");
+        MlflowTagConstants.SOURCE_NAME, "jobs/70/run/5");
       baseMap.put("jobId", "70");
       baseMap.put("idInJob", "5");
       DatabricksContext context = DatabricksContext.createIfAvailable(MyDynamicProvider.class.getName());

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/utils/DatabricksContextTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/utils/DatabricksContextTest.java
@@ -39,7 +39,7 @@ public class DatabricksContextTest {
   }
 
   @Test
-  public void testGetTags() {
+  public void testGetTagsWithEmptyNotebookAndJobDetails() {
     // Will return empty map if not in Databricks notebook.
     {
       baseMap.put("notebookId", null);
@@ -48,8 +48,25 @@ public class DatabricksContextTest {
       Assert.assertFalse(context.isInDatabricksNotebook());
       Assert.assertEquals(context.getTags(), Maps.newHashMap());
     }
+    // Will return empty map if not in Databricks job.
+    {
+      baseMap.put("jobId", null);
+      baseMap.put("jobRunId", null);
+      DatabricksContext context = DatabricksContext.createIfAvailable(MyDynamicProvider.class.getName());
+      Assert.assertFalse(context.isInDatabricksNotebook());
+      Assert.assertEquals(context.getTags(), Maps.newHashMap());
+    }
+    // Will return empty map if not config map is empty.
+    {
+      DatabricksContext context = DatabricksContext.createIfAvailable(MyDynamicProvider.class.getName());
+      Assert.assertFalse(context.isInDatabricksNotebook());
+      Assert.assertEquals(context.getTags(), Maps.newHashMap());
+    }
+  }
 
-    // Will return all tags if context is set as expected.
+  @Test
+  public void testGetTagsForNotebook() {
+    // Will return all tags if notebook context is set as expected.
     {
       baseMap = new HashMap<>();
       Map<String, String> expectedTags = ImmutableMap.of(
@@ -62,7 +79,6 @@ public class DatabricksContextTest {
       DatabricksContext context = DatabricksContext.createIfAvailable(MyDynamicProvider.class.getName());
       Assert.assertEquals(context.getTags(), expectedTags);
     }
-
     // Will not set notebook path tags if context doesn't have a notebookPath member.
     {
       baseMap = new HashMap<>();
@@ -70,6 +86,38 @@ public class DatabricksContextTest {
         MlflowTagConstants.DATABRICKS_NOTEBOOK_ID, "1");
       baseMap.put("notebookId", "1");
       baseMap.put("notebookPath", null);
+      DatabricksContext context = DatabricksContext.createIfAvailable(MyDynamicProvider.class.getName());
+      Assert.assertEquals(context.getTags(), expectedTags);
+    }
+  }
+
+  @Test
+  public void testGetTagsForJob() {
+    // Will return all tags if job context is set as expected.
+    {
+      baseMap = new HashMap<>();
+      Map<String, String> expectedTags = ImmutableMap.of(
+        MlflowTagConstants.DATABRICKS_JOB_ID, "70",
+        MlflowTagConstants.DATABRICKS_JOB_RUN_ID, "5",
+        MlflowTagConstants.DATABRICKS_JOB_TYPE, "notebook",
+        MlflowTagConstants.SOURCE_TYPE, "JOB",
+        MlflowTagConstants.SOURCE_NAME, "job/70/run/5");
+      baseMap.put("jobId", "70");
+      baseMap.put("idInJob", "5");
+      baseMap.put("jobType", "notebook");
+      DatabricksContext context = DatabricksContext.createIfAvailable(MyDynamicProvider.class.getName());
+      Assert.assertEquals(context.getTags(), expectedTags);
+    }
+    // Will not set job type tag if job type is absent.
+    {
+      baseMap = new HashMap<>();
+      Map<String, String> expectedTags = ImmutableMap.of(
+        MlflowTagConstants.DATABRICKS_JOB_ID, "70",
+        MlflowTagConstants.DATABRICKS_JOB_RUN_ID, "5",
+        MlflowTagConstants.SOURCE_TYPE, "JOB",
+        MlflowTagConstants.SOURCE_NAME, "job/70/run/5");
+      baseMap.put("jobId", "70");
+      baseMap.put("idInJob", "5");
       DatabricksContext context = DatabricksContext.createIfAvailable(MyDynamicProvider.class.getName());
       Assert.assertEquals(context.getTags(), expectedTags);
     }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds autodetection of Databricks job environments to the MLflow Java client.

## How is this patch tested?

In addition to unit tests introduced by the PR, these MLflow client changes were tested manually on Databricks against an updated Spark image that exposes job information via the driver.

## Release Notes

The MLflow Java client now detects and records Databricks Job information when the client is used within a Databricks Job.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [X] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
