### PR TITLE
Parameterize Python Path for Entry Points

### DIFF
--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -99,7 +99,10 @@ class Project(object):
         if entry_point in self._entry_points:
             return self._entry_points[entry_point]
         _, file_extension = os.path.splitext(entry_point)
-        ext_to_cmd = {".py": "python", ".sh": os.environ.get("SHELL", "bash")}
+        ext_to_cmd = {
+            ".py": os.environ.get("PYTHON", "python3"),
+            ".sh": os.environ.get("SHELL", "bash"),
+        }
         if file_extension in ext_to_cmd:
             command = "%s %s" % (ext_to_cmd[file_extension], shlex_quote(entry_point))
             if not is_string_type(command):

--- a/tests/projects/test_project_spec.py
+++ b/tests/projects/test_project_spec.py
@@ -29,7 +29,7 @@ def test_project_get_unspecified_entry_point():
     project = load_project()
     entry_point = project.get_entry_point("my_script.py")
     assert entry_point.name == "my_script.py"
-    assert entry_point.command == "python my_script.py"
+    assert entry_point.command == "python3 my_script.py"
     assert entry_point.parameters == {}
     entry_point = project.get_entry_point("my_script.sh")
     assert entry_point.name == "my_script.sh"


### PR DESCRIPTION
## What changes are proposed in this pull request?

MLflow calls `python` when running `*.py` entry points. In most environments, `python` might be linked to a Python 2 installation, which is deprecated. Aliasing `python3` as `python` is discouraged as per PEP 394 (https://legacy.python.org/dev/peps/pep-0394). In this PR we change the command to be run from `python` to `python3`. We also allow an environment variable to define the path to a customized Python installation.

## How is this patch tested?

Unit tests have been updated.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Parameterize Python command used to run entry points.

### What component(s) does this PR affect?

- [ ] UI
- [X] Command Line Interface
- [ ] API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [X] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
