### PR TITLE
Added usage of the model registry to the log_model function

### DIFF
--- a/examples/sklearn_elasticnet_wine/train.py
+++ b/examples/sklearn_elasticnet_wine/train.py
@@ -72,4 +72,15 @@ if __name__ == "__main__":
         mlflow.log_metric("r2", r2)
         mlflow.log_metric("mae", mae)
 
-        mlflow.sklearn.log_model(lr, "model")
+        tracking_url_type_store = mlflow.get_tracking_uri().split(":")[0]
+
+        # Model registry does not work with file store
+        if tracking_url_type_store != "file":
+
+            # Register the model
+            # There are other ways to use the Model Registry, which depends on the use case,
+            # please refer to the doc for more information:
+            # https://mlflow.org/docs/latest/model-registry.html#api-workflow
+            mlflow.sklearn.log_model(lr, "model", registered_model_name="ElasticnetWineModel")
+        else:
+            mlflow.sklearn.log_model(lr, "model")

--- a/examples/sklearn_elasticnet_wine/train.py
+++ b/examples/sklearn_elasticnet_wine/train.py
@@ -11,7 +11,7 @@ import numpy as np
 from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
 from sklearn.model_selection import train_test_split
 from sklearn.linear_model import ElasticNet
-
+from urllib.parse import urlparse
 import mlflow
 import mlflow.sklearn
 
@@ -72,7 +72,7 @@ if __name__ == "__main__":
         mlflow.log_metric("r2", r2)
         mlflow.log_metric("mae", mae)
 
-        tracking_url_type_store = mlflow.get_tracking_uri().split(":")[0]
+        tracking_url_type_store = urlparse(mlflow.get_tracking_uri()).scheme
 
         # Model registry does not work with file store
         if tracking_url_type_store != "file":


### PR DESCRIPTION
## What changes are proposed in this pull request?
Add to the sklearn_elasticnet_wine example the ability to register the model,
if the user uses tracking URL store other then "file"

This refers to #2341

## How is this patch tested?

Ran tests.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add to the sklearn_elasticnet_wine example the ability to register the model,
if the user uses tracking URL store other then "file"
### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [X] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
