### PR TITLE
Update ftp_artifact_repo.py

### DIFF
--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -1,3 +1,12 @@
+############# Summary of edit ################
+# Fixes FTP bug, when you use FTP server for artifact storage
+# example: https://github.com/mlflow/mlflow/issues/2677
+# Artifact path has a leading '/' when making directory and 
+# changing into the newly created dir.
+# Edits are on line 60 and 85 of this code.
+# Rahul Raj - 2020-04-28
+##############################################
+
 import os
 import ftplib
 from ftplib import FTP
@@ -49,6 +58,10 @@ class FTPArtifactRepository(ArtifactRepository):
 
     @staticmethod
     def _mkdir(ftp, artifact_dir):
+        ########### Begin Edit ##############
+        if len(artifact_dir) > 1 and artifact_dir[0] in ['/', '\\']:
+            artifact_dir = artifact_dir[1:]        
+        ########### End Edit ##############
         try:
             if not FTPArtifactRepository._is_dir(ftp, artifact_dir):
                 ftp.mkd(artifact_dir)
@@ -70,6 +83,10 @@ class FTPArtifactRepository(ArtifactRepository):
                 if artifact_path else self.path
             self._mkdir(ftp, artifact_dir)
             with open(local_file, 'rb') as f:
+                ########### Begin Edit ##############
+                if len(artifact_dir) > 1 and artifact_dir[0] in ['/', '\\']:
+                    artifact_dir = artifact_dir[1:]        
+                ########### End Edit ##############
                 ftp.cwd(artifact_dir)
                 ftp.storbinary('STOR ' + os.path.basename(local_file), f)
 

--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -1,12 +1,3 @@
-############# Summary of edit ################
-# Fixes FTP bug, when you use FTP server for artifact storage
-# example: https://github.com/mlflow/mlflow/issues/2677
-# Artifact path has a leading '/' when making directory and 
-# changing into the newly created dir.
-# Edits are on line 60 and 85 of this code.
-# Rahul Raj - 2020-04-28
-##############################################
-
 import os
 import ftplib
 from ftplib import FTP
@@ -58,10 +49,8 @@ class FTPArtifactRepository(ArtifactRepository):
 
     @staticmethod
     def _mkdir(ftp, artifact_dir):
-        ########### Begin Edit ##############
         if len(artifact_dir) > 1 and artifact_dir[0] in ['/', '\\']:
             artifact_dir = artifact_dir[1:]        
-        ########### End Edit ##############
         try:
             if not FTPArtifactRepository._is_dir(ftp, artifact_dir):
                 ftp.mkd(artifact_dir)
@@ -83,10 +72,8 @@ class FTPArtifactRepository(ArtifactRepository):
                 if artifact_path else self.path
             self._mkdir(ftp, artifact_dir)
             with open(local_file, 'rb') as f:
-                ########### Begin Edit ##############
                 if len(artifact_dir) > 1 and artifact_dir[0] in ['/', '\\']:
                     artifact_dir = artifact_dir[1:]        
-                ########### End Edit ##############
                 ftp.cwd(artifact_dir)
                 ftp.storbinary('STOR ' + os.path.basename(local_file), f)
 

--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -50,7 +50,7 @@ class FTPArtifactRepository(ArtifactRepository):
     @staticmethod
     def _mkdir(ftp, artifact_dir):
         if len(artifact_dir) > 1 and artifact_dir[0] in ['/', '\\']:
-            artifact_dir = artifact_dir[1:]        
+            artifact_dir = artifact_dir[1:]
         try:
             if not FTPArtifactRepository._is_dir(ftp, artifact_dir):
                 ftp.mkd(artifact_dir)
@@ -73,7 +73,7 @@ class FTPArtifactRepository(ArtifactRepository):
             self._mkdir(ftp, artifact_dir)
             with open(local_file, 'rb') as f:
                 if len(artifact_dir) > 1 and artifact_dir[0] in ['/', '\\']:
-                    artifact_dir = artifact_dir[1:]        
+                    artifact_dir = artifact_dir[1:]
                 ftp.cwd(artifact_dir)
                 ftp.storbinary('STOR ' + os.path.basename(local_file), f)
 


### PR DESCRIPTION
- Fixes FTP bug, when you use FTP server for artifact storage
- example: https://github.com/mlflow/mlflow/issues/2677 (I had a similar environment)
- Artifact path has a leading '/' when making directory and changing into the newly created dir.
- Edits are on line 60 and 85 of this code.
- Rahul Raj - 2020-04-28

## What changes are proposed in this pull request?
Fix FTP path issues. Remove leading / from folder being created from artifacts.

(Please fill in changes proposed in this fix)

## How is this patch tested?
(Not sure, first PR)
Edited code on my pip installed mlflow file.

(Details)

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [X] Command Line Interface
- [ ] API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [X] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
