### PR TITLE
Move_tracking_uri mock fixture into conftest.py

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -198,8 +198,11 @@ file for testing.
 
 If your tests require usage of a tracking URI, you can use the
 `pytest fixture <https://docs.pytest.org/en/3.2.1/fixture.html>`_
-`tracking_uri_mock <https://github.com/mlflow/mlflow/blob/master/tests/projects/utils.py#L74>`_
+`tracking_uri_mock <https://github.com/mlflow/mlflow/blob/master/tests/conftest.py#L74>`_
 to set up a mock tracking URI that will set itself up before your test runs and tear itself down after.
+To use pytest fixture, just add the name of the fixture as a parameter of your test. If you don't refer
+to the mock in your test, decore your test with ``@pytest.mark.usefixtures("tracking_uri_mock")`` to avoid
+unused argument warnings by the linter.
 
 Adding New Model Flavor Support
 -------------------------------

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -196,13 +196,11 @@ uses ``pytest==3.2.1`` for testing. Your tests should be added to the relevant f
 if there is no appropriate file, in a new file prefixed with ``test_`` so that ``pytest`` includes that
 file for testing.
 
-If your tests require usage of a tracking URI, you can use the
+If your tests require usage of a tracking URI, the
 `pytest fixture <https://docs.pytest.org/en/3.2.1/fixture.html>`_
-`tracking_uri_mock <https://github.com/mlflow/mlflow/blob/master/tests/conftest.py#L74>`_
-to set up a mock tracking URI that will set itself up before your test runs and tear itself down after.
-To use pytest fixture, just add the name of the fixture as a parameter of your test. If you don't refer
-to the mock in your test, decore your test with ``@pytest.mark.usefixtures("tracking_uri_mock")`` to avoid
-unused argument warnings by the linter.
+`tracking_uri_mock <https://github.com/mlflow/mlflow/blob/master/tests/conftest.py#L74>`_ is automatically set up
+for every tests. It sets up a mock tracking URI that will set itself up before your test runs and tear itself down after.
+If you want to deactivate the mock for your test, mark the test with `@pytest.mark.notrackingurimock` operator.
 
 Adding New Model Flavor Support
 -------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,9 @@
+import os
+
 import pytest
+
+import mlflow
+from mlflow.utils.file_utils import path_to_local_sqlite_uri
 
 
 @pytest.fixture
@@ -14,3 +19,12 @@ def reset_mock():
     for obj, attr, value in cache:
         setattr(obj, attr, value)
     cache[:] = []
+
+
+@pytest.fixture()
+def tracking_uri_mock(tmpdir):
+    try:
+        mlflow.set_tracking_uri(path_to_local_sqlite_uri(os.path.join(tmpdir.strpath, 'mlruns')))
+        yield tmpdir
+    finally:
+        mlflow.set_tracking_uri(None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,10 +21,12 @@ def reset_mock():
     cache[:] = []
 
 
-@pytest.fixture()
-def tracking_uri_mock(tmpdir):
+@pytest.fixture(autouse=True)
+def tracking_uri_mock(tmpdir, request):
     try:
-        mlflow.set_tracking_uri(path_to_local_sqlite_uri(os.path.join(tmpdir.strpath, 'mlruns')))
+        if 'notrackingurimock' not in request.keywords:
+            mlflow.set_tracking_uri(path_to_local_sqlite_uri(
+                os.path.join(tmpdir.strpath, 'mlruns')))
         yield tmpdir
     finally:
         mlflow.set_tracking_uri(None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,8 +25,12 @@ def reset_mock():
 def tracking_uri_mock(tmpdir, request):
     try:
         if 'notrackingurimock' not in request.keywords:
-            mlflow.set_tracking_uri(path_to_local_sqlite_uri(
-                os.path.join(tmpdir.strpath, 'mlruns')))
+            tracking_uri = path_to_local_sqlite_uri(
+                os.path.join(tmpdir.strpath, 'mlruns'))
+            mlflow.set_tracking_uri(tracking_uri)
+            os.environ["MLFLOW_TRACKING_URI"] = tracking_uri
         yield tmpdir
     finally:
         mlflow.set_tracking_uri(None)
+        if 'notrackingurimock' not in request.keywords:
+            del os.environ["MLFLOW_TRACKING_URI"]

--- a/tests/examples/README.md
+++ b/tests/examples/README.md
@@ -11,7 +11,7 @@ For purpose of discussion, `new_example_dir` designates the
 directory the example code is found, i.e., it is located in `examples/new_example_dir`.
 
 ## Examples that utilize `mlflow run` construct
-The `@pytest.mark.mark.parametrize` decorator for `def test_mlflow_run_example(tracking_uri_mock, directory, params):` 
+The `@pytest.mark.mark.parametrize` decorator for `def test_mlflow_run_example(directory, params):` 
 is updated.
 
 If the example is executed by `cd examples/new_example_dir && mflow run . -P parm1=99 -P parm2=3`, then
@@ -28,7 +28,7 @@ as shown below
     (os.path.join("sklearn_elasticnet_diabetes", "linux"), []),
     ("new_example_dir", ["-P", "parm1=123", "-P", "parm2=99"]),
 ])
-def test_mlflow_run_example(tracking_uri_mock, directory, params):
+def test_mlflow_run_example(directory, params):
 ```
 
 The `tuple` for an example requiring no parameters is simply:

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -42,13 +42,7 @@ def test_mlflow_run_example(directory, params):
     ('remote_store', ['python', 'remote_server.py']),
     ('xgboost', ['python', 'train.py', '--colsample-bytree', '0.8', '--subsample', '0.9'])
 ])
-def test_command_example(tmpdir, directory, command):
-    os.environ['MLFLOW_TRACKING_URI'] = path_to_local_file_uri(str(tmpdir.join("mlruns")))
+def test_command_example(directory, command):
     cwd_dir = os.path.join(EXAMPLES_DIR, directory)
-
-    try:
-        process.exec_cmd(command,
-                         cwd=cwd_dir)
-    finally:
-        shutil.rmtree(str(tmpdir))
-        del os.environ['MLFLOW_TRACKING_URI']
+    process.exec_cmd(command,
+                     cwd=cwd_dir)

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -8,12 +8,11 @@ from mlflow.utils.file_utils import path_to_local_file_uri
 from tests.integration.utils import invoke_cli_runner
 import pytest
 
-from tests.projects.utils import tracking_uri_mock
-
 EXAMPLES_DIR = 'examples'
 
 
 @pytest.mark.large
+@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("directory, params", [
     ('h2o', []),
     ('hyperparam', ['-e', 'train']),
@@ -29,7 +28,7 @@ EXAMPLES_DIR = 'examples'
     (os.path.join('tensorflow', 'tf1'), ['-P', 'steps=10']),
     ('xgboost', ['-P', 'colsample-bytree=0.8', '-P', 'subsample=0.9'])
 ])
-def test_mlflow_run_example(tracking_uri_mock, directory, params):
+def test_mlflow_run_example(directory, params):
     cli_run_list = [os.path.join(EXAMPLES_DIR, directory)] + params
     invoke_cli_runner(cli.run, cli_run_list)
 

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -12,7 +12,6 @@ EXAMPLES_DIR = 'examples'
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("directory, params", [
     ('h2o', []),
     ('hyperparam', ['-e', 'train']),

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -15,6 +15,7 @@ from mxnet.metric import Accuracy
 import mlflow
 import mlflow.gluon
 
+pytestmark = pytest.mark.notrackingurimock
 client = mlflow.tracking.MlflowClient()
 
 

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -15,9 +15,6 @@ from mxnet.metric import Accuracy
 import mlflow
 import mlflow.gluon
 
-pytestmark = pytest.mark.notrackingurimock
-client = mlflow.tracking.MlflowClient()
-
 
 class LogsDataset(Dataset):
     def __init__(self):
@@ -52,7 +49,7 @@ def gluon_random_data_run():
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             est.fit(data, epochs=3, val_data=validation)
-
+    client = mlflow.tracking.MlflowClient()
     return client.get_run(run.info.run_id)
 
 
@@ -71,6 +68,7 @@ def test_gluon_autolog_logs_expected_data(gluon_random_data_run):
 
 @pytest.mark.large
 def test_gluon_autolog_model_can_load_from_artifact(gluon_random_data_run):
+    client = mlflow.tracking.MlflowClient()
     artifacts = client.list_artifacts(gluon_random_data_run.info.run_id)
     artifacts = list(map(lambda x: x.path, artifacts))
     assert "model" in artifacts

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -32,7 +32,6 @@ from tests.helper_functions import score_model_in_sagemaker_docker_container
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 from tests.pyfunc.test_spark import score_model_as_udf
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 
 @pytest.fixture(scope='module')
@@ -282,7 +281,8 @@ def test_model_load_from_remote_uri_succeeds(model, model_path, mock_s3_bucket, 
 
 
 @pytest.mark.large
-def test_model_log(tracking_uri_mock, model, data, predicted):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_model_log(model, data, predicted):
     x, _ = data
     # should_start_run tests whether or not calling log_model() automatically starts a run.
     for should_start_run in [False, True]:
@@ -306,7 +306,8 @@ def test_model_log(tracking_uri_mock, model, data, predicted):  # pylint: disabl
             mlflow.end_run()
 
 
-def test_log_model_calls_register_model(tracking_uri_mock, model):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_model_calls_register_model(model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch:
@@ -317,7 +318,8 @@ def test_log_model_calls_register_model(tracking_uri_mock, model):
         mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
 
 
-def test_log_model_no_registered_model_name(tracking_uri_mock, model):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_model_no_registered_model_name(model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch:

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -281,7 +281,6 @@ def test_model_load_from_remote_uri_succeeds(model, model_path, mock_s3_bucket, 
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_model_log(model, data, predicted):
     x, _ = data
     # should_start_run tests whether or not calling log_model() automatically starts a run.
@@ -306,7 +305,6 @@ def test_model_log(model, data, predicted):
             mlflow.end_run()
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_model_calls_register_model(model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
@@ -318,7 +316,6 @@ def test_log_model_calls_register_model(model):
         mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_model_no_registered_model_name(model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -23,8 +23,8 @@ def random_one_hot_labels():
     return labels
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.fixture(params=[True, False])
+@pytest.mark.usefixtures("tracking_uri_mock")
 def manual_run(request):
     if request.param:
         mlflow.start_run()

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -24,7 +24,6 @@ def random_one_hot_labels():
 
 
 @pytest.fixture(params=[True, False])
-@pytest.mark.usefixtures("tracking_uri_mock")
 def manual_run(request):
     if request.param:
         mlflow.start_run()

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -1,6 +1,5 @@
 import pytest
 import numpy as np
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=W0611
 np.random.seed(1337)
 
 import keras  # noqa
@@ -24,8 +23,9 @@ def random_one_hot_labels():
     return labels
 
 
+@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.fixture(params=[True, False])
-def manual_run(request, tracking_uri_mock):
+def manual_run(request):
     if request.param:
         mlflow.start_run()
     yield

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -13,6 +13,8 @@ import mlflow.lightgbm
 mpl.use('Agg')
 client = mlflow.tracking.MlflowClient()
 
+pytestmark = pytest.mark.notrackingurimock
+
 
 def get_latest_run():
     return client.get_run(client.list_run_infos(experiment_id='0')[0].run_id)

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -11,12 +11,10 @@ import mlflow
 import mlflow.lightgbm
 
 mpl.use('Agg')
-client = mlflow.tracking.MlflowClient()
-
-pytestmark = pytest.mark.notrackingurimock
 
 
 def get_latest_run():
+    client = mlflow.tracking.MlflowClient()
     return client.get_run(client.list_run_infos(experiment_id='0')[0].run_id)
 
 
@@ -113,7 +111,7 @@ def test_lgb_autolog_logs_metrics_with_validation_data(bst_params, train_set):
               valid_names=['train'], evals_result=evals_result)
     run = get_latest_run()
     data = run.data
-
+    client = mlflow.tracking.MlflowClient()
     metric_key = 'train-multi_logloss'
     metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
     assert metric_key in data.metrics
@@ -133,7 +131,7 @@ def test_lgb_autolog_logs_metrics_with_multi_validation_data(bst_params, train_s
               valid_names=valid_names, evals_result=evals_result)
     run = get_latest_run()
     data = run.data
-
+    client = mlflow.tracking.MlflowClient()
     for valid_name in valid_names:
         metric_key = '{}-multi_logloss'.format(valid_name)
         metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
@@ -154,7 +152,7 @@ def test_lgb_autolog_logs_metrics_with_multi_metrics(bst_params, train_set):
               valid_names=valid_names, evals_result=evals_result)
     run = get_latest_run()
     data = run.data
-
+    client = mlflow.tracking.MlflowClient()
     for metric_name in params['metric']:
         metric_key = '{}-{}'.format(valid_names[0], metric_name)
         metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
@@ -175,7 +173,7 @@ def test_lgb_autolog_logs_metrics_with_multi_validation_data_and_metrics(bst_par
               valid_names=valid_names, evals_result=evals_result)
     run = get_latest_run()
     data = run.data
-
+    client = mlflow.tracking.MlflowClient()
     for valid_name in valid_names:
         for metric_name in params['metric']:
             metric_key = '{}-{}'.format(valid_name, metric_name)
@@ -198,7 +196,7 @@ def test_lgb_autolog_logs_metrics_with_early_stopping(bst_params, train_set):
                       valid_sets=valid_sets, valid_names=valid_names, evals_result=evals_result)
     run = get_latest_run()
     data = run.data
-
+    client = mlflow.tracking.MlflowClient()
     assert 'best_iteration' in data.metrics
     assert int(data.metrics['best_iteration']) == model.best_iteration
     assert 'stopped_iteration' in data.metrics
@@ -222,6 +220,7 @@ def test_lgb_autolog_logs_feature_importance(bst_params, train_set):
     run = get_latest_run()
     run_id = run.info.run_id
     artifacts_dir = run.info.artifact_uri.replace('file://', '')
+    client = mlflow.tracking.MlflowClient()
     artifacts = [x.path for x in client.list_artifacts(run_id)]
 
     for imp_type in ['split', 'gain']:

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -31,7 +31,6 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 from tests.helper_functions import score_model_in_sagemaker_docker_container
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_dataframe"])
 
@@ -135,7 +134,8 @@ def test_model_log(lgb_model, model_path):
                 mlflow.set_tracking_uri(old_uri)
 
 
-def test_log_model_calls_register_model(tracking_uri_mock, lgb_model):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_model_calls_register_model(lgb_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:
@@ -148,7 +148,8 @@ def test_log_model_calls_register_model(tracking_uri_mock, lgb_model):
         mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
 
 
-def test_log_model_no_registered_model_name(tracking_uri_mock, lgb_model):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_model_no_registered_model_name(lgb_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -134,7 +134,6 @@ def test_model_log(lgb_model, model_path):
                 mlflow.set_tracking_uri(old_uri)
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_model_calls_register_model(lgb_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
@@ -148,7 +147,6 @@ def test_log_model_calls_register_model(lgb_model):
         mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_model_no_registered_model_name(lgb_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -26,7 +26,6 @@ from tests.models import test_pyfunc
 from tests.helper_functions import pyfunc_build_image, pyfunc_serve_from_docker_image, \
     pyfunc_serve_from_docker_image_with_env_override, \
     RestEndpoint, get_safe_port, pyfunc_serve_and_score_model
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 from mlflow.protos.databricks_pb2 import ErrorCode, MALFORMED_REQUEST
 from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON_SPLIT_ORIENTED, \
     CONTENT_TYPE_JSON, CONTENT_TYPE_CSV
@@ -128,8 +127,8 @@ def test_model_with_no_deployable_flavors_fails_pollitely():
         assert "No suitable flavor backend was found for the model." in stderr
 
 
-def test_serve_gunicorn_opts(iris_data, sk_model,
-                             tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_serve_gunicorn_opts(iris_data, sk_model):
     if sys.platform == "win32":
         pytest.skip("This test requires gunicorn which is not available on windows.")
     with mlflow.start_run() as active_run:
@@ -161,7 +160,8 @@ def test_serve_gunicorn_opts(iris_data, sk_model,
         assert expected_command_pattern.search(stdout) is not None
 
 
-def test_predict(iris_data, sk_model, tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_predict(iris_data, sk_model):
     with TempDir(chdr=True) as tmp:
         with mlflow.start_run() as active_run:
             mlflow.sklearn.log_model(sk_model, "model", registered_model_name="impredicting")

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -245,6 +245,7 @@ def test_predict(iris_data, sk_model):
         assert all(expected == actual)
 
 
+@pytest.mark.notrackingurimock
 def test_prepare_env_passes(sk_model):
     if no_conda:
         pytest.skip("This test requires conda.")
@@ -270,6 +271,7 @@ def test_prepare_env_passes(sk_model):
         assert p.wait() == 0
 
 
+@pytest.mark.notrackingurimock
 def test_prepare_env_fails(sk_model):
     if no_conda:
         pytest.skip("This test requires conda.")
@@ -291,6 +293,7 @@ def test_prepare_env_fails(sk_model):
 
 
 @pytest.mark.large
+@pytest.mark.notrackingurimock
 def test_build_docker(iris_data, sk_model):
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model")
@@ -304,6 +307,7 @@ def test_build_docker(iris_data, sk_model):
 
 
 @pytest.mark.large
+@pytest.mark.notrackingurimock
 def test_build_docker_with_env_override(iris_data, sk_model):
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model")

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -127,7 +127,6 @@ def test_model_with_no_deployable_flavors_fails_pollitely():
         assert "No suitable flavor backend was found for the model." in stderr
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_serve_gunicorn_opts(iris_data, sk_model):
     if sys.platform == "win32":
         pytest.skip("This test requires gunicorn which is not available on windows.")
@@ -160,7 +159,6 @@ def test_serve_gunicorn_opts(iris_data, sk_model):
         assert expected_command_pattern.search(stdout) is not None
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_predict(iris_data, sk_model):
     with TempDir(chdr=True) as tmp:
         with mlflow.start_run() as active_run:

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -245,7 +245,6 @@ def test_predict(iris_data, sk_model):
         assert all(expected == actual)
 
 
-@pytest.mark.notrackingurimock
 def test_prepare_env_passes(sk_model):
     if no_conda:
         pytest.skip("This test requires conda.")
@@ -271,7 +270,6 @@ def test_prepare_env_passes(sk_model):
         assert p.wait() == 0
 
 
-@pytest.mark.notrackingurimock
 def test_prepare_env_fails(sk_model):
     if no_conda:
         pytest.skip("This test requires conda.")
@@ -293,7 +291,6 @@ def test_prepare_env_fails(sk_model):
 
 
 @pytest.mark.large
-@pytest.mark.notrackingurimock
 def test_build_docker(iris_data, sk_model):
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model")
@@ -307,7 +304,6 @@ def test_build_docker(iris_data, sk_model):
 
 
 @pytest.mark.large
-@pytest.mark.notrackingurimock
 def test_build_docker_with_env_override(iris_data, sk_model):
     with mlflow.start_run() as active_run:
         mlflow.sklearn.log_model(sk_model, "model")

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -263,7 +263,6 @@ def test_pyfunc_representation_of_float32_model_casts_and_evalutes_float64_input
 # TODO: Use the default conda environment once MLflow's Travis build supports the onnxruntime
 # library
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_model_log(onnx_model, onnx_custom_env):
     # pylint: disable=unused-argument
 
@@ -290,7 +289,6 @@ def test_model_log(onnx_model, onnx_custom_env):
             mlflow.end_run()
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_model_calls_register_model(onnx_model, onnx_custom_env):
     import mlflow.onnx
     artifact_path = "model"
@@ -303,7 +301,6 @@ def test_log_model_calls_register_model(onnx_model, onnx_custom_env):
         mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_model_no_registered_model_name(onnx_model, onnx_custom_env):
     import mlflow.onnx
     artifact_path = "model"
@@ -316,7 +313,6 @@ def test_log_model_no_registered_model_name(onnx_model, onnx_custom_env):
 
 # TODO: Mark this as large once MLflow's Travis build supports the onnxruntime library
 @pytest.mark.release
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_model_log_evaluate_pyfunc_format(onnx_model, data, predicted):
     import onnx
     import mlflow.onnx

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -21,7 +21,6 @@ from tests.helper_functions import pyfunc_serve_and_score_model
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 pytestmark = pytest.mark.skipif(
     (sys.version_info < (3, 6)),
@@ -264,7 +263,8 @@ def test_pyfunc_representation_of_float32_model_casts_and_evalutes_float64_input
 # TODO: Use the default conda environment once MLflow's Travis build supports the onnxruntime
 # library
 @pytest.mark.large
-def test_model_log(tracking_uri_mock, onnx_model, onnx_custom_env):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_model_log(onnx_model, onnx_custom_env):
     # pylint: disable=unused-argument
 
     import onnx
@@ -290,7 +290,8 @@ def test_model_log(tracking_uri_mock, onnx_model, onnx_custom_env):
             mlflow.end_run()
 
 
-def test_log_model_calls_register_model(tracking_uri_mock, onnx_model, onnx_custom_env):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_model_calls_register_model(onnx_model, onnx_custom_env):
     import mlflow.onnx
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
@@ -302,7 +303,8 @@ def test_log_model_calls_register_model(tracking_uri_mock, onnx_model, onnx_cust
         mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
 
 
-def test_log_model_no_registered_model_name(tracking_uri_mock, onnx_model, onnx_custom_env):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_model_no_registered_model_name(onnx_model, onnx_custom_env):
     import mlflow.onnx
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
@@ -314,7 +316,8 @@ def test_log_model_no_registered_model_name(tracking_uri_mock, onnx_model, onnx_
 
 # TODO: Mark this as large once MLflow's Travis build supports the onnxruntime library
 @pytest.mark.release
-def test_model_log_evaluate_pyfunc_format(tracking_uri_mock, onnx_model, data, predicted):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_model_log_evaluate_pyfunc_format(onnx_model, data, predicted):
     import onnx
     import mlflow.onnx
     x, y = data

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -24,7 +24,6 @@ from mlflow.utils.rest_utils import _DEFAULT_HEADERS
 from tests import helper_functions
 
 from tests.projects.utils import validate_exit_status, TEST_PROJECT_DIR
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 
 @pytest.fixture()
@@ -161,8 +160,8 @@ def test_upload_existing_project_to_dbfs(dbfs_path_exists_mock):  # pylint: disa
 ])
 def test_dbfs_path_exists_error_response_handling(response_mock):
     with mock.patch("mlflow.utils.databricks_utils.get_databricks_host_creds") \
-         as get_databricks_host_creds_mock, \
-         mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
+            as get_databricks_host_creds_mock, \
+            mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
         # given a well formed DatabricksJobRunner
         # note: databricks_profile is None needed because clients using profile are mocked
         job_runner = DatabricksJobRunner(databricks_profile=None)
@@ -214,10 +213,9 @@ def test_run_databricks_validations(
         databricks.before_run_validations("databricks", cluster_spec_mock)
 
 
-def test_run_databricks(
-        before_run_validations_mock,  # pylint: disable=unused-argument
-        tracking_uri_mock, runs_cancel_mock, dbfs_mocks,  # pylint: disable=unused-argument
-        runs_submit_mock, runs_get_mock, cluster_spec_mock, set_tag_mock):
+@pytest.mark.usefixtures("before_run_validations_mock", "tracking_uri_mock", "runs_cancel_mock",
+                         "dbfs_mocks")
+def test_run_databricks(runs_submit_mock, runs_get_mock, cluster_spec_mock, set_tag_mock):
     """Test running on Databricks with mocks."""
     with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
         # Test that MLflow gets the correct run status when performing a Databricks run
@@ -238,11 +236,10 @@ def test_run_databricks(
             validate_exit_status(submitted_run.get_status(), expect_status)
 
 
+@pytest.mark.usefixtures("before_run_validations_mock", "tracking_uri_mock", "runs_cancel_mock",
+                         "dbfs_mocks", "cluster_spec_mock", "set_tag_mock")
 def test_run_databricks_cluster_spec_json(
-        before_run_validations_mock,  # pylint: disable=unused-argument
-        tracking_uri_mock, runs_cancel_mock, dbfs_mocks,  # pylint: disable=unused-argument
-        runs_submit_mock, runs_get_mock,
-        cluster_spec_mock, set_tag_mock):  # pylint: disable=unused-argument
+        runs_submit_mock, runs_get_mock):
     with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
         runs_get_mock.return_value = mock_runs_get_result(succeeded=True)
         cluster_spec = {

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -258,8 +258,8 @@ def test_run_databricks_cluster_spec_json(
         assert req_body["new_cluster"] == cluster_spec
 
 
-def test_run_databricks_throws_exception_when_spec_uses_existing_cluster(
-        tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_run_databricks_throws_exception_when_spec_uses_existing_cluster():
     with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
         existing_cluster_spec = {
             "existing_cluster_id": "1000-123456-clust1",
@@ -270,8 +270,9 @@ def test_run_databricks_throws_exception_when_spec_uses_existing_cluster(
         assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
+@pytest.mark.usefixtures("tracking_uri_mock")
 def test_run_databricks_cancel(
-        before_run_validations_mock, tracking_uri_mock,  # pylint: disable=unused-argument
+        before_run_validations_mock,  # pylint: disable=unused-argument
         runs_submit_mock, dbfs_mocks, set_tag_mock,  # pylint: disable=unused-argument
         runs_cancel_mock, runs_get_mock, cluster_spec_mock):
     # Test that MLflow properly handles Databricks run cancellation. We mock the result of

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -213,7 +213,7 @@ def test_run_databricks_validations(
         databricks.before_run_validations("databricks", cluster_spec_mock)
 
 
-@pytest.mark.usefixtures("before_run_validations_mock", "tracking_uri_mock", "runs_cancel_mock",
+@pytest.mark.usefixtures("before_run_validations_mock", "runs_cancel_mock",
                          "dbfs_mocks")
 def test_run_databricks(runs_submit_mock, runs_get_mock, cluster_spec_mock, set_tag_mock):
     """Test running on Databricks with mocks."""
@@ -236,7 +236,7 @@ def test_run_databricks(runs_submit_mock, runs_get_mock, cluster_spec_mock, set_
             validate_exit_status(submitted_run.get_status(), expect_status)
 
 
-@pytest.mark.usefixtures("before_run_validations_mock", "tracking_uri_mock", "runs_cancel_mock",
+@pytest.mark.usefixtures("before_run_validations_mock", "runs_cancel_mock",
                          "dbfs_mocks", "cluster_spec_mock", "set_tag_mock")
 def test_run_databricks_cluster_spec_json(
         runs_submit_mock, runs_get_mock):
@@ -255,7 +255,6 @@ def test_run_databricks_cluster_spec_json(
         assert req_body["new_cluster"] == cluster_spec
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_run_databricks_throws_exception_when_spec_uses_existing_cluster():
     with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
         existing_cluster_spec = {
@@ -267,7 +266,6 @@ def test_run_databricks_throws_exception_when_spec_uses_existing_cluster():
         assert exc.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_run_databricks_cancel(
         before_run_validations_mock,  # pylint: disable=unused-argument
         runs_submit_mock, dbfs_mocks, set_tag_mock,  # pylint: disable=unused-argument

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -25,7 +25,6 @@ def _build_uri(base_uri, subdirectory):
     return base_uri
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
 def test_docker_project_execution(
         use_start_run,
@@ -91,7 +90,6 @@ def test_docker_project_tracking_uri_propagation(
         mlflow.set_tracking_uri(old_uri)
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_docker_uri_mode_validation(docker_example_base_image):  # pylint: disable=unused-argument
     with pytest.raises(ExecutionException):
         mlflow.projects.run(TEST_DOCKER_PROJECT_DIR, backend="databricks")

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -15,7 +15,6 @@ from mlflow.utils.mlflow_tags import (
 )
 from tests.projects.utils import TEST_DOCKER_PROJECT_DIR
 from tests.projects.utils import docker_example_base_image  # pylint: disable=unused-import
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 from mlflow.projects import _project_spec
 from mlflow.exceptions import MlflowException
 
@@ -26,10 +25,11 @@ def _build_uri(base_uri, subdirectory):
     return base_uri
 
 
+@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
 def test_docker_project_execution(
         use_start_run,
-        tmpdir, tracking_uri_mock, docker_example_base_image):  # pylint: disable=unused-argument
+        tmpdir, docker_example_base_image):  # pylint: disable=unused-argument
     expected_params = {"use_start_run": use_start_run}
     submitted_run = mlflow.projects.run(
         TEST_DOCKER_PROJECT_DIR, experiment_id=file_store.FileStore.DEFAULT_EXPERIMENT_ID,
@@ -91,8 +91,8 @@ def test_docker_project_tracking_uri_propagation(
         mlflow.set_tracking_uri(old_uri)
 
 
-def test_docker_uri_mode_validation(
-        tracking_uri_mock, docker_example_base_image):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_docker_uri_mode_validation(docker_example_base_image):  # pylint: disable=unused-argument
     with pytest.raises(ExecutionException):
         mlflow.projects.run(TEST_DOCKER_PROJECT_DIR, backend="databricks")
 

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -140,7 +140,6 @@ def test_fetch_project_validations(local_git_repo_uri):
         mlflow.projects._fetch_project(uri=TEST_PROJECT_DIR, force_tempdir=False, version="version")
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize('experiment_name,experiment_id,expected', [
     ('Default', None, '0'),
     ('add an experiment', None, '1'),
@@ -184,14 +183,12 @@ def test_parse_subdirectory():
         mlflow.projects._parse_subdirectory(period_fail_uri)
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_invalid_run_mode():
     """ Verify that we raise an exception given an invalid run mode """
     with pytest.raises(ExecutionException):
         mlflow.projects.run(uri=TEST_PROJECT_DIR, backend="some unsupported mode")
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_use_conda():
     """ Verify that we correctly handle the `use_conda` argument."""
     # Verify we throw an exception when conda is unavailable
@@ -210,7 +207,6 @@ def test_use_conda():
             os.environ["CONDA_EXE"] = conda_exe_path
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_expected_tags_logged_when_using_conda():
     with mock.patch.object(mlflow.tracking.MlflowClient, "set_tag") as tag_mock:
         try:
@@ -230,7 +226,6 @@ def test_is_valid_branch_name(local_git_repo):
     assert not mlflow.projects._is_valid_branch_name(local_git_repo, "dev")
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
 @pytest.mark.parametrize("version", [None, "master", "git-commit"])
 def test_run_local_git_repo(patch_user,  # pylint: disable=unused-argument
@@ -283,7 +278,6 @@ def test_run_local_git_repo(patch_user,  # pylint: disable=unused-argument
         assert tags[LEGACY_MLFLOW_GIT_REPO_URL] == local_git_repo_uri
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_invalid_version_local_git_repo(local_git_repo_uri):
     # Run project with invalid commit hash
     with pytest.raises(ExecutionException,
@@ -293,7 +287,6 @@ def test_invalid_version_local_git_repo(local_git_repo_uri):
                             use_conda=False, experiment_id=FileStore.DEFAULT_EXPERIMENT_ID)
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
 def test_run(tmpdir,  # pylint: disable=unused-argument
              patch_user,  # pylint: disable=unused-argument
@@ -332,7 +325,6 @@ def test_run(tmpdir,  # pylint: disable=unused-argument
     assert tags[MLFLOW_PROJECT_ENTRY_POINT] == "test_tracking"
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_run_with_parent(tmpdir):  # pylint: disable=unused-argument
     """Verify that if we are in a nested run, mlflow.projects.run() will have a parent_run_id."""
     with mlflow.start_run():
@@ -348,7 +340,6 @@ def test_run_with_parent(tmpdir):  # pylint: disable=unused-argument
     assert run.data.tags[MLFLOW_PARENT_RUN_ID] == parent_run_id
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_run_async():
     submitted_run0 = mlflow.projects.run(
         TEST_PROJECT_DIR, entry_point="sleep", parameters={"duration": 2},
@@ -378,7 +369,6 @@ def test_conda_path(mock_env, expected_conda, expected_activate):
         assert mlflow.projects._get_conda_bin_executable("activate") == expected_activate
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_cancel_run():
     submitted_run0, submitted_run1 = [mlflow.projects.run(
         TEST_PROJECT_DIR, entry_point="sleep", parameters={"duration": 2},

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -23,7 +23,6 @@ from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_USER, MLFLOW_S
 
 from tests.projects.utils import TEST_PROJECT_DIR, TEST_PROJECT_NAME, GIT_PROJECT_URI, \
     validate_exit_status, assert_dirs_equal
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 
 MOCK_USER = "janebloggs"
@@ -141,6 +140,7 @@ def test_fetch_project_validations(local_git_repo_uri):
         mlflow.projects._fetch_project(uri=TEST_PROJECT_DIR, force_tempdir=False, version="version")
 
 
+@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize('experiment_name,experiment_id,expected', [
     ('Default', None, '0'),
     ('add an experiment', None, '1'),
@@ -150,8 +150,7 @@ def test_fetch_project_validations(local_git_repo_uri):
 ])
 def test_resolve_experiment_id(experiment_name,
                                experiment_id,
-                               expected,
-                               tracking_uri_mock):  # pylint: disable=unused-argument
+                               expected):
     assert expected == _resolve_experiment_id(experiment_name=experiment_name,
                                               experiment_id=experiment_id)
 
@@ -185,13 +184,15 @@ def test_parse_subdirectory():
         mlflow.projects._parse_subdirectory(period_fail_uri)
 
 
-def test_invalid_run_mode(tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_invalid_run_mode():
     """ Verify that we raise an exception given an invalid run mode """
     with pytest.raises(ExecutionException):
         mlflow.projects.run(uri=TEST_PROJECT_DIR, backend="some unsupported mode")
 
 
-def test_use_conda(tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_use_conda():
     """ Verify that we correctly handle the `use_conda` argument."""
     # Verify we throw an exception when conda is unavailable
     old_path = os.environ["PATH"]
@@ -209,8 +210,8 @@ def test_use_conda(tracking_uri_mock):  # pylint: disable=unused-argument
             os.environ["CONDA_EXE"] = conda_exe_path
 
 
-def test_expected_tags_logged_when_using_conda(
-        tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_expected_tags_logged_when_using_conda():
     with mock.patch.object(mlflow.tracking.MlflowClient, "set_tag") as tag_mock:
         try:
             mlflow.projects.run(TEST_PROJECT_DIR, use_conda=True)
@@ -229,12 +230,12 @@ def test_is_valid_branch_name(local_git_repo):
     assert not mlflow.projects._is_valid_branch_name(local_git_repo, "dev")
 
 
+@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
 @pytest.mark.parametrize("version", [None, "master", "git-commit"])
 def test_run_local_git_repo(patch_user,  # pylint: disable=unused-argument
                             local_git_repo,
                             local_git_repo_uri,
-                            tracking_uri_mock,  # pylint: disable=unused-argument
                             use_start_run,
                             version):
     if version is not None:
@@ -282,8 +283,8 @@ def test_run_local_git_repo(patch_user,  # pylint: disable=unused-argument
         assert tags[LEGACY_MLFLOW_GIT_REPO_URL] == local_git_repo_uri
 
 
-def test_invalid_version_local_git_repo(local_git_repo_uri,
-                                        tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_invalid_version_local_git_repo(local_git_repo_uri):
     # Run project with invalid commit hash
     with pytest.raises(ExecutionException,
                        match=r'Unable to checkout version \'badc0de\''):
@@ -292,10 +293,10 @@ def test_invalid_version_local_git_repo(local_git_repo_uri,
                             use_conda=False, experiment_id=FileStore.DEFAULT_EXPERIMENT_ID)
 
 
+@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
 def test_run(tmpdir,  # pylint: disable=unused-argument
              patch_user,  # pylint: disable=unused-argument
-             tracking_uri_mock,  # pylint: disable=unused-argument
              use_start_run):
     submitted_run = mlflow.projects.run(
         TEST_PROJECT_DIR, entry_point="test_tracking",
@@ -331,7 +332,8 @@ def test_run(tmpdir,  # pylint: disable=unused-argument
     assert tags[MLFLOW_PROJECT_ENTRY_POINT] == "test_tracking"
 
 
-def test_run_with_parent(tmpdir, tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_run_with_parent(tmpdir):  # pylint: disable=unused-argument
     """Verify that if we are in a nested run, mlflow.projects.run() will have a parent_run_id."""
     with mlflow.start_run():
         parent_run_id = mlflow.active_run().info.run_id
@@ -346,7 +348,8 @@ def test_run_with_parent(tmpdir, tracking_uri_mock):  # pylint: disable=unused-a
     assert run.data.tags[MLFLOW_PARENT_RUN_ID] == parent_run_id
 
 
-def test_run_async(tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_run_async():
     submitted_run0 = mlflow.projects.run(
         TEST_PROJECT_DIR, entry_point="sleep", parameters={"duration": 2},
         use_conda=False, experiment_id=FileStore.DEFAULT_EXPERIMENT_ID, synchronous=False)
@@ -375,7 +378,8 @@ def test_conda_path(mock_env, expected_conda, expected_activate):
         assert mlflow.projects._get_conda_bin_executable("activate") == expected_activate
 
 
-def test_cancel_run(tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_cancel_run():
     submitted_run0, submitted_run1 = [mlflow.projects.run(
         TEST_PROJECT_DIR, entry_point="sleep", parameters={"duration": 2},
         use_conda=False, experiment_id=FileStore.DEFAULT_EXPERIMENT_ID,

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -14,13 +14,13 @@ from mlflow.utils import process
 from tests.integration.utils import invoke_cli_runner
 from tests.projects.utils import TEST_PROJECT_DIR, GIT_PROJECT_URI, SSH_PROJECT_URI, \
     TEST_NO_SPEC_PROJECT_DIR
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 _logger = logging.getLogger(__name__)
 
 
 @pytest.mark.large
-def test_run_local_params(tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_run_local_params():
     excitement_arg = 2
     name = "friend"
     invoke_cli_runner(cli.run, [TEST_PROJECT_DIR, "-e", "greeter", "-P",
@@ -29,12 +29,12 @@ def test_run_local_params(tracking_uri_mock):  # pylint: disable=unused-argument
 
 
 @pytest.mark.large
+@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("experiment_name", [
     b'test-experiment'.decode("utf-8"),
     'test-experiment',
 ])
-def test_run_local_experiment_specification(experiment_name,
-                                            tracking_uri_mock):  # pylint: disable=unused-argument
+def test_run_local_experiment_specification(experiment_name):
     invoke_cli_runner(
         cli.run,
         [
@@ -66,7 +66,8 @@ def clean_mlruns_dir():
 
 
 @pytest.mark.large
-def test_run_local_conda_env(tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_run_local_conda_env():
     with open(os.path.join(TEST_PROJECT_DIR, "conda.yaml"), "r") as handle:
         conda_env_contents = handle.read()
     expected_env_name = "mlflow-%s" % hashlib.sha1(conda_env_contents.encode("utf-8")).hexdigest()
@@ -81,7 +82,8 @@ def test_run_local_conda_env(tracking_uri_mock):  # pylint: disable=unused-argum
 
 
 @pytest.mark.large
-def test_run_local_no_spec(tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_run_local_no_spec():
     # Run an example project that doesn't contain an MLproject file
     expected_env_name = "mlflow-%s" % hashlib.sha1("".encode("utf-8")).hexdigest()
     invoke_cli_runner(cli.run, [TEST_NO_SPEC_PROJECT_DIR, "-e", "check_conda_env.py", "-P",
@@ -89,7 +91,8 @@ def test_run_local_no_spec(tracking_uri_mock):  # pylint: disable=unused-argumen
 
 
 @pytest.mark.large
-def test_run_git_https(tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_run_git_https():
     # Invoke command twice to ensure we set Git state in an isolated manner (e.g. don't attempt to
     # create a git repo in the same directory twice, etc)
     assert GIT_PROJECT_URI.startswith("https")
@@ -99,7 +102,8 @@ def test_run_git_https(tracking_uri_mock):  # pylint: disable=unused-argument
 
 @pytest.mark.large
 @pytest.mark.requires_ssh
-def test_run_git_ssh(tracking_uri_mock):  # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_run_git_ssh():
     # Note: this test requires SSH authentication to GitHub, and so is disabled in Travis, where SSH
     # keys are unavailable. However it should be run locally whenever logic related to running
     # Git projects is modified.

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -19,7 +19,6 @@ _logger = logging.getLogger(__name__)
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_run_local_params():
     excitement_arg = 2
     name = "friend"
@@ -29,7 +28,6 @@ def test_run_local_params():
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("experiment_name", [
     b'test-experiment'.decode("utf-8"),
     'test-experiment',
@@ -66,7 +64,6 @@ def clean_mlruns_dir():
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_run_local_conda_env():
     with open(os.path.join(TEST_PROJECT_DIR, "conda.yaml"), "r") as handle:
         conda_env_contents = handle.read()
@@ -82,7 +79,6 @@ def test_run_local_conda_env():
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_run_local_no_spec():
     # Run an example project that doesn't contain an MLproject file
     expected_env_name = "mlflow-%s" % hashlib.sha1("".encode("utf-8")).hexdigest()
@@ -91,7 +87,6 @@ def test_run_local_no_spec():
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_run_git_https():
     # Invoke command twice to ensure we set Git state in an isolated manner (e.g. don't attempt to
     # create a git repo in the same directory twice, etc)
@@ -102,7 +97,6 @@ def test_run_git_https():
 
 @pytest.mark.large
 @pytest.mark.requires_ssh
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_run_git_ssh():
     # Note: this test requires SSH authentication to GitHub, and so is disabled in Travis, where SSH
     # keys are unavailable. However it should be run locally whenever logic related to running
@@ -112,6 +106,7 @@ def test_run_git_ssh():
     invoke_cli_runner(cli.run, [SSH_PROJECT_URI, "--no-conda", "-P", "alpha=0.5"])
 
 
+@pytest.mark.notrackingurimock
 def test_run_databricks_cluster_spec(tmpdir):
     cluster_spec = {
         "spark_version": "5.0.x-scala2.11",

--- a/tests/projects/utils.py
+++ b/tests/projects/utils.py
@@ -6,12 +6,10 @@ from docker.errors import BuildError, APIError
 
 import pytest
 
-import mlflow
 from mlflow.utils.file_utils import TempDir, _copy_project
 
 from mlflow.entities import RunStatus
 from mlflow.projects import _project_spec
-from mlflow.utils.file_utils import path_to_local_sqlite_uri
 
 
 TEST_DIR = "tests"
@@ -68,12 +66,3 @@ def docker_example_base_image():
         except APIError as api_error:
             print(api_error.explanation)
             raise api_error
-
-
-@pytest.fixture()
-def tracking_uri_mock(tmpdir):
-    try:
-        mlflow.set_tracking_uri(path_to_local_sqlite_uri(os.path.join(tmpdir.strpath, 'mlruns')))
-        yield tmpdir
-    finally:
-        mlflow.set_tracking_uri(None)

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -34,7 +34,6 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 from tests.helper_functions import score_model_in_sagemaker_docker_container
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -155,7 +155,6 @@ def test_model_log(sklearn_logreg_model, model_path):
                 mlflow.set_tracking_uri(old_uri)
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_model_calls_register_model(sklearn_logreg_model):
     artifact_path = "linear"
     register_model_patch = mock.patch("mlflow.register_model")
@@ -169,7 +168,6 @@ def test_log_model_calls_register_model(sklearn_logreg_model):
         mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_model_no_registered_model_name(sklearn_logreg_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -156,7 +156,8 @@ def test_model_log(sklearn_logreg_model, model_path):
                 mlflow.set_tracking_uri(old_uri)
 
 
-def test_log_model_calls_register_model(tracking_uri_mock, sklearn_logreg_model):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_model_calls_register_model(sklearn_logreg_model):
     artifact_path = "linear"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:
@@ -169,7 +170,8 @@ def test_log_model_calls_register_model(tracking_uri_mock, sklearn_logreg_model)
         mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
 
 
-def test_log_model_no_registered_model_name(tracking_uri_mock, sklearn_logreg_model):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_model_no_registered_model_name(sklearn_logreg_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -350,7 +350,6 @@ def test_sparkml_model_log_invalid_args(spark_model_transformer, model_path):
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_model_calls_register_model(tmpdir, spark_model_iris):
     artifact_path = "model"
     dfs_tmp_dir = os.path.join(str(tmpdir), "test")
@@ -368,7 +367,6 @@ def test_log_model_calls_register_model(tmpdir, spark_model_iris):
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_model_no_registered_model_name(tmpdir, spark_model_iris):
     artifact_path = "model"
     dfs_tmp_dir = os.path.join(str(tmpdir), "test")

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -33,7 +33,6 @@ from tests.helper_functions import score_model_in_sagemaker_docker_container
 from tests.pyfunc.test_spark import score_model_as_udf
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 _logger = logging.getLogger(__name__)
 
@@ -351,7 +350,8 @@ def test_sparkml_model_log_invalid_args(spark_model_transformer, model_path):
 
 
 @pytest.mark.large
-def test_log_model_calls_register_model(tracking_uri_mock, tmpdir, spark_model_iris):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_model_calls_register_model(tmpdir, spark_model_iris):
     artifact_path = "model"
     dfs_tmp_dir = os.path.join(str(tmpdir), "test")
     try:
@@ -368,7 +368,8 @@ def test_log_model_calls_register_model(tracking_uri_mock, tmpdir, spark_model_i
 
 
 @pytest.mark.large
-def test_log_model_no_registered_model_name(tracking_uri_mock, tmpdir, spark_model_iris):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_model_no_registered_model_name(tmpdir, spark_model_iris):
     artifact_path = "model"
     dfs_tmp_dir = os.path.join(str(tmpdir), "test")
     try:

--- a/tests/spark_autologging/test_spark_datasource_autologging.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging.py
@@ -42,7 +42,6 @@ def _get_expected_table_info_row(path, data_format, version=None):
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_autologging_of_datasources_with_different_formats(
         spark_session, format_to_file_path):
     mlflow.spark.autolog()
@@ -93,7 +92,6 @@ def test_autologging_does_not_throw_on_api_failures(
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_autologging_dedups_multiple_reads_of_same_datasource(
         spark_session, format_to_file_path):
     mlflow.spark.autolog()
@@ -122,8 +120,7 @@ def test_autologging_dedups_multiple_reads_of_same_datasource(
 
 
 @pytest.mark.large
-def test_autologging_multiple_reads_same_run(spark_session, tracking_uri_mock, format_to_file_path):
-    # pylint: disable=unused-argument
+def test_autologging_multiple_reads_same_run(spark_session, format_to_file_path):
     mlflow.spark.autolog()
     with mlflow.start_run():
         for data_format, file_path in format_to_file_path.items():
@@ -141,8 +138,7 @@ def test_autologging_multiple_reads_same_run(spark_session, tracking_uri_mock, f
 
 
 @pytest.mark.large
-def test_autologging_does_not_start_run(spark_session, format_to_file_path, tracking_uri_mock):
-    # pylint: disable=unused-argument
+def test_autologging_does_not_start_run(spark_session, format_to_file_path):
     try:
         mlflow.spark.autolog()
         data_format = list(format_to_file_path.keys())[0]
@@ -160,7 +156,6 @@ def test_autologging_does_not_start_run(spark_session, format_to_file_path, trac
 
 @pytest.mark.large
 def test_autologging_slow_api_requests(spark_session, format_to_file_path, mlflow_client):
-    # pylint: disable=unused-argument
     import mlflow.utils.rest_utils
     orig = mlflow.utils.rest_utils.http_request
 
@@ -199,7 +194,6 @@ def test_autologging_slow_api_requests(spark_session, format_to_file_path, mlflo
 
 @pytest.mark.large
 def test_enabling_autologging_does_not_throw_when_spark_hasnt_been_started(
-        spark_session, tracking_uri_mock):
-    # pylint: disable=unused-argument
+        spark_session):
     spark_session.stop()
     mlflow.spark.autolog()

--- a/tests/spark_autologging/test_spark_datasource_autologging.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging.py
@@ -155,7 +155,8 @@ def test_autologging_does_not_start_run(spark_session, format_to_file_path):
 
 
 @pytest.mark.large
-def test_autologging_slow_api_requests(spark_session, format_to_file_path, mlflow_client):
+@pytest.mark.usefixtures("mlflow_client")
+def test_autologging_slow_api_requests(spark_session, format_to_file_path):
     import mlflow.utils.rest_utils
     orig = mlflow.utils.rest_utils.http_request
 

--- a/tests/spark_autologging/test_spark_datasource_autologging.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging.py
@@ -7,7 +7,6 @@ import mlflow
 import mlflow.spark
 from mlflow._spark_autologging import _SPARK_TABLE_INFO_TAG_NAME
 
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 from tests.tracking.test_rest_tracking import BACKEND_URIS
 from tests.tracking.test_rest_tracking import tracking_server_uri  # pylint: disable=unused-import
 from tests.tracking.test_rest_tracking import mlflow_client  # pylint: disable=unused-import
@@ -43,9 +42,9 @@ def _get_expected_table_info_row(path, data_format, version=None):
 
 
 @pytest.mark.large
+@pytest.mark.usefixtures("tracking_uri_mock")
 def test_autologging_of_datasources_with_different_formats(
-        spark_session, tracking_uri_mock, format_to_file_path):
-    # pylint: disable=unused-argument
+        spark_session, format_to_file_path):
     mlflow.spark.autolog()
     for data_format, file_path in format_to_file_path.items():
         base_df = spark_session.read.format(data_format).option("header", "true").\
@@ -94,9 +93,9 @@ def test_autologging_does_not_throw_on_api_failures(
 
 
 @pytest.mark.large
+@pytest.mark.usefixtures("tracking_uri_mock")
 def test_autologging_dedups_multiple_reads_of_same_datasource(
-        spark_session, format_to_file_path, tracking_uri_mock):
-    # pylint: disable=unused-argument
+        spark_session, format_to_file_path):
     mlflow.spark.autolog()
     data_format = list(format_to_file_path.keys())[0]
     file_path = format_to_file_path[data_format]

--- a/tests/spark_autologging/test_spark_datasource_autologging_crossframework.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging_crossframework.py
@@ -11,7 +11,6 @@ import mlflow.spark
 import mlflow.keras
 import mlflow.tensorflow
 
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 from tests.spark_autologging.utils import _assert_spark_data_logged
 from tests.spark_autologging.utils import spark_session  # pylint: disable=unused-import
 from tests.spark_autologging.utils import format_to_file_path  # pylint: disable=unused-import
@@ -67,9 +66,9 @@ def _fit_keras_model(pandas_df, epochs):
 
 
 @pytest.mark.large
+@pytest.mark.usefixtures("tracking_uri_mock")
 def test_spark_autologging_with_keras_autologging(
-        spark_session, data_format, file_path, tracking_uri_mock):
-    # pylint: disable=unused-argument
+        spark_session, data_format, file_path):
     assert mlflow.active_run() is None
     mlflow.spark.autolog()
     mlflow.keras.autolog()
@@ -82,9 +81,9 @@ def test_spark_autologging_with_keras_autologging(
 
 
 @pytest.mark.large
+@pytest.mark.usefixtures("tracking_uri_mock")
 def test_spark_keras_autologging_context_provider(
-        spark_session, tracking_uri_mock, data_format, file_path):
-    # pylint: disable=unused-argument
+        spark_session, data_format, file_path):
     mlflow.spark.autolog()
     mlflow.keras.autolog()
 
@@ -108,9 +107,9 @@ def test_spark_keras_autologging_context_provider(
 
 
 @pytest.mark.large
+@pytest.mark.usefixtures("tracking_uri_mock")
 def test_spark_and_keras_autologging_all_runs_managed(
-        spark_session, tracking_uri_mock, data_format, file_path):
-    # pylint: disable=unused-argument
+        spark_session, data_format, file_path):
     mlflow.spark.autolog()
     mlflow.keras.autolog()
     for _ in range(2):

--- a/tests/spark_autologging/test_spark_datasource_autologging_crossframework.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging_crossframework.py
@@ -66,7 +66,6 @@ def _fit_keras_model(pandas_df, epochs):
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_spark_autologging_with_keras_autologging(
         spark_session, data_format, file_path):
     assert mlflow.active_run() is None
@@ -81,7 +80,6 @@ def test_spark_autologging_with_keras_autologging(
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_spark_keras_autologging_context_provider(
         spark_session, data_format, file_path):
     mlflow.spark.autolog()
@@ -107,7 +105,6 @@ def test_spark_keras_autologging_context_provider(
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_spark_and_keras_autologging_all_runs_managed(
         spark_session, data_format, file_path):
     mlflow.spark.autolog()

--- a/tests/spark_autologging/test_spark_datasource_autologging_missing_jar.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging_missing_jar.py
@@ -7,7 +7,6 @@ from tests.spark_autologging.utils import _get_or_create_spark_session
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_enabling_autologging_throws_for_missing_jar():
     # pylint: disable=unused-argument
     spark_session = _get_or_create_spark_session(jars="")

--- a/tests/spark_autologging/test_spark_datasource_autologging_missing_jar.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging_missing_jar.py
@@ -4,11 +4,11 @@ import mlflow.spark
 from mlflow.exceptions import MlflowException
 
 from tests.spark_autologging.utils import _get_or_create_spark_session
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 
 @pytest.mark.large
-def test_enabling_autologging_throws_for_missing_jar(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_enabling_autologging_throws_for_missing_jar():
     # pylint: disable=unused-argument
     spark_session = _get_or_create_spark_session(jars="")
     try:

--- a/tests/spark_autologging/test_spark_datasource_autologging_unit.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging_unit.py
@@ -24,6 +24,7 @@ def mock_get_current_listener():
 
 
 @pytest.mark.large
+@pytest.mark.notrackingurimock
 def test_autolog_call_idempotent():
     mlflow.spark.autolog()
     listener = _get_current_listener()

--- a/tests/spark_autologging/test_spark_datasource_autologging_unit.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging_unit.py
@@ -24,7 +24,7 @@ def mock_get_current_listener():
 
 
 @pytest.mark.large
-@pytest.mark.notrackingurimock
+@pytest.mark.usefixtures("spark_session")
 def test_autolog_call_idempotent():
     mlflow.spark.autolog()
     listener = _get_current_listener()

--- a/tests/spark_autologging/test_spark_datasource_autologging_unit.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging_unit.py
@@ -24,7 +24,6 @@ def mock_get_current_listener():
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock", "spark_session")
 def test_autolog_call_idempotent():
     mlflow.spark.autolog()
     listener = _get_current_listener()
@@ -44,7 +43,6 @@ def test_subscriber_methods():
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_enabling_autologging_throws_for_wrong_spark_version(
         spark_session, mock_get_current_listener):
     # pylint: disable=unused-argument
@@ -56,7 +54,6 @@ def test_enabling_autologging_throws_for_wrong_spark_version(
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_enabling_autologging_throws_when_spark_hasnt_been_started(
         spark_session, mock_get_current_listener):
     # pylint: disable=unused-argument

--- a/tests/spark_autologging/test_spark_datasource_autologging_unit.py
+++ b/tests/spark_autologging/test_spark_datasource_autologging_unit.py
@@ -6,7 +6,6 @@ import mlflow
 from mlflow.exceptions import MlflowException
 import mlflow.spark
 from mlflow._spark_autologging import _get_current_listener, PythonSubscriber
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 from tests.spark_autologging.utils import _get_or_create_spark_session
 
 
@@ -25,8 +24,8 @@ def mock_get_current_listener():
 
 
 @pytest.mark.large
-def test_autolog_call_idempotent(spark_session, tracking_uri_mock):
-    # pylint: disable=unused-argument
+@pytest.mark.usefixtures("tracking_uri_mock", "spark_session")
+def test_autolog_call_idempotent():
     mlflow.spark.autolog()
     listener = _get_current_listener()
     mlflow.spark.autolog()
@@ -45,8 +44,9 @@ def test_subscriber_methods():
 
 
 @pytest.mark.large
+@pytest.mark.usefixtures("tracking_uri_mock")
 def test_enabling_autologging_throws_for_wrong_spark_version(
-        spark_session, tracking_uri_mock, mock_get_current_listener):
+        spark_session, mock_get_current_listener):
     # pylint: disable=unused-argument
     with mock.patch("mlflow._spark_autologging._get_spark_major_version") as get_version_mock:
         get_version_mock.return_value = 2
@@ -56,8 +56,9 @@ def test_enabling_autologging_throws_for_wrong_spark_version(
 
 
 @pytest.mark.large
+@pytest.mark.usefixtures("tracking_uri_mock")
 def test_enabling_autologging_throws_when_spark_hasnt_been_started(
-        spark_session, tracking_uri_mock, mock_get_current_listener):
+        spark_session, mock_get_current_listener):
     # pylint: disable=unused-argument
     spark_session.stop()
     with pytest.raises(MlflowException) as exc:

--- a/tests/store/artifact/test_cli.py
+++ b/tests/store/artifact/test_cli.py
@@ -75,7 +75,6 @@ def test_download_from_uri():
             assert expected_result == actual_result
 
 
-@pytest.mark.notrackingurimock
 def test_download_artifacts_from_uri():
     with mlflow.start_run() as run:
         with TempDir() as tmp:

--- a/tests/store/artifact/test_cli.py
+++ b/tests/store/artifact/test_cli.py
@@ -3,6 +3,7 @@ import os
 import posixpath
 
 from mock import mock
+import pytest
 
 import mlflow
 import mlflow.pyfunc
@@ -74,6 +75,7 @@ def test_download_from_uri():
             assert expected_result == actual_result
 
 
+@pytest.mark.notrackingurimock
 def test_download_artifacts_from_uri():
     with mlflow.start_run() as run:
         with TempDir() as tmp:

--- a/tests/store/artifact/test_cli.py
+++ b/tests/store/artifact/test_cli.py
@@ -3,7 +3,6 @@ import os
 import posixpath
 
 from mock import mock
-import pytest
 
 import mlflow
 import mlflow.pyfunc

--- a/tests/store/artifact/test_runs_artifact_repo.py
+++ b/tests/store/artifact/test_runs_artifact_repo.py
@@ -31,7 +31,6 @@ def test_parse_runs_uri_invalid_input(uri):
         RunsArtifactRepository.parse_runs_uri(uri)
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_runs_artifact_repo_init():
     artifact_location = "s3://blah_bucket/"
     experiment_id = mlflow.create_experiment("expr_abc", artifact_location)
@@ -46,7 +45,6 @@ def test_runs_artifact_repo_init():
     assert runs_repo.repo.artifact_uri == expected_absolute_uri
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_runs_artifact_repo_uses_repo_download_artifacts():
     """
     The RunsArtifactRepo should delegate `download_artifacts` to it's self.repo.download_artifacts

--- a/tests/store/artifact/test_runs_artifact_repo.py
+++ b/tests/store/artifact/test_runs_artifact_repo.py
@@ -6,8 +6,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
-
 
 @pytest.mark.parametrize("uri, expected_run_id, expected_artifact_path", [
     ('runs:/1234abcdf1394asdfwer33/path/to/model', '1234abcdf1394asdfwer33', 'path/to/model'),

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -38,7 +38,6 @@ def random_one_hot_labels():
 
 
 @pytest.fixture(params=[True, False])
-@pytest.mark.usefixtures("tracking_uri_mock")
 def manual_run(request):
     if request.param:
         mlflow.start_run()

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -37,8 +37,8 @@ def random_one_hot_labels():
     return labels
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.fixture(params=[True, False])
+@pytest.mark.usefixtures("tracking_uri_mock")
 def manual_run(request):
     if request.param:
         mlflow.start_run()

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -3,10 +3,7 @@
 from __future__ import print_function
 
 import collections
-import shutil
 import pytest
-import tempfile
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=W0611
 
 import numpy as np
 import pandas as pd
@@ -40,8 +37,9 @@ def random_one_hot_labels():
     return labels
 
 
+@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.fixture(params=[True, False])
-def manual_run(request, tracking_uri_mock):
+def manual_run(request):
     if request.param:
         mlflow.start_run()
     yield

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -180,6 +180,7 @@ def tf_keras_random_data_run_with_callback(random_train_data, random_one_hot_lab
 
 
 @pytest.mark.large
+@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize('restore_weights', [True])
 @pytest.mark.parametrize('callback', ['early'])
 @pytest.mark.parametrize('patience', [0, 1, 5])

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -38,7 +38,6 @@ def random_one_hot_labels():
 
 
 @pytest.fixture(params=[True, False])
-@pytest.mark.usefixtures("tracking_uri_mock")
 def manual_run(request):
     if request.param:
         mlflow.start_run()
@@ -180,7 +179,6 @@ def tf_keras_random_data_run_with_callback(random_train_data, random_one_hot_lab
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize('restore_weights', [True])
 @pytest.mark.parametrize('callback', ['early'])
 @pytest.mark.parametrize('patience', [0, 1, 5])
@@ -213,7 +211,6 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
 
 
 @pytest.mark.large
-@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize('restore_weights', [True])
 @pytest.mark.parametrize('callback', ['early'])
 @pytest.mark.parametrize('patience', [11])

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -213,6 +213,7 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
 
 
 @pytest.mark.large
+@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize('restore_weights', [True])
 @pytest.mark.parametrize('callback', ['early'])
 @pytest.mark.parametrize('patience', [11])

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -19,8 +19,8 @@ import mlflow.keras
 import os
 
 SavedModelInfo = collections.namedtuple(
-        "SavedModelInfo",
-        ["path", "meta_graph_tags", "signature_def_key", "inference_df", "expected_results_df"])
+    "SavedModelInfo",
+    ["path", "meta_graph_tags", "signature_def_key", "inference_df", "expected_results_df"])
 
 
 @pytest.fixture
@@ -37,8 +37,8 @@ def random_one_hot_labels():
     return labels
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.fixture(params=[True, False])
+@pytest.mark.usefixtures("tracking_uri_mock")
 def manual_run(request):
     if request.param:
         mlflow.start_run()

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -6,7 +6,6 @@ import collections
 import shutil
 import pytest
 import tempfile
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=W0611
 
 import numpy as np
 import pandas as pd
@@ -38,8 +37,9 @@ def random_one_hot_labels():
     return labels
 
 
+@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.fixture(params=[True, False])
-def manual_run(request, tracking_uri_mock):
+def manual_run(request):
     if request.param:
         mlflow.start_run()
     yield

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1,4 +1,3 @@
-import pytest
 from click.testing import CliRunner
 from mlflow.runs import list_run
 import mlflow
@@ -11,7 +10,6 @@ def test_list_run():
     assert 'apple' in result.output
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_list_run_experiment_id_required():
     result = CliRunner().invoke(list_run, [])
     assert 'Missing option "--experiment-id"' in result.output

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -3,8 +3,6 @@ from click.testing import CliRunner
 from mlflow.runs import list_run
 import mlflow
 
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
-
 
 def test_list_run():
     with mlflow.start_run(run_name='apple'):

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -10,6 +10,11 @@ from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.tracking._model_registry.utils import _get_store
 from mlflow.tracking._tracking_service.utils import _TRACKING_URI_ENV_VAR
 
+# Disable mocking tracking URI here, as we want to test setting the tracking URI via
+# environment variable. See
+# http://doc.pytest.org/en/latest/skipping.html#skip-all-test-functions-of-a-class-or-module
+# and https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#writing-python-tests
+# for more information.
 pytestmark = pytest.mark.notrackingurimock
 
 

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -10,6 +10,8 @@ from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.tracking._model_registry.utils import _get_store
 from mlflow.tracking._tracking_service.utils import _TRACKING_URI_ENV_VAR
 
+pytestmark = pytest.mark.notrackingurimock
+
 
 def test_get_store_rest_store_from_arg():
     env = {

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -16,6 +16,11 @@ from mlflow.tracking._tracking_service.utils import _get_store, _TRACKING_URI_EN
 
 # pylint: disable=unused-argument
 
+# Disable mocking tracking URI here, as we want to test setting the tracking URI via
+# environment variable. See
+# http://doc.pytest.org/en/latest/skipping.html#skip-all-test-functions-of-a-class-or-module
+# and https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#writing-python-tests
+# for more information.
 pytestmark = pytest.mark.notrackingurimock
 
 

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -16,6 +16,8 @@ from mlflow.tracking._tracking_service.utils import _get_store, _TRACKING_URI_EN
 
 # pylint: disable=unused-argument
 
+pytestmark = pytest.mark.notrackingurimock
+
 
 def test_get_store_file_store(tmp_wkdir):
     env = {}

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -23,7 +23,6 @@ from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_USER, MLFLOW_S
 from mlflow.tracking.fluent import _RUN_ID_ENV_VAR
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_create_experiment():
     with pytest.raises(TypeError):
         mlflow.create_experiment()  # pylint: disable=no-value-for-parameter
@@ -39,7 +38,6 @@ def test_create_experiment():
     assert exp_id is not None
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_create_experiment_with_duplicate_name():
     name = "popular_name"
     exp_id = mlflow.create_experiment(name)
@@ -71,7 +69,7 @@ def test_create_experiments_with_bad_name_types(name):
         assert e.message.contains("Invalid experiment name: %s. Expects a string." % name)
 
 
-@pytest.mark.usefixtures("tracking_uri_mock", "reset_active_experiment")
+@pytest.mark.usefixtures("reset_active_experiment")
 def test_set_experiment():
     with pytest.raises(TypeError):
         mlflow.set_experiment()  # pylint: disable=no-value-for-parameter
@@ -95,7 +93,6 @@ def test_set_experiment():
         assert another_run.info.experiment_id == exp_id2.experiment_id
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_set_experiment_with_deleted_experiment_name():
     name = "dead_exp"
     mlflow.set_experiment(name)
@@ -108,7 +105,6 @@ def test_set_experiment_with_deleted_experiment_name():
         mlflow.set_experiment(name)
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_list_experiments():
     def _assert_exps(ids_to_lifecycle_stage, view_type_arg):
         result = set([(exp.experiment_id, exp.lifecycle_stage)
@@ -140,7 +136,6 @@ def test_set_experiment_with_zero_id(reset_mock):
     MlflowClient.create_experiment.assert_not_called()
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_start_run_context_manager():
     with start_run() as first_run:
         first_uuid = first_run.info.run_id
@@ -161,7 +156,6 @@ def test_start_run_context_manager():
     assert finished_run2.info.status == RunStatus.to_string(RunStatus.FAILED)
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_start_and_end_run():
     # Use the start_run() and end_run() APIs without a `with` block, verify they work.
 
@@ -173,7 +167,6 @@ def test_start_and_end_run():
     assert finished_run.data.metrics["name_1"] == 25
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_metric_timestamp():
     with mlflow.start_run() as active_run:
         mlflow.log_metric("name_1", 25)
@@ -190,7 +183,7 @@ def test_metric_timestamp():
     ])
 
 
-@pytest.mark.usefixtures("tracking_uri_mock", "tmpdir")
+@pytest.mark.usefixtures("tmpdir")
 def test_log_batch():
     expected_metrics = {"metric-key0": 1.0, "metric-key1": 4.0}
     expected_params = {"param-key0": "param-val0", "param-key1": "param-val1"}
@@ -244,7 +237,6 @@ def test_log_batch():
             assert new_tags[tag_key] == tag_value
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_metric():
     with start_run() as active_run, mock.patch("time.time") as time_mock:
         time_mock.side_effect = [123 for _ in range(100)]
@@ -273,7 +265,6 @@ def test_log_metric():
     ])
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_metrics_uses_millisecond_timestamp_resolution_fluent():
     with start_run() as active_run, mock.patch("time.time") as time_mock:
         time_mock.side_effect = lambda: 123
@@ -302,7 +293,6 @@ def test_log_metrics_uses_millisecond_timestamp_resolution_fluent():
     ])
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_metrics_uses_millisecond_timestamp_resolution_client():
     with start_run() as active_run, mock.patch("time.time") as time_mock:
         time_mock.side_effect = lambda: 123
@@ -326,7 +316,6 @@ def test_log_metrics_uses_millisecond_timestamp_resolution_client():
     ])
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("step_kwarg", [None, -10, 5])
 def test_log_metrics_uses_common_timestamp_and_step_per_invocation(step_kwarg):
     expected_metrics = {"name_1": 30, "name_2": -3, "nested/nested/name": 40}
@@ -352,7 +341,6 @@ def get_store_mock():
         yield _get_store_mock
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_set_tags():
     exact_expected_tags = {"name_1": "c", "name_2": "b", "nested/nested/name": 5}
     approx_expected_tags = set([MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE])
@@ -369,7 +357,6 @@ def test_set_tags():
             assert str(exact_expected_tags[tag_key]) == tag_val
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_metric_validation():
     with start_run() as active_run:
         run_id = active_run.info.run_id
@@ -380,7 +367,6 @@ def test_log_metric_validation():
     assert len(finished_run.data.metrics) == 0
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_param():
     with start_run() as active_run:
         run_id = active_run.info.run_id
@@ -392,7 +378,6 @@ def test_log_param():
     assert finished_run.data.params == {"name_1": "a", "name_2": "b", "nested/nested/name": "5"}
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_params():
     expected_params = {"name_1": "c", "name_2": "b", "nested/nested/name": 5}
     with start_run() as active_run:
@@ -403,7 +388,6 @@ def test_log_params():
     assert finished_run.data.params == {"name_1": "c", "name_2": "b", "nested/nested/name": "5"}
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_batch_validates_entity_names_and_values():
     bad_kwargs = {
         "metrics": [
@@ -426,7 +410,6 @@ def test_log_batch_validates_entity_names_and_values():
                 assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_artifact_with_dirs(tmpdir):
     # Test log artifact with a directory
     art_dir = tmpdir.mkdir("parent")
@@ -467,7 +450,6 @@ def test_log_artifact_with_dirs(tmpdir):
             [os.path.basename(str(sub_dir))]
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_artifact():
     artifact_src_dir = tempfile.mkdtemp()
     # Create artifacts
@@ -519,7 +501,6 @@ def test_with_startrun():
     assert mlflow.active_run() is None
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_parent_create_run():
     with mlflow.start_run() as parent_run:
         parent_run_id = parent_run.info.run_id
@@ -553,7 +534,7 @@ def test_start_deleted_run():
     assert mlflow.active_run() is None
 
 
-@pytest.mark.usefixtures("tracking_uri_mock", "reset_active_experiment")
+@pytest.mark.usefixtures("reset_active_experiment")
 def test_start_run_exp_id_0():
     mlflow.set_experiment("some-experiment")
     # Create a run and verify that the current active experiment is the one we just set
@@ -579,7 +560,6 @@ def test_get_artifact_uri_uses_currently_active_run_id():
             run_id=active_run.info.run_id, artifact_path=artifact_path)
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("artifact_location, expected_uri_format", [
     (
         "mysql://user:password@host:port/dbname?driver=mydriver",
@@ -612,7 +592,7 @@ def test_get_artifact_uri_appends_to_uri_path_component_correctly(
                 run_id=run_id, path=artifact_path.lstrip("/"))
 
 
-@pytest.mark.usefixtures("tracking_uri_mock", "reset_active_experiment")
+@pytest.mark.usefixtures("reset_active_experiment")
 def test_search_runs():
     mlflow.set_experiment("exp-for-search")
     # Create a run and verify that the current active experiment is the one we just set
@@ -682,7 +662,7 @@ def test_search_runs():
     verify_runs(runs, [])
 
 
-@pytest.mark.usefixtures("tracking_uri_mock", "reset_active_experiment")
+@pytest.mark.usefixtures("reset_active_experiment")
 def test_search_runs_multiple_experiments():
     experiment_ids = [mlflow.create_experiment("exp__{}".format(exp_id)) for exp_id in range(1, 4)]
     for eid in experiment_ids:

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -21,12 +21,10 @@ from mlflow.utils.file_utils import local_file_uri_to_path
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_USER, MLFLOW_SOURCE_NAME, \
     MLFLOW_SOURCE_TYPE
 from mlflow.tracking.fluent import _RUN_ID_ENV_VAR
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
-
-# pylint: disable=unused-argument
 
 
-def test_create_experiment(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_create_experiment():
     with pytest.raises(TypeError):
         mlflow.create_experiment()  # pylint: disable=no-value-for-parameter
 
@@ -41,7 +39,8 @@ def test_create_experiment(tracking_uri_mock):
     assert exp_id is not None
 
 
-def test_create_experiment_with_duplicate_name(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_create_experiment_with_duplicate_name():
     name = "popular_name"
     exp_id = mlflow.create_experiment(name)
 
@@ -72,7 +71,8 @@ def test_create_experiments_with_bad_name_types(name):
         assert e.message.contains("Invalid experiment name: %s. Expects a string." % name)
 
 
-def test_set_experiment(tracking_uri_mock, reset_active_experiment):
+@pytest.mark.usefixtures("tracking_uri_mock", "reset_active_experiment")
+def test_set_experiment():
     with pytest.raises(TypeError):
         mlflow.set_experiment()  # pylint: disable=no-value-for-parameter
 
@@ -95,7 +95,8 @@ def test_set_experiment(tracking_uri_mock, reset_active_experiment):
         assert another_run.info.experiment_id == exp_id2.experiment_id
 
 
-def test_set_experiment_with_deleted_experiment_name(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_set_experiment_with_deleted_experiment_name():
     name = "dead_exp"
     mlflow.set_experiment(name)
     with start_run() as run:
@@ -107,7 +108,8 @@ def test_set_experiment_with_deleted_experiment_name(tracking_uri_mock):
         mlflow.set_experiment(name)
 
 
-def test_list_experiments(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_list_experiments():
     def _assert_exps(ids_to_lifecycle_stage, view_type_arg):
         result = set([(exp.experiment_id, exp.lifecycle_stage)
                       for exp in client.list_experiments(view_type=view_type_arg)])
@@ -124,7 +126,8 @@ def test_list_experiments(tracking_uri_mock):
     _assert_exps({'1': LifecycleStage.DELETED}, ViewType.DELETED_ONLY)
 
 
-def test_set_experiment_with_zero_id(reset_mock, reset_active_experiment):
+@pytest.mark.usefixtures("reset_active_experiment")
+def test_set_experiment_with_zero_id(reset_mock):
     reset_mock(MlflowClient, "get_experiment_by_name",
                mock.Mock(return_value=attrdict.AttrDict(
                    experiment_id=0,
@@ -137,7 +140,8 @@ def test_set_experiment_with_zero_id(reset_mock, reset_active_experiment):
     MlflowClient.create_experiment.assert_not_called()
 
 
-def test_start_run_context_manager(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_start_run_context_manager():
     with start_run() as first_run:
         first_uuid = first_run.info.run_id
         # Check that start_run() causes the run information to be persisted in the store
@@ -157,7 +161,8 @@ def test_start_run_context_manager(tracking_uri_mock):
     assert finished_run2.info.status == RunStatus.to_string(RunStatus.FAILED)
 
 
-def test_start_and_end_run(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_start_and_end_run():
     # Use the start_run() and end_run() APIs without a `with` block, verify they work.
 
     with start_run() as active_run:
@@ -168,7 +173,8 @@ def test_start_and_end_run(tracking_uri_mock):
     assert finished_run.data.metrics["name_1"] == 25
 
 
-def test_metric_timestamp(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_metric_timestamp():
     with mlflow.start_run() as active_run:
         mlflow.log_metric("name_1", 25)
         mlflow.log_metric("name_1", 30)
@@ -184,7 +190,8 @@ def test_metric_timestamp(tracking_uri_mock):
     ])
 
 
-def test_log_batch(tracking_uri_mock, tmpdir):
+@pytest.mark.usefixtures("tracking_uri_mock", "tmpdir")
+def test_log_batch():
     expected_metrics = {"metric-key0": 1.0, "metric-key1": 4.0}
     expected_params = {"param-key0": "param-val0", "param-key1": "param-val1"}
     exact_expected_tags = {"tag-key0": "tag-val0", "tag-key1": "tag-val1"}
@@ -237,7 +244,8 @@ def test_log_batch(tracking_uri_mock, tmpdir):
             assert new_tags[tag_key] == tag_value
 
 
-def test_log_metric(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_metric():
     with start_run() as active_run, mock.patch("time.time") as time_mock:
         time_mock.side_effect = [123 for _ in range(100)]
         run_id = active_run.info.run_id
@@ -265,7 +273,8 @@ def test_log_metric(tracking_uri_mock):
     ])
 
 
-def test_log_metrics_uses_millisecond_timestamp_resolution_fluent(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_metrics_uses_millisecond_timestamp_resolution_fluent():
     with start_run() as active_run, mock.patch("time.time") as time_mock:
         time_mock.side_effect = lambda: 123
         mlflow.log_metrics({
@@ -293,7 +302,8 @@ def test_log_metrics_uses_millisecond_timestamp_resolution_fluent(tracking_uri_m
     ])
 
 
-def test_log_metrics_uses_millisecond_timestamp_resolution_client(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_metrics_uses_millisecond_timestamp_resolution_client():
     with start_run() as active_run, mock.patch("time.time") as time_mock:
         time_mock.side_effect = lambda: 123
         mlflow_client = tracking.MlflowClient()
@@ -316,8 +326,9 @@ def test_log_metrics_uses_millisecond_timestamp_resolution_client(tracking_uri_m
     ])
 
 
+@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("step_kwarg", [None, -10, 5])
-def test_log_metrics_uses_common_timestamp_and_step_per_invocation(tracking_uri_mock, step_kwarg):
+def test_log_metrics_uses_common_timestamp_and_step_per_invocation(step_kwarg):
     expected_metrics = {"name_1": 30, "name_2": -3, "nested/nested/name": 40}
     with start_run() as active_run:
         run_id = active_run.info.run_id
@@ -335,12 +346,14 @@ def test_log_metrics_uses_common_timestamp_and_step_per_invocation(tracking_uri_
 
 
 @pytest.fixture
-def get_store_mock(tmpdir):
+@pytest.mark.usefixtures("tmpdir")
+def get_store_mock():
     with mock.patch("mlflow.store.file_store.FileStore.log_batch") as _get_store_mock:
         yield _get_store_mock
 
 
-def test_set_tags(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_set_tags():
     exact_expected_tags = {"name_1": "c", "name_2": "b", "nested/nested/name": 5}
     approx_expected_tags = set([MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE])
     with start_run() as active_run:
@@ -356,7 +369,8 @@ def test_set_tags(tracking_uri_mock):
             assert str(exact_expected_tags[tag_key]) == tag_val
 
 
-def test_log_metric_validation(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_metric_validation():
     with start_run() as active_run:
         run_id = active_run.info.run_id
         with pytest.raises(MlflowException) as e:
@@ -366,7 +380,8 @@ def test_log_metric_validation(tracking_uri_mock):
     assert len(finished_run.data.metrics) == 0
 
 
-def test_log_param(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_param():
     with start_run() as active_run:
         run_id = active_run.info.run_id
         mlflow.log_param("name_1", "a")
@@ -377,7 +392,8 @@ def test_log_param(tracking_uri_mock):
     assert finished_run.data.params == {"name_1": "a", "name_2": "b", "nested/nested/name": "5"}
 
 
-def test_log_params(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_params():
     expected_params = {"name_1": "c", "name_2": "b", "nested/nested/name": 5}
     with start_run() as active_run:
         run_id = active_run.info.run_id
@@ -387,7 +403,8 @@ def test_log_params(tracking_uri_mock):
     assert finished_run.data.params == {"name_1": "c", "name_2": "b", "nested/nested/name": "5"}
 
 
-def test_log_batch_validates_entity_names_and_values(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_batch_validates_entity_names_and_values():
     bad_kwargs = {
         "metrics": [
             [Metric(key="../bad/metric/name", value=0.3, timestamp=3, step=0)],
@@ -409,7 +426,8 @@ def test_log_batch_validates_entity_names_and_values(tracking_uri_mock):
                 assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 
-def test_log_artifact_with_dirs(tracking_uri_mock, tmpdir):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_artifact_with_dirs(tmpdir):
     # Test log artifact with a directory
     art_dir = tmpdir.mkdir("parent")
     file0 = art_dir.join("file0")
@@ -449,7 +467,8 @@ def test_log_artifact_with_dirs(tracking_uri_mock, tmpdir):
             [os.path.basename(str(sub_dir))]
 
 
-def test_log_artifact(tracking_uri_mock):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_artifact():
     artifact_src_dir = tempfile.mkdtemp()
     # Create artifacts
     _, path0 = tempfile.mkstemp(dir=artifact_src_dir)
@@ -500,8 +519,8 @@ def test_with_startrun():
     assert mlflow.active_run() is None
 
 
-def test_parent_create_run(tracking_uri_mock):
-
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_parent_create_run():
     with mlflow.start_run() as parent_run:
         parent_run_id = parent_run.info.run_id
     os.environ[_RUN_ID_ENV_VAR] = parent_run_id
@@ -534,7 +553,8 @@ def test_start_deleted_run():
     assert mlflow.active_run() is None
 
 
-def test_start_run_exp_id_0(tracking_uri_mock, reset_active_experiment):
+@pytest.mark.usefixtures("tracking_uri_mock", "reset_active_experiment")
+def test_start_run_exp_id_0():
     mlflow.set_experiment("some-experiment")
     # Create a run and verify that the current active experiment is the one we just set
     with mlflow.start_run() as active_run:
@@ -555,30 +575,31 @@ def test_get_artifact_uri_uses_currently_active_run_id():
     artifact_path = "artifact"
     with mlflow.start_run() as active_run:
         assert mlflow.get_artifact_uri(artifact_path=artifact_path) == \
-               tracking.artifact_utils.get_artifact_uri(
-                run_id=active_run.info.run_id, artifact_path=artifact_path)
+            tracking.artifact_utils.get_artifact_uri(
+            run_id=active_run.info.run_id, artifact_path=artifact_path)
 
 
+@pytest.mark.usefixtures("tracking_uri_mock")
 @pytest.mark.parametrize("artifact_location, expected_uri_format", [
     (
-     "mysql://user:password@host:port/dbname?driver=mydriver",
-     "mysql://user:password@host:port/dbname/{run_id}/artifacts/{path}?driver=mydriver",
+        "mysql://user:password@host:port/dbname?driver=mydriver",
+        "mysql://user:password@host:port/dbname/{run_id}/artifacts/{path}?driver=mydriver",
     ),
     (
-     "mysql+driver://user:password@host:port/dbname/subpath/#fragment",
-     "mysql+driver://user:password@host:port/dbname/subpath/{run_id}/artifacts/{path}#fragment",
+        "mysql+driver://user:password@host:port/dbname/subpath/#fragment",
+        "mysql+driver://user:password@host:port/dbname/subpath/{run_id}/artifacts/{path}#fragment",
     ),
     (
-     "s3://bucketname/rootpath",
-     "s3://bucketname/rootpath/{run_id}/artifacts/{path}",
+        "s3://bucketname/rootpath",
+        "s3://bucketname/rootpath/{run_id}/artifacts/{path}",
     ),
     (
-     "/dirname/rootpa#th?",
-     "/dirname/rootpa#th?/{run_id}/artifacts/{path}",
+        "/dirname/rootpa#th?",
+        "/dirname/rootpa#th?/{run_id}/artifacts/{path}",
     ),
 ])
 def test_get_artifact_uri_appends_to_uri_path_component_correctly(
-        tracking_uri_mock, artifact_location, expected_uri_format):
+        artifact_location, expected_uri_format):
     client = MlflowClient()
     client.create_experiment("get-artifact-uri-test", artifact_location=artifact_location)
     mlflow.set_experiment("get-artifact-uri-test")
@@ -591,7 +612,8 @@ def test_get_artifact_uri_appends_to_uri_path_component_correctly(
                 run_id=run_id, path=artifact_path.lstrip("/"))
 
 
-def test_search_runs(tracking_uri_mock, reset_active_experiment):
+@pytest.mark.usefixtures("tracking_uri_mock", "reset_active_experiment")
+def test_search_runs():
     mlflow.set_experiment("exp-for-search")
     # Create a run and verify that the current active experiment is the one we just set
     logged_runs = {}
@@ -660,7 +682,8 @@ def test_search_runs(tracking_uri_mock, reset_active_experiment):
     verify_runs(runs, [])
 
 
-def test_search_runs_multiple_experiments(tracking_uri_mock, reset_active_experiment):
+@pytest.mark.usefixtures("tracking_uri_mock", "reset_active_experiment")
+def test_search_runs_multiple_experiments():
     experiment_ids = [mlflow.create_experiment("exp__{}".format(exp_id)) for exp_id in range(1, 4)]
     for eid in experiment_ids:
         with mlflow.start_run(experiment_id=eid):

--- a/tests/utils/test_autologging_utils.py
+++ b/tests/utils/test_autologging_utils.py
@@ -2,7 +2,6 @@ import mlflow
 import pytest
 from mlflow.utils.autologging_utils import get_unspecified_default_args, \
     log_fn_args_as_params
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=W0611
 
 
 # Example function signature we are testing on
@@ -69,7 +68,8 @@ def test_get_three_unspecified_default_args(user_args, user_kwargs, all_param_na
 
 
 @pytest.fixture
-def start_run(tracking_uri_mock):  # pylint: disable=W0613
+@pytest.mark.usefixtures("tracking_uri_mock")
+def start_run():
     mlflow.start_run()
     yield
     mlflow.end_run()

--- a/tests/utils/test_autologging_utils.py
+++ b/tests/utils/test_autologging_utils.py
@@ -68,7 +68,6 @@ def test_get_three_unspecified_default_args(user_args, user_kwargs, all_param_na
 
 
 @pytest.fixture
-@pytest.mark.usefixtures("tracking_uri_mock")
 def start_run():
     mlflow.start_run()
     yield

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -10,8 +10,6 @@ import matplotlib as mpl
 import mlflow
 import mlflow.xgboost
 
-# pytestmark = pytest.mark.notrackingurimock
-
 mpl.use('Agg')
 
 

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -10,6 +10,8 @@ import matplotlib as mpl
 import mlflow
 import mlflow.xgboost
 
+pytestmark = pytest.mark.notrackingurimock
+
 mpl.use('Agg')
 client = mlflow.tracking.MlflowClient()
 

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -10,13 +10,13 @@ import matplotlib as mpl
 import mlflow
 import mlflow.xgboost
 
-pytestmark = pytest.mark.notrackingurimock
+# pytestmark = pytest.mark.notrackingurimock
 
 mpl.use('Agg')
-client = mlflow.tracking.MlflowClient()
 
 
 def get_latest_run():
+    client = mlflow.tracking.MlflowClient()
     return client.get_run(client.list_run_infos(experiment_id='0')[0].run_id)
 
 
@@ -111,8 +111,8 @@ def test_xgb_autolog_logs_metrics_with_validation_data(bst_params, dtrain):
               evals=[(dtrain, 'train')], evals_result=evals_result)
     run = get_latest_run()
     data = run.data
-
     metric_key = 'train-merror'
+    client = mlflow.tracking.MlflowClient()
     metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
     assert metric_key in data.metrics
     assert len(metric_history) == 20
@@ -127,7 +127,7 @@ def test_xgb_autolog_logs_metrics_with_multi_validation_data(bst_params, dtrain)
     xgb.train(bst_params, dtrain, num_boost_round=20, evals=evals, evals_result=evals_result)
     run = get_latest_run()
     data = run.data
-
+    client = mlflow.tracking.MlflowClient()
     for eval_name in [e[1] for e in evals]:
         metric_key = '{}-merror'.format(eval_name)
         metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
@@ -146,7 +146,7 @@ def test_xgb_autolog_logs_metrics_with_multi_metrics(bst_params, dtrain):
               evals=[(dtrain, 'train')], evals_result=evals_result)
     run = get_latest_run()
     data = run.data
-
+    client = mlflow.tracking.MlflowClient()
     for metric_name in params['eval_metric']:
         metric_key = 'train-{}'.format(metric_name)
         metric_history = [x.value for x in client.get_metric_history(run.info.run_id, metric_key)]
@@ -165,7 +165,7 @@ def test_xgb_autolog_logs_metrics_with_multi_validation_data_and_metrics(bst_par
     xgb.train(params, dtrain, num_boost_round=20, evals=evals, evals_result=evals_result)
     run = get_latest_run()
     data = run.data
-
+    client = mlflow.tracking.MlflowClient()
     for eval_name in [e[1] for e in evals]:
         for metric_name in params['eval_metric']:
             metric_key = '{}-{}'.format(eval_name, metric_name)
@@ -192,6 +192,7 @@ def test_xgb_autolog_logs_metrics_with_early_stopping(bst_params, dtrain):
     assert int(data.metrics['best_iteration']) == model.best_iteration
     assert 'stopped_iteration' in data.metrics
     assert int(data.metrics['stopped_iteration']) == len(evals_result['train']['merror']) - 1
+    client = mlflow.tracking.MlflowClient()
 
     for eval_name in [e[1] for e in evals]:
         for metric_name in params['eval_metric']:
@@ -212,6 +213,7 @@ def test_xgb_autolog_logs_feature_importance(bst_params, dtrain):
     run = get_latest_run()
     run_id = run.info.run_id
     artifacts_dir = run.info.artifact_uri.replace('file://', '')
+    client = mlflow.tracking.MlflowClient()
     artifacts = [x.path for x in client.list_artifacts(run_id)]
 
     importance_type = 'weight'
@@ -236,6 +238,7 @@ def test_xgb_autolog_logs_specified_feature_importance(bst_params, dtrain):
     run = get_latest_run()
     run_id = run.info.run_id
     artifacts_dir = run.info.artifact_uri.replace('file://', '')
+    client = mlflow.tracking.MlflowClient()
     artifacts = [x.path for x in client.list_artifacts(run_id)]
 
     for imp_type in importance_types:

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -134,7 +134,6 @@ def test_model_log(xgb_model, model_path):
                 mlflow.set_tracking_uri(old_uri)
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_model_calls_register_model(xgb_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
@@ -148,7 +147,6 @@ def test_log_model_calls_register_model(xgb_model):
         mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
 
 
-@pytest.mark.usefixtures("tracking_uri_mock")
 def test_log_model_no_registered_model_name(xgb_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -31,7 +31,6 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 from tests.helper_functions import score_model_in_sagemaker_docker_container
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_dataframe", "inference_dmatrix"])
 
@@ -135,7 +134,8 @@ def test_model_log(xgb_model, model_path):
                 mlflow.set_tracking_uri(old_uri)
 
 
-def test_log_model_calls_register_model(tracking_uri_mock, xgb_model):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_model_calls_register_model(xgb_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:
@@ -148,7 +148,8 @@ def test_log_model_calls_register_model(tracking_uri_mock, xgb_model):
         mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
 
 
-def test_log_model_no_registered_model_name(tracking_uri_mock, xgb_model):
+@pytest.mark.usefixtures("tracking_uri_mock")
+def test_log_model_no_registered_model_name(xgb_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:


### PR DESCRIPTION
## What changes are proposed in this pull request?

conftest.py is the way in pytest to share fixtures. This PR moves the most used fixture `tracking_uri_mock` into this confest.py

It also resolves lot of lint warning (unused-arguments/imports)

## How is this patch tested?
Run tests

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
