### PR TITLE
Onnx.predict handles list response

### DIFF
--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -175,9 +175,8 @@ class _OnnxModelWrapper:
         def format_output(data):
             # Output can be list and it should be converted to a numpy array
             # https://github.com/mlflow/mlflow/issues/2499
-            if isinstance(data, list):
-                data = np.asarray(data)
-            return data
+            data = np.asarray(data)
+            return data.reshape(-1)
         response = pd.DataFrame.from_dict({c: format_output(p)
                                            for (c, p) in zip(self.output_names, predicted)})
         return response

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -178,7 +178,8 @@ class _OnnxModelWrapper:
             if isinstance(data, list):
                 data = np.asarray(data)
             return data
-        response = pd.DataFrame.from_dict({c: format_output(p) for (c, p) in zip(self.output_names, predicted)})
+        response = pd.DataFrame.from_dict({c: format_output(p)
+                                           for (c, p) in zip(self.output_names, predicted)})
         return response
 
 

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -170,10 +170,16 @@ class _OnnxModelWrapper:
             }
         else:
             feed_dict = {self.inputs[0][0]: dataframe.values}
-
         predicted = self.rt.run(self.output_names, feed_dict)
-        return pd.DataFrame.from_dict(
-            {c: p.reshape(-1) for (c, p) in zip(self.output_names, predicted)})
+
+        def format_output(data):
+            # Output can be list and it should be converted to a numpy array
+            # https://github.com/mlflow/mlflow/issues/2499
+            if isinstance(data, list):
+                data = np.asarray(data)
+            return data
+        response = pd.DataFrame.from_dict({c: format_output(p) for (c, p) in zip(self.output_names, predicted)})
+        return response
 
 
 def _load_pyfunc(path):

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -77,6 +77,7 @@ def onnx_sklearn_model(sklearn_model):
 def predicted(model, data):
     return model.predict(data[0])
 
+
 @pytest.fixture(scope='module')
 def tf_model_multiple_inputs_float64():
     graph = tf.Graph()
@@ -443,15 +444,16 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 
     assert conda_env == mlflow.onnx.get_default_conda_env()
 
-"""
-https://github.com/mlflow/mlflow/issues/2499
-User encountered issue where an sklearn model, converted to onnx, would return a list response. The issue 
-resulted in an error because MLflow assumed it would be a numpy array. Therefore, the this test validates
-the service does not receive that error when using such a model.
-"""
+
 @pytest.mark.large
 def test_OnnxModelWrapper_predit_handles_list_output(onnx_sklearn_model,  model_path, data):
-    x,y = data
+    """
+    https://github.com/mlflow/mlflow/issues/2499
+    User encountered issue where an sklearn model, converted to onnx, would return a list response.
+    The issue resulted in an error because MLflow assumed it would be a numpy array. Therefore,
+    the this test validates the service does not receive that error when using such a model.
+    """
+    x, y = data
     mlflow.onnx.save_model(onnx_sklearn_model, model_path)
     wrapper = mlflow.onnx._OnnxModelWrapper(model_path + '/model.onnx')
     wrapper.predict(pd.DataFrame(x))

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -453,6 +453,7 @@ def test_pyfunc_predict_supports_models_with_list_outputs(onnx_sklearn_model,  m
     The issue resulted in an error because MLflow assumed it would be a numpy array. Therefore,
     the this test validates the service does not receive that error when using such a model.
     """
+    import mlflow.onnx
     x, y = data
     mlflow.onnx.save_model(onnx_sklearn_model, model_path)
     wrapper = mlflow.pyfunc.load_model(model_path)

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -453,6 +453,7 @@ def test_pyfunc_predict_supports_models_with_list_outputs(onnx_sklearn_model,  m
     The issue resulted in an error because MLflow assumed it would be a numpy array. Therefore,
     the this test validates the service does not receive that error when using such a model.
     """
+    import onnx
     import mlflow.onnx
     import skl2onnx
     x, y = data

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -8,7 +8,6 @@ import mock
 from keras.models import Sequential
 from keras.layers import Dense
 import sklearn.datasets as datasets
-from sklearn.linear_model import LogisticRegression
 import pandas as pd
 import numpy as np
 import yaml
@@ -57,6 +56,7 @@ def onnx_model(model):
 
 @pytest.fixture(scope='module')
 def sklearn_model(data):
+    from sklearn.linear_model import LogisticRegression
     x, y = data
     model = LogisticRegression()
     model.fit(x, y)

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -445,7 +445,8 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
     assert conda_env == mlflow.onnx.get_default_conda_env()
 
 
-@pytest.mark.large
+# TODO: Mark this as large once MLflow's Travis build supports the onnxruntime library
+@pytest.mark.release
 def test_pyfunc_predict_supports_models_with_list_outputs(onnx_sklearn_model,  model_path, data):
     """
     https://github.com/mlflow/mlflow/issues/2499

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -446,7 +446,7 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 
 
 @pytest.mark.large
-def test_OnnxModelWrapper_predit_handles_list_output(onnx_sklearn_model,  model_path, data):
+def test_pyfunc_predict_supports_models_with_list_outputs(onnx_sklearn_model,  model_path, data):
     """
     https://github.com/mlflow/mlflow/issues/2499
     User encountered issue where an sklearn model, converted to onnx, would return a list response.
@@ -455,5 +455,5 @@ def test_OnnxModelWrapper_predit_handles_list_output(onnx_sklearn_model,  model_
     """
     x, y = data
     mlflow.onnx.save_model(onnx_sklearn_model, model_path)
-    wrapper = mlflow.onnx._OnnxModelWrapper(model_path + '/model.onnx')
+    wrapper = mlflow.pyfunc.load_model(model_path)
     wrapper.predict(pd.DataFrame(x))

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -454,6 +454,7 @@ def test_pyfunc_predict_supports_models_with_list_outputs(onnx_sklearn_model,  m
     the this test validates the service does not receive that error when using such a model.
     """
     import mlflow.onnx
+    import skl2onnx
     x, y = data
     mlflow.onnx.save_model(onnx_sklearn_model, model_path)
     wrapper = mlflow.pyfunc.load_model(model_path)

--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -8,7 +8,7 @@ moto==1.3.7
 h2o==3.22.1.4
 onnx==1.4.1;
 onnxmltools==1.4.0;
-onnxruntime==1.2.0;
+onnxruntime==0.3.0;
 mleap==0.8.1
 mxnet==1.5.0
 pandas<=0.23.4

--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -8,7 +8,7 @@ moto==1.3.7
 h2o==3.22.1.4
 onnx==1.4.1;
 onnxmltools==1.4.0;
-onnxruntime==0.3.0;
+onnxruntime==1.2.0;
 mleap==0.8.1
 mxnet==1.5.0
 pandas<=0.23.4


### PR DESCRIPTION
## What changes are proposed in this pull request?

MLflow assumes that an onnx model will return a numpy array. A user
discovered this is not the case and in fact, the model can return a
python list.

The result is that the service throws an error when it attempts to call
reshape() on a python list and that function does not exist.

The fix is to look convert a list to numpy array before calling reshaping it.

## How is this patch tested?

1. There is a new python.large test that validates that it works with an sklearn based onnx model.
2. I manually ran the mlflow model using `mlflow models -m models.onnx` and crafted a request to verify it works successfully. 

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] CLI
- [ ] API
- [ ] REST-API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] Serving
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
