### PR TITLE
Make boto3 use $MLFLOW_S3_ENDPOINT_URL if specified

### DIFF
--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -27,8 +27,15 @@ def _fetch_dbfs(uri, local_path):
 def _fetch_s3(uri, local_path):
     import boto3
     print("=== Downloading S3 object %s to local path %s ===" % (uri, os.path.abspath(local_path)))
+
+    client_kwargs = {}
+    endpoint_url = os.environ.get('MLFLOW_S3_ENDPOINT_URL')
+
+    if endpoint_url:
+        client_kwargs['endpoint_url'] = endpoint_url
+
     (bucket, s3_path) = parse_s3_uri(uri)
-    boto3.client('s3').download_file(bucket, s3_path, local_path)
+    boto3.client('s3', **client_kwargs).download_file(bucket, s3_path, local_path)
 
 
 def _fetch_gs(uri, local_path):


### PR DESCRIPTION
## What changes are proposed in this pull request?

When downloading from S3, boto3 should use $MLFLOW_S3_ENDPOINT_URL if specified. It does now.
 
## How is this patch tested?

`python -m pytest tests/data/test_data.py` yields 2/2 passed tests.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [x] Tracking
- [ ] Projects
- [x] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
