### PR TITLE
[UI] Change default x-axis type of metrics plot to "step"

### DIFF
--- a/mlflow/server/js/src/Routes.js
+++ b/mlflow/server/js/src/Routes.js
@@ -1,4 +1,4 @@
-import {X_AXIS_RELATIVE} from "./components/MetricsPlotControls";
+import { X_AXIS_STEP } from "./components/MetricsPlotControls";
 
 class Routes {
   static rootRoute = "/";
@@ -43,7 +43,7 @@ class Routes {
    * @returns {string}
    */
   static getMetricPageRoute(runUuids, metricKey, experimentId, plotMetricKeys = null,
-                            plotLayout = {}, selectedXAxis = X_AXIS_RELATIVE, yAxisLogScale = false,
+                            plotLayout = {}, selectedXAxis = X_AXIS_STEP, yAxisLogScale = false,
                             lineSmoothness = 0, showPoint = false, deselectedCurves = [],
                             lastLinearYAxisRange = []) {
     // If runs to display are specified (e.g. if user filtered to specific runs in a metric

--- a/mlflow/server/js/src/utils/Utils.js
+++ b/mlflow/server/js/src/utils/Utils.js
@@ -404,7 +404,7 @@ class Utils {
    */
   static getMetricPlotStateFromUrl(search) {
     const defaultState = {
-      selectedXAxis: 'relative',
+      selectedXAxis: 'step',
       selectedMetricKeys: [],
       showPoint: false,
       yAxisLogScale: false,
@@ -416,7 +416,7 @@ class Utils {
       return defaultState;
     }
 
-    const selectedXAxis = params['x_axis'] || 'relative';
+    const selectedXAxis = params['x_axis'] || 'step';
     const selectedMetricKeys = JSON.parse(params['plot_metric_keys']) ||
         defaultState.selectedMetricKeys;
     const showPoint = params['show_point'] === 'true';

--- a/mlflow/server/js/src/utils/Utils.test.js
+++ b/mlflow/server/js/src/utils/Utils.test.js
@@ -205,13 +205,13 @@ test("getGitHubRegex", () => {
 
 test('getMetricPlotStateFromUrl', () => {
   const url0 = '?runs=["runUuid1","runUuid2"]&plot_metric_keys=[]' +
-      '&plot_layout={"xaxis":{"a": "b"}}&x_axis=step&y_axis_scale=log' +
+      '&plot_layout={"xaxis":{"a": "b"}}&x_axis=relative&y_axis_scale=log' +
       '&line_smoothness=0.53&show_point=true&selected_run_ids=["runUuid1"]';
   const url1 = '?runs=["runUuid1","runUuid2"]&plot_metric_keys=["metric_1"]&plot_layout={}&x_axis=wall&y_axis_scale=log&show_point=false';
   const url2 = '?runs=["runUuid1","runUuid2"]&plot_metric_keys=["metric_1","metric_2"]';
   // Test extracting plot keys, point info, y axis log scale, line smoothness, layout info
   expect(Utils.getMetricPlotStateFromUrl(url0)).toEqual({
-    selectedXAxis: X_AXIS_STEP,
+    selectedXAxis: X_AXIS_RELATIVE,
     selectedMetricKeys: [],
     showPoint: true,
     yAxisLogScale: true,
@@ -233,7 +233,7 @@ test('getMetricPlotStateFromUrl', () => {
     lastLinearYAxisRange: [],
   });
   expect(Utils.getMetricPlotStateFromUrl(url2)).toEqual({
-    selectedXAxis: X_AXIS_RELATIVE,
+    selectedXAxis: X_AXIS_STEP,
     selectedMetricKeys: ['metric_1', 'metric_2'],
     showPoint: false,
     yAxisLogScale: false,


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR changes the default x-axis type of the metrics plot to "step" because it's rare to see (or compare) metrics on the relative time axis.

<img width="801" alt="Screen Shot 2020-02-29 at 14 14 41" src="https://user-images.githubusercontent.com/17039389/75601401-fe6cf280-5afd-11ea-8d8e-142e6dab957f.png">


## How is this patch tested?

Manually tested.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
