### PR TITLE
Bump mxnet to 1.5.1

### DIFF
--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -10,7 +10,7 @@ onnx==1.4.1; python_version >= "3.0"
 onnxmltools==1.4.0; python_version >= "3.0"
 onnxruntime==0.3.0; python_version >= "3.0"
 mleap==0.8.1
-mxnet==1.5.0
+mxnet==1.5.1
 pandas<=0.23.4
 pyarrow==0.12.1
 pyspark==2.4.0

--- a/travis/small-requirements.txt
+++ b/travis/small-requirements.txt
@@ -5,7 +5,7 @@ botocore==1.12.84  # pinned for moto
 boto3==1.9.84      # pinned for moto
 mock==2.0.0
 moto==1.3.7
-mxnet==1.5.0
+mxnet==1.5.1
 pandas<=0.23.4
 scikit-learn==0.20.2
 scipy==1.2.1


### PR DESCRIPTION
## What changes are proposed in this pull request?

Small Python Travis tests are broken because `mxnet==1.5.0` cannot be found with `pip`. This PR attempts to fix it by pinning `mxnet==1.5.1`.

## How is this patch tested?

Travis

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
