### PR TITLE
Fix docstrings of set_tag, set_experiment_tag, and delete_tag

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -571,6 +571,7 @@ class SqlAlchemyStore(AbstractStore):
     def set_tag(self, run_id, tag):
         """
         Set a tag on a run.
+
         :param run_id: String ID of the run
         :param tag: RunTag instance to log
         """
@@ -583,6 +584,7 @@ class SqlAlchemyStore(AbstractStore):
     def delete_tag(self, run_id, key):
         """
         Delete a tag from a run. This is irreversible.
+
         :param run_id: String ID of the run
         :param key: Name of the tag
         """

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -181,6 +181,7 @@ class TrackingServiceClient(object):
     def set_experiment_tag(self, experiment_id, key, value):
         """
         Set a tag on the experiment with the specified ID. Value is converted to a string.
+
         :param experiment_id: String ID of the experiment.
         :param key: Name of the tag.
         :param value: Tag value (converted to a string).
@@ -192,6 +193,7 @@ class TrackingServiceClient(object):
     def set_tag(self, run_id, key, value):
         """
         Set a tag on the run with the specified ID. Value is converted to a string.
+
         :param run_id: String ID of the run.
         :param key: Name of the tag.
         :param value: Tag value (converted to a string)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -207,6 +207,7 @@ class MlflowClient(object):
     def set_experiment_tag(self, experiment_id, key, value):
         """
         Set a tag on the experiment with the specified ID. Value is converted to a string.
+
         :param experiment_id: String ID of the experiment.
         :param key: Name of the tag.
         :param value: Tag value (converted to a string).
@@ -216,6 +217,7 @@ class MlflowClient(object):
     def set_tag(self, run_id, key, value):
         """
         Set a tag on the run with the specified ID. Value is converted to a string.
+
         :param run_id: String ID of the run.
         :param key: Name of the tag.
         :param value: Tag value (converted to a string)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix docstrings of set_tag, set_experiment_tag, and delete_tag.

Before:
<img width="1039" alt="Screen Shot 2020-03-02 at 21 53 55" src="https://user-images.githubusercontent.com/17039389/75678182-64a96f00-5cd0-11ea-9fd8-535bc9b60ec1.png">

After:
<img width="620" alt="Screen Shot 2020-03-02 at 21 54 15" src="https://user-images.githubusercontent.com/17039389/75678189-6a9f5000-5cd0-11ea-937f-4fcfaee54153.png">


## How is this patch tested?

Manually verified the doc is rendered properly.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
