### PR TITLE
Import matplotlib.pyplot in log_feature_importance_plot

### DIFF
--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -212,7 +212,6 @@ def autolog():
     """
     import lightgbm
     import numpy as np
-    import matplotlib.pyplot as plt
 
     @gorilla.patch(lightgbm)
     def train(*args, **kwargs):
@@ -234,6 +233,8 @@ def autolog():
             """
             Log feature importance plot.
             """
+            import matplotlib.pyplot as plt
+
             indices = np.argsort(importance)
             features = np.array(features)[indices]
             importance = importance[indices]

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -216,7 +216,6 @@ def autolog(importance_types=['weight']):  # pylint: disable=W0102
     """
     import xgboost
     import numpy as np
-    import matplotlib.pyplot as plt
 
     @gorilla.patch(xgboost)
     def train(*args, **kwargs):
@@ -239,6 +238,8 @@ def autolog(importance_types=['weight']):  # pylint: disable=W0102
             """
             Log feature importance plot.
             """
+            import matplotlib.pyplot as plt
+
             features = np.array(features)
             importance = np.array(importance)
             indices = np.argsort(importance)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Follow-up for #2386. This PR moves the import statement `import matplotlib.pyplot as plt` in the `log_feature_importance_plot` function to prevent XGBoost and LIghtGBM `autolog` from failing entirely when `matplotlib` is not installed. 

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
