### PR TITLE
Allow numerical parameters with values >= 1'000 in R mlflow::mlflow_run()

### DIFF
--- a/mlflow/R/mlflow/R/project-run.R
+++ b/mlflow/R/mlflow/R/project-run.R
@@ -53,7 +53,7 @@ mlflow_run <- function(uri = ".", entry_point = NULL, version = NULL, parameters
     uri <- fs::path_expand(uri)
 
   param_list <- if (!is.null(parameters)) parameters %>%
-    purrr::imap_chr(~ paste0(.y, "=", .x)) %>%
+    purrr::imap_chr(~ paste0(.y, "=", format(.x, scientific = FALSE))) %>%
     purrr::reduce(~ mlflow_cli_param(.x, "--param-list", .y), .init = list())
 
   args <- list(uri) %>%

--- a/mlflow/R/mlflow/tests/testthat/test-run.R
+++ b/mlflow/R/mlflow/tests/testthat/test-run.R
@@ -46,3 +46,18 @@ test_that("mlflow run uses active experiment if not specified", {
       })
   })
 })
+
+
+test_that("mlflow_run passes all numbers as non-scientific", {
+  # we can only be sure conversion is actively avoided
+  # if default formatting turns into scientific.
+  expect_equal(as.character(10e4), "1e+05")
+  with_mock(.env = "mlflow", mlflow_cli = function(...){
+    args <- c(...)
+    expect_equal(sum("scientific=100000" == args), 1)
+    expect_equal(sum("non_scientific=30000" == args), 1)
+    list(stderr = "=== Run (ID '48734e7e2e8f44228a11c0c2cbcdc8b0') succeeded ===")
+  }, {
+    mlflow_run("project", parameters = c(scientific = 10e4, non_scientific = 30000))
+  })
+})


### PR DESCRIPTION
## What changes are proposed in this pull request?

Convert all numeric parameter values to non-scientific before passing it to `mlflow::mlflow_source()` in `mlflow::mlflow_run()` as suggested in #2664 to enable parameter values of 1'000 or larger. Closes #2664. 

## How is this patch tested?

Added relevant unit tests. I first add a test to show how the current version of mlflow [fails](https://travis-ci.org/github/lorenzwalthert/mlflow/builds/670680510) to handle the case and then commit the fix to make tests pass.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.


### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [x] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
