### PR TITLE
Fix SQL exception reporting

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -310,7 +310,7 @@ texinfo_documents = [
 nitpicky = True
 nitpick_ignore = [
     # Ignore "parent class reference not found" errors for subclasses of ``object``
-    ('py:class', 'object'),
+    ('py:class', 'object'), ('py:class', 'json.encoder.JSONEncoder')
 ]
 
 linkcheck_ignore = [

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -20,7 +20,7 @@ ERROR_CODE_TO_HTTP_STATUS = {
 
 
 class ExceptionEncoder(json.JSONEncoder):
-    def default(self, obj):
+    def default(self, obj):  # pylint: disable=E0202,W0221
         if isinstance(obj, Exception):
             return str(obj)
         return json.JSONEncoder.default(self, obj)

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -19,6 +19,13 @@ ERROR_CODE_TO_HTTP_STATUS = {
 }
 
 
+class ExceptionEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Exception):
+            return str(obj)
+        return json.JSONEncoder.default(self, obj)
+
+
 class MlflowException(Exception):
     """
     Generic exception thrown to surface failure information about external-facing operations.
@@ -47,7 +54,7 @@ class MlflowException(Exception):
     def serialize_as_json(self):
         exception_dict = {'error_code': self.error_code, 'message': self.message}
         exception_dict.update(self.json_kwargs)
-        return json.dumps(exception_dict)
+        return json.dumps(exception_dict, cls=ExceptionEncoder)
 
     def get_http_status_code(self):
         return ERROR_CODE_TO_HTTP_STATUS.get(self.error_code, 500)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -77,6 +77,7 @@ def _get_managed_session_maker(SessionMaker):
             raise
         except Exception as e:
             session.rollback()
+            _logger.exception("Exception in SQL query")
             raise MlflowException(message=e, error_code=INTERNAL_ERROR)
         finally:
             session.close()


### PR DESCRIPTION
## What changes are proposed in this pull request?

* Log sqlalchemy exception on server side with correct level
* Fix Serialization error in the JSON payload returned by the server

Exceptions are not JSON serializable. Therefore, in this patch, I just call `str` method to render the exception message in the payload. 

## How is this patch tested?


Launch a local mlflow server then use the following command to generate a SQL exception:
```python
import mlflow
mlflow.set_tracking_uri("http://0.0.0.0:5000") 
mlflow.start_run(experiment_id="blah")  
```
The playload should return the error message:
```
2020/02/05 11:37:11 ERROR mlflow.utils.rest_utils: API request to http://0.0.0.0:5000/api/2.0/mlflow/runs/create failed with code 500 != 200, retrying up to 2 more times. API response body: {"error_code": "INTERNAL_ERROR", "message": "(MySQLdb._exceptions.OperationalError) (1366, \"Incorrect integer value: 'blah' for column `mlflow_db`.`runs`.`experiment_id` at row 1\")\n[SQL: INSERT INTO runs (run_uuid, name, source_type, source_name, entry_point_name, user_id, status, start_time, end_time, source_version, lifecycle_stage, artifact_uri, experiment_id) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)]\n[parameters: ('73f3b4503e9d45898fd1e0973d1bf27c', '', 'UNKNOWN', '', '', 'jd.lesage', 'RUNNING', 1580899031660, None, '', 'active', '<some default_path>', 'blah')]\n(Background on this error at: http://sqlalche.me/e/e3q8)"}
```
In server logs, there is the SQLalchemy exception. There is no more JSON exception.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [X] REST-API
- [ ] Examples
- [ ] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
