### PR TITLE
Add action type to parameter

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -171,7 +171,8 @@ file in YAML syntax, to the project's root directory. The following is an exampl
         parameters:
           data_file: path
           regularization: {type: float, default: 0.1}
-        command: "python train.py -r {regularization} {data_file}"
+          args: {type: action, default: '--earlystopping'}
+        command: "python train.py -r {regularization} {data_file} {args}"
       validate:
         parameters:
           data_file: path
@@ -308,8 +309,12 @@ uri
     that know how to read from distributed storage (e.g., programs that use Spark).
 
 action
-    An action string. MLflow validates that the parameter is valid. Pass an empty string
-    to skip the argument
+    An action string. Pass an empty string to skip the argument.
+    More information on usage of action parameter can be found
+    `here https://docs.python.org/dev/library/argparse.html#action`_.
+    MLflow validates that the action parameter value is a
+    `valid identifier <https://docs.python.org/3/reference/lexical_analysis.html#identifiers>`_
+    that is prefixed either with single/double hyphen.
 
 .. _running-projects:
 

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -307,6 +307,10 @@ uri
     relative paths to absolute paths, as in the ``path`` type. Use this type for programs
     that know how to read from distributed storage (e.g., programs that use Spark).
 
+action
+    An action string. MLflow validates that the parameter is valid. Pass an empty string
+    to skip the argument
+
 .. _running-projects:
 
 Running Projects

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -65,6 +65,12 @@ def is_uri(string):
     return len(parsed_uri.scheme) > 0
 
 
+def is_action(action_string):
+    pattern = re.compile("^-{1,2}[a-zA-z]+")
+    return pattern.match(action_string)
+
+
+
 def download_uri(uri, output_path):
     if DBFS_REGEX.match(uri):
         _fetch_dbfs(uri, output_path)

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -10,6 +10,7 @@ from mlflow.utils import process
 DBFS_PREFIX = "dbfs:/"
 S3_PREFIX = "s3://"
 GS_PREFIX = "gs://"
+ACTION_REGEX = re.compile("^-{1,2}[^\d\W]\w*\Z")
 DBFS_REGEX = re.compile("^%s" % re.escape(DBFS_PREFIX))
 S3_REGEX = re.compile("^%s" % re.escape(S3_PREFIX))
 GS_REGEX = re.compile("^%s" % re.escape(GS_PREFIX))
@@ -66,8 +67,9 @@ def is_uri(string):
 
 
 def is_action(action_string):
-    pattern = re.compile("^-{1,2}[a-zA-z]+")
-    return pattern.match(action_string)
+    if len(action_string.strip()) > 0:
+        return ACTION_REGEX.match(action_string)
+    return True
 
 
 def download_uri(uri, output_path):

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -70,7 +70,6 @@ def is_action(action_string):
     return pattern.match(action_string)
 
 
-
 def download_uri(uri, output_path):
     if DBFS_REGEX.match(uri):
         _fetch_dbfs(uri, output_path)

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -10,7 +10,7 @@ from mlflow.utils import process
 DBFS_PREFIX = "dbfs:/"
 S3_PREFIX = "s3://"
 GS_PREFIX = "gs://"
-ACTION_REGEX = re.compile("^-{1,2}[^\d\W]\w*\Z")
+ACTION_REGEX = re.compile(r"^-{1,2}[^\d\W]\w*\Z")
 DBFS_REGEX = re.compile("^%s" % re.escape(DBFS_PREFIX))
 S3_REGEX = re.compile("^%s" % re.escape(S3_PREFIX))
 GS_REGEX = re.compile("^%s" % re.escape(GS_PREFIX))

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -13,7 +13,7 @@ from mlflow.utils.string_utils import is_string_type
 
 MLPROJECT_FILE_NAME = "mlproject"
 DEFAULT_CONDA_FILE_NAME = "conda.yaml"
-EMPTY_STRING_REGEX = "\s+((\"\")|(\'\'))"
+EMPTY_STRING_REGEX = r"\s+((\"\")|(\'\'))"
 
 
 def _find_mlproject(directory):

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -151,7 +151,6 @@ class EntryPoint(object):
         self._validate_parameters(user_parameters)
         final_params = {}
         extra_params = {}
-
         for key, param_obj in self.parameters.items():
             value = user_parameters[key] if key in user_parameters else self.parameters[key].default
             final_params[key] = param_obj.compute_value(value, storage_dir)
@@ -202,10 +201,18 @@ class Parameter(object):
             data.download_uri(uri=user_param_value, output_path=dest_path)
         return os.path.abspath(dest_path)
 
+    def _compute_action_value(self, user_param_value):
+        if not data.is_action(user_param_value):
+            raise ExecutionException("Expected parameter %s but got "
+                                     "%s" % (self.name, user_param_value))
+        return user_param_value
+
     def compute_value(self, param_value, storage_dir):
         if storage_dir and self.type == "path":
             return self._compute_path_value(param_value, storage_dir)
         elif self.type == "uri":
             return self._compute_uri_value(param_value)
+        elif self.type == "action":
+            return self._compute_action_value(param_value)
         else:
             return param_value

--- a/tests/projects/test_entry_point.py
+++ b/tests/projects/test_entry_point.py
@@ -15,17 +15,17 @@ def test_entry_point_compute_params():
     Tests that EntryPoint correctly computes a final set of parameters to use when running a project
     """
     project = load_project()
-    entry_point = project.get_entry_point("greeter")
+    entry_point = project.get_entry_point("greeter_compute_params")
     # Pass extra "excitement" param, use default value for `greeting` param
     with TempDir() as storage_dir:
         params, extra_params = entry_point.compute_parameters(
             {"name": "friend", "excitement": 10}, storage_dir)
-        assert params == {"name": "friend", "greeting": "hi"}
+        assert params == {"name": "friend", "greeting": "hi", "args": "--goodbye"}
         assert extra_params == {"excitement": "10"}
         # Don't pass extra "excitement" param, pass value for `greeting`
         params, extra_params = entry_point.compute_parameters(
             {"name": "friend", "greeting": "hello"}, storage_dir)
-        assert params == {"name": "friend", "greeting": "hello"}
+        assert params == {"name": "friend", "greeting": "hello", "args": "--goodbye"}
         assert extra_params == {}
         # Raise exception on missing required parameter
         with pytest.raises(ExecutionException):
@@ -47,6 +47,7 @@ def test_entry_point_compute_command():
         # Test shell escaping
         name_value = "friend; echo 'hi'"
         command = entry_point.compute_command({"name": name_value}, storage_dir)
+        print(command)
         assert command == "python greeter.py %s %s" % (shlex_quote("hi"), shlex_quote(name_value))
 
 
@@ -108,12 +109,14 @@ def test_uri_parameter():
             entry_point.compute_command(user_parameters={"uri": dst_dir}, storage_dir=dst_dir)
 
 
+
 def test_params():
     defaults = {
         "alpha": "float",
         "l1_ratio": {"type": "float", "default": 0.1},
         "l2_ratio": {"type": "float", "default": 0.0003},
         "random_str": {"type": "string", "default": "hello"},
+        "args": {"type": "action", "default": "--early-stopping"}
     }
     entry_point = EntryPoint("entry_point_name", defaults, "command_name script.py")
 
@@ -127,7 +130,7 @@ def test_params():
 
     user_3 = {"alpha": 0.004, "gamma": 0.89}
     expected_final_3 = {"alpha": '0.004', "l1_ratio": '0.1', "l2_ratio": '0.0003',
-                        "random_str": "hello"}
+                        "random_str": "hello", "args": "--early-stopping"}
     expected_extra_3 = {"gamma": "0.89"}
     final_3, extra_3 = entry_point.compute_parameters(user_3, None)
     assert expected_extra_3 == extra_3
@@ -135,7 +138,7 @@ def test_params():
 
     user_4 = {"alpha": 0.004, "l1_ratio": 0.0008, "random_str_2": "hello"}
     expected_final_4 = {"alpha": '0.004', "l1_ratio": '0.0008', "l2_ratio": '0.0003',
-                        "random_str": "hello"}
+                        "random_str": "hello", "args": "--early-stopping"}
     expected_extra_4 = {"random_str_2": "hello"}
     final_4, extra_4 = entry_point.compute_parameters(user_4, None)
     assert expected_extra_4 == extra_4
@@ -143,7 +146,7 @@ def test_params():
 
     user_5 = {"alpha": -0.99, "random_str": "hi"}
     expected_final_5 = {"alpha": '-0.99', "l1_ratio": '0.1', "l2_ratio": '0.0003',
-                        "random_str": "hi"}
+                        "random_str": "hi", "args": "--early-stopping"}
     expected_extra_5 = {}
     final_5, extra_5 = entry_point.compute_parameters(user_5, None)
     assert expected_final_5 == final_5
@@ -151,7 +154,7 @@ def test_params():
 
     user_6 = {"alpha": 0.77, "ALPHA": 0.89}
     expected_final_6 = {"alpha": '0.77', "l1_ratio": '0.1', "l2_ratio": '0.0003',
-                        "random_str": "hello"}
+                        "random_str": "hello", "args": "--early-stopping"}
     expected_extra_6 = {"ALPHA": "0.89"}
     final_6, extra_6 = entry_point.compute_parameters(user_6, None)
     assert expected_extra_6 == extra_6

--- a/tests/projects/test_entry_point.py
+++ b/tests/projects/test_entry_point.py
@@ -53,6 +53,9 @@ def test_entry_point_compute_command():
         command = entry_point.compute_command({"name": "friend", "excitement": 10, "args": ''},
                                               storage_dir)
         assert command == "python greeter.py hi friend --excitement 10"
+        command = entry_point.compute_command({"name": "friend", "excitement": 10, "args": '--goodbye'},
+                                              storage_dir)
+        assert command == "python greeter.py hi friend --goodbye --excitement 10"
         with pytest.raises(ExecutionException):
             entry_point.compute_command({}, storage_dir)
         # Test shell escaping
@@ -181,7 +184,7 @@ def test_params():
     with pytest.raises(ExecutionException):
         entry_point.compute_parameters(user_8, None)
 
-    user_9 = {"alpha": 0.004, "gamma": 0.89, "args": "early-stopping"}
+    user_9 = {"alpha": 0.004, "gamma": 0.89, "args": "earlystopping"}
     with pytest.raises(ExecutionException):
         entry_point.compute_parameters(user_9, None)
 

--- a/tests/projects/test_entry_point.py
+++ b/tests/projects/test_entry_point.py
@@ -53,7 +53,8 @@ def test_entry_point_compute_command():
         command = entry_point.compute_command({"name": "friend", "excitement": 10, "args": ''},
                                               storage_dir)
         assert command == "python greeter.py hi friend --excitement 10"
-        command = entry_point.compute_command({"name": "friend", "excitement": 10, "args": '--goodbye'},
+        command = entry_point.compute_command({"name": "friend", "excitement": 10,
+                                               "args": '--goodbye'},
                                               storage_dir)
         assert command == "python greeter.py hi friend --goodbye --excitement 10"
         with pytest.raises(ExecutionException):

--- a/tests/projects/test_entry_point.py
+++ b/tests/projects/test_entry_point.py
@@ -47,7 +47,6 @@ def test_entry_point_compute_command():
         # Test shell escaping
         name_value = "friend; echo 'hi'"
         command = entry_point.compute_command({"name": name_value}, storage_dir)
-        print(command)
         assert command == "python greeter.py %s %s" % (shlex_quote("hi"), shlex_quote(name_value))
 
 
@@ -107,7 +106,6 @@ def test_uri_parameter():
         # Test that we raise an exception if a local path is passed to a parameter of type URI
         with pytest.raises(ExecutionException):
             entry_point.compute_command(user_parameters={"uri": dst_dir}, storage_dir=dst_dir)
-
 
 
 def test_params():

--- a/tests/projects/test_project_spec.py
+++ b/tests/projects/test_project_spec.py
@@ -13,15 +13,18 @@ def test_project_get_entry_point():
     project = load_project()
     entry_point = project.get_entry_point("greeter")
     assert entry_point.name == "greeter"
-    assert entry_point.command == "python greeter.py {greeting} {name}"
+    assert entry_point.command == "python greeter.py {greeting} {name} {args}"
     # Validate parameters
-    assert set(entry_point.parameters.keys()) == set(["name", "greeting"])
+    assert set(entry_point.parameters.keys()) == set(["name", "greeting", "args"])
     name_param = entry_point.parameters["name"]
     assert name_param.type == "string"
     assert name_param.default is None
     greeting_param = entry_point.parameters["greeting"]
     assert greeting_param.type == "string"
     assert greeting_param.default == "hi"
+    greeting_param = entry_point.parameters["args"]
+    assert greeting_param.type == "action"
+    assert greeting_param.default == "--goodbye"
 
 
 def test_project_get_unspecified_entry_point():

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -31,6 +31,11 @@ def test_run_local_params(tracking_uri_mock):  # pylint: disable=unused-argument
                                 "greeting=hi", "-P", "name=%s" % name,
                                 "-P", "excitement=%s" % excitement_arg, "-P",
                                 "args=%s" % action_args])
+    action_args = ""
+    invoke_cli_runner(cli.run, [TEST_PROJECT_DIR, "-e", "greeter", "-P",
+                                "greeting=hi", "-P", "name=%s" % name,
+                                "-P", "excitement=%s" % excitement_arg, "-P",
+                                "args=%s" % action_args])
 
 
 @pytest.mark.large

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -23,9 +23,14 @@ _logger = logging.getLogger(__name__)
 def test_run_local_params(tracking_uri_mock):  # pylint: disable=unused-argument
     excitement_arg = 2
     name = "friend"
+    action_args = "--goodbye"
     invoke_cli_runner(cli.run, [TEST_PROJECT_DIR, "-e", "greeter", "-P",
                                 "greeting=hi", "-P", "name=%s" % name,
                                 "-P", "excitement=%s" % excitement_arg])
+    invoke_cli_runner(cli.run, [TEST_PROJECT_DIR, "-e", "greeter", "-P",
+                                "greeting=hi", "-P", "name=%s" % name,
+                                "-P", "excitement=%s" % excitement_arg, "-P",
+                                "args=%s" % action_args])
 
 
 @pytest.mark.large

--- a/tests/resources/example_project/MLproject
+++ b/tests/resources/example_project/MLproject
@@ -7,7 +7,8 @@ entry_points:
     parameters:
       greeting: {type: string, default: "hi"}
       name: string
-    command: "python greeter.py {greeting} {name}"
+      args: {type: action, default: "--goodbye"}
+    command: "python greeter.py {greeting} {name} {args}"
   line_count:
     parameters:
       path: path
@@ -20,12 +21,6 @@ entry_points:
     parameters:
       duration: int
     command: "sleep {duration}"
-  greeter_compute_params:
-    parameters:
-      greeting: {type: string, default: "hi"}
-      name: string
-      args: {type: action, default: "--goodbye"}
-    command: "python greeter.py {greeting} {name} {args}"
   test_tracking:
     parameters:
       use_start_run: bool

--- a/tests/resources/example_project/MLproject
+++ b/tests/resources/example_project/MLproject
@@ -20,6 +20,12 @@ entry_points:
     parameters:
       duration: int
     command: "sleep {duration}"
+  greeter_compute_params:
+    parameters:
+      greeting: {type: string, default: "hi"}
+      name: string
+      args: {type: action, default: "--goodbye"}
+    command: "python greeter.py {greeting} {name} {args}"
   test_tracking:
     parameters:
       use_start_run: bool

--- a/tests/resources/example_project/greeter.py
+++ b/tests/resources/example_project/greeter.py
@@ -9,8 +9,11 @@ if __name__ == "__main__":
     parser.add_argument("greeting", help="Greeting to use", type=str)
     parser.add_argument("name", help="Name of person to greet", type=str)
     parser.add_argument("--excitement", help="Excitement level (int) of greeting", type=int)
+    parser.add_argument("--goodbye", "-g", help="Say goodbye after greeting", action='store_true')
     args = parser.parse_args()
     greeting = [args.greeting, args.name]
     if args.excitement is not None:
         greeting.append("!" * args.excitement)
     print(" ".join(greeting))
+    if args.goodbye:
+        print("Goodbye {}".format(args.name))


### PR DESCRIPTION
## What changes are proposed in this pull request?
Add action type to MLProjects parameters. Currently there is support for string, uri, path and float. 

Related issue:
https://github.com/mlflow/mlflow/issues/1945

However, to make this consistent with current parameter support there is no support for making the parameters optional but rather allow users to pass default value.

## How is this patch tested?
Unit tested and tests are included in test_entry_point in projects tests.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add support for action type.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [x] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
