### PR TITLE
Update Copyright year across docs to 2020

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'MLflow'
-copyright = 'Databricks 2019. All rights reserved'
+copyright = 'Databricks 2020. All rights reserved'
 author = 'Databricks'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
## What changes are proposed in this pull request?
Updating the copyright year in the documentation

(Please fill in changes proposed in this fix)
Changes the sphinx config in `docs/source/config` from 2019 to 2020

## How is this patch tested?
Run the docs test
(Details)

## Release Notes

### Is this a user-facing change?
Yes. Users simply see the copyright 2020 instead of 2019


### What component(s) does this PR affect?
 UI

### How should the PR be classified in the release notes? Choose one:
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

