### PR TITLE
Use LibYAML by default to increase performance in FileUtils

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -61,9 +61,9 @@ Where Runs Are Recorded
 
 MLflow runs can be recorded to local files, to a SQLAlchemy compatible database, or remotely
 to a tracking server. By default, the MLflow Python API logs runs locally to files in an ``mlruns`` directory wherever you
-ran your program. You can then run ``mlflow ui`` to see the logged runs. 
+ran your program. You can then run ``mlflow ui`` to see the logged runs.
 
-To log runs remotely, set the ``MLFLOW_TRACKING_URI`` environment variable to a tracking server's URI or 
+To log runs remotely, set the ``MLFLOW_TRACKING_URI`` environment variable to a tracking server's URI or
 call :py:func:`mlflow.set_tracking_uri`.
 
 There are different kinds of remote tracking URIs:
@@ -169,7 +169,7 @@ statement exits, even if it exits due to an exception.
 Performance Tracking with Metrics
 ---------------------------------
 
-You log MLflow metrics with ``log`` methods in the Tracking API. The ``log`` methods support two alternative methods for distinguishing metric values on the x-axis: ``timestamp`` and ``step``. 
+You log MLflow metrics with ``log`` methods in the Tracking API. The ``log`` methods support two alternative methods for distinguishing metric values on the x-axis: ``timestamp`` and ``step``.
 
 ``timestamp`` is an optional long value that represents the time that the metric was logged. ``timestamp`` defaults to the current time. ``step`` is an optional integer that represents any measurement of training progress (number of training iterations, number of epochs, and so on). ``step`` defaults to 0 and has the following requirements and properties:
 
@@ -185,7 +185,7 @@ Examples
 
 Python
   .. code-block:: py
-  
+
     with mlflow.start_run():
         for epoch in range(0, 3):
             mlflow.log_metric(key="quality", value=2*epoch, step=epoch)
@@ -212,7 +212,7 @@ Here is an example plot of the :ref:`quick start tutorial <quickstart>` with the
 .. figure:: _static/images/metrics-time-wall.png
 
   X-axis wall time - graphs the absolute time each metric was logged
-  
+
 .. figure:: _static/images/metrics-time-relative.png
 
   X-axis relative time - graphs the time relative to the first metric logged, for each run
@@ -373,7 +373,7 @@ Managing Experiments and Runs with the Tracking Service API
 
 MLflow provides a more detailed Tracking Service API for managing experiments and runs directly,
 which is available through client SDK in the :py:mod:`mlflow.tracking` module.
-This makes it possible to query data about past runs, log additional information about them, create experiments, 
+This makes it possible to query data about past runs, log additional information about them, create experiments,
 add tags to a run, and more.
 
 .. rubric:: Example
@@ -395,7 +395,7 @@ The :py:func:`mlflow.tracking.MlflowClient.set_tag` function lets you add custom
 .. code-block:: py
 
   client.set_tag(run.info.run_id, "tag_key", "tag_value")
-  
+
 .. important:: Do not use the prefix ``mlflow`` for a tag.  This prefix is reserved for use by MLflow.
 
 .. _tracking_ui:
@@ -424,7 +424,7 @@ Querying Runs Programmatically
 
 You can access all of the functions in the Tracking UI programmatically. This makes it easy to do several common tasks:
 
-* Query and compare runs using any data analysis tool of your choice, for example, **pandas**. 
+* Query and compare runs using any data analysis tool of your choice, for example, **pandas**.
 * Determine the artifact URI for a run to feed some of its artifacts into a new run when executing a workflow. For an example of querying runs and constructing a multistep workflow, see the MLflow `Multistep Workflow Example project <https://github.com/mlflow/mlflow/blob/15cc05ce2217b7c7af4133977b07542934a9a19f/examples/multistep_workflow/main.py#L63>`_.
 * Load artifacts from past runs as :ref:`models`. For an example of training, exporting, and loading a model, and predicting using the model, see the MLflow `TensorFlow example <https://github.com/mlflow/mlflow/tree/master/examples/tensorflow>`_.
 * Run automated parameter search algorithms, where you query the metrics from various runs to submit new ones. For an example of running automated parameter search algorithms, see the MLflow `Hyperparameter Tuning Example project <https://github.com/mlflow/mlflow/blob/master/examples/hyperparam/README.rst>`_.
@@ -504,6 +504,29 @@ See `Set up AWS Credentials and Region for Development <https://docs.aws.amazon.
   is a path inside the file store. Typically this is not an appropriate location, as the client and
   server probably refer to different physical locations (that is, the same path on different disks).
 
+File store performance
+~~~~~~~~~~~~~~~~~~~~~~
+
+MLflow will automatically try to use `LibYAML <https://pyyaml.org/wiki/LibYAML>`_ bindings if they are already installed.
+However if you notice any performance issues when using *file store* backend, it could mean LibYAML is not installed on your system.
+On Linux or Mac you can easily install it using your system package manager:
+
+.. code-block:: sh
+
+    # On Ubuntu/Debian
+    apt-get install libyaml-cpp-dev libyaml-dev
+
+    # On macOS using Homebrew
+    brew install yaml-cpp libyaml
+
+After installing LibYAML, you need to reinstall PyYAML:
+
+.. code-block:: sh
+
+    # Reinstall PyYAML
+    pip --no-cache-dir install --force-reinstall -I pyyaml
+
+
 Deletion Behavior
 ~~~~~~~~~~~~~~~~~
 In order to allow MLflow Runs to be restored, Run metadata and artifacts are not automatically removed
@@ -581,7 +604,7 @@ to access Google Cloud Storage; MLflow does not declare a dependency on this pac
 FTP server
 ^^^^^^^^^^^
 
-To store artifacts in a FTP server, specify a URI of the form ftp://user@host/path/to/directory . 
+To store artifacts in a FTP server, specify a URI of the form ftp://user@host/path/to/directory .
 The URI may optionally include a password for logging into the server, e.g. ``ftp://user:pass@host/path/to/directory``
 
 SFTP Server
@@ -617,7 +640,7 @@ There are also two ways to authenticate to HDFS:
   export MLFLOW_KERBEROS_TICKET_CACHE=/tmp/krb5cc_22222222
   export MLFLOW_KERBEROS_USER=user_name_to_use
 
-Most of the cluster contest settings are read from ``hdfs-site.xml`` accessed by the HDFS native 
+Most of the cluster contest settings are read from ``hdfs-site.xml`` accessed by the HDFS native
 driver using the ``CLASSPATH`` environment variable.
 
 Optionally you can select a different version of the HDFS driver library using:
@@ -645,10 +668,10 @@ Additionally, you should ensure that the ``--backend-store-uri`` (which defaults
 Logging to a Tracking Server
 ----------------------------
 
-To log to a tracking server, set the ``MLFLOW_TRACKING_URI`` environment variable to the server's URI, 
-along with its scheme and port (for example, ``http://10.0.0.1:5000``) or call :py:func:`mlflow.set_tracking_uri`. 
+To log to a tracking server, set the ``MLFLOW_TRACKING_URI`` environment variable to the server's URI,
+along with its scheme and port (for example, ``http://10.0.0.1:5000``) or call :py:func:`mlflow.set_tracking_uri`.
 
-The :py:func:`mlflow.start_run`, :py:func:`mlflow.log_param`, and :py:func:`mlflow.log_metric` calls 
+The :py:func:`mlflow.start_run`, :py:func:`mlflow.log_param`, and :py:func:`mlflow.log_metric` calls
 then make API requests to your remote tracking server.
 
   .. code-section::

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -14,9 +14,9 @@ from six.moves import urllib
 
 import yaml
 try:
-    from yaml import CSafeLoader as SafeLoader, CSafeDumper as SafeDumper
+    from yaml import CSafeLoader as YamlSafeLoader, CSafeDumper as YamlSafeDumper
 except ImportError:
-    from yaml import SafeLoader, SafeDumper
+    from yaml import SafeLoader as YamlSafeLoader, SafeDumper as YamlSafeDumper
 
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MissingConfigException
@@ -142,7 +142,9 @@ def write_yaml(root, file_name, data, overwrite=False):
     try:
         with codecs.open(yaml_file_name, mode='w', encoding=ENCODING) as yaml_file:
             yaml.dump(data, yaml_file,
-                      default_flow_style=False, allow_unicode=True, Dumper=SafeDumper)
+                      default_flow_style=False,
+                      allow_unicode=True,
+                      Dumper=YamlSafeDumper)
     except Exception as e:
         raise e
 
@@ -165,7 +167,7 @@ def read_yaml(root, file_name):
         raise MissingConfigException("Yaml file '%s' does not exist." % file_path)
     try:
         with codecs.open(file_path, mode='r', encoding=ENCODING) as yaml_file:
-            return yaml.load(yaml_file, Loader=SafeLoader)
+            return yaml.load(yaml_file, Loader=YamlSafeLoader)
     except Exception as e:
         raise e
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -13,6 +13,10 @@ from six.moves.urllib.parse import unquote
 from six.moves import urllib
 
 import yaml
+try:
+    from yaml import CSafeLoader as SafeLoader, CSafeDumper as SafeDumper
+except ImportError:
+    from yaml import SafeLoader, SafeDumper
 
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MissingConfigException
@@ -137,7 +141,7 @@ def write_yaml(root, file_name, data, overwrite=False):
 
     try:
         with codecs.open(yaml_file_name, mode='w', encoding=ENCODING) as yaml_file:
-            yaml.safe_dump(data, yaml_file, default_flow_style=False, allow_unicode=True)
+            yaml.dump(data, yaml_file, default_flow_style=False, allow_unicode=True, Dumper=SafeDumper)
     except Exception as e:
         raise e
 
@@ -160,7 +164,7 @@ def read_yaml(root, file_name):
         raise MissingConfigException("Yaml file '%s' does not exist." % file_path)
     try:
         with codecs.open(file_path, mode='r', encoding=ENCODING) as yaml_file:
-            return yaml.safe_load(yaml_file)
+            return yaml.load(yaml_file, Loader=SafeLoader)
     except Exception as e:
         raise e
 

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -141,7 +141,8 @@ def write_yaml(root, file_name, data, overwrite=False):
 
     try:
         with codecs.open(yaml_file_name, mode='w', encoding=ENCODING) as yaml_file:
-            yaml.dump(data, yaml_file, default_flow_style=False, allow_unicode=True, Dumper=SafeDumper)
+            yaml.dump(data, yaml_file,
+                      default_flow_style=False, allow_unicode=True, Dumper=SafeDumper)
     except Exception as e:
         raise e
 


### PR DESCRIPTION
I've noticed significant performance issues when using *file store* tracking backend compared to other frameworks. After profiling the code, I've noticed the `log_metric` method ([file_store.py:642](https://github.com/mlflow/mlflow/blob/master/mlflow/store/tracking/file_store.py#L642)) is loading YAML file with the run information to see if the run is currently active or not. This check is happening every time the `mlflow.log_metric` function is called.

By default, Python's YAML is using Python parser, which is significantly slower than its C++ counterpart. See [PyYAML Documentaion](https://pyyaml.org/wiki/PyYAMLDocumentation).

## What changes are proposed in this pull request?

I've added a try-except block into the `mlflow/utils/file_utils.py`, which tries to import the `CSafeLoader` and `CSafeDumper` to replace the Python's default ones. If this fails, it means *LibYAML* is not installed on the system and `file_utils.py` will import the default ones.

I also added small paragraph about *File store performance* under **Storage** section, see the file `docs/source/tracking.rst`. Mainly to inform users that if the LibYAML is not installed and they experience some performance issues, they can easily install it.

## How is this patch tested?

- tested it on macOS
- tested in Docker - Debian with and without LibYAML

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improves performance of reading experiment data from local filesystem when LibYAML is installed

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [x] Docs
- [x] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
