### PR TITLE
Update _mlflow_conda_env to add pip when necessary

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -19,16 +19,22 @@ def _mlflow_conda_env(path=None, additional_conda_deps=None, additional_pip_deps
                  in dictionary format.
     :param additional_conda_deps: List of additional conda dependencies passed as strings.
     :param additional_pip_deps: List of additional pip dependencies passed as strings.
-    :param additional_channels: List of additional conda channels to search when resolving packages.
+    :param additional_conda_channels: List of additional conda channels to search when resolving packages.
     :return: ``None`` if ``path`` is specified. Otherwise, the a dictionary representation of the
              Conda environment.
     """
-    env = yaml.safe_load(_conda_header)
-    env["dependencies"] = ["python={}".format(PYTHON_VERSION)]
     pip_deps = (["mlflow"] if install_mlflow else []) + (
         additional_pip_deps if additional_pip_deps else [])
-    if additional_conda_deps is not None:
-        env["dependencies"] += additional_conda_deps
+
+    pip_not_specified = (additional_conda_deps is None
+                         or not [i for i in additional_conda_deps if "pip==" in i or "pip" == i])
+    conda_deps = (additional_conda_deps if additional_conda_deps else []) + (
+        ["pip"] if pip_deps and pip_not_specified else [])
+
+    env = yaml.safe_load(_conda_header)
+    env["dependencies"] = ["python={}".format(PYTHON_VERSION)]
+    if conda_deps is not None:
+        env["dependencies"] += conda_deps
     env["dependencies"].append({"pip": pip_deps})
     if additional_conda_channels is not None:
         env["channels"] += additional_conda_channels

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -19,7 +19,8 @@ def _mlflow_conda_env(path=None, additional_conda_deps=None, additional_pip_deps
                  in dictionary format.
     :param additional_conda_deps: List of additional conda dependencies passed as strings.
     :param additional_pip_deps: List of additional pip dependencies passed as strings.
-    :param additional_conda_channels: List of additional conda channels to search when resolving packages.
+    :param additional_conda_channels: List of additional conda channels to search when resolving
+                                      packages.
     :return: ``None`` if ``path`` is specified. Otherwise, the a dictionary representation of the
              Conda environment.
     """

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -12,7 +12,9 @@ channels:
 def _mlflow_conda_env(path=None, additional_conda_deps=None, additional_pip_deps=None,
                       additional_conda_channels=None, install_mlflow=True):
     """
-    Creates a Conda environment with the specified package channels and dependencies.
+    Creates a Conda environment with the specified package channels and dependencies. If there are any pip dependencies,
+    including from the install_mlflow parameter, then pip will be added to the conda dependencies. This is done to
+    ensure that the pip inside the conda environment is used to install the pip dependencies.
 
     :param path: Local filesystem path where the conda env file is to be written. If unspecified,
                  the conda env will not be written to the filesystem; it will still be returned

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -26,11 +26,8 @@ def _mlflow_conda_env(path=None, additional_conda_deps=None, additional_pip_deps
     """
     pip_deps = (["mlflow"] if install_mlflow else []) + (
         additional_pip_deps if additional_pip_deps else [])
-
-    pip_not_specified = (additional_conda_deps is None
-                         or not [i for i in additional_conda_deps if "pip==" in i or "pip" == i])
     conda_deps = (additional_conda_deps if additional_conda_deps else []) + (
-        ["pip"] if pip_deps and pip_not_specified else [])
+        ["pip"] if pip_deps else [])
 
     env = yaml.safe_load(_conda_header)
     env["dependencies"] = ["python={}".format(PYTHON_VERSION)]

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -12,9 +12,10 @@ channels:
 def _mlflow_conda_env(path=None, additional_conda_deps=None, additional_pip_deps=None,
                       additional_conda_channels=None, install_mlflow=True):
     """
-    Creates a Conda environment with the specified package channels and dependencies. If there are any pip dependencies,
-    including from the install_mlflow parameter, then pip will be added to the conda dependencies. This is done to
-    ensure that the pip inside the conda environment is used to install the pip dependencies.
+    Creates a Conda environment with the specified package channels and dependencies. If there are
+    any pip dependencies, including from the install_mlflow parameter, then pip will be added to
+    the conda dependencies. This is done to ensure that the pip inside the conda environment is
+    used to install the pip dependencies.
 
     :param path: Local filesystem path where the conda env file is to be written. If unspecified,
                  the conda env will not be written to the filesystem; it will still be returned

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -52,4 +52,4 @@ def test_mlflow_conda_env_includes_pip_dependencies_and_pip_is_specified(pip_spe
     for conda_dep in conda_deps:
         assert conda_dep in env["dependencies"]
     assert pip_specification in env["dependencies"]
-    assert env["dependencies"].count("pip") == (1 if pip_specification == "pip" else 0)
+    assert env["dependencies"].count("pip") == (2 if pip_specification == "pip" else 1)

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -26,3 +26,30 @@ def test_mlflow_conda_env_returns_expected_env_dict_when_output_path_is_not_spec
 
     for conda_dep in conda_deps:
         assert conda_dep in env["dependencies"]
+
+
+@pytest.mark.parametrize("conda_deps", [["conda-dep-1=0.0.1", "conda-dep-2"], None])
+def test_mlflow_conda_env_includes_pip_dependencies_but_pip_is_not_specified(conda_deps):
+    additional_pip_deps = ["pip-dep==0.0.1"]
+    env = _mlflow_conda_env(
+                path=None,
+                additional_conda_deps=conda_deps,
+                additional_pip_deps=additional_pip_deps)
+    if conda_deps is not None:
+        for conda_dep in conda_deps:
+            assert conda_dep in env["dependencies"]
+    assert "pip" in env["dependencies"]
+
+
+@pytest.mark.parametrize("pip_specification", ["pip", "pip==20.0.02"])
+def test_mlflow_conda_env_includes_pip_dependencies_and_pip_is_specified(pip_specification):
+    conda_deps = ["conda-dep-1=0.0.1", "conda-dep-2", pip_specification]
+    additional_pip_deps = ["pip-dep==0.0.1"]
+    env = _mlflow_conda_env(
+                path=None,
+                additional_conda_deps=conda_deps,
+                additional_pip_deps=additional_pip_deps)
+    for conda_dep in conda_deps:
+        assert conda_dep in env["dependencies"]
+    assert pip_specification in env["dependencies"]
+    assert env["dependencies"].count("pip") == (1 if pip_specification == "pip" else 0)


### PR DESCRIPTION
## What changes are proposed in this pull request?

I have updated _mlflow_conda_env to automatically add pip to the conda dependencies when there exist pip dependencies but pip is not specified. 

This PR addresses one of the issues found here, [https://github.com/mlflow/mlflow/issues/2603](https://github.com/mlflow/mlflow/issues/2603)

## How is this patch tested?

Additional unit tests have been added.

## Release Notes

### Is this a user-facing change?

- [ X ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

It's fixes a bug in the automatic generation of dependencies

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ X ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ X ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
