### PR TITLE
Fix quotes style due to the new release of click

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,7 +79,7 @@ def test_mlflow_run():
     with mock.patch("mlflow.cli.projects") as mock_projects:
         result = CliRunner().invoke(run)
         mock_projects.run.assert_not_called()
-        assert 'Missing argument "URI"' in result.output
+        assert "Missing argument 'URI' in result.output"
 
     with mock.patch("mlflow.cli.projects") as mock_projects:
         CliRunner().invoke(run, ["project_uri"])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -79,7 +79,7 @@ def test_mlflow_run():
     with mock.patch("mlflow.cli.projects") as mock_projects:
         result = CliRunner().invoke(run)
         mock_projects.run.assert_not_called()
-        assert "Missing argument 'URI' in result.output"
+        assert "Missing argument 'URI'" in result.output
 
     with mock.patch("mlflow.cli.projects") as mock_projects:
         CliRunner().invoke(run, ["project_uri"])

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -16,4 +16,4 @@ def test_list_run():
 @pytest.mark.usefixtures("tracking_uri_mock")
 def test_list_run_experiment_id_required():
     result = CliRunner().invoke(list_run, [])
-    assert 'Missing option "--experiment-id"' in result.output
+    assert "Missing option '--experiment-id'" in result.output


### PR DESCRIPTION
## What changes are proposed in this pull request?
With the release of click 7.1 today, the double quotes were changed to simple quotes. It breaks 2 tests.
This PR hopefully fixes these tests (change quotes style)

## How is this patch tested?
Run tests

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
