### PR TITLE
Display an appropriate number of significant figures for metrics in new runs table

### DIFF
--- a/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView2.js
@@ -262,10 +262,9 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
       const tags = tagsList[idx];
       const params = paramsList[idx];
       const metrics = metricsList[idx].map(({key, value}) => {
-        const formattedMetric = Utils.formatMetric(value);
         return {
           key: key,
-          value: formattedMetric,
+          value: Utils.formatMetric(value),
         };
       });
       const runInfo = runInfos[idx];

--- a/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView2.js
@@ -261,7 +261,13 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
     const runs = mergedRows.map(({ idx, isParent, hasExpander, expanderOpen, childrenIds }) => {
       const tags = tagsList[idx];
       const params = paramsList[idx];
-      const metrics = metricsList[idx];
+      const metrics = metricsList[idx].map(({key, value}) => {
+        const formattedMetric = Utils.formatMetric(value);
+        return {
+          key: key,
+          value: formattedMetric,
+        };
+      });
       const runInfo = runInfos[idx];
 
       const user = Utils.getUser(runInfo, tags);


### PR DESCRIPTION
## What changes are proposed in this pull request?

Metrics columns in the new runs table view are displayed with many significant figures (sometimes 30+); this creates a lot of noise. In other parts of the UI (e.g., the old runs table view, the metric plot view, etc), metric values are processed prior to display via [Utils.formatMetric](https://github.com/mlflow/mlflow/blob/a861515a60469b33d5a97b0abcb2b0ba9e4fffd5/mlflow/server/js/src/utils/Utils.js#L42), which determines how many significant figures to display.

This PR applies [Utils.formatMetric](https://github.com/mlflow/mlflow/blob/a861515a60469b33d5a97b0abcb2b0ba9e4fffd5/mlflow/server/js/src/utils/Utils.js#L42) before rendering metric values in the new runs table view (it's worth noting that the "unbagged cell" approach used by the currently-disabled [ExperimentRunsTableMultiColumnView](https://github.com/mlflow/mlflow/blob/master/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView.js) already does this metric formatting as well: https://github.com/mlflow/mlflow/blob/a861515a60469b33d5a97b0abcb2b0ba9e4fffd5/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView.js#L78, https://github.com/mlflow/mlflow/blob/a861515a60469b33d5a97b0abcb2b0ba9e4fffd5/mlflow/server/js/src/components/ExperimentViewUtil.js#L293; therefore, the current behavior for ExperimentRunsTableMultiColumnView2 appears to be an oversight).

This PR fixes #2548.

## How is this patch tested?

Manual testing via generation of example metrics.

Before:

<img width="1139" alt="Screen Shot 2020-03-17 at 4 44 46 PM" src="https://user-images.githubusercontent.com/39497902/76911803-01dada80-686f-11ea-89ac-bd5cb780207a.png">

After:

<img width="1151" alt="Screen Shot 2020-03-17 at 4 43 53 PM" src="https://user-images.githubusercontent.com/39497902/76911798-fdaebd00-686e-11ea-9711-2bdfb7842850.png">


## Release Notes

Metric values in the column-based runs table are now rounded to an appropriate number of significant figures.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [X] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
