### PR TITLE
Add `--ignore-flavors` option for pytest to simplify test command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ matrix:
         - pip install -r travis/small-requirements.txt
         - pip install -e .
       script:
-        - pytest --verbose --ignore=tests/h2o --ignore=tests/keras --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn  --ignore=tests/spark --ignore=tests/tensorflow --ignore=tests/keras_autolog --ignore=tests/tensorflow_autolog --ignore tests/azureml --ignore tests/onnx --ignore tests/projects --ignore=tests/xgboost --ignore=tests/lightgbm --ignore=tests/spark_autologging --ignore=tests/spacy --ignore=tests/fastai tests
+        - pytest --verbose --ignore-flavors tests
 
     - language: python
       python: 3.6
@@ -98,18 +98,17 @@ matrix:
         - make rsthtml SPHINXOPTS="-W --keep-going" # Interpret Sphinx warnings as errors via the `-W` flag
         - make javadocs
 
-
 # Travis runs an extra top-level job for each build stage - depending on the build stage, we either
 # run small or large Python tests below.
 install:
   - echo "Build stage $TRAVIS_BUILD_STAGE_NAME";
   - CHANGED_FILES=$(git diff --name-only master..HEAD | grep "tests/examples\|examples") || true;
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-      echo "skipping this step on windows.";
+    echo "skipping this step on windows.";
     elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "Nightly" ]] && ! [[ "$TRAVIS_EVENT_TYPE" == "cron" || ! -z "$CHANGED_FILES" ]]; then
-      echo "skipping the nightly stage because this build is not nightly and there are no changed files associated with nightly tests.";
+    echo "skipping the nightly stage because this build is not nightly and there are no changed files associated with nightly tests.";
     else
-      INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh;
+    INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh;
     fi;
 
 script:
@@ -121,14 +120,15 @@ notifications:
   # https://docs.travis-ci.com/user/notifications/#changing-notification-frequency for more info.
   email:
     recipients:
-    - secure: "UFN6LLWRASxILSKY/hD5ugxP78Bhuq58X4H0ar6BnNl6SS70bhJFbJFuvkWBoLHAhydV876h2nBZLfTUCvf3\
-      RyOz4nvkGfRaFH3ZUnseSZSSXydFOixYjk+byDy7sjzjTKuqtQu2WKqZxT8cdtP2lWc7y/LPlLBR4cYKjQZZZWIGKef/Q\
-      JuHp50HwLq3LKqAsg9EpukBqkfxncDItvr2Fis9krRgc288BZkwQh+G5S9WNFY1Bu7G60bzfbOJJYTV3TQPnPpaMh+IsG\
-      0G+xC/gZV7bEPDHEIUFRDnnXK9msvhu55plkOnAbHWnAYiZruVWpmIj76wayjEafOiTKp8G6lVtfDZdQ+cX4c8pN4Lq37\
-      wolvZ+ZuxMt51D03iUQ5aWi0TXyV6ZMnB7r3k0yWlLr7faHt1b1bvtAPVasKKUHHjvoc0ehz+K2oaJ/my275L+gytZs6b\
-      nLUZQ0Qclcsv/Z5szquf5HwV76WKIy+nMceGYtmMwHMbQv0Z+CEGYqdeD/PwMT7HQc/NwsOQ2CL/WNRqI/7E7EZHY+8Xp\
-      anyvXFez3SsalJ8xJM7kmH2zAAHKciZQMin9ND7kWaqYOdhpPxhWcqUtyAI7N4YMKrnUap2H9OOLeKDyzhR/m9D9w5DoQ\
-      MotE8n5J3OtQQ8Yl304J/uR2QX4YwulMQKr/BmrQs="
+      - secure:
+          "UFN6LLWRASxILSKY/hD5ugxP78Bhuq58X4H0ar6BnNl6SS70bhJFbJFuvkWBoLHAhydV876h2nBZLfTUCvf3\
+          RyOz4nvkGfRaFH3ZUnseSZSSXydFOixYjk+byDy7sjzjTKuqtQu2WKqZxT8cdtP2lWc7y/LPlLBR4cYKjQZZZWIGKef/Q\
+          JuHp50HwLq3LKqAsg9EpukBqkfxncDItvr2Fis9krRgc288BZkwQh+G5S9WNFY1Bu7G60bzfbOJJYTV3TQPnPpaMh+IsG\
+          0G+xC/gZV7bEPDHEIUFRDnnXK9msvhu55plkOnAbHWnAYiZruVWpmIj76wayjEafOiTKp8G6lVtfDZdQ+cX4c8pN4Lq37\
+          wolvZ+ZuxMt51D03iUQ5aWi0TXyV6ZMnB7r3k0yWlLr7faHt1b1bvtAPVasKKUHHjvoc0ehz+K2oaJ/my275L+gytZs6b\
+          nLUZQ0Qclcsv/Z5szquf5HwV76WKIy+nMceGYtmMwHMbQv0Z+CEGYqdeD/PwMT7HQc/NwsOQ2CL/WNRqI/7E7EZHY+8Xp\
+          anyvXFez3SsalJ8xJM7kmH2zAAHKciZQMin9ND7kWaqYOdhpPxhWcqUtyAI7N4YMKrnUap2H9OOLeKDyzhR/m9D9w5DoQ\
+          MotE8n5J3OtQQ8Yl304J/uR2QX4YwulMQKr/BmrQs="
     on_success: "never"
     on_failure: "always"
 # TODO(sid): Reenable Slack notifications on build failures once we've de-noised them

--- a/.travis.yml
+++ b/.travis.yml
@@ -98,17 +98,18 @@ matrix:
         - make rsthtml SPHINXOPTS="-W --keep-going" # Interpret Sphinx warnings as errors via the `-W` flag
         - make javadocs
 
+
 # Travis runs an extra top-level job for each build stage - depending on the build stage, we either
 # run small or large Python tests below.
 install:
   - echo "Build stage $TRAVIS_BUILD_STAGE_NAME";
   - CHANGED_FILES=$(git diff --name-only master..HEAD | grep "tests/examples\|examples") || true;
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-    echo "skipping this step on windows.";
+      echo "skipping this step on windows.";
     elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "Nightly" ]] && ! [[ "$TRAVIS_EVENT_TYPE" == "cron" || ! -z "$CHANGED_FILES" ]]; then
-    echo "skipping the nightly stage because this build is not nightly and there are no changed files associated with nightly tests.";
+      echo "skipping the nightly stage because this build is not nightly and there are no changed files associated with nightly tests.";
     else
-    INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh;
+      INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh;
     fi;
 
 script:
@@ -120,15 +121,14 @@ notifications:
   # https://docs.travis-ci.com/user/notifications/#changing-notification-frequency for more info.
   email:
     recipients:
-      - secure:
-          "UFN6LLWRASxILSKY/hD5ugxP78Bhuq58X4H0ar6BnNl6SS70bhJFbJFuvkWBoLHAhydV876h2nBZLfTUCvf3\
-          RyOz4nvkGfRaFH3ZUnseSZSSXydFOixYjk+byDy7sjzjTKuqtQu2WKqZxT8cdtP2lWc7y/LPlLBR4cYKjQZZZWIGKef/Q\
-          JuHp50HwLq3LKqAsg9EpukBqkfxncDItvr2Fis9krRgc288BZkwQh+G5S9WNFY1Bu7G60bzfbOJJYTV3TQPnPpaMh+IsG\
-          0G+xC/gZV7bEPDHEIUFRDnnXK9msvhu55plkOnAbHWnAYiZruVWpmIj76wayjEafOiTKp8G6lVtfDZdQ+cX4c8pN4Lq37\
-          wolvZ+ZuxMt51D03iUQ5aWi0TXyV6ZMnB7r3k0yWlLr7faHt1b1bvtAPVasKKUHHjvoc0ehz+K2oaJ/my275L+gytZs6b\
-          nLUZQ0Qclcsv/Z5szquf5HwV76WKIy+nMceGYtmMwHMbQv0Z+CEGYqdeD/PwMT7HQc/NwsOQ2CL/WNRqI/7E7EZHY+8Xp\
-          anyvXFez3SsalJ8xJM7kmH2zAAHKciZQMin9ND7kWaqYOdhpPxhWcqUtyAI7N4YMKrnUap2H9OOLeKDyzhR/m9D9w5DoQ\
-          MotE8n5J3OtQQ8Yl304J/uR2QX4YwulMQKr/BmrQs="
+    - secure: "UFN6LLWRASxILSKY/hD5ugxP78Bhuq58X4H0ar6BnNl6SS70bhJFbJFuvkWBoLHAhydV876h2nBZLfTUCvf3\
+      RyOz4nvkGfRaFH3ZUnseSZSSXydFOixYjk+byDy7sjzjTKuqtQu2WKqZxT8cdtP2lWc7y/LPlLBR4cYKjQZZZWIGKef/Q\
+      JuHp50HwLq3LKqAsg9EpukBqkfxncDItvr2Fis9krRgc288BZkwQh+G5S9WNFY1Bu7G60bzfbOJJYTV3TQPnPpaMh+IsG\
+      0G+xC/gZV7bEPDHEIUFRDnnXK9msvhu55plkOnAbHWnAYiZruVWpmIj76wayjEafOiTKp8G6lVtfDZdQ+cX4c8pN4Lq37\
+      wolvZ+ZuxMt51D03iUQ5aWi0TXyV6ZMnB7r3k0yWlLr7faHt1b1bvtAPVasKKUHHjvoc0ehz+K2oaJ/my275L+gytZs6b\
+      nLUZQ0Qclcsv/Z5szquf5HwV76WKIy+nMceGYtmMwHMbQv0Z+CEGYqdeD/PwMT7HQc/NwsOQ2CL/WNRqI/7E7EZHY+8Xp\
+      anyvXFez3SsalJ8xJM7kmH2zAAHKciZQMin9ND7kWaqYOdhpPxhWcqUtyAI7N4YMKrnUap2H9OOLeKDyzhR/m9D9w5DoQ\
+      MotE8n5J3OtQQ8Yl304J/uR2QX4YwulMQKr/BmrQs="
     on_success: "never"
     on_failure: "always"
 # TODO(sid): Reenable Slack notifications on build failures once we've de-noised them

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ matrix:
         - pip install -r travis/small-requirements.txt
         - pip install -e .
       script:
-        - pytest --verbose --ignore-flavors tests
+        - pytest --verbose --ignore-flavors --ignore=tests/projects tests
 
     - language: python
       python: 3.6
@@ -98,18 +98,17 @@ matrix:
         - make rsthtml SPHINXOPTS="-W --keep-going" # Interpret Sphinx warnings as errors via the `-W` flag
         - make javadocs
 
-
 # Travis runs an extra top-level job for each build stage - depending on the build stage, we either
 # run small or large Python tests below.
 install:
   - echo "Build stage $TRAVIS_BUILD_STAGE_NAME";
   - CHANGED_FILES=$(git diff --name-only master..HEAD | grep "tests/examples\|examples") || true;
   - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-      echo "skipping this step on windows.";
+    echo "skipping this step on windows.";
     elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "Nightly" ]] && ! [[ "$TRAVIS_EVENT_TYPE" == "cron" || ! -z "$CHANGED_FILES" ]]; then
-      echo "skipping the nightly stage because this build is not nightly and there are no changed files associated with nightly tests.";
+    echo "skipping the nightly stage because this build is not nightly and there are no changed files associated with nightly tests.";
     else
-      INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh;
+    INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh;
     fi;
 
 script:
@@ -121,14 +120,15 @@ notifications:
   # https://docs.travis-ci.com/user/notifications/#changing-notification-frequency for more info.
   email:
     recipients:
-    - secure: "UFN6LLWRASxILSKY/hD5ugxP78Bhuq58X4H0ar6BnNl6SS70bhJFbJFuvkWBoLHAhydV876h2nBZLfTUCvf3\
-      RyOz4nvkGfRaFH3ZUnseSZSSXydFOixYjk+byDy7sjzjTKuqtQu2WKqZxT8cdtP2lWc7y/LPlLBR4cYKjQZZZWIGKef/Q\
-      JuHp50HwLq3LKqAsg9EpukBqkfxncDItvr2Fis9krRgc288BZkwQh+G5S9WNFY1Bu7G60bzfbOJJYTV3TQPnPpaMh+IsG\
-      0G+xC/gZV7bEPDHEIUFRDnnXK9msvhu55plkOnAbHWnAYiZruVWpmIj76wayjEafOiTKp8G6lVtfDZdQ+cX4c8pN4Lq37\
-      wolvZ+ZuxMt51D03iUQ5aWi0TXyV6ZMnB7r3k0yWlLr7faHt1b1bvtAPVasKKUHHjvoc0ehz+K2oaJ/my275L+gytZs6b\
-      nLUZQ0Qclcsv/Z5szquf5HwV76WKIy+nMceGYtmMwHMbQv0Z+CEGYqdeD/PwMT7HQc/NwsOQ2CL/WNRqI/7E7EZHY+8Xp\
-      anyvXFez3SsalJ8xJM7kmH2zAAHKciZQMin9ND7kWaqYOdhpPxhWcqUtyAI7N4YMKrnUap2H9OOLeKDyzhR/m9D9w5DoQ\
-      MotE8n5J3OtQQ8Yl304J/uR2QX4YwulMQKr/BmrQs="
+      - secure:
+          "UFN6LLWRASxILSKY/hD5ugxP78Bhuq58X4H0ar6BnNl6SS70bhJFbJFuvkWBoLHAhydV876h2nBZLfTUCvf3\
+          RyOz4nvkGfRaFH3ZUnseSZSSXydFOixYjk+byDy7sjzjTKuqtQu2WKqZxT8cdtP2lWc7y/LPlLBR4cYKjQZZZWIGKef/Q\
+          JuHp50HwLq3LKqAsg9EpukBqkfxncDItvr2Fis9krRgc288BZkwQh+G5S9WNFY1Bu7G60bzfbOJJYTV3TQPnPpaMh+IsG\
+          0G+xC/gZV7bEPDHEIUFRDnnXK9msvhu55plkOnAbHWnAYiZruVWpmIj76wayjEafOiTKp8G6lVtfDZdQ+cX4c8pN4Lq37\
+          wolvZ+ZuxMt51D03iUQ5aWi0TXyV6ZMnB7r3k0yWlLr7faHt1b1bvtAPVasKKUHHjvoc0ehz+K2oaJ/my275L+gytZs6b\
+          nLUZQ0Qclcsv/Z5szquf5HwV76WKIy+nMceGYtmMwHMbQv0Z+CEGYqdeD/PwMT7HQc/NwsOQ2CL/WNRqI/7E7EZHY+8Xp\
+          anyvXFez3SsalJ8xJM7kmH2zAAHKciZQMin9ND7kWaqYOdhpPxhWcqUtyAI7N4YMKrnUap2H9OOLeKDyzhR/m9D9w5DoQ\
+          MotE8n5J3OtQQ8Yl304J/uR2QX4YwulMQKr/BmrQs="
     on_success: "never"
     on_failure: "always"
 # TODO(sid): Reenable Slack notifications on build failures once we've de-noised them

--- a/conftest.py
+++ b/conftest.py
@@ -62,6 +62,7 @@ def pytest_ignore_collect(path, config):
         ]
 
         relpath = os.path.relpath(str(path))
+        print(relpath)
 
         if relpath in model_flavors:
             outcome.force_result(True)

--- a/conftest.py
+++ b/conftest.py
@@ -36,7 +36,7 @@ def pytest_ignore_collect(path, config):
     relpath = os.path.relpath(str(path), config.rootdir)
     ignore = config.getoption("--ignore")
 
-    if relpath in ignore:
+    if ignore is not None and relpath in ignore:
         return True
 
     if not config.getoption("--ignore-flavors"):

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,6 @@
+import os
+
+
 def pytest_addoption(parser):
     parser.addoption('--large-only', action='store_true', dest="large_only",
                      default=False, help="Run only tests decorated with 'large' annotation")
@@ -9,6 +12,8 @@ def pytest_addoption(parser):
                      default=False, help="Run tests decorated with 'requires_ssh' annotation. "
                                          "These tests require keys to be configured locally "
                                          "for SSH authentication.")
+    parser.addoption("--ignore-flavors", action='store_true', dest="ignore_flavors",
+                     default=False, help="Ignore tests for model flavors.")
 
 
 def pytest_configure(config):
@@ -25,3 +30,35 @@ def pytest_configure(config):
         markexpr.append('not requires_ssh')
     if len(markexpr) > 0:
         setattr(config.option, 'markexpr', " and ".join(markexpr))
+
+
+def pytest_ignore_collect(path, config):
+    if not config.getoption("--ignore-flavors"):
+        return False
+
+    flavors_to_ignore = [
+        "tests/examples",
+        "tests/h2o",
+        "tests/keras",
+        "tests/pytorch",
+        "tests/pyfunc",
+        "tests/sagemaker",
+        "tests/sklearn",
+        "tests/spark",
+        "tests/tensorflow",
+        "tests/azureml",
+        "tests/onnx",
+        "tests/keras_autolog",
+        "tests/tensorflow_autolog",
+        "tests/gluon",
+        "tests/gluon_autolog",
+        "tests/xgboost",
+        "tests/lightgbm",
+        "tests/spacy",
+        "tests/spark_autologging",
+        "tests/models",
+    ]
+
+    relpath = os.path.relpath(str(path), config.rootdir)
+
+    return relpath in flavors_to_ignore

--- a/conftest.py
+++ b/conftest.py
@@ -58,6 +58,7 @@ def pytest_ignore_collect(path, config):
             "tests/lightgbm",
             "tests/spacy",
             "tests/spark_autologging",
+            "tests/fastai",
         ]
 
         relpath = os.path.relpath(str(path), config.rootdir)

--- a/conftest.py
+++ b/conftest.py
@@ -61,7 +61,7 @@ def pytest_ignore_collect(path, config):
             "tests/fastai",
         ]
 
-        relpath = os.path.relpath(str(path), config.rootdir)
+        relpath = os.path.relpath(str(path))
 
         if relpath in model_flavors:
             outcome.force_result(True)

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,5 @@
 import os
+import posixpath
 import pytest
 
 
@@ -62,7 +63,7 @@ def pytest_ignore_collect(path, config):
         ]
 
         relpath = os.path.relpath(str(path))
-        print(relpath)
+        relpath = relpath.replace(os.sep, posixpath.sep)  # for Windows
 
         if relpath in model_flavors:
             outcome.force_result(True)

--- a/conftest.py
+++ b/conftest.py
@@ -37,7 +37,6 @@ def pytest_ignore_collect(path, config):
         return False
 
     flavors_to_ignore = [
-        "tests/examples",
         "tests/h2o",
         "tests/keras",
         "tests/pytorch",
@@ -56,7 +55,6 @@ def pytest_ignore_collect(path, config):
         "tests/lightgbm",
         "tests/spacy",
         "tests/spark_autologging",
-        "tests/models",
     ]
 
     relpath = os.path.relpath(str(path), config.rootdir)

--- a/conftest.py
+++ b/conftest.py
@@ -33,6 +33,12 @@ def pytest_configure(config):
 
 
 def pytest_ignore_collect(path, config):
+    relpath = os.path.relpath(str(path), config.rootdir)
+    ignore = config.getoption("--ignore")
+
+    if relpath in ignore:
+        return True
+
     if not config.getoption("--ignore-flavors"):
         return False
 
@@ -56,7 +62,5 @@ def pytest_ignore_collect(path, config):
         "tests/spacy",
         "tests/spark_autologging",
     ]
-
-    relpath = os.path.relpath(str(path), config.rootdir)
 
     return relpath in flavors_to_ignore

--- a/travis/run-large-python-tests.sh
+++ b/travis/run-large-python-tests.sh
@@ -7,11 +7,6 @@ trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
 # NB: Also add --ignore'd tests to run-small-python-tests.sh
-pytest tests --large --ignore=tests/examples --ignore=tests/h2o --ignore=tests/keras \
-  --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn \
-  --ignore=tests/spark --ignore=tests/tensorflow --ignore=tests/azureml --ignore=tests/onnx \
-  --ignore=tests/keras_autolog --ignore=tests/tensorflow_autolog --ignore=tests/gluon \
-  --ignore=tests/gluon_autolog --ignore=tests/xgboost --ignore=tests/lightgbm \
-  --ignore=tests/spacy --ignore=tests/spark_autologging --ignore=tests/models
+pytest tests --large --ignore-flavors --ignore=tests/examples --ignore=tests/models
 
 test $err = 0

--- a/travis/run-small-python-tests.sh
+++ b/travis/run-small-python-tests.sh
@@ -7,10 +7,6 @@ trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
 # NB: Also add --ignore'd tests to run-large-python-tests.sh
-pytest --cov=mlflow --verbose --ignore=tests/h2o --ignore=tests/keras \
-  --ignore=tests/pytorch --ignore=tests/pyfunc --ignore=tests/sagemaker --ignore=tests/sklearn \
-  --ignore=tests/spark --ignore=tests/tensorflow --ignore=tests/keras_autolog \
-  --ignore=tests/tensorflow_autolog --ignore tests/azureml --ignore tests/onnx \
-  --ignore=tests/xgboost --ignore=tests/spacy --ignore=tests/lightgbm tests --ignore=tests/spark_autologging
+pytest --cov=mlflow --verbose --ignore-flavors
 
 test $err = 0


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add `--ignore-flavors` option for pytest to simplify the pytest command.

## How is this patch tested?

Manually verified:
- Tests for model flavors are ignored when `--ignore-flavors` is enabled.
- `--ignore` option works with `--ignore-flavors`.


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] Command Line Interface
- [ ] API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
