### PR TITLE
PyTorch Pillow dependency fix

### DIFF
--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -25,6 +25,8 @@ xgboost>=0.82
 lightgbm==2.3.0
 # Install typing to fix torch on Python 2.7 (see https://github.com/pytorch/pytorch/issues/16775)
 typing==3.6.6
+# Pin pillow to fix torch on Python 3 (see https://github.com/pytorch/vision/issues/1712)
+pillow==6.2.1
 pysftp==0.2.9
 keras==2.3.1
 attrdict==2.0.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

PyTorch tests for Python 3 have been broken since Pillow updated to 7.0 (see [here](https://github.com/pytorch/vision/issues/1712)). This fix pins pillow to be `6.2.1` to fix the tests.

## How is this patch tested?

Travis

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
