### PR TITLE
[WIP] Remove double model directory

### DIFF
--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -74,15 +74,15 @@ class FTPArtifactRepository(ArtifactRepository):
                 ftp.storbinary('STOR ' + os.path.basename(local_file), f)
 
     def log_artifacts(self, local_dir, artifact_path=None):
-        dest_path = posixpath.join(self.path, artifact_path) \
-            if artifact_path else self.path
+        dest_path = self.path
+        if artifact_path and artifact_path != 'model':
+            dest_path = posixpath.join(self.path, artifact_path)
 
         dest_path = posixpath.join(
             dest_path, os.path.split(local_dir)[1])
         dest_path_re = os.path.split(local_dir)[1]
-        if artifact_path:
-            dest_path_re = posixpath.join(
-                artifact_path, os.path.split(local_dir)[1])
+        if artifact_path and artifact_path != 'model':
+            dest_path_re = posixpath.join(artifact_path, os.path.split(local_dir)[1])
 
         local_dir = os.path.abspath(local_dir)
         for (root, _, filenames) in os.walk(local_dir):

--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -74,29 +74,20 @@ class FTPArtifactRepository(ArtifactRepository):
                 ftp.storbinary('STOR ' + os.path.basename(local_file), f)
 
     def log_artifacts(self, local_dir, artifact_path=None):
-        dest_path = self.path
-        if artifact_path and artifact_path != 'model':
-            dest_path = posixpath.join(self.path, artifact_path)
-
-        dest_path = posixpath.join(
-            dest_path, os.path.split(local_dir)[1])
-        dest_path_re = os.path.split(local_dir)[1]
-        if artifact_path and artifact_path != 'model':
-            dest_path_re = posixpath.join(artifact_path, os.path.split(local_dir)[1])
-
-        local_dir = os.path.abspath(local_dir)
-        for (root, _, filenames) in os.walk(local_dir):
-            upload_path = dest_path
-            if root != local_dir:
-                rel_path = os.path.relpath(root, local_dir)
+        artifact_path = artifact_path or ''
+        for (dirpath, _, filenames) in os.walk(local_dir):
+            artifact_subdir = artifact_path
+            if dirpath != local_dir:
+                rel_path = os.path.relpath(dirpath, local_dir)
                 rel_path = relative_path_to_artifact_path(rel_path)
-                upload_path = posixpath.join(dest_path_re, rel_path)
+                artifact_subdir = posixpath.join(artifact_path, rel_path)
             if not filenames:
                 with self.get_ftp_client() as ftp:
-                    self._mkdir(ftp, posixpath.join(self.path, upload_path))
-            for f in filenames:
-                if os.path.isfile(os.path.join(root, f)):
-                    self.log_artifact(os.path.join(root, f), upload_path)
+                    self._mkdir(ftp, posixpath.join(self.path, artifact_path))
+            for name in filenames:
+                file_path = os.path.join(dirpath, name)
+                if os.path.isfile(file_path):
+                    self.log_artifact(file_path, artifact_subdir)
 
     def _is_directory(self, artifact_path):
         artifact_dir = self.path


### PR DESCRIPTION
## What changes are proposed in this pull request?

When a customer uses an FTP artifact store, the artifact uri is incorrect. 

Correct: `ftp://0.0.0.0:9821/0/543736e8ba4a4b93a84662cf96b043b4/artifacts/model/data`
Incorrect: `ftp://0.0.0.0:9821/0/543736e8ba4a4b93a84662cf96b043b4/artifacts/model/model/data`

## How is this patch tested?

Manual Testing

1. Setup an FTP server and ran a keras model using the FTP as the artifact store

<img width="1843" alt="Screen Shot 2020-04-09 at 3 37 20 PM" src="https://user-images.githubusercontent.com/58712524/78946676-3873d180-7a78-11ea-936d-e10c42df90b1.png">


Automated

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [x] Tracking
- [ ] Projects
- [x] Artifacts
- [ ] Models
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
