### PR TITLE
Escape % in db_url

### DIFF
--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -100,6 +100,9 @@ def _get_alembic_config(db_url, alembic_dir=None):
     from alembic.config import Config
     final_alembic_dir = os.path.join(_get_package_dir(), 'store', 'db_migrations')\
         if alembic_dir is None else alembic_dir
+    # Escape any '%' that appears in a db_url. This could be in a password,
+    # url, or anything that is part of a potentially complex database url
+    db_url = db_url.replace('%', '%%')
     config = Config(os.path.join(final_alembic_dir, 'alembic.ini'))
     config.set_main_option('script_location', final_alembic_dir)
     config.set_main_option('sqlalchemy.url', db_url)

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -18,3 +18,9 @@ def test_create_sqlalchemy_engine_no_pool_options():
         with mock.patch('sqlalchemy.create_engine') as mock_create_engine:
             utils.create_sqlalchemy_engine("mydb://host:port/")
             mock_create_engine.assert_called_once_with("mydb://host:port/", pool_pre_ping=True)
+
+
+def test_alembic_escape_logic():
+    url = "fakesql://cooluser%40stillusername:apassword@localhost:3306/testingdb"
+    config = utils._get_alembic_config(url)
+    assert config.get_main_option("sqlalchemy.url") == url


### PR DESCRIPTION
See https://github.com/mlflow/mlflow/issues/1487 for full discussion

## What changes are proposed in this pull request?

Escape `%` characters in database urls as it clashes with the alembic DSL.

## How is this patch tested?

Ran in production on my own fork for a few months.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
