### PR TITLE
Update error messaging to specify type

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -585,8 +585,8 @@ def save_model(path, loader_module=None, data_path=None, code_path=None, conda_e
                     second_set_entries=second_argument_set)),
             error_code=INVALID_PARAMETER_VALUE)
     elif (loader_module is None) and (python_model is None):
-        msg = "Either `loader_module` or `python_model` must be specified. A `loader_module` should" \
-              " be a python module. A `python_model` should be a subclass of PythonModel"
+        msg = "Either `loader_module` or `python_model` must be specified. A `loader_module` " \
+              "should be a python module. A `python_model` should be a subclass of PythonModel"
         raise MlflowException(
             message=msg,
             error_code=INVALID_PARAMETER_VALUE)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -585,8 +585,8 @@ def save_model(path, loader_module=None, data_path=None, code_path=None, conda_e
                     second_set_entries=second_argument_set)),
             error_code=INVALID_PARAMETER_VALUE)
     elif (loader_module is None) and (python_model is None):
-        msg = "Either `loader_module` or `python_model` must be specified. `loader_module` should" \
-              " be a python module. python_model` should be a subclass of PythonModel"
+        msg = "Either `loader_module` or `python_model` must be specified. A `loader_module` should" \
+              " be a python module. A `python_model` should be a subclass of PythonModel"
         raise MlflowException(
             message=msg,
             error_code=INVALID_PARAMETER_VALUE)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -585,8 +585,10 @@ def save_model(path, loader_module=None, data_path=None, code_path=None, conda_e
                     second_set_entries=second_argument_set)),
             error_code=INVALID_PARAMETER_VALUE)
     elif (loader_module is None) and (python_model is None):
+        msg = "Either `loader_module` or `python_model` must be specified. " \
+                  "`loader_module` should be a python module. python_model` should be a subclass of PythonModel"
         raise MlflowException(
-            message="Either `loader_module` or `python_model` must be specified!",
+            message=msg,
             error_code=INVALID_PARAMETER_VALUE)
 
     if first_argument_set_specified:

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -585,8 +585,8 @@ def save_model(path, loader_module=None, data_path=None, code_path=None, conda_e
                     second_set_entries=second_argument_set)),
             error_code=INVALID_PARAMETER_VALUE)
     elif (loader_module is None) and (python_model is None):
-        msg = "Either `loader_module` or `python_model` must be specified. " \
-                  "`loader_module` should be a python module. python_model` should be a subclass of PythonModel"
+        msg = "Either `loader_module` or `python_model` must be specified. `loader_module` should" \
+              " be a python module. python_model` should be a subclass of PythonModel"
         raise MlflowException(
             message=msg,
             error_code=INVALID_PARAMETER_VALUE)

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -688,7 +688,9 @@ def test_log_model_with_unsupported_argument_combinations_throws_exception():
                                     "artifact": "/path/to/artifact",
                                 },
                                 python_model=None)
-    assert "Either `loader_module` or `python_model` must be specified!" in str(exc_info)
+    assert  "Either `loader_module` or `python_model` must be specified. A `loader_module` " \
+            "should be a python module. A `python_model` should be a subclass of PythonModel" \
+            in str(exc_info)
 
     python_model = ModuleScopedSklearnModel(predict_fn=None)
     loader_module = __name__

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -688,9 +688,9 @@ def test_log_model_with_unsupported_argument_combinations_throws_exception():
                                     "artifact": "/path/to/artifact",
                                 },
                                 python_model=None)
-    assert  "Either `loader_module` or `python_model` must be specified. A `loader_module` " \
-            "should be a python module. A `python_model` should be a subclass of PythonModel" \
-            in str(exc_info)
+    assert "Either `loader_module` or `python_model` must be specified. A `loader_module` " \
+           "should be a python module. A `python_model` should be a subclass of " \
+           "PythonModel" in str(exc_info)
 
     python_model = ModuleScopedSklearnModel(predict_fn=None)
     loader_module = __name__


### PR DESCRIPTION
## What changes are proposed in this pull request?

A user reported that the current error message `Either `loader_module` or `python_model` must be specified!` caused some pain for him due to it being unclear what `python_model` meant. He requested the error be updated to specify the type or class. 

Related to issue: https://github.com/mlflow/mlflow/pull/2404

## How is this patch tested?

1. Ran unit tests
2. Manually tested error

```
>>> mlflow.pyfunc.log_model('artifact_path')
mlflow.exceptions.MlflowException: Either `loader_module` or `python_model` must be specified. `loader_module` should be a python module. python_model` should be a subclass of PythonModel
```

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Updated error to explain what `loader_module` and `python_model` types are.  

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [x] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
