### PR TITLE
Log artifact without copying file metadata

### DIFF
--- a/mlflow/store/artifact/local_artifact_repo.py
+++ b/mlflow/store/artifact/local_artifact_repo.py
@@ -29,7 +29,7 @@ class LocalArtifactRepository(ArtifactRepository):
             self.artifact_dir
         if not os.path.exists(artifact_dir):
             mkdir(artifact_dir)
-        shutil.copy(local_file, artifact_dir)
+        shutil.copyfile(local_file, os.path.join(artifact_dir, os.path.basename(local_file)))
 
     def _is_directory(self, artifact_path):
         # NOTE: The path is expected to be in posix format.
@@ -48,7 +48,7 @@ class LocalArtifactRepository(ArtifactRepository):
             self.artifact_dir
         if not os.path.exists(artifact_dir):
             mkdir(artifact_dir)
-        dir_util.copy_tree(src=local_dir, dst=artifact_dir)
+        dir_util.copy_tree(src=local_dir, dst=artifact_dir, preserve_mode=0, preserve_times=0)
 
     def download_artifacts(self, artifact_path, dst_path=None):
         """


### PR DESCRIPTION
## What changes are proposed in this pull request?

Log artifacts without copying file permissions or times. It solved the issue #1215 . 
When logging artifacts to an NFS mount or a local path that the client doesn't have chmod permission, the logging could be completed without permission error.

## How is this patch tested?

Tested with Unit test and logging artifacts to an NFS mount without having chmod permission.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.


### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [x] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
