### PR TITLE
Check type on code_paths parameter when saving model

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -250,6 +250,8 @@ def save_model(pytorch_model, path, conda_env=None, mlflow_model=Model(), code_p
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     if code_paths is not None:
+        if not isinstance(code_paths, list):
+            raise TypeError(f'Code_paths should be a list, not {type(code_paths)}')
         code_dir_subpath = "code"
         for code_path in code_paths:
             _copy_file_or_tree(src=code_path, dst=path, dst_dir=code_dir_subpath)

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -251,7 +251,7 @@ def save_model(pytorch_model, path, conda_env=None, mlflow_model=Model(), code_p
 
     if code_paths is not None:
         if not isinstance(code_paths, list):
-            raise TypeError(f'Code_paths should be a list, not {type(code_paths)}')
+            raise TypeError('Code_paths should be a list, not {type(code_paths)}')
         code_dir_subpath = "code"
         for code_path in code_paths:
             _copy_file_or_tree(src=code_path, dst=path, dst_dir=code_dir_subpath)


### PR DESCRIPTION
## What changes are proposed in this pull request?
When saving a PyTorch model using mlflow.pytorch.save_model, no type checking is performed on the code_paths parameter. Specifically, it is not considered that this parameter could accidentally be passed as a string, leading to the following (funny) outcome.
Fixes #2309

(Please fill in changes proposed in this fix)
from this
```
if code_paths is not None:
        code_dir_subpath = "code"
        for code_path in code_paths:
            _copy_file_or_tree(src=code_path, dst=path, dst_dir=code_dir_subpath)
```
to
```
if code_paths is not None:
        if not isinstance(code_paths, list):
            raise TypeError(f'Code_paths should be a list, not {type(code_paths)}')
        code_dir_subpath = "code"
        for code_path in code_paths:
            _copy_file_or_tree(src=code_path, dst=path, dst_dir=code_dir_subpath)
```
## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
