### PR TITLE
- added windows support for pushing images to aws ecr

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -144,7 +144,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
 
     cmd = os_command_separator.join(
         [docker_login_cmd, docker_tag_cmd, docker_push_cmd])
-    _logger.info(f"Executing {cmd}")
+    _logger.info("Executing {cmd}".format(cmd=cmd))
     os.system(cmd)
 
 

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -133,9 +133,9 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
         os_command_separator = ' && '
         # In order to execute the outcome of aws ecr get-login
         # in cmd, we need to save it in a temp file first
-        docker_login_cmd = f"aws ecr get-login --no-include-email > docker_login_url_temp.cmd" \
+        docker_login_cmd = "aws ecr get-login --no-include-email > docker_login_url_temp.cmd" \
             "{os_command_separator} call docker_login_url_temp.cmd {os_command_separator}" \
-            "del docker_login_url_temp.cmd"
+            "del docker_login_url_temp.cmd".format(os_command_separator=os_command_separator)
     else:
         docker_login_cmd = "$(aws ecr get-login --no-include-email)"
     docker_tag_cmd = "docker tag {image} {fullname}".format(

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -131,9 +131,11 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
     os_command_separator = ';\n'
     if platform.system() == 'Windows':
         os_command_separator = ' && '
-        # In order to execute the outcome of aws ecr get-login ... in cmd, we need to save it in temp file first
-        docker_login_cmd = f"aws ecr get-login --no-include-email > docker_login_url_temp.cmd {os_command_separator}" \
-            "call docker_login_url_temp.cmd {os_command_separator} del docker_login_url_temp.cmd"
+        # In order to execute the outcome of aws ecr get-login
+        # in cmd, we need to save it in a temp file first
+        docker_login_cmd = f"aws ecr get-login --no-include-email > docker_login_url_temp.cmd" \
+            "{os_command_separator} call docker_login_url_temp.cmd {os_command_separator}" \
+            "del docker_login_url_temp.cmd"
     else:
         docker_login_cmd = "$(aws ecr get-login --no-include-email)"
     docker_tag_cmd = "docker tag {image} {fullname}".format(

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -10,6 +10,7 @@ import sys
 import tarfile
 import logging
 import time
+import platform
 
 import mlflow
 import mlflow.version
@@ -127,11 +128,21 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
     # x = ecr_client.get_authorization_token()['authorizationData'][0]
     # docker_login_cmd = "docker login -u AWS -p {token} {url}".format(token=x['authorizationToken']
     #                                                                ,url=x['proxyEndpoint'])
-    docker_login_cmd = "$(aws ecr get-login --no-include-email)"
+    os_command_separator = ';\n'
+    if platform.system() == 'Windows':
+        os_command_separator = ' && '
+        # In order to execute the outcome of aws ecr get-login ... in cmd, we need to save it in temp file first
+        docker_login_cmd = f"aws ecr get-login --no-include-email > docker_login_url_temp.cmd {os_command_separator}" \
+            "call docker_login_url_temp.cmd {os_command_separator} del docker_login_url_temp.cmd"
+    else:
+        docker_login_cmd = "$(aws ecr get-login --no-include-email)"
     docker_tag_cmd = "docker tag {image} {fullname}".format(
         image=image, fullname=fullname)
     docker_push_cmd = "docker push {}".format(fullname)
-    cmd = ";\n".join([docker_login_cmd, docker_tag_cmd, docker_push_cmd])
+
+    cmd = os_command_separator.join(
+        [docker_login_cmd, docker_tag_cmd, docker_push_cmd])
+    _logger.info(f"Executing {cmd}")
     os.system(cmd)
 
 

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -128,9 +128,9 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
     # x = ecr_client.get_authorization_token()['authorizationData'][0]
     # docker_login_cmd = "docker login -u AWS -p {token} {url}".format(token=x['authorizationToken']
     #                                                                ,url=x['proxyEndpoint'])
-    os_command_separator = ';\n'
-    if platform.system() == 'Windows':
-        os_command_separator = ' && '
+    os_command_separator = ";\n"
+    if platform.system() == "Windows":
+        os_command_separator = " && "
         # In order to execute the outcome of aws ecr get-login
         # in cmd, we need to save it in a temp file first
         docker_login_cmd = "aws ecr get-login --no-include-email > docker_login_url_temp.cmd" \
@@ -144,7 +144,7 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
 
     cmd = os_command_separator.join(
         [docker_login_cmd, docker_tag_cmd, docker_push_cmd])
-    _logger.info("Executing {cmd}".format(cmd=cmd))
+    _logger.info("Executing: %s", cmd)
     os.system(cmd)
 
 


### PR DESCRIPTION
- import platform

## What changes are proposed in this pull request?

Bugfix [2311](https://github.com/mlflow/mlflow/issues/2311). Added support for Windows in the Sagemaker `mlflow sagemaker build-and-push-container` CLI Command.

## How is this patch tested?

Tested on Windows 10, Python 3.6.8 with execution of the code and successful deployment of local ML Model to AWS Sagemaker Service.
A final test on Linux machine would be great. (Can't do that at the moment)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(MLFlow Sagemaker CLI now supports sagemaker deployment from a Windows machine.)

### What component(s) does this PR affect?

- [ ] UI
- [x] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
