### PR TITLE
Fix support for conda env dicts with pyfunc.log_model

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -718,7 +718,6 @@ def _save_model_with_loader_module_and_data_path(path, loader_module, data_path=
 
     code = None
     data = None
-    env = None
 
     if data_path is not None:
         model_file = _copy_file_or_tree(src=data_path, dst=path, dst_dir="data")

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -194,6 +194,7 @@ import numpy as np
 import os
 import pandas
 import shutil
+import yaml
 from copy import deepcopy
 
 import mlflow
@@ -728,12 +729,17 @@ def _save_model_with_loader_module_and_data_path(path, loader_module, data_path=
             _copy_file_or_tree(src=code_path, dst=path, dst_dir="code")
         code = "code"
 
-    if conda_env is not None:
-        shutil.copy(src=conda_env, dst=os.path.join(path, "mlflow_env.yml"))
-        env = "mlflow_env.yml"
+    conda_env_subpath = "mlflow_env.yml"
+    if conda_env is None:
+        conda_env = get_default_conda_env()
+    elif not isinstance(conda_env, dict):
+        with open(conda_env, "r") as f:
+            conda_env = yaml.safe_load(f)
+    with open(os.path.join(path, conda_env_subpath), "w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     mlflow.pyfunc.add_to_model(
-        mlflow_model, loader_module=loader_module, code=code, data=data, env=env)
+        mlflow_model, loader_module=loader_module, code=code, data=data, env=conda_env_subpath)
     mlflow_model.save(os.path.join(path, 'MLmodel'))
     return mlflow_model
 

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import os
 import pickle
+import yaml
 
 import numpy as np
 import pytest
@@ -17,7 +18,8 @@ import mlflow.sklearn
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-
+from mlflow.utils.environment import _mlflow_conda_env
+from mlflow.utils.model_utils import _get_flavor_configuration
 
 def _load_pyfunc(path):
     with open(path, "rb") as f:
@@ -25,6 +27,23 @@ def _load_pyfunc(path):
             return pickle.load(f)
         else:
             return pickle.load(f, encoding='latin1')  # pylint: disable=unexpected-keyword-arg
+
+
+@pytest.fixture
+def pyfunc_custom_env_file(tmpdir):
+    conda_env = os.path.join(str(tmpdir), "conda_env.yml")
+    _mlflow_conda_env(
+        conda_env,
+        additional_conda_deps=["scikit-learn", "pytest", "cloudpickle"],
+        additional_pip_deps=["-e " + os.path.dirname(mlflow.__path__[0])])
+    return conda_env
+
+
+@pytest.fixture
+def pyfunc_custom_env_dict(tmpdir):
+    return _mlflow_conda_env(
+        additional_conda_deps=["scikit-learn", "pytest", "cloudpickle"],
+        additional_pip_deps=["-e " + os.path.dirname(mlflow.__path__[0])])
 
 
 @pytest.fixture(scope="module")
@@ -131,3 +150,91 @@ def test_log_model_with_unsupported_argument_combinations_throws_exception():
         mlflow.pyfunc.log_model(artifact_path="pyfunc_model",
                                 data_path="/path/to/data")
     assert "Either `loader_module` or `python_model` must be specified" in str(exc_info)
+
+
+@pytest.mark.large
+def test_log_model_persists_specified_conda_env_file_in_mlflow_model_directory(
+        sklearn_knn_model, tmpdir, pyfunc_custom_env_file):
+    sk_model_path = os.path.join(str(tmpdir), "knn.pkl")
+    with open(sk_model_path, "wb") as f:
+        pickle.dump(sklearn_knn_model, f)
+
+    pyfunc_artifact_path = "pyfunc_model"
+    with mlflow.start_run():
+        mlflow.pyfunc.log_model(artifact_path=pyfunc_artifact_path,
+                                data_path=sk_model_path,
+                                loader_module=os.path.basename(__file__)[:-3],
+                                code_path=[__file__],
+                                conda_env=pyfunc_custom_env_file)
+        run_id = mlflow.active_run().info.run_id
+
+    pyfunc_model_path = _download_artifact_from_uri("runs:/{run_id}/{artifact_path}".format(
+        run_id=run_id, artifact_path=pyfunc_artifact_path))
+
+    pyfunc_conf = _get_flavor_configuration(
+        model_path=pyfunc_model_path, flavor_name=mlflow.pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(pyfunc_model_path, pyfunc_conf[mlflow.pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+    assert saved_conda_env_path != pyfunc_custom_env_file
+
+    with open(pyfunc_custom_env_file, "r") as f:
+        pyfunc_custom_env_parsed = yaml.safe_load(f)
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == pyfunc_custom_env_parsed
+
+
+@pytest.mark.large
+def test_log_model_persists_specified_conda_env_dict_in_mlflow_model_directory(
+        sklearn_knn_model, tmpdir, pyfunc_custom_env_dict):
+    sk_model_path = os.path.join(str(tmpdir), "knn.pkl")
+    with open(sk_model_path, "wb") as f:
+        pickle.dump(sklearn_knn_model, f)
+
+    pyfunc_artifact_path = "pyfunc_model"
+    with mlflow.start_run():
+        mlflow.pyfunc.log_model(artifact_path=pyfunc_artifact_path,
+                                data_path=sk_model_path,
+                                loader_module=os.path.basename(__file__)[:-3],
+                                code_path=[__file__],
+                                conda_env=pyfunc_custom_env_dict)
+        run_id = mlflow.active_run().info.run_id
+
+    pyfunc_model_path = _download_artifact_from_uri("runs:/{run_id}/{artifact_path}".format(
+        run_id=run_id, artifact_path=pyfunc_artifact_path))
+
+    pyfunc_conf = _get_flavor_configuration(
+        model_path=pyfunc_model_path, flavor_name=mlflow.pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(pyfunc_model_path, pyfunc_conf[mlflow.pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == pyfunc_custom_env_dict
+
+
+@pytest.mark.large
+def test_log_model_without_specified_conda_env_uses_default_env_with_expected_dependencies(
+        sklearn_knn_model, tmpdir):
+    sk_model_path = os.path.join(str(tmpdir), "knn.pkl")
+    with open(sk_model_path, "wb") as f:
+        pickle.dump(sklearn_knn_model, f)
+
+    pyfunc_artifact_path = "pyfunc_model"
+    with mlflow.start_run():
+        mlflow.pyfunc.log_model(artifact_path=pyfunc_artifact_path,
+                                data_path=sk_model_path,
+                                loader_module=os.path.basename(__file__)[:-3],
+                                code_path=[__file__])
+        run_id = mlflow.active_run().info.run_id
+
+    pyfunc_model_path = _download_artifact_from_uri("runs:/{run_id}/{artifact_path}".format(
+        run_id=run_id, artifact_path=pyfunc_artifact_path))
+
+    pyfunc_conf = _get_flavor_configuration(
+        model_path=pyfunc_model_path, flavor_name=mlflow.pyfunc.FLAVOR_NAME)
+    conda_env_path = os.path.join(pyfunc_model_path, pyfunc_conf[mlflow.pyfunc.ENV])
+    with open(conda_env_path, "r") as f:
+        conda_env = yaml.safe_load(f)
+
+    assert conda_env == mlflow.pyfunc.model.get_default_conda_env()

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -21,6 +21,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 
+
 def _load_pyfunc(path):
     with open(path, "rb") as f:
         if six.PY2:

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -41,7 +41,7 @@ def pyfunc_custom_env_file(tmpdir):
 
 
 @pytest.fixture
-def pyfunc_custom_env_dict(tmpdir):
+def pyfunc_custom_env_dict():
     return _mlflow_conda_env(
         additional_conda_deps=["scikit-learn", "pytest", "cloudpickle"],
         additional_pip_deps=["-e " + os.path.dirname(mlflow.__path__[0])])


### PR DESCRIPTION
## What changes are proposed in this pull request?

When `pyfunc.log_model` is called with `loader_module` and `data_path` arguments, conda environment dictionaries are not saved properly. This PR fixes the issue and introduces appropriate tests.

Fixes #2580.

## How is this patch tested?

I have manually verified that I can log a pyfunc model with a `conda_env` dictionary while specifying the `loader_module` and `data_path` arguments. Further, I have introduced appropriate unit tests to prevent recurrences of this issue.

## Release Notes

Fixes a bug that prevented `mlflow.pyfunc.log_model` and `mlflow.pyfunc.save_model` from persisting Conda environment dictionaries in certain cases.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [X] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
