### PR TITLE
Fix invalid fitler_string in tests

### DIFF
--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1260,17 +1260,17 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase, AbstractStoreTest):
         six.assertCountEqual(self, [r1, r2], self._search(experiment_id, filter_string))
 
         # all params and metrics match
-        filter_string = ("params.generic_param = 'p_val' and metrics.common = 1.0"
+        filter_string = ("params.generic_param = 'p_val' and metrics.common = 1.0 "
                          "and metrics.m_a > 1.0")
         six.assertCountEqual(self, [r1], self._search(experiment_id, filter_string))
 
         # test with mismatch param
-        filter_string = ("params.random_bad_name = 'p_val' and metrics.common = 1.0"
+        filter_string = ("params.random_bad_name = 'p_val' and metrics.common = 1.0 "
                          "and metrics.m_a > 1.0")
         six.assertCountEqual(self, [], self._search(experiment_id, filter_string))
 
         # test with mismatch metric
-        filter_string = ("params.generic_param = 'p_val' and metrics.common = 1.0"
+        filter_string = ("params.generic_param = 'p_val' and metrics.common = 1.0 "
                          "and metrics.m_a > 100.0")
         six.assertCountEqual(self, [], self._search(experiment_id, filter_string))
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

The CI fails when parsing `filter_string`. This PR fixes invalid `filter_strings`.

```
   def test_search_full(self):
        experiment_id = self._experiment_factory('search_params')
        r1 = self._run_factory(self._get_run_configs(experiment_id)).info.run_id
        r2 = self._run_factory(self._get_run_configs(experiment_id)).info.run_id
    
        self.store.log_param(r1, entities.Param('generic_param', 'p_val'))
        self.store.log_param(r2, entities.Param('generic_param', 'p_val'))
    
        self.store.log_param(r1, entities.Param('p_a', 'abc'))
        self.store.log_param(r2, entities.Param('p_b', 'ABC'))
    
        self.store.log_metric(r1, entities.Metric("common", 1.0, 1, 0))
        self.store.log_metric(r2, entities.Metric("common", 1.0, 1, 0))
    
        self.store.log_metric(r1, entities.Metric("m_a", 2.0, 2, 0))
        self.store.log_metric(r2, entities.Metric("m_b", 3.0, 2, 0))
        self.store.log_metric(r2, entities.Metric("m_b", 4.0, 8, 0))
        self.store.log_metric(r2, entities.Metric("m_b", 8.0, 3, 0))
    
        filter_string = "params.generic_param = 'p_val' and metrics.common = 1.0"
        six.assertCountEqual(self, [r1, r2], self._search(experiment_id, filter_string))
    
        # all params and metrics match
        filter_string = ("params.generic_param = 'p_val' and metrics.common = 1.0"
                         "and metrics.m_a > 1.0")
>       six.assertCountEqual(self, [r1], self._search(experiment_id, filter_string))
tests/store/tracking/test_sqlalchemy_store.py:1265: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/store/tracking/test_sqlalchemy_store.py:907: in _search
    for r in self.store.search_runs(exps, filter_string, run_view_type, max_results)]
mlflow/store/tracking/abstract_store.py:230: in search_runs
    order_by, page_token)
mlflow/store/tracking/sqlalchemy_store.py:629: in _search_runs
    parsed_filters = SearchUtils.parse_search_filter(filter_string)
mlflow/utils/search_utils.py:212: in parse_search_filter
    return SearchUtils._process_statement(parsed[0])
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
cls = <class 'mlflow.utils.search_utils.SearchUtils'>
statement = <Statement 'params...' at 0x7F14FED121B0>
    @classmethod
    def _process_statement(cls, statement):
        # check validity
        invalids = list(filter(cls._invalid_statement_token, statement.tokens))
        if len(invalids) > 0:
            invalid_clauses = ", ".join("'%s'" % token for token in invalids)
            raise MlflowException("Invalid clause(s) in filter string: %s" % invalid_clauses,
>                                 error_code=INVALID_PARAMETER_VALUE)
E           mlflow.exceptions.MlflowException: Invalid clause(s) in filter string: 'metrics.common = 1.0and'
```

## What triggered this error?
The latest version (0.3.1) of `sqlparse` that was released yesterday, triggered this error ([release history](https://pypi.org/project/sqlparse/0.3.1/#history)).

I wrote a simple python script and ran it with 0.3.0 and 0.3.1

```python
# test.py
import sqlparse

filter_string = ("metrics.common = 1.0and metrics.m_a > 1.0")
parsed = sqlparse.parse(filter_string)
for t in parsed[0].tokens:
    print(t)
```

Result in 0.3.0 (can handle invalid filter_string):
```python
>>> pip install sqlparse==0.3.0
>>> python test.py
metrics.common = 1.0
and
 
metrics.m_a > 1.0
```

Result in 0.3.1 (can't handle invalid filter_string):
```python
>>> pip install sqlparse==0.3.1
>>> python test.py
metrics.common = 1.0and
 
metrics.m_a > 1.0
```


## How is this patch tested?

Verified the failed tests pass.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
