### PR TITLE
FileStore: Fix parameter reading logic to support param values with newlines

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -637,8 +637,29 @@ class FileStore(AbstractStore):
 
     def _log_run_param(self, run_info, param):
         param_path = self._get_param_path(run_info.experiment_id, run_info.run_id, param.key)
+        writeable_param_value = self._writeable_value(param.value)
+        if os.path.exists(param_path):
+            self._validate_new_param_value(
+                param_path=param_path, param_key=param.key,
+                run_id=run_info.run_id, new_value=writeable_param_value)
         make_containing_dirs(param_path)
-        write_to(param_path, self._writeable_value(param.value))
+        write_to(param_path, writeable_param_value)
+
+    def _validate_new_param_value(self, param_path, param_key, run_id, new_value):
+        """
+        When logging a parameter with a key that already exists, this function is used to
+        enforce immutability by verifying that the specified parameter value matches the existing
+        value.
+        :raises: py:class:`mlflow.exceptions.MlflowException` if the specified new parameter value
+                 does not match the existing parameter value.
+        """
+        with open(param_path, "r") as param_file:
+            current_value = param_file.read()
+        if current_value != new_value:
+            raise MlflowException(
+                "Changing param value is not allowed. Param with key='{}' was already"
+                " logged with value='{}' for run ID='{}'. Attempted logging new value"
+                " '{}'.".format(param_key, current_value, run_id, new_value))
 
     def set_experiment_tag(self, experiment_id, tag):
         """

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -657,9 +657,10 @@ class FileStore(AbstractStore):
             current_value = param_file.read()
         if current_value != new_value:
             raise MlflowException(
-                "Changing param value is not allowed. Param with key='{}' was already"
+                "Changing param values is not allowed. Param with key='{}' was already"
                 " logged with value='{}' for run ID='{}'. Attempted logging new value"
-                " '{}'.".format(param_key, current_value, run_id, new_value))
+                " '{}'.".format(param_key, current_value, run_id, new_value),
+                databricks_pb2.INVALID_PARAMETER_VALUE)
 
     def set_experiment_tag(self, experiment_id, tag):
         """

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -515,13 +515,7 @@ class FileStore(AbstractStore):
     @staticmethod
     def _get_param_from_file(parent_path, param_name):
         _validate_param_name(param_name)
-        param_data = read_file_lines(parent_path, param_name)
-        if len(param_data) > 1:
-            raise Exception("Unexpected data for param '%s'. Param recorded more than once"
-                            % param_name)
-        # The only cause for param_data's length to be zero is the param's
-        # value is an empty string
-        value = '' if len(param_data) == 0 else str(param_data[0].strip())
+        value = read_file(parent_path, param_name)
         return Param(param_name, value)
 
     def get_all_params(self, run_uuid):

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -518,7 +518,7 @@ class SqlAlchemyStore(AbstractStore):
                     old_value = existing_params[0]
                     raise MlflowException(
                         "Changing param value is not allowed. Param with key='{}' was already"
-                        " logged with value='{}' for run ID='{}. Attempted logging new value"
+                        " logged with value='{}' for run ID='{}'. Attempted logging new value"
                         " '{}'.".format(
                             param.key, old_value, run_id, param.value), INVALID_PARAMETER_VALUE)
                 else:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -517,7 +517,7 @@ class SqlAlchemyStore(AbstractStore):
                 if len(existing_params) > 0:
                     old_value = existing_params[0]
                     raise MlflowException(
-                        "Changing param value is not allowed. Param with key='{}' was already"
+                        "Changing param values is not allowed. Param with key='{}' was already"
                         " logged with value='{}' for run ID='{}'. Attempted logging new value"
                         " '{}'.".format(
                             param.key, old_value, run_id, param.value), INVALID_PARAMETER_VALUE)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -627,7 +627,6 @@ class TestFileStore(unittest.TestCase):
         run = fs.get_run(run_id)
         assert run.data.params[param_name] == "value1"
 
-
     def test_weird_metric_names(self):
         WEIRD_METRIC_NAME = "this is/a weird/but valid metric"
         fs = FileStore(self.test_root)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -19,7 +19,9 @@ from mlflow.exceptions import MlflowException, MissingConfigException
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.file_store import FileStore
 from mlflow.utils.file_utils import write_yaml, read_yaml, path_to_local_file_uri, TempDir
-from mlflow.protos.databricks_pb2 import ErrorCode, RESOURCE_DOES_NOT_EXIST, INTERNAL_ERROR
+from mlflow.protos.databricks_pb2 import (
+    ErrorCode, RESOURCE_DOES_NOT_EXIST, INTERNAL_ERROR, INVALID_PARAMETER_VALUE
+)
 
 from tests.helper_functions import random_int, random_str, safe_edit_yaml
 
@@ -611,6 +613,20 @@ class TestFileStore(unittest.TestCase):
         fs.log_param(run_id, Param(param_name, param_value))
         run = fs.get_run(run_id)
         assert run.data.params[param_name] == param_value
+
+    def test_log_param_enforces_value_immutability(self):
+        param_name = "new param"
+        fs = FileStore(self.test_root)
+        run_id = self.exp_data[FileStore.DEFAULT_EXPERIMENT_ID]["runs"][0]
+        fs.log_param(run_id, Param(param_name, "value1"))
+        # Duplicate calls to `log_param` with the same key and value should succeed
+        fs.log_param(run_id, Param(param_name, "value1"))
+        with pytest.raises(MlflowException) as exc:
+            fs.log_param(run_id, Param(param_name, "value2"))
+        assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        run = fs.get_run(run_id)
+        assert run.data.params[param_name] == "value1"
+
 
     def test_weird_metric_names(self):
         WEIRD_METRIC_NAME = "this is/a weird/but valid metric"

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -595,13 +595,22 @@ class TestFileStore(unittest.TestCase):
         run = fs.get_run(run_id)
         assert run.data.params[WEIRD_PARAM_NAME] == "Value"
 
-    def test_log_empty_str(self):
+    def test_log_param_empty_str(self):
         PARAM_NAME = "new param"
         fs = FileStore(self.test_root)
         run_id = self.exp_data[FileStore.DEFAULT_EXPERIMENT_ID]["runs"][0]
         fs.log_param(run_id, Param(PARAM_NAME, ""))
         run = fs.get_run(run_id)
         assert run.data.params[PARAM_NAME] == ""
+
+    def test_log_param_with_newline(self):
+        param_name = "new param"
+        param_value = "a string\nwith multiple\nlines"
+        fs = FileStore(self.test_root)
+        run_id = self.exp_data[FileStore.DEFAULT_EXPERIMENT_ID]["runs"][0]
+        fs.log_param(run_id, Param(param_name, param_value))
+        run = fs.get_run(run_id)
+        assert run.data.params[param_name] == param_value
 
     def test_weird_metric_names(self):
         WEIRD_METRIC_NAME = "this is/a weird/but valid metric"

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -619,7 +619,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         with self.assertRaises(MlflowException) as e:
             self.store.log_param(run.info.run_id, param2)
-        self.assertIn("Changing param value is not allowed. Param with key=", e.exception.message)
+        self.assertIn("Changing param values is not allowed. Param with key=", e.exception.message)
 
     def test_log_empty_str(self):
         run = self._run_factory()
@@ -1333,7 +1333,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         with self.assertRaises(MlflowException) as e:
             self.store.log_batch(run.info.run_id, metrics=[metric], params=[overwrite_param],
                                  tags=[tag])
-        self.assertIn("Changing param value is not allowed. Param with key=", e.exception.message)
+        self.assertIn("Changing param values is not allowed. Param with key=", e.exception.message)
         assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         self._verify_logged(run.info.run_id, metrics=[], params=[param], tags=[])
 
@@ -1348,7 +1348,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         with self.assertRaises(MlflowException) as e:
             self.store.log_batch(run.info.run_id, metrics=[metric], params=[param0, param1],
                                  tags=[tag])
-        self.assertIn("Changing param value is not allowed. Param with key=", e.exception.message)
+        self.assertIn("Changing param values is not allowed. Param with key=", e.exception.message)
         assert e.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         self._verify_logged(run.info.run_id, metrics=[], params=[param0], tags=[])
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

The FileStore currently reads parameter files line-by-line and throws an exception if multiple lines are encountered for the same parameter. As a result, parameters whose values contain newlines are not supported. However, the FileStore does not *write* parameter values line-by-line, nor does it support storing multiple parameter values in the same file. Accordingly, there's no obvious reason to read the file line-by-line or include this validation.

This PR corrects & simplifies the FileStore logic used for reading parameter values, introducing support for parameter values containing newlines. It fixes #2235.

## How is this patch tested?

Unit tests

## Release Notes

* Fixes a bug in the FileStore that prevented users from reading parameters whose values contain newlines (`\n`).

* The FileStore now correctly enforces the immutability of parameter values.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
