### PR TITLE
Increase stale bot timeouts

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,11 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 21
+daysUntilStale: 365
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 60
+daysUntilClose: 730
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: []
@@ -39,7 +39,7 @@ unmarkComment: >
 
 # Comment to post when closing a stale Issue or Pull Request.
 closeComment: >
-   This issue has not been interacted with for 60 days since it was marked as stale! As such, the
+   This issue has not been interacted with for 365 days since it was marked as stale! As such, the
    issue is now closed. If you have this issue or more information, please re-open the issue!
 
 # Limit the number of actions per hour, from 1-30. Default is 30


### PR DESCRIPTION
# What changes are proposed in this pull request?

Change stalebot settings to 1 year to stale, 2 years to close.

## How is this patch tested?

We'll see how it works out...

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
