### PR TITLE
Pin fbprophet to avoid import error in Python 2

### DIFF
--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -35,6 +35,7 @@ pytest-localserver==0.5.0
 sqlalchemy==1.3.0
 kubernetes==9.0.0
 pystan==2.17.1.0
-fbprophet>=0.5
+# TODO (harupy): Unpin fbprophet when MLflow drops Python 2 support in a future release.
+fbprophet==0.5
 # test plugin
 tests/resources/mlflow-test-plugin/

--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -35,7 +35,7 @@ pytest-localserver==0.5.0
 sqlalchemy==1.3.0
 kubernetes==9.0.0
 pystan==2.17.1.0
-# TODO (harupy): Unpin fbprophet when MLflow drops Python 2 support in a future release.
+# TODO (harupy): Unpin fbprophet once https://github.com/facebook/prophet/issues/1339 is fixed.
 fbprophet==0.5
 # test plugin
 tests/resources/mlflow-test-plugin/


### PR DESCRIPTION
## What changes are proposed in this pull request?

The CI fails when importing `fbprophet` due to SyntaxError in Python 2.
This PR pins ` fbprophet` to avoid the error.

### Related issue
https://github.com/facebook/prophet/issues/1339

### Error log
```
    ERROR: Command errored out with exit status 1:
     command: /home/travis/miniconda/envs/test-environment/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-zwK91o/fbprophet/setup.py'"'"'; __file__='"'"'/tmp/pip-install-zwK91o/fbprophet/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-zwK91o/fbprophet/pip-egg-info
         cwd: /tmp/pip-install-zwK91o/fbprophet/
    Complete output (6 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-zwK91o/fbprophet/setup.py", line 30
        def get_backends_from_env() -> List[str]:
                                    ^
    SyntaxError: invalid syntax
    ----------------------------------------
```

https://travis-ci.org/mlflow/mlflow/jobs/652344271#L855

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
