### PR TITLE
Add a new API GetLatestProdModel

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
@@ -26017,6 +26017,1527 @@ public final class ModelRegistry {
 
   }
 
+  public interface GetLatestProdModelOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mlflow.GetLatestProdModel)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * Name of the registered model
+     * </pre>
+     *
+     * <code>optional string model_name = 1;</code>
+     */
+    boolean hasModelName();
+    /**
+     * <pre>
+     * Name of the registered model
+     * </pre>
+     *
+     * <code>optional string model_name = 1;</code>
+     */
+    java.lang.String getModelName();
+    /**
+     * <pre>
+     * Name of the registered model
+     * </pre>
+     *
+     * <code>optional string model_name = 1;</code>
+     */
+    com.google.protobuf.ByteString
+        getModelNameBytes();
+  }
+  /**
+   * Protobuf type {@code mlflow.GetLatestProdModel}
+   */
+  public  static final class GetLatestProdModel extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:mlflow.GetLatestProdModel)
+      GetLatestProdModelOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use GetLatestProdModel.newBuilder() to construct.
+    private GetLatestProdModel(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private GetLatestProdModel() {
+      modelName_ = "";
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private GetLatestProdModel(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              modelName_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetLatestProdModel_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetLatestProdModel_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.class, org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Builder.class);
+    }
+
+    public interface ResponseOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mlflow.GetLatestProdModel.Response)
+        com.google.protobuf.MessageOrBuilder {
+
+      /**
+       * <pre>
+       * Latest prod model version
+       * </pre>
+       *
+       * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+       */
+      boolean hasLatestModelVersion();
+      /**
+       * <pre>
+       * Latest prod model version
+       * </pre>
+       *
+       * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+       */
+      org.mlflow.api.proto.ModelRegistry.ModelVersion getLatestModelVersion();
+      /**
+       * <pre>
+       * Latest prod model version
+       * </pre>
+       *
+       * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+       */
+      org.mlflow.api.proto.ModelRegistry.ModelVersionOrBuilder getLatestModelVersionOrBuilder();
+
+      /**
+       * <pre>
+       * URI corresponding to the latest prod model
+       * </pre>
+       *
+       * <code>optional string artifact_uri = 2;</code>
+       */
+      boolean hasArtifactUri();
+      /**
+       * <pre>
+       * URI corresponding to the latest prod model
+       * </pre>
+       *
+       * <code>optional string artifact_uri = 2;</code>
+       */
+      java.lang.String getArtifactUri();
+      /**
+       * <pre>
+       * URI corresponding to the latest prod model
+       * </pre>
+       *
+       * <code>optional string artifact_uri = 2;</code>
+       */
+      com.google.protobuf.ByteString
+          getArtifactUriBytes();
+    }
+    /**
+     * Protobuf type {@code mlflow.GetLatestProdModel.Response}
+     */
+    public  static final class Response extends
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:mlflow.GetLatestProdModel.Response)
+        ResponseOrBuilder {
+    private static final long serialVersionUID = 0L;
+      // Use Response.newBuilder() to construct.
+      private Response(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+        super(builder);
+      }
+      private Response() {
+        artifactUri_ = "";
+      }
+
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+      getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Response(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        int mutable_bitField0_ = 0;
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                org.mlflow.api.proto.ModelRegistry.ModelVersion.Builder subBuilder = null;
+                if (((bitField0_ & 0x00000001) == 0x00000001)) {
+                  subBuilder = latestModelVersion_.toBuilder();
+                }
+                latestModelVersion_ = input.readMessage(org.mlflow.api.proto.ModelRegistry.ModelVersion.PARSER, extensionRegistry);
+                if (subBuilder != null) {
+                  subBuilder.mergeFrom(latestModelVersion_);
+                  latestModelVersion_ = subBuilder.buildPartial();
+                }
+                bitField0_ |= 0x00000001;
+                break;
+              }
+              case 18: {
+                com.google.protobuf.ByteString bs = input.readBytes();
+                bitField0_ |= 0x00000002;
+                artifactUri_ = bs;
+                break;
+              }
+              default: {
+                if (!parseUnknownField(
+                    input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetLatestProdModel_Response_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetLatestProdModel_Response_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response.class, org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response.Builder.class);
+      }
+
+      private int bitField0_;
+      public static final int LATEST_MODEL_VERSION_FIELD_NUMBER = 1;
+      private org.mlflow.api.proto.ModelRegistry.ModelVersion latestModelVersion_;
+      /**
+       * <pre>
+       * Latest prod model version
+       * </pre>
+       *
+       * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+       */
+      public boolean hasLatestModelVersion() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <pre>
+       * Latest prod model version
+       * </pre>
+       *
+       * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+       */
+      public org.mlflow.api.proto.ModelRegistry.ModelVersion getLatestModelVersion() {
+        return latestModelVersion_ == null ? org.mlflow.api.proto.ModelRegistry.ModelVersion.getDefaultInstance() : latestModelVersion_;
+      }
+      /**
+       * <pre>
+       * Latest prod model version
+       * </pre>
+       *
+       * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+       */
+      public org.mlflow.api.proto.ModelRegistry.ModelVersionOrBuilder getLatestModelVersionOrBuilder() {
+        return latestModelVersion_ == null ? org.mlflow.api.proto.ModelRegistry.ModelVersion.getDefaultInstance() : latestModelVersion_;
+      }
+
+      public static final int ARTIFACT_URI_FIELD_NUMBER = 2;
+      private volatile java.lang.Object artifactUri_;
+      /**
+       * <pre>
+       * URI corresponding to the latest prod model
+       * </pre>
+       *
+       * <code>optional string artifact_uri = 2;</code>
+       */
+      public boolean hasArtifactUri() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <pre>
+       * URI corresponding to the latest prod model
+       * </pre>
+       *
+       * <code>optional string artifact_uri = 2;</code>
+       */
+      public java.lang.String getArtifactUri() {
+        java.lang.Object ref = artifactUri_;
+        if (ref instanceof java.lang.String) {
+          return (java.lang.String) ref;
+        } else {
+          com.google.protobuf.ByteString bs = 
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            artifactUri_ = s;
+          }
+          return s;
+        }
+      }
+      /**
+       * <pre>
+       * URI corresponding to the latest prod model
+       * </pre>
+       *
+       * <code>optional string artifact_uri = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getArtifactUriBytes() {
+        java.lang.Object ref = artifactUri_;
+        if (ref instanceof java.lang.String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          artifactUri_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+
+      private byte memoizedIsInitialized = -1;
+      @java.lang.Override
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      @java.lang.Override
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          output.writeMessage(1, getLatestModelVersion());
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          com.google.protobuf.GeneratedMessageV3.writeString(output, 2, artifactUri_);
+        }
+        unknownFields.writeTo(output);
+      }
+
+      @java.lang.Override
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        if (((bitField0_ & 0x00000001) == 0x00000001)) {
+          size += com.google.protobuf.CodedOutputStream
+            .computeMessageSize(1, getLatestModelVersion());
+        }
+        if (((bitField0_ & 0x00000002) == 0x00000002)) {
+          size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, artifactUri_);
+        }
+        size += unknownFields.getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response)) {
+          return super.equals(obj);
+        }
+        org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response other = (org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response) obj;
+
+        boolean result = true;
+        result = result && (hasLatestModelVersion() == other.hasLatestModelVersion());
+        if (hasLatestModelVersion()) {
+          result = result && getLatestModelVersion()
+              .equals(other.getLatestModelVersion());
+        }
+        result = result && (hasArtifactUri() == other.hasArtifactUri());
+        if (hasArtifactUri()) {
+          result = result && getArtifactUri()
+              .equals(other.getArtifactUri());
+        }
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        if (hasLatestModelVersion()) {
+          hash = (37 * hash) + LATEST_MODEL_VERSION_FIELD_NUMBER;
+          hash = (53 * hash) + getLatestModelVersion().hashCode();
+        }
+        if (hasArtifactUri()) {
+          hash = (37 * hash) + ARTIFACT_URI_FIELD_NUMBER;
+          hash = (53 * hash) + getArtifactUri().hashCode();
+        }
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response parseFrom(
+          java.nio.ByteBuffer data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response parseFrom(
+          java.nio.ByteBuffer data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+
+      @java.lang.Override
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+      public static Builder newBuilder(org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+      @java.lang.Override
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE
+            ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code mlflow.GetLatestProdModel.Response}
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mlflow.GetLatestProdModel.Response)
+          org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.ResponseOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetLatestProdModel_Response_descriptor;
+        }
+
+        @java.lang.Override
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetLatestProdModel_Response_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response.class, org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response.Builder.class);
+        }
+
+        // Construct using org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
+            getLatestModelVersionFieldBuilder();
+          }
+        }
+        @java.lang.Override
+        public Builder clear() {
+          super.clear();
+          if (latestModelVersionBuilder_ == null) {
+            latestModelVersion_ = null;
+          } else {
+            latestModelVersionBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000001);
+          artifactUri_ = "";
+          bitField0_ = (bitField0_ & ~0x00000002);
+          return this;
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetLatestProdModel_Response_descriptor;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response getDefaultInstanceForType() {
+          return org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response.getDefaultInstance();
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response build() {
+          org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response buildPartial() {
+          org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response result = new org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response(this);
+          int from_bitField0_ = bitField0_;
+          int to_bitField0_ = 0;
+          if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+            to_bitField0_ |= 0x00000001;
+          }
+          if (latestModelVersionBuilder_ == null) {
+            result.latestModelVersion_ = latestModelVersion_;
+          } else {
+            result.latestModelVersion_ = latestModelVersionBuilder_.build();
+          }
+          if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+            to_bitField0_ |= 0x00000002;
+          }
+          result.artifactUri_ = artifactUri_;
+          result.bitField0_ = to_bitField0_;
+          onBuilt();
+          return result;
+        }
+
+        @java.lang.Override
+        public Builder clone() {
+          return (Builder) super.clone();
+        }
+        @java.lang.Override
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return (Builder) super.setField(field, value);
+        }
+        @java.lang.Override
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return (Builder) super.clearField(field);
+        }
+        @java.lang.Override
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return (Builder) super.clearOneof(oneof);
+        }
+        @java.lang.Override
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, java.lang.Object value) {
+          return (Builder) super.setRepeatedField(field, index, value);
+        }
+        @java.lang.Override
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return (Builder) super.addRepeatedField(field, value);
+        }
+        @java.lang.Override
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response) {
+            return mergeFrom((org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response other) {
+          if (other == org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response.getDefaultInstance()) return this;
+          if (other.hasLatestModelVersion()) {
+            mergeLatestModelVersion(other.getLatestModelVersion());
+          }
+          if (other.hasArtifactUri()) {
+            bitField0_ |= 0x00000002;
+            artifactUri_ = other.artifactUri_;
+            onChanged();
+          }
+          this.mergeUnknownFields(other.unknownFields);
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response) e.getUnfinishedMessage();
+            throw e.unwrapIOException();
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        private int bitField0_;
+
+        private org.mlflow.api.proto.ModelRegistry.ModelVersion latestModelVersion_ = null;
+        private com.google.protobuf.SingleFieldBuilderV3<
+            org.mlflow.api.proto.ModelRegistry.ModelVersion, org.mlflow.api.proto.ModelRegistry.ModelVersion.Builder, org.mlflow.api.proto.ModelRegistry.ModelVersionOrBuilder> latestModelVersionBuilder_;
+        /**
+         * <pre>
+         * Latest prod model version
+         * </pre>
+         *
+         * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+         */
+        public boolean hasLatestModelVersion() {
+          return ((bitField0_ & 0x00000001) == 0x00000001);
+        }
+        /**
+         * <pre>
+         * Latest prod model version
+         * </pre>
+         *
+         * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+         */
+        public org.mlflow.api.proto.ModelRegistry.ModelVersion getLatestModelVersion() {
+          if (latestModelVersionBuilder_ == null) {
+            return latestModelVersion_ == null ? org.mlflow.api.proto.ModelRegistry.ModelVersion.getDefaultInstance() : latestModelVersion_;
+          } else {
+            return latestModelVersionBuilder_.getMessage();
+          }
+        }
+        /**
+         * <pre>
+         * Latest prod model version
+         * </pre>
+         *
+         * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+         */
+        public Builder setLatestModelVersion(org.mlflow.api.proto.ModelRegistry.ModelVersion value) {
+          if (latestModelVersionBuilder_ == null) {
+            if (value == null) {
+              throw new NullPointerException();
+            }
+            latestModelVersion_ = value;
+            onChanged();
+          } else {
+            latestModelVersionBuilder_.setMessage(value);
+          }
+          bitField0_ |= 0x00000001;
+          return this;
+        }
+        /**
+         * <pre>
+         * Latest prod model version
+         * </pre>
+         *
+         * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+         */
+        public Builder setLatestModelVersion(
+            org.mlflow.api.proto.ModelRegistry.ModelVersion.Builder builderForValue) {
+          if (latestModelVersionBuilder_ == null) {
+            latestModelVersion_ = builderForValue.build();
+            onChanged();
+          } else {
+            latestModelVersionBuilder_.setMessage(builderForValue.build());
+          }
+          bitField0_ |= 0x00000001;
+          return this;
+        }
+        /**
+         * <pre>
+         * Latest prod model version
+         * </pre>
+         *
+         * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+         */
+        public Builder mergeLatestModelVersion(org.mlflow.api.proto.ModelRegistry.ModelVersion value) {
+          if (latestModelVersionBuilder_ == null) {
+            if (((bitField0_ & 0x00000001) == 0x00000001) &&
+                latestModelVersion_ != null &&
+                latestModelVersion_ != org.mlflow.api.proto.ModelRegistry.ModelVersion.getDefaultInstance()) {
+              latestModelVersion_ =
+                org.mlflow.api.proto.ModelRegistry.ModelVersion.newBuilder(latestModelVersion_).mergeFrom(value).buildPartial();
+            } else {
+              latestModelVersion_ = value;
+            }
+            onChanged();
+          } else {
+            latestModelVersionBuilder_.mergeFrom(value);
+          }
+          bitField0_ |= 0x00000001;
+          return this;
+        }
+        /**
+         * <pre>
+         * Latest prod model version
+         * </pre>
+         *
+         * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+         */
+        public Builder clearLatestModelVersion() {
+          if (latestModelVersionBuilder_ == null) {
+            latestModelVersion_ = null;
+            onChanged();
+          } else {
+            latestModelVersionBuilder_.clear();
+          }
+          bitField0_ = (bitField0_ & ~0x00000001);
+          return this;
+        }
+        /**
+         * <pre>
+         * Latest prod model version
+         * </pre>
+         *
+         * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+         */
+        public org.mlflow.api.proto.ModelRegistry.ModelVersion.Builder getLatestModelVersionBuilder() {
+          bitField0_ |= 0x00000001;
+          onChanged();
+          return getLatestModelVersionFieldBuilder().getBuilder();
+        }
+        /**
+         * <pre>
+         * Latest prod model version
+         * </pre>
+         *
+         * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+         */
+        public org.mlflow.api.proto.ModelRegistry.ModelVersionOrBuilder getLatestModelVersionOrBuilder() {
+          if (latestModelVersionBuilder_ != null) {
+            return latestModelVersionBuilder_.getMessageOrBuilder();
+          } else {
+            return latestModelVersion_ == null ?
+                org.mlflow.api.proto.ModelRegistry.ModelVersion.getDefaultInstance() : latestModelVersion_;
+          }
+        }
+        /**
+         * <pre>
+         * Latest prod model version
+         * </pre>
+         *
+         * <code>optional .mlflow.ModelVersion latest_model_version = 1;</code>
+         */
+        private com.google.protobuf.SingleFieldBuilderV3<
+            org.mlflow.api.proto.ModelRegistry.ModelVersion, org.mlflow.api.proto.ModelRegistry.ModelVersion.Builder, org.mlflow.api.proto.ModelRegistry.ModelVersionOrBuilder> 
+            getLatestModelVersionFieldBuilder() {
+          if (latestModelVersionBuilder_ == null) {
+            latestModelVersionBuilder_ = new com.google.protobuf.SingleFieldBuilderV3<
+                org.mlflow.api.proto.ModelRegistry.ModelVersion, org.mlflow.api.proto.ModelRegistry.ModelVersion.Builder, org.mlflow.api.proto.ModelRegistry.ModelVersionOrBuilder>(
+                    getLatestModelVersion(),
+                    getParentForChildren(),
+                    isClean());
+            latestModelVersion_ = null;
+          }
+          return latestModelVersionBuilder_;
+        }
+
+        private java.lang.Object artifactUri_ = "";
+        /**
+         * <pre>
+         * URI corresponding to the latest prod model
+         * </pre>
+         *
+         * <code>optional string artifact_uri = 2;</code>
+         */
+        public boolean hasArtifactUri() {
+          return ((bitField0_ & 0x00000002) == 0x00000002);
+        }
+        /**
+         * <pre>
+         * URI corresponding to the latest prod model
+         * </pre>
+         *
+         * <code>optional string artifact_uri = 2;</code>
+         */
+        public java.lang.String getArtifactUri() {
+          java.lang.Object ref = artifactUri_;
+          if (!(ref instanceof java.lang.String)) {
+            com.google.protobuf.ByteString bs =
+                (com.google.protobuf.ByteString) ref;
+            java.lang.String s = bs.toStringUtf8();
+            if (bs.isValidUtf8()) {
+              artifactUri_ = s;
+            }
+            return s;
+          } else {
+            return (java.lang.String) ref;
+          }
+        }
+        /**
+         * <pre>
+         * URI corresponding to the latest prod model
+         * </pre>
+         *
+         * <code>optional string artifact_uri = 2;</code>
+         */
+        public com.google.protobuf.ByteString
+            getArtifactUriBytes() {
+          java.lang.Object ref = artifactUri_;
+          if (ref instanceof String) {
+            com.google.protobuf.ByteString b = 
+                com.google.protobuf.ByteString.copyFromUtf8(
+                    (java.lang.String) ref);
+            artifactUri_ = b;
+            return b;
+          } else {
+            return (com.google.protobuf.ByteString) ref;
+          }
+        }
+        /**
+         * <pre>
+         * URI corresponding to the latest prod model
+         * </pre>
+         *
+         * <code>optional string artifact_uri = 2;</code>
+         */
+        public Builder setArtifactUri(
+            java.lang.String value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+          artifactUri_ = value;
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * URI corresponding to the latest prod model
+         * </pre>
+         *
+         * <code>optional string artifact_uri = 2;</code>
+         */
+        public Builder clearArtifactUri() {
+          bitField0_ = (bitField0_ & ~0x00000002);
+          artifactUri_ = getDefaultInstance().getArtifactUri();
+          onChanged();
+          return this;
+        }
+        /**
+         * <pre>
+         * URI corresponding to the latest prod model
+         * </pre>
+         *
+         * <code>optional string artifact_uri = 2;</code>
+         */
+        public Builder setArtifactUriBytes(
+            com.google.protobuf.ByteString value) {
+          if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+          artifactUri_ = value;
+          onChanged();
+          return this;
+        }
+        @java.lang.Override
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        @java.lang.Override
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
+
+        // @@protoc_insertion_point(builder_scope:mlflow.GetLatestProdModel.Response)
+      }
+
+      // @@protoc_insertion_point(class_scope:mlflow.GetLatestProdModel.Response)
+      private static final org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response DEFAULT_INSTANCE;
+      static {
+        DEFAULT_INSTANCE = new org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response();
+      }
+
+      public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      @java.lang.Deprecated public static final com.google.protobuf.Parser<Response>
+          PARSER = new com.google.protobuf.AbstractParser<Response>() {
+        @java.lang.Override
+        public Response parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Response(input, extensionRegistry);
+        }
+      };
+
+      public static com.google.protobuf.Parser<Response> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<Response> getParserForType() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Response getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+
+    }
+
+    private int bitField0_;
+    public static final int MODEL_NAME_FIELD_NUMBER = 1;
+    private volatile java.lang.Object modelName_;
+    /**
+     * <pre>
+     * Name of the registered model
+     * </pre>
+     *
+     * <code>optional string model_name = 1;</code>
+     */
+    public boolean hasModelName() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <pre>
+     * Name of the registered model
+     * </pre>
+     *
+     * <code>optional string model_name = 1;</code>
+     */
+    public java.lang.String getModelName() {
+      java.lang.Object ref = modelName_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          modelName_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Name of the registered model
+     * </pre>
+     *
+     * <code>optional string model_name = 1;</code>
+     */
+    public com.google.protobuf.ByteString
+        getModelNameBytes() {
+      java.lang.Object ref = modelName_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        modelName_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, modelName_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, modelName_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.mlflow.api.proto.ModelRegistry.GetLatestProdModel)) {
+        return super.equals(obj);
+      }
+      org.mlflow.api.proto.ModelRegistry.GetLatestProdModel other = (org.mlflow.api.proto.ModelRegistry.GetLatestProdModel) obj;
+
+      boolean result = true;
+      result = result && (hasModelName() == other.hasModelName());
+      if (hasModelName()) {
+        result = result && getModelName()
+            .equals(other.getModelName());
+      }
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasModelName()) {
+        hash = (37 * hash) + MODEL_NAME_FIELD_NUMBER;
+        hash = (53 * hash) + getModelName().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.mlflow.api.proto.ModelRegistry.GetLatestProdModel prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mlflow.GetLatestProdModel}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mlflow.GetLatestProdModel)
+        org.mlflow.api.proto.ModelRegistry.GetLatestProdModelOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetLatestProdModel_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetLatestProdModel_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.class, org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.Builder.class);
+      }
+
+      // Construct using org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        modelName_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.mlflow.api.proto.ModelRegistry.internal_static_mlflow_GetLatestProdModel_descriptor;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.GetLatestProdModel getDefaultInstanceForType() {
+        return org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.GetLatestProdModel build() {
+        org.mlflow.api.proto.ModelRegistry.GetLatestProdModel result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.ModelRegistry.GetLatestProdModel buildPartial() {
+        org.mlflow.api.proto.ModelRegistry.GetLatestProdModel result = new org.mlflow.api.proto.ModelRegistry.GetLatestProdModel(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.modelName_ = modelName_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.mlflow.api.proto.ModelRegistry.GetLatestProdModel) {
+          return mergeFrom((org.mlflow.api.proto.ModelRegistry.GetLatestProdModel)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.mlflow.api.proto.ModelRegistry.GetLatestProdModel other) {
+        if (other == org.mlflow.api.proto.ModelRegistry.GetLatestProdModel.getDefaultInstance()) return this;
+        if (other.hasModelName()) {
+          bitField0_ |= 0x00000001;
+          modelName_ = other.modelName_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.mlflow.api.proto.ModelRegistry.GetLatestProdModel parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.mlflow.api.proto.ModelRegistry.GetLatestProdModel) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object modelName_ = "";
+      /**
+       * <pre>
+       * Name of the registered model
+       * </pre>
+       *
+       * <code>optional string model_name = 1;</code>
+       */
+      public boolean hasModelName() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <pre>
+       * Name of the registered model
+       * </pre>
+       *
+       * <code>optional string model_name = 1;</code>
+       */
+      public java.lang.String getModelName() {
+        java.lang.Object ref = modelName_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            modelName_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Name of the registered model
+       * </pre>
+       *
+       * <code>optional string model_name = 1;</code>
+       */
+      public com.google.protobuf.ByteString
+          getModelNameBytes() {
+        java.lang.Object ref = modelName_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          modelName_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Name of the registered model
+       * </pre>
+       *
+       * <code>optional string model_name = 1;</code>
+       */
+      public Builder setModelName(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        modelName_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Name of the registered model
+       * </pre>
+       *
+       * <code>optional string model_name = 1;</code>
+       */
+      public Builder clearModelName() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        modelName_ = getDefaultInstance().getModelName();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Name of the registered model
+       * </pre>
+       *
+       * <code>optional string model_name = 1;</code>
+       */
+      public Builder setModelNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        modelName_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:mlflow.GetLatestProdModel)
+    }
+
+    // @@protoc_insertion_point(class_scope:mlflow.GetLatestProdModel)
+    private static final org.mlflow.api.proto.ModelRegistry.GetLatestProdModel DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.mlflow.api.proto.ModelRegistry.GetLatestProdModel();
+    }
+
+    public static org.mlflow.api.proto.ModelRegistry.GetLatestProdModel getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<GetLatestProdModel>
+        PARSER = new com.google.protobuf.AbstractParser<GetLatestProdModel>() {
+      @java.lang.Override
+      public GetLatestProdModel parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new GetLatestProdModel(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<GetLatestProdModel> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<GetLatestProdModel> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public org.mlflow.api.proto.ModelRegistry.GetLatestProdModel getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mlflow_RegisteredModel_descriptor;
   private static final 
@@ -26167,6 +27688,16 @@ public final class ModelRegistry {
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_mlflow_GetModelVersionDownloadUri_Response_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_GetLatestProdModel_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_GetLatestProdModel_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_GetLatestProdModel_Response_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_GetLatestProdModel_Response_fieldAccessorTable;
 
   public static com.google.protobuf.Descriptors.FileDescriptor
       getDescriptor() {
@@ -26248,74 +27779,84 @@ public final class ModelRegistry {
       "\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370" +
       "\206\031\001\032 \n\010Response\022\024\n\014artifact_uri\030\001 \001(\t:+\342" +
       "?(\n&com.databricks.rpc.RPC[$this.Respons" +
-      "e]*R\n\022ModelVersionStatus\022\030\n\024PENDING_REGI" +
-      "STRATION\020\001\022\027\n\023FAILED_REGISTRATION\020\002\022\t\n\005R" +
-      "EADY\020\0032\227\024\n\024ModelRegistryService\022\266\001\n\025crea" +
-      "teRegisteredModel\022\035.mlflow.CreateRegiste" +
-      "redModel\032&.mlflow.CreateRegisteredModel." +
-      "Response\"V\362\206\031R\n6\n\004POST\022(/preview/mlflow/" +
-      "registered-models/create\032\004\010\002\020\000\020\001*\026Create" +
-      " RegisteredModel\022\266\001\n\025renameRegisteredMod" +
-      "el\022\035.mlflow.RenameRegisteredModel\032&.mlfl" +
-      "ow.RenameRegisteredModel.Response\"V\362\206\031R\n" +
-      "6\n\004POST\022(/preview/mlflow/registered-mode" +
-      "ls/rename\032\004\010\002\020\000\020\001*\026Rename RegisteredMode" +
-      "l\022\267\001\n\025updateRegisteredModel\022\035.mlflow.Upd" +
-      "ateRegisteredModel\032&.mlflow.UpdateRegist" +
-      "eredModel.Response\"W\362\206\031S\n7\n\005PATCH\022(/prev" +
-      "iew/mlflow/registered-models/update\032\004\010\002\020" +
-      "\000\020\001*\026Update RegisteredModel\022\270\001\n\025deleteRe" +
-      "gisteredModel\022\035.mlflow.DeleteRegisteredM" +
-      "odel\032&.mlflow.DeleteRegisteredModel.Resp" +
-      "onse\"X\362\206\031T\n8\n\006DELETE\022(/preview/mlflow/re" +
-      "gistered-models/delete\032\004\010\002\020\000\020\001*\026Delete R" +
-      "egisteredModel\022\246\001\n\022getRegisteredModel\022\032." +
-      "mlflow.GetRegisteredModel\032#.mlflow.GetRe" +
-      "gisteredModel.Response\"O\362\206\031K\n2\n\003GET\022%/pr" +
-      "eview/mlflow/registered-models/get\032\004\010\002\020\000" +
-      "\020\001*\023Get RegisteredModel\022\257\001\n\024listRegister" +
-      "edModels\022\034.mlflow.ListRegisteredModels\032%" +
-      ".mlflow.ListRegisteredModels.Response\"R\362" +
-      "\206\031N\n3\n\003GET\022&/preview/mlflow/registered-m" +
-      "odels/list\032\004\010\002\020\000\020\001*\025List RegisteredModel" +
-      "s\022\270\001\n\021getLatestVersions\022\031.mlflow.GetLate" +
-      "stVersions\032\".mlflow.GetLatestVersions.Re" +
-      "sponse\"d\362\206\031`\nB\n\003GET\0225/preview/mlflow/reg" +
-      "istered-models/get-latest-versions\032\004\010\002\020\000" +
-      "\020\001*\030Get Latest ModelVersions\022\247\001\n\022createM" +
-      "odelVersion\022\032.mlflow.CreateModelVersion\032" +
-      "#.mlflow.CreateModelVersion.Response\"P\362\206" +
-      "\031L\n3\n\004POST\022%/preview/mlflow/model-versio" +
-      "ns/create\032\004\010\002\020\000\020\001*\023Create ModelVersion\022\250" +
-      "\001\n\022updateModelVersion\022\032.mlflow.UpdateMod" +
-      "elVersion\032#.mlflow.UpdateModelVersion.Re" +
-      "sponse\"Q\362\206\031M\n4\n\005PATCH\022%/preview/mlflow/m" +
-      "odel-versions/update\032\004\010\002\020\000\020\001*\023Update Mod" +
-      "elVersion\022\326\001\n\033transitionModelVersionStag" +
-      "e\022#.mlflow.TransitionModelVersionStage\032," +
-      ".mlflow.TransitionModelVersionStage.Resp" +
-      "onse\"d\362\206\031`\n=\n\004POST\022//preview/mlflow/mode" +
-      "l-versions/transition-stage\032\004\010\002\020\000\020\001*\035Tra" +
-      "nsition ModelVersion Stage\022\251\001\n\022deleteMod" +
-      "elVersion\022\032.mlflow.DeleteModelVersion\032#." +
-      "mlflow.DeleteModelVersion.Response\"R\362\206\031N" +
-      "\n5\n\006DELETE\022%/preview/mlflow/model-versio" +
-      "ns/delete\032\004\010\002\020\000\020\001*\023Delete ModelVersion\022\227" +
-      "\001\n\017getModelVersion\022\027.mlflow.GetModelVers" +
-      "ion\032 .mlflow.GetModelVersion.Response\"I\362" +
-      "\206\031E\n/\n\003GET\022\"/preview/mlflow/model-versio" +
-      "ns/get\032\004\010\002\020\000\020\001*\020Get ModelVersion\022\252\001\n\023sea" +
-      "rchModelVersions\022\033.mlflow.SearchModelVer" +
-      "sions\032$.mlflow.SearchModelVersions.Respo" +
-      "nse\"P\362\206\031L\n2\n\003GET\022%/preview/mlflow/model-" +
-      "versions/search\032\004\010\002\020\000\020\001*\024Search ModelVer" +
-      "sions\022\340\001\n\032getModelVersionDownloadUri\022\".m" +
-      "lflow.GetModelVersionDownloadUri\032+.mlflo" +
-      "w.GetModelVersionDownloadUri.Response\"q\362" +
-      "\206\031m\n<\n\003GET\022//preview/mlflow/model-versio" +
-      "ns/get-download-uri\032\004\010\002\020\000\020\001*+Get Downloa" +
-      "d URI For ModelVersion ArtifactsB!\n\024org." +
-      "mlflow.api.proto\220\001\001\240\001\001\342?\002\020\001"
+      "e]\"\253\001\n\022GetLatestProdModel\022\022\n\nmodel_name\030" +
+      "\001 \001(\t\032T\n\010Response\0222\n\024latest_model_versio" +
+      "n\030\001 \001(\0132\024.mlflow.ModelVersion\022\024\n\014artifac" +
+      "t_uri\030\002 \001(\t:+\342?(\n&com.databricks.rpc.RPC" +
+      "[$this.Response]*R\n\022ModelVersionStatus\022\030" +
+      "\n\024PENDING_REGISTRATION\020\001\022\027\n\023FAILED_REGIS" +
+      "TRATION\020\002\022\t\n\005READY\020\0032\350\025\n\024ModelRegistrySe" +
+      "rvice\022\266\001\n\025createRegisteredModel\022\035.mlflow" +
+      ".CreateRegisteredModel\032&.mlflow.CreateRe" +
+      "gisteredModel.Response\"V\362\206\031R\n6\n\004POST\022(/p" +
+      "review/mlflow/registered-models/create\032\004" +
+      "\010\002\020\000\020\001*\026Create RegisteredModel\022\266\001\n\025renam" +
+      "eRegisteredModel\022\035.mlflow.RenameRegister" +
+      "edModel\032&.mlflow.RenameRegisteredModel.R" +
+      "esponse\"V\362\206\031R\n6\n\004POST\022(/preview/mlflow/r" +
+      "egistered-models/rename\032\004\010\002\020\000\020\001*\026Rename " +
+      "RegisteredModel\022\267\001\n\025updateRegisteredMode" +
+      "l\022\035.mlflow.UpdateRegisteredModel\032&.mlflo" +
+      "w.UpdateRegisteredModel.Response\"W\362\206\031S\n7" +
+      "\n\005PATCH\022(/preview/mlflow/registered-mode" +
+      "ls/update\032\004\010\002\020\000\020\001*\026Update RegisteredMode" +
+      "l\022\270\001\n\025deleteRegisteredModel\022\035.mlflow.Del" +
+      "eteRegisteredModel\032&.mlflow.DeleteRegist" +
+      "eredModel.Response\"X\362\206\031T\n8\n\006DELETE\022(/pre" +
+      "view/mlflow/registered-models/delete\032\004\010\002" +
+      "\020\000\020\001*\026Delete RegisteredModel\022\246\001\n\022getRegi" +
+      "steredModel\022\032.mlflow.GetRegisteredModel\032" +
+      "#.mlflow.GetRegisteredModel.Response\"O\362\206" +
+      "\031K\n2\n\003GET\022%/preview/mlflow/registered-mo" +
+      "dels/get\032\004\010\002\020\000\020\001*\023Get RegisteredModel\022\257\001" +
+      "\n\024listRegisteredModels\022\034.mlflow.ListRegi" +
+      "steredModels\032%.mlflow.ListRegisteredMode" +
+      "ls.Response\"R\362\206\031N\n3\n\003GET\022&/preview/mlflo" +
+      "w/registered-models/list\032\004\010\002\020\000\020\001*\025List R" +
+      "egisteredModels\022\270\001\n\021getLatestVersions\022\031." +
+      "mlflow.GetLatestVersions\032\".mlflow.GetLat" +
+      "estVersions.Response\"d\362\206\031`\nB\n\003GET\0225/prev" +
+      "iew/mlflow/registered-models/get-latest-" +
+      "versions\032\004\010\002\020\000\020\001*\030Get Latest ModelVersio" +
+      "ns\022\247\001\n\022createModelVersion\022\032.mlflow.Creat" +
+      "eModelVersion\032#.mlflow.CreateModelVersio" +
+      "n.Response\"P\362\206\031L\n3\n\004POST\022%/preview/mlflo" +
+      "w/model-versions/create\032\004\010\002\020\000\020\001*\023Create " +
+      "ModelVersion\022\250\001\n\022updateModelVersion\022\032.ml" +
+      "flow.UpdateModelVersion\032#.mlflow.UpdateM" +
+      "odelVersion.Response\"Q\362\206\031M\n4\n\005PATCH\022%/pr" +
+      "eview/mlflow/model-versions/update\032\004\010\002\020\000" +
+      "\020\001*\023Update ModelVersion\022\326\001\n\033transitionMo" +
+      "delVersionStage\022#.mlflow.TransitionModel" +
+      "VersionStage\032,.mlflow.TransitionModelVer" +
+      "sionStage.Response\"d\362\206\031`\n=\n\004POST\022//previ" +
+      "ew/mlflow/model-versions/transition-stag" +
+      "e\032\004\010\002\020\000\020\001*\035Transition ModelVersion Stage" +
+      "\022\251\001\n\022deleteModelVersion\022\032.mlflow.DeleteM" +
+      "odelVersion\032#.mlflow.DeleteModelVersion." +
+      "Response\"R\362\206\031N\n5\n\006DELETE\022%/preview/mlflo" +
+      "w/model-versions/delete\032\004\010\002\020\000\020\001*\023Delete " +
+      "ModelVersion\022\227\001\n\017getModelVersion\022\027.mlflo" +
+      "w.GetModelVersion\032 .mlflow.GetModelVersi" +
+      "on.Response\"I\362\206\031E\n/\n\003GET\022\"/preview/mlflo" +
+      "w/model-versions/get\032\004\010\002\020\000\020\001*\020Get ModelV" +
+      "ersion\022\252\001\n\023searchModelVersions\022\033.mlflow." +
+      "SearchModelVersions\032$.mlflow.SearchModel" +
+      "Versions.Response\"P\362\206\031L\n2\n\003GET\022%/preview" +
+      "/mlflow/model-versions/search\032\004\010\002\020\000\020\001*\024S" +
+      "earch ModelVersions\022\340\001\n\032getModelVersionD" +
+      "ownloadUri\022\".mlflow.GetModelVersionDownl" +
+      "oadUri\032+.mlflow.GetModelVersionDownloadU" +
+      "ri.Response\"q\362\206\031m\n<\n\003GET\022//preview/mlflo" +
+      "w/model-versions/get-download-uri\032\004\010\002\020\000\020" +
+      "\001*+Get Download URI For ModelVersion Art" +
+      "ifacts\022\316\001\n\022getLatestProdModel\022\032.mlflow.G" +
+      "etLatestProdModel\032#.mlflow.GetLatestProd" +
+      "Model.Response\"w\362\206\031s\nC\n\003GET\0226/preview/ml" +
+      "flow/model-versions/get-latest-prod-vers" +
+      "ion\032\004\010\002\020\000\020\001**Get Latest Prod Version Giv" +
+      "en a Model NameB!\n\024org.mlflow.api.proto\220" +
+      "\001\001\240\001\001\342?\002\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -26511,6 +28052,18 @@ public final class ModelRegistry {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetModelVersionDownloadUri_Response_descriptor,
         new java.lang.String[] { "ArtifactUri", });
+    internal_static_mlflow_GetLatestProdModel_descriptor =
+      getDescriptor().getMessageTypes().get(16);
+    internal_static_mlflow_GetLatestProdModel_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_GetLatestProdModel_descriptor,
+        new java.lang.String[] { "ModelName", });
+    internal_static_mlflow_GetLatestProdModel_Response_descriptor =
+      internal_static_mlflow_GetLatestProdModel_descriptor.getNestedTypes().get(0);
+    internal_static_mlflow_GetLatestProdModel_Response_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_GetLatestProdModel_Response_descriptor,
+        new java.lang.String[] { "LatestModelVersion", "ArtifactUri", });
     com.google.protobuf.ExtensionRegistry registry =
         com.google.protobuf.ExtensionRegistry.newInstance();
     registry.add(com.databricks.api.proto.databricks.Databricks.rpc);

--- a/mlflow/protos/model_registry.proto
+++ b/mlflow/protos/model_registry.proto
@@ -210,6 +210,20 @@ service ModelRegistryService {
       rpc_doc_title: "Get Download URI For ModelVersion Artifacts",
     };
   }
+
+  // .. note::
+  //     Experimental: This APY may change or be removed in a future release without warning.
+  rpc getLatestProdModel (GetLatestProdModel) returns (GetLatestProdModel.Response) {
+    option (rpc) = {
+      endpoints: [{
+        method: "GET",
+        path: "/preview/mlflow/model-versions/get-latest-prod-version"
+        since { major: 2, minor: 0 },
+      }],
+      visibility:PUBLIC,
+      rpc_doc_title:"Get Latest Prod Version Given a Model Name",
+    };
+  }
 }
 
 // .. note::
@@ -502,5 +516,20 @@ message GetModelVersionDownloadUri {
   message Response {
     // URI corresponding to where artifacts for this model version are stored.
     optional string artifact_uri = 1;
+  }
+}
+
+message GetLatestProdModel {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // Name of the registered model
+  optional string model_name = 1;
+
+  message Response {
+    // Latest prod model version
+    optional ModelVersion latest_model_version = 1;
+
+    // URI corresponding to the latest prod model
+    optional string artifact_uri = 2;
   }
 }

--- a/mlflow/protos/model_registry_pb2.py
+++ b/mlflow/protos/model_registry_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\024org.mlflow.api.proto\220\001\001\240\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\x14model_registry.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xb0\x01\n\x0fRegisteredModel\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x02 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x03 \x01(\x03\x12\x0f\n\x07user_id\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12-\n\x0flatest_versions\x18\x06 \x03(\x0b\x32\x14.mlflow.ModelVersion\"\x8a\x02\n\x0cModelVersion\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x03 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x04 \x01(\x03\x12\x0f\n\x07user_id\x18\x05 \x01(\t\x12\x15\n\rcurrent_stage\x18\x06 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x07 \x01(\t\x12\x0e\n\x06source\x18\x08 \x01(\t\x12\x0e\n\x06run_id\x18\t \x01(\t\x12*\n\x06status\x18\n \x01(\x0e\x32\x1a.mlflow.ModelVersionStatus\x12\x16\n\x0estatus_message\x18\x0b \x01(\t\"\x97\x01\n\x15\x43reateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa9\x01\n\x15RenameRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\x15UpdateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"d\n\x15\x44\x65leteRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x94\x01\n\x12GetRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9f\x01\n\x14ListRegisteredModels\x12\x1a\n\x0bmax_results\x18\x01 \x01(\x03:\x05\x35\x30\x30\x30\x30\x1a>\n\x08Response\x12\x32\n\x11registered_models\x18\x01 \x03(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9e\x01\n\x11GetLatestVersions\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06stages\x18\x02 \x03(\t\x1a\x38\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb4\x01\n\x12\x43reateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x14\n\x06source\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x01\n\x12UpdateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xec\x01\n\x1bTransitionModelVersionStage\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05stage\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\'\n\x19\x61rchive_existing_versions\x18\x04 \x01(\x08\x42\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"x\n\x12\x44\x65leteModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa2\x01\n\x0fGetModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe8\x01\n\x13SearchModelVersions\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x1b\n\x0bmax_results\x18\x02 \x01(\x03:\x06\x32\x30\x30\x30\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aQ\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\x1aGetModelVersionDownloadUri\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a \n\x08Response\x12\x14\n\x0c\x61rtifact_uri\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*R\n\x12ModelVersionStatus\x12\x18\n\x14PENDING_REGISTRATION\x10\x01\x12\x17\n\x13\x46\x41ILED_REGISTRATION\x10\x02\x12\t\n\x05READY\x10\x03\x32\x97\x14\n\x14ModelRegistryService\x12\xb6\x01\n\x15\x63reateRegisteredModel\x12\x1d.mlflow.CreateRegisteredModel\x1a&.mlflow.CreateRegisteredModel.Response\"V\xf2\x86\x19R\n6\n\x04POST\x12(/preview/mlflow/registered-models/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x43reate RegisteredModel\x12\xb6\x01\n\x15renameRegisteredModel\x12\x1d.mlflow.RenameRegisteredModel\x1a&.mlflow.RenameRegisteredModel.Response\"V\xf2\x86\x19R\n6\n\x04POST\x12(/preview/mlflow/registered-models/rename\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Rename RegisteredModel\x12\xb7\x01\n\x15updateRegisteredModel\x12\x1d.mlflow.UpdateRegisteredModel\x1a&.mlflow.UpdateRegisteredModel.Response\"W\xf2\x86\x19S\n7\n\x05PATCH\x12(/preview/mlflow/registered-models/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Update RegisteredModel\x12\xb8\x01\n\x15\x64\x65leteRegisteredModel\x12\x1d.mlflow.DeleteRegisteredModel\x1a&.mlflow.DeleteRegisteredModel.Response\"X\xf2\x86\x19T\n8\n\x06\x44\x45LETE\x12(/preview/mlflow/registered-models/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x44\x65lete RegisteredModel\x12\xa6\x01\n\x12getRegisteredModel\x12\x1a.mlflow.GetRegisteredModel\x1a#.mlflow.GetRegisteredModel.Response\"O\xf2\x86\x19K\n2\n\x03GET\x12%/preview/mlflow/registered-models/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Get RegisteredModel\x12\xaf\x01\n\x14listRegisteredModels\x12\x1c.mlflow.ListRegisteredModels\x1a%.mlflow.ListRegisteredModels.Response\"R\xf2\x86\x19N\n3\n\x03GET\x12&/preview/mlflow/registered-models/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x15List RegisteredModels\x12\xb8\x01\n\x11getLatestVersions\x12\x19.mlflow.GetLatestVersions\x1a\".mlflow.GetLatestVersions.Response\"d\xf2\x86\x19`\nB\n\x03GET\x12\x35/preview/mlflow/registered-models/get-latest-versions\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Get Latest ModelVersions\x12\xa7\x01\n\x12\x63reateModelVersion\x12\x1a.mlflow.CreateModelVersion\x1a#.mlflow.CreateModelVersion.Response\"P\xf2\x86\x19L\n3\n\x04POST\x12%/preview/mlflow/model-versions/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x43reate ModelVersion\x12\xa8\x01\n\x12updateModelVersion\x12\x1a.mlflow.UpdateModelVersion\x1a#.mlflow.UpdateModelVersion.Response\"Q\xf2\x86\x19M\n4\n\x05PATCH\x12%/preview/mlflow/model-versions/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Update ModelVersion\x12\xd6\x01\n\x1btransitionModelVersionStage\x12#.mlflow.TransitionModelVersionStage\x1a,.mlflow.TransitionModelVersionStage.Response\"d\xf2\x86\x19`\n=\n\x04POST\x12//preview/mlflow/model-versions/transition-stage\x1a\x04\x08\x02\x10\x00\x10\x01*\x1dTransition ModelVersion Stage\x12\xa9\x01\n\x12\x64\x65leteModelVersion\x12\x1a.mlflow.DeleteModelVersion\x1a#.mlflow.DeleteModelVersion.Response\"R\xf2\x86\x19N\n5\n\x06\x44\x45LETE\x12%/preview/mlflow/model-versions/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x44\x65lete ModelVersion\x12\x97\x01\n\x0fgetModelVersion\x12\x17.mlflow.GetModelVersion\x1a .mlflow.GetModelVersion.Response\"I\xf2\x86\x19\x45\n/\n\x03GET\x12\"/preview/mlflow/model-versions/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x10Get ModelVersion\x12\xaa\x01\n\x13searchModelVersions\x12\x1b.mlflow.SearchModelVersions\x1a$.mlflow.SearchModelVersions.Response\"P\xf2\x86\x19L\n2\n\x03GET\x12%/preview/mlflow/model-versions/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x14Search ModelVersions\x12\xe0\x01\n\x1agetModelVersionDownloadUri\x12\".mlflow.GetModelVersionDownloadUri\x1a+.mlflow.GetModelVersionDownloadUri.Response\"q\xf2\x86\x19m\n<\n\x03GET\x12//preview/mlflow/model-versions/get-download-uri\x1a\x04\x08\x02\x10\x00\x10\x01*+Get Download URI For ModelVersion ArtifactsB!\n\x14org.mlflow.api.proto\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\x14model_registry.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xb0\x01\n\x0fRegisteredModel\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x02 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x03 \x01(\x03\x12\x0f\n\x07user_id\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12-\n\x0flatest_versions\x18\x06 \x03(\x0b\x32\x14.mlflow.ModelVersion\"\x8a\x02\n\x0cModelVersion\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x03 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x04 \x01(\x03\x12\x0f\n\x07user_id\x18\x05 \x01(\t\x12\x15\n\rcurrent_stage\x18\x06 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x07 \x01(\t\x12\x0e\n\x06source\x18\x08 \x01(\t\x12\x0e\n\x06run_id\x18\t \x01(\t\x12*\n\x06status\x18\n \x01(\x0e\x32\x1a.mlflow.ModelVersionStatus\x12\x16\n\x0estatus_message\x18\x0b \x01(\t\"\x97\x01\n\x15\x43reateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa9\x01\n\x15RenameRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\x15UpdateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"d\n\x15\x44\x65leteRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x94\x01\n\x12GetRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9f\x01\n\x14ListRegisteredModels\x12\x1a\n\x0bmax_results\x18\x01 \x01(\x03:\x05\x35\x30\x30\x30\x30\x1a>\n\x08Response\x12\x32\n\x11registered_models\x18\x01 \x03(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9e\x01\n\x11GetLatestVersions\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06stages\x18\x02 \x03(\t\x1a\x38\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb4\x01\n\x12\x43reateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x14\n\x06source\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x01\n\x12UpdateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xec\x01\n\x1bTransitionModelVersionStage\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05stage\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\'\n\x19\x61rchive_existing_versions\x18\x04 \x01(\x08\x42\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"x\n\x12\x44\x65leteModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa2\x01\n\x0fGetModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe8\x01\n\x13SearchModelVersions\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x1b\n\x0bmax_results\x18\x02 \x01(\x03:\x06\x32\x30\x30\x30\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aQ\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\x1aGetModelVersionDownloadUri\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a \n\x08Response\x12\x14\n\x0c\x61rtifact_uri\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xab\x01\n\x12GetLatestProdModel\x12\x12\n\nmodel_name\x18\x01 \x01(\t\x1aT\n\x08Response\x12\x32\n\x14latest_model_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion\x12\x14\n\x0c\x61rtifact_uri\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*R\n\x12ModelVersionStatus\x12\x18\n\x14PENDING_REGISTRATION\x10\x01\x12\x17\n\x13\x46\x41ILED_REGISTRATION\x10\x02\x12\t\n\x05READY\x10\x03\x32\xe8\x15\n\x14ModelRegistryService\x12\xb6\x01\n\x15\x63reateRegisteredModel\x12\x1d.mlflow.CreateRegisteredModel\x1a&.mlflow.CreateRegisteredModel.Response\"V\xf2\x86\x19R\n6\n\x04POST\x12(/preview/mlflow/registered-models/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x43reate RegisteredModel\x12\xb6\x01\n\x15renameRegisteredModel\x12\x1d.mlflow.RenameRegisteredModel\x1a&.mlflow.RenameRegisteredModel.Response\"V\xf2\x86\x19R\n6\n\x04POST\x12(/preview/mlflow/registered-models/rename\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Rename RegisteredModel\x12\xb7\x01\n\x15updateRegisteredModel\x12\x1d.mlflow.UpdateRegisteredModel\x1a&.mlflow.UpdateRegisteredModel.Response\"W\xf2\x86\x19S\n7\n\x05PATCH\x12(/preview/mlflow/registered-models/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Update RegisteredModel\x12\xb8\x01\n\x15\x64\x65leteRegisteredModel\x12\x1d.mlflow.DeleteRegisteredModel\x1a&.mlflow.DeleteRegisteredModel.Response\"X\xf2\x86\x19T\n8\n\x06\x44\x45LETE\x12(/preview/mlflow/registered-models/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x44\x65lete RegisteredModel\x12\xa6\x01\n\x12getRegisteredModel\x12\x1a.mlflow.GetRegisteredModel\x1a#.mlflow.GetRegisteredModel.Response\"O\xf2\x86\x19K\n2\n\x03GET\x12%/preview/mlflow/registered-models/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Get RegisteredModel\x12\xaf\x01\n\x14listRegisteredModels\x12\x1c.mlflow.ListRegisteredModels\x1a%.mlflow.ListRegisteredModels.Response\"R\xf2\x86\x19N\n3\n\x03GET\x12&/preview/mlflow/registered-models/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x15List RegisteredModels\x12\xb8\x01\n\x11getLatestVersions\x12\x19.mlflow.GetLatestVersions\x1a\".mlflow.GetLatestVersions.Response\"d\xf2\x86\x19`\nB\n\x03GET\x12\x35/preview/mlflow/registered-models/get-latest-versions\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Get Latest ModelVersions\x12\xa7\x01\n\x12\x63reateModelVersion\x12\x1a.mlflow.CreateModelVersion\x1a#.mlflow.CreateModelVersion.Response\"P\xf2\x86\x19L\n3\n\x04POST\x12%/preview/mlflow/model-versions/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x43reate ModelVersion\x12\xa8\x01\n\x12updateModelVersion\x12\x1a.mlflow.UpdateModelVersion\x1a#.mlflow.UpdateModelVersion.Response\"Q\xf2\x86\x19M\n4\n\x05PATCH\x12%/preview/mlflow/model-versions/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Update ModelVersion\x12\xd6\x01\n\x1btransitionModelVersionStage\x12#.mlflow.TransitionModelVersionStage\x1a,.mlflow.TransitionModelVersionStage.Response\"d\xf2\x86\x19`\n=\n\x04POST\x12//preview/mlflow/model-versions/transition-stage\x1a\x04\x08\x02\x10\x00\x10\x01*\x1dTransition ModelVersion Stage\x12\xa9\x01\n\x12\x64\x65leteModelVersion\x12\x1a.mlflow.DeleteModelVersion\x1a#.mlflow.DeleteModelVersion.Response\"R\xf2\x86\x19N\n5\n\x06\x44\x45LETE\x12%/preview/mlflow/model-versions/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x44\x65lete ModelVersion\x12\x97\x01\n\x0fgetModelVersion\x12\x17.mlflow.GetModelVersion\x1a .mlflow.GetModelVersion.Response\"I\xf2\x86\x19\x45\n/\n\x03GET\x12\"/preview/mlflow/model-versions/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x10Get ModelVersion\x12\xaa\x01\n\x13searchModelVersions\x12\x1b.mlflow.SearchModelVersions\x1a$.mlflow.SearchModelVersions.Response\"P\xf2\x86\x19L\n2\n\x03GET\x12%/preview/mlflow/model-versions/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x14Search ModelVersions\x12\xe0\x01\n\x1agetModelVersionDownloadUri\x12\".mlflow.GetModelVersionDownloadUri\x1a+.mlflow.GetModelVersionDownloadUri.Response\"q\xf2\x86\x19m\n<\n\x03GET\x12//preview/mlflow/model-versions/get-download-uri\x1a\x04\x08\x02\x10\x00\x10\x01*+Get Download URI For ModelVersion Artifacts\x12\xce\x01\n\x12getLatestProdModel\x12\x1a.mlflow.GetLatestProdModel\x1a#.mlflow.GetLatestProdModel.Response\"w\xf2\x86\x19s\nC\n\x03GET\x12\x36/preview/mlflow/model-versions/get-latest-prod-version\x1a\x04\x08\x02\x10\x00\x10\x01**Get Latest Prod Version Given a Model NameB!\n\x14org.mlflow.api.proto\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -49,8 +49,8 @@ _MODELVERSIONSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=2884,
-  serialized_end=2966,
+  serialized_start=3058,
+  serialized_end=3140,
 )
 _sym_db.RegisterEnumDescriptor(_MODELVERSIONSTATUS)
 
@@ -1186,6 +1186,74 @@ _GETMODELVERSIONDOWNLOADURI = _descriptor.Descriptor(
   serialized_end=2882,
 )
 
+
+_GETLATESTPRODMODEL_RESPONSE = _descriptor.Descriptor(
+  name='Response',
+  full_name='mlflow.GetLatestProdModel.Response',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='latest_model_version', full_name='mlflow.GetLatestProdModel.Response.latest_model_version', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='artifact_uri', full_name='mlflow.GetLatestProdModel.Response.artifact_uri', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto2',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2927,
+  serialized_end=3011,
+)
+
+_GETLATESTPRODMODEL = _descriptor.Descriptor(
+  name='GetLatestProdModel',
+  full_name='mlflow.GetLatestProdModel',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='model_name', full_name='mlflow.GetLatestProdModel.model_name', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_GETLATESTPRODMODEL_RESPONSE, ],
+  enum_types=[
+  ],
+  serialized_options=_b('\342?(\n&com.databricks.rpc.RPC[$this.Response]'),
+  is_extendable=False,
+  syntax='proto2',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=2885,
+  serialized_end=3056,
+)
+
 _REGISTEREDMODEL.fields_by_name['latest_versions'].message_type = _MODELVERSION
 _MODELVERSION.fields_by_name['status'].enum_type = _MODELVERSIONSTATUS
 _CREATEREGISTEREDMODEL_RESPONSE.fields_by_name['registered_model'].message_type = _REGISTEREDMODEL
@@ -1213,6 +1281,8 @@ _GETMODELVERSION_RESPONSE.containing_type = _GETMODELVERSION
 _SEARCHMODELVERSIONS_RESPONSE.fields_by_name['model_versions'].message_type = _MODELVERSION
 _SEARCHMODELVERSIONS_RESPONSE.containing_type = _SEARCHMODELVERSIONS
 _GETMODELVERSIONDOWNLOADURI_RESPONSE.containing_type = _GETMODELVERSIONDOWNLOADURI
+_GETLATESTPRODMODEL_RESPONSE.fields_by_name['latest_model_version'].message_type = _MODELVERSION
+_GETLATESTPRODMODEL_RESPONSE.containing_type = _GETLATESTPRODMODEL
 DESCRIPTOR.message_types_by_name['RegisteredModel'] = _REGISTEREDMODEL
 DESCRIPTOR.message_types_by_name['ModelVersion'] = _MODELVERSION
 DESCRIPTOR.message_types_by_name['CreateRegisteredModel'] = _CREATEREGISTEREDMODEL
@@ -1229,6 +1299,7 @@ DESCRIPTOR.message_types_by_name['DeleteModelVersion'] = _DELETEMODELVERSION
 DESCRIPTOR.message_types_by_name['GetModelVersion'] = _GETMODELVERSION
 DESCRIPTOR.message_types_by_name['SearchModelVersions'] = _SEARCHMODELVERSIONS
 DESCRIPTOR.message_types_by_name['GetModelVersionDownloadUri'] = _GETMODELVERSIONDOWNLOADURI
+DESCRIPTOR.message_types_by_name['GetLatestProdModel'] = _GETLATESTPRODMODEL
 DESCRIPTOR.enum_types_by_name['ModelVersionStatus'] = _MODELVERSIONSTATUS
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
@@ -1456,6 +1527,21 @@ GetModelVersionDownloadUri = _reflection.GeneratedProtocolMessageType('GetModelV
 _sym_db.RegisterMessage(GetModelVersionDownloadUri)
 _sym_db.RegisterMessage(GetModelVersionDownloadUri.Response)
 
+GetLatestProdModel = _reflection.GeneratedProtocolMessageType('GetLatestProdModel', (_message.Message,), dict(
+
+  Response = _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), dict(
+    DESCRIPTOR = _GETLATESTPRODMODEL_RESPONSE,
+    __module__ = 'model_registry_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.GetLatestProdModel.Response)
+    ))
+  ,
+  DESCRIPTOR = _GETLATESTPRODMODEL,
+  __module__ = 'model_registry_pb2'
+  # @@protoc_insertion_point(class_scope:mlflow.GetLatestProdModel)
+  ))
+_sym_db.RegisterMessage(GetLatestProdModel)
+_sym_db.RegisterMessage(GetLatestProdModel.Response)
+
 
 DESCRIPTOR._options = None
 _CREATEREGISTEREDMODEL.fields_by_name['name']._options = None
@@ -1492,6 +1578,7 @@ _SEARCHMODELVERSIONS._options = None
 _GETMODELVERSIONDOWNLOADURI.fields_by_name['name']._options = None
 _GETMODELVERSIONDOWNLOADURI.fields_by_name['version']._options = None
 _GETMODELVERSIONDOWNLOADURI._options = None
+_GETLATESTPRODMODEL._options = None
 
 _MODELREGISTRYSERVICE = _descriptor.ServiceDescriptor(
   name='ModelRegistryService',
@@ -1499,8 +1586,8 @@ _MODELREGISTRYSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=2969,
-  serialized_end=5552,
+  serialized_start=3143,
+  serialized_end=5935,
   methods=[
   _descriptor.MethodDescriptor(
     name='createRegisteredModel',
@@ -1627,6 +1714,15 @@ _MODELREGISTRYSERVICE = _descriptor.ServiceDescriptor(
     input_type=_GETMODELVERSIONDOWNLOADURI,
     output_type=_GETMODELVERSIONDOWNLOADURI_RESPONSE,
     serialized_options=_b('\362\206\031m\n<\n\003GET\022//preview/mlflow/model-versions/get-download-uri\032\004\010\002\020\000\020\001*+Get Download URI For ModelVersion Artifacts'),
+  ),
+  _descriptor.MethodDescriptor(
+    name='getLatestProdModel',
+    full_name='mlflow.ModelRegistryService.getLatestProdModel',
+    index=14,
+    containing_service=None,
+    input_type=_GETLATESTPRODMODEL,
+    output_type=_GETLATESTPRODMODEL_RESPONSE,
+    serialized_options=_b('\362\206\031s\nC\n\003GET\0226/preview/mlflow/model-versions/get-latest-prod-version\032\004\010\002\020\000\020\001**Get Latest Prod Version Given a Model Name'),
   ),
 ])
 _sym_db.RegisterServiceDescriptor(_MODELREGISTRYSERVICE)


### PR DESCRIPTION
## What changes are proposed in this pull request?

An new API is added to pull artifact for GetLatestProdModel. I am from Pinterest ML Platform team and we are using MLFlow as our model hub. One gap we need to close is to integrate with different deployment system, and now we use a pull mode so that we need an API to expose latest prod version for a model.

## How is this patch tested?

This PR is only for proto change. Implementation PR will come later in a separate one and will be tested by unit tests.

## Release Notes

### Is this a user-facing change?

- [ x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ x] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
