### PR TITLE
Fix handleLayoutChange to update dragmode

### DIFF
--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -221,7 +221,6 @@ export class MetricsPlotPanel extends React.Component {
   handleLayoutChange = (newLayout) => {
     // Unfortunately, we need to parse out the x & y axis range changes from the onLayout event...
     // see https://plot.ly/javascript/plotlyjs-events/#update-data
-    // debugger;
     const {
       "xaxis.range[0]": newXRange0,
       "xaxis.range[1]": newXRange1,

--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -51,6 +51,7 @@ export class MetricsPlotPanel extends React.Component {
       // and then back to linear scale (we save the initial negative linear y-axis bounds so
       // that we can restore them when converting from log back to linear scale)
       lastLinearYAxisRange: [],
+      layout: {},
     };
     this.loadMetricHistory(this.props.runUuids, this.state.selectedMetricKeys);
   }

--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -260,6 +260,14 @@ export class MetricsPlotPanel extends React.Component {
         yaxis: { autorange: true, type: axisType },
       };
     }
+
+    if (newLayout.dragmode) {
+      mergedLayout = {
+        ...mergedLayout,
+        dragmode: newLayout.dragmode,
+      };
+    }
+
     this.setState({ layout: mergedLayout, lastLinearYAxisRange });
   };
 

--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -228,6 +228,8 @@ export class MetricsPlotPanel extends React.Component {
       "yaxis.range[1]": newYRange1,
       "xaxis.autorange": xAxisAutorange,
       "yaxis.autorange": yAxisAutorange,
+      "yaxis.showspikes": yAxisShowSpikes,
+      "xaxis.showspikes": xAxisShowSpikes,
       ...restFields
     } = newLayout;
 
@@ -236,38 +238,39 @@ export class MetricsPlotPanel extends React.Component {
       ...restFields,
     };
     let lastLinearYAxisRange = [...this.state.lastLinearYAxisRange];
+
+    // Set fields for x axis
+    const newXAxis = mergedLayout.xaxis || {};
     if (newXRange0 !== undefined && newXRange1 !== undefined) {
-      mergedLayout = {
-        ...mergedLayout,
-        xaxis: {
-          range: [newXRange0, newXRange1],
-        },
-      };
+      newXAxis.range = [newXRange0, newXRange1];
     }
-    if (newYRange0 !== undefined && newYRange1 !== undefined) {
-      lastLinearYAxisRange = [];
-      mergedLayout = {
-        ...mergedLayout,
-        yaxis: {
-          range: [newYRange0, newYRange1],
-        },
-      };
+    if (xAxisShowSpikes) {
+      newXAxis.showspikes = true;
     }
     if (xAxisAutorange === true) {
-      mergedLayout = {
-        ...mergedLayout,
-        xaxis: { autorange: true },
-      };
+      newXAxis.autorange = true;
+    }
+    // Set fields for y axis
+    const newYAxis = mergedLayout.yaxis || {};
+    if (newYRange0 !== undefined && newYRange1 !== undefined) {
+      newYAxis.range = [newYRange0, newYRange1];
+    }
+    if (yAxisShowSpikes) {
+      newYAxis.showspikes = true;
     }
     if (yAxisAutorange === true) {
       lastLinearYAxisRange = [];
       const axisType = this.state.layout && this.state.layout.yaxis &&
         this.state.layout.yaxis.type === 'log' ? "log" : "linear";
-      mergedLayout = {
-        ...mergedLayout,
-        yaxis: { autorange: true, type: axisType },
-      };
+      newYAxis.autorange = true;
+      newYAxis.type = axisType;
     }
+    // Merge new X & Y axis info into layout
+    mergedLayout = {
+      ...mergedLayout,
+      xaxis: newXAxis,
+      yaxis: newYAxis,
+    };
     this.setState({ layout: mergedLayout, lastLinearYAxisRange });
   };
 

--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -234,7 +234,6 @@ export class MetricsPlotPanel extends React.Component {
       ...this.state.layout,
       ...rest,
     };
-
     let lastLinearYAxisRange = [...this.state.lastLinearYAxisRange];
     if (newXRange0 !== undefined && newXRange1 !== undefined) {
       mergedLayout = {
@@ -268,7 +267,6 @@ export class MetricsPlotPanel extends React.Component {
         yaxis: { autorange: true, type: axisType },
       };
     }
-
     this.setState({ layout: mergedLayout, lastLinearYAxisRange });
   };
 

--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -220,13 +220,21 @@ export class MetricsPlotPanel extends React.Component {
   handleLayoutChange = (newLayout) => {
     // Unfortunately, we need to parse out the x & y axis range changes from the onLayout event...
     // see https://plot.ly/javascript/plotlyjs-events/#update-data
-    const newXRange0 = newLayout["xaxis.range[0]"];
-    const newXRange1 = newLayout["xaxis.range[1]"];
-    const newYRange0 = newLayout["yaxis.range[0]"];
-    const newYRange1 = newLayout["yaxis.range[1]"];
+    const {
+      "xaxis.range[0]": newXRange0,
+      "xaxis.range[1]": newXRange1,
+      "yaxis.range[0]": newYRange0,
+      "yaxis.range[1]": newYRange1,
+      "xaxis.autorange": xAxisAutorange,
+      "yaxis.autorange": yAxisAutorange,
+      ...rest
+    } = newLayout;
+
     let mergedLayout = {
       ...this.state.layout,
+      ...rest,
     };
+
     let lastLinearYAxisRange = [...this.state.lastLinearYAxisRange];
     if (newXRange0 !== undefined && newXRange1 !== undefined) {
       mergedLayout = {
@@ -245,26 +253,19 @@ export class MetricsPlotPanel extends React.Component {
         },
       };
     }
-    if (newLayout["xaxis.autorange"] === true) {
+    if (xAxisAutorange === true) {
       mergedLayout = {
         ...mergedLayout,
         xaxis: { autorange: true },
       };
     }
-    if (newLayout["yaxis.autorange"] === true) {
+    if (yAxisAutorange === true) {
       lastLinearYAxisRange = [];
       const axisType = this.state.layout && this.state.layout.yaxis &&
         this.state.layout.yaxis.type === 'log' ? "log" : "linear";
       mergedLayout = {
         ...mergedLayout,
         yaxis: { autorange: true, type: axisType },
-      };
-    }
-
-    if (newLayout.dragmode) {
-      mergedLayout = {
-        ...mergedLayout,
-        dragmode: newLayout.dragmode,
       };
     }
 

--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -248,7 +248,7 @@ export class MetricsPlotPanel extends React.Component {
     if (xAxisShowSpikes) {
       newXAxis.showspikes = true;
     }
-    if (xAxisAutorange === true) {
+    if (xAxisAutorange) {
       newXAxis.autorange = true;
     }
     // Set fields for y axis
@@ -260,7 +260,7 @@ export class MetricsPlotPanel extends React.Component {
     if (yAxisShowSpikes) {
       newYAxis.showspikes = true;
     }
-    if (yAxisAutorange === true) {
+    if (yAxisAutorange) {
       lastLinearYAxisRange = [];
       const axisType = this.state.layout && this.state.layout.yaxis &&
         this.state.layout.yaxis.type === 'log' ? "log" : "linear";

--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -231,7 +231,6 @@ export class MetricsPlotPanel extends React.Component {
       "yaxis.autorange": yAxisAutorange,
       "yaxis.showspikes": yAxisShowSpikes,
       "xaxis.showspikes": xAxisShowSpikes,
-      dragmode,
       ...restFields
     } = newLayout;
 
@@ -245,6 +244,7 @@ export class MetricsPlotPanel extends React.Component {
     const newXAxis = mergedLayout.xaxis || {};
     if (newXRange0 !== undefined && newXRange1 !== undefined) {
       newXAxis.range = [newXRange0, newXRange1];
+      newXAxis.autorange = false;
     }
     if (xAxisShowSpikes) {
       newXAxis.showspikes = true;
@@ -256,6 +256,7 @@ export class MetricsPlotPanel extends React.Component {
     const newYAxis = mergedLayout.yaxis || {};
     if (newYRange0 !== undefined && newYRange1 !== undefined) {
       newYAxis.range = [newYRange0, newYRange1];
+      newYAxis.autorange = false;
     }
     if (yAxisShowSpikes) {
       newYAxis.showspikes = true;
@@ -266,12 +267,6 @@ export class MetricsPlotPanel extends React.Component {
         this.state.layout.yaxis.type === 'log' ? "log" : "linear";
       newYAxis.autorange = true;
       newYAxis.type = axisType;
-    }
-    // Handle changing dragmode (disable autorange if dragmode is set)
-    if (dragmode) {
-      newXAxis.autorange = false;
-      newYAxis.autorange = false;
-      mergedLayout.dragmode = dragmode;
     }
     // Merge new X & Y axis info into layout
     mergedLayout = {

--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -228,12 +228,12 @@ export class MetricsPlotPanel extends React.Component {
       "yaxis.range[1]": newYRange1,
       "xaxis.autorange": xAxisAutorange,
       "yaxis.autorange": yAxisAutorange,
-      ...rest
+      ...restFields
     } = newLayout;
 
     let mergedLayout = {
       ...this.state.layout,
-      ...rest,
+      ...restFields,
     };
     let lastLinearYAxisRange = [...this.state.lastLinearYAxisRange];
     if (newXRange0 !== undefined && newXRange1 !== undefined) {

--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -221,6 +221,7 @@ export class MetricsPlotPanel extends React.Component {
   handleLayoutChange = (newLayout) => {
     // Unfortunately, we need to parse out the x & y axis range changes from the onLayout event...
     // see https://plot.ly/javascript/plotlyjs-events/#update-data
+    // debugger;
     const {
       "xaxis.range[0]": newXRange0,
       "xaxis.range[1]": newXRange1,
@@ -230,6 +231,7 @@ export class MetricsPlotPanel extends React.Component {
       "yaxis.autorange": yAxisAutorange,
       "yaxis.showspikes": yAxisShowSpikes,
       "xaxis.showspikes": xAxisShowSpikes,
+      dragmode,
       ...restFields
     } = newLayout;
 
@@ -264,6 +266,12 @@ export class MetricsPlotPanel extends React.Component {
         this.state.layout.yaxis.type === 'log' ? "log" : "linear";
       newYAxis.autorange = true;
       newYAxis.type = axisType;
+    }
+    // Handle changing dragmode (disable autorange if dragmode is set)
+    if (dragmode) {
+      newXAxis.autorange = false;
+      newYAxis.autorange = false;
+      mergedLayout.dragmode = dragmode;
     }
     // Merge new X & Y axis info into layout
     mergedLayout = {

--- a/mlflow/server/js/src/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/components/MetricsPlotView.js
@@ -117,9 +117,7 @@ export class MetricsPlotView extends React.Component {
         <Plot
           {...plotProps}
           useResizeHandler
-          onRelayout={(newLayout) => {
-            onLayoutChange(newLayout);
-          }}
+          onRelayout={onLayoutChange}
           style={{ width: '100%', height: '100%' }}
           layout={_.cloneDeep(plotProps.layout)}
           config={{

--- a/mlflow/server/js/src/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/components/MetricsPlotView.js
@@ -118,6 +118,21 @@ export class MetricsPlotView extends React.Component {
           {...plotProps}
           useResizeHandler
           onRelayout={onLayoutChange}
+          onButtonClicked={(first, second, third) => {
+            debugger;
+          }}
+          onSelected={(first, second, third) => {
+            debugger;
+          }}
+          onRestyle={(first, second, third) => {
+            debugger;
+          }}
+          onRedraw={(first, second, third) => {
+            debugger;
+          }}
+          onAutoSize={(first, second, third) => {
+          // debugger;
+        }}
           style={{ width: '100%', height: '100%' }}
           layout={_.cloneDeep(plotProps.layout)}
           config={{

--- a/mlflow/server/js/src/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/components/MetricsPlotView.js
@@ -118,18 +118,6 @@ export class MetricsPlotView extends React.Component {
           {...plotProps}
           useResizeHandler
           onRelayout={onLayoutChange}
-          onButtonClicked={(first, second, third) => {
-            debugger;
-          }}
-          onSelected={(first, second, third) => {
-            debugger;
-          }}
-          onRestyle={(first, second, third) => {
-            debugger;
-          }}
-          onRedraw={(first, second, third) => {
-            debugger;
-          }}
           onAutoSize={(first, second, third) => {
           // debugger;
         }}

--- a/mlflow/server/js/src/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/components/MetricsPlotView.js
@@ -118,9 +118,6 @@ export class MetricsPlotView extends React.Component {
           {...plotProps}
           useResizeHandler
           onRelayout={onLayoutChange}
-          onAutoSize={(first, second, third) => {
-          // debugger;
-        }}
           style={{ width: '100%', height: '100%' }}
           layout={_.cloneDeep(plotProps.layout)}
           config={{


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fixes a bug introduced in https://github.com/mlflow/mlflow/pull/2408, namely modifying  `handleLayoutChange` in `MetricsPlotPanel` to update `dragmode` of the plot.

Before (`dragmode` can't be changed)
![relayout-before](https://user-images.githubusercontent.com/17039389/75083589-20de9900-555d-11ea-87a0-dbefab91e4f2.gif)

After (`dragmode`can be changed.)
![relayout-after](https://user-images.githubusercontent.com/17039389/75083592-289e3d80-555d-11ea-804f-b0e1984ebe39.gif)


## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
