### PR TITLE
Use pytest.ini to specify `--color=yes`

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --color=yes

--- a/travis/run-large-python-tests.sh
+++ b/travis/run-large-python-tests.sh
@@ -16,7 +16,7 @@ else
 fi
 
 # NB: Also add --ignore'd tests to run-small-python-tests.sh
-pytest tests --color=yes --large --ignore=tests/examples --ignore=tests/h2o --ignore=tests/keras \
+pytest tests --large --ignore=tests/examples --ignore=tests/h2o --ignore=tests/keras \
   --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn \
   --ignore=tests/spark --ignore=tests/tensorflow --ignore=tests/azureml --ignore=tests/onnx \
   --ignore=tests/keras_autolog --ignore=tests/tensorflow_autolog --ignore=tests/gluon \
@@ -24,30 +24,30 @@ pytest tests --color=yes --large --ignore=tests/examples --ignore=tests/h2o --ig
   --ignore=tests/spacy --ignore=tests/spark_autologging --ignore=tests/models
 # Run ML framework tests in their own Python processes to avoid OOM issues due to per-framework
 # overhead
-pytest --color=yes --verbose tests/pytorch --large
-pytest --color=yes --verbose tests/h2o --large
-pytest --color=yes --verbose tests/onnx --large
-pytest --color=yes --verbose tests/pyfunc --large
-pytest --color=yes --verbose tests/sagemaker --large
-pytest --color=yes --verbose tests/sagemaker/mock --large
-pytest --color=yes --verbose tests/sklearn --large
-pytest --color=yes --verbose tests/spark --large
-pytest --color=yes --verbose tests/tensorflow/test_tensorflow_model_export.py --large
-pytest --color=yes --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
-pytest --color=yes --verbose tests/azureml --large
-pytest --color=yes --verbose tests/models --large
-pytest --color=yes --verbose tests/xgboost --large
-pytest --color=yes --verbose tests/lightgbm --large
+pytest --verbose tests/pytorch --large
+pytest --verbose tests/h2o --large
+pytest --verbose tests/onnx --large
+pytest --verbose tests/pyfunc --large
+pytest --verbose tests/sagemaker --large
+pytest --verbose tests/sagemaker/mock --large
+pytest --verbose tests/sklearn --large
+pytest --verbose tests/spark --large
+pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
+pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
+pytest --verbose tests/azureml --large
+pytest --verbose tests/models --large
+pytest --verbose tests/xgboost --large
+pytest --verbose tests/lightgbm --large
 # TODO(smurching) Unpin TensorFlow dependency version once test failures with TF 2.1.0 have been
 # fixed
 pip install 'tensorflow==2.0.0'
-pytest --color=yes --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
-pytest --color=yes --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
-pytest --color=yes --verbose tests/keras --large
-pytest --color=yes --verbose tests/keras_autolog --large
-pytest --color=yes --verbose tests/gluon --large
-pytest --color=yes --verbose tests/gluon_autolog --large
-pytest --color=yes --verbose tests/spacy --large
+pytest --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
+pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
+pytest --verbose tests/keras --large
+pytest --verbose tests/keras_autolog --large
+pytest --verbose tests/gluon --large
+pytest --verbose tests/gluon_autolog --large
+pytest --verbose tests/spacy --large
 
 # Run Spark autologging tests
 ./travis/test-spark-autologging.sh

--- a/travis/run-python-flavor-tests.sh
+++ b/travis/run-python-flavor-tests.sh
@@ -8,17 +8,17 @@ export MLFLOW_HOME=$(pwd)
 
 # Run ML framework tests in their own Python processes to avoid OOM issues due to per-framework
 # overhead
-pytest --color=yes --verbose tests/pytorch --large
-pytest --color=yes --verbose tests/h2o --large
-pytest --color=yes --verbose tests/onnx --large
-pytest --color=yes --verbose tests/pyfunc --large
-pytest --color=yes --verbose tests/sklearn --large
-pytest --color=yes --verbose tests/azureml --large
-pytest --color=yes --verbose tests/models --large
-pytest --color=yes --verbose tests/xgboost --large
-pytest --color=yes --verbose tests/lightgbm --large
-pytest --color=yes --verbose tests/gluon --large
-pytest --color=yes --verbose tests/gluon_autolog --large
-pytest --color=yes --verbose tests/spacy --large
+pytest --verbose tests/pytorch --large
+pytest --verbose tests/h2o --large
+pytest --verbose tests/onnx --large
+pytest --verbose tests/pyfunc --large
+pytest --verbose tests/sklearn --large
+pytest --verbose tests/azureml --large
+pytest --verbose tests/models --large
+pytest --verbose tests/xgboost --large
+pytest --verbose tests/lightgbm --large
+pytest --verbose tests/gluon --large
+pytest --verbose tests/gluon_autolog --large
+pytest --verbose tests/spacy --large
 
 test $err = 0

--- a/travis/run-python-sagemaker-tests.sh
+++ b/travis/run-python-sagemaker-tests.sh
@@ -15,11 +15,11 @@ else
   cat $SAGEMAKER_OUT;
 fi
 
-pytest --color=yes --verbose tests/sagemaker --large
-pytest --color=yes --verbose tests/sagemaker/mock --large
+pytest --verbose tests/sagemaker --large
+pytest --verbose tests/sagemaker/mock --large
 
 # Added here due to dependency on sagemaker
 # TODO: split out sagemaker tests and move other spark tests to run-python-flavor-tests.sh
-pytest --color=yes --verbose tests/spark --large
+pytest --verbose tests/spark --large
 
 test $err = 0

--- a/travis/run-python-tf-tests.sh
+++ b/travis/run-python-tf-tests.sh
@@ -6,15 +6,15 @@ err=0
 trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
-pytest --color=yes --verbose tests/tensorflow/test_tensorflow_model_export.py --large
-pytest --color=yes --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
+pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
+pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
 # TODO(smurching) Unpin TensorFlow dependency version once test failures with TF 2.1.0 have been
 # fixed
 pip install 'tensorflow==2.0.0'
-pytest --color=yes --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
-pytest --color=yes --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
-pytest --color=yes --verbose tests/keras --large
-pytest --color=yes --verbose tests/keras_autolog --large
+pytest --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
+pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
+pytest --verbose tests/keras --large
+pytest --verbose tests/keras_autolog --large
 
 # Run Spark autologging tests, which rely on tensorflow
 ./travis/test-spark-autologging.sh

--- a/travis/run-small-python-tests.sh
+++ b/travis/run-small-python-tests.sh
@@ -7,7 +7,7 @@ trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
 # NB: Also add --ignore'd tests to run-large-python-tests.sh
-pytest --color=yes --cov=mlflow --verbose --ignore=tests/h2o --ignore=tests/keras \
+pytest --cov=mlflow --verbose --ignore=tests/h2o --ignore=tests/keras \
   --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn \
   --ignore=tests/spark --ignore=tests/tensorflow --ignore=tests/keras_autolog \
   --ignore=tests/tensorflow_autolog --ignore tests/azureml --ignore tests/onnx \

--- a/travis/stage-python3.sh
+++ b/travis/stage-python3.sh
@@ -18,7 +18,7 @@ fi
 CHANGED_FILES=$(git diff --name-only master..HEAD | grep "tests/examples\|examples") || true
 if [[ "$TRAVIS_EVENT_TYPE" == "cron" || "$CHANGED_FILES" == *"examples"* ]] && [[ "$TRAVIS_BUILD_STAGE_NAME" == "Nightly" ]]
 then
-  pytest --color=yes --verbose tests/examples --large;
+  pytest --verbose tests/examples --large;
 fi
 if [[ "$TRAVIS_EVENT_TYPE" == "cron" || "$CHANGED_FILES" == *"Dockerfile"* ]] && [[ "$TRAVIS_BUILD_STAGE_NAME" == "Nightly" ]]
 then


### PR DESCRIPTION
## What changes are proposed in this pull request?

Instead of adding `--color=yes` to all the pytest commands, we can write it in `pytest.ini`.

## How is this patch tested?

Verified the pytest output is colored.

https://github.com/mlflow/mlflow/pull/2716/checks?check_run_id=592800991

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
