### PR TITLE
Fix typos and docs for update_registered_model

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -379,7 +379,9 @@ class MlflowClient(object):
 
         :param name: Name of the registered model to update.
         :param new_name: (Deprecated) New proposed name for the registered model.
-                         This argument is deprecated, use rename_registered_model instead..
+                         This argument is deprecated. Use the
+                         :py:func:`rename_registered_model <MlflowClient.rename_registered_model>`
+                         method to rename registered models instead.
         :param description: (Optional) New description.
         :return: A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
@@ -391,8 +393,8 @@ class MlflowClient(object):
 
         res = None
         if new_name is not None:
-            _logger.warning("'new_name' argument in update_registered_model is deprecated, "
-                            "please use  renamed_registered_model instead.")
+            _logger.warning("The `new_name` argument in update_registered_model is deprecated."
+                            " Please use the `rename_registered_model` method instead.")
             res = self._get_registry_client().rename_registered_model(name=name, new_name=new_name)
             name = new_name
         if description is not None:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -394,7 +394,7 @@ class MlflowClient(object):
         res = None
         if new_name is not None:
             _logger.warning("The `new_name` argument in update_registered_model is deprecated."
-                            " Please use the `rename_registered_model` method instead.")
+                            " Use the `rename_registered_model` method instead.")
             res = self._get_registry_client().rename_registered_model(name=name, new_name=new_name)
             name = new_name
         if description is not None:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix typos and docs for `update_registered_model` to correctly redirect callers from the `new_name` argument of `update_registered_model` to the `rename_registered_model` **method**

## How is this patch tested?

Manual generation of docs and testing of the error condition. Unit tests are in place for semantic correctness of the affected API.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
