### PR TITLE
[WIP] Update deletion modal to allow / recommend deleting nested runs along with parent runs

### DIFF
--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -356,6 +356,13 @@ export class ExperimentView extends Component {
     const deleteDisabled = Object.keys(this.state.runsSelected).length < 1;
     const restoreDisabled = Object.keys(this.state.runsSelected).length < 1;
     const noteInfo = NoteInfo.fromTags(experimentTags);
+    const runsExpanded = persistedState.runsExpanded;
+    const parentsWithChildren = ExperimentViewUtil.getRowRenderMetadata({runInfos, tagsList,
+      runsExpanded}).filter((row) => row.childrenIds && row.childrenIds.length > 0);
+    const parentToChildRunIds = {};
+    parentsWithChildren.forEach(
+        (rowMetadata) => parentToChildRunIds[rowMetadata.runId] = rowMetadata.childrenIds);
+
     const searchInputHelpTooltipContent = (
       <div className="search-input-tooltip-content">
         Search runs using a simplified version of the SQL <b>WHERE</b> clause.<br/>
@@ -374,6 +381,7 @@ export class ExperimentView extends Component {
           isOpen={this.state.showDeleteRunModal}
           onClose={this.onCloseDeleteRunModal}
           selectedRunIds={Object.keys(this.state.runsSelected)}
+          parentRunIdToChildren={parentToChildRunIds}
         />
         <RestoreRunModal
           isOpen={this.state.showRestoreRunModal}

--- a/mlflow/server/js/src/components/modals/ConfirmModal.js
+++ b/mlflow/server/js/src/components/modals/ConfirmModal.js
@@ -35,6 +35,10 @@ export class ConfirmModal extends Component {
     title: PropTypes.string.isRequired,
     helpText: PropTypes.node.isRequired,
     confirmButtonText: PropTypes.string.isRequired,
+    // The component displays an additional confirm button per element of this array,
+    // allowing for the specification of multiple confirm options (e.g. "Delete selected runs" and
+    // "Delete selected runs and child runs")
+    extraConfirmButtonContents: PropTypes.arrayOf(String),
   };
 
   state = {
@@ -47,15 +51,16 @@ export class ConfirmModal extends Component {
     }
   }
 
-  handleSubmitWrapper() {
+  handleSubmitWrapper(confirmText) {
     this.setState({ isSubmitting: true });
-    this.props.handleSubmit().finally(() => {
+    this.props.handleSubmit(confirmText).finally(() => {
       this.props.onClose();
       this.setState({ isSubmitting: false });
     });
   }
 
   render() {
+    const extraConfirmButtonContents = this.props.extraConfirmButtonContents || [];
     return (
       <ReactModal
         isOpen={this.props.isOpen}
@@ -85,12 +90,22 @@ export class ConfirmModal extends Component {
           </Button>
           <Button
             bsStyle="primary"
-            onClick={this.handleSubmitWrapper}
+            onClick={() => this.handleSubmitWrapper(this.props.confirmButtonText)}
             disabled={this.state.isSubmitting}
             className="mlflow-save-button mlflow-form-button"
           >
             {this.props.confirmButtonText}
           </Button>
+          {extraConfirmButtonContents.map((confirmText) => {
+            return <Button
+                bsStyle="primary"
+                onClick={() => this.handleSubmitWrapper(confirmText)}
+                disabled={this.state.isSubmitting}
+                className="mlflow-save-button mlflow-form-button"
+            >
+              {confirmText}
+            </Button>;
+          })}
         </Modal.Footer>
       </ReactModal>
     );

--- a/mlflow/server/js/src/components/modals/ConfirmModal.js
+++ b/mlflow/server/js/src/components/modals/ConfirmModal.js
@@ -89,16 +89,16 @@ export class ConfirmModal extends Component {
             Cancel
           </Button>
           <Button
-            bsStyle="primary"
+            bsStyle={extraConfirmButtonContents.length === 0 ? "primary" : "default"}
             onClick={() => this.handleSubmitWrapper(this.props.confirmButtonText)}
             disabled={this.state.isSubmitting}
             className="mlflow-save-button mlflow-form-button"
           >
             {this.props.confirmButtonText}
           </Button>
-          {extraConfirmButtonContents.map((confirmText) => {
+          {extraConfirmButtonContents.map((confirmText, i) => {
             return <Button
-                bsStyle="primary"
+                bsStyle={i === extraConfirmButtonContents.length - 1 ? "primary" : "default"}
                 onClick={() => this.handleSubmitWrapper(confirmText)}
                 disabled={this.state.isSubmitting}
                 className="mlflow-save-button mlflow-form-button"

--- a/mlflow/server/js/src/components/modals/DeleteRunModal.js
+++ b/mlflow/server/js/src/components/modals/DeleteRunModal.js
@@ -36,7 +36,6 @@ class DeleteRunModal extends Component {
       });
     }
     const deletePromises = [];
-    debugger;
     idsToDelete.forEach((runId) => {
       deletePromises.push(this.props.dispatch(deleteRunApi(runId)));
     });

--- a/mlflow/server/js/src/components/modals/DeleteRunModal.js
+++ b/mlflow/server/js/src/components/modals/DeleteRunModal.js
@@ -50,17 +50,22 @@ class DeleteRunModal extends Component {
     const number = selectedRunIds.length;
     const parentIdsSelectedForDeletion = this.getParentsSelectedForDeletion();
     const extraConfirmButtonContents = parentIdsSelectedForDeletion.length === 0 ? [] :
-        ["Delete parent and child runs"];
+        ["Delete selected runs and their children"];
+    const promptMessage = `Delete Experiment ${Utils.pluralize("Run", number)}`;
+    const runNoun = Utils.pluralize('run', number);
+    const description = parentIdsSelectedForDeletion.length === 0 ?
+        `${number} experiment ${runNoun} will be deleted.` :
+        `Selected ${number} ${runNoun}, delete selected runs and optionally children as well`;
     return (
       <ConfirmModal
         isOpen={this.props.isOpen}
         onClose={this.props.onClose}
         handleSubmit={this.handleSubmit}
-        title={`Delete Experiment ${Utils.pluralize("Run", number)}`}
+        title={promptMessage}
         helpText={
           <div>
             <p>
-              <b>{number} experiment {Utils.pluralize('run', number)} will be deleted.</b>
+              <b>{description}</b>
             </p>
             {
               process.env.SHOW_GDPR_PURGING_MESSAGES === 'true' ?

--- a/mlflow/server/js/src/components/modals/DeleteRunModal.js
+++ b/mlflow/server/js/src/components/modals/DeleteRunModal.js
@@ -50,12 +50,12 @@ class DeleteRunModal extends Component {
     const number = selectedRunIds.length;
     const parentIdsSelectedForDeletion = this.getParentsSelectedForDeletion();
     const extraConfirmButtonContents = parentIdsSelectedForDeletion.length === 0 ? [] :
-        ["Delete selected runs and their children"];
+        ["Delete selected and children"];
     const promptMessage = `Delete Experiment ${Utils.pluralize("Run", number)}`;
     const runNoun = Utils.pluralize('run', number);
     const description = parentIdsSelectedForDeletion.length === 0 ?
         `${number} experiment ${runNoun} will be deleted.` :
-        `Selected ${number} ${runNoun}, delete selected runs and optionally children as well`;
+        `Selected ${number} ${runNoun}`;
     return (
       <ConfirmModal
         isOpen={this.props.isOpen}
@@ -78,7 +78,7 @@ class DeleteRunModal extends Component {
             }
           </div>
         }
-        confirmButtonText={"Delete"}
+        confirmButtonText={extraConfirmButtonContents.length > 0 ? "Delete selected" : "Delete"}
         extraConfirmButtonContents={extraConfirmButtonContents}
       />
     );


### PR DESCRIPTION
## What changes are proposed in this pull request?
Addresses #2347  by updating run deletion modal to allow / recommend deleting nested runs along with parent runs. 

In particular, when selecting parent runs for deletion, the confirmation modal now exposes a button for deleting children of the selected runs:
![image](https://user-images.githubusercontent.com/2358483/73977964-2773dc00-48e0-11ea-90b9-26808f002d72.png)

If only childless runs are selected, the UX is the same as before:
![image](https://user-images.githubusercontent.com/2358483/73978057-64d86980-48e0-11ea-99d7-03d6e1699e00.png)



## How is this patch tested?

So far, manual tests - need to write unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
