### PR TITLE
Add R search API example

### DIFF
--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -185,6 +185,19 @@ To search all known experiments for any MLflow runs created using the Inception 
   all_experiments = [exp.experiment_id for exp in MlflowClient().list_experiments()]
   runs = MlflowClient().search_runs(experiment_ids=all_experiments, filter_string="params.model = 'Inception'", run_view_type=ViewType.ALL)
 
+R
+^^^^^^
+The R API is similar to the Python API.
+
+.. code-block:: r
+
+  library(mlflow)
+  mlflow_search_runs(
+    'tags.experiment_iteration = "1"',
+    experiment_ids = as.character(2:3),
+    order_by = "tags.start_time DESCR"
+  )
+
 Java
 ^^^^
 The Java API is similar to Python API.

--- a/docs/source/search-syntax.rst
+++ b/docs/source/search-syntax.rst
@@ -193,9 +193,9 @@ The R API is similar to the Python API.
 
   library(mlflow)
   mlflow_search_runs(
-    'tags.experiment_iteration = "1"',
-    experiment_ids = as.character(2:3),
-    order_by = "tags.start_time DESCR"
+    filter = "metrics.rmse < 0.9 and tags.production = 'true'",
+    experiment_ids = as.character(1:2),
+    order_by = "params.lr DESC"
   )
 
 Java


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add an example for the R language to the search html doc. There were Python and Java examples already.

## How is this patch tested?

inspecting the docs after rendering with 
``` 
cd docs
make livehtml
```

And executing the command in an existing project to make sure it succeeds.

As suggested by the contributing guide.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [x] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
