### PR TITLE
Cleanup: remove reference to ModelVersionDetailed structure in pydocs

### DIFF
--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -91,7 +91,7 @@ class ModelVersion(_ModelRegistryEntity):
     # proto mappers
     @classmethod
     def from_proto(cls, proto):
-        # input: mlflow.protos.model_registry_pb2.ModelVersionDetailed
+        # input: mlflow.protos.model_registry_pb2.ModelVersion
         # returns: ModelVersion entity
         return cls(proto.name,
                    proto.version,
@@ -106,8 +106,8 @@ class ModelVersion(_ModelRegistryEntity):
                    proto.status_message)
 
     def to_proto(self):
-        # input: ModelVersionDetailed entity
-        # returns mlflow.protos.model_registry_pb2.ModelVersionDetailed
+        # input: ModelVersion entity
+        # returns mlflow.protos.model_registry_pb2.ModelVersion
         model_version = ProtoModelVersion()
         model_version.name = self.name
         model_version.version = str(self.version)

--- a/mlflow/entities/model_registry/model_version_status.py
+++ b/mlflow/entities/model_registry/model_version_status.py
@@ -2,7 +2,7 @@ from mlflow.protos.model_registry_pb2 import ModelVersionStatus as ProtoModelVer
 
 
 class ModelVersionStatus(object):
-    """Enum for status of an :py:class:`mlflow.entities.model_registry.ModelVersionDetailed`."""
+    """Enum for status of an :py:class:`mlflow.entities.model_registry.ModelVersion`."""
     PENDING_REGISTRATION = ProtoModelVersionStatus.Value('PENDING_REGISTRATION')
     FAILED_REGISTRATION = ProtoModelVersionStatus.Value('FAILED_REGISTRATION')
     READY = ProtoModelVersionStatus.Value('READY')

--- a/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
@@ -45,7 +45,7 @@ class ModelVersionPage extends React.Component {
     this.getModelVersionDetailAndRunInfo(isInitialLoading).catch(console.error);
   };
 
-  // We need to do this because currently the ModelVersionDetailed we got does not contain
+  // We need to do this because currently the ModelVersion we got does not contain
   // experimentId. We need experimentId to construct a link to the source run. This workaround can
   // be removed after the availability of experimentId.
   getModelVersionDetailAndRunInfo(isInitialLoading) {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove all references to `ModelVersionDetailed` from pydocs are mentioned in #2523 

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
