### PR TITLE
Fix travis script. Was not failing where some small tests were broken.

### DIFF
--- a/travis/stage-python3.sh
+++ b/travis/stage-python3.sh
@@ -7,7 +7,8 @@ then
      echo "skipping this step on windows."
   elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "Small" ]]
   then
-    ./travis/run-small-python-tests.sh && ./test-generate-protos.sh
+    ./travis/run-small-python-tests.sh
+    ./test-generate-protos.sh
   else
     ./travis/run-large-python-tests.sh
     ./travis/test-anaconda-compatibility.sh "anaconda3:2020.02"


### PR DESCRIPTION
## What changes are proposed in this pull request?
The travis script was ignoring some small tests errors. The problem seems to be in concatenating commands via && - the observed behavior is that the right hand side is not evaluetd if theleft hand side fails, however, the script does not bail and continues executing subsequent commands and eventually returns exit code 0.

I have repro this on my laptop and verified the fix manually (I have discovered this when looking at my other PR )

