### PR TITLE
allow kwargs in `pyfunc` models

### DIFF
--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -67,7 +67,7 @@ class PythonModel(object):
         """
 
     @abstractmethod
-    def predict(self, context, model_input):
+    def predict(self, context, model_input, **kwargs):
         """
         Evaluates a pyfunc-compatible input and produces a pyfunc-compatible output.
         For more information about the pyfunc input/output API, see the :ref:`pyfunc-inference-api`.
@@ -239,5 +239,5 @@ class _PythonModelPyfuncWrapper(object):
         self.python_model = python_model
         self.context = context
 
-    def predict(self, model_input):
-        return self.python_model.predict(self.context, model_input)
+    def predict(self, model_input, **kwargs):
+        return self.python_model.predict(self.context, model_input, **kwargs)


### PR DESCRIPTION
Allow pyfunc kwargs as per #2360 

## How is this patch tested?

No extra tests added.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [X] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
