### PR TITLE
Announce deprecation of Python 2 support in MLflow

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -40,18 +40,19 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E
 # log a deprecated warning only once per function per module
 warnings.filterwarnings("module", category=DeprecationWarning)
 
-if sys.version_info.major == 2:
-    warnings.warn("Python 2 support for MLflow is deprecated. A future release of MLflow "
-                  "will drop support for Python 2. At that point, existing Python 2 workflows that "
-                  "use MLflow will continue to work without modification, but Python 2 users will "
-                  "no longer get access to the latest features and bugfixes.", DeprecationWarning)
-
-
 # pylint: disable=wrong-import-position
 import mlflow.projects as projects  # noqa
 import mlflow.tracking as tracking  # noqa
 
 _configure_mlflow_loggers(root_module_name=__name__)
+
+if sys.version_info.major == 2:
+    warnings.warn("Python 2 support for MLflow is deprecated and will be dropped in a future "
+                  "MLflow release. At that point, existing Python 2 workflows that "
+                  "use MLflow will continue to work without modification, but Python 2 users will "
+                  "no longer get access to the latest features and bugfixes. We recommend you "
+                  "upgrade to Python 3 - see https://docs.python.org/3/howto/pyporting.html for "
+                  "a migration guide.", DeprecationWarning)
 
 ActiveRun = mlflow.tracking.fluent.ActiveRun
 log_param = mlflow.tracking.fluent.log_param

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -42,7 +42,7 @@ warnings.filterwarnings("module", category=DeprecationWarning)
 
 if sys.version_info.major == 2:
     warnings.warn("Python 2 support for MLflow is deprecated. A future release of MLflow "
-                  "will drop support for Python 2. At that point, existing Python 2 workflows that"
+                  "will drop support for Python 2. At that point, existing Python 2 workflows that "
                   "use MLflow will continue to work without modification, but Python 2 users will "
                   "no longer get access to the latest features and bugfixes.", DeprecationWarning)
 

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -24,6 +24,8 @@ implement mutual exclusion manually.
 
 For a lower level API, see the :py:mod:`mlflow.tracking` module.
 """
+import sys
+
 from mlflow.version import VERSION as __version__
 from mlflow.utils.logging_utils import _configure_mlflow_loggers
 import mlflow.tracking._model_registry.fluent
@@ -37,6 +39,10 @@ warnings.filterwarnings("ignore", message="numpy.dtype size changed")  # noqa: E
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E402
 # log a deprecated warning only once per function per module
 warnings.filterwarnings("module", category=DeprecationWarning)
+
+if sys.version == "2":
+    warnings.warn("Usage of Python 2 with MLflow is deprecated. Future versions of MLflow will "
+                  "drop support for Python 2.")
 
 # pylint: disable=wrong-import-position
 import mlflow.projects as projects  # noqa

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -40,9 +40,12 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E
 # log a deprecated warning only once per function per module
 warnings.filterwarnings("module", category=DeprecationWarning)
 
-if sys.version == "2":
-    warnings.warn("Usage of Python 2 with MLflow is deprecated. Future versions of MLflow will "
-                  "drop support for Python 2.")
+if sys.version_info.major == 2:
+    warnings.warn("Python 2 support for MLflow is deprecated. A future release of MLflow "
+                  "will drop support for Python 2. At that point, existing Python 2 workflows that"
+                  "use MLflow will continue to work without modification, but Python 2 users will "
+                  "no longer get access to the latest features and bugfixes.", DeprecationWarning)
+
 
 # pylint: disable=wrong-import-position
 import mlflow.projects as projects  # noqa

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -48,11 +48,11 @@ _configure_mlflow_loggers(root_module_name=__name__)
 
 if sys.version_info.major == 2:
     warnings.warn("MLflow support for Python 2 is deprecated and will be dropped in a future "
-                  "MLflow release. At that point, existing Python 2 workflows that "
-                  "use MLflow will continue to work without modification, but Python 2 users will "
-                  "no longer get access to the latest features and bugfixes. We recommend you "
-                  "upgrade to Python 3 - see https://docs.python.org/3/howto/pyporting.html for "
-                  "a migration guide.", DeprecationWarning)
+                  "release. At that point, existing Python 2 workflows that use MLflow will "
+                  "continue to work without modification, but Python 2 users will no longer "
+                  "get access to the latest MLflow features and bugfixes. We recommend that "
+                  "you upgrade to Python 3 - see https://docs.python.org/3/howto/pyporting.html "
+                  "for a migration guide.", DeprecationWarning)
 
 ActiveRun = mlflow.tracking.fluent.ActiveRun
 log_param = mlflow.tracking.fluent.log_param

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -47,7 +47,7 @@ import mlflow.tracking as tracking  # noqa
 _configure_mlflow_loggers(root_module_name=__name__)
 
 if sys.version_info.major == 2:
-    warnings.warn("Python 2 support for MLflow is deprecated and will be dropped in a future "
+    warnings.warn("MLflow support for Python 2 is deprecated and will be dropped in a future "
                   "MLflow release. At that point, existing Python 2 workflows that "
                   "use MLflow will continue to work without modification, but Python 2 users will "
                   "no longer get access to the latest features and bugfixes. We recommend you "


### PR DESCRIPTION
## What changes are proposed in this pull request?

Announces deprecation of Python 2 support, to be dropped entirely from MLflow in a future release.

Python 2 is EOL, and many popular packages already no longer publish new Python 2-compatible releases, e.g. [Numpy](https://numpy.org/neps/nep-0029-deprecation_policy.html), [Pandas](https://pandas.pydata.org/pandas-docs/version/0.23.1/install.html#plan-for-dropping-python-2-7) and [TensorFlow](https://github.com/tensorflow/tensorflow/releases/tag/v2.1.0) have already dropped support. Dropping Python 2 support in MLflow will reduce our maintenance burden & CI times, in particular:

* Reduce cost of maintaining separate test dependency trees for Python 2 vs Python 3 (this cost will grow as more libraries, e.g. TF, drop Python 2 support)
* Reduce cost of maintaining separate test logic/selectively flagging tests to run on Python 2 & Python 3 (cost will also grow as more libraries e.g. TF drop Python 2 support)
* Reduce ongoing tech debt of using Python 2 & Python 3 compatibility libraries like `six`
* Reduce CI times

The main user-facing impact of doing so is that Python 2 users will no longer receive new features/bugfixes.

This PR therefore announces deprecation of Python 2 support. The idea is to publish another MLflow release with Python 2 support & this deprecation warning, and then drop support entirely in the subsequent release.


## How is this patch tested?

Manually verified the deprecation warning appears on the first `import mlflow` in a Python 2 conda environment (& not in a Python 3 conda environment):

### Python 2
```
(mlflow-python2) ➜  mlflow git:(deprecate-python-2) ✗ python
Python 2.7.16 |Anaconda, Inc.| (default, Mar 14 2019, 16:24:02) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import mlflow
mlflow/__init__.py:47: DeprecationWarning: Python 2 support for MLflow is deprecated. A future release of MLflow will drop support for Python 2. At that point, existing Python 2 workflows that use MLflow will continue to work without modification, but Python 2 users will no longer get access to the latest features and bugfixes.
  "no longer get access to the latest features and bugfixes.", DeprecationWarning)
>>> import mlflow
>>> import mlflow.tracking.fluent
>>>
```

### Python 3
```
(mlflow-python3) ➜  mlflow git:(deprecate-python-2) ✗ python
Python 3.6.8 |Anaconda, Inc.| (default, Dec 29 2018, 19:04:46) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import mlflow
>>> 
>>> import mlflow
>>> 
```

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
