### PR TITLE
Move all small tests to GitHub Actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,19 +51,13 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - uses: r-lib/actions/setup-r@v1
-      with:
-        r-version: '3.3.0'
     - name: Install dependencies
       run: |
-        export GITHUB_WORKFLOW=1
-        # cached packages dramatically decreases build time, but it must not include mlflow
-        rm -rf $HOME/R/Library/mlflow
-        cd mlflow/R/mlflow
-        Rscript -e 'install.packages("devtools")'
-        Rscript -e 'devtools::install_deps(dependencies = TRUE, upgrade = FALSE)'
+        install.packages("devtools")
+        remotes::install_deps(dependencies = TRUE, upgrade = FALSE)
+      shell: Rscript {0}
     - name: Run tests
       run: |
-        export GITHUB_WORKFLOW=1
         source ./travis/install-common-deps.sh
         export PATH="$HOME/miniconda/bin:$PATH"
         source activate test-environment

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -7,6 +7,26 @@ on:
     branches: [ master ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        export GITHUB_WORKFLOW=1
+        INSTALL_LARGE_PYTHON_DEPS=true INSTALL_SMALL_PYTHON_DEPS=true source ./travis/install-common-deps.sh
+        pip install -r ./travis/lint-requirements.txt
+    - name: Run tests
+      run: |
+        export GITHUB_WORKFLOW=1
+        export PATH="$HOME/miniconda/bin:$PATH"
+        source activate test-environment
+        ./lint.sh
+
   python-small:
     runs-on: ubuntu-latest
     steps:
@@ -25,3 +45,65 @@ jobs:
         export PATH="$HOME/miniconda/bin:$PATH"
         source activate test-environment
         ./travis/run-small-python-tests.sh
+
+  r-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up R
+      uses: actions/setup-r@v1
+    - name: Install dependencies
+      run: |
+        export GITHUB_WORKFLOW=1
+        # cached packages dramatically decreases build time, but it must not include mlflow
+        rm -rf $HOME/R/Library/mlflow
+        cd mlflow/R/mlflow
+        Rscript -e 'install.packages("devtools")'
+        Rscript -e 'devtools::install_deps(dependencies = TRUE, upgrade = FALSE)'
+    - name: Run tests
+      run: |
+        export GITHUB_WORKFLOW=1
+        source ./travis/install-common-deps.sh
+        cd mlflow/R/mlflow
+        # Building the package here populates the /home/travis/R/Library cache,
+        # and is also used when python forks into R (e.g., rfunc via models CLI).
+        R CMD build .
+        export LINTR_COMMENT_BOT=false
+        cd tests
+        Rscript ../.travis.R
+        export COVR_RUNNING=true
+        Rscript -e 'covr::codecov()'
+
+  java:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Java
+      uses: actions/setup-java@v1
+    - name: Install dependencies
+      run: |
+        export GITHUB_WORKFLOW=1
+        source ./travis/install-common-deps.sh
+    - name: Run tests
+      run: |
+        export GITHUB_WORKFLOW=1
+        cd mlflow/java
+        mvn clean package -q
+
+  js:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Node
+      uses: actions/setup-node@v1
+    - name: Install dependencies
+      run: |
+        export GITHUB_WORKFLOW=1
+        source ./travis/install-common-deps.sh
+    - name: Run tests
+      run: |
+        cd mlflow/server/js
+        npm i
+        npm run lint
+        set -e
+        for file in $(find src | grep test.js | sort) ; do npm run test -- $file; done

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -83,3 +83,15 @@ jobs:
         npm run lint
         set -e
         for file in $(find src | grep test.js | sort) ; do npm run test -- $file; done
+
+  protos:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O /travis-install/protoc.zip
+        sudo unzip /travis-install/protoc.zip -d /usr
+    - name: Run tests
+      run: |
+        ./test-generate-protos.sh

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -65,6 +65,8 @@ jobs:
       run: |
         export GITHUB_WORKFLOW=1
         source ./travis/install-common-deps.sh
+        export PATH="$HOME/miniconda/bin:$PATH"
+        source activate test-environment
         cd mlflow/R/mlflow
         # Building the package here populates the /home/travis/R/Library cache,
         # and is also used when python forks into R (e.g., rfunc via models CLI).
@@ -90,6 +92,8 @@ jobs:
     - name: Run tests
       run: |
         export GITHUB_WORKFLOW=1
+        export PATH="$HOME/miniconda/bin:$PATH"
+        source activate test-environment
         cd mlflow/java
         mvn clean package -q
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -49,10 +49,10 @@ jobs:
   r-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: r-lib/actions/setup-r@v1
-        with:
-          r-version: '3.5.3'
+    - uses: actions/checkout@master
+    - uses: r-lib/actions/setup-r@v1
+      with:
+        r-version: '3.5.3'
     - name: Install dependencies
       run: |
         export GITHUB_WORKFLOW=1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -49,9 +49,10 @@ jobs:
   r-tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up R
-      uses: actions/setup-r@v1
+      - uses: actions/checkout@master
+      - uses: r-lib/actions/setup-r@v1
+        with:
+          r-version: '3.5.3'
     - name: Install dependencies
       run: |
         export GITHUB_WORKFLOW=1
@@ -80,6 +81,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Set up Java
       uses: actions/setup-java@v1
+      with:
+        java-version: 8
     - name: Install dependencies
       run: |
         export GITHUB_WORKFLOW=1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -52,7 +52,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: r-lib/actions/setup-r@v1
       with:
-        r-version: '3.5.3'
+        r-version: '3.3.0'
     - name: Install dependencies
       run: |
         export GITHUB_WORKFLOW=1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -90,8 +90,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install dependencies
       run: |
-        wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O /travis-install/protoc.zip
-        sudo unzip /travis-install/protoc.zip -d /usr
+        wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O $HOME/protoc.zip
+        sudo unzip $HOME/protoc.zip -d /usr
     - name: Run tests
       run: |
         ./test-generate-protos.sh

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -17,12 +17,10 @@ jobs:
         python-version: 3.6
     - name: Install dependencies
       run: |
-        export GITHUB_WORKFLOW=1
         INSTALL_LARGE_PYTHON_DEPS=true INSTALL_SMALL_PYTHON_DEPS=true source ./travis/install-common-deps.sh
         pip install -r ./travis/lint-requirements.txt
     - name: Run tests
       run: |
-        export GITHUB_WORKFLOW=1
         export PATH="$HOME/miniconda/bin:$PATH"
         source activate test-environment
         ./lint.sh
@@ -37,11 +35,9 @@ jobs:
         python-version: 3.6
     - name: Install dependencies
       run: |
-        export GITHUB_WORKFLOW=1
         INSTALL_SMALL_PYTHON_DEPS=true source ./travis/install-common-deps.sh
     - name: Run tests
       run: |
-        export GITHUB_WORKFLOW=1
         export PATH="$HOME/miniconda/bin:$PATH"
         source activate test-environment
         ./travis/run-small-python-tests.sh
@@ -56,11 +52,9 @@ jobs:
         java-version: 8
     - name: Install dependencies
       run: |
-        export GITHUB_WORKFLOW=1
         source ./travis/install-common-deps.sh
     - name: Run tests
       run: |
-        export GITHUB_WORKFLOW=1
         export PATH="$HOME/miniconda/bin:$PATH"
         source activate test-environment
         cd mlflow/java
@@ -72,9 +66,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Set up Node
       uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
     - name: Install dependencies
       run: |
-        export GITHUB_WORKFLOW=1
         source ./travis/install-common-deps.sh
     - name: Run tests
       run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -16,8 +16,11 @@ jobs:
       with:
         python-version: 3.6
     - name: Install dependencies
+      env:
+        INSTALL_LARGE_PYTHON_DEPS: true
+        INSTALL_SMALL_PYTHON_DEPS: true
       run: |
-        INSTALL_LARGE_PYTHON_DEPS=true INSTALL_SMALL_PYTHON_DEPS=true source ./travis/install-common-deps.sh
+        source ./travis/install-common-deps.sh
         pip install -r ./travis/lint-requirements.txt
     - name: Run tests
       run: |
@@ -34,8 +37,10 @@ jobs:
       with:
         python-version: 3.6
     - name: Install dependencies
+      env:
+        INSTALL_LARGE_PYTHON_DEPS: true
       run: |
-        INSTALL_SMALL_PYTHON_DEPS=true source ./travis/install-common-deps.sh
+        source ./travis/install-common-deps.sh
     - name: Run tests
       run: |
         export PATH="$HOME/miniconda/bin:$PATH"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -46,31 +46,6 @@ jobs:
         source activate test-environment
         ./travis/run-small-python-tests.sh
 
-  r-tests:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@master
-    - uses: r-lib/actions/setup-r@v1
-    - name: Install dependencies
-      run: |
-        install.packages("devtools")
-        remotes::install_deps(dependencies = TRUE, upgrade = FALSE)
-      shell: Rscript {0}
-    - name: Run tests
-      run: |
-        source ./travis/install-common-deps.sh
-        export PATH="$HOME/miniconda/bin:$PATH"
-        source activate test-environment
-        cd mlflow/R/mlflow
-        # Building the package here populates the /home/travis/R/Library cache,
-        # and is also used when python forks into R (e.g., rfunc via models CLI).
-        R CMD build .
-        export LINTR_COMMENT_BOT=false
-        cd tests
-        Rscript ../.travis.R
-        export COVR_RUNNING=true
-        Rscript -e 'covr::codecov()'
-
   java:
     runs-on: ubuntu-latest
     steps:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,6 @@ matrix:
     # Nightly builds run the tests/examples end-to-end test suite.
     # Does not include Windows since Projects/Models are mostly not compatible with Windows as of now.
     - stage: Nightly
-    - stage: Small
-      if: type != cron
-    - language: python
-      name: "Lint (Python 3.6)"
-      if: type != cron
-      python: 3.6
-      install:
-        - INSTALL_SMALL_PYTHON_DEPS=true INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh
-        - pip install -r ./travis/lint-requirements.txt
-      script:
-        - ./lint.sh
     - language: r
       name: "R"
       if: type != cron
@@ -48,26 +37,6 @@ matrix:
         - Rscript -e 'covr::codecov()'
       after_failure:
         - "[ -r /home/travis/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log ] && cat /home/travis/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
-    - language: java
-      name: "Java"
-      if: type != cron
-      install:
-        - source ./travis/install-common-deps.sh
-      script:
-        - cd mlflow/java
-        - mvn clean package -q
-    - language: node_js
-      node_js:
-        - "node" # Use latest NodeJS: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions
-      install:
-      name: "Node.js"
-      if: type != cron
-      script:
-        - cd mlflow/server/js
-        - npm i
-        - npm run lint
-        - set -e
-        - for file in $(find src | grep test.js | sort) ; do npm run test -- $file; done
     - stage: Large
       if: type != cron
     - language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ matrix:
     # Nightly builds run the tests/examples end-to-end test suite.
     # Does not include Windows since Projects/Models are mostly not compatible with Windows as of now.
     - stage: Nightly
-    - stage: Small
+      if: type == cron
+    - stage: Large
       if: type != cron
     - language: r
       name: "R"
@@ -39,8 +40,6 @@ matrix:
         - Rscript -e 'covr::codecov()'
       after_failure:
         - "[ -r /home/travis/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log ] && cat /home/travis/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
-    - stage: Large
-      if: type != cron
     - language: python
       python: 3.6
       name: "Flavors"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     # Nightly builds run the tests/examples end-to-end test suite.
     # Does not include Windows since Projects/Models are mostly not compatible with Windows as of now.
     - stage: Nightly
+    - stage: Small
+      if: type != cron
     - language: r
       name: "R"
       if: type != cron

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,10 +105,6 @@ install:
   - CHANGED_FILES=$(git diff --name-only master..HEAD | grep "tests/examples\|examples") || true;
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
       echo "skipping this step on windows.";
-    elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "Small" ]]; then
-      INSTALL_SMALL_PYTHON_DEPS=true source ./travis/install-common-deps.sh &&
-      wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O /travis-install/protoc.zip &&
-      sudo unzip /travis-install/protoc.zip -d /usr;
     elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "Nightly" ]] && ! [[ "$TRAVIS_EVENT_TYPE" == "cron" || ! -z "$CHANGED_FILES" ]]; then
       echo "skipping the nightly stage because this build is not nightly and there are no changed files associated with nightly tests.";
     else

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -6,6 +6,8 @@ sudo apt clean
 df -h
 docker rmi $(docker image ls -aq)
 df -h
+rm -rf $HOME/miniconda
+df -h
 
 set -ex
 sudo mkdir -p /travis-install

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -2,8 +2,6 @@
 
 set -x
 df -h
-sudo rm -f /swapfile
-df -h
 sudo apt clean
 df -h
 docker rmi $(docker image ls -aq)

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -1,5 +1,14 @@
 #!/usr/bin/env bash
 
+set -x
+df -h
+sudo rm -f /swapfile
+df -h
+sudo apt clean
+df -h
+docker rmi $(docker image ls -aq)
+df -h
+
 set -ex
 sudo mkdir -p /travis-install
 # GITHUB_WORKFLOW is set by default during GitHub workflows

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -1,15 +1,11 @@
 #!/usr/bin/env bash
 
-set -x
-df -h
+set -ex
+
+# Cleanup apt repository to make room for tests.
 sudo apt clean
 df -h
-docker rmi $(docker image ls -aq)
-df -h
-rm -rf $HOME/miniconda
-df -h
 
-set -ex
 sudo mkdir -p /travis-install
 # GITHUB_WORKFLOW is set by default during GitHub workflows
 if [[ -z $GITHUB_WORKFLOW ]]; then

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -2,6 +2,7 @@
 
 set -ex
 sudo mkdir -p /travis-install
+# GITHUB_WORKFLOW is set by default during GitHub workflows
 if [[ -z $GITHUB_WORKFLOW ]]; then
   sudo chown travis /travis-install
 fi

--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -35,5 +35,6 @@ cloudpickle==0.8.0
 pytest-localserver==0.5.0
 sqlalchemy==1.3.0
 kubernetes==9.0.0
+matplotlib==3.2.1
 # test plugin
 tests/resources/mlflow-test-plugin/

--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -35,8 +35,5 @@ cloudpickle==0.8.0
 pytest-localserver==0.5.0
 sqlalchemy==1.3.0
 kubernetes==9.0.0
-pystan==2.17.1.0
-# TODO (harupy): Unpin fbprophet once https://github.com/facebook/prophet/issues/1339 is fixed.
-fbprophet==0.5
 # test plugin
 tests/resources/mlflow-test-plugin/

--- a/travis/stage-python3.sh
+++ b/travis/stage-python3.sh
@@ -7,8 +7,7 @@ then
      echo "skipping this step on windows."
   elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "Small" ]]
   then
-    ./travis/run-small-python-tests.sh
-    ./test-generate-protos.sh
+    echo 'Small tests are replaced by Github Actions'
   else
     ./travis/run-large-python-tests.sh
     ./travis/test-anaconda-compatibility.sh "anaconda3:2020.02"

--- a/travis/stage-python3.sh
+++ b/travis/stage-python3.sh
@@ -5,9 +5,6 @@ then
   if [[ "$TRAVIS_OS_NAME" == "windows" ]]
   then
      echo "skipping this step on windows."
-  elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "Small" ]]
-  then
-    echo 'Small tests are replaced by Github Actions'
   else
     ./travis/run-large-python-tests.sh
     ./travis/test-anaconda-compatibility.sh "anaconda3:2020.02"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds lint, Java, JS, and proto tests to GitHub actions, and removes them from Travis. Travis doesn't allow us to run very many concurrent builds (despite our longest step taking 20 minutes, and most steps running in parallel, builds typically take ~50 minutes to run -- and if you have 2 PRs in progress, the second one will block behind the first).

I tried and failed to get the R build to work (complaints about `curl` and `gh` not being installed by `usethis`), so gave up and just moved R to the large tests in Travis.