### PR TITLE
Try to fix R build by upgrading to xenial, which stringi seems to test against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ matrix:
         - export NOT_CRAN=true
         - cd mlflow/R/mlflow
         - Rscript -e 'install.packages("devtools")'
-        - Rscript -e 'devtools::install_deps(dependencies = TRUE, upgrade = "always")'
+        - Rscript -e 'devtools::install_deps(dependencies = TRUE, upgrade = FALSE)'
         - cd ../../..
       install:
         - source ./travis/install-common-deps.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-dist: trusty
+dist: xenial
 
 services:
   - docker

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -4,6 +4,7 @@ set -ex
 sudo mkdir -p /travis-install
 sudo chown travis /travis-install
 which java
+rm -rf /usr/local/lib/jvm/openjdk11
 sudo apt install openjdk-8-jdk
 which java
 java -version

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -4,7 +4,7 @@ set -ex
 sudo mkdir -p /travis-install
 sudo chown travis /travis-install
 sudo apt install openjdk-8-jdk
-sudo update-alternatives --config java
+export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
 java -version
 # (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)
 # We do this conditionally because it saves us some downloading if the

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -3,7 +3,9 @@
 set -ex
 sudo mkdir -p /travis-install
 sudo chown travis /travis-install
-which java
+# Remove JDK 11 that's installed by default in Travis xenial images (see 
+# https://docs.travis-ci.com/user/reference/xenial/#environment-common-to-all-xenial-images)
+# in favor of JDK 8, which is needed to run tests with Spark 2.x
 sudo rm -rf /usr/local/lib/jvm/openjdk11
 sudo apt install openjdk-8-jdk
 export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -3,6 +3,7 @@
 set -ex
 sudo mkdir -p /travis-install
 sudo chown travis /travis-install
+sudo apt install openjdk-8-jdk
 # (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)
 # We do this conditionally because it saves us some downloading if the
 # version is the same.

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -4,6 +4,8 @@ set -ex
 sudo mkdir -p /travis-install
 sudo chown travis /travis-install
 sudo apt install openjdk-8-jdk
+sudo update-alternatives --config java
+java -version
 # (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)
 # We do this conditionally because it saves us some downloading if the
 # version is the same.

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -3,8 +3,9 @@
 set -ex
 sudo mkdir -p /travis-install
 sudo chown travis /travis-install
+which java
 sudo apt install openjdk-8-jdk
-export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
+which java
 java -version
 # (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)
 # We do this conditionally because it saves us some downloading if the

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -6,6 +6,7 @@ sudo chown travis /travis-install
 which java
 sudo rm -rf /usr/local/lib/jvm/openjdk11
 sudo apt install openjdk-8-jdk
+export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
 hash -r
 which java
 java -version

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -6,6 +6,7 @@ sudo chown travis /travis-install
 which java
 sudo rm -rf /usr/local/lib/jvm/openjdk11
 sudo apt install openjdk-8-jdk
+hash -r
 which java
 java -version
 # (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -4,7 +4,7 @@ set -ex
 sudo mkdir -p /travis-install
 sudo chown travis /travis-install
 which java
-rm -rf /usr/local/lib/jvm/openjdk11
+sudo rm -rf /usr/local/lib/jvm/openjdk11
 sudo apt install openjdk-8-jdk
 which java
 java -version

--- a/travis/test-spark-autologging.sh
+++ b/travis/test-spark-autologging.sh
@@ -6,7 +6,7 @@ set -ex
 
 # Build Java package
 pushd mlflow/java/spark
-mvn package -DskipTests
+mvn package -q -DskipTests
 popd
 
 # Install PySpark 3.0 preview & run tests. For faster local iteration, you can also simply download
@@ -16,7 +16,7 @@ popd
 TEMPDIR=$(mktemp -d)
 pushd $TEMPDIR
 wget https://archive.apache.org/dist/spark/spark-3.0.0-preview/spark-3.0.0-preview-bin-hadoop2.7.tgz -O /tmp/spark.tgz
-tar -xvf /tmp/spark.tgz
+tar -xf /tmp/spark.tgz
 pip install -e spark-3.0.0-preview-bin-hadoop2.7/python
 popd
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

The R build seems broken by today's release of the `stringi` package, which is a transitive dependency of MLflow. This patch attempts to fix the issue by bumping the build OS to xenial, which stringi seems to test against: https://github.com/gagolews/stringi/blob/master/.travis.yml. A separate parallel attempt (PR) will just pin stringi to an older version in the R package's dependencies.

## How is this patch tested?
Existing tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
