### PR TITLE
Pinning fbprophet version for large tests

### DIFF
--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -35,6 +35,6 @@ pytest-localserver==0.5.0
 sqlalchemy==1.3.0
 kubernetes==9.0.0
 pystan==2.17.1.0
-fbprophet>=0.5
+fbprophet==0.5
 # test plugin
 tests/resources/mlflow-test-plugin/


### PR DESCRIPTION
## What changes are proposed in this pull request?

Pins `fbprophet==0.5` to fix broken tests like https://travis-ci.org/mlflow/mlflow/jobs/652371322

## How is this patch tested?

Travis

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
