### PR TITLE
Unblock Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
     # Nightly builds run the tests/examples end-to-end test suite.
     # Does not include Windows since Projects/Models are mostly not compatible with Windows as of now.
     - stage: Nightly
-    - stage: small
+    - stage: Small
       if: type != cron
     - language: python
       name: "Lint (Python 3.6)"

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -32,10 +32,10 @@ if [[ "$INSTALL_SMALL_PYTHON_DEPS" == "true" ]]; then
 fi
 if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   pip install -r ./travis/large-requirements.txt
-  echo "spark home = "$SPARK_HOME"
-  echo "looking for spark submit
+  echo "spark home = $SPARK_HOME"
+  echo "looking for spark submit"
   find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"
-  ls -lha /anaconda3/envs/mlflow-dev/lib/python3.6/site-packages/pyspark/./bin/spark-submit
+  ls -lha `/home/travis/miniconda/envs/test-environment/ -name "spark-submit"`
 fi
 pip install .
 export MLFLOW_HOME=$(pwd)

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -34,7 +34,7 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   pip install -r ./travis/large-requirements.txt
   # Hack: make sure all spark-* scripts are executable. 
   # Conda installs 2 version spark-* scripts and makes the ones spark
-  # uses not executable. This is a temporary fix to unblock tets.
+  # uses not executable. This is a temporary fix to unblock the tests.
   ls -lha `find /home/travis/miniconda/envs/test-environment/ -path "*bin/spark-*"`
   chmod 777 `find /home/travis/miniconda/envs/test-environment/ -path "*bin/spark-*"`
   ls -lha `find /home/travis/miniconda/envs/test-environment/ -path "*bin/spark-*"`

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -35,7 +35,8 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   echo "spark home = $SPARK_HOME"
   echo "looking for spark submit"
   find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"
-  ls -lha `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"`
+  ls -lha `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"
+  chmod 777 `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"`
 fi
 pip install .
 export MLFLOW_HOME=$(pwd)

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -32,6 +32,10 @@ if [[ "$INSTALL_SMALL_PYTHON_DEPS" == "true" ]]; then
 fi
 if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   pip install -r ./travis/large-requirements.txt
+  echo "spark home = "$SPARK_HOME"
+  echo "looking for spark submit
+  find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"
+  ls -lha /anaconda3/envs/mlflow-dev/lib/python3.6/site-packages/pyspark/./bin/spark-submit
 fi
 pip install .
 export MLFLOW_HOME=$(pwd)

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -32,8 +32,9 @@ if [[ "$INSTALL_SMALL_PYTHON_DEPS" == "true" ]]; then
 fi
 if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   pip install -r ./travis/large-requirements.txt
-  # Hack: make sure all spark-submit scripts are executable. 
-  # For some reason conda installs 2 spark submits and only one of them is executable
+  # Hack: make sure all spark-* scripts are executable. 
+  # Conda installs 2 version spark-* scripts and makes the ones spark
+  # uses not executable. This is a temporary fix to unblock tets.
   ls -lha `find /home/travis/miniconda/envs/test-environment/ -path "*bin/spark-*"`
   chmod 777 `find /home/travis/miniconda/envs/test-environment/ -path "*bin/spark-*"`
   ls -lha `find /home/travis/miniconda/envs/test-environment/ -path "*bin/spark-*"`

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -35,7 +35,7 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   echo "spark home = $SPARK_HOME"
   echo "looking for spark submit"
   find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"
-  ls -lha `/home/travis/miniconda/envs/test-environment/ -name "spark-submit"`
+  ls -lha `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"`
 fi
 pip install .
 export MLFLOW_HOME=$(pwd)

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -34,9 +34,9 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   pip install -r ./travis/large-requirements.txt
   # Hack: make sure all spark-submit scripts are executable. 
   # For some reason conda installs 2 spark submits and only one of them is executable
-  ls -lha `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"`
-  chmod 777 `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"`
-  ls -lha `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"`
+  ls -lha `find /home/travis/miniconda/envs/test-environment/ -path "*bin/spark-*"`
+  chmod 777 `find /home/travis/miniconda/envs/test-environment/ -path "*bin/spark-*"`
+  ls -lha `find /home/travis/miniconda/envs/test-environment/ -path "*bin/spark-*"`
 fi
 pip install .
 export MLFLOW_HOME=$(pwd)

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -32,9 +32,8 @@ if [[ "$INSTALL_SMALL_PYTHON_DEPS" == "true" ]]; then
 fi
 if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   pip install -r ./travis/large-requirements.txt
-  echo "spark home = $SPARK_HOME"
-  echo "looking for spark submit"
-  find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"
+  # Hack: make sure all spark-submit scripts are executable. 
+  # For some reason conda installs 2 spark submits and only one of them is executable
   ls -lha `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"`
   chmod 777 `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"`
   ls -lha `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"`

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -35,8 +35,9 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   echo "spark home = $SPARK_HOME"
   echo "looking for spark submit"
   find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"
-  ls -lha `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"
+  ls -lha `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"`
   chmod 777 `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"`
+  ls -lha `find /home/travis/miniconda/envs/test-environment/ -name "spark-submit"`
 fi
 pip install .
 export MLFLOW_HOME=$(pwd)

--- a/travis/run-large-python-tests.sh
+++ b/travis/run-large-python-tests.sh
@@ -31,7 +31,7 @@ pytest --verbose tests/pyfunc --large
 pytest --verbose tests/sagemaker --large
 pytest --verbose tests/sagemaker/mock --large
 pytest --verbose tests/sklearn --large
-pytest --verbose tests/spark --large
+SPARK_HOME=/home/travis/miniconda/envs/test-environment/ pytest --verbose tests/spark --large
 pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
 pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
 pytest --verbose tests/azureml --large

--- a/travis/run-large-python-tests.sh
+++ b/travis/run-large-python-tests.sh
@@ -31,7 +31,7 @@ pytest --verbose tests/pyfunc --large
 pytest --verbose tests/sagemaker --large
 pytest --verbose tests/sagemaker/mock --large
 pytest --verbose tests/sklearn --large
-SPARK_HOME=/home/travis/miniconda/envs/test-environment/ pytest --verbose tests/spark --large
+pytest --verbose tests/spark --large
 pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
 pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
 pytest --verbose tests/azureml --large


### PR DESCRIPTION
2 test fixes:

1.  we were running large python tests instead of the small tests due to a typo. 
     renamed stage "small" to "Small" so that it's recognized in the shell script that runs tests.
2.  spark test were failing due to misconfigured rights. 
   It looks like that executable spark scripts such as spark-submit, spark-class etc get installed in two 
   places and only on of them is executable. Spark happens to use the location which is not 
   executable. This PR fixes it by chmoding all spark-* executables. This is a quick fix, we should look into it more later, but I think we should unblock tests first.

