### PR TITLE
Temporarily disable mxnet and gluon tests

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -5,7 +5,8 @@ set -e
 FWDIR="$(cd "`dirname $0`"; pwd)"
 cd "$FWDIR"
 
-pycodestyle --max-line-length=100 --exclude mlflow/protos,mlflow/server/js,mlflow/store/db_migrations,mlflow/temporary_db_migrations_for_pre_1_users -- mlflow tests
+# TODO: remove gluon from this list once https://github.com/pypa/pip/issues/7626 is resolved
+pycodestyle --max-line-length=100 --exclude mlflow/gluon.py,mlflow/protos,mlflow/server/js,mlflow/store/db_migrations,mlflow/temporary_db_migrations_for_pre_1_users -- mlflow tests
 pylint --msg-template="{path} ({line},{column}): [{msg_id} {symbol}] {msg}" --rcfile="$FWDIR/pylintrc" -- mlflow tests
 
 rstcheck README.rst

--- a/pylintrc
+++ b/pylintrc
@@ -7,7 +7,8 @@ extension-pkg-whitelist=
 
 # Add files or directories to the blacklist. They should be base names, not
 # paths.
-ignore=build,protos,sdk,db_migrations,temporary_db_migrations_for_pre_1_users
+# TODO: remove gluon from this list once https://github.com/pypa/pip/issues/7626 is resolved
+ignore=build,protos,sdk,db_migrations,temporary_db_migrations_for_pre_1_users,gluon.py
 
 
 # Add files or directories matching the regex patterns to the blacklist. The

--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -10,7 +10,8 @@ onnx==1.4.1; python_version >= "3.0"
 onnxmltools==1.4.0; python_version >= "3.0"
 onnxruntime==0.3.0; python_version >= "3.0"
 mleap==0.8.1
-mxnet==1.5.0
+# TODO(juntai-zheng) Re-enable mxnet install once pip is patched
+# mxnet==1.5.0  disabling since pip is broken: https://github.com/pypa/pip/issues/7626
 pandas<=0.23.4
 pyarrow==0.12.1
 pyspark==2.4.0

--- a/travis/run-large-python-tests.sh
+++ b/travis/run-large-python-tests.sh
@@ -45,8 +45,10 @@ pytest --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
 pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
 pytest --verbose tests/keras --large
 pytest --verbose tests/keras_autolog --large
-pytest --verbose tests/gluon --large
-pytest --verbose tests/gluon_autolog --large
+# TODO(juntai-zheng) Re-enable mxnet tests once pip is patched
+# Disabling mxnet.gluon since pip is broken: https://github.com/pypa/pip/issues/7626
+# pytest --verbose tests/gluon --large
+# pytest --verbose tests/gluon_autolog --large
 
 # Run Spark autologging tests
 ./travis/test-spark-autologging.sh

--- a/travis/run-small-python-tests.sh
+++ b/travis/run-small-python-tests.sh
@@ -11,6 +11,7 @@ pytest --cov=mlflow --verbose --ignore=tests/h2o --ignore=tests/keras \
   --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn \
   --ignore=tests/spark --ignore=tests/tensorflow --ignore=tests/keras_autolog \
   --ignore=tests/tensorflow_autolog --ignore tests/azureml --ignore tests/onnx \
-  --ignore=tests/xgboost --ignore=tests/lightgbm tests --ignore=tests/spark_autologging
+  --ignore=tests/xgboost --ignore=tests/lightgbm tests --ignore=tests/spark_autologging \
+  --ignore=tests/gluon --ignore=tests/gluon_autolog
 
 test $err = 0

--- a/travis/small-requirements.txt
+++ b/travis/small-requirements.txt
@@ -5,7 +5,8 @@ botocore==1.12.84  # pinned for moto
 boto3==1.9.84      # pinned for moto
 mock==2.0.0
 moto==1.3.7
-mxnet==1.5.0
+# TODO(juntai-zheng) Re-enable mxnet install once pip is patched
+# mxnet==1.5.0  disabling since pip is broken: https://github.com/pypa/pip/issues/7626
 pandas<=0.23.4
 scikit-learn==0.20.2
 scipy==1.2.1


### PR DESCRIPTION
## What changes are proposed in this pull request?

Pip is currently broken and mxnet cannot be installed correctly (see https://github.com/pypa/pip/issues/7626). For tests to pass, we'll disable `mxnet` related tests and installs for Travis until pip is fixed. See an example error here: https://travis-ci.org/mlflow/mlflow/jobs/640064770?utm_medium=notification&utm_source=github_status

## How is this patch tested?

on Travis

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
