### PR TITLE
SqlAlchemy: Reuse connection for DB upgrades

### DIFF
--- a/mlflow/db.py
+++ b/mlflow/db.py
@@ -24,6 +24,7 @@ def upgrade(url):
     large migrations and includes information about how to estimate their performance and
     recover from failures.
     """
-    if mlflow.store.db.utils._is_initialized_before_mlflow_1(url):
-        mlflow.store.db.utils._upgrade_db_initialized_before_mlflow_1(url)
-    mlflow.store.db.utils._upgrade_db(url)
+    engine = mlflow.store.db.utils.create_sqlalchemy_engine(url)
+    if mlflow.store.db.utils._is_initialized_before_mlflow_1(engine):
+        mlflow.store.db.utils._upgrade_db_initialized_before_mlflow_1(engine)
+    mlflow.store.db.utils._upgrade_db(engine)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -129,7 +129,7 @@ def _upgrade_db(engine):
     # https://alembic.sqlalchemy.org/en/latest/cookbook.html#sharing-a-
     # connection-with-a-series-of-migration-commands-and-environments
     with engine.begin() as connection:
-        config.attributes['connection'] = connection # pylint: disable=E1137
+        config.attributes['connection'] = connection  # pylint: disable=E1137
         command.upgrade(config, 'heads')
 
 

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -129,7 +129,7 @@ def _upgrade_db(engine):
     # https://alembic.sqlalchemy.org/en/latest/cookbook.html#sharing-a-
     # connection-with-a-series-of-migration-commands-and-environments
     with engine.begin() as connection:
-        config.attributes['connection'] = connection
+        config.attributes['connection'] = connection # pylint: disable=E1137
         command.upgrade(config, 'heads')
 
 

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -123,6 +123,11 @@ def _upgrade_db(engine):
     db_url = str(engine.url)
     _logger.info("Updating database tables at %s", db_url)
     config = _get_alembic_config(db_url)
+    # Initialize a shared connection to be used for the database upgrade, ensuring that
+    # any connection-dependent state (e.g., the state of an in-memory database) is preserved
+    # for reference by the upgrade routine. For more information, see
+    # https://alembic.sqlalchemy.org/en/latest/cookbook.html#sharing-a-
+    # connection-with-a-series-of-migration-commands-and-environments
     with engine.begin() as connection:
         config.attributes['connection'] = connection
         command.upgrade(config, 'heads')

--- a/mlflow/store/db_migrations/env.py
+++ b/mlflow/store/db_migrations/env.py
@@ -57,6 +57,11 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
+    # If available, use a shared connection for the database upgrade, ensuring that any
+    # connection-dependent state (e.g., the state of an in-memory database) is preserved
+    # for reference by the upgrade routine. For more information, see
+    # https://alembic.sqlalchemy.org/en/latest/cookbook.html#sharing-a-
+    # connection-with-a-series-of-migration-commands-and-environments
     connectable = config.attributes.get('connection', None)
     if connectable is None:
         connectable = engine_from_config(

--- a/mlflow/store/db_migrations/env.py
+++ b/mlflow/store/db_migrations/env.py
@@ -57,11 +57,13 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-    )
+    connectable = config.attributes.get('connection', None)
+    if connectable is None:
+        connectable = engine_from_config(
+            config.get_section(config.config_ini_section),
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
+        )
 
     with connectable.connect() as connection:
         context.configure(

--- a/mlflow/temporary_db_migrations_for_pre_1_users/env.py
+++ b/mlflow/temporary_db_migrations_for_pre_1_users/env.py
@@ -57,6 +57,11 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
+    # If available, use a shared connection for the database upgrade, ensuring that any
+    # connection-dependent state (e.g., the state of an in-memory database) is preserved
+    # for reference by the upgrade routine. For more information, see
+    # https://alembic.sqlalchemy.org/en/latest/cookbook.html#sharing-a-
+    # connection-with-a-series-of-migration-commands-and-environments
     connectable = config.attributes.get('connection', None)
     if connectable is None:
         connectable = engine_from_config(

--- a/mlflow/temporary_db_migrations_for_pre_1_users/env.py
+++ b/mlflow/temporary_db_migrations_for_pre_1_users/env.py
@@ -57,11 +57,13 @@ def run_migrations_online():
     and associate a connection with the context.
 
     """
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-    )
+    connectable = config.attributes.get('connection', None)
+    if connectable is None:
+        connectable = engine_from_config(
+            config.get_section(config.config_ini_section),
+            prefix="sqlalchemy.",
+            poolclass=pool.NullPool,
+        )
 
     with connectable.connect() as connection:
         context.configure(

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1650,6 +1650,22 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase, AbstractStoreTest):
         assert len(run_results) == 2
 
 
+def test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db():
+    store = SqlAlchemyStore("sqlite:///:memory:", ARTIFACT_URI)
+    experiment_id = store.create_experiment(name="exp1")
+    run = store.create_run(
+        experiment_id=experiment_id, user_id="user", start_time=0, tags=[])
+    run_id = run.info.run_id
+    metric = entities.Metric("mymetric", 1, 0, 0) 
+    store.log_metric(run_id=run_id, metric=metric)
+    param = entities.Param("myparam", "A")
+    store.log_param(run_id=run_id, param=param)
+    fetched_run = store.get_run(run_id=run_id)
+    assert fetched_run.info.run_id == run_id
+    assert metric.key in fetched_run.data.metrics
+    assert param.key in fetched_run.data.params
+
+
 class TestSqlAlchemyStoreSqliteMigratedDB(TestSqlAlchemyStoreSqlite):
     """
     Test case where user has an existing DB with schema generated before MLflow 1.0,

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1656,7 +1656,7 @@ def test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db():
     run = store.create_run(
         experiment_id=experiment_id, user_id="user", start_time=0, tags=[])
     run_id = run.info.run_id
-    metric = entities.Metric("mymetric", 1, 0, 0) 
+    metric = entities.Metric("mymetric", 1, 0, 0)
     store.log_metric(run_id=run_id, metric=metric)
     param = entities.Param("myparam", "A")
     store.log_param(run_id=run_id, param=param)


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes #2569 by modifying DB upgrade logic to reuse a single database engine / connection between the process that initiates a database upgrade and the Alembic process that performs the upgrade. As a result, both processes now share DB memory state.

## How is this patch tested?

This patch is tested via existing unit tests and manual testing against in-memory Sqlite databases (I ran `mlflow server --backend-store-uri sqlite:///:memory: --default-artifact-root ./` and confirmed that the server starts + params, metrics, and tags can be logged successfully).

## Release Notes

Fix a `SqlAlchemyStore` bug that prevented in-memory databases (e.g., `sqlite:///:memory:`) from being used with MLflow Tracking.

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
