### PR TITLE
Use df.iloc instead of df.ix in spacy flavor test to resolve deprecation warning

### DIFF
--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -169,7 +169,7 @@ class _SpacyModelWrapper:
             raise MlflowException('Shape of input dataframe must be (n_rows, 1column)')
 
         return pd.DataFrame({
-            'predictions': dataframe.ix[:, 0].apply(lambda text: self.spacy_model(text).cats)
+            'predictions': dataframe.iloc[:, 0].apply(lambda text: self.spacy_model(text).cats)
         })
 
 

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -260,5 +260,5 @@ def _get_train_test_dataset(cats_to_fetch, limit=100):
 
 def _predict(spacy_model, test_x):
     return pd.DataFrame({
-        'predictions': test_x.ix[:, 0].apply(lambda text: spacy_model(text).cats)
+        'predictions': test_x.iloc[:, 0].apply(lambda text: spacy_model(text).cats)
     })


### PR DESCRIPTION
## What changes are proposed in this pull request?

Use `df.iloc` instead of `df.ix` in the spacy flavor test to resolve deprecation warning.

Before

<img width="792" alt="Screen Shot 2020-04-19 at 22 19 02" src="https://user-images.githubusercontent.com/17039389/79688824-e73fbb00-828b-11ea-9eb7-f5be25668c87.png">

After

<img width="833" alt="Screen Shot 2020-04-20 at 11 02 37" src="https://user-images.githubusercontent.com/17039389/79707167-86999800-82f6-11ea-9eb9-f5cd24b4aeb9.png">



## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
