### PR TITLE
documenting datatype for `step` argument in `log_metric`

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -194,7 +194,8 @@ class MlflowClient(object):
                       as +/- Infinity may be replaced by other values depending on the store. For
                       example, the SQLAlchemy store replaces +/- Inf with max / min float values.
         :param timestamp: Time when this metric was calculated. Defaults to the current system time.
-        :param step: Training step (iteration) at which was the metric calculated. Defaults to 0.
+        :param step: Integer training step (iteration) at which was the metric calculated.
+                     Defaults to 0.
         """
         self._tracking_client.log_metric(run_id, key, value, timestamp, step)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Documenting expected datatype for `step` argument in `log_metric` to match [REST API](https://mlflow.org/docs/latest/rest-api.html#log-metric).
ref: #1443 

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [x] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
