### PR TITLE
Fix killed status constraint upgrade

### DIFF
--- a/mlflow/store/db_migrations/versions/0a8213491aaa_drop_duplicate_killed_constraint.py
+++ b/mlflow/store/db_migrations/versions/0a8213491aaa_drop_duplicate_killed_constraint.py
@@ -1,0 +1,37 @@
+"""drop_duplicate_killed_constraint
+
+Revision ID: 0a8213491aaa
+Revises: cfd24bdc0731
+Create Date: 2020-01-28 15:26:14.757445
+
+"""
+import logging
+from alembic import op
+
+_logger = logging.getLogger(__name__)
+
+# revision identifiers, used by Alembic.
+revision = '0a8213491aaa'
+down_revision = 'cfd24bdc0731'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Attempt to drop any existing `status` constraints on the `runs` table. This operation
+    # may fail against certain backends with different classes of Exception. For example,
+    # in MySQL <= 8.0.15, dropping constraints produces an invalid `ALTER TABLE` expression.
+    # Further, in certain versions of sqlite, `ALTER` (which is invoked by `drop_constraint`)
+    # is unsupported on `CHECK` constraints. Accordingly, we catch the generic `Exception`
+    # object because the failure modes are not well-enumerated or consistent across database
+    # backends.
+    try:
+        op.drop_constraint(constraint_name="status", table_name="runs", type_="check")
+    except Exception as e: # pylint: disable=broad-except
+        _logger.warning(
+            "Failed to drop check constraint. Dropping check constraints may not be supported"
+            " by your SQL database. Exception content: %s", e)
+
+
+def downgrade():
+    pass

--- a/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
+++ b/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
@@ -6,9 +6,13 @@ Create Date: 2019-10-11 15:55:10.853449
 
 """
 from alembic import op, context
-from mlflow.entities import RunStatus
+from mlflow.entities import RunStatus, ViewType
+from mlflow.entities.lifecycle_stage import LifecycleStage
 from sqlalchemy import CheckConstraint, Enum
 from sqlalchemy.engine.reflection import Inspector
+
+from mlflow.store.tracking.dbmodels.models import SqlRun, SourceTypes
+
 
 # revision identifiers, used by Alembic.
 revision = 'cfd24bdc0731'
@@ -16,7 +20,7 @@ down_revision = '2b4d017a5e9b'
 branch_labels = None
 depends_on = None
 
-new_run_status = [
+new_run_statuses = [
     RunStatus.to_string(RunStatus.SCHEDULED),
     RunStatus.to_string(RunStatus.FAILED),
     RunStatus.to_string(RunStatus.FINISHED),
@@ -24,7 +28,7 @@ new_run_status = [
     RunStatus.to_string(RunStatus.KILLED)
 ]
 
-previous_run_status = [
+previous_run_statuses = [
     RunStatus.to_string(RunStatus.SCHEDULED),
     RunStatus.to_string(RunStatus.FAILED),
     RunStatus.to_string(RunStatus.FINISHED),
@@ -49,26 +53,35 @@ def get_check_constraints():
                    if constraint['name'] != 'status']
     return constraints
 
+def expected_check_constraints():
+    return (
+        CheckConstraint(SqlRun.source_type.in_(SourceTypes), name='source_type'),
+        CheckConstraint(SqlRun.status.in_(previous_run_statuses), name='status'),
+        CheckConstraint(SqlRun.lifecycle_stage.in_(LifecycleStage.view_type_to_stages(ViewType.ALL)),
+                        name='runs_lifecycle_stage'),
+    )
 
 def upgrade():
-    if _has_check_constraints():
-        with op.batch_alter_table("runs", table_args=get_check_constraints()) as batch_op:
-            # Update the "status" constraint via the SqlAlchemy `Enum` type. Specify
-            # `native_enum=False` to create a check constraint rather than a
-            # database-backend-dependent enum (see https://docs.sqlalchemy.org/en/13/core/
-            # type_basics.html#sqlalchemy.types.Enum.params.native_enum)
-            batch_op.alter_column("status",
-                                  type_=Enum(*new_run_status, create_constraint=True,
-                                             constraint_name="status", native_enum=False))
+    print(get_check_constraints())
+
+    # if _has_check_constraints():
+    # with op.batch_alter_table("runs", table_args=get_check_constraints()) as batch_op:
+    # with op.batch_alter_table("runs", copy_from=SqlRun.__table__, table_args={'extend_existing': True}) as batch_op:
+    # with op.batch_alter_table("runs", copy_from=SqlRun.__table__, extend_existing=True) as batch_op:
+    with op.batch_alter_table("runs", table_args=expected_check_constraints()) as batch_op:
+    # with op.batch_alter_table("runs", table_args={'extend_existing': True}) as batch_op:
+    # with op.batch_alter_table("runs") as batch_op:
+        # Update the "status" constraint via the SqlAlchemy `Enum` type. Specify
+        # `native_enum=False` to create a check constraint rather than a
+        # database-backend-dependent enum (see https://docs.sqlalchemy.org/en/13/core/
+        # type_basics.html#sqlalchemy.types.Enum.params.native_enum)
+        batch_op.alter_column("status",
+                              type_=Enum(*new_run_statuses, create_constraint=True,
+                                         constraint_name="status", native_enum=False))
 
 
 def downgrade():
-    if _has_check_constraints():
-        with op.batch_alter_table("runs", table_args=get_check_constraints()) as batch_op:
-            # Update the "status" constraint via the SqlAlchemy `Enum` construct. Specify
-            # `native_enum=False` to create a check constraint rather than a
-            # database-backend-dependent enum (see https://docs.sqlalchemy.org/en/13/core/
-            # type_basics.html#sqlalchemy.types.Enum.params.native_enum)
-            batch_op.alter_column("status",
-                                  type_=Enum(*previous_run_status, create_constraint=True,
-                                             constraint_name="status", native_enum=False))
+    # Omit downgrade logic for now - we don't currently provide users a command/API for
+    # reverting a database migration, instead recommending that they take a database backup
+    # before running the migration.
+    pass

--- a/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
+++ b/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
@@ -5,14 +5,14 @@ Revises: 89d4b8295536
 Create Date: 2019-10-11 15:55:10.853449
 
 """
-from alembic import op, context
+import logging
+from alembic import op 
 from mlflow.entities import RunStatus, ViewType
 from mlflow.entities.lifecycle_stage import LifecycleStage
-from sqlalchemy import CheckConstraint, Enum
-from sqlalchemy.engine.reflection import Inspector
-
 from mlflow.store.tracking.dbmodels.models import SqlRun, SourceTypes
+from sqlalchemy import CheckConstraint, Enum, String
 
+_logger = logging.getLogger(__name__)
 
 # revision identifiers, used by Alembic.
 revision = 'cfd24bdc0731'
@@ -35,47 +35,40 @@ previous_run_statuses = [
     RunStatus.to_string(RunStatus.RUNNING)
 ]
 
+# Certain SQL backends (e.g., SQLite) do not preserve CHECK constraints during migrations.
+# For these backends, CHECK constraints must be specified as table arguments. Here, we define
+# the collection of CHECK constraints that should be preserved when performing the migration.
+# The "status" constraint is excluded from this set because it is explicitly modified
+# within the migration's `upgrade()` routine.
+check_constraint_table_args = [
+    CheckConstraint(SqlRun.source_type.in_(SourceTypes), name='source_type'),
+    CheckConstraint(SqlRun.lifecycle_stage.in_(LifecycleStage.view_type_to_stages(ViewType.ALL)),
+                    name='runs_lifecycle_stage'),
+]
 
-def _has_check_constraints():
-    inspector = Inspector(context.get_bind().engine)
-    constraints = [constraint['name']
-                   for constraint in inspector.get_check_constraints("runs")]
-    return "status" in constraints
-
-
-def get_check_constraints():
-    """
-    Get all check constraint except status
-    """
-    inspector = Inspector(context.get_bind().engine)
-    constraints = [CheckConstraint(constraint['sqltext'], name=constraint['name'])
-                   for constraint in inspector.get_check_constraints("runs")
-                   if constraint['name'] != 'status']
-    return constraints
-
-def expected_check_constraints():
-    return (
-        CheckConstraint(SqlRun.source_type.in_(SourceTypes), name='source_type'),
-        CheckConstraint(SqlRun.status.in_(previous_run_statuses), name='status'),
-        CheckConstraint(SqlRun.lifecycle_stage.in_(LifecycleStage.view_type_to_stages(ViewType.ALL)),
-                        name='runs_lifecycle_stage'),
-    )
 
 def upgrade():
-    print(get_check_constraints())
+    # Attempt to drop any existing `status` constraints on the `runs` table. This operation
+    # may fail against certain backends with different classes of Exception. For example,
+    # in MySQL <= 8.0.15, dropping constraints produces an invalid `ALTER TABLE` expression.
+    # Further, in certain versions of sqlite, `ALTER` (which is invoked by `drop_constraint`)
+    # is unsupported on `CHECK` constraints. Accordingly, we catch the generic `Exception`
+    # object because the failure modes are not well-enumerated or consistent across database
+    # backends.
+    try:
+        op.drop_constraint(constraint_name="status", table_name="runs", type_="check")
+    except Exception as e: # pylint: disable=broad-except
+        _logger.warning(
+            "Failed to drop check constraint. Dropping check constraints may not be supported"
+            " by your SQL database.\nException content: %s", e)
 
-    # if _has_check_constraints():
-    # with op.batch_alter_table("runs", table_args=get_check_constraints()) as batch_op:
-    # with op.batch_alter_table("runs", copy_from=SqlRun.__table__, table_args={'extend_existing': True}) as batch_op:
-    # with op.batch_alter_table("runs", copy_from=SqlRun.__table__, extend_existing=True) as batch_op:
-    with op.batch_alter_table("runs", table_args=expected_check_constraints()) as batch_op:
-    # with op.batch_alter_table("runs", table_args={'extend_existing': True}) as batch_op:
-    # with op.batch_alter_table("runs") as batch_op:
-        # Update the "status" constraint via the SqlAlchemy `Enum` type. Specify
+    with op.batch_alter_table("runs", table_args=check_constraint_table_args) as batch_op:
+        # Define a new "status" constraint via the SqlAlchemy `Enum` type. Specify
         # `native_enum=False` to create a check constraint rather than a
         # database-backend-dependent enum (see https://docs.sqlalchemy.org/en/13/core/
-        # type_basics.html#sqlalchemy.types.Enum.params.native_enum)
+        # type_basics.html#sqlalchemy.types.En
         batch_op.alter_column("status",
+                              existing_type=String,
                               type_=Enum(*new_run_statuses, create_constraint=True,
                                          constraint_name="status", native_enum=False))
 

--- a/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
+++ b/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
@@ -11,7 +11,6 @@ from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.store.tracking.dbmodels.models import SqlRun, SourceTypes
 from sqlalchemy import CheckConstraint, Enum
 
-
 # revision identifiers, used by Alembic.
 revision = 'cfd24bdc0731'
 down_revision = '2b4d017a5e9b'
@@ -40,7 +39,7 @@ check_constraint_table_args = [
 
 def upgrade():
     with op.batch_alter_table("runs", table_args=check_constraint_table_args) as batch_op:
-        # Define a new "status" constraint via the SqlAlchemy `Enum` type. Specify
+        # Transform the "status" column to an `Enum` and define a new check constraint. Specify
         # `native_enum=False` to create a check constraint rather than a
         # database-backend-dependent enum (see https://docs.sqlalchemy.org/en/13/core/
         # type_basics.html#sqlalchemy.types.Enum.params.native_enum)

--- a/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
+++ b/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
@@ -45,7 +45,7 @@ def upgrade():
         # type_basics.html#sqlalchemy.types.Enum.params.native_enum)
         batch_op.alter_column("status",
                               type_=Enum(*new_run_statuses, create_constraint=True,
-                                         constraint_name="status", native_enum=False))
+                                         native_enum=False))
 
 
 def downgrade():

--- a/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
+++ b/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
@@ -28,13 +28,6 @@ new_run_statuses = [
     RunStatus.to_string(RunStatus.KILLED)
 ]
 
-previous_run_statuses = [
-    RunStatus.to_string(RunStatus.SCHEDULED),
-    RunStatus.to_string(RunStatus.FAILED),
-    RunStatus.to_string(RunStatus.FINISHED),
-    RunStatus.to_string(RunStatus.RUNNING)
-]
-
 # Certain SQL backends (e.g., SQLite) do not preserve CHECK constraints during migrations.
 # For these backends, CHECK constraints must be specified as table arguments. Here, we define
 # the collection of CHECK constraints that should be preserved when performing the migration.

--- a/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
+++ b/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
@@ -53,13 +53,13 @@ def upgrade():
     except Exception as e: # pylint: disable=broad-except
         _logger.warning(
             "Failed to drop check constraint. Dropping check constraints may not be supported"
-            " by your SQL database.\nException content: %s", e)
+            " by your SQL database. Exception content: %s", e)
 
     with op.batch_alter_table("runs", table_args=check_constraint_table_args) as batch_op:
         # Define a new "status" constraint via the SqlAlchemy `Enum` type. Specify
         # `native_enum=False` to create a check constraint rather than a
         # database-backend-dependent enum (see https://docs.sqlalchemy.org/en/13/core/
-        # type_basics.html#sqlalchemy.types.En
+        # type_basics.html#sqlalchemy.types.Enum.params.native_enum)
         batch_op.alter_column("status",
                               existing_type=String,
                               type_=Enum(*new_run_statuses, create_constraint=True,

--- a/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
+++ b/mlflow/store/db_migrations/versions/cfd24bdc0731_update_run_status_constraint_with_killed.py
@@ -6,7 +6,7 @@ Create Date: 2019-10-11 15:55:10.853449
 
 """
 import logging
-from alembic import op 
+from alembic import op
 from mlflow.entities import RunStatus, ViewType
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.store.tracking.dbmodels.models import SqlRun, SourceTypes


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes #2330 by patching the migration that adds the `KILLED` run state to the collection of constraints imposed on the `runs` table in the `SqlAlchemyStore` for MLflow tracking.

## How is this patch tested?

Manual testing of the fresh database creation and database migration flow from 1.4 -> `master` against MySQL versions 8.0.15 and 8.0.18, SQL Server, sqlite3, and Postgres.

## Release Notes

Fixed a migration bug in the SqlAlchemyStore that prevented users from running MLflow Tracking on SQL Server.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
