### PR TITLE
[UI] Use history.replace instead of history.push when updating page URL on MetricsPlotPanel

### DIFF
--- a/mlflow/server/js/src/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.js
@@ -107,7 +107,7 @@ export class MetricsPlotPanel extends React.Component {
     };
     const { selectedXAxis, selectedMetricKeys, showPoint, yAxisLogScale, lineSmoothness,
       layout, deselectedCurves, lastLinearYAxisRange } = newState;
-    history.push(Routes.getMetricPageRoute(runUuids, metricKey, experimentId, selectedMetricKeys,
+    history.replace(Routes.getMetricPageRoute(runUuids, metricKey, experimentId, selectedMetricKeys,
       layout, selectedXAxis, yAxisLogScale, lineSmoothness, showPoint, deselectedCurves,
       lastLinearYAxisRange));
   };

--- a/mlflow/server/js/src/components/MetricsPlotPanel.test.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.test.js
@@ -16,9 +16,6 @@ describe('unit tests', () => {
         '&plot_metric_keys=["metric_1","metric_2"]&plot_layout={}',
     };
     const history = {
-      push: (url) => {
-        location.search = "?" + url.split("?")[1];
-      },
       replace: (url) => {
         location.search = "?" + url.split("?")[1];
       },

--- a/mlflow/server/js/src/components/MetricsPlotPanel.test.js
+++ b/mlflow/server/js/src/components/MetricsPlotPanel.test.js
@@ -19,6 +19,9 @@ describe('unit tests', () => {
       push: (url) => {
         location.search = "?" + url.split("?")[1];
       },
+      replace: (url) => {
+        location.search = "?" + url.split("?")[1];
+      },
     };
     minimalPropsForLineChart = {
       experimentId: 1,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use `history.replace` instead of `history.push` when updating page URL on `MetricsPlotPanel` so that the user can go back to the previous **page** instead of the previous **state**.

Before

![before](https://user-images.githubusercontent.com/17039389/75887987-fef2e980-5e6d-11ea-9da1-655628a2ab54.gif)

After

![after](https://user-images.githubusercontent.com/17039389/75888000-03b79d80-5e6e-11ea-9166-0c3cc94e05c3.gif)


## How is this patch tested?

Tested manually

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
