### PR TITLE
Issue policy and template tweaks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -7,7 +7,7 @@ title: "[BUG]"
 Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
 for additional information about bug reports. For help with debugging your code, please refer to [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
 
-**Please fill in this template. Bug reports that do not complete this template will not be reviewed.**
+**Please fill in this bug report template to ensure a thorough response.**
 
 ### Willingness to contribute
 The MLflow Community encourages bug fix contributions. Would you or another member of your organization be willing to contribute a fix

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -4,8 +4,8 @@ about: Use this template for reporting bugs encountered while using MLflow.
 labels: 'bug'
 title: "[BUG]"
 ---
-Thank you for submitting an issue. **Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
-for additional information about bug reports. For help with debugging your code, please refer to [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).**
+Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
+for additional information about bug reports. For help with debugging your code, please refer to [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
 
 **Please fill in this template. Bug reports that do not complete this template will not be reviewed.**
 

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -4,8 +4,10 @@ about: Use this template for reporting bugs encountered while using MLflow.
 labels: 'bug'
 title: "[BUG]"
 ---
-Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
-for information on what types of issues we address. For help with debugging your code, please refer to [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
+Thank you for submitting an issue. **Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
+for additional information about bug reports. For help with debugging your code, please refer to [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).**
+
+**Please fill in this template. Bug reports that do not complete this template will not be reviewed.**
 
 ### Willingness to contribute
 The MLflow Community encourages bug fix contributions. Would you or another member of your organization be willing to contribute a fix for this bug to the MLflow code base?

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -7,6 +7,13 @@ title: "[BUG]"
 Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
 for information on what types of issues we address. For help with debugging your code, please refer to [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
 
+### Willingness to contribute
+The MLflow Community encourages bug fix contributions. Would you or another member of your organization be willing to contribute a fix for this bug to the MLflow code base?
+
+- [ ] Yes. I can contribute a fix for this bug independently.
+- [ ] Yes. I would be willing to contribute a fix for this bug with guidance from the MLflow community.
+- [ ] No. **Explanation:**
+
 Please fill in this template and do not delete it unless you are sure your issue is outside its scope.
 
 ### System information

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -10,13 +10,12 @@ for additional information about bug reports. For help with debugging your code,
 **Please fill in this template. Bug reports that do not complete this template will not be reviewed.**
 
 ### Willingness to contribute
-The MLflow Community encourages bug fix contributions. Would you or another member of your organization be willing to contribute a fix for this bug to the MLflow code base?
+The MLflow Community encourages bug fix contributions. Would you or another member of your organization be willing to contribute a fix
+for this bug to the MLflow code base?
 
 - [ ] Yes. I can contribute a fix for this bug independently.
 - [ ] Yes. I would be willing to contribute a fix for this bug with guidance from the MLflow community.
 - [ ] No. **Explanation:**
-
-Please fill in this template and do not delete it unless you are sure your issue is outside its scope.
 
 ### System information
 - **Have I written custom code (as opposed to using a stock example script provided in MLflow)**:

--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -7,7 +7,7 @@ title: "[BUG]"
 Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
 for additional information about bug reports. For help with debugging your code, please refer to [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
 
-**Please fill in this bug report template to ensure a thorough response.**
+**Please fill in this bug report template to ensure a timely and thorough response.**
 
 ### Willingness to contribute
 The MLflow Community encourages bug fix contributions. Would you or another member of your organization be willing to contribute a fix
@@ -15,7 +15,7 @@ for this bug to the MLflow code base?
 
 - [ ] Yes. I can contribute a fix for this bug independently.
 - [ ] Yes. I would be willing to contribute a fix for this bug with guidance from the MLflow community.
-- [ ] No. **Explanation:**
+- [ ] No. I cannot contribute a bug fix at this time.
 
 ### System information
 - **Have I written custom code (as opposed to using a stock example script provided in MLflow)**:

--- a/.github/ISSUE_TEMPLATE/doc_fix_template.md
+++ b/.github/ISSUE_TEMPLATE/doc_fix_template.md
@@ -7,7 +7,7 @@ title: "[DOC-FIX]"
 Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
 for information on what types of issues we address.
 
-**Please fill in this documentation issue template to ensure a thorough response.**
+**Please fill in this documentation issue template to ensure a timely and thorough response.**
 
 ### Willingness to contribute
 The MLflow Community encourages documentation fix contributions. Would you or another member of your organization be willing to
@@ -15,7 +15,7 @@ contribute a fix for this documentation issue to the MLflow code base?
 
 - [ ] Yes. I can contribute a documentation fix independently.
 - [ ] Yes. I would be willing to contribute a document fix with guidance from the MLflow community.
-- [ ] No. **Explanation:**
+- [ ] No. I cannot contribute a documentation fix at this time.
 
 ### URL(s) with the issue:
 

--- a/.github/ISSUE_TEMPLATE/doc_fix_template.md
+++ b/.github/ISSUE_TEMPLATE/doc_fix_template.md
@@ -7,7 +7,7 @@ title: "[DOC-FIX]"
 Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
 for information on what types of issues we address.
 
-**Please fill in this template. Documentation issues that do not complete this template will not be reviewed.**
+**Please fill in this documentation issue template to ensure a thorough response.**
 
 ### Willingness to contribute
 The MLflow Community encourages documentation fix contributions. Would you or another member of your organization be willing to

--- a/.github/ISSUE_TEMPLATE/doc_fix_template.md
+++ b/.github/ISSUE_TEMPLATE/doc_fix_template.md
@@ -7,7 +7,15 @@ title: "[DOC-FIX]"
 Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
 for information on what types of issues we address.
 
-Please fill in this template and do not delete it unless you are sure your issue is outside its scope.
+**Please fill in this template. Documentation issues that do not complete this template will not be reviewed.**
+
+### Willingness to contribute
+The MLflow Community encourages documentation fix contributions. Would you or another member of your organization be willing to
+contribute a fix for this documentation issue to the MLflow code base?
+
+- [ ] Yes. I can contribute a documentation fix independently.
+- [ ] Yes. I would be willing to contribute a document fix with guidance from the MLflow community.
+- [ ] No. **Explanation:**
 
 ### URL(s) with the issue:
 

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -60,7 +60,7 @@ If you selected “No”, please complete the subsequent sections.
 - [ ] Python
 
 ### Implementation impact
-Please answer the following questions to the best of your ability. If you are not familiar with the MLflow code base, please feel free to leave questions about implementation details blank as necessary, and check the following “Needs implementation input” box:
+Please answer the following questions to the best of your ability. If you are not familiar with the MLflow code base, please feel free to leave questions about implementation details blank as necessary, and select the following “Needs implementation input” box:
 - [ ] Needs implementation input
 
 - Does this feature introduce any new libraries to MLflow? If so, which ones?
@@ -71,7 +71,7 @@ Please answer the following questions to the best of your ability. If you are no
 
 - Does this feature make backwards-incompatible changes to existing MLflow APIs and behaviors? (Please describe why any backwards-incompatible changes cannot be avoided)
 
-- Does this feature introduce changes to any of the following backend APIs (selected all that apply)?:
+- Does this feature introduce changes to any of the following backend APIs (select all that apply)?:
    - [ ] Tracking Artifact Repository
    - [ ] Tracking Backend Store
    - [ ] Model Registry Backend Store

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -25,22 +25,7 @@ The MLflow Community encourages new feature contributions. Would you or another 
 - Why is this use case valuable to support for your project(s) or organization?
 - Why is it currently difficult to achieve this use case? (please be as specific as possible about why related MLflow features and components are insufficient)
 
-## Proposed Changes
-
-### Can this feature be introduced as an MLflow Plugin?
-[MLflow Plugins] enable integration of third-party modules with many of MLflow’s components, allowing you to maintain and iterate on certain features independently of the MLflow Repository.
-
-Please refer to the https://mlflow.org/docs/latest/plugins.html for a list of supported MLflow Plugin types. Afterwards, select the option that best applies and fill in the **Explanation** field if applicable:
-
-- [ ] Yes. I think this feature can be introduced as an MLflow Plugin.
-- [ ] No. It does not make sense to structure this feature as an MLflow Plugin. **Explanation:**
-- [ ] No. I don’t think MLflow Plugins currently support this type of feature. **Explanation:**
-
-If you selected “Yes,” please submit this feature request and add the “Plugin” GitHub label. An MLflow Community member will provide further guidance on how to get started with developing this feature as an MLflow Plugin.
-
-If you selected “No”, please complete the subsequent sections.
-
-### Which MLflow component(s) does this feature affect?
+## Which MLflow component(s) does this feature affect?
 
 - [ ] UI
 - [ ] CLI
@@ -57,26 +42,8 @@ If you selected “No”, please complete the subsequent sections.
 - [ ] Java
 - [ ] Python
 
-### Implementation impact
-Please answer the following questions to the best of your ability. If you are not familiar with the MLflow code base, please feel free to leave questions about implementation details blank as necessary, and select the following “Needs implementation input” box:
-- [ ] Needs implementation input
+## Details
 
-- Does this feature introduce any new libraries to MLflow? If so, which ones?
-
-- Does this feature introduce changes or additions to the [MLflow REST API](https://mlflow.org/docs/latest/rest-api.html)? If so, why are these changes absolutely necessary? (Please describe alternative approaches you’ve considered and why they won’t work)
-
-- Does this feature introduce new MLflow Client or Fluent APIs? If so, why are these changes absolutely necessary? (Please describe alternative approaches you’ve considered and why they won’t work)
-
-- Does this feature make backwards-incompatible changes to existing MLflow APIs and behaviors? (Please describe why any backwards-incompatible changes cannot be avoided)
-
-- Does this feature introduce changes to any of the following backend APIs (select all that apply)?:
-   - [ ] Tracking Artifact Repository
-   - [ ] Tracking Backend Store
-   - [ ] Model Registry Backend Store
-   - [ ] Other backend APIs
-
-   (If you selected any of the fields above, please outline the proposed API changes)
-
-### Further Design
-
-(Use this section to include any additional information about your proposed changes. If you have a design document, please provide a link here.)
+(Use this section to include any additional information about the feature. If you have a proposal
+for how to implement this feature, please include it here. For implementation guidelines, please
+refer to the Contributing Guide.)

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -30,7 +30,7 @@ The MLflow Community encourages new feature contributions. Would you or another 
 ## Which MLflow component(s) does this feature affect?
 
 - [ ] UI
-- [ ] CLI
+- [ ] Command Line Interface
 - [ ] API
 - [ ] Examples
 - [ ] Docs

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -5,7 +5,7 @@ labels: 'enhancement'
 title: "[FR]"
 ---
 Thank you for submitting a feature request. **Before proceeding, please review MLflow's
-[Issue Policy for feature requests](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md##feature-requests)
+[Issue Policy for feature requests](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md#feature-requests)
 and the [MLflow Contributing Guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst)**.
 
 **Please fill in this feature request template to ensure a timely and thorough response.**

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -6,14 +6,14 @@ title: "[FR]"
 ---
 Thank you for submitting a feature request. **Before proceeding, please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md) for guidelines and information about the feature request lifecycle**.
 
-**Please fill in this feature request template to ensure a thorough review.**
+**Please fill in this feature request template to ensure a timely and thorough response.**
 
 ## Willingness to contribute
 The MLflow Community encourages new feature contributions. Would you or another member of your organization be willing to contribute an implementation of this feature (either as an MLflow Plugin or an enhancement to the MLflow code base)?
 
 - [ ] Yes. I can contribute this feature independently.
 - [ ] Yes. I would be willing to contribute this feature with guidance from the MLflow community.
-- [ ] No. **Explanation:**
+- [ ] No. I cannot contribute this feature at this time.
 
 ## Proposal Summary
 
@@ -34,7 +34,7 @@ Please refer to the https://mlflow.org/docs/latest/plugins.html for a list of su
 
 - [ ] Yes. I think this feature can be introduced as an MLflow Plugin.
 - [ ] No. It does not make sense to structure this feature as an MLflow Plugin. **Explanation:**
-- [ ] No. I don’t think MLflow Plugins currently supports this type of feature. **Explanation:**
+- [ ] No. I don’t think MLflow Plugins currently support this type of feature. **Explanation:**
 
 If you selected “Yes,” please submit this feature request and add the “Plugin” GitHub label. An MLflow Community member will provide further guidance on how to get started with developing this feature as an MLflow Plugin.
 
@@ -45,7 +45,6 @@ If you selected “No”, please complete the subsequent sections.
 - [ ] UI
 - [ ] CLI
 - [ ] API
-- [ ] REST-API
 - [ ] Examples
 - [ ] Docs
 - [ ] Tracking
@@ -54,7 +53,6 @@ If you selected “No”, please complete the subsequent sections.
 - [ ] Models
 - [ ] Model Registry
 - [ ] Scoring
-- [ ] Serving
 - [ ] R
 - [ ] Java
 - [ ] Python

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -4,29 +4,82 @@ about: Use this template for feature and enhancement proposals.
 labels: 'enhancement'
 title: "[FR]"
 ---
-Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
-for information on what types of issues we address.
+Thank you for submitting a feature request. **Before proceeding, please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md) for guidelines and information about the feature request lifecycle**.
 
-Please fill in this template and do not delete it unless you are sure your issue is outside its scope.
+**Please fill in this template. Feature requests that do not complete this template will not be reviewed.**
 
--------
-## Guidelines
+## Willingness to contribute
+The MLflow Community encourages new feature contributions. Would you or another member of your organization be willing to contribute an implementation of this feature (either as an MLflow Plugin or an enhancement to the MLflow code base)?
 
-Feature requests typically go through the following lifecycle:
+- [ ] Yes. I can contribute this feature independently.
+- [ ] Yes. I would be willing to contribute this feature with guidance from the MLflow community.
+- [ ] No. Explanation:
 
-1. Submit feature request with high-level description on GitHub issues (this is what you're doing now)
-2. Discuss feature request with a committer, who may ask for a more detailed design
-3. After discussion & agreement on feature request, start implementation
+## Proposal Summary
 
+(In a few sentences, provide a clear, high-level description of the feature request)
 
-## Describe the proposal
-Provide a clear high-level description of the feature request in the following sections. Feature requests that are likely to be accepted:
-* Are minimal in scope (note that it's always easier to add additional functionality later than remove functionality)
-* Are extensible (e.g. if adding an integration with an ML framework, is it possible to add similar integrations with other frameworks?)
-* Have user impact & value that justifies the maintenance burden of supporting the feature moving forwards. The [JQuery contributor guide](https://contribute.jquery.org/open-source/#contributing-something-new) has an excellent discussion on this.
+## Motivation
+- What is the use case for this feature?
+- Why is this use case valuable to support for MLflow users in general?
+- (If applicable) Why is this use case valuable to support for your projects or organization?
+- Why is it currently difficult to achieve this use case? (please be as specific as possible about why related MLflow features and components are insufficient)
 
-### Motivation
-What is the use case in mind?  Why is it valuable to support, and why is it currently difficult or impossible to achieve? Could the desired functionality alternatively be implemented as a third-party package using MLflow public APIs?
+## Proposed Changes
 
-### Proposed Changes
-For user-facing changes, what APIs are you proposing to add or modify? For internal changes, what code paths will need to be modified?
+### Can this feature be introduced as an MLflow Plugin?
+[MLflow Plugins] enable integration of third-party modules with many of MLflow’s components, allowing you to maintain and iterate on certain features independently of the MLflow Repository.
+
+Please refer to the https://mlflow.org/docs/latest/plugins.html for a list of supported MLflow Plugin types. Afterwards, select the option that best applies and fill in the **Explanation** field if applicable:
+
+- [ ] Yes. I think this feature can be introduced as an MLflow Plugin.
+- [ ] No. It does not make sense to structure this feature as an MLflow Plugin. Explanation:
+- [ ] No. I don’t think MLflow Plugins currently supports this type of feature. Explanation:
+
+If you selected “Yes,” please submit this feature request and add the “Plugin” GitHub label. An MLflow Community member will provide further guidance on how to get started with developing this feature as an MLflow Plugin.
+
+If you selected “No”, please complete the subsequent sections.
+
+### Which MLflow component(s) does this feature affect?
+
+- [ ] UI
+- [ ] CLI
+- [ ] API
+- [ ] REST-API
+- [ ] Examples
+- [ ] Docs
+- [ ] Tracking
+- [ ] Projects
+- [ ] Artifacts
+- [ ] Models
+- [ ] Model Registry
+- [ ] Scoring
+- [ ] Serving
+- [ ] R
+- [ ] Java
+- [ ] Python
+
+### Implementation impact
+Please answer the following questions to the best of your ability. If you are not familiar with the MLflow code base, please feel free to leave questions about implementation details blank as necessary, and check the following “Needs implementation input” box:
+- [ ] Needs implementation input
+
+- Does this feature introduce any new libraries to MLflow? If so, which ones?
+
+- Does this feature introduce changes or additions to the [MLflow REST API](https://mlflow.org/docs/latest/rest-api.html)? If so, why are these changes absolutely necessary? (Please describe alternative approaches you’ve considered and why they won’t work)
+
+- Does this feature introduce new MLflow Client or Fluent APIs? If so, why are these changes absolutely necessary? (Please describe alternative approaches you’ve considered and why they won’t work)
+
+- Does this feature make backwards-incompatible changes to existing MLflow APIs and behaviors? (Please describe why any backwards-incompatible changes cannot be avoided)
+
+- Does this feature introduce changes to any of the following backend APIs (selected all that apply)?:
+   - [ ] Tracking Artifact Repository
+   - [ ] Tracking Backend Store
+   - [ ] Model Registry Backend Store
+   - [ ] ...
+   - [ ] Other backend API
+
+(If you selected any of the fields above, please outline the proposed API changes)
+
+### Further Design
+
+(Use this section to include any additional information about your proposed changes. If you have a design document, please provide a link here.)

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -22,7 +22,7 @@ The MLflow Community encourages new feature contributions. Would you or another 
 ## Motivation
 - What is the use case for this feature?
 - Why is this use case valuable to support for MLflow users in general?
-- (If applicable) Why is this use case valuable to support for your projects or organization?
+- Why is this use case valuable to support for your project(s) or organization?
 - Why is it currently difficult to achieve this use case? (please be as specific as possible about why related MLflow features and components are insufficient)
 
 ## Proposed Changes

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -13,7 +13,7 @@ The MLflow Community encourages new feature contributions. Would you or another 
 
 - [ ] Yes. I can contribute this feature independently.
 - [ ] Yes. I would be willing to contribute this feature with guidance from the MLflow community.
-- [ ] No. Explanation:
+- [ ] No. **Explanation:**
 
 ## Proposal Summary
 
@@ -33,8 +33,8 @@ The MLflow Community encourages new feature contributions. Would you or another 
 Please refer to the https://mlflow.org/docs/latest/plugins.html for a list of supported MLflow Plugin types. Afterwards, select the option that best applies and fill in the **Explanation** field if applicable:
 
 - [ ] Yes. I think this feature can be introduced as an MLflow Plugin.
-- [ ] No. It does not make sense to structure this feature as an MLflow Plugin. Explanation:
-- [ ] No. I don’t think MLflow Plugins currently supports this type of feature. Explanation:
+- [ ] No. It does not make sense to structure this feature as an MLflow Plugin. **Explanation:**
+- [ ] No. I don’t think MLflow Plugins currently supports this type of feature. **Explanation:**
 
 If you selected “Yes,” please submit this feature request and add the “Plugin” GitHub label. An MLflow Community member will provide further guidance on how to get started with developing this feature as an MLflow Plugin.
 
@@ -75,10 +75,9 @@ Please answer the following questions to the best of your ability. If you are no
    - [ ] Tracking Artifact Repository
    - [ ] Tracking Backend Store
    - [ ] Model Registry Backend Store
-   - [ ] ...
-   - [ ] Other backend API
+   - [ ] Other backend APIs
 
-(If you selected any of the fields above, please outline the proposed API changes)
+   (If you selected any of the fields above, please outline the proposed API changes)
 
 ### Further Design
 

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -4,7 +4,9 @@ about: Use this template for feature and enhancement proposals.
 labels: 'enhancement'
 title: "[FR]"
 ---
-Thank you for submitting a feature request. **Before proceeding, please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md) for guidelines and information about the feature request lifecycle**.
+Thank you for submitting a feature request. **Before proceeding, please review MLflow's
+[Issue Policy for feature requests](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md##feature-requests)
+and the [MLflow Contributing Guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst)**.
 
 **Please fill in this feature request template to ensure a timely and thorough response.**
 
@@ -46,4 +48,4 @@ The MLflow Community encourages new feature contributions. Would you or another 
 
 (Use this section to include any additional information about the feature. If you have a proposal
 for how to implement this feature, please include it here. For implementation guidelines, please
-refer to the `Contributing Guide`.)
+refer to the [Contributing Guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#contribution-guidelines).)

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -46,4 +46,4 @@ The MLflow Community encourages new feature contributions. Would you or another 
 
 (Use this section to include any additional information about the feature. If you have a proposal
 for how to implement this feature, please include it here. For implementation guidelines, please
-refer to the Contributing Guide.)
+refer to the `Contributing Guide`.)

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -6,7 +6,7 @@ title: "[FR]"
 ---
 Thank you for submitting a feature request. **Before proceeding, please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md) for guidelines and information about the feature request lifecycle**.
 
-**Please fill in this template. Feature requests that do not complete this template will not be reviewed.**
+**Please fill in this feature request template to ensure a thorough review.**
 
 ## Willingness to contribute
 The MLflow Community encourages new feature contributions. Would you or another member of your organization be willing to contribute an implementation of this feature (either as an MLflow Plugin or an enhancement to the MLflow code base)?

--- a/.github/ISSUE_TEMPLATE/installation_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue_template.md
@@ -7,7 +7,7 @@ title: "[SETUP-BUG]"
 Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
 for information on what types of issues we address.
 
-**Please fill in this template. Installation issues that do not complete this template will not be reviewed.**
+**Please fill in this installation issue template to ensure a thorough response.**
 
 ### System information
 - **OS Platform and Distribution (e.g., Linux Ubuntu 16.04)**:

--- a/.github/ISSUE_TEMPLATE/installation_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue_template.md
@@ -7,7 +7,7 @@ title: "[SETUP-BUG]"
 Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
 for information on what types of issues we address.
 
-**Please fill in this installation issue template to ensure a thorough response.**
+**Please fill in this installation issue template to ensure a timely and thorough response.**
 
 ### System information
 - **OS Platform and Distribution (e.g., Linux Ubuntu 16.04)**:

--- a/.github/ISSUE_TEMPLATE/installation_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue_template.md
@@ -7,7 +7,7 @@ title: "[SETUP-BUG]"
 Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
 for information on what types of issues we address.
 
-Please fill in this template and do not delete it unless you are sure your issue is outside its scope.
+**Please fill in this template. Installation issues that do not complete this template will not be reviewed.**
 
 ### System information
 - **OS Platform and Distribution (e.g., Linux Ubuntu 16.04)**:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@
 ### What component(s) does this PR affect?
 
 - [ ] UI
-- [ ] CLI
+- [ ] Command Line Interface
 - [ ] API
 - [ ] Examples
 - [ ] Docs

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,6 @@
 - [ ] UI
 - [ ] CLI
 - [ ] API
-- [ ] REST-API
 - [ ] Examples
 - [ ] Docs
 - [ ] Tracking
@@ -29,7 +28,6 @@
 - [ ] Models
 - [ ] Model Registry
 - [ ] Scoring
-- [ ] Serving
 - [ ] R
 - [ ] Java
 - [ ] Python

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -314,16 +314,16 @@ You can see an example flavor PR `here <https://github.com/mlflow/mlflow/pull/21
 Building Protobuf Files
 ~~~~~~~~~~~~~~~~~~~~~~~
 To build protobuf files, simply run ``generate-protos.sh``. The required ``protoc`` version is ``3.6.0``.
-You can find the URL of a system-appropriate installation of ``protoc`` at 
-https://github.com/protocolbuffers/protobuf/releases/tag/v3.6.0, e.g. 
-https://github.com/protocolbuffers/protobuf/releases/download/v3.6.0/protoc-3.6.0-osx-x86_64.zip if 
+You can find the URL of a system-appropriate installation of ``protoc`` at
+https://github.com/protocolbuffers/protobuf/releases/tag/v3.6.0, e.g.
+https://github.com/protocolbuffers/protobuf/releases/download/v3.6.0/protoc-3.6.0-osx-x86_64.zip if
 you're on 64-bit Mac OSX.
 
 Then, run the following to install ``protoc``:
 
 .. code-block:: bash
 
-    # Update PROTOC_ZIP if on a platform other than 64-bit Mac OSX 
+    # Update PROTOC_ZIP if on a platform other than 64-bit Mac OSX
     PROTOC_ZIP=protoc-3.6.0-osx-x86_64.zip
     curl -OL https://github.com/protocolbuffers/protobuf/releases/download/v3.6.0/$PROTOC_ZIP
     sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -15,11 +15,13 @@ an MLflow committer before investing heavily in implementation. This is particul
 implementation:
 
 - Introduces changes or additions to the `MLflow REST API <https://mlflow.org/docs/latest/rest-api.html>`_
+
   - The MLflow REST API is implemented by a variety of open source and proprietary platforms. Changes to the REST
     API impact all of these platforms. Accordingly, we encourage developers to thoroughly explore alternatives
     before attempting to introduce REST API changes.
 
 - Introduces new user-facing MLflow APIs
+
   - MLflow's API surface is carefully designed to generalize across a variety of common ML operations.
     It is important to ensure that new APIs are broadly useful to ML developers, easy to work with,
     and simple yet powerful.
@@ -43,7 +45,7 @@ MLflow Plugin. MLflow Plugins are a great choice for the following types of chan
 3. Introducing a new implementation of the Model Registry backend (`Abstract Store
    <https://github.com/mlflow/mlflow/blob/cdc6a651d5af0f29bd448d2c87a198cf5d32792b/mlflow/store/model_registry/abstract_store.py>`_)
    for a particular platform
-4. Automatically capturing and recording information about MLflow Runs created in specific environments.
+4. Automatically capturing and recording information about MLflow Runs created in specific environments
 
 MLflow committers and community members are happy to provide assistance with the development and review of
 new MLflow Plugins. For more information about Plugins, see https://mlflow.org/docs/latest/plugins.html.

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,12 +1,59 @@
 Contributing to MLflow
 ======================
-We welcome community contributions to MLflow. This page describes how to develop/test your changes
-to MLflow locally.
+We welcome community contributions to MLflow. This page describes:
+1. The contribution process and guidelines
+2. How to develop/test your changes to MLflow locally
 
-The majority of the MLflow codebase is in Python. This includes the CLI, Tracking Server,
+Contribution process and guidelines
+###################################
+
+Write designs for significant changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For significant changes to MLflow, we recommend outlining a design for the feature or patch and discussing it with
+an MLflow committer before investing heavily in implementation. This is particularly important if your proposed
+implementation:
+
+- Introduces changes or additions to the `MLflow REST API <https://mlflow.org/docs/latest/rest-api.html>`_
+  - The MLflow REST API is implemented by a variety of open source and proprietary platforms. Changes to the REST
+    API impact all of these platforms. Accordingly, we encourage developers to thoroughly explore alternatives
+    before attempting to introduce REST API changes.
+
+- Introduces new user-facing MLflow APIs
+  - MLflow's API surface is carefully designed to generalize across a variety of common ML operations.
+    It is important to ensure that new APIs are broadly useful to ML developers, easy to work with,
+    and simple yet powerful.
+
+- Adds new library dependencies to MLflow
+
+- Makes changes to critical internal abstractions. Examples include: the Tracking Artifact Repository,
+  the Tracking Abstract Store, and the Model Registry Abstract Store.
+
+Consider introducing new features as MLflow Plugins
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`MLflow Plugins <https://mlflow.org/docs/latest/plugins.html>`_ enable integration of third-party modules with many of
+MLflow’s components, allowing you to maintain and iterate on certain features independently of the MLflow Repository.
+Before implementing changes to the MLflow code base, consider whether your feature might be better structured as an
+MLflow Plugin. MLflow Plugins are a great choice for the following types of changes:
+
+1. Supporting a new storage platform for MLflow artifacts
+2. Introducing a new implementation of the MLflow Tracking backend (`Abstract Store
+   <https://github.com/mlflow/mlflow/blob/cdc6a651d5af0f29bd448d2c87a198cf5d32792b/mlflow/store/tracking/abstract_store.py>`_)
+   for a particular platform
+3. Introducing a new implementation of the Model Registry backend (`Abstract Store
+   <https://github.com/mlflow/mlflow/blob/cdc6a651d5af0f29bd448d2c87a198cf5d32792b/mlflow/store/model_registry/abstract_store.py>`_)
+   for a particular platform
+4. Automatically capturing and recording information about MLflow Runs created in specific environments.
+
+MLflow committers and community members are happy to provide assistance with the development and review of
+new MLflow Plugins. For more information about Plugins, see https://mlflow.org/docs/latest/plugins.html.
+
+
+Developing and testing changes to MLflow
+########################################
+The majority of the MLflow codebase is developed in Python. This includes the CLI, Tracking Server,
 Artifact Repositories (e.g., S3 or Azure Blob Storage backends), and of course the Python fluent,
 tracking, and model APIs.
-
 
 Prerequisites
 ~~~~~~~~~~~~~
@@ -23,9 +70,9 @@ by running the following from your checkout of MLflow:
     pip install -r test-requirements.txt
     pip install -e .  # installs mlflow from current checkout
 
-You may need to run ``conda install cmake`` for the test requirements to properly install, as ``onnx`` needs ``cmake``. 
+You may need to run ``conda install cmake`` for the test requirements to properly install, as ``onnx`` needs ``cmake``.
 
-Ensure `Docker <https://www.docker.com/>`_ is installed. 
+Ensure `Docker <https://www.docker.com/>`_ is installed.
 
 ``npm`` is required to run the Javascript dev server and the tracking UI.
 You can verify that ``npm`` is on the PATH by running ``npm -v``, and

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,9 +1,11 @@
 Contributing to MLflow
 ======================
-We welcome community contributions to MLflow. This page describes:
-1. The contribution process
-2. Contribution guidelines
-3. How to develop/test your changes to MLflow locally
+We welcome community contributions to MLflow. This page provides useful information about
+contributing to MLflow.
+
+.. contents:: **Table of Contents**
+  :local:
+  :depth: 3
 
 Contribution process
 ####################
@@ -14,25 +16,25 @@ Details about each issue type and the issue lifecycle are discussed in the `MLfl
 
 MLflow committers actively triage and respond to GitHub issues. In general, we recommend waiting
 for feebdack from an MLflow committer or community member before proceeding to implement a feature
-or patch. This is particularly important for :ref:`significant changes <significant-changes>`.
+or patch. This is particularly important for
+`significant changes <https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#write-designs-for-significant-changes>`_.
 
 After you have agreed upon an implementation strategy for your feature or patch with an MLflow
-committer, the next step is to introduce your changes (see :ref:`developing-changes`) as a
-pull request against the MLflow Repository or as a standalone MLflow Plugin. MLflow committers
+committer, the next step is to introduce your changes (see `developing changes
+<https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#developing-and-testing-changes-to-mlflow>`_)
+as a pull request against the MLflow Repository or as a standalone MLflow Plugin. MLflow committers
 actively review pull requests and are also happy to provide implementation guidance for Plugins.
 
 Once your pull request against the MLflow Repository has been merged, your corresponding changes
 will be automatically included in the next MLflow release. Every change is listed in the MLflow
-release notes and `Changelog <https://github.com/mlflow/mlflow/blob/cdc6a651d5af0f29bd448d2c87a198cf5d32792b/CHANGELOG.rst>`_.
+release notes and `Changelog <https://github.com/mlflow/mlflow/blob/master/CHANGELOG.rst>`_.
 Congratulations, you have just contributed to MLflow! We appreciate your contribution!
 
-.. _contribution-guidelines:
 Contribution guidelines
 #######################
 In this section, we provide guidelines to consider as you develop new features and patches for
 MLflow.
 
-.. _significant-changes:
 Write designs for significant changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -84,7 +86,7 @@ MLflow Plugin. MLflow Plugins are a great choice for the following types of chan
 MLflow committers and community members are happy to provide assistance with the development and review of
 new MLflow Plugins.
 
-Finally, MLflow maintains a list of Plugins developed by community members:
+Finally, MLflow maintains a list of Plugins developed by community members, which is located at
 https://mlflow.org/docs/latest/plugins.html#community-plugins. This is an excellent way to
 inform MLflow users about your exciting new Plugins. To list your plugin, simply introduce
 a new pull request against the `corresponding docs section of the MLflow code base
@@ -92,7 +94,6 @@ a new pull request against the `corresponding docs section of the MLflow code ba
 
 For more information about Plugins, see https://mlflow.org/docs/latest/plugins.html.
 
-.. _developing-changes:
 Developing and testing changes to MLflow
 ########################################
 The majority of the MLflow codebase is developed in Python. This includes the CLI, Tracking Server,
@@ -148,7 +149,7 @@ If modifying dependencies in ``mlflow/server/js/package.json``, run ``npm update
 
 
 Java
-----
+~~~~
 Certain MLflow modules are implemented in Java, under the ``mlflow/java/`` directory.
 These are the Java Tracking API client (``mlflow/java/client``) and the Model Scoring Server
 for Java-based models like MLeap (``mlflow/java/scoring``).
@@ -169,7 +170,7 @@ If opening a PR that makes API changes, please regenerate API documentation as d
 
 
 R
--
+~
 
 The ``mlflow/R/mlflow`` directory contains R wrappers for the Projects, Tracking and Models
 components. These wrappers depend on the Python package, so first install
@@ -226,7 +227,7 @@ Please also follow the recommendations from the
 `Advanced R - Style Guide <http://adv-r.had.co.nz/Style.html>`_ regarding naming and styling.
 
 Python
-------
+~~~~~~
 Verify that the unit tests & linter pass before submitting a pull request by running:
 
 .. code-block:: bash
@@ -280,7 +281,7 @@ If opening a PR that changes or adds new APIs, please update or add Python docum
 described in `Writing Docs`_ and commit the docs to your PR branch.
 
 Writing Python Tests
---------------------
+~~~~~~~~~~~~~~~~~~~~
 If your PR includes code that isn't currently covered by our tests (e.g. adding a new flavor, adding
 autolog support to a flavor, etc.), you should write tests that cover your new code. MLflow currently
 uses ``pytest==3.2.1`` for testing. Your tests should be added to the relevant file under ``tests``, or
@@ -294,7 +295,7 @@ for every tests. It sets up a mock tracking URI that will set itself up before y
 If you want to deactivate the mock for your test, mark the test with `@pytest.mark.notrackingurimock` operator.
 
 Adding New Model Flavor Support
--------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If you are adding new framework flavor support, you'll need to modify ``pytest`` and Travis configurations so tests for your code can run properly. Generally, the files you'll have to edit are:
 
@@ -311,7 +312,7 @@ You can see an example flavor PR `here <https://github.com/mlflow/mlflow/pull/21
 
 
 Building Protobuf Files
------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 To build protobuf files, simply run ``generate-protos.sh``. The required ``protoc`` version is ``3.6.0``.
 You can find the URL of a system-appropriate installation of ``protoc`` at 
 https://github.com/protocolbuffers/protobuf/releases/tag/v3.6.0, e.g. 
@@ -333,7 +334,7 @@ Verify that .proto files and autogenerated code are in sync by running ``./test-
 
 
 Database Schema Changes
------------------------
+~~~~~~~~~~~~~~~~~~~~~~~
 MLflow's Tracking component supports storing experiment and run data in a SQL backend. To
 make changes to the tracking database schema, run the following from your
 checkout of MLflow:
@@ -355,7 +356,7 @@ migration logic.
 
 
 Launching the Development UI
-----------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 We recommend `Running the Javascript Dev Server`_ - otherwise, the tracking frontend will request
 files in the ``mlflow/server/js/build`` directory, which is not checked into Git.
 Alternatively, you can generate the necessary files in ``mlflow/server/js/build`` as described in
@@ -363,7 +364,7 @@ Alternatively, you can generate the necessary files in ``mlflow/server/js/build`
 
 
 Running the Javascript Dev Server
----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `Install Node Modules`_, then run the following:
 
 In one shell:
@@ -382,7 +383,7 @@ In another shell:
 The MLflow Tracking UI will show runs logged in ``./mlruns`` at `<http://localhost:3000>`_.
 
 Building a Distributable Artifact
----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `Install Node Modules`_, then run the following:
 
 Generate JS files in ``mlflow/server/js/build``:
@@ -401,7 +402,7 @@ Build a pip-installable wheel in ``dist/``:
 
 
 Writing Docs
-------------
+~~~~~~~~~~~~
 First, install dependencies for building docs as described in `Prerequisites`_.
 
 To generate a live preview of Python & other rst documentation, run the following snippet. Note

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,12 +1,38 @@
 Contributing to MLflow
 ======================
 We welcome community contributions to MLflow. This page describes:
-1. The contribution process and guidelines
-2. How to develop/test your changes to MLflow locally
+1. The contribution process
+2. Contribution guidelines
+3. How to develop/test your changes to MLflow locally
 
-Contribution process and guidelines
-###################################
+Contribution process
+####################
+The MLflow contribution process starts with filing a GitHub issue. MLflow defines four
+categories of issues: feature requests, bug reports, documentation fixes, and installation issues.
+Details about each issue type and the issue lifecycle are discussed in the `MLflow Issue Policy
+<https://github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md>`_.
 
+MLflow committers actively triage and respond to GitHub issues. In general, we recommend waiting
+for feebdack from an MLflow committer or community member before proceeding to implement a feature
+or patch. This is particularly important for :ref:`significant changes <significant-changes>`.
+
+After you have agreed upon an implementation strategy for your feature or patch with an MLflow
+committer, the next step is to introduce your changes (see :ref:`developing-changes`) as a
+pull request against the MLflow Repository or as a standalone MLflow Plugin. MLflow committers
+actively review pull requests and are also happy to provide implementation guidance for Plugins.
+
+Once your pull request against the MLflow Repository has been merged, your corresponding changes
+will be automatically included in the next MLflow release. Every change is listed in the MLflow
+release notes and `Changelog <https://github.com/mlflow/mlflow/blob/cdc6a651d5af0f29bd448d2c87a198cf5d32792b/CHANGELOG.rst>`_.
+Congratulations, you have just contributed to MLflow! We appreciate your contribution!
+
+.. _contribution-guidelines:
+Contribution guidelines
+#######################
+In this section, we provide guidelines to consider as you develop new features and patches for
+MLflow.
+
+.. _significant-changes:
 Write designs for significant changes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -31,6 +57,14 @@ implementation:
 - Makes changes to critical internal abstractions. Examples include: the Tracking Artifact Repository,
   the Tracking Abstract Store, and the Model Registry Abstract Store.
 
+Make changes backwards compatibile
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+MLflow's users rely on specific platform and API behaviors in their daily workflows. As new versions
+of MLflow are developed and released, it is important to ensure that users' workflows continue to
+operate as expected. Accordingly, please take care to consider backwards compatibility when introducing
+changes to the MLflow code base. If you are unsure of the backwards compatibility implications of
+a particular change, feel free to ask an MLflow committer or community member for input.
+
 Consider introducing new features as MLflow Plugins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 `MLflow Plugins <https://mlflow.org/docs/latest/plugins.html>`_ enable integration of third-party modules with many of
@@ -48,9 +82,17 @@ MLflow Plugin. MLflow Plugins are a great choice for the following types of chan
 4. Automatically capturing and recording information about MLflow Runs created in specific environments
 
 MLflow committers and community members are happy to provide assistance with the development and review of
-new MLflow Plugins. For more information about Plugins, see https://mlflow.org/docs/latest/plugins.html.
+new MLflow Plugins.
 
+Finally, MLflow maintains a list of Plugins developed by community members:
+https://mlflow.org/docs/latest/plugins.html#community-plugins. This is an excellent way to
+inform MLflow users about your exciting new Plugins. To list your plugin, simply introduce
+a new pull request against the `corresponding docs section of the MLflow code base
+<https://github.com/mlflow/mlflow/blob/cdc6a651d5af0f29bd448d2c87a198cf5d32792b/docs/source/plugins.rst#community-plugins>`_.
 
+For more information about Plugins, see https://mlflow.org/docs/latest/plugins.html.
+
+.. _developing-changes:
 Developing and testing changes to MLflow
 ########################################
 The majority of the MLflow codebase is developed in Python. This includes the CLI, Tracking Server,

--- a/ISSUE_POLICY.md
+++ b/ISSUE_POLICY.md
@@ -21,6 +21,16 @@ issue is outside its scope.
 
 ### Feature Requests
 
+#### Guidelines
+Feature requests that are likely to be accepted:
+
+* Are minimal in scope (note that it's always easier to add additional functionality later than remove functionality)
+* Are extensible (e.g. if adding an integration with an ML framework, is it possible to add similar integrations with other frameworks?)
+* Have user impact & value that justifies the maintenance burden of supporting the feature moving forwards. The
+  [JQuery contributor guide](https://contribute.jquery.org/open-source/#contributing-something-new) has an excellent discussion on this.
+
+#### Lifecycle
+
 Feature requests typically go through the following lifecycle:
 
 1. A feature request GitHub Issue is submitted, which contains a high-level description of the proposal and its motivation.
@@ -28,7 +38,8 @@ Feature requests typically go through the following lifecycle:
 2. The feature request is discussed with a committer. The committer will provide input on the implementation overview or
    ask for a more detailed design, if applicable.
 3. After discussion & agreement on the feature request and its implementation, an implementation owner is identified.
-4. The implementation owner begins developing the feature and ultimately files associated pull requests.
+4. The implementation owner begins developing the feature and ultimately files associated pull requests against the
+   MLflow Repository or packages the feature as an MLflow Plugin.
 
 ### Bug reports
 

--- a/ISSUE_POLICY.md
+++ b/ISSUE_POLICY.md
@@ -7,6 +7,8 @@ they address yours.
 
 For support (ex. "How do I do X?"), please ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
 
+## Issue Categories
+
 Our policy is that GitHub issues fall into one of the following categories:
 
 1. Bug reports
@@ -17,7 +19,7 @@ Our policy is that GitHub issues fall into one of the following categories:
 Each category has its own GitHub issue template. Please do not delete the issue template unless you are certain your
 issue is outside its scope.
 
-## Feature Requests
+### Feature Requests
 
 Feature requests typically go through the following lifecycle:
 

--- a/ISSUE_POLICY.md
+++ b/ISSUE_POLICY.md
@@ -25,5 +25,6 @@ Feature requests typically go through the following lifecycle:
 
 1. Submit feature request on GitHub issues containing a high-level description of the proposal and its motivation.
    We encourage requesters to provide an overview of the feature's implementation as well, if possible.
-2. Discuss feature request with a committer, who will provide input on the implementation overview or ask for a more detailed design, if applicable.
+2. Discuss feature request with a committer. The committer will provide input on the implementation overview or 
+   ask for a more detailed design, if applicable.
 3. After discussion & agreement on feature request, start implementation.

--- a/ISSUE_POLICY.md
+++ b/ISSUE_POLICY.md
@@ -23,8 +23,39 @@ issue is outside its scope.
 
 Feature requests typically go through the following lifecycle:
 
-1. Submit feature request on GitHub issues containing a high-level description of the proposal and its motivation.
+1. A feature request GitHub Issue is submitted, which contains a high-level description of the proposal and its motivation.
    We encourage requesters to provide an overview of the feature's implementation as well, if possible.
-2. Discuss feature request with a committer. The committer will provide input on the implementation overview or 
+2. The feature request is discussed with a committer. The committer will provide input on the implementation overview or 
    ask for a more detailed design, if applicable.
-3. After discussion & agreement on feature request, start implementation.
+3. After discussion & agreement on the feature request and its implementation, an implementation owner is identified.
+4. The implementation owner begins developing the feature and ultimately files associated pull requests.
+
+### Bug reports 
+
+Bug reports typically go through the following lifecycle:
+
+1. A bug report GitHub Issue is submitted, which contains a high-level description of the bug and information required to reproduce it.
+2. An MLflow committer reproduces the bug and provides feedback about how to implement a fix.
+3. After an approach has been agreed upon, an owner for the fix is identified. MLflow committers may choose to adopt
+   ownership of severe bugs to ensure a timely fix.
+4. The fix owner begins implementing the fix and ultimately files associated pull requests.
+
+### Documentation fixes
+
+Documentation issues typically go through the following lifecycle:
+
+1. A documentation GitHub Issue is submitted, which contains a description of the issue and its location(s) in the MLflow documentation.
+2. An MLflow committer confirms the documentation issue and provides feedback about how to implement a fix.
+3. After an approach has been agreed upon, an owner for the fix is identified. MLflow committers may choose to adopt
+   ownership of severe documentation issues to ensure a timely fix.
+4. The fix owner begins implementing the fix and ultimately files associated pull requests.
+
+### Installation fixes
+
+Installation issues typically go through the following lifecycle:
+
+1. An installation GitHub Issue is submitted, which contains a description of the issue and the platforms its affects.
+2. An MLflow committer confirms the installation issue and provides feedback about how to implement a fix.
+3. After an approach has been agreed upon, an owner for the fix is identified. MLflow committers may choose to adopt
+   ownership of severe installation issues to ensure a timely fix.
+4. The fix owner begins implementing the fix and ultimately files associated pull requests.

--- a/ISSUE_POLICY.md
+++ b/ISSUE_POLICY.md
@@ -3,7 +3,7 @@ The MLflow Issue Policy outlines the categories of MLflow GitHub issues and disc
 associated with each type of issue.
 
 Before filing an issue, make sure to [search for related issues](https://github.com/mlflow/mlflow/issues) and check if
-they address yours. 
+they address yours.
 
 For support (ex. "How do I do X?"), please ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
 
@@ -11,9 +11,9 @@ For support (ex. "How do I do X?"), please ask on [Stack Overflow](https://stack
 
 Our policy is that GitHub issues fall into one of the following categories:
 
-1. Bug reports
-2. Documentation fixes
-3. Feature requests
+1. Feature Requests
+2. Bug reports
+3. Documentation fixes
 4. Installation issues
 
 Each category has its own GitHub issue template. Please do not delete the issue template unless you are certain your
@@ -25,12 +25,12 @@ Feature requests typically go through the following lifecycle:
 
 1. A feature request GitHub Issue is submitted, which contains a high-level description of the proposal and its motivation.
    We encourage requesters to provide an overview of the feature's implementation as well, if possible.
-2. The feature request is discussed with a committer. The committer will provide input on the implementation overview or 
+2. The feature request is discussed with a committer. The committer will provide input on the implementation overview or
    ask for a more detailed design, if applicable.
 3. After discussion & agreement on the feature request and its implementation, an implementation owner is identified.
 4. The implementation owner begins developing the feature and ultimately files associated pull requests.
 
-### Bug reports 
+### Bug reports
 
 Bug reports typically go through the following lifecycle:
 
@@ -50,7 +50,7 @@ Documentation issues typically go through the following lifecycle:
    ownership of severe documentation issues to ensure a timely fix.
 4. The fix owner begins implementing the fix and ultimately files associated pull requests.
 
-### Installation fixes
+### Installation issues
 
 Installation issues typically go through the following lifecycle:
 

--- a/ISSUE_POLICY.md
+++ b/ISSUE_POLICY.md
@@ -1,10 +1,27 @@
+# Issue Policy
+The MLflow Issue Policy outlines the categories of MLflow GitHub issues and discusses the guidelines & processes
+associated with each type of issue.
+
 Before filing an issue, make sure to [search for related issues](https://github.com/mlflow/mlflow/issues) and check if
 they address yours. 
 
 For support (ex. "How do I do X?"), please ask on [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
 
+Our policy is that GitHub issues fall into one of the following categories:
 
-Our policy is that GitHub issues are
-for bug reports, documentation fixes, feature requests, 
-and installation issues. Please do not delete the issue template placeholder unless you are certain your
+1. Bug reports
+2. Documentation fixes
+3. Feature requests
+4. Installation issues
+
+Each category has its own GitHub issue template. Please do not delete the issue template unless you are certain your
 issue is outside its scope.
+
+## Feature Requests
+
+Feature requests typically go through the following lifecycle:
+
+1. Submit feature request on GitHub issues containing a high-level description of the proposal and its motivation.
+   We encourage requesters to provide an overview of the feature's implementation as well, if possible.
+2. Discuss feature request with a committer, who will provide input on the implementation overview or ask for a more detailed design, if applicable.
+3. After discussion & agreement on feature request, start implementation.


### PR DESCRIPTION
## What changes are proposed in this pull request?

* Revamp "feature request" template to prompt filers for specific motivation questions and high-level implementation details (if possible)
* Revamp Issue Policy to address the lifecycle for each issue type
* Add "Willingness to contribute" sections to the feature request, bug report, and documentation fix templates

## How is this patch tested?

Manually - I recommend viewing the associated files in a markdown renderer (e.g., open the file in the GitHub file browser).

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
