### PR TITLE
[UI] Better error messages for model registry

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -32,6 +32,7 @@ from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.validation import _validate_batch_log_api_req
 from mlflow.utils.string_utils import is_string_type
+from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 
 _logger = logging.getLogger(__name__)
 _tracking_store = None
@@ -62,9 +63,7 @@ class TrackingStoreRegistryWrapper(TrackingStoreRegistry):
 class ModelRegistryStoreRegistryWrapper(ModelRegistryStoreRegistry):
     def __init__(self):
         super(ModelRegistryStoreRegistryWrapper, self).__init__()
-        # Model Registry does not support file based stores
-        self.register('', lambda store_uri: None)
-        self.register('file', lambda store_uri: None)
+        # NB: Model Registry does not support file based stores
         for scheme in DATABASE_ENGINES:
             self.register(scheme, self._get_sqlalchemy_store)
         self.register_entrypoints()
@@ -100,7 +99,10 @@ def _get_model_registry_store(backend_store_uri=None):
 
 def initialize_backend_stores(backend_store_uri=None, default_artifact_root=None):
     _get_tracking_store(backend_store_uri, default_artifact_root)
-    _get_model_registry_store(backend_store_uri)
+    try:
+        _get_model_registry_store(backend_store_uri)
+    except UnsupportedModelRegistryStoreURIException:
+        pass
 
 
 def _get_request_json(flask_request=request):

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -13,7 +13,7 @@ class UnsupportedModelRegistryStoreURIException(MlflowException):
         message = ("Unsupported URI '{}' for model registry store. Supported schemes are: {}."
                    " See https://www.mlflow.org/docs/latest/tracking.html#storage for how to"
                    " setup a compatible server.").format(
-            unsupported_uri, supported_uri_schemes,)
+            unsupported_uri, supported_uri_schemes)
         super(UnsupportedModelRegistryStoreURIException, self).__init__(
             message, error_code=INVALID_PARAMETER_VALUE)
         self.supported_uri_schemes = supported_uri_schemes

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -10,8 +10,10 @@ from mlflow.utils.uri import get_uri_scheme
 class UnsupportedModelRegistryStoreURIException(MlflowException):
     """Exception thrown when building a model registry store with an unsupported URI"""
     def __init__(self, unsupported_uri, supported_uri_schemes):
-        message = "Unsupported URI '{}' for model registry store. Supported schemes are: {}".format(
-            unsupported_uri, supported_uri_schemes)
+        message = ("Unsupported URI '{}' for model registry store. Supported schemes are: {}."
+                   " See https://www.mlflow.org/docs/latest/tracking.html#storage for how to"
+                   " setup a compatible server.").format(
+            unsupported_uri, supported_uri_schemes,)
         super(UnsupportedModelRegistryStoreURIException, self).__init__(
             message, error_code=INVALID_PARAMETER_VALUE)
         self.supported_uri_schemes = supported_uri_schemes


### PR DESCRIPTION
## What changes are proposed in this pull request?

Before this PR, attempting to register a model from the UI would result in an opaque "INTERNAL_SERVER_ERROR". This changes it to return the same message as would be returned by calling the API.

![image](https://user-images.githubusercontent.com/1400247/74996908-afda9c80-5409-11ea-90b2-991a009d7954.png)

Note that there are 2 shown because we make 2 API calls from the JS...