### PR TITLE
[WIP] Torchscript as another flavor

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -69,6 +69,7 @@ def pytest_ignore_collect(path, config):
             "tests/h2o",
             "tests/keras",
             "tests/pytorch",
+            "tests/torchscript",
             "tests/pyfunc",
             "tests/sagemaker",
             "tests/sklearn",

--- a/docs/source/python_api/mlflow.torchscript.rst
+++ b/docs/source/python_api/mlflow.torchscript.rst
@@ -1,0 +1,7 @@
+mlflow.torchscript
+==================
+
+.. automodule:: mlflow.torchscript
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/examples/torchscript/MLproject
+++ b/examples/torchscript/MLproject
@@ -1,0 +1,25 @@
+name: pytorch_tutorial
+
+conda_env: conda.yaml
+
+entry_points:
+  main:
+    parameters:
+      batch-size: {type: int, default: 16}
+      test-batch-size: {type: int, default: 1000}
+      epochs: {type: int, default: 10}
+      lr: {type: float, default: 0.01}
+      momentum: {type: float, default: 0.5}
+      enable-cuda: {type: string, default: 'False'}
+      seed: {type: int, default: 5}
+      log-interval: {type: int, default: 100}
+    command: |
+          python mnist_tensorboard_artifact.py \
+            --batch-size {batch-size} \
+            --test-batch-size {test-batch-size} \
+            --epochs {epochs} \
+            --lr {lr} \
+            --momentum {momentum} \
+            --enable-cuda {enable-cuda} \
+            --seed {seed} \
+            --log-interval {log-interval}

--- a/examples/torchscript/README.md
+++ b/examples/torchscript/README.md
@@ -1,0 +1,35 @@
+# Torchscript Example
+This example trains a simple CNN model on MNIST dataset and logs weights, hyperparameters and metrics
+and trained torchscript model
+
+## Training the network
+`mlfow run` command will run the script `mnist_tensorboard_artifact.py` with default arguments
+which will in turn save the artifacts, params and scalars
+
+```bash
+mlflow run .
+```
+
+For more details about the arguments available, run
+
+```bash
+python mnist_tensorboard_artifact.py --help
+```
+
+And that will generate the help string
+```bash
+Torchscript MNIST Example
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --batch-size N        input batch size for training (default: 64)
+  --test-batch-size N   input batch size for testing (default: 1000)
+  --epochs N            number of epochs to train (default: 10)
+  --lr LR               learning rate (default: 0.01)
+  --momentum M          SGD momentum (default: 0.5)
+  --enable-cuda {True,False}
+                        enables or disables CUDA training
+  --seed S              random seed (default: 1)
+  --log-interval N      how many batches to wait before logging training
+
+```

--- a/examples/torchscript/conda.yaml
+++ b/examples/torchscript/conda.yaml
@@ -1,0 +1,11 @@
+name: torchscript_example
+channels:
+  - defaults
+  - pytorch
+dependencies:
+  - python=3.6
+  - pip:
+    - torch==1.4.0
+    - torchvision==0.5.0
+    - mlflow>=1.0
+    - tensorboardX

--- a/examples/torchscript/mnist_tensorboard_artifact.py
+++ b/examples/torchscript/mnist_tensorboard_artifact.py
@@ -156,8 +156,7 @@ def log_scalar(name, value, step):
 
 with mlflow.start_run() as run:
     # Log our parameters into mlflow
-    for key, value in vars(args).items():
-        mlflow.log_param(key, value)
+    mlflow.log_params(vars(args))
 
     # Create a SummaryWriter to write TensorBoard events locally
     output_dir = dirpath = tempfile.mkdtemp()

--- a/examples/torchscript/mnist_tensorboard_artifact.py
+++ b/examples/torchscript/mnist_tensorboard_artifact.py
@@ -24,8 +24,9 @@ from torchvision import datasets, transforms
 from torch.autograd import Variable
 from tensorboardX import SummaryWriter
 
+
 # Command-line arguments
-parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
+parser = argparse.ArgumentParser(description='Torchscript MNIST Example')
 parser.add_argument('--batch-size', type=int, default=64, metavar='N',
                     help='input batch size for training (default: 64)')
 parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
@@ -102,8 +103,6 @@ if args.cuda:
     model.cuda()
 
 optimizer = optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)
-
-writer = None # Will be used to write TensorBoard events
 
 
 def train(epoch):

--- a/examples/torchscript/mnist_tensorboard_artifact.py
+++ b/examples/torchscript/mnist_tensorboard_artifact.py
@@ -1,0 +1,180 @@
+#
+# Trains an MNIST digit recognizer using PyTorch, and uses tensorboardX to log training metrics
+# and weights in TensorBoard event format to the MLflow run's artifact directory. This stores the
+# TensorBoard events in MLflow for later access using the TensorBoard command line tool.
+#
+# NOTE: This example requires you to first install PyTorch (using the instructions at pytorch.org)
+#       and tensorboardX (using pip install tensorboardX).
+#
+# Code based on https://github.com/lanpa/tensorboard-pytorch-examples/blob/master/mnist/main.py.
+#
+
+from __future__ import print_function
+import argparse
+import os
+import mlflow
+import mlflow.pytorch
+import mlflow.torchscript
+import tempfile
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.optim as optim
+from torchvision import datasets, transforms
+from torch.autograd import Variable
+from tensorboardX import SummaryWriter
+
+# Command-line arguments
+parser = argparse.ArgumentParser(description='PyTorch MNIST Example')
+parser.add_argument('--batch-size', type=int, default=64, metavar='N',
+                    help='input batch size for training (default: 64)')
+parser.add_argument('--test-batch-size', type=int, default=1000, metavar='N',
+                    help='input batch size for testing (default: 1000)')
+parser.add_argument('--epochs', type=int, default=10, metavar='N',
+                    help='number of epochs to train (default: 10)')
+parser.add_argument('--lr', type=float, default=0.01, metavar='LR',
+                    help='learning rate (default: 0.01)')
+parser.add_argument('--momentum', type=float, default=0.5, metavar='M',
+                    help='SGD momentum (default: 0.5)')
+parser.add_argument('--enable-cuda', type=str, choices=['True', 'False'], default='True',
+                    help='enables or disables CUDA training')
+parser.add_argument('--seed', type=int, default=1, metavar='S',
+                    help='random seed (default: 1)')
+parser.add_argument('--log-interval', type=int, default=100, metavar='N',
+                    help='how many batches to wait before logging training status')
+args = parser.parse_args()
+
+enable_cuda_flag = True if args.enable_cuda == 'True' else False
+
+args.cuda = enable_cuda_flag and torch.cuda.is_available()
+
+torch.manual_seed(args.seed)
+if args.cuda:
+    torch.cuda.manual_seed(args.seed)
+
+kwargs = {'num_workers': 1, 'pin_memory': True} if args.cuda else {}
+train_loader = torch.utils.data.DataLoader(
+    datasets.MNIST('../data', train=True, download=True,
+                   transform=transforms.Compose([
+                       transforms.ToTensor(),
+                       transforms.Normalize((0.1307,), (0.3081,))
+                   ])),
+    batch_size=args.batch_size, shuffle=True, **kwargs)
+test_loader = torch.utils.data.DataLoader(
+    datasets.MNIST('../data', train=False, transform=transforms.Compose([
+                       transforms.ToTensor(),
+                       transforms.Normalize((0.1307,), (0.3081,))
+                   ])),
+    batch_size=args.test_batch_size, shuffle=True, **kwargs)
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
+        self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
+        self.conv2_drop = nn.Dropout2d()
+        self.fc1 = nn.Linear(320, 50)
+        self.fc2 = nn.Linear(50, 10)
+
+    def forward(self, x):
+        x = F.relu(F.max_pool2d(self.conv1(x), 2))
+        x = F.relu(F.max_pool2d(self.conv2_drop(self.conv2(x)), 2))
+        x = x.view(-1, 320)
+        x = F.relu(self.fc1(x))
+        x = F.dropout(x, training=self.training)
+        x = self.fc2(x)
+        return F.log_softmax(x, dim=0)
+
+    def log_weights(self, step):
+        writer.add_histogram('weights/conv1/weight', model.conv1.weight.data, step)
+        writer.add_histogram('weights/conv1/bias', model.conv1.bias.data, step)
+        writer.add_histogram('weights/conv2/weight', model.conv2.weight.data, step)
+        writer.add_histogram('weights/conv2/bias', model.conv2.bias.data, step)
+        writer.add_histogram('weights/fc1/weight', model.fc1.weight.data, step)
+        writer.add_histogram('weights/fc1/bias', model.fc1.bias.data, step)
+        writer.add_histogram('weights/fc2/weight', model.fc2.weight.data, step)
+        writer.add_histogram('weights/fc2/bias', model.fc2.bias.data, step)
+
+
+model = Net()
+if args.cuda:
+    model.cuda()
+
+optimizer = optim.SGD(model.parameters(), lr=args.lr, momentum=args.momentum)
+
+writer = None # Will be used to write TensorBoard events
+
+
+def train(epoch):
+    model.train()
+    for batch_idx, (data, target) in enumerate(train_loader):
+        if args.cuda:
+            data, target = data.cuda(), target.cuda()
+        data, target = Variable(data), Variable(target)
+        optimizer.zero_grad()
+        output = model(data)
+        loss = F.nll_loss(output, target)
+        loss.backward()
+        optimizer.step()
+        if batch_idx % args.log_interval == 0:
+            print('Train Epoch: {} [{}/{} ({:.0f}%)]\tLoss: {:.6f}'.format(
+                epoch, batch_idx * len(data), len(train_loader.dataset),
+                100. * batch_idx / len(train_loader), loss.data.item()))
+            step = epoch * len(train_loader) + batch_idx
+            log_scalar('train_loss', loss.data.item(), step)
+            model.log_weights(step)
+
+
+def test(epoch):
+    model.eval()
+    test_loss = 0
+    correct = 0
+    with torch.no_grad():
+        for data, target in test_loader:
+            if args.cuda:
+                data, target = data.cuda(), target.cuda()
+            data, target = Variable(data), Variable(target)
+            output = model(data)
+            test_loss += F.nll_loss(output, target, reduction='sum').data.item() # sum up batch loss
+            pred = output.data.max(1)[1] # get the index of the max log-probability
+            correct += pred.eq(target.data).cpu().sum().item()
+
+    test_loss /= len(test_loader.dataset)
+    test_accuracy = 100.0 * correct / len(test_loader.dataset)
+    print('\nTest set: Average loss: {:.4f}, Accuracy: {}/{} ({:.0f}%)\n'.format(
+        test_loss, correct, len(test_loader.dataset), test_accuracy))
+    step = (epoch + 1) * len(train_loader)
+    log_scalar('test_loss', test_loss, step)
+    log_scalar('test_accuracy', test_accuracy, step)
+
+
+def log_scalar(name, value, step):
+    """Log a scalar value to both MLflow and TensorBoard"""
+    writer.add_scalar(name, value, step)
+    mlflow.log_metric(name, value)
+
+
+with mlflow.start_run() as run:
+    # Log our parameters into mlflow
+    for key, value in vars(args).items():
+        mlflow.log_param(key, value)
+
+    # Create a SummaryWriter to write TensorBoard events locally
+    output_dir = dirpath = tempfile.mkdtemp()
+    writer = SummaryWriter(output_dir)
+    print("Writing TensorBoard events locally to %s\n" % output_dir)
+
+    for epoch in range(1, args.epochs + 1):
+        train(epoch)
+        test(epoch)
+    print("Saving TorchScript Model ..")
+    torchscript_model = torch.jit.script(model)
+    artifact_path = 'model'
+    mlflow.torchscript.log_model(torchscript_model, artifact_path=artifact_path)
+
+    # Upload the TensorBoard event logs as a run artifact
+    print("Uploading TensorBoard events as a run artifact...")
+    mlflow.log_artifacts(output_dir, artifact_path="events")
+    print("\nLaunch TensorBoard with:\n\ntensorboard --logdir=%s" %
+          os.path.join(mlflow.get_artifact_uri(), "events"))

--- a/mlflow/torchscript.py
+++ b/mlflow/torchscript.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+import logging
+import yaml
+
+import torch
+import pandas as pd
+import numpy as np
+import mlflow
+from mlflow import pyfunc
+from mlflow.models import Model
+from mlflow.exceptions import MlflowException
+from mlflow.utils.environment import _mlflow_conda_env
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.utils.model_utils import _get_flavor_configuration
+
+FLAVOR_NAME = "torchscript"
+_SERIALIZED_TORCH_MODEL_FILE_NAME = "model.pt"
+_logger = logging.getLogger(__name__)
+
+
+def get_default_conda_env():
+    """
+    :return: The default Conda environment for MLflow Models produced by calls to
+             :func:`save_model()` and :func:`log_model()`.
+    """
+    import torch
+
+    return _mlflow_conda_env(
+        additional_conda_deps=[
+            "pytorch={}".format(torch.__version__),
+        ],
+        additional_conda_channels=[
+            "pytorch",
+        ])
+
+
+def log_model(model, artifact_path, conda_env=None, registered_model_name=None, **kwargs):
+    Model.log(artifact_path=artifact_path, flavor=mlflow.torchscript, model=model,
+              conda_env=conda_env, registered_model_name=registered_model_name, **kwargs)
+
+
+def save_model(model, path, conda_env=None, mlflow_model=Model(), **kwargs):
+    if not hasattr(model, 'state_dict') or not hasattr(model, 'save'):
+        # If it walks like a duck and it quacks like a duck, then it must be a duck
+        raise TypeError("Argument 'model' should be a TorchScript model")
+    path = Path(path)
+    try:
+        path.mkdir(parents=True, exist_ok=False)
+    except FileExistsError:
+        raise MlflowException("Path '{}' already exists".format(path))
+    filepath = str(path / 'model.pt')
+    model.save(filepath, **kwargs)
+    conda_env_subpath = "conda.yaml"
+    if conda_env is None:
+        conda_env = get_default_conda_env()
+    elif not isinstance(conda_env, dict):
+        with open(conda_env, "r") as f:
+            conda_env = yaml.safe_load(f)
+    with open(path / conda_env_subpath, "w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
+    mlflow_model.add_flavor(FLAVOR_NAME, pytorch_version=torch.__version__)
+    pyfunc.add_to_model(mlflow_model, loader_module="mlflow.pytorch", env=conda_env_subpath)
+    mlflow_model.save(path / "MLmodel")
+
+
+def load_model(model_uri, **kwargs):
+    local_model_path = Path(_download_artifact_from_uri(artifact_uri=model_uri))
+    pytorch_conf = _get_flavor_configuration(model_path=local_model_path,
+                                             flavor_name=FLAVOR_NAME)
+    if torch.__version__ != pytorch_conf["pytorch_version"]:
+        _logger.warning(
+            "Stored model version '%s' does not match installed PyTorch version '%s'",
+            pytorch_conf["pytorch_version"], torch.__version__)
+    return torch.jit.load(str(local_model_path / 'model.pt'), **kwargs)
+
+
+def _load_pyfunc(path, **kwargs):
+    """
+    Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
+
+    :param path: Local filesystem path to the MLflow Model with the ``torchscript`` flavor.
+    """
+    return _PyTorchWrapper(torch.jit.load(path, **kwargs))
+
+
+class _PyTorchWrapper(object):
+    """
+    Wrapper class that creates a predict function such that
+    predict(data: pd.DataFrame) -> model's output as pd.DataFrame (pandas DataFrame)
+    """
+    def __init__(self, torchscript_model):
+        self.torchscript_model = torchscript_model
+
+    def predict(self, data, device='cpu'):
+        if not isinstance(data, pd.DataFrame):
+            raise TypeError("Input data should be pandas.DataFrame")
+        self.torchscript_model.to(device)
+        self.torchscript_model.eval()
+        with torch.no_grad():
+            input_tensor = torch.from_numpy(data.values.astype(np.float32)).to(device)
+            preds = self.torchscript_model(input_tensor)
+            if not isinstance(preds, torch.Tensor):
+                raise TypeError("Expected PyTorch model to output a single output tensor, "
+                                "but got output of type '{}'".format(type(preds)))
+            predicted = pd.DataFrame(preds.numpy())
+            predicted.index = data.index
+            return predicted
+

--- a/tests/torchscript/test_model_export.py
+++ b/tests/torchscript/test_model_export.py
@@ -1,0 +1,744 @@
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader
+import importlib
+import os
+import json
+import logging
+import mock
+import pickle
+
+import pytest
+import numpy as np
+import pandas as pd
+import sklearn.datasets as datasets
+import yaml
+
+import mlflow.pyfunc as pyfunc
+import mlflow.torchscript
+import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
+from mlflow import tracking
+from mlflow.exceptions import MlflowException
+from mlflow.models import Model, infer_signature
+from mlflow.models.utils import _read_example
+from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.utils.environment import _mlflow_conda_env
+from mlflow.utils.file_utils import TempDir
+from mlflow.utils.model_utils import _get_flavor_configuration
+
+
+# TODO: test traced model and script functions
+
+_logger = logging.getLogger(__name__)
+
+# This test suite is included as a code dependency when testing PyTorch model scoring in new
+# processes and docker containers. In these environments, the `tests` module is not available.
+# Therefore, we attempt to import from `tests` and gracefully emit a warning if it's unavailable.
+try:
+    from tests.helper_functions import pyfunc_serve_and_score_model
+    from tests.helper_functions import score_model_in_sagemaker_docker_container
+    from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
+    from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
+except ImportError:
+    _logger.warning(
+        "Failed to import test helper functions. Tests depending on these functions may fail!")
+
+
+@pytest.fixture(scope='module')
+def data():
+    iris = datasets.load_iris()
+    data = pd.DataFrame(data=np.c_[iris['data'], iris['target']],
+                        columns=iris['feature_names'] + ['target'])
+    y = data['target']
+    x = data.drop('target', axis=1)
+    return x, y
+
+
+def get_dataset(data):
+    x, y = data
+    dataset = [(xi.astype(np.float32), yi.astype(np.float32))
+               for xi, yi in zip(x.values, y.values)]
+    return dataset
+
+
+def train_model(model, data):
+    dataset = get_dataset(data)
+    criterion = nn.MSELoss()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
+    batch_size = 16
+    num_workers = 4
+    dataloader = DataLoader(dataset, batch_size=batch_size,
+                            num_workers=num_workers, shuffle=True, drop_last=False)
+
+    model.train()
+    for _ in range(5):
+        for batch in dataloader:
+            optimizer.zero_grad()
+            batch_size = batch[0].shape[0]
+            y_pred = model(batch[0]).squeeze(dim=1)
+            loss = criterion(y_pred, batch[1])
+            loss.backward()
+            optimizer.step()
+
+
+@pytest.fixture(scope='module')
+def sequential_model(data):
+    model = nn.Sequential(
+        nn.Linear(4, 3),
+        nn.ReLU(),
+        nn.Linear(3, 1),
+    )
+
+    model = torch.jit.script(model)
+    train_model(model=model, data=data)
+    return model
+
+
+def get_subclassed_model_definition():
+    """
+    Defines a PyTorch model class that inherits from ``torch.nn.Module``. This method can be invoked
+    within a pytest fixture to define the model class in the ``__main__`` scope. Alternatively, it
+    can be invoked within a module to define the class in the module's scope.
+    """
+    class SubclassedModel(torch.nn.Module):
+
+        def __init__(self):
+            super(SubclassedModel, self).__init__()
+            self.linear = torch.nn.Linear(4, 1)
+
+        def forward(self, x):
+            y_pred = self.linear(x)
+            return y_pred
+
+    return SubclassedModel
+
+
+@pytest.fixture(scope='module')
+def main_scoped_subclassed_model(data):
+    """
+    A custom PyTorch model inheriting from ``torch.nn.Module`` whose class is defined in the
+    "__main__" scope.
+    """
+    model_class = get_subclassed_model_definition()
+    model = torch.jit.script(model_class())
+    train_model(model=model, data=data)
+    return model
+
+
+class ModuleScopedSubclassedModel(get_subclassed_model_definition()):
+    """
+    A custom PyTorch model class defined in the test module scope. This is a subclass of
+    ``torch.nn.Module``.
+    """
+
+
+@pytest.fixture(scope='module')
+def module_scoped_subclassed_model(data):
+    """
+    A custom PyTorch model inheriting from ``torch.nn.Module`` whose class is defined in the test
+    module scope.
+    """
+    model = torch.jit.script(ModuleScopedSubclassedModel())
+    train_model(model=model, data=data)
+    return model
+
+
+@pytest.fixture
+def model_path(tmpdir):
+    return os.path.join(str(tmpdir), "model")
+
+
+@pytest.fixture
+def pytorch_custom_env(tmpdir):
+    conda_env = os.path.join(str(tmpdir), "conda_env.yml")
+    _mlflow_conda_env(
+            conda_env,
+            additional_conda_deps=["pytorch", "torchvision", "pytest"],
+            additional_conda_channels=["pytorch"])
+    return conda_env
+
+
+def _predict(model, data):
+    dataset = get_dataset(data)
+    batch_size = 16
+    num_workers = 4
+    dataloader = DataLoader(dataset, batch_size=batch_size,
+                            num_workers=num_workers, shuffle=False, drop_last=False)
+    predictions = np.zeros((len(dataloader.sampler),))
+    model.eval()
+    with torch.no_grad():
+        for i, batch in enumerate(dataloader):
+            y_preds = model(batch[0]).squeeze(dim=1).numpy()
+            predictions[i * batch_size:(i + 1) * batch_size] = y_preds
+    return predictions
+
+
+@pytest.fixture(scope='module')
+def sequential_predicted(sequential_model, data):
+    return _predict(sequential_model, data)
+
+
+@pytest.mark.large
+def test_signature_and_examples_are_saved_correctly(sequential_model, data):
+    model = sequential_model
+    signature_ = infer_signature(*data)
+    example_ = data[0].head(3)
+    for signature in (None, signature_):
+        for example in (None, example_):
+            with TempDir() as tmp:
+                path = tmp.path("model")
+                mlflow.torchscript.save_model(model, path=path,
+                                              signature=signature,
+                                              input_example=example)
+                mlflow_model = Model.load(path)
+                assert signature == mlflow_model.signature
+                if example is None:
+                    assert mlflow_model.saved_input_example_info is None
+                else:
+                    assert all((_read_example(mlflow_model, path) == example).all())
+
+
+@pytest.mark.large
+def test_log_model(sequential_model, data, sequential_predicted):
+    old_uri = tracking.get_tracking_uri()
+    # should_start_run tests whether or not calling log_model() automatically starts a run.
+    for should_start_run in [False, True]:
+        with TempDir(chdr=True, remove_on_exit=True) as tmp:
+            try:
+                tracking.set_tracking_uri(tmp.path("test"))
+                if should_start_run:
+                    mlflow.start_run()
+
+                artifact_path = "torchscript"
+                mlflow.torchscript.log_model(sequential_model, artifact_path=artifact_path)
+                model_uri = "runs:/{run_id}/{artifact_path}".format(
+                    run_id=mlflow.active_run().info.run_id,
+                    artifact_path=artifact_path)
+
+                # Load model
+                sequential_model_loaded = mlflow.torchscript.load_model(model_uri=model_uri)
+
+                test_predictions = _predict(sequential_model_loaded, data)
+                np.testing.assert_array_equal(test_predictions, sequential_predicted)
+            finally:
+                mlflow.end_run()
+                tracking.set_tracking_uri(old_uri)
+
+
+def test_log_model_calls_register_model(module_scoped_subclassed_model):
+    artifact_path = "model"
+    register_model_patch = mock.patch("mlflow.register_model")
+    with mlflow.start_run(), register_model_patch:
+        mlflow.torchscript.log_model(
+            artifact_path=artifact_path,
+            model=module_scoped_subclassed_model,
+            conda_env=None,
+            registered_model_name="AdsModel1")
+        model_uri = "runs:/{run_id}/{artifact_path}".format(run_id=mlflow.active_run().info.run_id,
+                                                            artifact_path=artifact_path)
+        mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
+
+
+def test_log_model_no_registered_model_name(module_scoped_subclassed_model):
+    artifact_path = "model"
+    register_model_patch = mock.patch("mlflow.register_model")
+    with mlflow.start_run(), register_model_patch:
+        mlflow.torchscript.log_model(
+            artifact_path=artifact_path,
+            model=module_scoped_subclassed_model,
+            conda_env=None)
+        mlflow.register_model.assert_not_called()
+
+
+@pytest.mark.large
+def test_raise_exception(sequential_model):
+    with TempDir(chdr=True, remove_on_exit=True) as tmp:
+        path = tmp.path("model")
+        with pytest.raises(IOError):
+            mlflow.torchscript.load_model(path)
+
+        with pytest.raises(TypeError):
+            mlflow.torchscript.save_model([1, 2, 3], path)
+
+        mlflow.torchscript.save_model(sequential_model, path)
+        with pytest.raises(RuntimeError):
+            mlflow.torchscript.save_model(sequential_model, path)
+
+        from mlflow import sklearn
+        import sklearn.neighbors as knn
+        path = tmp.path("knn.pkl")
+        knn = knn.KNeighborsClassifier()
+        with open(path, "wb") as f:
+            pickle.dump(knn, f)
+        path = tmp.path("knn")
+        sklearn.save_model(knn, path=path)
+        with pytest.raises(MlflowException):
+            mlflow.torchscript.load_model(path)
+
+
+@pytest.mark.large
+def test_save_and_load_model(sequential_model, model_path, data, sequential_predicted):
+    mlflow.torchscript.save_model(sequential_model, model_path)
+
+    # Loading pytorch model
+    sequential_model_loaded = mlflow.torchscript.load_model(model_path)
+    np.testing.assert_array_equal(_predict(sequential_model_loaded, data), sequential_predicted)
+
+    # Loading pyfunc model
+    pyfunc_loaded = mlflow.pyfunc.load_pyfunc(model_path)
+    np.testing.assert_array_almost_equal(
+        pyfunc_loaded.predict(data[0]).values[:, 0], sequential_predicted, decimal=4)
+
+
+@pytest.mark.large
+def test_load_model_from_remote_uri_succeeds(
+        sequential_model, model_path, mock_s3_bucket, data, sequential_predicted):
+    mlflow.pytorch.save_model(sequential_model, model_path)
+
+    artifact_root = "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
+    artifact_path = "model"
+    artifact_repo = S3ArtifactRepository(artifact_root)
+    artifact_repo.log_artifacts(model_path, artifact_path=artifact_path)
+
+    model_uri = artifact_root + "/" + artifact_path
+    sequential_model_loaded = mlflow.pytorch.load_model(model_uri=model_uri)
+    np.testing.assert_array_equal(_predict(sequential_model_loaded, data), sequential_predicted)
+
+
+@pytest.mark.large
+def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
+        sequential_model, model_path, pytorch_custom_env):
+    mlflow.pytorch.save_model(
+            pytorch_model=sequential_model, path=model_path, conda_env=pytorch_custom_env)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+    assert saved_conda_env_path != pytorch_custom_env
+
+    with open(pytorch_custom_env, "r") as f:
+        pytorch_custom_env_text = f.read()
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_text = f.read()
+    assert saved_conda_env_text == pytorch_custom_env_text
+
+
+@pytest.mark.large
+def test_model_save_accepts_conda_env_as_dict(sequential_model, model_path):
+    conda_env = dict(mlflow.pytorch.get_default_conda_env())
+    conda_env["dependencies"].append("pytest")
+    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path, conda_env=conda_env)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == conda_env
+
+
+@pytest.mark.large
+def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
+        sequential_model, pytorch_custom_env):
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.pytorch.log_model(pytorch_model=sequential_model,
+                                 artifact_path=artifact_path,
+                                 conda_env=pytorch_custom_env)
+        model_path = _download_artifact_from_uri("runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path))
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+    assert saved_conda_env_path != pytorch_custom_env
+
+    with open(pytorch_custom_env, "r") as f:
+        pytorch_custom_env_text = f.read()
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_text = f.read()
+    assert saved_conda_env_text == pytorch_custom_env_text
+
+
+@pytest.mark.large
+def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
+        sequential_model, model_path):
+    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path, conda_env=None)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    with open(conda_env_path, "r") as f:
+        conda_env = yaml.safe_load(f)
+
+    assert conda_env == mlflow.pytorch.get_default_conda_env()
+
+
+@pytest.mark.large
+def test_model_log_without_specified_conda_env_uses_default_env_with_expected_dependencies(
+        sequential_model):
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.pytorch.log_model(pytorch_model=sequential_model,
+                                 artifact_path=artifact_path,
+                                 conda_env=None)
+        model_path = _download_artifact_from_uri("runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path))
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    with open(conda_env_path, "r") as f:
+        conda_env = yaml.safe_load(f)
+
+    assert conda_env == mlflow.pytorch.get_default_conda_env()
+
+
+@pytest.mark.large
+def test_load_model_with_differing_pytorch_version_logs_warning(sequential_model, model_path):
+    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path)
+    saver_pytorch_version = "1.0"
+    model_config_path = os.path.join(model_path, "MLmodel")
+    model_config = Model.load(model_config_path)
+    model_config.flavors[mlflow.pytorch.FLAVOR_NAME]["pytorch_version"] = saver_pytorch_version
+    model_config.save(model_config_path)
+
+    log_messages = []
+
+    def custom_warn(message_text, *args, **kwargs):
+        log_messages.append(message_text % args % kwargs)
+
+    loader_pytorch_version = "0.8.2"
+    with mock.patch("mlflow.pytorch._logger.warning") as warn_mock,\
+            mock.patch("torch.__version__") as torch_version_mock:
+        torch_version_mock.__str__ = lambda *args, **kwargs: loader_pytorch_version
+        warn_mock.side_effect = custom_warn
+        mlflow.pytorch.load_model(model_uri=model_path)
+
+    assert any([
+        "does not match installed PyTorch version" in log_message and
+        saver_pytorch_version in log_message and
+        loader_pytorch_version in log_message
+        for log_message in log_messages
+    ])
+
+
+@pytest.mark.large
+def test_pyfunc_model_serving_with_module_scoped_subclassed_model_and_default_conda_env(
+        module_scoped_subclassed_model, model_path, data):
+    mlflow.pytorch.save_model(
+        path=model_path,
+        pytorch_model=module_scoped_subclassed_model,
+        conda_env=None,
+        code_paths=[__file__])
+
+    scoring_response = pyfunc_serve_and_score_model(
+            model_uri=model_path,
+            data=data[0],
+            content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+            extra_args=["--no-conda"])
+    assert scoring_response.status_code == 200
+
+    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
+    np.testing.assert_array_almost_equal(
+        deployed_model_preds.values[:, 0],
+        _predict(model=module_scoped_subclassed_model, data=data),
+        decimal=4)
+
+
+def test_save_model_with_wrong_codepaths_fails_corrrectly(
+        module_scoped_subclassed_model, model_path, data):
+    with pytest.raises(TypeError) as exc_info:
+        mlflow.pytorch.save_model(
+            path=model_path,
+            pytorch_model=module_scoped_subclassed_model,
+            conda_env=None,
+            code_paths="some string")
+    assert "TypeError: Argument code_paths should be a list, not {}".format(type("")) \
+           in str(exc_info)
+    assert not os.path.exists(model_path)
+
+
+@pytest.mark.large
+def test_pyfunc_model_serving_with_main_scoped_subclassed_model_and_custom_pickle_module(
+        main_scoped_subclassed_model, model_path, data):
+    mlflow.pytorch.save_model(
+        path=model_path,
+        pytorch_model=main_scoped_subclassed_model,
+        conda_env=None,
+        pickle_module=mlflow_pytorch_pickle_module)
+
+    scoring_response = pyfunc_serve_and_score_model(
+            model_uri=model_path,
+            data=data[0],
+            content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+            extra_args=["--no-conda"])
+    assert scoring_response.status_code == 200
+
+    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
+    np.testing.assert_array_almost_equal(
+        deployed_model_preds.values[:, 0],
+        _predict(model=main_scoped_subclassed_model, data=data),
+        decimal=4)
+
+
+@pytest.mark.large
+def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
+        module_scoped_subclassed_model, model_path, data):
+    # Save a PyTorch model whose class is defined in the current test suite. Because the
+    # `tests` module is not available when the model is deployed for local scoring, we include
+    # the test suite file as a code dependency
+    mlflow.pytorch.save_model(
+        path=model_path,
+        pytorch_model=module_scoped_subclassed_model,
+        conda_env=None,
+        code_paths=[__file__])
+
+    # Define a custom pyfunc model that loads a PyTorch model artifact using
+    # `mlflow.pytorch.load_model`
+    class TorchValidatorModel(pyfunc.PythonModel):
+
+        def load_context(self, context):
+            self.pytorch_model = mlflow.pytorch.load_model(context.artifacts["pytorch_model"])
+
+        def predict(self, context, model_input):
+            with torch.no_grad():
+                input_tensor = torch.from_numpy(model_input.values.astype(np.float32))
+                output_tensor = self.pytorch_model(input_tensor)
+                return pd.DataFrame(output_tensor.numpy())
+
+    pyfunc_artifact_path = "pyfunc_model"
+    with mlflow.start_run():
+        pyfunc.log_model(artifact_path=pyfunc_artifact_path,
+                         python_model=TorchValidatorModel(),
+                         artifacts={
+                            "pytorch_model": model_path,
+                         })
+        pyfunc_model_path = _download_artifact_from_uri("runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id, artifact_path=pyfunc_artifact_path))
+
+    # Deploy the custom pyfunc model and ensure that it is able to successfully load its
+    # constituent PyTorch model via `mlflow.pytorch.load_model`
+    scoring_response = pyfunc_serve_and_score_model(
+            model_uri=pyfunc_model_path,
+            data=data[0],
+            content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+            extra_args=["--no-conda"])
+    assert scoring_response.status_code == 200
+
+    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
+    np.testing.assert_array_almost_equal(
+        deployed_model_preds.values[:, 0],
+        _predict(model=module_scoped_subclassed_model, data=data),
+        decimal=4)
+
+
+@pytest.mark.large
+def test_load_pyfunc_loads_torch_model_using_pickle_module_specified_at_save_time(
+        module_scoped_subclassed_model, model_path):
+    custom_pickle_module = pickle
+
+    mlflow.pytorch.save_model(
+        path=model_path,
+        pytorch_model=module_scoped_subclassed_model,
+        conda_env=None,
+        pickle_module=custom_pickle_module)
+
+    import_module_fn = importlib.import_module
+    imported_modules = []
+
+    def track_module_imports(module_name):
+        imported_modules.append(module_name)
+        return import_module_fn(module_name)
+
+    with mock.patch("importlib.import_module") as import_mock,\
+            mock.patch("torch.load") as torch_load_mock:
+        import_mock.side_effect = track_module_imports
+        pyfunc.load_pyfunc(model_path)
+
+    torch_load_mock.assert_called_with(mock.ANY, pickle_module=custom_pickle_module)
+    assert custom_pickle_module.__name__ in imported_modules
+
+
+@pytest.mark.large
+def test_load_model_loads_torch_model_using_pickle_module_specified_at_save_time(
+        module_scoped_subclassed_model):
+    custom_pickle_module = pickle
+
+    artifact_path = "pytorch_model"
+    with mlflow.start_run():
+        mlflow.pytorch.log_model(
+            artifact_path=artifact_path,
+            pytorch_model=module_scoped_subclassed_model,
+            conda_env=None,
+            pickle_module=custom_pickle_module)
+        model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id,
+            artifact_path=artifact_path)
+
+    import_module_fn = importlib.import_module
+    imported_modules = []
+
+    def track_module_imports(module_name):
+        imported_modules.append(module_name)
+        return import_module_fn(module_name)
+
+    with mock.patch("importlib.import_module") as import_mock,\
+            mock.patch("torch.load") as torch_load_mock:
+        import_mock.side_effect = track_module_imports
+        pyfunc.load_pyfunc(model_uri=model_uri)
+
+    torch_load_mock.assert_called_with(mock.ANY, pickle_module=custom_pickle_module)
+    assert custom_pickle_module.__name__ in imported_modules
+
+
+@pytest.mark.large
+def test_load_pyfunc_succeeds_when_data_is_model_file_instead_of_directory(
+        module_scoped_subclassed_model, model_path, data):
+    """
+    This test verifies that PyTorch models saved in older versions of MLflow are loaded successfully
+    by ``mlflow.pytorch.load_model``. The ``data`` path associated with these older models is
+    serialized PyTorch model file, as opposed to the current format: a directory containing a
+    serialized model file and pickle module information.
+    """
+    mlflow.pytorch.save_model(
+        path=model_path,
+        pytorch_model=module_scoped_subclassed_model,
+        conda_env=None)
+
+    model_conf_path = os.path.join(model_path, "MLmodel")
+    model_conf = Model.load(model_conf_path)
+    pyfunc_conf = model_conf.flavors.get(pyfunc.FLAVOR_NAME)
+    assert pyfunc_conf is not None
+    model_data_path = os.path.join(model_path, pyfunc_conf[pyfunc.DATA])
+    assert os.path.exists(model_data_path)
+    assert mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME in os.listdir(model_data_path)
+    pyfunc_conf[pyfunc.DATA] = os.path.join(
+        model_data_path, mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME)
+    model_conf.save(model_conf_path)
+
+    loaded_pyfunc = pyfunc.load_pyfunc(model_path)
+
+    np.testing.assert_array_almost_equal(
+        loaded_pyfunc.predict(data[0]),
+        pd.DataFrame(_predict(model=module_scoped_subclassed_model, data=data)),
+        decimal=4)
+
+
+@pytest.mark.large
+def test_load_model_succeeds_when_data_is_model_file_instead_of_directory(
+        module_scoped_subclassed_model, model_path, data):
+    """
+    This test verifies that PyTorch models saved in older versions of MLflow are loaded successfully
+    by ``mlflow.pytorch.load_model``. The ``data`` path associated with these older models is
+    serialized PyTorch model file, as opposed to the current format: a directory containing a
+    serialized model file and pickle module information.
+    """
+    artifact_path = "pytorch_model"
+    with mlflow.start_run():
+        mlflow.pytorch.log_model(
+            artifact_path=artifact_path,
+            pytorch_model=module_scoped_subclassed_model,
+            conda_env=None)
+        model_path = _download_artifact_from_uri("runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path))
+
+    model_conf_path = os.path.join(model_path, "MLmodel")
+    model_conf = Model.load(model_conf_path)
+    pyfunc_conf = model_conf.flavors.get(pyfunc.FLAVOR_NAME)
+    assert pyfunc_conf is not None
+    model_data_path = os.path.join(model_path, pyfunc_conf[pyfunc.DATA])
+    assert os.path.exists(model_data_path)
+    assert mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME in os.listdir(model_data_path)
+    pyfunc_conf[pyfunc.DATA] = os.path.join(
+        model_data_path, mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME)
+    model_conf.save(model_conf_path)
+
+    loaded_pyfunc = pyfunc.load_pyfunc(model_path)
+
+    np.testing.assert_array_almost_equal(
+        loaded_pyfunc.predict(data[0]),
+        pd.DataFrame(_predict(model=module_scoped_subclassed_model, data=data)),
+        decimal=4)
+
+
+@pytest.mark.large
+def test_load_model_allows_user_to_override_pickle_module_via_keyword_argument(
+        module_scoped_subclassed_model, model_path):
+    mlflow.pytorch.save_model(
+        path=model_path,
+        pytorch_model=module_scoped_subclassed_model,
+        conda_env=None,
+        pickle_module=pickle)
+
+    mlflow_torch_pickle_load = mlflow_pytorch_pickle_module.load
+    pickle_call_results = {
+        "mlflow_torch_pickle_load_called": False,
+    }
+
+    def validate_mlflow_torch_pickle_load_called(*args, **kwargs):
+        pickle_call_results["mlflow_torch_pickle_load_called"] = True
+        return mlflow_torch_pickle_load(*args, **kwargs)
+
+    log_messages = []
+
+    def custom_warn(message_text, *args, **kwargs):
+        log_messages.append(message_text % args % kwargs)
+
+    with mock.patch("mlflow.pytorch.pickle_module.load") as mlflow_torch_pickle_load_mock,\
+            mock.patch("mlflow.pytorch._logger.warning") as warn_mock:
+        mlflow_torch_pickle_load_mock.side_effect = validate_mlflow_torch_pickle_load_called
+        warn_mock.side_effect = custom_warn
+        mlflow.pytorch.load_model(model_uri=model_path, pickle_module=mlflow_pytorch_pickle_module)
+
+    assert all(pickle_call_results.values())
+    assert any([
+        "does not match the pickle module that was used to save the model" in log_message and
+        pickle.__name__ in log_message and
+        mlflow_pytorch_pickle_module.__name__ in log_message
+        for log_message in log_messages
+    ])
+
+
+@pytest.mark.large
+def test_load_model_raises_exception_when_pickle_module_cannot_be_imported(
+        main_scoped_subclassed_model, model_path):
+    mlflow.pytorch.save_model(
+        path=model_path,
+        pytorch_model=main_scoped_subclassed_model,
+        conda_env=None)
+
+    bad_pickle_module_name = "not.a.real.module"
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    model_data_path = os.path.join(model_path, pyfunc_conf[pyfunc.DATA])
+    assert os.path.exists(model_data_path)
+    assert mlflow.pytorch._PICKLE_MODULE_INFO_FILE_NAME in os.listdir(model_data_path)
+    with open(
+            os.path.join(model_data_path, mlflow.pytorch._PICKLE_MODULE_INFO_FILE_NAME), "w") as f:
+        f.write(bad_pickle_module_name)
+
+    with pytest.raises(MlflowException) as exc_info:
+        mlflow.pytorch.load_model(model_uri=model_path)
+
+    assert "Failed to import the pickle module" in str(exc_info)
+    assert bad_pickle_module_name in str(exc_info)
+
+
+@pytest.mark.release
+def test_sagemaker_docker_model_scoring_with_sequential_model_and_default_conda_env(
+        model, model_path, data, sequential_predicted):
+    mlflow.pytorch.save_model(pytorch_model=model, path=model_path, conda_env=None)
+
+    scoring_response = score_model_in_sagemaker_docker_container(
+            model_uri=model_path,
+            data=data[0],
+            content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+            flavor=mlflow.pyfunc.FLAVOR_NAME,
+            activity_polling_timeout_seconds=360)
+    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
+
+    np.testing.assert_array_almost_equal(
+        deployed_model_preds.values[:, 0],
+        sequential_predicted,
+        decimal=4)

--- a/tests/torchscript/test_model_export.py
+++ b/tests/torchscript/test_model_export.py
@@ -29,6 +29,7 @@ from tests.helper_functions import pyfunc_serve_and_score_model
 
 _logger = logging.getLogger(__name__)
 
+
 @pytest.fixture(scope='module')
 def data():
     iris = datasets.load_iris()

--- a/tests/torchscript/test_model_export.py
+++ b/tests/torchscript/test_model_export.py
@@ -26,6 +26,7 @@ from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 from tests.helper_functions import pyfunc_serve_and_score_model
+from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 
@@ -211,7 +212,9 @@ def test_log_model_calls_register_model(subclassed_model):
             registered_model_name="AdsModel1")
         model_uri = "runs:/{run_id}/{artifact_path}".format(run_id=mlflow.active_run().info.run_id,
                                                             artifact_path=artifact_path)
-        mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
+        mlflow.register_model.assert_called_once_with(
+            model_uri, "AdsModel1", await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+        )
 
 
 def test_log_model_no_registered_model_name(subclassed_model):

--- a/tests/torchscript/test_model_export.py
+++ b/tests/torchscript/test_model_export.py
@@ -1,7 +1,6 @@
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
-import importlib
 import os
 import json
 import logging
@@ -26,24 +25,9 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
-
-
-# TODO: test traced model and script functions
+from tests.helper_functions import pyfunc_serve_and_score_model
 
 _logger = logging.getLogger(__name__)
-
-# This test suite is included as a code dependency when testing PyTorch model scoring in new
-# processes and docker containers. In these environments, the `tests` module is not available.
-# Therefore, we attempt to import from `tests` and gracefully emit a warning if it's unavailable.
-try:
-    from tests.helper_functions import pyfunc_serve_and_score_model
-    from tests.helper_functions import score_model_in_sagemaker_docker_container
-    from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
-    from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
-except ImportError:
-    _logger.warning(
-        "Failed to import test helper functions. Tests depending on these functions may fail!")
-
 
 @pytest.fixture(scope='module')
 def data():
@@ -95,51 +79,24 @@ def sequential_model(data):
     return model
 
 
-def get_subclassed_model_definition():
-    """
-    Defines a PyTorch model class that inherits from ``torch.nn.Module``. This method can be invoked
-    within a pytest fixture to define the model class in the ``__main__`` scope. Alternatively, it
-    can be invoked within a module to define the class in the module's scope.
-    """
-    class SubclassedModel(torch.nn.Module):
+class PyTorchModel(torch.nn.Module):
 
-        def __init__(self):
-            super(SubclassedModel, self).__init__()
-            self.linear = torch.nn.Linear(4, 1)
+    def __init__(self):
+        super().__init__()
+        self.linear = torch.nn.Linear(4, 1)
 
-        def forward(self, x):
-            y_pred = self.linear(x)
-            return y_pred
-
-    return SubclassedModel
+    def forward(self, x):
+        y_pred = self.linear(x)
+        return y_pred
 
 
 @pytest.fixture(scope='module')
-def main_scoped_subclassed_model(data):
+def subclassed_model(data):
     """
     A custom PyTorch model inheriting from ``torch.nn.Module`` whose class is defined in the
     "__main__" scope.
     """
-    model_class = get_subclassed_model_definition()
-    model = torch.jit.script(model_class())
-    train_model(model=model, data=data)
-    return model
-
-
-class ModuleScopedSubclassedModel(get_subclassed_model_definition()):
-    """
-    A custom PyTorch model class defined in the test module scope. This is a subclass of
-    ``torch.nn.Module``.
-    """
-
-
-@pytest.fixture(scope='module')
-def module_scoped_subclassed_model(data):
-    """
-    A custom PyTorch model inheriting from ``torch.nn.Module`` whose class is defined in the test
-    module scope.
-    """
-    model = torch.jit.script(ModuleScopedSubclassedModel())
+    model = torch.jit.script(PyTorchModel())
     train_model(model=model, data=data)
     return model
 
@@ -226,13 +183,13 @@ def test_log_model(sequential_model, data, sequential_predicted):
                 tracking.set_tracking_uri(old_uri)
 
 
-def test_log_model_calls_register_model(module_scoped_subclassed_model):
+def test_log_model_calls_register_model(subclassed_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch:
         mlflow.torchscript.log_model(
             artifact_path=artifact_path,
-            model=module_scoped_subclassed_model,
+            model=subclassed_model,
             conda_env=None,
             registered_model_name="AdsModel1")
         model_uri = "runs:/{run_id}/{artifact_path}".format(run_id=mlflow.active_run().info.run_id,
@@ -240,13 +197,13 @@ def test_log_model_calls_register_model(module_scoped_subclassed_model):
         mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
 
 
-def test_log_model_no_registered_model_name(module_scoped_subclassed_model):
+def test_log_model_no_registered_model_name(subclassed_model):
     artifact_path = "model"
     register_model_patch = mock.patch("mlflow.register_model")
     with mlflow.start_run(), register_model_patch:
         mlflow.torchscript.log_model(
             artifact_path=artifact_path,
-            model=module_scoped_subclassed_model,
+            model=subclassed_model,
             conda_env=None)
         mlflow.register_model.assert_not_called()
 
@@ -281,7 +238,7 @@ def test_raise_exception(sequential_model):
 def test_save_and_load_model(sequential_model, model_path, data, sequential_predicted):
     mlflow.torchscript.save_model(sequential_model, model_path)
 
-    # Loading pytorch model
+    # Loading torchscript model
     sequential_model_loaded = mlflow.torchscript.load_model(model_path)
     np.testing.assert_array_equal(_predict(sequential_model_loaded, data), sequential_predicted)
 
@@ -294,7 +251,7 @@ def test_save_and_load_model(sequential_model, model_path, data, sequential_pred
 @pytest.mark.large
 def test_load_model_from_remote_uri_succeeds(
         sequential_model, model_path, mock_s3_bucket, data, sequential_predicted):
-    mlflow.pytorch.save_model(sequential_model, model_path)
+    mlflow.torchscript.save_model(sequential_model, model_path)
 
     artifact_root = "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
     artifact_path = "model"
@@ -302,15 +259,15 @@ def test_load_model_from_remote_uri_succeeds(
     artifact_repo.log_artifacts(model_path, artifact_path=artifact_path)
 
     model_uri = artifact_root + "/" + artifact_path
-    sequential_model_loaded = mlflow.pytorch.load_model(model_uri=model_uri)
+    sequential_model_loaded = mlflow.torchscript.load_model(model_uri=model_uri)
     np.testing.assert_array_equal(_predict(sequential_model_loaded, data), sequential_predicted)
 
 
 @pytest.mark.large
 def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
         sequential_model, model_path, pytorch_custom_env):
-    mlflow.pytorch.save_model(
-            pytorch_model=sequential_model, path=model_path, conda_env=pytorch_custom_env)
+    mlflow.torchscript.save_model(
+            model=sequential_model, path=model_path, conda_env=pytorch_custom_env)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -326,9 +283,9 @@ def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
 
 @pytest.mark.large
 def test_model_save_accepts_conda_env_as_dict(sequential_model, model_path):
-    conda_env = dict(mlflow.pytorch.get_default_conda_env())
+    conda_env = dict(mlflow.torchscript.get_default_conda_env())
     conda_env["dependencies"].append("pytest")
-    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path, conda_env=conda_env)
+    mlflow.torchscript.save_model(model=sequential_model, path=model_path, conda_env=conda_env)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -344,9 +301,9 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
         sequential_model, pytorch_custom_env):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.pytorch.log_model(pytorch_model=sequential_model,
-                                 artifact_path=artifact_path,
-                                 conda_env=pytorch_custom_env)
+        mlflow.torchscript.log_model(model=sequential_model,
+                                     artifact_path=artifact_path,
+                                     conda_env=pytorch_custom_env)
         model_path = _download_artifact_from_uri("runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path))
 
@@ -365,14 +322,14 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
 @pytest.mark.large
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
         sequential_model, model_path):
-    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path, conda_env=None)
+    mlflow.torchscript.save_model(model=sequential_model, path=model_path, conda_env=None)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
     with open(conda_env_path, "r") as f:
         conda_env = yaml.safe_load(f)
 
-    assert conda_env == mlflow.pytorch.get_default_conda_env()
+    assert conda_env == mlflow.torchscript.get_default_conda_env()
 
 
 @pytest.mark.large
@@ -380,9 +337,9 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
         sequential_model):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.pytorch.log_model(pytorch_model=sequential_model,
-                                 artifact_path=artifact_path,
-                                 conda_env=None)
+        mlflow.torchscript.log_model(model=sequential_model,
+                                     artifact_path=artifact_path,
+                                     conda_env=None)
         model_path = _download_artifact_from_uri("runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path))
 
@@ -391,16 +348,16 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
     with open(conda_env_path, "r") as f:
         conda_env = yaml.safe_load(f)
 
-    assert conda_env == mlflow.pytorch.get_default_conda_env()
+    assert conda_env == mlflow.torchscript.get_default_conda_env()
 
 
 @pytest.mark.large
 def test_load_model_with_differing_pytorch_version_logs_warning(sequential_model, model_path):
-    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path)
+    mlflow.torchscript.save_model(model=sequential_model, path=model_path)
     saver_pytorch_version = "1.0"
     model_config_path = os.path.join(model_path, "MLmodel")
     model_config = Model.load(model_config_path)
-    model_config.flavors[mlflow.pytorch.FLAVOR_NAME]["pytorch_version"] = saver_pytorch_version
+    model_config.flavors[mlflow.torchscript.FLAVOR_NAME]["pytorch_version"] = saver_pytorch_version
     model_config.save(model_config_path)
 
     log_messages = []
@@ -409,11 +366,11 @@ def test_load_model_with_differing_pytorch_version_logs_warning(sequential_model
         log_messages.append(message_text % args % kwargs)
 
     loader_pytorch_version = "0.8.2"
-    with mock.patch("mlflow.pytorch._logger.warning") as warn_mock,\
+    with mock.patch("mlflow.torchscript._logger.warning") as warn_mock,\
             mock.patch("torch.__version__") as torch_version_mock:
         torch_version_mock.__str__ = lambda *args, **kwargs: loader_pytorch_version
         warn_mock.side_effect = custom_warn
-        mlflow.pytorch.load_model(model_uri=model_path)
+        mlflow.torchscript.load_model(model_uri=model_path)
 
     assert any([
         "does not match installed PyTorch version" in log_message and
@@ -424,321 +381,22 @@ def test_load_model_with_differing_pytorch_version_logs_warning(sequential_model
 
 
 @pytest.mark.large
-def test_pyfunc_model_serving_with_module_scoped_subclassed_model_and_default_conda_env(
-        module_scoped_subclassed_model, model_path, data):
-    mlflow.pytorch.save_model(
+def test_pyfunc_model_serving_with_default_conda_env(
+        subclassed_model, model_path, data):
+    mlflow.torchscript.save_model(
         path=model_path,
-        pytorch_model=module_scoped_subclassed_model,
-        conda_env=None,
-        code_paths=[__file__])
-
-    scoring_response = pyfunc_serve_and_score_model(
-            model_uri=model_path,
-            data=data[0],
-            content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-            extra_args=["--no-conda"])
-    assert scoring_response.status_code == 200
-
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
-    np.testing.assert_array_almost_equal(
-        deployed_model_preds.values[:, 0],
-        _predict(model=module_scoped_subclassed_model, data=data),
-        decimal=4)
-
-
-def test_save_model_with_wrong_codepaths_fails_corrrectly(
-        module_scoped_subclassed_model, model_path, data):
-    with pytest.raises(TypeError) as exc_info:
-        mlflow.pytorch.save_model(
-            path=model_path,
-            pytorch_model=module_scoped_subclassed_model,
-            conda_env=None,
-            code_paths="some string")
-    assert "TypeError: Argument code_paths should be a list, not {}".format(type("")) \
-           in str(exc_info)
-    assert not os.path.exists(model_path)
-
-
-@pytest.mark.large
-def test_pyfunc_model_serving_with_main_scoped_subclassed_model_and_custom_pickle_module(
-        main_scoped_subclassed_model, model_path, data):
-    mlflow.pytorch.save_model(
-        path=model_path,
-        pytorch_model=main_scoped_subclassed_model,
-        conda_env=None,
-        pickle_module=mlflow_pytorch_pickle_module)
-
-    scoring_response = pyfunc_serve_and_score_model(
-            model_uri=model_path,
-            data=data[0],
-            content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-            extra_args=["--no-conda"])
-    assert scoring_response.status_code == 200
-
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
-    np.testing.assert_array_almost_equal(
-        deployed_model_preds.values[:, 0],
-        _predict(model=main_scoped_subclassed_model, data=data),
-        decimal=4)
-
-
-@pytest.mark.large
-def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
-        module_scoped_subclassed_model, model_path, data):
-    # Save a PyTorch model whose class is defined in the current test suite. Because the
-    # `tests` module is not available when the model is deployed for local scoring, we include
-    # the test suite file as a code dependency
-    mlflow.pytorch.save_model(
-        path=model_path,
-        pytorch_model=module_scoped_subclassed_model,
-        conda_env=None,
-        code_paths=[__file__])
-
-    # Define a custom pyfunc model that loads a PyTorch model artifact using
-    # `mlflow.pytorch.load_model`
-    class TorchValidatorModel(pyfunc.PythonModel):
-
-        def load_context(self, context):
-            self.pytorch_model = mlflow.pytorch.load_model(context.artifacts["pytorch_model"])
-
-        def predict(self, context, model_input):
-            with torch.no_grad():
-                input_tensor = torch.from_numpy(model_input.values.astype(np.float32))
-                output_tensor = self.pytorch_model(input_tensor)
-                return pd.DataFrame(output_tensor.numpy())
-
-    pyfunc_artifact_path = "pyfunc_model"
-    with mlflow.start_run():
-        pyfunc.log_model(artifact_path=pyfunc_artifact_path,
-                         python_model=TorchValidatorModel(),
-                         artifacts={
-                            "pytorch_model": model_path,
-                         })
-        pyfunc_model_path = _download_artifact_from_uri("runs:/{run_id}/{artifact_path}".format(
-            run_id=mlflow.active_run().info.run_id, artifact_path=pyfunc_artifact_path))
-
-    # Deploy the custom pyfunc model and ensure that it is able to successfully load its
-    # constituent PyTorch model via `mlflow.pytorch.load_model`
-    scoring_response = pyfunc_serve_and_score_model(
-            model_uri=pyfunc_model_path,
-            data=data[0],
-            content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-            extra_args=["--no-conda"])
-    assert scoring_response.status_code == 200
-
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
-    np.testing.assert_array_almost_equal(
-        deployed_model_preds.values[:, 0],
-        _predict(model=module_scoped_subclassed_model, data=data),
-        decimal=4)
-
-
-@pytest.mark.large
-def test_load_pyfunc_loads_torch_model_using_pickle_module_specified_at_save_time(
-        module_scoped_subclassed_model, model_path):
-    custom_pickle_module = pickle
-
-    mlflow.pytorch.save_model(
-        path=model_path,
-        pytorch_model=module_scoped_subclassed_model,
-        conda_env=None,
-        pickle_module=custom_pickle_module)
-
-    import_module_fn = importlib.import_module
-    imported_modules = []
-
-    def track_module_imports(module_name):
-        imported_modules.append(module_name)
-        return import_module_fn(module_name)
-
-    with mock.patch("importlib.import_module") as import_mock,\
-            mock.patch("torch.load") as torch_load_mock:
-        import_mock.side_effect = track_module_imports
-        pyfunc.load_pyfunc(model_path)
-
-    torch_load_mock.assert_called_with(mock.ANY, pickle_module=custom_pickle_module)
-    assert custom_pickle_module.__name__ in imported_modules
-
-
-@pytest.mark.large
-def test_load_model_loads_torch_model_using_pickle_module_specified_at_save_time(
-        module_scoped_subclassed_model):
-    custom_pickle_module = pickle
-
-    artifact_path = "pytorch_model"
-    with mlflow.start_run():
-        mlflow.pytorch.log_model(
-            artifact_path=artifact_path,
-            pytorch_model=module_scoped_subclassed_model,
-            conda_env=None,
-            pickle_module=custom_pickle_module)
-        model_uri = "runs:/{run_id}/{artifact_path}".format(
-            run_id=mlflow.active_run().info.run_id,
-            artifact_path=artifact_path)
-
-    import_module_fn = importlib.import_module
-    imported_modules = []
-
-    def track_module_imports(module_name):
-        imported_modules.append(module_name)
-        return import_module_fn(module_name)
-
-    with mock.patch("importlib.import_module") as import_mock,\
-            mock.patch("torch.load") as torch_load_mock:
-        import_mock.side_effect = track_module_imports
-        pyfunc.load_pyfunc(model_uri=model_uri)
-
-    torch_load_mock.assert_called_with(mock.ANY, pickle_module=custom_pickle_module)
-    assert custom_pickle_module.__name__ in imported_modules
-
-
-@pytest.mark.large
-def test_load_pyfunc_succeeds_when_data_is_model_file_instead_of_directory(
-        module_scoped_subclassed_model, model_path, data):
-    """
-    This test verifies that PyTorch models saved in older versions of MLflow are loaded successfully
-    by ``mlflow.pytorch.load_model``. The ``data`` path associated with these older models is
-    serialized PyTorch model file, as opposed to the current format: a directory containing a
-    serialized model file and pickle module information.
-    """
-    mlflow.pytorch.save_model(
-        path=model_path,
-        pytorch_model=module_scoped_subclassed_model,
+        model=subclassed_model,
         conda_env=None)
 
-    model_conf_path = os.path.join(model_path, "MLmodel")
-    model_conf = Model.load(model_conf_path)
-    pyfunc_conf = model_conf.flavors.get(pyfunc.FLAVOR_NAME)
-    assert pyfunc_conf is not None
-    model_data_path = os.path.join(model_path, pyfunc_conf[pyfunc.DATA])
-    assert os.path.exists(model_data_path)
-    assert mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME in os.listdir(model_data_path)
-    pyfunc_conf[pyfunc.DATA] = os.path.join(
-        model_data_path, mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME)
-    model_conf.save(model_conf_path)
-
-    loaded_pyfunc = pyfunc.load_pyfunc(model_path)
-
-    np.testing.assert_array_almost_equal(
-        loaded_pyfunc.predict(data[0]),
-        pd.DataFrame(_predict(model=module_scoped_subclassed_model, data=data)),
-        decimal=4)
-
-
-@pytest.mark.large
-def test_load_model_succeeds_when_data_is_model_file_instead_of_directory(
-        module_scoped_subclassed_model, model_path, data):
-    """
-    This test verifies that PyTorch models saved in older versions of MLflow are loaded successfully
-    by ``mlflow.pytorch.load_model``. The ``data`` path associated with these older models is
-    serialized PyTorch model file, as opposed to the current format: a directory containing a
-    serialized model file and pickle module information.
-    """
-    artifact_path = "pytorch_model"
-    with mlflow.start_run():
-        mlflow.pytorch.log_model(
-            artifact_path=artifact_path,
-            pytorch_model=module_scoped_subclassed_model,
-            conda_env=None)
-        model_path = _download_artifact_from_uri("runs:/{run_id}/{artifact_path}".format(
-            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path))
-
-    model_conf_path = os.path.join(model_path, "MLmodel")
-    model_conf = Model.load(model_conf_path)
-    pyfunc_conf = model_conf.flavors.get(pyfunc.FLAVOR_NAME)
-    assert pyfunc_conf is not None
-    model_data_path = os.path.join(model_path, pyfunc_conf[pyfunc.DATA])
-    assert os.path.exists(model_data_path)
-    assert mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME in os.listdir(model_data_path)
-    pyfunc_conf[pyfunc.DATA] = os.path.join(
-        model_data_path, mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME)
-    model_conf.save(model_conf_path)
-
-    loaded_pyfunc = pyfunc.load_pyfunc(model_path)
-
-    np.testing.assert_array_almost_equal(
-        loaded_pyfunc.predict(data[0]),
-        pd.DataFrame(_predict(model=module_scoped_subclassed_model, data=data)),
-        decimal=4)
-
-
-@pytest.mark.large
-def test_load_model_allows_user_to_override_pickle_module_via_keyword_argument(
-        module_scoped_subclassed_model, model_path):
-    mlflow.pytorch.save_model(
-        path=model_path,
-        pytorch_model=module_scoped_subclassed_model,
-        conda_env=None,
-        pickle_module=pickle)
-
-    mlflow_torch_pickle_load = mlflow_pytorch_pickle_module.load
-    pickle_call_results = {
-        "mlflow_torch_pickle_load_called": False,
-    }
-
-    def validate_mlflow_torch_pickle_load_called(*args, **kwargs):
-        pickle_call_results["mlflow_torch_pickle_load_called"] = True
-        return mlflow_torch_pickle_load(*args, **kwargs)
-
-    log_messages = []
-
-    def custom_warn(message_text, *args, **kwargs):
-        log_messages.append(message_text % args % kwargs)
-
-    with mock.patch("mlflow.pytorch.pickle_module.load") as mlflow_torch_pickle_load_mock,\
-            mock.patch("mlflow.pytorch._logger.warning") as warn_mock:
-        mlflow_torch_pickle_load_mock.side_effect = validate_mlflow_torch_pickle_load_called
-        warn_mock.side_effect = custom_warn
-        mlflow.pytorch.load_model(model_uri=model_path, pickle_module=mlflow_pytorch_pickle_module)
-
-    assert all(pickle_call_results.values())
-    assert any([
-        "does not match the pickle module that was used to save the model" in log_message and
-        pickle.__name__ in log_message and
-        mlflow_pytorch_pickle_module.__name__ in log_message
-        for log_message in log_messages
-    ])
-
-
-@pytest.mark.large
-def test_load_model_raises_exception_when_pickle_module_cannot_be_imported(
-        main_scoped_subclassed_model, model_path):
-    mlflow.pytorch.save_model(
-        path=model_path,
-        pytorch_model=main_scoped_subclassed_model,
-        conda_env=None)
-
-    bad_pickle_module_name = "not.a.real.module"
-
-    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
-    model_data_path = os.path.join(model_path, pyfunc_conf[pyfunc.DATA])
-    assert os.path.exists(model_data_path)
-    assert mlflow.pytorch._PICKLE_MODULE_INFO_FILE_NAME in os.listdir(model_data_path)
-    with open(
-            os.path.join(model_data_path, mlflow.pytorch._PICKLE_MODULE_INFO_FILE_NAME), "w") as f:
-        f.write(bad_pickle_module_name)
-
-    with pytest.raises(MlflowException) as exc_info:
-        mlflow.pytorch.load_model(model_uri=model_path)
-
-    assert "Failed to import the pickle module" in str(exc_info)
-    assert bad_pickle_module_name in str(exc_info)
-
-
-@pytest.mark.release
-def test_sagemaker_docker_model_scoring_with_sequential_model_and_default_conda_env(
-        model, model_path, data, sequential_predicted):
-    mlflow.pytorch.save_model(pytorch_model=model, path=model_path, conda_env=None)
-
-    scoring_response = score_model_in_sagemaker_docker_container(
+    scoring_response = pyfunc_serve_and_score_model(
             model_uri=model_path,
             data=data[0],
             content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-            flavor=mlflow.pyfunc.FLAVOR_NAME,
-            activity_polling_timeout_seconds=360)
-    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
+            extra_args=["--no-conda"])
+    assert scoring_response.status_code == 200
 
+    deployed_model_preds = pd.DataFrame(json.loads(scoring_response.content))
     np.testing.assert_array_almost_equal(
         deployed_model_preds.values[:, 0],
-        sequential_predicted,
+        _predict(model=subclassed_model, data=data),
         decimal=4)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Adding torchscript as another flavor that exposes necessary functionalities especially `log_model`, `save_model`, `load_model` and `_load_pyfunc`. There have been a discussion about whether torchscript needs another flavor or it just has to be an optional format under the current pytorch flavor. But finally, we agreed to keep it as another flavor. More details can be found at the [issue page](https://github.com/mlflow/mlflow/issues/2263)
## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introduces torchscript as another flavor for exporting pytorch models for production (nonpython) runtime

### What component(s) does this PR affect?

- [ ] UI
- [x] CLI
- [x] API
- [ ] REST-API
- [x] Examples
- [x] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
