### PR TITLE
Fix autologging of Keras optimizers for TF.Keras 1.X

### DIFF
--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -471,10 +471,12 @@ class __MLflowTfKerasCallback(Callback):
 
     def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
         opt = self.model.optimizer
-        # Secondary checks are if the optimizer is a TensorFlow optimizer rather than a Keras one.
         if hasattr(opt, '_name'):
             try_mlflow_log(mlflow.log_param, 'optimizer_name', opt._name)
+        # Elif checks are if the optimizer is a TensorFlow optimizer rather than a Keras one.
         elif hasattr(opt, 'optimizer'):
+            # TensorFlow optimizer parameters are associated with the inner optimizer variable.
+            # Therefore, we assign opt to be opt.optimizer for logging parameters.
             opt = opt.optimizer
             try_mlflow_log(mlflow.log_param, 'optimizer_name', type(opt).__name__)
         if hasattr(opt, 'lr'):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -471,13 +471,23 @@ class __MLflowTfKerasCallback(Callback):
 
     def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
         opt = self.model.optimizer
-        if hasattr(opt, 'optimizer'):
+        # Secondary checks are if the optimizer is a TensorFlow optimizer rather than a Keras one.
+        if hasattr(opt, '_name'):
+            try_mlflow_log(mlflow.log_param, 'optimizer_name', opt._name)
+        elif hasattr(opt, 'optimizer'):
             opt = opt.optimizer
             try_mlflow_log(mlflow.log_param, 'optimizer_name', type(opt).__name__)
-        if hasattr(opt, '_lr'):
+        if hasattr(opt, 'lr'):
+            lr = opt.lr if type(opt.lr) is float else tensorflow.keras.backend.eval(opt.lr)
+            try_mlflow_log(mlflow.log_param, 'learning_rate', lr)
+        elif hasattr(opt, '_lr'):
             lr = opt._lr if type(opt._lr) is float else tensorflow.keras.backend.eval(opt._lr)
             try_mlflow_log(mlflow.log_param, 'learning_rate', lr)
-        if hasattr(opt, '_epsilon'):
+        if hasattr(opt, 'epsilon'):
+            epsilon = opt.epsilon if type(opt.epsilon) is float \
+                else tensorflow.keras.backend.eval(opt.epsilon)
+            try_mlflow_log(mlflow.log_param, 'epsilon', epsilon)
+        elif hasattr(opt, '_epsilon'):
             epsilon = opt._epsilon if type(opt._epsilon) is float \
                 else tensorflow.keras.backend.eval(opt._epsilon)
             try_mlflow_log(mlflow.log_param, 'epsilon', epsilon)

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -52,7 +52,9 @@ def create_tf_keras_model():
     model.add(layers.Dense(64, activation='relu'))
     model.add(layers.Dense(10, activation='softmax'))
 
-    model.compile(optimizer=tf.train.AdamOptimizer(0.001),
+    model.compile(optimizer=tf.keras.optimizers.Adam(learning_rate=0.002,
+                                                     epsilon=1e-08,
+                                                     name='Eve'),
                   loss='categorical_crossentropy',
                   metrics=['accuracy'])
     return model
@@ -131,7 +133,11 @@ def test_tf_keras_autolog_logs_expected_data(tf_keras_random_data_run):
     assert 'validation_data' not in data.params
     # Testing optimizer parameters are logged
     assert 'optimizer_name' in data.params
-    assert data.params['optimizer_name'] == 'AdamOptimizer'
+    assert data.params['optimizer_name'] == 'Eve'
+    assert 'learning_rate' in data.params
+    assert data.params['learning_rate'] == '0.002'
+    assert 'epsilon' in data.params
+    assert data.params['epsilon'] == '1e-08'
     client = mlflow.tracking.MlflowClient()
     all_epoch_acc = client.get_metric_history(tf_keras_random_data_run.info.run_id, 'epoch_acc')
     assert all((x.step - 1) % 5 == 0 for x in all_epoch_acc)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Originally, MLflow would only autolog TensorFlow optimizers when using Tensorflow.Keras models. This change allows for the autologging of Keras optimizers as well.

## How is this patch tested?

Changed the test in `tests/tensorflow_autolog/test_tensorflow_autolog.py` to reflect this change.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Keras optimizers are now correctly logged when autologging with TensorFlow.Keras 1.X models.

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [X] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
