### PR TITLE
Fix tf.keras 1.X pyfunc prediction

### DIFF
--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -351,7 +351,6 @@ class _KerasModelWrapper:
         # In TensorFlow >= 2.0, we do not use a graph and session to predict
         else:
             predicted = pd.DataFrame(self.keras_model.predict(dataframe.values))
-        print(type(dataframe))
         predicted.index = dataframe.index
         return predicted
 

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -67,13 +67,10 @@ def get_default_conda_env(include_cloudpickle=False, keras_module=None):
     # The Keras pyfunc representation requires the TensorFlow
     # backend for Keras. Therefore, the conda environment must
     # include TensorFlow
-    if LooseVersion(tf.__version__) < LooseVersion('2.0.0'):
+    if LooseVersion(tf.__version__) <= LooseVersion('1.13.2'):
         conda_deps.append("tensorflow=={}".format(tf.__version__))
     else:
-        if pip_deps is not None:
-            pip_deps.append("tensorflow=={}".format(tf.__version__))
-        else:
-            pip_deps.append("tensorflow=={}".format(tf.__version__))
+        pip_deps.append("tensorflow=={}".format(tf.__version__))
 
     return _mlflow_conda_env(
         additional_conda_deps=conda_deps,

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -24,6 +24,8 @@ from mlflow import pyfunc
 from mlflow.models import Model
 import mlflow.tracking
 from mlflow.exceptions import MlflowException
+from mlflow.models.signature import ModelSignature
+from mlflow.models.utils import ModelInputExample
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -148,7 +150,6 @@ def save_model(keras_model, path, conda_env=None, mlflow_model=Model(), custom_o
             keras_module = importlib.import_module("keras")
         elif _is_tf_keras(keras_model):
             keras_module = importlib.import_module("tensorflow.keras")
-            print("ZZZZZZZZZZZZZZZZZZZ")
         else:
             raise MlflowException("Unable to infer keras module from the model, please specify "
                                   "which keras module ('keras' or 'tensorflow.keras') is to be "
@@ -212,7 +213,8 @@ def save_model(keras_model, path, conda_env=None, mlflow_model=Model(), custom_o
 
 
 def log_model(keras_model, artifact_path, conda_env=None, custom_objects=None, keras_module=None,
-              registered_model_name=None, **kwargs):
+              registered_model_name=None, signature: ModelSignature=None,
+              input_example: ModelInputExample=None, **kwargs):
     """
     Log a Keras model as an MLflow artifact for the current run.
 
@@ -245,10 +247,28 @@ def log_model(keras_model, artifact_path, conda_env=None, custom_objects=None, k
     :param keras_module: Keras module to be used to save / load the model
                          (``keras`` or ``tf.keras``). If not provided, MLflow will
                          attempt to infer the Keras module based on the given model.
-    :param registered_model_name: Note:: Experimental: This argument may change or be removed in a
-                                  future release without warning. If given, create a model
-                                  version under ``registered_model_name``, also creating a
-                                  registered model if one with the given name does not exist.
+    :param registered_model_name: (Experimental) If given, create a model version under
+                                  ``registered_model_name``, also creating a registered model if one
+                                  with the given name does not exist.
+
+    :param signature: (Experimental) :py:class:`ModelSignature <mlflow.models.ModelSignature>`
+                      describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
+                      The model signature can be :py:func:`inferred <mlflow.models.infer_signature>`
+                      from datasets with valid model input (e.g. the training dataset) and valid
+                      model output (e.g. model predictions generated on the training dataset),
+                      for example:
+
+                      .. code-block:: python
+
+                        from mlflow.models.signature import infer_signature
+                        train = df.drop_column("target_label")
+                        signature = infer_signature(train, model.predict(train))
+    :param input_example: (Experimental) Input example provides one or several instances of valid
+                          model input. The example can be used as a hint of what data to feed the
+                          model. The given example will be converted to a Pandas DataFrame and then
+                          serialized to json using the Pandas split-oriented format. Bytes are
+                          base64-encoded.
+
     :param kwargs: kwargs to pass to ``keras_model.save`` method.
 
     .. code-block:: python
@@ -267,7 +287,9 @@ def log_model(keras_model, artifact_path, conda_env=None, custom_objects=None, k
     """
     Model.log(artifact_path=artifact_path, flavor=mlflow.keras,
               keras_model=keras_model, conda_env=conda_env, custom_objects=custom_objects,
-              keras_module=keras_module, registered_model_name=registered_model_name, **kwargs)
+              keras_module=keras_module, registered_model_name=registered_model_name,
+              signature=signature, input_example=input_example,
+              **kwargs)
 
 
 def _save_custom_objects(path, custom_objects):
@@ -328,7 +350,7 @@ class _KerasModelWrapper:
                     predicted = pd.DataFrame(self.keras_model.predict(dataframe.values))
         # In TensorFlow >= 2.0, we do not use a graph and session to predict
         else:
-            predicted = pd.DataFrame(self.keras_model.predict(dataframe))
+            predicted = pd.DataFrame(self.keras_model.predict(dataframe.values))
         print(type(dataframe))
         predicted.index = dataframe.index
         return predicted

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -103,6 +103,8 @@ def pyfunc_serve_from_docker_image_with_env_override(image_name,
     on the host machine. Returns a handle (Popen object) to the server process.
     """
     env = dict(os.environ)
+    print("LOOK!")
+    print(env)
     env.update(LC_ALL="en_US.UTF-8", LANG="en_US.UTF-8")
     scoring_cmd = ['docker', 'run', "-e", "GUNICORN_CMD_ARGS=%s" % gunicorn_opts,
                    "-p", "%s:8080" % host_port, image_name]

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -103,8 +103,6 @@ def pyfunc_serve_from_docker_image_with_env_override(image_name,
     on the host machine. Returns a handle (Popen object) to the server process.
     """
     env = dict(os.environ)
-    print("LOOK!")
-    print(env)
     env.update(LC_ALL="en_US.UTF-8", LANG="en_US.UTF-8")
     scoring_cmd = ['docker', 'run', "-e", "GUNICORN_CMD_ARGS=%s" % gunicorn_opts,
                    "-p", "%s:8080" % host_port, image_name]

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -153,8 +153,8 @@ def test_that_keras_module_arg_works(model_path):
     def _import_module(name, **kwargs):
         if name.startswith(FakeKerasModule.__name__):
             return FakeKerasModule
-        else:
-            return importlib.import_module(name, **kwargs)
+        # else:
+        #     return importlib.import_module(name, **kwargs)
 
     with mock.patch("importlib.import_module") as import_module_mock:
         import_module_mock.side_effect = _import_module

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -150,11 +150,13 @@ def test_that_keras_module_arg_works(model_path):
         def load_model(file, **kwars):
             return MyModel(file.get("x").value)
 
+    original_import = importlib.import_module
+
     def _import_module(name, **kwargs):
         if name.startswith(FakeKerasModule.__name__):
             return FakeKerasModule
-        # else:
-        #     return importlib.import_module(name, **kwargs)
+        else:
+            return original_import(name, **kwargs)
 
     with mock.patch("importlib.import_module") as import_module_mock:
         import_module_mock.side_effect = _import_module

--- a/travis/run-python-tf-tests.sh
+++ b/travis/run-python-tf-tests.sh
@@ -6,6 +6,7 @@ err=0
 trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
+pytest --verbose tests/keras --large
 pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
 pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
 # TODO(smurching) Unpin TensorFlow dependency version once test failures with TF 2.1.0 have been

--- a/travis/run-python-tf-tests.sh
+++ b/travis/run-python-tf-tests.sh
@@ -6,6 +6,7 @@ err=0
 trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
+pip install 'tensorflow==1.15.2'
 pytest --verbose tests/keras --large
 pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
 pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large

--- a/travis/run-python-tf-tests.sh
+++ b/travis/run-python-tf-tests.sh
@@ -6,7 +6,6 @@ err=0
 trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
-pip install 'tensorflow==1.15.2'
 pytest --verbose tests/keras --large
 pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
 pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large


### PR DESCRIPTION
## What changes are proposed in this pull request?

Addresses https://github.com/mlflow/mlflow/issues/2552 as `pyfunc` input values were incorrectly typed (MLflow incorrectly passed a `pandas` dataframe to `keras`'s predict function).

Also enables `keras` tests on TF 1.X, fixing a couple of bugs that enable it to run.

## How is this patch tested?

Travis tests

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] Command Line Interface
- [ ] API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] R
- [ ] Java
- [X] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
