### PR TITLE
cross test anaconda3 2019.03 and 2019.10 for compatibility

### DIFF
--- a/travis/stage-python3.sh
+++ b/travis/stage-python3.sh
@@ -11,9 +11,7 @@ then
   else
     ./travis/run-large-python-tests.sh
     ./travis/test-anaconda-compatibility.sh "anaconda3:2019.10"
-    ./travis/test-anaconda-compatibility.sh "anaconda:2019.10"
     ./travis/test-anaconda-compatibility.sh "anaconda3:2019.03"
-    ./travis/test-anaconda-compatibility.sh "anaconda:2019.03"
   fi
 fi
 CHANGED_FILES=$(git diff --name-only master..HEAD | grep "tests/examples\|examples") || true

--- a/travis/stage-python3.sh
+++ b/travis/stage-python3.sh
@@ -10,7 +10,10 @@ then
     ./travis/run-small-python-tests.sh && ./test-generate-protos.sh
   else
     ./travis/run-large-python-tests.sh
-    ./travis/test-anaconda-compatibility.sh
+    ./travis/test-anaconda-compatibility.sh "anaconda3:2019.10"
+    ./travis/test-anaconda-compatibility.sh "anaconda:2019.10"
+    ./travis/test-anaconda-compatibility.sh "anaconda3:2019.03"
+    ./travis/test-anaconda-compatibility.sh "anaconda:2019.03"
   fi
 fi
 CHANGED_FILES=$(git diff --name-only master..HEAD | grep "tests/examples\|examples") || true

--- a/travis/test-anaconda-compatibility.sh
+++ b/travis/test-anaconda-compatibility.sh
@@ -8,7 +8,7 @@ set -eux
 MLFLOW_DIR=$(cd "$(dirname ${BASH_SOURCE[0]})/.."; pwd)
 
 PYTHON_MAJOR_VERSION=$(python -c "import sys; print(sys.version_info[0])")
-DEFAULT_ANACONDA_VERSIONS=([2]="anaconda:2019.03" [3]="anaconda3:2019.03")
+DEFAULT_ANACONDA_VERSIONS=([2]="anaconda:2019.10" [3]="anaconda3:2019.10")
 ANACONDA_VERSION=${1:-${DEFAULT_ANACONDA_VERSIONS["$PYTHON_MAJOR_VERSION"]}}
 docker run --rm -v "${MLFLOW_DIR}:/mnt/mlflow" continuumio/${ANACONDA_VERSION} \
   bash /mnt/mlflow/travis/test-anaconda-compatibility-in-docker.sh


### PR DESCRIPTION
## What changes are proposed in this pull request?

To ensure MLflow is fully compatible with both Anaconda 2/3 2019.03/2019.10.

## How is this patch tested?

Ran the scripts.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
