### PR TITLE
Add learning rate in XGBoost example and update readme for same

### DIFF
--- a/examples/xgboost/MLproject
+++ b/examples/xgboost/MLproject
@@ -8,6 +8,6 @@ entry_points:
       subsample: {type: float, default: 1.0}
     command: |
         python train.py \
-          --learning_rate={learning_rate} \
+          --learning-rate={learning_rate} \
           --colsample-bytree={colsample-bytree} \
           --subsample={subsample}

--- a/examples/xgboost/MLproject
+++ b/examples/xgboost/MLproject
@@ -8,6 +8,6 @@ entry_points:
       subsample: {type: float, default: 1.0}
     command: |
         python train.py \
-          --learning-rate={learning_rate} \
+          --learning-rate={learning-rate} \
           --colsample-bytree={colsample-bytree} \
           --subsample={subsample}

--- a/examples/xgboost/MLproject
+++ b/examples/xgboost/MLproject
@@ -3,9 +3,11 @@ conda_env: conda.yaml
 entry_points:
   main:
     parameters:
+      learning_rate: {type: float, default: 0.3}
       colsample-bytree: {type: float, default: 1.0}
       subsample: {type: float, default: 1.0}
     command: |
         python train.py \
+          --learning_rate={learning_rate} \
           --colsample-bytree={colsample-bytree} \
           --subsample={subsample}

--- a/examples/xgboost/MLproject
+++ b/examples/xgboost/MLproject
@@ -3,7 +3,7 @@ conda_env: conda.yaml
 entry_points:
   main:
     parameters:
-      learning_rate: {type: float, default: 0.3}
+      learning-rate: {type: float, default: 0.3}
       colsample-bytree: {type: float, default: 1.0}
       subsample: {type: float, default: 1.0}
     command: |

--- a/examples/xgboost/README.md
+++ b/examples/xgboost/README.md
@@ -7,7 +7,7 @@ This example trains an XGBoost classifier with the iris dataset and logs hyperpa
 ```
 python train.py --eta 0.2 --colsample-bytree 0.8 --subsample 0.9
 ```
-After that try experiments with different parameters like:
+You can try experimenting with different parameter values like:
 ```
 python train.py --eta 0.4 --colsample-bytree 0.7 --subsample 0.8
 ```

--- a/examples/xgboost/README.md
+++ b/examples/xgboost/README.md
@@ -5,8 +5,18 @@ This example trains an XGBoost classifier with the iris dataset and logs hyperpa
 ## Running the code
 
 ```
-python train.py --colsample-bytree 0.8 --subsample 0.9
+python train.py --eta 0.2 --colsample-bytree 0.8 --subsample 0.9
 ```
+After that try experiments with different parameters like:
+```
+python train.py --eta 0.4 --colsample-bytree 0.7 --subsample 0.8
+```
+
+Then you can open the mlflow ui to compare your logs and track the experiments by:
+```
+mflow ui
+```
+
 
 ## Running the code as a project
 

--- a/examples/xgboost/README.md
+++ b/examples/xgboost/README.md
@@ -14,7 +14,7 @@ python train.py --eta 0.4 --colsample-bytree 0.7 --subsample 0.8
 
 Then you can open the MLflow UI to track the experiments and compare your runs via:
 ```
-mflow ui
+mlflow ui
 ```
 
 

--- a/examples/xgboost/README.md
+++ b/examples/xgboost/README.md
@@ -5,11 +5,11 @@ This example trains an XGBoost classifier with the iris dataset and logs hyperpa
 ## Running the code
 
 ```
-python train.py --eta 0.2 --colsample-bytree 0.8 --subsample 0.9
+python train.py --learning_rate 0.2 --colsample-bytree 0.8 --subsample 0.9
 ```
 You can try experimenting with different parameter values like:
 ```
-python train.py --eta 0.4 --colsample-bytree 0.7 --subsample 0.8
+python train.py --learning_rate 0.4 --colsample-bytree 0.7 --subsample 0.8
 ```
 
 Then you can open the MLflow UI to track the experiments and compare your runs via:
@@ -21,5 +21,5 @@ mlflow ui
 ## Running the code as a project
 
 ```
-mlflow run . -P colsample-bytree=0.8 -P subsample=0.9
+mlflow run . -P learning_rate=0.2 -P colsample-bytree=0.8 -P subsample=0.9
 ```

--- a/examples/xgboost/README.md
+++ b/examples/xgboost/README.md
@@ -5,11 +5,11 @@ This example trains an XGBoost classifier with the iris dataset and logs hyperpa
 ## Running the code
 
 ```
-python train.py --learning_rate 0.2 --colsample-bytree 0.8 --subsample 0.9
+python train.py --learning-rate 0.2 --colsample-bytree 0.8 --subsample 0.9
 ```
 You can try experimenting with different parameter values like:
 ```
-python train.py --learning_rate 0.4 --colsample-bytree 0.7 --subsample 0.8
+python train.py --learning-rate 0.4 --colsample-bytree 0.7 --subsample 0.8
 ```
 
 Then you can open the MLflow UI to track the experiments and compare your runs via:
@@ -21,5 +21,5 @@ mlflow ui
 ## Running the code as a project
 
 ```
-mlflow run . -P learning_rate=0.2 -P colsample-bytree=0.8 -P subsample=0.9
+mlflow run . -P learning-rate=0.2 -P colsample-bytree=0.8 -P subsample=0.9
 ```

--- a/examples/xgboost/README.md
+++ b/examples/xgboost/README.md
@@ -12,7 +12,7 @@ You can try experimenting with different parameter values like:
 python train.py --eta 0.4 --colsample-bytree 0.7 --subsample 0.8
 ```
 
-Then you can open the mlflow ui to compare your logs and track the experiments by:
+Then you can open the MLflow UI to track the experiments and compare your runs via:
 ```
 mflow ui
 ```

--- a/examples/xgboost/train.py
+++ b/examples/xgboost/train.py
@@ -15,6 +15,8 @@ mpl.use('Agg')
 
 def parse_args():
     parser = argparse.ArgumentParser(description='XGBoost example')
+    parser.add_argument('--eta', type=float, default=0.3,
+                        help='learning rate to update step size at each boosting step (default=0.3)')
     parser.add_argument('--colsample-bytree', type=float, default=1.0,
                         help='subsample ratio of columns when constructing each tree (default: 1.0)')
     parser.add_argument('--subsample', type=float, default=1.0,
@@ -43,6 +45,7 @@ def main():
         params = {
             'objective': 'multi:softprob',
             'num_class': 3,
+            'learning_rate': args.eta,
             'eval_metric': 'mlogloss',
             'colsample_bytree': args.colsample_bytree,
             'subsample': args.subsample,

--- a/examples/xgboost/train.py
+++ b/examples/xgboost/train.py
@@ -15,7 +15,7 @@ mpl.use('Agg')
 
 def parse_args():
     parser = argparse.ArgumentParser(description='XGBoost example')
-    parser.add_argument('--learning_rate', type=float, default=0.3,
+    parser.add_argument('--learning-rate', type=float, default=0.3,
                         help='learning rate to update step size at each boosting step (default: 0.3)')
     parser.add_argument('--colsample-bytree', type=float, default=1.0,
                         help='subsample ratio of columns when constructing each tree (default: 1.0)')

--- a/examples/xgboost/train.py
+++ b/examples/xgboost/train.py
@@ -16,7 +16,7 @@ mpl.use('Agg')
 def parse_args():
     parser = argparse.ArgumentParser(description='XGBoost example')
     parser.add_argument('--learning_rate', type=float, default=0.3,
-                        help='learning rate to update step size at each boosting step (default=0.3)')
+                        help='learning rate to update step size at each boosting step (default: 0.3)')
     parser.add_argument('--colsample-bytree', type=float, default=1.0,
                         help='subsample ratio of columns when constructing each tree (default: 1.0)')
     parser.add_argument('--subsample', type=float, default=1.0,

--- a/examples/xgboost/train.py
+++ b/examples/xgboost/train.py
@@ -15,7 +15,7 @@ mpl.use('Agg')
 
 def parse_args():
     parser = argparse.ArgumentParser(description='XGBoost example')
-    parser.add_argument('--eta', type=float, default=0.3,
+    parser.add_argument('--learning_rate', type=float, default=0.3,
                         help='learning rate to update step size at each boosting step (default=0.3)')
     parser.add_argument('--colsample-bytree', type=float, default=1.0,
                         help='subsample ratio of columns when constructing each tree (default: 1.0)')
@@ -45,7 +45,7 @@ def main():
         params = {
             'objective': 'multi:softprob',
             'num_class': 3,
-            'learning_rate': args.eta,
+            'learning_rate': args.learning_rate,
             'eval_metric': 'mlogloss',
             'colsample_bytree': args.colsample_bytree,
             'subsample': args.subsample,

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -41,7 +41,7 @@ def test_mlflow_run_example(directory, params):
     ('quickstart', ['python', 'mlflow_tracking.py']),
     ('remote_store', ['python', 'remote_server.py']),
     ('xgboost', ['python', 'train.py', '--learning_rate', '0.2', '--colsample-bytree', '0.8',
-    '--subsample', '0.9'])
+                 '--subsample', '0.9'])
 ])
 def test_command_example(directory, command):
     cwd_dir = os.path.join(EXAMPLES_DIR, directory)

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -25,7 +25,7 @@ EXAMPLES_DIR = 'examples'
     ('sklearn_elasticnet_wine', ['-P', 'alpha=0.5']),
     (os.path.join('sklearn_elasticnet_diabetes', 'linux'), []),
     (os.path.join('tensorflow', 'tf1'), ['-P', 'steps=10']),
-    ('xgboost', ['-P', 'learning_rate=0.2', '-P', 'colsample-bytree=0.8', '-P', 'subsample=0.9'])
+    ('xgboost', ['-P', 'learning_rate=0.3', '-P', 'colsample-bytree=0.8', '-P', 'subsample=0.9'])
 ])
 def test_mlflow_run_example(directory, params):
     cli_run_list = [os.path.join(EXAMPLES_DIR, directory)] + params
@@ -40,8 +40,8 @@ def test_mlflow_run_example(directory, params):
     ('lightgbm', ['python', 'train.py', '--colsample-bytree', '0.8', '--subsample', '0.9']),
     ('quickstart', ['python', 'mlflow_tracking.py']),
     ('remote_store', ['python', 'remote_server.py']),
-    ('xgboost', ['python', 'train.py', '--learning_rate', '0.2', '--colsample-bytree', '0.8', \
-     '--subsample', '0.9'])
+    ('xgboost', ['python', 'train.py', '--learning_rate', '0.2', '--colsample-bytree', '0.8',
+    '--subsample', '0.9'])
 ])
 def test_command_example(directory, command):
     cwd_dir = os.path.join(EXAMPLES_DIR, directory)

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -25,7 +25,7 @@ EXAMPLES_DIR = 'examples'
     ('sklearn_elasticnet_wine', ['-P', 'alpha=0.5']),
     (os.path.join('sklearn_elasticnet_diabetes', 'linux'), []),
     (os.path.join('tensorflow', 'tf1'), ['-P', 'steps=10']),
-    ('xgboost', ['-P', 'learning_rate=0.3', '-P', 'colsample-bytree=0.8', '-P', 'subsample=0.9'])
+    ('xgboost', ['-P', 'learning-rate=0.3', '-P', 'colsample-bytree=0.8', '-P', 'subsample=0.9'])
 ])
 def test_mlflow_run_example(directory, params):
     cli_run_list = [os.path.join(EXAMPLES_DIR, directory)] + params
@@ -40,7 +40,7 @@ def test_mlflow_run_example(directory, params):
     ('lightgbm', ['python', 'train.py', '--colsample-bytree', '0.8', '--subsample', '0.9']),
     ('quickstart', ['python', 'mlflow_tracking.py']),
     ('remote_store', ['python', 'remote_server.py']),
-    ('xgboost', ['python', 'train.py', '--learning_rate', '0.2', '--colsample-bytree', '0.8',
+    ('xgboost', ['python', 'train.py', '--learning-rate', '0.2', '--colsample-bytree', '0.8',
                  '--subsample', '0.9'])
 ])
 def test_command_example(directory, command):

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -25,7 +25,7 @@ EXAMPLES_DIR = 'examples'
     ('sklearn_elasticnet_wine', ['-P', 'alpha=0.5']),
     (os.path.join('sklearn_elasticnet_diabetes', 'linux'), []),
     (os.path.join('tensorflow', 'tf1'), ['-P', 'steps=10']),
-    ('xgboost', ['-P', 'colsample-bytree=0.8', '-P', 'subsample=0.9'])
+    ('xgboost', ['-P', 'learning_rate=0.2', '-P', 'colsample-bytree=0.8', '-P', 'subsample=0.9'])
 ])
 def test_mlflow_run_example(directory, params):
     cli_run_list = [os.path.join(EXAMPLES_DIR, directory)] + params
@@ -40,7 +40,7 @@ def test_mlflow_run_example(directory, params):
     ('lightgbm', ['python', 'train.py', '--colsample-bytree', '0.8', '--subsample', '0.9']),
     ('quickstart', ['python', 'mlflow_tracking.py']),
     ('remote_store', ['python', 'remote_server.py']),
-    ('xgboost', ['python', 'train.py', '--colsample-bytree', '0.8', '--subsample', '0.9'])
+    ('xgboost', ['python', 'train.py', '--learning_rate', '0.2', '--colsample-bytree', '0.8', '--subsample', '0.9'])
 ])
 def test_command_example(directory, command):
     cwd_dir = os.path.join(EXAMPLES_DIR, directory)

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -40,7 +40,8 @@ def test_mlflow_run_example(directory, params):
     ('lightgbm', ['python', 'train.py', '--colsample-bytree', '0.8', '--subsample', '0.9']),
     ('quickstart', ['python', 'mlflow_tracking.py']),
     ('remote_store', ['python', 'remote_server.py']),
-    ('xgboost', ['python', 'train.py', '--learning_rate', '0.2', '--colsample-bytree', '0.8', '--subsample', '0.9'])
+    ('xgboost', ['python', 'train.py', '--learning_rate', '0.2', '--colsample-bytree', '0.8', \
+     '--subsample', '0.9'])
 ])
 def test_command_example(directory, command):
     cwd_dir = os.path.join(EXAMPLES_DIR, directory)


### PR DESCRIPTION
## What changes are proposed in this pull request?

I have added the learning rate in xgboost example as the parameter play a huge role in optimization, moreover updated the readme by adding a way to do experiments and track them on  mlflow UI
## How is this patch tested?
I have tested this on my local machine and it is running fine
(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

This PR will make changes in xgboost example, which consists of the addition of an important parameter `learning rate ` which plays a huge role in optimization. Moreover, Readme for the example is changed for the same modification and adding a way to do experiments and performance tracking with mlflow.

### What component(s) does this PR affect?

- [ ] UI
- [ ] Command Line Interface
- [ ] API
- [x] Examples
- [x] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
