### PR TITLE
Add spark autologging JAR javadoc generation

### DIFF
--- a/mlflow/java/scoring/pom.xml
+++ b/mlflow/java/scoring/pom.xml
@@ -118,7 +118,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
-          <sourcepath>${project.basedir}/src/main/scala</sourcepath>
+          <sourcepath>${project.basedir}/src/main/java</sourcepath>
         </configuration>
       </plugin>
       <plugin>

--- a/mlflow/java/spark/pom.xml
+++ b/mlflow/java/spark/pom.xml
@@ -98,6 +98,12 @@
               </args>
             </configuration>
           </execution>
+          <execution>
+            <id>attach-javadocs</id>
+              <goals>
+                <goal>doc-jar</goal>
+              </goals>
+          </execution>
         </executions>
       </plugin>
       <plugin>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes generation of Javadoc for Spark autologging JAR (mlflow-spark), so that we can submit the package to maven central - Javadocs are required as per the [Maven Central docs](https://central.sonatype.org/pages/requirements.html#supply-javadoc-and-sources). Verified the fix by running `mvn deploy` & observing the generated Javadoc JAR in bintray

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
