### PR TITLE
Add metadata indicating that MLflow Python package requires Python >= 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,5 +81,11 @@ setup(
         'Programming Language :: Python :: 3.6',
     ],
     keywords='ml ai databricks',
-    url='https://mlflow.org/'
+    url='https://mlflow.org/',
+    # Support Python >= 2.7. TODO: update this version bound to >= 3.5 in order to drop
+    # Python 2 e.g. in MLflow 1.8.0), as described in
+    # https://packaging.python.org/guides/dropping-older-python-versions/#dropping-a-python-release.
+    # The recommendation to use 3.5 stems from 3.4 being EOL, see
+    # https://devguide.python.org/#status-of-python-branches
+    python_requires='>=2.7',
 )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `python_requires` field to setup.py indicating that MLflow requires Python >= 2.7. As described [in the Python docs](https://packaging.python.org/guides/dropping-older-python-versions/#dropping-a-python-release), this is necessary to enable dropping Python 2 support in a future MLflow version (in that future version, we can update `python_requires >= 3.5`). This is the same mechanism used by other packages like sklearn to control supported versions, e.g. see https://github.com/scikit-learn/scikit-learn/pull/15106/files

## How is this patch tested?

Existing tests (which build, install, & test the MLflow wheel in Python 2.7 & Python 3.6).

Also, some manual testing:
1. Verified that a wheel built from source from this branch contains the correct 'Requires-Python' metadata:
```
(mlflow-python3) ➜  mlflow git:(add-python-requires) ✗ python
Python 3.6.8 |Anaconda, Inc.| (default, Dec 29 2018, 19:04:46) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import importlib_metadata
>>> obj = importlib_metadata.metadata('mlflow')
>>> 
>>> obj['Requires-Python']
'>=2.7'
>>> 
```

2. Uploaded a custom version (1.6.1.dev1) built off this branch to testpypi ([link](https://test.pypi.org/project/mlflow/1.6.1.dev1/#files)), pip-installed it, verified the `Requires-Python` metadata was correctly set:

```
(mlflow-python3) ➜  mlflow git:(add-python-requires) ✗ pip install --extra-index-url https://testpypi.python.org/pypi mlflow==1.6.1.dev1
Looking in indexes: https://pypi.org/simple, https://testpypi.python.org/pypi
...
Installing collected packages: mlflow
Successfully installed mlflow-1.6.1.dev1
(mlflow-python3) ➜  mlflow git:(add-python-requires) ✗ python
Python 3.6.8 |Anaconda, Inc.| (default, Dec 29 2018, 19:04:46) 
[GCC 4.2.1 Compatible Clang 4.0.1 (tags/RELEASE_401/final)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import mlflow
>>> 
>>> mlflow.__version__
'1.6.1.dev1'
>>> import importlib_metadata
>>> obj = importlib_metadata.metadata('mlflow')
>>> obj['Requires-Python']
'>=2.7'
```

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
