### PR TITLE
Minor improvement to error message readability for SqlAlchemyStore

### DIFF
--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -292,10 +292,10 @@ class SqlAlchemyStore(AbstractStore):
         versions = session.query(SqlModelVersion).filter(*conditions).all()
 
         if len(versions) == 0:
-            raise MlflowException('Model Version (name={}, version{}) '
+            raise MlflowException('Model Version (name={}, version={}) '
                                   'not found'.format(name, version), RESOURCE_DOES_NOT_EXIST)
         if len(versions) > 1:
-            raise MlflowException('Expected only 1 model version with (name={}, version{}). '
+            raise MlflowException('Expected only 1 model version with (name={}, version={}). '
                                   'Found {}.'.format(name, version, len(versions)),
                                   INVALID_STATE)
         return versions[0]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add missing `=` to SqlAlchemyStore exceptions thrown when Model Versions are not found. 

## How is this patch tested?

Manual verification that the new `=` sign is included in the error message when an MV is not found.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section. (Barely qualifies)
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
