### PR TITLE
Fix bug causing erroneous deletion of TensorBoard logging directory

### DIFF
--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -607,6 +607,10 @@ def _get_tensorboard_callback(lst):
     return None
 
 
+from collections import namedtuple
+TensorBoardLogDir = namedtuple("TensorBoardLogDir", ["location", "is_temp"])
+
+
 def _setup_callbacks(lst):
     """
     Adds TensorBoard and MlfLowTfKeras callbacks to the
@@ -614,10 +618,10 @@ def _setup_callbacks(lst):
     """
     tb = _get_tensorboard_callback(lst)
     if tb is None:
-        log_dir = tempfile.mkdtemp()
-        out_list = lst + [TensorBoard(log_dir)]
+        log_dir = TensorBoardLogDir(location=tempfile.mkdtemp(), is_temp=True)
+        out_list = lst + [TensorBoard(log_dir.location)]
     else:
-        log_dir = tb.log_dir
+        log_dir = TensorBoardLogDir(location=tb.log_dir, is_temp=False)
         out_list = lst
     if LooseVersion(tensorflow.__version__) < LooseVersion('2.0.0'):
         out_list += [__MLflowTfKerasCallback()]
@@ -814,8 +818,10 @@ def autolog(every_n_iter=100):
             _log_early_stop_callback_metrics(early_stop_callback, history)
 
             _flush_queue()
-            _log_artifacts_with_warning(local_dir=log_dir, artifact_path='tensorboard_logs')
-            shutil.rmtree(log_dir)
+            _log_artifacts_with_warning(
+                local_dir=log_dir.location, artifact_path='tensorboard_logs')
+            if log_dir.is_temp:
+                shutil.rmtree(log_dir.location)
 
             return history
 
@@ -839,8 +845,10 @@ def autolog(every_n_iter=100):
                 kwargs['callbacks'], log_dir = _setup_callbacks([])
             result = original(self, *args, **kwargs)
             _flush_queue()
-            _log_artifacts_with_warning(local_dir=log_dir, artifact_path='tensorboard_logs')
-            shutil.rmtree(log_dir)
+            _log_artifacts_with_warning(
+                local_dir=log_dir.location, artifact_path='tensorboard_logs')
+            if log_dir.is_temp:
+                shutil.rmtree(log_dir.location)
 
             return result
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -608,6 +608,10 @@ def _get_tensorboard_callback(lst):
 
 
 from collections import namedtuple
+# A representation of a TensorBoard event logging directory with two attributes:
+# :location - string: The filesystem location of the logging directory
+# :is_temp - boolean: `True` if the logging directory was created for temporary use by MLflow,
+#                     `False` otherwise
 TensorBoardLogDir = namedtuple("TensorBoardLogDir", ["location", "is_temp"])
 
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -612,7 +612,7 @@ from collections import namedtuple
 # :location - string: The filesystem location of the logging directory
 # :is_temp - boolean: `True` if the logging directory was created for temporary use by MLflow,
 #                     `False` otherwise
-TensorBoardLogDir = namedtuple("TensorBoardLogDir", ["location", "is_temp"])
+_TensorBoardLogDir = namedtuple("_TensorBoardLogDir", ["location", "is_temp"])
 
 
 def _setup_callbacks(lst):
@@ -622,10 +622,10 @@ def _setup_callbacks(lst):
     """
     tb = _get_tensorboard_callback(lst)
     if tb is None:
-        log_dir = TensorBoardLogDir(location=tempfile.mkdtemp(), is_temp=True)
+        log_dir = _TensorBoardLogDir(location=tempfile.mkdtemp(), is_temp=True)
         out_list = lst + [TensorBoard(log_dir.location)]
     else:
-        log_dir = TensorBoardLogDir(location=tb.log_dir, is_temp=False)
+        log_dir = _TensorBoardLogDir(location=tb.log_dir, is_temp=False)
         out_list = lst
     if LooseVersion(tensorflow.__version__) < LooseVersion('2.0.0'):
         out_list += [__MLflowTfKerasCallback()]

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -20,6 +20,7 @@ import warnings
 import atexit
 import time
 import tempfile
+from collections import namedtuple
 
 import pandas
 
@@ -607,7 +608,6 @@ def _get_tensorboard_callback(lst):
     return None
 
 
-from collections import namedtuple
 # A representation of a TensorBoard event logging directory with two attributes:
 # :location - string: The filesystem location of the logging directory
 # :is_temp - boolean: `True` if the logging directory was created for temporary use by MLflow,

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -48,12 +48,6 @@ def manual_run(request, tracking_uri_mock):
     mlflow.end_run()
 
 
-@pytest.fixture(scope='function', autouse=True)
-def end_run_if_necessary():
-    yield
-    mlflow.end_run()
-
-
 def create_tf_keras_model():
     model = tf.keras.Sequential()
 
@@ -310,60 +304,60 @@ def test_tf_keras_autolog_non_early_stop_callback_no_log(tf_keras_random_data_ru
     assert len(metric_history) == num_of_epochs
 
 
-# @pytest.mark.large
-# @pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-# def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
-#         tmpdir, random_train_data, random_one_hot_labels, fit_variant):
-#     tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
-#     tensorboard_callback = tf.keras.callbacks.TensorBoard(
-#         tensorboard_callback_logging_dir_path, histogram_freq=0)
-#
-#     mlflow.tensorflow.autolog()
-#
-#     data = random_train_data
-#     labels = random_one_hot_labels
-#
-#     model = create_tf_keras_model()
-#
-#     if fit_variant == 'fit_generator':
-#         def generator():
-#             while True:
-#                 yield data, labels
-#         model.fit_generator(
-#             generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
-#     else:
-#         model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
-#
-#     assert os.path.exists(tensorboard_callback_logging_dir_path)
+@pytest.mark.large
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
+        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+    tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
+    tensorboard_callback = tf.keras.callbacks.TensorBoard(
+        tensorboard_callback_logging_dir_path, histogram_freq=0)
+
+    mlflow.tensorflow.autolog()
+
+    data = random_train_data
+    labels = random_one_hot_labels
+
+    model = create_tf_keras_model()
+
+    if fit_variant == 'fit_generator':
+        def generator():
+            while True:
+                yield data, labels
+        model.fit_generator(
+            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
+    else:
+        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
+
+    assert os.path.exists(tensorboard_callback_logging_dir_path)
 
 
-# @pytest.mark.large
-# @pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-# def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent
-#         tmpdir, random_train_data, random_one_hot_labels, fit_variant):
-#     import mock
-#     from mlflow.tensorflow import _TensorBoardLogDir
-#
-#     mlflow.tensorflow.autolog()
-#
-#     mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
-#     with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
-#         mock_log_dir_class.return_value = mock_log_dir_inst
-#
-#         data = random_train_data
-#         labels = random_one_hot_labels
-#
-#         model = create_tf_keras_model()
-#
-#         if fit_variant == 'fit_generator':
-#             def generator():
-#                 while True:
-#                     yield data, labels
-#             model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
-#         else:
-#             model.fit(data, labels, epochs=10)
-#
-#         assert not os.path.exists(mock_log_dir_inst.location)
+@pytest.mark.large
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent(
+        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+    import mock
+    from mlflow.tensorflow import _TensorBoardLogDir
+
+    mlflow.tensorflow.autolog()
+
+    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir.mkdir("tb_logging")), is_temp=True)
+    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
+        mock_log_dir_class.return_value = mock_log_dir_inst
+
+        data = random_train_data
+        labels = random_one_hot_labels
+
+        model = create_tf_keras_model()
+
+        if fit_variant == 'fit_generator':
+            def generator():
+                while True:
+                    yield data, labels
+            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
+        else:
+            model.fit(data, labels, epochs=10)
+
+        assert not os.path.exists(mock_log_dir_inst.location)
 
 
 def create_tf_estimator_model(dir, export):

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -313,22 +313,22 @@ def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_call
         tensorboard_callback_logging_dir_path, histogram_freq=0)
 
     mlflow.tensorflow.autolog()
+    with mlflow.start_run():
+        data = random_train_data
+        labels = random_one_hot_labels
 
-    data = random_train_data
-    labels = random_one_hot_labels
+        model = create_tf_keras_model()
 
-    model = create_tf_keras_model()
+        if fit_variant == 'fit_generator':
+            def generator():
+                while True:
+                    yield data, labels
+            model.fit_generator(
+                generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
+        else:
+            model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
 
-    if fit_variant == 'fit_generator':
-        def generator():
-            while True:
-                yield data, labels
-        model.fit_generator(
-            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
-    else:
-        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
-
-    assert os.path.exists(tensorboard_callback_logging_dir_path)
+        assert os.path.exists(tensorboard_callback_logging_dir_path)
 
 
 @pytest.mark.large
@@ -339,7 +339,8 @@ def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboa
     from mlflow.tensorflow import _TensorBoardLogDir
 
     mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
-    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
+    with mlflow.start_run(), mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True)\
+            as mock_log_dir_class:
         mock_log_dir_class.return_value = mock_log_dir_inst
 
         mlflow.tensorflow.autolog()
@@ -455,16 +456,9 @@ def test_tf_estimator_autolog_model_can_load_from_artifact(tf_estimator_random_d
                                          "/model")
 
 
-@pytest.fixture
-def duplicate_autolog_tf_estimator_run(tmpdir, manual_run, export):
-    mlflow.tensorflow.autolog(every_n_iter=23)  # 23 is prime; no false positives in test
-    run = tf_estimator_random_data_run(tmpdir, manual_run, export)
-    return run  # should be autologged every 4 steps
-
-
 @pytest.mark.large
 @pytest.mark.parametrize('export', [True, False])
-def test_duplicate_autolog_second_overrides(duplicate_autolog_tf_estimator_run):
+def test_duplicate_autolog_second_overrides(tf_estimator_random_data_run):
     client = mlflow.tracking.MlflowClient()
-    metrics = client.get_metric_history(duplicate_autolog_tf_estimator_run.info.run_id, 'loss')
+    metrics = client.get_metric_history(tf_estimator_random_data_run.info.run_id, 'loss')
     assert all((x.step - 1) % 4 == 0 for x in metrics)

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -450,7 +450,7 @@ def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboa
 
     mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
     with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
-        mock_log_dir_class.return_value = mock_log_dir_inst 
+        mock_log_dir_class.return_value = mock_log_dir_inst
 
         mlflow.tensorflow.autolog()
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -439,3 +439,32 @@ def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_call
         model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
 
     assert os.path.exists(tensorboard_callback_logging_dir_path)
+
+
+@pytest.mark.large
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent(
+        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+    import mock
+    from mlflow.tensorflow import _TensorBoardLogDir
+
+    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
+    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
+        mock_log_dir_class.return_value = mock_log_dir_inst 
+
+        mlflow.tensorflow.autolog()
+
+        data = random_train_data
+        labels = random_one_hot_labels
+
+        model = create_tf_keras_model()
+
+        if fit_variant == 'fit_generator':
+            def generator():
+                while True:
+                    yield data, labels
+            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
+        else:
+            model.fit(data, labels, epochs=10)
+
+        assert not os.path.exists(mock_log_dir_inst.location)

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -313,22 +313,22 @@ def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_call
         tensorboard_callback_logging_dir_path, histogram_freq=0)
 
     mlflow.tensorflow.autolog()
-    with mlflow.start_run():
-        data = random_train_data
-        labels = random_one_hot_labels
 
-        model = create_tf_keras_model()
+    data = random_train_data
+    labels = random_one_hot_labels
 
-        if fit_variant == 'fit_generator':
-            def generator():
-                while True:
-                    yield data, labels
-            model.fit_generator(
-                generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
-        else:
-            model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
+    model = create_tf_keras_model()
 
-        assert os.path.exists(tensorboard_callback_logging_dir_path)
+    if fit_variant == 'fit_generator':
+        def generator():
+            while True:
+                yield data, labels
+        model.fit_generator(
+            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
+    else:
+        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
+
+    assert os.path.exists(tensorboard_callback_logging_dir_path)
 
 
 @pytest.mark.large
@@ -338,12 +338,11 @@ def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboa
     import mock
     from mlflow.tensorflow import _TensorBoardLogDir
 
-    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
-    with mlflow.start_run(), mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True)\
-            as mock_log_dir_class:
-        mock_log_dir_class.return_value = mock_log_dir_inst
+    mlflow.tensorflow.autolog()
 
-        mlflow.tensorflow.autolog()
+    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
+    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
+        mock_log_dir_class.return_value = mock_log_dir_inst
 
         data = random_train_data
         labels = random_one_hot_labels

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -304,6 +304,62 @@ def test_tf_keras_autolog_non_early_stop_callback_no_log(tf_keras_random_data_ru
     assert len(metric_history) == num_of_epochs
 
 
+@pytest.mark.large
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
+        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+    tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
+    tensorboard_callback = tf.keras.callbacks.TensorBoard(
+        tensorboard_callback_logging_dir_path, histogram_freq=0)
+
+    mlflow.tensorflow.autolog()
+
+    data = random_train_data
+    labels = random_one_hot_labels
+
+    model = create_tf_keras_model()
+
+    if fit_variant == 'fit_generator':
+        def generator():
+            while True:
+                yield data, labels
+        model.fit_generator(
+            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
+    else:
+        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
+
+    assert os.path.exists(tensorboard_callback_logging_dir_path)
+
+
+@pytest.mark.large
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent(
+        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+    import mock
+    from mlflow.tensorflow import _TensorBoardLogDir
+
+    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
+    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
+        mock_log_dir_class.return_value = mock_log_dir_inst
+
+        mlflow.tensorflow.autolog()
+
+        data = random_train_data
+        labels = random_one_hot_labels
+
+        model = create_tf_keras_model()
+
+        if fit_variant == 'fit_generator':
+            def generator():
+                while True:
+                    yield data, labels
+            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
+        else:
+            model.fit(data, labels, epochs=10)
+
+        assert not os.path.exists(mock_log_dir_inst.location)
+
+
 def create_tf_estimator_model(dir, export):
     CSV_COLUMN_NAMES = ['SepalLength', 'SepalWidth', 'PetalLength', 'PetalWidth', 'Species']
     SPECIES = ['Setosa', 'Versicolor', 'Virginica']
@@ -412,59 +468,3 @@ def test_duplicate_autolog_second_overrides(duplicate_autolog_tf_estimator_run):
     client = mlflow.tracking.MlflowClient()
     metrics = client.get_metric_history(duplicate_autolog_tf_estimator_run.info.run_id, 'loss')
     assert all((x.step - 1) % 4 == 0 for x in metrics)
-
-
-@pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
-        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
-    tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
-    tensorboard_callback = tf.keras.callbacks.TensorBoard(
-        tensorboard_callback_logging_dir_path, histogram_freq=0)
-
-    mlflow.tensorflow.autolog()
-
-    data = random_train_data
-    labels = random_one_hot_labels
-
-    model = create_tf_keras_model()
-
-    if fit_variant == 'fit_generator':
-        def generator():
-            while True:
-                yield data, labels
-        model.fit_generator(
-            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
-    else:
-        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
-
-    assert os.path.exists(tensorboard_callback_logging_dir_path)
-
-
-@pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent(
-        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
-    import mock
-    from mlflow.tensorflow import _TensorBoardLogDir
-
-    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
-    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
-        mock_log_dir_class.return_value = mock_log_dir_inst
-
-        mlflow.tensorflow.autolog()
-
-        data = random_train_data
-        labels = random_one_hot_labels
-
-        model = create_tf_keras_model()
-
-        if fit_variant == 'fit_generator':
-            def generator():
-                while True:
-                    yield data, labels
-            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
-        else:
-            model.fit(data, labels, epochs=10)
-
-        assert not os.path.exists(mock_log_dir_inst.location)

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -48,6 +48,12 @@ def manual_run(request, tracking_uri_mock):
     mlflow.end_run()
 
 
+@pytest.fixture(scope='function', autouse=True)
+def end_run_if_necessary():
+    yield
+    mlflow.end_run()
+
+
 def create_tf_keras_model():
     model = tf.keras.Sequential()
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -310,60 +310,60 @@ def test_tf_keras_autolog_non_early_stop_callback_no_log(tf_keras_random_data_ru
     assert len(metric_history) == num_of_epochs
 
 
-@pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
-        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
-    tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
-    tensorboard_callback = tf.keras.callbacks.TensorBoard(
-        tensorboard_callback_logging_dir_path, histogram_freq=0)
+# @pytest.mark.large
+# @pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+# def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
+#         tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+#     tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
+#     tensorboard_callback = tf.keras.callbacks.TensorBoard(
+#         tensorboard_callback_logging_dir_path, histogram_freq=0)
+#
+#     mlflow.tensorflow.autolog()
+#
+#     data = random_train_data
+#     labels = random_one_hot_labels
+#
+#     model = create_tf_keras_model()
+#
+#     if fit_variant == 'fit_generator':
+#         def generator():
+#             while True:
+#                 yield data, labels
+#         model.fit_generator(
+#             generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
+#     else:
+#         model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
+#
+#     assert os.path.exists(tensorboard_callback_logging_dir_path)
 
-    mlflow.tensorflow.autolog()
 
-    data = random_train_data
-    labels = random_one_hot_labels
-
-    model = create_tf_keras_model()
-
-    if fit_variant == 'fit_generator':
-        def generator():
-            while True:
-                yield data, labels
-        model.fit_generator(
-            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
-    else:
-        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
-
-    assert os.path.exists(tensorboard_callback_logging_dir_path)
-
-
-@pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent(
-        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
-    import mock
-    from mlflow.tensorflow import _TensorBoardLogDir
-
-    mlflow.tensorflow.autolog()
-
-    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
-    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
-        mock_log_dir_class.return_value = mock_log_dir_inst
-
-        data = random_train_data
-        labels = random_one_hot_labels
-
-        model = create_tf_keras_model()
-
-        if fit_variant == 'fit_generator':
-            def generator():
-                while True:
-                    yield data, labels
-            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
-        else:
-            model.fit(data, labels, epochs=10)
-
-        assert not os.path.exists(mock_log_dir_inst.location)
+# @pytest.mark.large
+# @pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+# def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent
+#         tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+#     import mock
+#     from mlflow.tensorflow import _TensorBoardLogDir
+#
+#     mlflow.tensorflow.autolog()
+#
+#     mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
+#     with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
+#         mock_log_dir_class.return_value = mock_log_dir_inst
+#
+#         data = random_train_data
+#         labels = random_one_hot_labels
+#
+#         model = create_tf_keras_model()
+#
+#         if fit_variant == 'fit_generator':
+#             def generator():
+#                 while True:
+#                     yield data, labels
+#             model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
+#         else:
+#             model.fit(data, labels, epochs=10)
+#
+#         assert not os.path.exists(mock_log_dir_inst.location)
 
 
 def create_tf_estimator_model(dir, export):

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -294,60 +294,60 @@ def test_tf_keras_autolog_non_early_stop_callback_no_log(tf_keras_random_data_ru
     assert len(metric_history) == num_of_epochs
 
 
-@pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
-        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
-    tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
-    tensorboard_callback = tf.keras.callbacks.TensorBoard(
-        tensorboard_callback_logging_dir_path, histogram_freq=0)
+# @pytest.mark.large
+# @pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+# def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
+#         tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+#     tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
+#     tensorboard_callback = tf.keras.callbacks.TensorBoard(
+#         tensorboard_callback_logging_dir_path, histogram_freq=0)
+#
+#     mlflow.tensorflow.autolog()
+#
+#     data = random_train_data
+#     labels = random_one_hot_labels
+#
+#     model = create_tf_keras_model()
+#
+#     if fit_variant == 'fit_generator':
+#         def generator():
+#             while True:
+#                 yield data, labels
+#         model.fit_generator(
+#             generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
+#     else:
+#         model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
+#
+#     assert os.path.exists(tensorboard_callback_logging_dir_path)
 
-    mlflow.tensorflow.autolog()
 
-    data = random_train_data
-    labels = random_one_hot_labels
-
-    model = create_tf_keras_model()
-
-    if fit_variant == 'fit_generator':
-        def generator():
-            while True:
-                yield data, labels
-        model.fit_generator(
-            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
-    else:
-        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
-
-    assert os.path.exists(tensorboard_callback_logging_dir_path)
-
-
-@pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent(
-        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
-    import mock
-    from mlflow.tensorflow import _TensorBoardLogDir
-
-    mlflow.tensorflow.autolog()
-
-    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
-    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
-        mock_log_dir_class.return_value = mock_log_dir_inst
-
-        data = random_train_data
-        labels = random_one_hot_labels
-
-        model = create_tf_keras_model()
-
-        if fit_variant == 'fit_generator':
-            def generator():
-                while True:
-                    yield data, labels
-            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
-        else:
-            model.fit(data, labels, epochs=10)
-
-        assert not os.path.exists(mock_log_dir_inst.location)
+# @pytest.mark.large
+# @pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+# def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent
+#         tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+#     import mock
+#     from mlflow.tensorflow import _TensorBoardLogDir
+#
+#     mlflow.tensorflow.autolog()
+#
+#     mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
+#     with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
+#         mock_log_dir_class.return_value = mock_log_dir_inst
+#
+#         data = random_train_data
+#         labels = random_one_hot_labels
+#
+#         model = create_tf_keras_model()
+#
+#         if fit_variant == 'fit_generator':
+#             def generator():
+#                 while True:
+#                     yield data, labels
+#             model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
+#         else:
+#             model.fit(data, labels, epochs=10)
+#
+#         assert not os.path.exists(mock_log_dir_inst.location)
 
 
 @pytest.fixture

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -46,6 +46,12 @@ def manual_run(request, tracking_uri_mock):
     mlflow.end_run()
 
 
+@pytest.fixture(scope='function', autouse=True)
+def end_run_if_necessary():
+    yield
+    mlflow.end_run()
+
+
 def create_tf_keras_model():
     model = tf.keras.Sequential()
 

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -297,22 +297,22 @@ def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_call
         tensorboard_callback_logging_dir_path, histogram_freq=0)
 
     mlflow.tensorflow.autolog()
-    with mlflow.start_run():
-        data = random_train_data
-        labels = random_one_hot_labels
 
-        model = create_tf_keras_model()
+    data = random_train_data
+    labels = random_one_hot_labels
 
-        if fit_variant == 'fit_generator':
-            def generator():
-                while True:
-                    yield data, labels
-            model.fit_generator(
-                generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
-        else:
-            model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
+    model = create_tf_keras_model()
 
-        assert os.path.exists(tensorboard_callback_logging_dir_path)
+    if fit_variant == 'fit_generator':
+        def generator():
+            while True:
+                yield data, labels
+        model.fit_generator(
+            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
+    else:
+        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
+
+    assert os.path.exists(tensorboard_callback_logging_dir_path)
 
 
 @pytest.mark.large
@@ -322,12 +322,11 @@ def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboa
     import mock
     from mlflow.tensorflow import _TensorBoardLogDir
 
-    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
-    with mlflow.start_run(), mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True)\
-            as mock_log_dir_class:
-        mock_log_dir_class.return_value = mock_log_dir_inst
+    mlflow.tensorflow.autolog()
 
-        mlflow.tensorflow.autolog()
+    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
+    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
+        mock_log_dir_class.return_value = mock_log_dir_inst
 
         data = random_train_data
         labels = random_one_hot_labels

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -297,22 +297,22 @@ def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_call
         tensorboard_callback_logging_dir_path, histogram_freq=0)
 
     mlflow.tensorflow.autolog()
+    with mlflow.start_run():
+        data = random_train_data
+        labels = random_one_hot_labels
 
-    data = random_train_data
-    labels = random_one_hot_labels
+        model = create_tf_keras_model()
 
-    model = create_tf_keras_model()
+        if fit_variant == 'fit_generator':
+            def generator():
+                while True:
+                    yield data, labels
+            model.fit_generator(
+                generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
+        else:
+            model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
 
-    if fit_variant == 'fit_generator':
-        def generator():
-            while True:
-                yield data, labels
-        model.fit_generator(
-            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
-    else:
-        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
-
-    assert os.path.exists(tensorboard_callback_logging_dir_path)
+        assert os.path.exists(tensorboard_callback_logging_dir_path)
 
 
 @pytest.mark.large
@@ -323,7 +323,8 @@ def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboa
     from mlflow.tensorflow import _TensorBoardLogDir
 
     mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
-    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
+    with mlflow.start_run(), mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True)\
+            as mock_log_dir_class:
         mock_log_dir_class.return_value = mock_log_dir_inst
 
         mlflow.tensorflow.autolog()
@@ -479,16 +480,10 @@ def test_tf_estimator_autolog_model_can_load_from_artifact(tf_estimator_random_d
                                          "/model", session)
 
 
-@pytest.fixture
-def duplicate_autolog_tf_estimator_run(tmpdir, manual_run, export):
-    mlflow.tensorflow.autolog(every_n_iter=23)  # 23 is prime; no false positives in test
-    run = tf_estimator_random_data_run(tmpdir, manual_run, export)
-    return run  # should be autologged every 4 steps
-
-
 @pytest.mark.large
 @pytest.mark.parametrize('export', [True, False])
-def test_duplicate_autolog_second_overrides(duplicate_autolog_tf_estimator_run):
+def test_duplicate_autolog_second_overrides(tf_estimator_random_data_run):
+    mlflow.tensorflow.autolog(every_n_iter=23)
     client = mlflow.tracking.MlflowClient()
-    metrics = client.get_metric_history(duplicate_autolog_tf_estimator_run.info.run_id, 'loss')
+    metrics = client.get_metric_history(tf_estimator_random_data_run.info.run_id, 'loss')
     assert all((x.step - 1) % 4 == 0 for x in metrics)

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -288,6 +288,62 @@ def test_tf_keras_autolog_non_early_stop_callback_no_log(tf_keras_random_data_ru
     assert len(metric_history) == num_of_epochs
 
 
+@pytest.mark.large
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
+        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+    tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
+    tensorboard_callback = tf.keras.callbacks.TensorBoard(
+        tensorboard_callback_logging_dir_path, histogram_freq=0)
+
+    mlflow.tensorflow.autolog()
+
+    data = random_train_data
+    labels = random_one_hot_labels
+
+    model = create_tf_keras_model()
+
+    if fit_variant == 'fit_generator':
+        def generator():
+            while True:
+                yield data, labels
+        model.fit_generator(
+            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
+    else:
+        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
+
+    assert os.path.exists(tensorboard_callback_logging_dir_path)
+
+
+@pytest.mark.large
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent(
+        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+    import mock
+    from mlflow.tensorflow import _TensorBoardLogDir
+
+    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
+    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
+        mock_log_dir_class.return_value = mock_log_dir_inst
+
+        mlflow.tensorflow.autolog()
+
+        data = random_train_data
+        labels = random_one_hot_labels
+
+        model = create_tf_keras_model()
+
+        if fit_variant == 'fit_generator':
+            def generator():
+                while True:
+                    yield data, labels
+            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
+        else:
+            model.fit(data, labels, epochs=10)
+
+        assert not os.path.exists(mock_log_dir_inst.location)
+
+
 @pytest.fixture
 def tf_core_random_tensors():
     mlflow.tensorflow.autolog(every_n_iter=4)
@@ -436,59 +492,3 @@ def test_duplicate_autolog_second_overrides(duplicate_autolog_tf_estimator_run):
     client = mlflow.tracking.MlflowClient()
     metrics = client.get_metric_history(duplicate_autolog_tf_estimator_run.info.run_id, 'loss')
     assert all((x.step - 1) % 4 == 0 for x in metrics)
-
-
-@pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
-        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
-    tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
-    tensorboard_callback = tf.keras.callbacks.TensorBoard(
-        tensorboard_callback_logging_dir_path, histogram_freq=0)
-
-    mlflow.tensorflow.autolog()
-
-    data = random_train_data
-    labels = random_one_hot_labels
-
-    model = create_tf_keras_model()
-
-    if fit_variant == 'fit_generator':
-        def generator():
-            while True:
-                yield data, labels
-        model.fit_generator(
-            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
-    else:
-        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
-
-    assert os.path.exists(tensorboard_callback_logging_dir_path)
-
-
-@pytest.mark.large
-@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent(
-        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
-    import mock
-    from mlflow.tensorflow import _TensorBoardLogDir
-
-    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
-    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
-        mock_log_dir_class.return_value = mock_log_dir_inst
-
-        mlflow.tensorflow.autolog()
-
-        data = random_train_data
-        labels = random_one_hot_labels
-
-        model = create_tf_keras_model()
-
-        if fit_variant == 'fit_generator':
-            def generator():
-                while True:
-                    yield data, labels
-            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
-        else:
-            model.fit(data, labels, epochs=10)
-
-        assert not os.path.exists(mock_log_dir_inst.location)

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -436,3 +436,59 @@ def test_duplicate_autolog_second_overrides(duplicate_autolog_tf_estimator_run):
     client = mlflow.tracking.MlflowClient()
     metrics = client.get_metric_history(duplicate_autolog_tf_estimator_run.info.run_id, 'loss')
     assert all((x.step - 1) % 4 == 0 for x in metrics)
+
+
+@pytest.mark.large
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
+        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+    tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
+    tensorboard_callback = tf.keras.callbacks.TensorBoard(
+        tensorboard_callback_logging_dir_path, histogram_freq=0)
+
+    mlflow.tensorflow.autolog()
+
+    data = random_train_data
+    labels = random_one_hot_labels
+
+    model = create_tf_keras_model()
+
+    if fit_variant == 'fit_generator':
+        def generator():
+            while True:
+                yield data, labels
+        model.fit_generator(
+            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
+    else:
+        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
+
+    assert os.path.exists(tensorboard_callback_logging_dir_path)
+
+
+@pytest.mark.large
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent(
+        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+    import mock
+    from mlflow.tensorflow import _TensorBoardLogDir
+
+    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
+    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
+        mock_log_dir_class.return_value = mock_log_dir_inst 
+
+        mlflow.tensorflow.autolog()
+
+        data = random_train_data
+        labels = random_one_hot_labels
+
+        model = create_tf_keras_model()
+
+        if fit_variant == 'fit_generator':
+            def generator():
+                while True:
+                    yield data, labels
+            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
+        else:
+            model.fit(data, labels, epochs=10)
+
+        assert not os.path.exists(mock_log_dir_inst.location)

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -474,7 +474,7 @@ def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboa
 
     mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
     with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
-        mock_log_dir_class.return_value = mock_log_dir_inst 
+        mock_log_dir_class.return_value = mock_log_dir_inst
 
         mlflow.tensorflow.autolog()
 

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -46,12 +46,6 @@ def manual_run(request, tracking_uri_mock):
     mlflow.end_run()
 
 
-@pytest.fixture(scope='function', autouse=True)
-def end_run_if_necessary():
-    yield
-    mlflow.end_run()
-
-
 def create_tf_keras_model():
     model = tf.keras.Sequential()
 
@@ -294,60 +288,60 @@ def test_tf_keras_autolog_non_early_stop_callback_no_log(tf_keras_random_data_ru
     assert len(metric_history) == num_of_epochs
 
 
-# @pytest.mark.large
-# @pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-# def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
-#         tmpdir, random_train_data, random_one_hot_labels, fit_variant):
-#     tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
-#     tensorboard_callback = tf.keras.callbacks.TensorBoard(
-#         tensorboard_callback_logging_dir_path, histogram_freq=0)
-#
-#     mlflow.tensorflow.autolog()
-#
-#     data = random_train_data
-#     labels = random_one_hot_labels
-#
-#     model = create_tf_keras_model()
-#
-#     if fit_variant == 'fit_generator':
-#         def generator():
-#             while True:
-#                 yield data, labels
-#         model.fit_generator(
-#             generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
-#     else:
-#         model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
-#
-#     assert os.path.exists(tensorboard_callback_logging_dir_path)
+@pytest.mark.large
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+def test_tf_keras_autolog_does_not_delete_logging_directory_for_tensorboard_callback(
+        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+    tensorboard_callback_logging_dir_path = str(tmpdir.mkdir("tb_logs"))
+    tensorboard_callback = tf.keras.callbacks.TensorBoard(
+        tensorboard_callback_logging_dir_path, histogram_freq=0)
+
+    mlflow.tensorflow.autolog()
+
+    data = random_train_data
+    labels = random_one_hot_labels
+
+    model = create_tf_keras_model()
+
+    if fit_variant == 'fit_generator':
+        def generator():
+            while True:
+                yield data, labels
+        model.fit_generator(
+            generator(), epochs=10, steps_per_epoch=1, callbacks=[tensorboard_callback])
+    else:
+        model.fit(data, labels, epochs=10, callbacks=[tensorboard_callback])
+
+    assert os.path.exists(tensorboard_callback_logging_dir_path)
 
 
-# @pytest.mark.large
-# @pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
-# def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent
-#         tmpdir, random_train_data, random_one_hot_labels, fit_variant):
-#     import mock
-#     from mlflow.tensorflow import _TensorBoardLogDir
-#
-#     mlflow.tensorflow.autolog()
-#
-#     mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir), is_temp=True)
-#     with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
-#         mock_log_dir_class.return_value = mock_log_dir_inst
-#
-#         data = random_train_data
-#         labels = random_one_hot_labels
-#
-#         model = create_tf_keras_model()
-#
-#         if fit_variant == 'fit_generator':
-#             def generator():
-#                 while True:
-#                     yield data, labels
-#             model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
-#         else:
-#             model.fit(data, labels, epochs=10)
-#
-#         assert not os.path.exists(mock_log_dir_inst.location)
+@pytest.mark.large
+@pytest.mark.parametrize('fit_variant', ['fit', 'fit_generator'])
+def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboard_callback_absent(
+        tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+    import mock
+    from mlflow.tensorflow import _TensorBoardLogDir
+
+    mlflow.tensorflow.autolog()
+
+    mock_log_dir_inst = _TensorBoardLogDir(location=str(tmpdir.mkdir("tb_logging")), is_temp=True)
+    with mock.patch("mlflow.tensorflow._TensorBoardLogDir", autospec=True) as mock_log_dir_class:
+        mock_log_dir_class.return_value = mock_log_dir_inst
+
+        data = random_train_data
+        labels = random_one_hot_labels
+
+        model = create_tf_keras_model()
+
+        if fit_variant == 'fit_generator':
+            def generator():
+                while True:
+                    yield data, labels
+            model.fit_generator(generator(), epochs=10, steps_per_epoch=1)
+        else:
+            model.fit(data, labels, epochs=10)
+
+        assert not os.path.exists(mock_log_dir_inst.location)
 
 
 @pytest.fixture


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes #2644 by introducing a conditional check to prevent deleting the destination directory for TensorBoard logs if this directory was specified by an explicit TensorBoard callback passed to `model.fit()` or `model.fit()` generator.

## How is this patch tested?

This PR includes unit tests for TensorFlow 1.x and TensorFlow 2.0. Further, I manually verified that the workflow included in #2644 (https://colab.research.google.com/drive/1-bn6HGKoXEg5qGzWjvTyW34fBRgA6TJv) now produces TensorBoard logs that persist after the `model.fit()` call completes with autologging enabled.

## Release Notes

Fixes an autologging bug that caused accidental deletion of the TensorBoard logging directory when users specified an explicit TensorBoard callback as part of `model.fit()` or `model.fit_generator()`.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [X] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
