### PR TITLE
Do not open a new window when downloading artifacts

### DIFF
--- a/mlflow/server/js/src/components/ArtifactView.js
+++ b/mlflow/server/js/src/components/ArtifactView.js
@@ -74,7 +74,7 @@ export class ArtifactView extends Component {
     const { activeNodeId } = this.state;
     return (
       <div className='artifact-info-link'>
-        <a href={getSrc(activeNodeId, runUuid)} target='_blank' title='Download artifact'>
+        <a href={getSrc(activeNodeId, runUuid)} title='Download artifact'>
           <i className='fas fa-download' />
         </a>
       </div>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove `target='_blank'` in the artifact download button and prevent a browser from opening a new window.

Before
![before](https://user-images.githubusercontent.com/17039389/74030271-fc79ad00-49f1-11ea-8172-03b8c0c72220.gif)

After
![after](https://user-images.githubusercontent.com/17039389/74030288-08fe0580-49f2-11ea-848f-2ed55709b32b.gif)


## How is this patch tested?

Manual test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
