### PR TITLE
Adds an example of querying for the best model

### DIFF
--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -165,14 +165,14 @@ For example, if you'd like to identify the best `active` run from experiment ID 
 
 
 To get all active runs from experiments IDs 3, 4, and 17 that used a CNN model
-with 10 layers and had an accuracy of 94.5% or higher, use:
+with 10 layers and had a prediction accuracy of 94.5% or higher, use:
 
 .. code-block:: py
 
   from mlflow.tracking.client import MlflowClient
   from mlflow.entities import ViewType
 
-  query = "params.model = 'CNN' and params.layers = '10' and metrics.accuracy >= 0.945"
+  query = "params.model = 'CNN' and params.layers = '10' and metrics.`prediction accuracy` >= 0.945"
   runs = MlflowClient().search_runs(experiment_ids=["3", "4", "17"], filter_string=query, run_view_type=ViewType.ACTIVE_ONLY)
 
 To search all known experiments for any MLflow runs created using the Inception model architecture:

--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -148,7 +148,17 @@ search programmatically. You can specify the list of columns to order by
 optional ``DESC`` or ``ASC`` value; the default is ``ASC``. The default ordering is to sort by 
 ``start_time DESC``, then ``run_id``.
 
-For example, to get all `active` runs from experiments IDs 3, 4, and 17 that used a CNN model
+For example, to extract the best `active` run from experiment ID 0 by MAE, use:
+
+.. code-block:: py
+
+  from mlflow.tracking.client import MlflowClient
+  from mlflow.entities import ViewType
+
+  run = MlflowClient().search_runs("0", "", ViewType.ACTIVE_ONLY, max_results=1, order_by=["metrics.mae DESC"])[0]
+
+
+To get all active runs from experiments IDs 3, 4, and 17 that used a CNN model
 with 10 layers and had a prediction accuracy of 94.5% or higher, use:
 
 .. code-block:: py

--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -42,7 +42,7 @@ Example Expressions
 Identifier
 ^^^^^^^^^^
 
-Required in the LHS of a search expression. Signifies an entity to compare against. 
+Required in the LHS of a search expression. Signifies an entity to compare against.
 
 An identifier has two parts separated by a period: the type of the entity and the name of the entity. The type of the entity is ``metrics``, ``params``, ``attributes``, or ``tags``. The entity name can contain alphanumeric characters and special characters.
 
@@ -86,10 +86,10 @@ Run Attributes
 You can search using two run attributes contained in :py:class:`mlflow.entities.RunInfo`: ``status`` and ``artifact_uri``. Both attributes have string values. Other fields in ``mlflow.entities.RunInfo`` are not searchable.
 
 .. note::
-  
-  - The experiment ID is implicitly selected by the search API. 
-  - A run's ``lifecycle_stage`` attribute is not allowed because it is already encoded as a part of the API's ``run_view_type`` field. To search for runs using ``run_id``, it is more efficient to use ``get_run`` APIs. 
-  
+
+  - The experiment ID is implicitly selected by the search API.
+  - A run's ``lifecycle_stage`` attribute is not allowed because it is already encoded as a part of the API's ``run_view_type`` field. To search for runs using ``run_id``, it is more efficient to use ``get_run`` APIs.
+
 .. rubric:: Example
 
 .. code-block:: sql
@@ -102,7 +102,7 @@ You can search using two run attributes contained in :py:class:`mlflow.entities.
 MLflow Tags
 ~~~~~~~~~~~
 
-You can search for MLflow tags by enclosing the tag name in double quotes or backticks. For example, to search for the name of an MLflow run, specify ``tags."mlflow.runName"`` or ``tags.`mlflow.runName```. 
+You can search for MLflow tags by enclosing the tag name in double quotes or backticks. For example, to search for the name of an MLflow run, specify ``tags."mlflow.runName"`` or ``tags.`mlflow.runName```.
 
 .. rubric:: Examples
 
@@ -142,32 +142,38 @@ multiple experiments, use one of the client APIs.
 Python
 ^^^^^^
 
-Use the :py:func:`mlflow.tracking.MlflowClient.search_runs` or :py:func:`mlflow.search_runs` API to 
-search programmatically. You can specify the list of columns to order by 
-(for example, "metrics.rmse") in the ``order_by`` column. The column can contain an 
-optional ``DESC`` or ``ASC`` value; the default is ``ASC``. The default ordering is to sort by 
+Use the :py:func:`mlflow.tracking.MlflowClient.search_runs` or :py:func:`mlflow.search_runs` API to
+search programmatically. You can specify the list of columns to order by
+(for example, "metrics.rmse") in the ``order_by`` column. The column can contain an
+optional ``DESC`` or ``ASC`` value; the default is ``ASC``. The default ordering is to sort by
 ``start_time DESC``, then ``run_id``.
 
-For example, to extract the best `active` run from experiment ID 0 by MAE, use:
+For example, if you'd like to identify the best `active` run from experiment ID 0 by accuracy, use:
 
 .. code-block:: py
 
   from mlflow.tracking.client import MlflowClient
   from mlflow.entities import ViewType
 
-  run = MlflowClient().search_runs("0", "", ViewType.ACTIVE_ONLY, max_results=1, order_by=["metrics.mae DESC"])[0]
+  run = MlflowClient().search_runs(
+    experiment_ids="0",
+    filter_string="",
+    run_view_type=ViewType.ACTIVE_ONLY,
+    max_results=1,
+    order_by=["metrics.accuracy DESC"]
+  )[0]
 
 
 To get all active runs from experiments IDs 3, 4, and 17 that used a CNN model
-with 10 layers and had a prediction accuracy of 94.5% or higher, use:
+with 10 layers and had an accuracy of 94.5% or higher, use:
 
 .. code-block:: py
 
   from mlflow.tracking.client import MlflowClient
   from mlflow.entities import ViewType
 
-  query = "params.model = 'CNN' and params.layers = '10' and metrics.'prediction accuracy' >= 0.945"
-  runs = MlflowClient().search_runs(["3", "4", "17"], query, ViewType.ACTIVE_ONLY)
+  query = "params.model = 'CNN' and params.layers = '10' and metrics.accuracy >= 0.945"
+  runs = MlflowClient().search_runs(experiment_ids=["3", "4", "17"], filter_string=query, run_view_type=ViewType.ACTIVE_ONLY)
 
 To search all known experiments for any MLflow runs created using the Inception model architecture:
 
@@ -177,7 +183,7 @@ To search all known experiments for any MLflow runs created using the Inception 
   from mlflow.entities import ViewType
 
   all_experiments = [exp.experiment_id for exp in MlflowClient().list_experiments()]
-  runs = MlflowClient().search_runs(all_experiments, "params.model = 'Inception'", ViewType.ALL)
+  runs = MlflowClient().search_runs(experiment_ids=all_experiments, filter_string="params.model = 'Inception'", run_view_type=ViewType.ALL)
 
 Java
 ^^^^

--- a/examples/quickstart/mlflow_tracking.py
+++ b/examples/quickstart/mlflow_tracking.py
@@ -11,6 +11,7 @@ if __name__ == "__main__":
     log_metric("foo", random())
     log_metric("foo", random() + 1)
     log_metric("foo", random() + 2)
+    log_metric("accuracy 2", random())
 
     if not os.path.exists("outputs"):
         os.makedirs("outputs")

--- a/examples/quickstart/mlflow_tracking.py
+++ b/examples/quickstart/mlflow_tracking.py
@@ -11,7 +11,6 @@ if __name__ == "__main__":
     log_metric("foo", random())
     log_metric("foo", random() + 1)
     log_metric("foo", random() + 2)
-    log_metric("accuracy 2", random())
 
     if not os.path.exists("outputs"):
         os.makedirs("outputs")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Note that this does not add documentation of finding the best model across multiple experiments. I feel this would be redundant, as we now have examples of:
(1) Find the best run
(2) Search for runs with particular parameters between experiments

From these examples, the user will infer how to find the best run across multiple experiments.

## How is this patch tested?

Docs were built and viewed in the browser.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [Y] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [Y] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [Y] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
