### PR TITLE
Bug Fix: Validate experiment name when calling the rename/update endpoint

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -223,9 +223,8 @@ class FileStore(AbstractStore):
                 raise MlflowException(
                     "Experiment '%s' already exists in deleted state. "
                     "You can restore the experiment, or permanently delete the experiment "
-                    "from the .trash folder (under tracking server's root folder) before "
-                    "creating a new one with the same name "
-                    "or renaming an experiment." % experiment.name,
+                    "from the .trash folder (under tracking server's root folder) in order to "
+                    "use this experiment name again." % experiment.name,
                     databricks_pb2.RESOURCE_ALREADY_EXISTS)
             else:
                 raise MlflowException("Experiment '%s' already exists." % experiment.name,

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -212,8 +212,8 @@ class FileStore(AbstractStore):
         write_yaml(meta_dir, FileStore.META_DATA_FILE_NAME, experiment_dict)
         return experiment_id
 
-    def create_experiment(self, name, artifact_location=None):
-        self._check_root_dir()
+    def _validate_experiment_name(self, name):
+        """Check the validity of an experiment name."""
         if name is None or name == "":
             raise MlflowException("Invalid experiment name '%s'" % name,
                                   databricks_pb2.INVALID_PARAMETER_VALUE)
@@ -224,11 +224,16 @@ class FileStore(AbstractStore):
                     "Experiment '%s' already exists in deleted state. "
                     "You can restore the experiment, or permanently delete the experiment "
                     "from the .trash folder (under tracking server's root folder) before "
-                    "creating a new one with the same name." % experiment.name,
+                    "creating a new one with the same name "
+                    "or renaming an experiment." % experiment.name,
                     databricks_pb2.RESOURCE_ALREADY_EXISTS)
             else:
                 raise MlflowException("Experiment '%s' already exists." % experiment.name,
                                       databricks_pb2.RESOURCE_ALREADY_EXISTS)
+
+    def create_experiment(self, name, artifact_location=None):
+        self._check_root_dir()
+        self._validate_experiment_name(name)
         # Get all existing experiments and find the one with largest ID.
         # len(list_all(..)) would not work when experiments are deleted.
         experiments_ids = [int(e.experiment_id) for e in self.list_experiments(ViewType.ALL)]
@@ -301,6 +306,7 @@ class FileStore(AbstractStore):
         if experiment is None:
             raise MlflowException("Experiment '%s' does not exist." % experiment_id,
                                   databricks_pb2.RESOURCE_DOES_NOT_EXIST)
+        self._validate_experiment_name(new_name)
         experiment._set_name(new_name)
         if experiment.lifecycle_stage != LifecycleStage.ACTIVE:
             raise Exception("Cannot rename experiment in non-active lifecycle stage."

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -283,12 +283,12 @@ class TestFileStore(unittest.TestCase):
             fs.rename_experiment(exp_id, None)
         with self.assertRaises(Exception):
             # test that names of existing experiments are checked before renaming
-            exp_id_alternative = None
+            other_exp_id = None
             for exp in self.experiments:
                 if exp != exp_id:
-                    exp_id_alternative = exp
+                    other_exp_id = exp
                     break
-            fs.rename_experiment(exp_id, fs.get_experiment(exp_id_alternative).name)
+            fs.rename_experiment(exp_id, fs.get_experiment(other_exp_id).name)
 
         exp_name = self.exp_data[exp_id]["name"]
         new_name = exp_name + "!!!"

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -277,6 +277,19 @@ class TestFileStore(unittest.TestCase):
     def test_rename_experiment(self):
         fs = FileStore(self.test_root)
         exp_id = self.experiments[random_int(0, len(self.experiments) - 1)]
+
+        # Error cases
+        with self.assertRaises(Exception):
+            fs.rename_experiment(exp_id, None)
+        with self.assertRaises(Exception):
+            # test that names of existing experiments are checked before renaming
+            exp_id_alternative = None
+            for exp in self.experiments:
+                if exp != exp_id:
+                    exp_id_alternative = exp
+                    break
+            fs.rename_experiment(exp_id, fs.get_experiment(exp_id_alternative).name)
+
         exp_name = self.exp_data[exp_id]["name"]
         new_name = exp_name + "!!!"
         self.assertNotEqual(exp_name, new_name)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Bug Fix:
Added a validity check w.r.t. the provided experiment name when trying to rename an experiment.
While users were blocked from creating experiments with the same name, there was no such check when calling the 'Update Experiment' API (`/experiments/update`) or using the `rename_experiment` command. Having experiments with the same name could cause some issues (e.g. when calling `mlflow.set_experiment(experiment_name)`).

Discovered in PR https://github.com/mlflow/mlflow/pull/2348.

## How is this patch tested?

- Manual testing
- Unit tests

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [X] CLI
- [ ] API
- [X] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
