### PR TITLE
Set rootID at run creation time and passed it down to all descendants.

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -135,15 +135,17 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False):
     else:
         if len(_active_run_stack) > 0:
             parent_run_id = _active_run_stack[-1].info.run_id
+            root_run_id = _active_run_stack[0].info.run_id
         else:
             parent_run_id = None
 
         exp_id_for_run = experiment_id if experiment_id is not None else _get_experiment_id()
 
         user_specified_tags = {}
+
         if parent_run_id is not None:
             user_specified_tags[MLFLOW_PARENT_RUN_ID] = parent_run_id
-            user_specified_tags[MLFLOW_ROOT_RUN_ID] = _active_run_stack[0].info.run_id
+            user_specified_tags[MLFLOW_ROOT_RUN_ID] = root_run_id
         else:
             user_specified_tags[MLFLOW_ROOT_RUN_ID] = None
 
@@ -451,7 +453,7 @@ def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.AC
                 params[key].append(PARAM_NULL)
         new_params = set(run.data.params.keys()) - param_keys
         for p in new_params:
-            params[p] = [PARAM_NULL]*i  # Fill in null values for all previous runs
+            params[p] = [PARAM_NULL] * i  # Fill in null values for all previous runs
             params[p].append(run.data.params[p])
 
         # Metrics
@@ -463,7 +465,7 @@ def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.AC
                 metrics[key].append(METRIC_NULL)
         new_metrics = set(run.data.metrics.keys()) - metric_keys
         for m in new_metrics:
-            metrics[m] = [METRIC_NULL]*i
+            metrics[m] = [METRIC_NULL] * i
             metrics[m].append(run.data.metrics[m])
 
         # Tags
@@ -475,7 +477,7 @@ def search_runs(experiment_ids=None, filter_string="", run_view_type=ViewType.AC
                 tags[key].append(TAG_NULL)
         new_tags = set(run.data.tags.keys()) - tag_keys
         for t in new_tags:
-            tags[t] = [TAG_NULL]*i
+            tags[t] = [TAG_NULL] * i
             tags[t].append(run.data.tags[t])
 
     data = {}
@@ -493,8 +495,8 @@ def _get_paginated_runs(experiment_ids, filter_string, run_view_type, max_result
                         order_by):
     all_runs = []
     next_page_token = None
-    while(len(all_runs) < max_results):
-        runs_to_get = max_results-len(all_runs)
+    while (len(all_runs) < max_results):
+        runs_to_get = max_results - len(all_runs)
         if runs_to_get < NUM_RUNS_PER_PAGE_PANDAS:
             runs = MlflowClient().search_runs(experiment_ids, filter_string, run_view_type,
                                               runs_to_get, order_by, next_page_token)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -12,7 +12,6 @@ import time
 import logging
 import numpy as np
 import pandas as pd
-import uuid
 
 from mlflow.entities import Run, RunStatus, Param, RunTag, Metric, ViewType
 from mlflow.entities.lifecycle_stage import LifecycleStage
@@ -144,15 +143,12 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False):
         user_specified_tags = {}
         if parent_run_id is not None:
             user_specified_tags[MLFLOW_PARENT_RUN_ID] = parent_run_id
+            user_specified_tags[MLFLOW_ROOT_RUN_ID] = _active_run_stack[0].info.run_id
+        else:
+            user_specified_tags[MLFLOW_ROOT_RUN_ID] = None
+
         if run_name is not None:
             user_specified_tags[MLFLOW_RUN_NAME] = run_name
-
-        if _active_run_stack:
-            user_specified_tags[MLFLOW_ROOT_RUN_ID] = _active_run_stack[0].data.tags[MLFLOW_ROOT_RUN_ID]
-        else:
-            user_specified_tags[MLFLOW_ROOT_RUN_ID] = uuid.uuid4().hex
-
-
 
         tags = context_registry.resolve_tags(user_specified_tags)
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -12,6 +12,7 @@ import time
 import logging
 import numpy as np
 import pandas as pd
+import uuid
 
 from mlflow.entities import Run, RunStatus, Param, RunTag, Metric, ViewType
 from mlflow.entities.lifecycle_stage import LifecycleStage
@@ -21,7 +22,7 @@ from mlflow.tracking import artifact_utils
 from mlflow.tracking.context import registry as context_registry
 from mlflow.utils import env
 from mlflow.utils.databricks_utils import is_in_databricks_notebook, get_notebook_id
-from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_RUN_NAME
+from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_RUN_NAME, MLFLOW_ROOT_RUN_ID
 from mlflow.utils.validation import _validate_run_id
 
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"
@@ -145,6 +146,13 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False):
             user_specified_tags[MLFLOW_PARENT_RUN_ID] = parent_run_id
         if run_name is not None:
             user_specified_tags[MLFLOW_RUN_NAME] = run_name
+
+        if _active_run_stack:
+            user_specified_tags[MLFLOW_ROOT_RUN_ID] = _active_run_stack[0].data.tags[MLFLOW_ROOT_RUN_ID]
+        else:
+            user_specified_tags[MLFLOW_ROOT_RUN_ID] = uuid.uuid4().hex
+
+
 
         tags = context_registry.resolve_tags(user_specified_tags)
 

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -6,6 +6,7 @@ See the REST API documentation for information on the meaning of these tags.
 
 MLFLOW_RUN_NAME = "mlflow.runName"
 MLFLOW_PARENT_RUN_ID = "mlflow.parentRunId"
+MLFLOW_ROOT_RUN_ID = "mlflow.rootRunId"
 MLFLOW_USER = "mlflow.user"
 MLFLOW_SOURCE_TYPE = "mlflow.source.type"
 MLFLOW_SOURCE_NAME = "mlflow.source.name"

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -529,13 +529,17 @@ def test_rootID_is_passed_to_all_descandants():
                 pass
 
     def verify_root_id_tag_is_passed_to_descendants(descendants_id, root_id):
-        root_tags = tracking.MlflowClient().get_run(root_id).data.tags
         descendants_tags = tracking.MlflowClient().get_run(descendants_id).data.tags
-        assert descendants_tags[MLFLOW_ROOT_RUN_ID] == root_tags[MLFLOW_ROOT_RUN_ID]
+        assert descendants_tags[MLFLOW_ROOT_RUN_ID] == root_id
+
+    def verify_descendants_have_the_same_root_id(descendant1_id, descendant2_id):
+        descendant1_tags = tracking.MlflowClient().get_run(descendant1_id).data.tags
+        descendant2_tags = tracking.MlflowClient().get_run(descendant2_id).data.tags
+        assert descendant1_tags[MLFLOW_ROOT_RUN_ID] == descendant2_tags[MLFLOW_ROOT_RUN_ID]
 
     verify_root_id_tag_is_passed_to_descendants(child_run.info.run_id, parent_run.info.run_id)
     verify_root_id_tag_is_passed_to_descendants(grand_child_run.info.run_id, parent_run.info.run_id)
-    verify_root_id_tag_is_passed_to_descendants(grand_child_run.info.run_id, child_run.info.run_id)
+    verify_descendants_have_the_same_root_id(child_run.info.run_id, grand_child_run.info.run_id)
     assert mlflow.active_run() is None
 
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -522,26 +522,29 @@ def test_parent_create_run():
     verify_has_parent_id_tag(grand_child_run.info.run_id, child_run.info.run_id)
     assert mlflow.active_run() is None
 
-def test_rootID_is_passed_to_all_descandants():
+
+def test_setting_root_run_id_in_start_run():
     with mlflow.start_run() as parent_run:
+        parent_run_id = parent_run.info.run_id
         with mlflow.start_run(nested=True) as child_run:
             with mlflow.start_run(nested=True) as grand_child_run:
                 pass
 
-    def verify_root_id_tag_is_passed_to_descendants(descendants_id, root_id):
-        descendants_tags = tracking.MlflowClient().get_run(descendants_id).data.tags
-        assert descendants_tags[MLFLOW_ROOT_RUN_ID] == root_id
+    def verify_root_id_tag_is_passed_to_descendants(descendant_id, root_id):
+        descendant_tags = tracking.MlflowClient().get_run(descendant_id).data.tags
+        assert descendant_tags[MLFLOW_ROOT_RUN_ID] == root_id
 
     def verify_descendants_have_the_same_root_id(descendant1_id, descendant2_id):
         descendant1_tags = tracking.MlflowClient().get_run(descendant1_id).data.tags
         descendant2_tags = tracking.MlflowClient().get_run(descendant2_id).data.tags
         assert descendant1_tags[MLFLOW_ROOT_RUN_ID] == descendant2_tags[MLFLOW_ROOT_RUN_ID]
 
+    assert (tracking.MlflowClient().get_run(parent_run_id).data.tags[MLFLOW_ROOT_RUN_ID] is None)
+
     verify_root_id_tag_is_passed_to_descendants(child_run.info.run_id, parent_run.info.run_id)
     verify_root_id_tag_is_passed_to_descendants(grand_child_run.info.run_id, parent_run.info.run_id)
     verify_descendants_have_the_same_root_id(child_run.info.run_id, grand_child_run.info.run_id)
     assert mlflow.active_run() is None
-
 
 
 def test_start_deleted_run():


### PR DESCRIPTION
## What changes are proposed in this pull request?
Nested Run Deletion: Setting rootRunId at run creation time in the Python client.

(Please fill in changes proposed in this fix)

## How is this patch tested?
Unit tested using pytest.
(Details)

## Release Notes

### Is this a user-facing change?

- [ x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ x] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
