### PR TITLE
Fix javadoc generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,6 @@ matrix:
       script:
         - cd mlflow/java
         - mvn clean package -q
-        - cd ../../docs
-        - make javadocs
     - language: node_js
       node_js:
         - "node" # Use latest NodeJS: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions
@@ -116,13 +114,19 @@ matrix:
         - ./travis/run-small-python-tests.sh
     - language: python
       python: 3.6
-      name: "Docs (rsthtml)"
+      name: "Docs (rsthtml, javadocs)"
       if: type != cron
       install:
         - INSTALL_SMALL_PYTHON_DEPS=true INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
         - pip install sphinx==2.2.1 sphinx-click==2.3.0
+        # Install Java & Maven
+        - sudo add-apt-repository ppa:webupd8team/java
+        - sudo apt-get update
+        - sudo apt-get install oracle-java8-installer
+        - sudo apt-get install maven
       script:
         - cd docs
+        - make javadocs
         - make rsthtml SPHINXOPTS="-W --keep-going" # Interpret Sphinx warnings as errors via the `-W` flag
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
         - sudo apt-get install maven -y
         - java -version
 #        - INSTALL_SMALL_PYTHON_DEPS=true INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
-#        - pip install sphinx==2.2.1 sphinx-click==2.3.0
+        - pip install sphinx==2.2.1 sphinx-click==2.3.0
       script:
         - cd docs
         - make javadocs

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,13 @@ matrix:
       name: "Docs (rsthtml, javadocs)"
       if: type != cron
       install:
-        - INSTALL_SMALL_PYTHON_DEPS=true INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
-        - pip install sphinx==2.2.1 sphinx-click==2.3.0
         # Install Java & Maven
-        - sudo add-apt-repository ppa:webupd8team/java
-        - sudo apt-get update
-        - sudo apt-get install oracle-java8-installer
-        - sudo apt-get install maven
+        - sudo add-apt-repository ppa:webupd8team/java -y
+        - sudo apt-get update -y
+        - sudo apt-get install oracle-java8-installer -y
+        - sudo apt-get install maven -y
+        - INSTALL_SMALL_PYTHON_DEPS=true INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
+        - pip install sphinx==2.2.1 sphinx-click==2.3.0-
       script:
         - cd docs
         - make javadocs

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,22 +11,6 @@ matrix:
     # Does not include Windows since Projects/Models are mostly not compatible with Windows as of now.
     - stage: Nightly
     - language: python
-      python: 3.6
-      name: "Docs (rsthtml, javadocs)"
-      if: type != cron
-      install:
-        # Install Java & Maven
-        - sudo apt-get update
-        - sudo apt-get install default-jdk -y
-        - sudo apt-get install maven -y
-        - java -version
-#        - INSTALL_SMALL_PYTHON_DEPS=true INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
-        - pip install sphinx==2.2.1 sphinx-click==2.3.0
-      script:
-        - cd docs
-        - make javadocs
-#        - make rsthtml SPHINXOPTS="-W --keep-going" # Interpret Sphinx warnings as errors via the `-W` flag
-    - language: python
       python: 2.7
       install:
         # CHANGED_FILES detects whether or not files related to the nightly build are changed.
@@ -128,6 +112,23 @@ matrix:
         - INSTALL_SMALL_PYTHON_DEPS=true source ./travis/install-common-deps.sh
       script:
         - ./travis/run-small-python-tests.sh
+    - language: python
+      python: 3.6
+      name: "Docs (rsthtml, javadocs)"
+      if: type != cron
+      install:
+        # Install Java & Maven
+        - sudo apt-get update
+        - sudo apt-get install default-jdk -y
+        - sudo apt-get install maven -y
+        - java -version
+        # Install Python doc deps
+        - INSTALL_SMALL_PYTHON_DEPS=true INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
+        - pip install sphinx==2.2.1 sphinx-click==2.3.0
+      script:
+        - cd docs
+        - make rsthtml SPHINXOPTS="-W --keep-going" # Interpret Sphinx warnings as errors via the `-W` flag
+        - make javadocs
 
 
 # Travis runs an extra top-level job for each build stage - depending on the build stage, we either

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,16 @@ matrix:
       if: type != cron
       install:
         # Install Java & Maven
+        - sudo apt-get update
         - sudo apt-get install default-jdk -y
         - sudo apt-get install maven -y
-        - INSTALL_SMALL_PYTHON_DEPS=true INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
-        - pip install sphinx==2.2.1 sphinx-click==2.3.0-
+        - java -version
+#        - INSTALL_SMALL_PYTHON_DEPS=true INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
+#        - pip install sphinx==2.2.1 sphinx-click==2.3.0
       script:
         - cd docs
         - make javadocs
-        - make rsthtml SPHINXOPTS="-W --keep-going" # Interpret Sphinx warnings as errors via the `-W` flag
+#        - make rsthtml SPHINXOPTS="-W --keep-going" # Interpret Sphinx warnings as errors via the `-W` flag
     - language: python
       python: 2.7
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,22 @@ matrix:
     # Does not include Windows since Projects/Models are mostly not compatible with Windows as of now.
     - stage: Nightly
     - language: python
+      python: 3.6
+      name: "Docs (rsthtml, javadocs)"
+      if: type != cron
+      install:
+        - INSTALL_SMALL_PYTHON_DEPS=true INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
+        - pip install sphinx==2.2.1 sphinx-click==2.3.0
+        # Install Java & Maven
+        - sudo add-apt-repository ppa:webupd8team/java
+        - sudo apt-get update
+        - sudo apt-get install oracle-java8-installer
+        - sudo apt-get install maven
+      script:
+        - cd docs
+        - make javadocs
+        - make rsthtml SPHINXOPTS="-W --keep-going" # Interpret Sphinx warnings as errors via the `-W` flag
+    - language: python
       python: 2.7
       install:
         # CHANGED_FILES detects whether or not files related to the nightly build are changed.
@@ -112,22 +128,6 @@ matrix:
         - INSTALL_SMALL_PYTHON_DEPS=true source ./travis/install-common-deps.sh
       script:
         - ./travis/run-small-python-tests.sh
-    - language: python
-      python: 3.6
-      name: "Docs (rsthtml, javadocs)"
-      if: type != cron
-      install:
-        - INSTALL_SMALL_PYTHON_DEPS=true INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
-        - pip install sphinx==2.2.1 sphinx-click==2.3.0
-        # Install Java & Maven
-        - sudo add-apt-repository ppa:webupd8team/java
-        - sudo apt-get update
-        - sudo apt-get install oracle-java8-installer
-        - sudo apt-get install maven
-      script:
-        - cd docs
-        - make javadocs
-        - make rsthtml SPHINXOPTS="-W --keep-going" # Interpret Sphinx warnings as errors via the `-W` flag
 
 
 # Travis runs an extra top-level job for each build stage - depending on the build stage, we either

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,7 @@ matrix:
       if: type != cron
       install:
         # Install Java & Maven
-        - sudo add-apt-repository ppa:webupd8team/java -y
-        - sudo apt-get update -y
-        - sudo apt-get install oracle-java8-installer -y
+        - sudo apt-get install default-jdk -y
         - sudo apt-get install maven -y
         - INSTALL_SMALL_PYTHON_DEPS=true INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
         - pip install sphinx==2.2.1 sphinx-click==2.3.0-

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,8 @@ matrix:
       script:
         - cd mlflow/java
         - mvn clean package -q
+        - cd ../../docs
+        - make javadocs
     - language: node_js
       node_js:
         - "node" # Use latest NodeJS: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions

--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -85,7 +85,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <configuration>
           <sourcepath>${project.basedir}/src/main/java</sourcepath>
-          <excludePackageNames>com.databricks.api.proto.databricks:org.mlflow.scalapb_interface:org.mlflow.tracking:org.mlflow.artifacts:org.mlflow.api</excludePackageNames>
+          <excludePackageNames>com.databricks.api.proto.databricks:org.mlflow.scalapb_interface:org.mlflow.tracking.samples:org.mlflow.artifacts</excludePackageNames>
           <groups>
             <group>
               <title>Tracking API</title>

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -687,7 +687,8 @@ public class MlflowClient {
    *
    *    <pre>
    *        import org.mlflow.api.proto.ModelRegistry.ModelVersion;
-   *        List{@code <ModelVersion>} detailsList  = getLatestVersions("model", Lists.newArrayList{@code <String>}("Staging"));
+   *        List{@code <ModelVersion>} detailsList =
+   *          getLatestVersions("model", Lists.newArrayList{@code <String>}("Staging"));
    *
    *        for (ModelVersion details : detailsList) {
    *            System.out.println("Model Name: " + details.getModelVersion()

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -658,9 +658,10 @@ public class MlflowClient {
    * The current available stages are: [None, Staging, Production, Archived].
    *
    *    <pre>
-   *        List<ModelVersionDetailed> detailsList = getLatestVersions("model");
+   *        import org.mlflow.api.proto.ModelRegistry.ModelVersion;
+   *        List{@code <ModelVersion>} detailsList = getLatestVersions("model");
    *
-   *        for (ModelVersionDetailed details : detailsList) {
+   *        for (ModelVersion details : detailsList) {
    *            System.out.println("Model Name: " + details.getModelVersion()
    *                                                       .getRegisteredModel()
    *                                                       .getName());
@@ -685,10 +686,10 @@ public class MlflowClient {
    * The current available stages are: [None, Staging, Production, Archived].
    *
    *    <pre>
-   *        List<ModelVersionDetailed> detailsList  = getLatestVersions("model",
-   *                                                              Lists.newArrayList<>("Staging"));
+   *        import org.mlflow.api.proto.ModelRegistry.ModelVersion;
+   *        List{@code <ModelVersion>} detailsList  = getLatestVersions("model", Lists.newArrayList{@code <String>}("Staging"));
    *
-   *        for (ModelVersionDetailed details : detailsList) {
+   *        for (ModelVersion details : detailsList) {
    *            System.out.println("Model Name: " + details.getModelVersion()
    *                                                       .getRegisteredModel()
    *                                                       .getName());
@@ -744,7 +745,7 @@ public class MlflowClient {
    *
    * @param modelName The name of the model
    * @param version The version number of the model
-   * @return A local file or directory ({@ java.io.File}) containing model artifacts
+   * @return A local file or directory ({@link java.io.File}) containing model artifacts
    */
   public File downloadModelVersion(@Nonnull String modelName, String version) {
     String downloadUri = getModelVersionDownloadUri(modelName, version);
@@ -771,7 +772,7 @@ public class MlflowClient {
    *
    * @param modelName The name of the model
    * @param stage The name of the stage
-   * @return A local file or directory ({@ java.io.File}) containing model artifacts
+   * @return A local file or directory ({@link java.io.File}) containing model artifacts
    */
   public File downloadLatestModelVersion(@Nonnull String modelName, @Nonnull String stage) {
       List<ModelVersion> versions = getLatestVersions(modelName, Lists.newArrayList(stage));


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes Java API docstring issues that cause Javadoc generation to fail

## How is this patch tested?

Manually verified I could rebuild Javadocs via `cd mlflow/docs && make javadocs`. Also added a step to the Travis CI Java builder to verify Javadocs can in fact be properly generated

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
