### PR TITLE
Fix bar chart bug introduced in #2393

### DIFF
--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -315,9 +315,13 @@ export class MetricsPlotPanel extends React.Component {
   // Return unique key identifying the curve or bar chart corresponding to the specified
   // Plotly plot data element
   static getCurveKey(plotDataElem) {
+    // In bar charts, each legend item consists of a single run ID (all bars for that run are
+    // associated with & toggled by that legend item)
     if (plotDataElem.type === "bar") {
       return plotDataElem.runId;
     } else {
+      // In line charts, each (run, metricKey) tuple has its own legend item, so construct
+      // a unique legend item identifier by concatenating the run id & metric key
       return Utils.getCurveKey(plotDataElem.runId, plotDataElem.metricName);
     }
   }

--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -312,6 +312,16 @@ export class MetricsPlotPanel extends React.Component {
     this.updateUrlState({ layout: mergedLayout, lastLinearYAxisRange });
   };
 
+  // Return unique key identifying the curve or bar chart corresponding to the specified
+  // Plotly plot data element
+  static getCurveKey(plotDataElem) {
+    if (plotDataElem.type === "bar") {
+      return plotDataElem.runId;
+    } else {
+      return Utils.getCurveKey(plotDataElem.runId, plotDataElem.metricName);
+    }
+  }
+
   /**
    * Handle clicking on a single curve within the plot legend in order to toggle its display
    * on/off.
@@ -328,7 +338,7 @@ export class MetricsPlotPanel extends React.Component {
       // Otherwise, record time of current click & trigger click event
       // Wait full double-click window to trigger setting state, and only if there was no
       // double-click do we run the single-click logic (we wait a little extra to be safe)
-      const curveKey = Utils.getCurveKey(data[curveNumber].runId, data[curveNumber].metricName);
+      const curveKey = MetricsPlotPanel.getCurveKey(data[curveNumber]);
       this.legendClickTimeout = window.setTimeout(() => {
         const existingDeselectedCurves = new Set(state.deselectedCurves);
         if (existingDeselectedCurves.has(curveKey)) {
@@ -351,9 +361,9 @@ export class MetricsPlotPanel extends React.Component {
    */
   handleLegendDoubleClick = ({curveNumber, data}) => {
     window.clearTimeout(this.legendClickTimeout);
-    const curveKey = Utils.getCurveKey(data[curveNumber].runId, data[curveNumber].metricName);
     // Exclude everything besides the current curve key
-    const allCurveKeys = data.map((elem) => Utils.getCurveKey(elem.runId, elem.metricName));
+    const curveKey = MetricsPlotPanel.getCurveKey(data[curveNumber]);
+    const allCurveKeys = data.map((elem) => MetricsPlotPanel.getCurveKey(elem));
     const newDeselectedCurves = allCurveKeys.filter((curvePair) => curvePair !== curveKey);
     this.updateUrlState({deselectedCurves: newDeselectedCurves});
     return false;

--- a/mlflow/server/js/src/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/components/MetricsPlotView.js
@@ -80,7 +80,7 @@ export class MetricsPlotView extends React.Component {
 
   getPlotPropsForBarChart = () => {
     /* eslint-disable no-param-reassign */
-    const { runUuids, runDisplayNames, deselectedCurves } = this.props;
+    const { runUuids, runDisplayNames } = this.props;
 
     // A reverse lookup of `metricKey: { runUuid: value, metricKey }`
     const historyByMetricKey = this.props.metrics.reduce((map, metric) => {
@@ -100,13 +100,11 @@ export class MetricsPlotView extends React.Component {
     );
 
     const sortedMetricKeys = arrayOfHistorySortedByMetricKey.map((history) => history.metricKey);
-    const deselectedCurvesSet = new Set(deselectedCurves);
     const data = runUuids.map((runUuid, i) => ({
       name: Utils.truncateString(runDisplayNames[i], MAX_RUN_NAME_DISPLAY_LENGTH),
       x: sortedMetricKeys,
       y: arrayOfHistorySortedByMetricKey.map((history) => history[runUuid]),
       type: 'bar',
-      visible: deselectedCurvesSet.has(runUuid),
     }));
 
     const layout = { barmode: 'group' };

--- a/mlflow/server/js/src/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/components/MetricsPlotView.js
@@ -104,7 +104,7 @@ export class MetricsPlotView extends React.Component {
     const data = runUuids.map((runUuid, i) => {
       const visibility = deselectedCurvesSet.has(runUuid) ?
         { visible: 'legendonly' } : {};
-      const res = {
+      return {
         name: Utils.truncateString(runDisplayNames[i], MAX_RUN_NAME_DISPLAY_LENGTH),
         x: sortedMetricKeys,
         y: arrayOfHistorySortedByMetricKey.map((history) => history[runUuid]),
@@ -112,7 +112,6 @@ export class MetricsPlotView extends React.Component {
         runId: runUuid,
         ...visibility,
       };
-      return res;
     });
 
     const layout = { barmode: 'group' };

--- a/mlflow/server/js/src/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/components/MetricsPlotView.js
@@ -80,7 +80,7 @@ export class MetricsPlotView extends React.Component {
 
   getPlotPropsForBarChart = () => {
     /* eslint-disable no-param-reassign */
-    const { runUuids, runDisplayNames } = this.props;
+    const { runUuids, runDisplayNames, deselectedCurves } = this.props;
 
     // A reverse lookup of `metricKey: { runUuid: value, metricKey }`
     const historyByMetricKey = this.props.metrics.reduce((map, metric) => {
@@ -100,12 +100,20 @@ export class MetricsPlotView extends React.Component {
     );
 
     const sortedMetricKeys = arrayOfHistorySortedByMetricKey.map((history) => history.metricKey);
-    const data = runUuids.map((runUuid, i) => ({
-      name: Utils.truncateString(runDisplayNames[i], MAX_RUN_NAME_DISPLAY_LENGTH),
-      x: sortedMetricKeys,
-      y: arrayOfHistorySortedByMetricKey.map((history) => history[runUuid]),
-      type: 'bar',
-    }));
+    const deselectedCurvesSet = new Set(deselectedCurves);
+    const data = runUuids.map((runUuid, i) => {
+      const visibility = deselectedCurvesSet.has(runUuid) ?
+        { visible: 'legendonly' } : {};
+      const res = {
+        name: Utils.truncateString(runDisplayNames[i], MAX_RUN_NAME_DISPLAY_LENGTH),
+        x: sortedMetricKeys,
+        y: arrayOfHistorySortedByMetricKey.map((history) => history[runUuid]),
+        type: 'bar',
+        runId: runUuid,
+        ...visibility,
+      };
+      return res;
+    });
 
     const layout = { barmode: 'group' };
     const props = { data, layout };

--- a/mlflow/server/js/src/components/MetricsPlotView.test.js
+++ b/mlflow/server/js/src/components/MetricsPlotView.test.js
@@ -95,8 +95,9 @@ describe('unit tests', () => {
       yAxisLogScale: false,
       lineSmoothness: 0,
       onLayoutChange: jest.fn(),
-      onDoubleClick: jest.fn(),
-      onClick: jest.fn(),
+      onLegendDoubleClick: jest.fn(),
+      onLegendClick: jest.fn(),
+      deselectedCurves: [],
     };
     minimalPropsForBarChart = {
       ...minimalPropsForLineChart,
@@ -161,12 +162,14 @@ describe('unit tests', () => {
           x: ['metric_0'],
           y: [100],
           type: 'bar',
+          runId: 'runUuid1',
         },
         {
           name: 'RunDisplayName2',
           x: ['metric_0'],
           y: [300],
           type: 'bar',
+          runId: 'runUuid2',
         },
       ],
       layout: {

--- a/mlflow/server/js/src/components/MetricsPlotView.test.js
+++ b/mlflow/server/js/src/components/MetricsPlotView.test.js
@@ -161,14 +161,12 @@ describe('unit tests', () => {
           x: ['metric_0'],
           y: [100],
           type: 'bar',
-          visible: false,
         },
         {
           name: 'RunDisplayName2',
           x: ['metric_0'],
           y: [300],
           type: 'bar',
-          visible: false,
         },
       ],
       layout: {


### PR DESCRIPTION
## What changes are proposed in this pull request?

#2393 introduced a bug where metric bar charts (for metrics with only a single history value) would not render properly, due to the introduction of an unsupported `visible` attribute in the bar chart's config (the `visible` attribute is supported for line charts but not bar charts).

### Before
![image](https://user-images.githubusercontent.com/2358483/75418429-45819a80-58e8-11ea-95ec-4045c6134943.png)


### After
![image](https://user-images.githubusercontent.com/2358483/75418412-3995d880-58e8-11ea-94af-d11d7a99fa82.png)


## How is this patch tested?
Manual testing, updated unit tests to verify appropriate props are passed to Plotly for the bar-chart case

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
