### PR TITLE
Attempt to fix flaky Spark autologging & model export tests

### DIFF
--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -37,6 +37,7 @@ from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-imp
 
 _logger = logging.getLogger(__name__)
 
+
 @pytest.fixture
 def spark_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import json
@@ -34,6 +35,7 @@ from tests.helper_functions import set_boto_credentials  # pylint: disable=unuse
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
+_logger = logging.getLogger(__name__)
 
 @pytest.fixture
 def spark_custom_env(tmpdir):
@@ -59,12 +61,19 @@ def spark_context():
              value='ml.combust.mleap:mleap-spark-base_2.11:0.12.0,'
                    'ml.combust.mleap:mleap-spark_2.11:0.12.0')
     conf.set(key="spark_session.python.worker.reuse", value=True)
-    spark = pyspark.sql.SparkSession.builder\
-        .config(conf=conf)\
-        .master("local-cluster[2, 1, 1024]")\
-        .getOrCreate()
-    sc = spark.sparkContext
-    return sc
+    max_tries = 3
+    for num_tries in range(max_tries):
+        try:
+            spark = pyspark.sql.SparkSession.builder\
+                .config(conf=conf)\
+                .master("local-cluster[2, 1, 1024]")\
+                .getOrCreate()
+            return spark.sparkContext
+        except Exception as e:
+            if num_tries >= max_tries - 1:
+                raise
+            _logger.exception(e, "Attempt %s to create a SparkSession failed, retrying..." %
+                              num_tries)
 
 
 @pytest.fixture(scope="session")

--- a/tests/spark_autologging/test_spark_datasource_autologging_crossframework.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging_crossframework.py
@@ -32,6 +32,11 @@ def _fit_keras(pandas_df, epochs):
     keras_model.add(Dense(1))
     keras_model.compile(loss='mean_squared_error', optimizer='SGD')
     keras_model.fit(x, y, epochs=epochs)
+    # Sleep to allow time for datasource read event to fire asynchronously from the JVM & for
+    # the Python-side event handler to run & log a tag to the current active run.
+    # This race condition (& the risk of dropping datasource read events for short-lived runs)
+    # is known and documented in
+    # https://mlflow.org/docs/latest/python_api/mlflow.spark.html#mlflow.spark.autolog
     time.sleep(5)
 
 

--- a/tests/spark_autologging/test_spark_datasource_autologging_crossframework.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging_crossframework.py
@@ -32,7 +32,7 @@ def _fit_keras(pandas_df, epochs):
     keras_model.add(Dense(1))
     keras_model.compile(loss='mean_squared_error', optimizer='SGD')
     keras_model.fit(x, y, epochs=epochs)
-    time.sleep(2)
+    time.sleep(5)
 
 
 def _fit_keras_model_with_active_run(pandas_df, epochs):

--- a/travis/test-spark-autologging.sh
+++ b/travis/test-spark-autologging.sh
@@ -6,7 +6,7 @@ set -ex
 
 # Build Java package
 pushd mlflow/java/spark
-mvn package -DskipTests
+mvn package -DskipTests -q
 popd
 
 # Install PySpark 3.0 preview & run tests. For faster local iteration, you can also simply download

--- a/travis/test-spark-autologging.sh
+++ b/travis/test-spark-autologging.sh
@@ -16,7 +16,7 @@ popd
 TEMPDIR=$(mktemp -d)
 pushd $TEMPDIR
 wget https://archive.apache.org/dist/spark/spark-3.0.0-preview/spark-3.0.0-preview-bin-hadoop2.7.tgz -O /tmp/spark.tgz
-tar -xvf /tmp/spark.tgz
+tar -xf /tmp/spark.tgz
 pip install -e spark-3.0.0-preview-bin-hadoop2.7/python
 popd
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Increases sleep duration for Spark autologging test, & adds retries around initializing a SparkSession for Spark model export tests, as sometimes initializing a SparkSession with the necessary dependent libraries (mleap) can fail due to timeouts while fetching mleap JARs.

Also makes cosmetic fixes to reduce build log length

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
