### PR TITLE
Let curl follow redirects (fix #2691)

### DIFF
--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -29,7 +29,7 @@ RUN apt-get -y update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Download and setup miniconda
-RUN curl https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh >> miniconda.sh
+RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh >> miniconda.sh
 RUN bash ./miniconda.sh -b -p /miniconda; rm ./miniconda.sh;
 ENV PATH="/miniconda/bin:$PATH"
 ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64


### PR DESCRIPTION
## What changes are proposed in this pull request?

To fix #2691, this PR proposes to let curl follow redirects during `mlflow models build-docker`.
Otherwise, curl does not download the miniconda installer and the build-docker fails.

## How is this patch tested?

1. Get a dev environment by following instructions at [here](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#prerequisites)
2. Run `mlflow models build-docker` locally
3. Get the following log messages

```
Step 3/17 : RUN curl -L https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh >> miniconda.sh
 ---> Running in 300c830c23d7
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  3 81.1M    3 2614k    0     0  4040k      0  0:00:20 --:--:--  0:00:20 4040k
 18 81.1M   18 14.7M    0     0  9171k      0  0:00:09  0:00:01  0:00:08 9171k
 35 81.1M   35 28.7M    0     0  10.8M      0  0:00:07  0:00:02  0:00:05 10.8M
 52 81.1M   52 42.5M    0     0  11.6M      0  0:00:06  0:00:03  0:00:03 11.6M
 68 81.1M   68 55.1M    0     0  11.8M      0  0:00:06  0:00:04  0:00:02 11.8M
 85 81.1M   85 68.9M    0     0  12.2M      0  0:00:06  0:00:05  0:00:01 13.2M
100 81.1M  100 81.1M    0     0  12.3M      0  0:00:06  0:00:06 --:--:-- 13.5M
Removing intermediate container 300c830c23d7
 ---> 181bea8b809b
```

Without this PR, the corresponding step results in the following log messages:
```
Step 3/17 : RUN curl https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh >> miniconda.sh
 ---> Running in 5119867f0b51
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
```

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [x] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [x] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
