### PR TITLE
Fix a typo in CLI help

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -78,7 +78,7 @@ def cli():
                    "at https://www.mlflow.org/docs/latest/projects.html.")
 @cli_args.NO_CONDA
 @click.option("--storage-dir", envvar="MLFLOW_TMP_DIR",
-              help="Only valid when ``backend`` is local."
+              help="Only valid when ``backend`` is local. "
                    "MLflow downloads artifacts from distributed URIs passed to parameters of "
                    "type 'path' to subdirectories of storage_dir.")
 @click.option("--run-id", metavar="RUN_ID",


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds a missing whitespace (after "Only valid when ``backend`` is local.") in the CLI help.

As of v1.8.0
```
$ mlflow run --help
...
  --storage-dir TEXT            Only valid when ``backend`` is local.MLflow
                                downloads artifacts from distributed URIs
                                passed to parameters of type 'path' to
                                subdirectories of storage_dir.
```

With this PR,

```
  --storage-dir TEXT            Only valid when ``backend`` is local. MLflow
                                downloads artifacts from distributed URIs
                                passed to parameters of type 'path' to
                                subdirectories of storage_dir.
```

## How is this patch tested?

Applied this PR locally, installed locally, and printed out the CLI help.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [x] Command Line Interface
- [ ] API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
