### PR TITLE
Use suppressFieldDotNotation to prevent cells from being blank when a field name contains dot

### DIFF
--- a/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView2.js
@@ -420,6 +420,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
           onColumnGroupOpened={this.persistGridState}
           suppressRowClickSelection
           suppressScrollOnNewData // retain scroll position after nested run toggling operations
+          suppressFieldDotNotation
           enableCellTextSelection
           frameworkComponents={frameworkComponents}
           fullWidthCellRendererFramework={FullWidthCellRenderer}


### PR DESCRIPTION
## What changes are proposed in this pull request?

Cells on the runs table become blank when a field name contains `.`. This PR fixes it by adding `suppressFieldDotNotation` to `AgGridReact`. 

Ref: https://www.ag-grid.com/javascript-grid-properties/#columns

before
<img width="1056" alt="Screen Shot 2020-02-06 at 21 26 17" src="https://user-images.githubusercontent.com/17039389/73937175-d091f500-4927-11ea-9dcf-643fb67d5ed4.png">

after
<img width="1056" alt="Screen Shot 2020-02-06 at 21 26 00" src="https://user-images.githubusercontent.com/17039389/73937187-d8ea3000-4927-11ea-803c-ac11189f779d.png">


Code to generate sample data to reproduce the bug.
```python
import mlflow

mlflow.log_params({
    'test.param1': 0,
    'test.param2': 0,
})

mlflow.log_metrics({
    'test.metric1': 0,
    'test.metric2': 0,
})

```

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
