### PR TITLE
Add get latest and download model version interface to java client

### DIFF
--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -50,11 +50,6 @@
       <groupId>org.ini4j</groupId>
       <artifactId>ini4j</artifactId>
     </dependency>
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -50,6 +50,11 @@
       <groupId>org.ini4j</groupId>
       <artifactId>ini4j</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>

--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -85,7 +85,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <sourcepath>${project.basedir}/src/main/java</sourcepath>
-          <excludePackageNames>com.databricks.api.proto.databricks:org.mlflow.scalapb_interface:org.mlflow.tracking.samples:org.mlflow.artifacts</excludePackageNames>
+          <excludePackageNames>com.databricks.api.proto.databricks:org.mlflow.scalapb_interface:org.mlflow.tracking:org.mlflow.artifacts:org.mlflow.api</excludePackageNames>
           <groups>
             <group>
               <title>Tracking API</title>

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -681,25 +681,29 @@ public class MlflowClient {
   }
 
   /**
-   * Return the latest model version for each stage..
+   * Return the latest model version for each stage requested.
    * The current stages are: [None, Staging, Production, Archived].
    *
    *    <pre>
-   *        ModelVersionDetailed details = getLatestVersions("model", "Staging");
+   *        List<ModelVersionDetailed> detailsList  = getLatestVersions("model",
+   *                                                              Lists.newArrayList<>("Staging"));
    *
-   *        System.out.println("Model Name: " + details.getModelVersion()
-   *                                                   .getRegisteredModel()
-   *                                                   .getName());
-   *        System.out.println("Model Version: " + details.getModelVersion().getVersion());
-   *        System.out.println("Current Stage: " + details.getCurrentStage());
+   *        for (ModelVersionDetailed details : detailsList) {
+   *            System.out.println("Model Name: " + details.getModelVersion()
+   *                                                       .getRegisteredModel()
+   *                                                       .getName());
+   *            System.out.println("Model Version: " + details.getModelVersion().getVersion());
+   *            System.out.println("Current Stage: " + details.getCurrentStage());
+   *        }
    *    </pre>
    *
    * @param modelName The name of the model
-   * @param stage The name of the stage
+   * @param stages A list of stages
    * @return The latest model version
    *         {@link org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed}
    */
-  public ModelVersionDetailed getLatestVersions(@Nonnull String modelName, @Nonnull String stage) {
+  public List<ModelVersionDetailed> getLatestVersions(@Nonnull String modelName,
+                                                      @Nonnull Iterable<String> stages) {
     throw new UnsupportedOperationException("getLatestVersion is not supported");
   }
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -22,6 +22,7 @@ import org.mlflow.tracking.creds.DatabricksDynamicHostCredsProvider;
 import org.mlflow.tracking.creds.HostCredsProviderChain;
 import org.mlflow.tracking.creds.MlflowHostCredsProvider;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -676,7 +676,7 @@ public class MlflowClient {
    * @param modelName The name of the model
    * @return A collection of {@link org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed}
    */
-  public List<ModelVersionDetailed> getLatestVersions(@Nonnull String modelName) {
+  public List<ModelVersionDetailed> getLatestVersions(String modelName) {
     throw new UnsupportedOperationException("getLatestVersion is not supported");
   }
 
@@ -699,7 +699,7 @@ public class MlflowClient {
    * @return The latest model version
    *         {@link org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed}
    */
-  public ModelVersionDetailed getLatestVersions(@Nonnull String modelName, @Nonnull String stage) {
+  public ModelVersionDetailed getLatestVersions(String modelName, String stage) {
     throw new UnsupportedOperationException("getLatestVersion is not supported");
   }
 
@@ -719,7 +719,7 @@ public class MlflowClient {
    * @param version The version number of the model
    * @return The specified model version's URI.
    */
-  public String getModelVersionDownloadUri(@Nonnull String modelName, long version) {
+  public String getModelVersionDownloadUri(String modelName, long version) {
     throw new UnsupportedOperationException("getModelVersionDownloadUri is not supported");
   }
 
@@ -735,7 +735,7 @@ public class MlflowClient {
    * @param version The version number of the model
    * @return A the local file or directory ({@ java.io.File}) containing model artifacts
    */
-  public File downloadModelVersion(@Nonnull String modelName, long version) {
+  public File downloadModelVersion(String modelName, long version) {
     throw new UnsupportedOperationException("downloadModel is not currently supported");
   }
 
@@ -754,7 +754,7 @@ public class MlflowClient {
    * @param stage The name of the stage
    * @return A the local file or directory ({@ java.io.File}) containing model artifacts
    */
-  public File downloadLatestModelVersion(@Nonnull String modelName,@Nonnull String stage) {
+  public File downloadLatestModelVersion(String modelName,String stage) {
     throw new UnsupportedOperationException("downloadModel is not currently supported");
   }
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -22,7 +22,6 @@ import org.mlflow.tracking.creds.DatabricksDynamicHostCredsProvider;
 import org.mlflow.tracking.creds.HostCredsProviderChain;
 import org.mlflow.tracking.creds.MlflowHostCredsProvider;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -1,20 +1,33 @@
 package org.mlflow.tracking;
 
 import org.apache.http.client.utils.URIBuilder;
-
-import org.mlflow.api.proto.Service.*;
-import org.mlflow.tracking.creds.*;
+import org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed;
+import org.mlflow.api.proto.Service.CreateRun;
+import org.mlflow.api.proto.Service.Experiment;
+import org.mlflow.api.proto.Service.FileInfo;
+import org.mlflow.api.proto.Service.GetExperiment;
+import org.mlflow.api.proto.Service.Metric;
+import org.mlflow.api.proto.Service.Param;
+import org.mlflow.api.proto.Service.Run;
+import org.mlflow.api.proto.Service.RunInfo;
+import org.mlflow.api.proto.Service.RunStatus;
+import org.mlflow.api.proto.Service.RunTag;
+import org.mlflow.api.proto.Service.SearchRuns;
+import org.mlflow.api.proto.Service.ViewType;
 import org.mlflow.artifacts.ArtifactRepository;
 import org.mlflow.artifacts.ArtifactRepositoryFactory;
-import org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed;
-import org.mlflow.api.proto.ModelRegistry.ModelVersion;
+import org.mlflow.tracking.creds.BasicMlflowHostCreds;
+import org.mlflow.tracking.creds.DatabricksConfigHostCredsProvider;
+import org.mlflow.tracking.creds.DatabricksDynamicHostCredsProvider;
+import org.mlflow.tracking.creds.HostCredsProviderChain;
+import org.mlflow.tracking.creds.MlflowHostCredsProvider;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
-import java.lang.Iterable;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -646,7 +659,7 @@ public class MlflowClient {
 
   /**
    * Return the latest model version for each stage.
-   * Currently only the following stages are supported: [None, Staging, Production, Archived].
+   * The current stages are: [None, Staging, Production, Archived].
    *
    *    <pre>
    *        List<ModelVersionDetailed> detailsList = getLatestVersions("model");
@@ -661,13 +674,13 @@ public class MlflowClient {
    * @param modelName The name of the model
    * @return A collection of {@link org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed}
    */
-  public List<ModelVersionDetailed> getLatestVersions(String modelName) {
+  public List<ModelVersionDetailed> getLatestVersions(@Nonnull String modelName) {
     throw new UnsupportedOperationException("getLatestVersion is not currently supported");
   }
 
   /**
    * Return the latest model version for each stage..
-   * Currently only the following stages are supported: [None, Staging, Production, Archived].
+   * The current stages are: [None, Staging, Production, Archived].
    *
    *    <pre>
    *        ModelVersionDetailed details = getLatestVersions("model", "Staging");
@@ -681,9 +694,11 @@ public class MlflowClient {
    * @param stage The name of the stage
    * @return The latest model version {@link org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed}
    */
-  public ModelVersionDetailed getLatestVersions(String modelName, String stage) {
+  public ModelVersionDetailed getLatestVersions(@Nonnull String modelName, @Nonnull String stage) {
     throw new UnsupportedOperationException("getLatestVersion is not currently supported");
   }
+
+
 
   /**
    * Return the model URI containing for the given model version. THe model URI can be used to download
@@ -696,10 +711,10 @@ public class MlflowClient {
    *    </pre>
    *
    * @param modelName The name of the model
-   * @param modelVersion The version number of the model
+   * @param version The version number of the model
    * @return The specified model version's URI.
    */
-  public String getModelVersionDownloadUri(String modelName, long modelVersion) {
+  public String getModelVersionDownloadUri(@Nonnull String modelName, long version) {
     throw new UnsupportedOperationException("getModelVersionDownloadUri is not currently supported");
   }
 
@@ -715,24 +730,7 @@ public class MlflowClient {
    * @param version The version number of the model
    * @return A the local file or directory ({@ java.io.File}) containing model artifacts
    */
-  public File downloadModelVersion(String modelName, long version) {
-    throw new UnsupportedOperationException("downloadModel is not currently supported");
-  }
-
-  /**
-   * Return a local file or directory containing all artifacts within the latest registered model version in the
-   * production stage. The method will download the model version artifacts to the local file system.
-   *
-   *    <pre>
-   *        File modelVersionFile = downloadLatestModelVersion("model");
-   *    </pre>
-   *
-   * (i.e., the contents of the local directory are now available).
-   *
-   * @param modelName The name of the model
-   * @return A the local file or directory ({@ java.io.File}) containing model artifacts
-   */
-  public File downloadLatestModelVersion(String modelName) {
+  public File downloadModelVersion(@Nonnull String modelName, long version) {
     throw new UnsupportedOperationException("downloadModel is not currently supported");
   }
 
@@ -750,7 +748,7 @@ public class MlflowClient {
    * @param stage The name of the stage
    * @return A the local file or directory ({@ java.io.File}) containing model artifacts
    */
-  public File downloadLatestModelVersion(String modelName, String stage) {
+  public File downloadLatestModelVersion(@Nonnull String modelName,@Nonnull String stage) {
     throw new UnsupportedOperationException("downloadModel is not currently supported");
   }
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -675,7 +675,7 @@ public class MlflowClient {
    * @param modelName The name of the model
    * @return A collection of {@link org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed}
    */
-  public List<ModelVersionDetailed> getLatestVersions(String modelName) {
+  public List<ModelVersionDetailed> getLatestVersions(@Nonnull String modelName) {
     throw new UnsupportedOperationException("getLatestVersion is not supported");
   }
 
@@ -698,7 +698,7 @@ public class MlflowClient {
    * @return The latest model version
    *         {@link org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed}
    */
-  public ModelVersionDetailed getLatestVersions(String modelName, String stage) {
+  public ModelVersionDetailed getLatestVersions(@Nonnull String modelName, @Nonnull String stage) {
     throw new UnsupportedOperationException("getLatestVersion is not supported");
   }
 
@@ -718,7 +718,7 @@ public class MlflowClient {
    * @param version The version number of the model
    * @return The specified model version's URI.
    */
-  public String getModelVersionDownloadUri(String modelName, long version) {
+  public String getModelVersionDownloadUri(@Nonnull String modelName, long version) {
     throw new UnsupportedOperationException("getModelVersionDownloadUri is not supported");
   }
 
@@ -734,7 +734,7 @@ public class MlflowClient {
    * @param version The version number of the model
    * @return A the local file or directory ({@ java.io.File}) containing model artifacts
    */
-  public File downloadModelVersion(String modelName, long version) {
+  public File downloadModelVersion(@Nonnull String modelName, long version) {
     throw new UnsupportedOperationException("downloadModel is not currently supported");
   }
 
@@ -753,7 +753,7 @@ public class MlflowClient {
    * @param stage The name of the stage
    * @return A the local file or directory ({@ java.io.File}) containing model artifacts
    */
-  public File downloadLatestModelVersion(String modelName,String stage) {
+  public File downloadLatestModelVersion(@Nonnull String modelName,@Nonnull String stage) {
     throw new UnsupportedOperationException("downloadModel is not currently supported");
   }
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -3,9 +3,11 @@ package org.mlflow.tracking;
 import org.apache.http.client.utils.URIBuilder;
 
 import org.mlflow.api.proto.Service.*;
+import org.mlflow.tracking.creds.*;
 import org.mlflow.artifacts.ArtifactRepository;
 import org.mlflow.artifacts.ArtifactRepositoryFactory;
-import org.mlflow.tracking.creds.*;
+import org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed;
+import org.mlflow.api.proto.ModelRegistry.ModelVersion;
 
 import java.io.File;
 import java.net.URI;
@@ -636,4 +638,81 @@ public class MlflowClient {
     URI baseArtifactUri = URI.create(getRun(runId).getInfo().getArtifactUri());
     return artifactRepositoryFactory.getArtifactRepository(baseArtifactUri, runId);
   }
+
+
+  // ********************
+  // * Model Repository *
+  // ********************
+
+  /**
+   * Return the latest model version for each stage (devo, staging, prod).
+   *
+   *    <pre>
+   *        List<ModelVersionDetailed> detailsList = getLatestModelVersionPerStage("model");
+   *
+   *        for (ModelVersionDetailed details : detailsList) {
+   *            System.out.println("Model Name: " + details.getModelVersion().getRegisteredModel().getName());
+   *            System.out.println("Model Version: " + details.getModelVersion().getVersion());
+   *            System.out.println("Current Stage: " + details.getCurrentStage());
+   *        }
+   *    </pre>
+   *
+   * @param modelName The name of the model
+   * @return A collection of {@link org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed}
+   */
+  public List<ModelVersionDetailed> getLatestModelVersionPerStage(String modelName) {
+    throw new UnsupportedOperationException("getLatestVersion is not currently supported");
+  }
+
+  /**
+   * Return the model URI containing for the given model version. THe model URI can be used to download
+   * the model version artifacts.
+   *
+   * For example, the model URI
+   *
+   *    <pre>
+   *        String modelUri = getModelVersionDownloadUri("model", 0);
+   *    </pre>
+   *
+   * @param modelName The name of the model
+   * @param modelVersion The version number of the model
+   * @return The specified model version's URI.
+   */
+  public String getModelVersionDownloadUri(String modelName, long modelVersion) {
+    throw new UnsupportedOperationException("getModelVersionDownloadUri is not currently supported");
+  }
+
+  /**
+   * Return a local file or directory containing all artifacts within the given registered model version. The method
+   * will download the model version artifacts to the local file system.
+   *
+   *    <pre>
+   *        File modelVersionFile = downloadModelVersion("model", 0);
+   *    </pre>
+   *
+   * @param modelName The name of the model
+   * @param modelVersion The version number of the model
+   * @return A the local file or directory ({@ java.io.File}) containing model artifacts
+   */
+  public File downloadModelVersion(String modelName, long modelVersion) {
+    throw new UnsupportedOperationException("downloadModel is not currently supported");
+  }
+
+  /**
+   * Return a local file or directory containing all artifacts within the latest registered model version. The method
+   * will download the model version artifacts to the local file system.
+   *
+   *    <pre>
+   *        File modelVersionFile = downloadLatestModelVersion("model");
+   *    </pre>
+   *
+   * (i.e., the contents of the local directory are now available).
+   *
+   * @param modelName The name of the model
+   * @return A the local file or directory ({@ java.io.File}) containing model artifacts
+   */
+  public File downloadLatestModelVersion(String modelName) {
+    throw new UnsupportedOperationException("downloadModel is not currently supported");
+  }
+
 }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -641,14 +641,15 @@ public class MlflowClient {
 
 
   // ********************
-  // * Model Repository *
+  // * Model Registry *
   // ********************
 
   /**
-   * Return the latest model version for each stage (devo, staging, prod).
+   * Return the latest model version for each stage.
+   * Currently only the following stages are supported: [None, Staging, Production, Archived].
    *
    *    <pre>
-   *        List<ModelVersionDetailed> detailsList = getLatestModelVersionPerStage("model");
+   *        List<ModelVersionDetailed> detailsList = getLatestVersions("model");
    *
    *        for (ModelVersionDetailed details : detailsList) {
    *            System.out.println("Model Name: " + details.getModelVersion().getRegisteredModel().getName());
@@ -660,7 +661,27 @@ public class MlflowClient {
    * @param modelName The name of the model
    * @return A collection of {@link org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed}
    */
-  public List<ModelVersionDetailed> getLatestModelVersionPerStage(String modelName) {
+  public List<ModelVersionDetailed> getLatestVersions(String modelName) {
+    throw new UnsupportedOperationException("getLatestVersion is not currently supported");
+  }
+
+  /**
+   * Return the latest model version for each stage..
+   * Currently only the following stages are supported: [None, Staging, Production, Archived].
+   *
+   *    <pre>
+   *        ModelVersionDetailed details = getLatestVersions("model", "Staging");
+   *
+   *        System.out.println("Model Name: " + details.getModelVersion().getRegisteredModel().getName());
+   *        System.out.println("Model Version: " + details.getModelVersion().getVersion());
+   *        System.out.println("Current Stage: " + details.getCurrentStage());
+   *    </pre>
+   *
+   * @param modelName The name of the model
+   * @param stage The name of the stage
+   * @return The latest model version {@link org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed}
+   */
+  public ModelVersionDetailed getLatestVersions(String modelName, String stage) {
     throw new UnsupportedOperationException("getLatestVersion is not currently supported");
   }
 
@@ -691,16 +712,16 @@ public class MlflowClient {
    *    </pre>
    *
    * @param modelName The name of the model
-   * @param modelVersion The version number of the model
+   * @param version The version number of the model
    * @return A the local file or directory ({@ java.io.File}) containing model artifacts
    */
-  public File downloadModelVersion(String modelName, long modelVersion) {
+  public File downloadModelVersion(String modelName, long version) {
     throw new UnsupportedOperationException("downloadModel is not currently supported");
   }
 
   /**
-   * Return a local file or directory containing all artifacts within the latest registered model version. The method
-   * will download the model version artifacts to the local file system.
+   * Return a local file or directory containing all artifacts within the latest registered model version in the
+   * production stage. The method will download the model version artifacts to the local file system.
    *
    *    <pre>
    *        File modelVersionFile = downloadLatestModelVersion("model");
@@ -712,6 +733,24 @@ public class MlflowClient {
    * @return A the local file or directory ({@ java.io.File}) containing model artifacts
    */
   public File downloadLatestModelVersion(String modelName) {
+    throw new UnsupportedOperationException("downloadModel is not currently supported");
+  }
+
+  /**
+   * Return a local file or directory containing all artifacts within the latest registered model version in
+   * the given stage. The method will download the model version artifacts to the local file system.
+   *
+   *    <pre>
+   *        File modelVersionFile = downloadLatestModelVersion("model", "Staging");
+   *    </pre>
+   *
+   * (i.e., the contents of the local directory are now available).
+   *
+   * @param modelName The name of the model
+   * @param stage The name of the stage
+   * @return A the local file or directory ({@ java.io.File}) containing model artifacts
+   */
+  public File downloadLatestModelVersion(String modelName, String stage) {
     throw new UnsupportedOperationException("downloadModel is not currently supported");
   }
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -141,7 +141,7 @@ public class MlflowClient {
    * Return RunInfos from provided list of experiments that satisfy the search query.
    * @deprecated As of 1.1.0 - please use {@link #searchRuns(List, String, ViewType, int)} or
    *                    similar that returns a page of Run results.
-   * 
+   *
    * @param experimentIds List of experiment IDs.
    * @param searchFilter SQL compatible search query string. Format of this query string is
    *                     similar to that specified on MLflow UI.
@@ -157,7 +157,7 @@ public class MlflowClient {
 
   /**
    * Return RunInfos from provided list of experiments that satisfy the search query.
-   * @deprecated As of 1.1.0 - please use {@link #searchRuns(List, String, ViewType, int)} or 
+   * @deprecated As of 1.1.0 - please use {@link #searchRuns(List, String, ViewType, int)} or
    *                    similar that returns a page of Run results.
    *
    * @param experimentIds List of experiment IDs.
@@ -665,7 +665,9 @@ public class MlflowClient {
    *        List<ModelVersionDetailed> detailsList = getLatestVersions("model");
    *
    *        for (ModelVersionDetailed details : detailsList) {
-   *            System.out.println("Model Name: " + details.getModelVersion().getRegisteredModel().getName());
+   *            System.out.println("Model Name: " + details.getModelVersion()
+   *                                                       .getRegisteredModel()
+   *                                                       .getName());
    *            System.out.println("Model Version: " + details.getModelVersion().getVersion());
    *            System.out.println("Current Stage: " + details.getCurrentStage());
    *        }
@@ -675,7 +677,7 @@ public class MlflowClient {
    * @return A collection of {@link org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed}
    */
   public List<ModelVersionDetailed> getLatestVersions(@Nonnull String modelName) {
-    throw new UnsupportedOperationException("getLatestVersion is not currently supported");
+    throw new UnsupportedOperationException("getLatestVersion is not supported");
   }
 
   /**
@@ -685,24 +687,27 @@ public class MlflowClient {
    *    <pre>
    *        ModelVersionDetailed details = getLatestVersions("model", "Staging");
    *
-   *        System.out.println("Model Name: " + details.getModelVersion().getRegisteredModel().getName());
+   *        System.out.println("Model Name: " + details.getModelVersion()
+   *                                                   .getRegisteredModel()
+   *                                                   .getName());
    *        System.out.println("Model Version: " + details.getModelVersion().getVersion());
    *        System.out.println("Current Stage: " + details.getCurrentStage());
    *    </pre>
    *
    * @param modelName The name of the model
    * @param stage The name of the stage
-   * @return The latest model version {@link org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed}
+   * @return The latest model version
+   *         {@link org.mlflow.api.proto.ModelRegistry.ModelVersionDetailed}
    */
   public ModelVersionDetailed getLatestVersions(@Nonnull String modelName, @Nonnull String stage) {
-    throw new UnsupportedOperationException("getLatestVersion is not currently supported");
+    throw new UnsupportedOperationException("getLatestVersion is not supported");
   }
 
 
 
   /**
-   * Return the model URI containing for the given model version. THe model URI can be used to download
-   * the model version artifacts.
+   * Return the model URI containing for the given model version. The model URI can be used
+   * to download the model version artifacts.
    *
    * For example, the model URI
    *
@@ -715,12 +720,12 @@ public class MlflowClient {
    * @return The specified model version's URI.
    */
   public String getModelVersionDownloadUri(@Nonnull String modelName, long version) {
-    throw new UnsupportedOperationException("getModelVersionDownloadUri is not currently supported");
+    throw new UnsupportedOperationException("getModelVersionDownloadUri is not supported");
   }
 
   /**
-   * Return a local file or directory containing all artifacts within the given registered model version. The method
-   * will download the model version artifacts to the local file system.
+   * Return a local file or directory containing all artifacts within the given registered model
+   * version. The method will download the model version artifacts to the local file system.
    *
    *    <pre>
    *        File modelVersionFile = downloadModelVersion("model", 0);
@@ -735,8 +740,9 @@ public class MlflowClient {
   }
 
   /**
-   * Return a local file or directory containing all artifacts within the latest registered model version in
-   * the given stage. The method will download the model version artifacts to the local file system.
+   * Return a local file or directory containing all artifacts within the latest registered
+   * model version in the given stage. The method will download the model version artifacts
+   * to the local file system.
    *
    *    <pre>
    *        File modelVersionFile = downloadLatestModelVersion("model", "Staging");


### PR DESCRIPTION
Add Java interfaces defininga the following functions

    1. getLatestModelVersionPerStage
    2. getModelVersionDownloadUri
    3. downloadModel

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [x] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [x] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [x] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
