### PR TITLE
Fix the typo in CLI hlep

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -255,7 +255,7 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
               help="Additional command line options for waitress-serve.")
 @click.option("--expose-prometheus", default=None,
               help="Path to the directory where metrics will be stored. If the directory "
-                   "doesn't exist, it will be created."
+                   "doesn't exist, it will be created. "
                    "Activate prometheus exporter to expose metrics on /metrics endpoint.")
 def server(backend_store_uri, default_artifact_root, host, port,
            workers, static_prefix, gunicorn_opts, waitress_opts, expose_prometheus):

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -254,7 +254,7 @@ def _validate_static_prefix(ctx, param, value):  # pylint: disable=unused-argume
 @click.option("--waitress-opts", default=None,
               help="Additional command line options for waitress-serve.")
 @click.option("--expose-prometheus", default=None,
-              help="Path to the directory where metrics will be stored. If the directory"
+              help="Path to the directory where metrics will be stored. If the directory "
                    "doesn't exist, it will be created."
                    "Activate prometheus exporter to expose metrics on /metrics endpoint.")
 def server(backend_store_uri, default_artifact_root, host, port,


### PR DESCRIPTION
## What changes are proposed in this pull request?
reproduce :
`mlflow server --help`

```
  --expose-prometheus TEXT     Path to the directory where metrics will be
                               stored. If the directorydoesn't exist, it will
                               be created.Activate prometheus exporter to
                               expose metrics on /metrics endpoint.
  --help                       Show this message and exit.
```

After Add a whitespace between `directory` and `doesn't`
![Screenshot from 2020-03-23 13-27-01](https://user-images.githubusercontent.com/37936015/77284589-03dae880-6d0a-11ea-8f17-ebc56decf4b7.png)
## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [x] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
