### PR TITLE
Make MLflow page titles more descriptive

### DIFF
--- a/mlflow/server/js/src/components/CompareRunView.js
+++ b/mlflow/server/js/src/components/CompareRunView.js
@@ -33,6 +33,10 @@ class CompareRunView extends Component {
     runDisplayNames: PropTypes.arrayOf(String).isRequired,
   };
 
+  componentDidMount() {
+    document.title = `Comparing ${this.props.runInfos.length} MLflow Runs`;
+  }
+
   render() {
     const experiment = this.props.experiment;
     const experimentId = experiment.getExperimentId();

--- a/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/components/ExperimentRunsTableMultiColumnView2.js
@@ -32,7 +32,7 @@ const EMPTY_CELL_PLACEHOLDER = '-';
 
 export class ExperimentRunsTableMultiColumnView2 extends React.Component {
   static propTypes = {
-    experimentId: PropTypes.number,
+    experimentId: PropTypes.string,
     runInfos: PropTypes.arrayOf(RunInfo).isRequired,
     // List of list of params in all the visible runs
     paramsList: PropTypes.arrayOf(Array).isRequired,

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -187,7 +187,7 @@ export class ExperimentView extends Component {
     if (this.props.location.pathname === "/") {
       document.title = "MLflow Experiments";
     } else {
-      document.title = this.props.experiment.name;
+      document.title = `${this.props.experiment.name} - MLflow Experiment`;
     }
   }
 

--- a/mlflow/server/js/src/components/ExperimentView.js
+++ b/mlflow/server/js/src/components/ExperimentView.js
@@ -114,6 +114,7 @@ export class ExperimentView extends Component {
     handleLoadMoreRuns: PropTypes.func.isRequired,
     loadingMore: PropTypes.bool.isRequired,
     setExperimentTagApi: PropTypes.func.isRequired,
+    location: PropTypes.object.isRequired,
   };
 
   /** Returns default values for state attributes that aren't persisted in local storage. */
@@ -179,6 +180,14 @@ export class ExperimentView extends Component {
     // in ExperimentPage
     if (!this.filtersDidUpdate(prevState)) {
       this.snapshotComponentState();
+    }
+  }
+
+  componentDidMount() {
+    if (this.props.location.pathname === "/") {
+      document.title = "MLflow Experiments";
+    } else {
+      document.title = this.props.experiment.name;
     }
   }
 

--- a/mlflow/server/js/src/components/ExperimentView.test.js
+++ b/mlflow/server/js/src/components/ExperimentView.test.js
@@ -42,6 +42,7 @@ const getExperimentViewMock = () => {
     handleLoadMoreRuns={jest.fn()}
     orderByKey={null}
     orderByAsc={false}
+    location={{pathname: "/"}}
   />);
 };
 

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -41,7 +41,7 @@ class RunView extends Component {
   };
 
   componentDidMount() {
-    document.title = this.props.runDisplayName;
+    document.title = `${this.props.runDisplayName} - MLflow Run`;
   }
 
   handleRenameRunClick = () => {

--- a/mlflow/server/js/src/components/RunView.js
+++ b/mlflow/server/js/src/components/RunView.js
@@ -40,6 +40,10 @@ class RunView extends Component {
     showTags: Utils.getVisibleTagValues(this.props.tags).length > 0,
   };
 
+  componentDidMount() {
+    document.title = this.props.runDisplayName;
+  }
+
   handleRenameRunClick = () => {
     this.setState({ showRunRenameModal: true });
   };

--- a/mlflow/server/js/src/model-registry/components/ModelListView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelListView.js
@@ -34,6 +34,10 @@ export class ModelListView extends React.Component {
     nameFilter: '',
   };
 
+  componentDidMount() {
+    document.title = 'MLflow Models';
+  }
+
   getColumns = () => {
     return [
       {

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.js
@@ -112,6 +112,10 @@ export class ModelVersionView extends React.Component {
     return null;
   }
 
+  componentDidMount() {
+    document.title = `${this.props.modelName} v${this.props.modelVersion.version} - MLflow Model`;
+  }
+
   render() {
     const {
       modelName,

--- a/mlflow/server/js/src/model-registry/components/ModelView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelView.js
@@ -40,6 +40,10 @@ export class ModelView extends React.Component {
     this.setState({ stageFilter: e.target.value });
   };
 
+  componentDidMount() {
+    document.title = `${this.props.model.registered_model.name} - MLflow Model`;
+  }
+
   getActiveVersionsCount() {
     const { modelVersions } = this.props;
     return modelVersions


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, all MLflow experiment and run pages have title "MLflow", which is frustrating when you have many MLflow tabs open. This PR changes the titles to the following pages:
Experiment View
Run View
Compare Runs
Model List View
Model View
Model Version View

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
Make MLflow page titles more descriptive.

### What component(s) does this PR affect?

- [x] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
