### PR TITLE
Experiment Searching: Search for experiments by name in the UI

### DIFF
--- a/mlflow/server/js/src/components/ExperimentListView.css
+++ b/mlflow/server/js/src/components/ExperimentListView.css
@@ -40,7 +40,6 @@ input.experiment-list-search-input[type="text"]:focus{
 .experiments-header {
   font-weight: normal;
   display: inline-block;
-  /* padding-bottom: 6px; */
   margin-bottom: 8px;
 }
 

--- a/mlflow/server/js/src/components/ExperimentListView.css
+++ b/mlflow/server/js/src/components/ExperimentListView.css
@@ -23,10 +23,19 @@
   padding-left: 12px;
 }
 
+.experiment-list-search-input {
+  flex: 1;
+  overflow-y: scroll;
+  overflow-x: hidden;
+  width: 220px;
+  padding-bottom: 6px;
+  margin-bottom: 8px;
+}
+
 .experiments-header {
   font-weight: normal;
   display: inline-block;
-  padding-bottom: 6px;
+  /* padding-bottom: 6px; */
   margin-bottom: 8px;
 }
 

--- a/mlflow/server/js/src/components/ExperimentListView.css
+++ b/mlflow/server/js/src/components/ExperimentListView.css
@@ -32,6 +32,11 @@
   margin-bottom: 8px;
 }
 
+input.experiment-list-search-input[type="text"]:focus{
+  border-color: #258BD2;
+  outline: none;
+}
+
 .experiments-header {
   font-weight: normal;
   display: inline-block;

--- a/mlflow/server/js/src/components/ExperimentListView.js
+++ b/mlflow/server/js/src/components/ExperimentListView.js
@@ -22,7 +22,7 @@ export class ExperimentListView extends Component {
 
   componentDidMount() {
     this.resizeListener = () => {
-      this.setState({height: window.innerHeight });
+      this.setState({ height: window.innerHeight });
     };
     window.addEventListener('resize', this.resizeListener);
   }
@@ -31,9 +31,11 @@ export class ExperimentListView extends Component {
     window.removeEventListener('resize', this.resizeListener);
   }
 
-  handleSearchInput = (event) => {
+  handleSearchInputChange = (event) => {
     this.setState({ searchInput: event.target.value });
-  }
+  };
+
+  preventDefault = (ev) => ev.preventDefault();
 
   render() {
     const height = this.state.height || window.innerHeight;
@@ -43,54 +45,46 @@ export class ExperimentListView extends Component {
     // get searchInput from state
     const { searchInput } = this.state;
     return (
-      <div className="experiment-list-outer-container">
+      <div className='experiment-list-outer-container'>
         <div>
-          <h1 className="experiments-header">Experiments</h1>
-          <div className="collapser-container">
-            <i onClick={this.props.onClickListExperiments}
-               title="Hide experiment list"
-               className="collapser fa fa-chevron-left login-icon"/>
+          <h1 className='experiments-header'>Experiments</h1>
+          <div className='collapser-container'>
+            <i
+              onClick={this.props.onClickListExperiments}
+              title='Hide experiment list'
+              className='collapser fa fa-chevron-left login-icon'
+            />
           </div>
           <input
-            className="experiment-list-search-input"
-            type="text"
-            placeholder="Search Experiments"
+            className='experiment-list-search-input'
+            type='text'
+            placeholder='Search Experiments'
             value={searchInput}
-            onChange={this.handleSearchInput}
+            onChange={this.handleSearchInputChange}
           />
-          <div className="experiment-list-container" style={{ height: experimentListHeight }}>
-            {
-            // filter experiments based on searchInput
-            this.props.experiments.filter((e) => e.getName().toLowerCase().includes(
-              searchInput.toLowerCase()
-            )).map((e, idx) => {
-              let active;
-              const parsedExperimentId = parseInt(e.getExperimentId(), 10);
-              if (this.props.activeExperimentId !== undefined) {
-                active = parsedExperimentId === this.props.activeExperimentId;
-              } else {
-                active = idx === 0;
-              }
-              let className = "experiment-list-item";
-              if (active) {
-                className = `${className} active-experiment-list-item`;
-              }
-              return (
-                <Link
-                  style={{ textDecoration: 'none', color: 'unset' }}
-                  key={e.getExperimentId()}
-                  to={Routes.getExperimentPageRoute(e.getExperimentId())}
-                  onClick={active ? ev => ev.preventDefault() : ev => ev}
-                >
-                  <div
-                    className={className}
-                    title={e.getName()}
+          <div className='experiment-list-container' style={{ height: experimentListHeight }}>
+            {this.props.experiments
+              // filter experiments based on searchInput
+              .filter((exp) => exp.getName().toLowerCase().includes(searchInput.toLowerCase()))
+              .map((exp, idx) => {
+                const { name, experiment_id } = exp;
+                const parsedExperimentId = parseInt(experiment_id, 10);
+                const active = this.props.activeExperimentId !== undefined
+                  ? parsedExperimentId === this.props.activeExperimentId
+                  : idx === 0;
+                const className =
+                  `experiment-list-item ${active ? 'active-experiment-list-item' : ''}`;
+                return (
+                  <Link
+                    style={{ textDecoration: 'none', color: 'unset' }}
+                    key={name}
+                    to={Routes.getExperimentPageRoute(experiment_id)}
+                    onClick={active ? this.preventDefault : undefined}
                   >
-                    {e.getName()}
-                  </div>
-                </Link>
-              );
-            })}
+                    <div className={className} title={name}>{name}</div>
+                  </Link>
+                );
+              })}
           </div>
         </div>
       </div>

--- a/mlflow/server/js/src/components/ExperimentListView.js
+++ b/mlflow/server/js/src/components/ExperimentListView.js
@@ -60,7 +60,7 @@ export class ExperimentListView extends Component {
                 type="text"
                 placeholder="Search Experiments"
                 value={searchInput}
-                  onChange={this.onSearchInput}
+                onChange={this.onSearchInput}
           />
           <div className="experiment-list-container" style={{ height: experimentListHeight }}>
             {

--- a/mlflow/server/js/src/components/ExperimentListView.js
+++ b/mlflow/server/js/src/components/ExperimentListView.js
@@ -63,12 +63,17 @@ export class ExperimentListView extends Component {
                   onChange={this.onSearchInput}
           />
           <div className="experiment-list-container" style={{ height: experimentListHeight }}>
-            {this.props.experiments.map((e, idx) => {
+            {
+            // filter experiments based on searchInput
+            this.props.experiments.filter((e) => {
+              return e.getName().toLowerCase().includes(searchInput.toLowerCase());
+            }).map((e, idx) => {
               let active;
+              const parsedExperimentId = parseInt(e.getExperimentId(), 10);
               if (this.props.activeExperimentId) {
-                active = parseInt(e.getExperimentId(), 10) === this.props.activeExperimentId;
+                active = parsedExperimentId === this.props.activeExperimentId;
               } else {
-                active = idx === 0;
+                active = parsedExperimentId === 0;
               }
               let className = "experiment-list-item";
               if (active) {

--- a/mlflow/server/js/src/components/ExperimentListView.js
+++ b/mlflow/server/js/src/components/ExperimentListView.js
@@ -8,20 +8,16 @@ import Routes from '../Routes';
 import { Link } from 'react-router-dom';
 
 export class ExperimentListView extends Component {
-  constructor(props) {
-    super(props);
-    this.onSearchInput = this.onSearchInput.bind(this);
-
-    this.state = {
-      height: undefined,
-      searchInput: '',
-    };
-  }
   static propTypes = {
     onClickListExperiments: PropTypes.func.isRequired,
     // If activeExperimentId is undefined, then the active experiment is the first one.
     activeExperimentId: PropTypes.number,
     experiments: PropTypes.arrayOf(Experiment).isRequired,
+  };
+
+  state = {
+    height: undefined,
+    searchInput: '',
   };
 
   componentDidMount() {
@@ -35,7 +31,7 @@ export class ExperimentListView extends Component {
     window.removeEventListener('resize', this.resizeListener);
   }
 
-  onSearchInput(event) {
+  handleSearchInput = (event) => {
     this.setState({ searchInput: event.target.value });
   }
 
@@ -56,11 +52,11 @@ export class ExperimentListView extends Component {
                className="collapser fa fa-chevron-left login-icon"/>
           </div>
           <input
-                className="experiment-list-search-input"
-                type="text"
-                placeholder="Search Experiments"
-                value={searchInput}
-                onChange={this.onSearchInput}
+            className="experiment-list-search-input"
+            type="text"
+            placeholder="Search Experiments"
+            value={searchInput}
+            onChange={this.handleSearchInput}
           />
           <div className="experiment-list-container" style={{ height: experimentListHeight }}>
             {

--- a/mlflow/server/js/src/components/ExperimentListView.js
+++ b/mlflow/server/js/src/components/ExperimentListView.js
@@ -8,15 +8,20 @@ import Routes from '../Routes';
 import { Link } from 'react-router-dom';
 
 export class ExperimentListView extends Component {
+  constructor(props) {
+    super(props);
+    this.onSearchInput = this.onSearchInput.bind(this);
+
+    this.state = {
+      height: undefined,
+      searchInput: '',
+    };
+  }
   static propTypes = {
     onClickListExperiments: PropTypes.func.isRequired,
     // If activeExperimentId is undefined, then the active experiment is the first one.
     activeExperimentId: PropTypes.number,
     experiments: PropTypes.arrayOf(Experiment).isRequired,
-  };
-
-  state = {
-    height: undefined,
   };
 
   componentDidMount() {
@@ -30,11 +35,17 @@ export class ExperimentListView extends Component {
     window.removeEventListener('resize', this.resizeListener);
   }
 
+  onSearchInput(event) {
+    this.setState({ searchInput: event.target.value });
+  }
+
   render() {
     const height = this.state.height || window.innerHeight;
     // 60 pixels for the height of the top bar.
     // 100 for the experiments header and some for bottom padding.
     const experimentListHeight = height - 60 - 100;
+    // get searchInput from state
+    const {searchInput} = this.state;
     return (
       <div className="experiment-list-outer-container">
         <div>
@@ -44,6 +55,13 @@ export class ExperimentListView extends Component {
                title="Hide experiment list"
                className="collapser fa fa-chevron-left login-icon"/>
           </div>
+          <input
+                className="experiment-list-search-input"
+                type="text"
+                placeholder="Search Experiments"
+                value={searchInput}
+                  onChange={this.onSearchInput}
+          />
           <div className="experiment-list-container" style={{ height: experimentListHeight }}>
             {this.props.experiments.map((e, idx) => {
               let active;

--- a/mlflow/server/js/src/components/ExperimentListView.js
+++ b/mlflow/server/js/src/components/ExperimentListView.js
@@ -41,7 +41,7 @@ export class ExperimentListView extends Component {
     // 100 for the experiments header and some for bottom padding.
     const experimentListHeight = height - 60 - 100;
     // get searchInput from state
-    const {searchInput} = this.state;
+    const { searchInput } = this.state;
     return (
       <div className="experiment-list-outer-container">
         <div>
@@ -61,15 +61,15 @@ export class ExperimentListView extends Component {
           <div className="experiment-list-container" style={{ height: experimentListHeight }}>
             {
             // filter experiments based on searchInput
-            this.props.experiments.filter((e) => {
-              return e.getName().toLowerCase().includes(searchInput.toLowerCase());
-            }).map((e, idx) => {
+            this.props.experiments.filter((e) => e.getName().toLowerCase().includes(
+              searchInput.toLowerCase()
+            )).map((e, idx) => {
               let active;
               const parsedExperimentId = parseInt(e.getExperimentId(), 10);
-              if (this.props.activeExperimentId) {
+              if (this.props.activeExperimentId !== undefined) {
                 active = parsedExperimentId === this.props.activeExperimentId;
               } else {
-                active = parsedExperimentId === 0;
+                active = idx === 0;
               }
               let className = "experiment-list-item";
               if (active) {

--- a/mlflow/server/js/src/components/ExperimentListView.test.js
+++ b/mlflow/server/js/src/components/ExperimentListView.test.js
@@ -34,6 +34,7 @@ test('If searchInput is set to "Test" and default experiment is active then no a
   const wrapper = shallow(<ExperimentListView
     onClickListExperiments={() => {}}
     experiments={Fixtures.experiments}
+    activeExperimentId={0}
   />);
 
   wrapper.setState({ searchInput: 'Test' });

--- a/mlflow/server/js/src/components/ExperimentListView.test.js
+++ b/mlflow/server/js/src/components/ExperimentListView.test.js
@@ -19,3 +19,23 @@ test('If activeExperimentId is undefined then choose first experiment', () => {
   />);
   expect(wrapper.find('.active-experiment-list-item').first().prop('title')).toEqual('Default');
 });
+
+test('If searchInput is set to "Test" then first shown element in experiment list has the title "Test"', () => {
+  const wrapper = shallow(<ExperimentListView
+    onClickListExperiments={() => {}}
+    experiments={Fixtures.experiments}
+  />);
+
+  wrapper.setState({ searchInput: 'Test' });
+  expect(wrapper.find('.experiment-list-item').first().prop('title')).toEqual('Test');
+});
+
+test('If searchInput is set to "Test" and default experiment is active then no active element is shown in the experiment list', () => {
+  const wrapper = shallow(<ExperimentListView
+    onClickListExperiments={() => {}}
+    experiments={Fixtures.experiments}
+  />);
+
+  wrapper.setState({ searchInput: 'Test' });
+  expect(wrapper.find('.active-experiment-list-item')).toHaveLength(0);
+});


### PR DESCRIPTION
## What changes are proposed in this pull request?

Experiment Searching: Added option to search for experiments by name to the UI. This is especially useful when e.g. collaborating within a team and creating a large number of experiments. A case-insensitive 'contains' search is performed when searching for an experiment.
This feature has also been requested in https://github.com/mlflow/mlflow/issues/1431.
Please refer to the following gif which demonstrates the change:

![search_experiment](https://user-images.githubusercontent.com/15968047/72704764-87136e80-3b0e-11ea-950b-eec44cb0c05d.gif)



## How is this patch tested?

- Added unit tests to ExperimentListView.test.js
- Manual testing


## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added option to search for experiments by name to the UI.

### What component(s) does this PR affect?

- [X] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
