### PR TITLE
RFC: Allow string experiment IDs in the UI

### DIFF
--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -563,6 +563,28 @@ class Utils {
       return error && error.getErrorCode() === ErrorCodes.RESOURCE_DOES_NOT_EXIST;
     });
   }
+
+  static compareExperiments(a, b) {
+    const aId = typeof (a.getExperimentId) === "function" ? a.getExperimentId() : a.experiment_id;
+    const bId = typeof (b.getExperimentId) === "function" ? b.getExperimentId() : b.experiment_id;
+
+    const aIntId = parseInt(aId, 10);
+    const bIntId = parseInt(bId, 10);
+
+    if (Number.isNaN(aIntId)) {
+      if (!Number.isNaN(bIntId)) {
+        // Int IDs before anything else
+        return 1;
+      }
+    } else if (Number.isNaN(bIntId)) {
+      // Int IDs before anything else
+      return -1;
+    } else {
+      return aIntId - bIntId;
+    }
+
+    return aId.localeCompare(bId);
+  }
 }
 
 export default Utils;

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -282,3 +282,18 @@ test('getSearchUrlFromState', () => {
   expect(Utils.getSearchUrlFromState(st2)).toEqual("b=bbbbbb");
   expect(Utils.getSearchUrlFromState(st3)).toEqual("param=params&metrics=&searchInput=someExpression");
 });
+
+
+test('compareExperiments', () => {
+  const exp0 = { experiment_id: '0' };
+  const exp1 = { experiment_id: '1' };
+  const expA = { experiment_id: 'A' };
+  const expB = { experiment_id: 'B' };
+
+  expect(Utils.compareExperiments(exp0, exp1)).toEqual(-1);
+  expect(Utils.compareExperiments(exp1, exp0)).toEqual(1);
+  expect(Utils.compareExperiments(exp1, expA)).toEqual(-1);
+  expect(Utils.compareExperiments(expA, expB)).toEqual(-1);
+
+  expect([expB, exp1, expA, exp0].sort(Utils.compareExperiments)).toEqual([exp0, exp1, expA, expB]);
+});

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.js
@@ -9,7 +9,7 @@ import { getUUID } from '../../common/utils/ActionUtils';
 
 class CompareRunPage extends Component {
   static propTypes = {
-    experimentId: PropTypes.number.isRequired,
+    experimentId: PropTypes.string.isRequired,
     runUuids: PropTypes.arrayOf(String).isRequired,
     dispatch: PropTypes.func.isRequired,
   };
@@ -41,7 +41,7 @@ const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps;
   const searchValues = qs.parse(location.search);
   const runUuids = JSON.parse(searchValues["?runs"]);
-  const experimentId = parseInt(searchValues["experiment"], 10);
+  const experimentId = searchValues["experiment"];
   return { experimentId, runUuids };
 };
 

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -10,12 +10,13 @@ import { Link } from 'react-router-dom';
 import { CreateExperimentModal } from './modals/CreateExperimentModal';
 import { DeleteExperimentModal } from './modals/DeleteExperimentModal';
 import { RenameExperimentModal } from './modals/RenameExperimentModal';
+import Utils from '../../common/utils/Utils';
 
 export class ExperimentListView extends Component {
   static propTypes = {
     onClickListExperiments: PropTypes.func.isRequired,
     // If activeExperimentId is undefined, then the active experiment is the first one.
-    activeExperimentId: PropTypes.number,
+    activeExperimentId: PropTypes.string,
     experiments: PropTypes.arrayOf(Experiment).isRequired,
   };
 
@@ -25,7 +26,7 @@ export class ExperimentListView extends Component {
     showCreateExperimentModal: false,
     showDeleteExperimentModal: false,
     showRenameExperimentModal: false,
-    selectedExperimentId: 0,
+    selectedExperimentId: '0',
     selectedExperimentName: '',
   };
 
@@ -65,7 +66,7 @@ export class ExperimentListView extends Component {
     });
 
     const data = ev.currentTarget.dataset;
-    this.updateSelectedExperiment(parseInt(data.experimentid, 10), data.experimentname);
+    this.updateSelectedExperiment(data.experimentid, data.experimentname);
   };
 
   handleRenameExperiment = (ev) => {
@@ -74,7 +75,7 @@ export class ExperimentListView extends Component {
     });
 
     const data = ev.currentTarget.dataset;
-    this.updateSelectedExperiment(parseInt(data.experimentid, 10), data.experimentname);
+    this.updateSelectedExperiment(data.experimentid, data.experimentname);
   };
 
   handleCloseCreateExperimentModal = () => {
@@ -88,7 +89,7 @@ export class ExperimentListView extends Component {
       showDeleteExperimentModal: false,
     });
     // reset
-    this.updateSelectedExperiment(0, '');
+    this.updateSelectedExperiment('0', '');
   };
 
   handleCloseRenameExperimentModal = () => {
@@ -96,7 +97,7 @@ export class ExperimentListView extends Component {
       showRenameExperimentModal: false,
     });
     // reset
-    this.updateSelectedExperiment(0, '');
+    this.updateSelectedExperiment('0', '');
   };
 
   render() {
@@ -154,9 +155,8 @@ export class ExperimentListView extends Component {
               .filter((exp) => exp.getName().toLowerCase().includes(searchInput.toLowerCase()))
               .map((exp, idx) => {
                 const { name, experiment_id } = exp;
-                const parsedExperimentId = parseInt(experiment_id, 10);
                 const active = this.props.activeExperimentId !== undefined
-                    ? parsedExperimentId === this.props.activeExperimentId
+                    ? experiment_id === this.props.activeExperimentId
                     : idx === 0;
                 const className =
                   `experiment-list-item ${active ? 'active-experiment-list-item' : ''}`;
@@ -198,9 +198,7 @@ export class ExperimentListView extends Component {
 
 const mapStateToProps = (state) => {
   const experiments = getExperiments(state);
-  experiments.sort((a, b) => {
-    return parseInt(a.getExperimentId(), 10) - parseInt(b.getExperimentId(), 10);
-  });
+  experiments.sort(Utils.compareExperiments);
   return { experiments };
 };
 

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.js
@@ -10,7 +10,7 @@ test('If activeExperimentId is defined then choose that one', () => {
   const wrapper = shallow(<ExperimentListView
     onClickListExperiments={() => {}}
     experiments={Fixtures.experiments}
-    activeExperimentId={1}
+    activeExperimentId={'1'}
   />);
   expect(wrapper.find('.active-experiment-list-item').first().prop('title')).toEqual('Test');
 });
@@ -37,7 +37,7 @@ test('If searchInput is set to "Test" and default experiment is active then no a
   const wrapper = shallow(<ExperimentListView
     onClickListExperiments={() => {}}
     experiments={Fixtures.experiments}
-    activeExperimentId={0}
+    activeExperimentId={'0'}
   />);
 
   wrapper.setState({ searchInput: 'Test' });

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.js
@@ -97,7 +97,7 @@ export class ExperimentPage extends Component {
   };
 
   static propTypes = {
-    experimentId: PropTypes.number.isRequired,
+    experimentId: PropTypes.string.isRequired,
     getExperimentApi: PropTypes.func.isRequired,
     searchRunsApi: PropTypes.func.isRequired,
     loadMoreRunsApi: PropTypes.func.isRequired,

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.test.js
@@ -11,7 +11,7 @@ import { ErrorWrapper } from '../../common/utils/ActionUtils';
 
 
 const BASE_PATH = "/experiments/17/s";
-const EXPERIMENT_ID = 17;
+const EXPERIMENT_ID = '17';
 
 let searchRunsApi;
 let getExperimentApi;

--- a/mlflow/server/js/src/experiment-tracking/components/HomePage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/HomePage.js
@@ -10,7 +10,7 @@ import { getUUID } from '../../common/utils/ActionUtils';
 export class HomePageImpl extends Component {
   static propTypes = {
     dispatchListExperimentsApi: PropTypes.func.isRequired,
-    experimentId: PropTypes.number,
+    experimentId: PropTypes.string,
   };
 
   state = {
@@ -38,7 +38,7 @@ const mapStateToProps = (state, ownProps) => {
   if (match.url === "/") {
     return {};
   }
-  return { experimentId: parseInt(match.params.experimentId, 10) };
+  return { experimentId: match.params.experimentId };
 };
 
 const mapDispatchToProps = (dispatch) => {

--- a/mlflow/server/js/src/experiment-tracking/components/HomePage.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/HomePage.test.js
@@ -50,7 +50,7 @@ describe('HomePage', () => {
   test('should render HomeView', () => {
     const props = {
       ...minimalProps,
-      experimentId: 0,
+      experimentId: '0',
     };
 
     wrapper = shallow(<HomePageImpl {...props}/>,

--- a/mlflow/server/js/src/experiment-tracking/components/HomeView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/HomeView.js
@@ -5,9 +5,10 @@ import ExperimentListView from './ExperimentListView';
 import ExperimentPage from './ExperimentPage';
 import { getExperiments } from '../reducers/Reducers';
 import { NoExperimentView } from './NoExperimentView';
+import Utils from '../../common/utils/Utils';
 
 export const getFirstActiveExperiment = (experiments) => {
-  const sorted = experiments.concat().sort((a, b) => (a.experiment_id - b.experiment_id));
+  const sorted = experiments.concat().sort(Utils.compareExperiments);
   return sorted.find((e) => e.lifecycle_stage === "active");
 };
 
@@ -18,7 +19,7 @@ class HomeView extends Component {
   }
 
   static propTypes = {
-    experimentId: PropTypes.number,
+    experimentId: PropTypes.string,
   };
 
   state = {
@@ -92,7 +93,7 @@ const mapStateToProps = (state, ownProps) => {
   if (ownProps.experimentId === undefined) {
     const firstExp = getFirstActiveExperiment(getExperiments(state));
     if (firstExp) {
-      return { experimentId: parseInt(firstExp.experiment_id, 10) };
+      return { experimentId: firstExp.experiment_id };
     }
   }
   return {};

--- a/mlflow/server/js/src/experiment-tracking/components/MetricPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricPage.js
@@ -12,7 +12,7 @@ export class MetricPageImpl extends Component {
   static propTypes = {
     runUuids: PropTypes.arrayOf(String).isRequired,
     metricKey: PropTypes.string.isRequired,
-    experimentId: PropTypes.number,
+    experimentId: PropTypes.string,
     dispatch: PropTypes.func.isRequired,
   };
 
@@ -63,7 +63,7 @@ const mapStateToProps = (state, ownProps) => {
   const runUuids = JSON.parse(searchValues["?runs"]);
   let experimentId = null;
   if (searchValues.hasOwnProperty("experiment")) {
-    experimentId = parseInt(searchValues["experiment"], 10);
+    experimentId = searchValues["experiment"];
   }
   const { metricKey } = match.params;
   return {

--- a/mlflow/server/js/src/experiment-tracking/components/MetricView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricView.js
@@ -20,7 +20,7 @@ export class MetricViewImpl extends Component {
 
   render() {
     const { experiment, runUuids, runNames, metricKey, location } = this.props;
-    const experimentId = parseInt(experiment.experiment_id, 10);
+    const experimentId = experiment.experiment_id;
     const { selectedMetricKeys } = Utils.getMetricPlotStateFromUrl(location.search);
     return (
       <div className='MetricView'>

--- a/mlflow/server/js/src/experiment-tracking/components/MetricView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricView.test.js
@@ -58,7 +58,7 @@ describe('MetricView', () => {
 
     const metricsPlotPanel = wrapper.find(MetricsPlotPanel);
     expect(metricsPlotPanel.length).toBe(1);
-    expect(metricsPlotPanel.props().experimentId).toBe(2);
+    expect(metricsPlotPanel.props().experimentId).toBe('2');
     expect(metricsPlotPanel.props().runUuids).toEqual(['a', 'b', 'c']);
     expect(metricsPlotPanel.props().metricKey).toBe('metricKey');
   });

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.js
@@ -24,7 +24,7 @@ export const CHART_TYPE_BAR = 'bar';
 
 export class MetricsPlotPanel extends React.Component {
   static propTypes = {
-    experimentId: PropTypes.number.isRequired,
+    experimentId: PropTypes.string.isRequired,
     runUuids: PropTypes.arrayOf(String).isRequired,
     metricKey: PropTypes.string.isRequired,
     // A map of { runUuid : { metricKey: value } }

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.test.js
@@ -21,7 +21,7 @@ describe('unit tests', () => {
       },
     };
     minimalPropsForLineChart = {
-      experimentId: 1,
+      experimentId: '1',
       runUuids: ['runUuid1', 'runUuid2'],
       metricKey: 'metric_1',
       latestMetricsByRunUuid: {
@@ -76,7 +76,7 @@ describe('unit tests', () => {
     };
 
     minimalPropsForBarChart = {
-      experimentId: 1,
+      experimentId: '1',
       runUuids: ['runUuid1', 'runUuid2'],
       metricKey: 'metric_1',
       latestMetricsByRunUuid: {

--- a/mlflow/server/js/src/experiment-tracking/components/RunLinksPopover.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunLinksPopover.js
@@ -7,7 +7,7 @@ import Utils from '../../common/utils/Utils';
 
 export class RunLinksPopover extends React.Component {
   static propTypes = {
-    experimentId: PropTypes.number.isRequired,
+    experimentId: PropTypes.string.isRequired,
     visible: PropTypes.bool.isRequired,
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired,

--- a/mlflow/server/js/src/experiment-tracking/components/RunLinksPopover.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunLinksPopover.test.js
@@ -11,7 +11,7 @@ describe('unit tests', () => {
 
   beforeEach(() => {
     minimalProps = {
-      experimentId: 0,
+      experimentId: '0',
       visible: false,
       x: 0,
       y: 0,

--- a/mlflow/server/js/src/experiment-tracking/components/RunPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunPage.js
@@ -14,7 +14,7 @@ import { getUUID } from '../../common/utils/ActionUtils';
 class RunPage extends Component {
   static propTypes = {
     runUuid: PropTypes.string.isRequired,
-    experimentId: PropTypes.number.isRequired,
+    experimentId: PropTypes.string.isRequired,
     modelVersions: PropTypes.arrayOf(Object),
     getRunApi: PropTypes.func.isRequired,
     listArtifactsApi: PropTypes.func.isRequired,
@@ -85,7 +85,7 @@ class RunPage extends Component {
 const mapStateToProps = (state, ownProps) => {
   const { match } = ownProps;
   const runUuid = match.params.runUuid;
-  const experimentId = parseInt(match.params.experimentId, 10);
+  const experimentId = match.params.experimentId;
   return {
     runUuid,
     experimentId,

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -24,7 +24,7 @@ class RunView extends Component {
     runUuid: PropTypes.string.isRequired,
     run: PropTypes.object.isRequired,
     experiment: PropTypes.instanceOf(Experiment).isRequired,
-    experimentId: PropTypes.number.isRequired,
+    experimentId: PropTypes.string.isRequired,
     params: PropTypes.object.isRequired,
     tags: PropTypes.object.isRequired,
     latestMetrics: PropTypes.object.isRequired,

--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.js
@@ -12,8 +12,8 @@ export class DeleteExperimentModalImpl extends Component {
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    activeExperimentId: PropTypes.number,
-    experimentId: PropTypes.number.isRequired,
+    activeExperimentId: PropTypes.string,
+    experimentId: PropTypes.string.isRequired,
     experimentName: PropTypes.string.isRequired,
     deleteExperimentApi: PropTypes.func.isRequired,
     listExperimentsApi: PropTypes.func.isRequired,

--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.test.js
@@ -21,8 +21,8 @@ describe('DeleteExperimentModal', () => {
     minimalProps = {
       isOpen: false,
       onClose: jest.fn(),
-      activeExperimentId: 0,
-      experimentId: 0,
+      activeExperimentId: '0',
+      experimentId: '0',
       experimentName: 'myFirstExperiment',
       deleteExperimentApi: (experimentId, deleteExperimentRequestId) => {
         const response = { value: { experiment_id: fakeExperimentId } };
@@ -65,7 +65,7 @@ describe('DeleteExperimentModal', () => {
   test('handleSubmit does not perform redirection if deleted experiment is not active ' +
     'experiment', (done) => {
     wrapper = shallow(<DeleteExperimentModalImpl
-      {...{...minimalProps, activeExperimentId: -1}}
+      {...{...minimalProps, activeExperimentId: undefined}}
     />);
     instance = wrapper.instance();
     instance.handleSubmit().then(() => {

--- a/mlflow/server/js/src/experiment-tracking/components/modals/RenameExperimentModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/RenameExperimentModal.js
@@ -13,7 +13,7 @@ import { getExperiments } from '../../reducers/Reducers';
 class RenameExperimentModalImpl extends Component {
   static propTypes = {
     isOpen: PropTypes.bool,
-    experimentId: PropTypes.number,
+    experimentId: PropTypes.string,
     experimentName: PropTypes.string,
     experimentNames: PropTypes.arrayOf(String).isRequired,
     onClose: PropTypes.func.isRequired,

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowMessages.js
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowMessages.js
@@ -115,7 +115,7 @@ export const RunInfo = Immutable.Record({
   // optional STRING
   run_uuid: undefined,
 
-  // optional INT64
+  // optional STRING
   experiment_id: undefined,
 
   // optional STRING
@@ -155,7 +155,7 @@ const extended_RunInfo = ModelBuilder.extend(RunInfo, {
     return this.run_uuid !== undefined ? this.run_uuid : '';
   },
   getExperimentId() {
-    return this.experiment_id !== undefined ? this.experiment_id : 0;
+    return this.experiment_id !== undefined ? this.experiment_id : '0';
   },
   getStatus() {
     return this.status !== undefined ? this.status : 'RUNNING';
@@ -287,7 +287,7 @@ Run.fromJs = function fromJs(pojo) {
 };
 
 export const Experiment = Immutable.Record({
-  // optional INT64
+  // optional STRING
   experiment_id: undefined,
 
   // optional STRING
@@ -328,7 +328,7 @@ Experiment.fromJsReviver = function fromJsReviver(key, value) {
 const extended_Experiment = ModelBuilder.extend(Experiment, {
 
   getExperimentId() {
-    return this.experiment_id !== undefined ? this.experiment_id : 0;
+    return this.experiment_id !== undefined ? this.experiment_id : '0';
   },
   getName() {
     return this.name !== undefined ? this.name : '';
@@ -441,7 +441,7 @@ ListExperiments.fromJs = function fromJs(pojo) {
 };
 
 export const GetExperiment = Immutable.Record({
-  // required INT64
+  // required STRING
   experiment_id: undefined,
 }, 'GetExperiment');
 
@@ -460,7 +460,7 @@ GetExperiment.fromJsReviver = function fromJsReviver(key, value) {
 const extended_GetExperiment = ModelBuilder.extend(GetExperiment, {
 
   getExperimentId() {
-    return this.experiment_id !== undefined ? this.experiment_id : 0;
+    return this.experiment_id !== undefined ? this.experiment_id : '0';
   },
 });
 
@@ -732,7 +732,7 @@ StringClause.fromJs = function fromJs(pojo) {
 };
 
 export const SearchRuns = Immutable.Record({
-  // repeated INT64
+  // repeated STRING
   experiment_ids: Immutable.List(),
 
   // optional ViewType

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -237,9 +237,13 @@ class FileStore(AbstractStore):
     def create_experiment(self, name, artifact_location=None):
         self._check_root_dir()
         self._validate_experiment_name(name)
-        # Get all existing experiments and find the one with largest ID.
+        # Get all existing experiments and find the one with largest numerical ID.
         # len(list_all(..)) would not work when experiments are deleted.
-        experiments_ids = [int(e.experiment_id) for e in self.list_experiments(ViewType.ALL)]
+        experiments_ids = [
+            int(e.experiment_id)
+            for e in self.list_experiments(ViewType.ALL)
+            if e.experiment_id.isdigit()
+        ]
         experiment_id = max(experiments_ids) + 1 if experiments_ids else 0
         return self._create_experiment_with_id(name, str(experiment_id), artifact_location)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

0b871a44b534dcf5e641bb6967f484f3e338ffb0 changed experiment IDs from int64 to strings, but the JavaScript UI was not updated to support those. This PR updates the UI to support non-numerical experiment IDs.

The FileStore was fixed to still supports "auto-incremented" numerical experiment IDs.

## How is this patch tested?

 - npm test (in mlflow/server/js)
 - Manual testing of UI and file_store.py change.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support alphanumerical experiment IDs in the UI.

### What component(s) does this PR affect?

- [x] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
