### PR TITLE
[UI] Fix bug for RunLinksPopover

### DIFF
--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -260,6 +260,7 @@ export class MetricsPlotPanel extends React.Component {
    * and schema.
    */
   handleLayoutChange = (newLayout) => {
+    this.isClicked = false;
     const state = this.getUrlState();
     // Unfortunately, we need to parse out the x & y axis range changes from the onLayout event...
     // see https://plot.ly/javascript/plotlyjs-events/#update-data

--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -71,6 +71,7 @@ export class MetricsPlotPanel extends React.Component {
       popoverY: 0,
       popoverRunItems: [],
     };
+    this.isClicked = false;
     this.loadMetricHistory(this.props.runUuids, this.getUrlState().selectedMetricKeys);
   }
 

--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -71,7 +71,7 @@ export class MetricsPlotPanel extends React.Component {
       popoverY: 0,
       popoverRunItems: [],
     };
-    this.isClicked = false;
+    this.isPlotClicked = false;
     this.loadMetricHistory(this.props.runUuids, this.getUrlState().selectedMetricKeys);
   }
 
@@ -261,7 +261,7 @@ export class MetricsPlotPanel extends React.Component {
    * and schema.
    */
   handleLayoutChange = (newLayout) => {
-    this.isClicked = false;
+    this.isPlotClicked = false;
     const state = this.getUrlState();
     // Unfortunately, we need to parse out the x & y axis range changes from the onLayout event...
     // see https://plot.ly/javascript/plotlyjs-events/#update-data
@@ -403,12 +403,12 @@ export class MetricsPlotPanel extends React.Component {
   };
 
   updatePopover = (data) => {
-    this.isClicked = !this.isClicked;
+    this.isPlotClicked = !this.isPlotClicked;
 
     // Ignore double click.
     setTimeout(() => {
-      if (this.isClicked) {
-        this.isClicked = false;
+      if (this.isPlotClicked) {
+        this.isPlotClicked = false;
         const { popoverVisible, popoverX, popoverY } = this.state;
         const { points, event: { clientX, clientY } } = data;
         const samePointClicked = popoverX === clientX && popoverY === clientY;

--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -71,7 +71,7 @@ export class MetricsPlotPanel extends React.Component {
       popoverY: 0,
       popoverRunItems: [],
     };
-    this.isPlotClicked = false;
+    this.displayPopover = false;
     this.loadMetricHistory(this.props.runUuids, this.getUrlState().selectedMetricKeys);
   }
 
@@ -261,7 +261,7 @@ export class MetricsPlotPanel extends React.Component {
    * and schema.
    */
   handleLayoutChange = (newLayout) => {
-    this.isPlotClicked = false;
+    this.displayPopover = false;
     const state = this.getUrlState();
     // Unfortunately, we need to parse out the x & y axis range changes from the onLayout event...
     // see https://plot.ly/javascript/plotlyjs-events/#update-data
@@ -403,12 +403,12 @@ export class MetricsPlotPanel extends React.Component {
   };
 
   updatePopover = (data) => {
-    this.isPlotClicked = !this.isPlotClicked;
+    this.displayPopover = !this.displayPopover;
 
     // Ignore double click.
     setTimeout(() => {
-      if (this.isPlotClicked) {
-        this.isPlotClicked = false;
+      if (this.displayPopover) {
+        this.displayPopover = false;
         const { popoverVisible, popoverX, popoverY } = this.state;
         const { points, event: { clientX, clientY } } = data;
         const samePointClicked = popoverX === clientX && popoverY === clientY;


### PR DESCRIPTION
## What changes are proposed in this pull request?

The run links popover unintentionally shows up on relayout by double click (please take a look at the attached gif). This PR fixes it.

![demo](https://user-images.githubusercontent.com/17039389/75600427-9fee4700-5af2-11ea-84b2-674d18c73bff.gif)

## How is this patch tested?

Manually tested

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
