### PR TITLE
Replace data.download_uri with more updated artifact handling

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -299,7 +299,7 @@ float
 path
     A path on the local file system. MLflow converts any relative ``path`` parameters to absolute 
     paths. MLflow also downloads any paths passed as distributed storage URIs 
-    (``s3://`` and ``dbfs://``) to local files. Use this type for programs that can only read local 
+    (``s3://``, ``dbfs://``, gs://, etc.) to local files. Use this type for programs that can only read local
     files.
 
 uri

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -6,6 +6,7 @@ import re
 from six.moves import urllib
 
 from mlflow.utils import process
+from mlflow.utils import deprecated
 
 DBFS_PREFIX = "dbfs:/"
 S3_PREFIX = "s3://"
@@ -72,6 +73,7 @@ def is_uri(string):
     return len(parsed_uri.scheme) > 0
 
 
+@deprecated(alternative="mlflow.store.artifact.artifact_repo.ArtifactRepo.download_artifacts", since="1.8.2")
 def download_uri(uri, output_path):
     if DBFS_REGEX.match(uri):
         _fetch_dbfs(uri, output_path)

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -73,8 +73,7 @@ def is_uri(string):
     return len(parsed_uri.scheme) > 0
 
 
-@deprecated(alternative="mlflow.store.artifact.artifact_repo.ArtifactRepo.download_artifacts",
-            since="1.8.2")
+@deprecated(alternative="mlflow.tracking.MlflowClient.download_artifacts", since="1.9")
 def download_uri(uri, output_path):
     if DBFS_REGEX.match(uri):
         _fetch_dbfs(uri, output_path)

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -73,7 +73,8 @@ def is_uri(string):
     return len(parsed_uri.scheme) > 0
 
 
-@deprecated(alternative="mlflow.store.artifact.artifact_repo.ArtifactRepo.download_artifacts", since="1.8.2")
+@deprecated(alternative="mlflow.store.artifact.artifact_repo.ArtifactRepo.download_artifacts",
+            since="1.8.2")
 def download_uri(uri, output_path):
     if DBFS_REGEX.match(uri):
         _fetch_dbfs(uri, output_path)

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -200,7 +200,8 @@ class Parameter(object):
         basename = os.path.basename(user_param_value)
         dest_path = os.path.join(storage_dir, basename)
         if dest_path != user_param_value:
-            artifact_utils._download_artifact_from_uri(artifact_uri=user_param_value, output_path=dest_path)
+            artifact_utils._download_artifact_from_uri(artifact_uri=user_param_value,
+                                                       output_path=dest_path)
         return os.path.abspath(dest_path)
 
     def compute_value(self, param_value, storage_dir):

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -153,14 +153,12 @@ class EntryPoint(object):
         final_params = {}
         extra_params = {}
 
-        for key, param_obj in self.parameters.items():
+        parameter_keys = list(self.parameters.keys())
+        for key in parameter_keys:
+            param_obj = self.parameters[key]
+            key_position = parameter_keys.index(key)
             value = user_parameters[key] if key in user_parameters else self.parameters[key].default
-            target_sub_dir = 'param_{}'.format(list(self.parameters.keys()).index(key))
-            download_dir = None
-            if storage_dir:
-                download_dir = os.path.join(storage_dir, target_sub_dir)
-                os.mkdir(download_dir)
-            final_params[key] = param_obj.compute_value(value, download_dir)
+            final_params[key] = param_obj.compute_value(value, storage_dir, key_position)
         for key in user_parameters:
             if key not in final_params:
                 extra_params[key] = user_parameters[key]
@@ -195,19 +193,22 @@ class Parameter(object):
                                      "%s" % (self.name, user_param_value))
         return user_param_value
 
-    def _compute_path_value(self, user_param_value, storage_dir):
+    def _compute_path_value(self, user_param_value, storage_dir, key_position):
         local_path = get_local_path_or_none(user_param_value)
         if local_path:
             if not os.path.exists(local_path):
                 raise ExecutionException("Got value %s for parameter %s, but no such file or "
                                          "directory was found." % (user_param_value, self.name))
             return os.path.abspath(local_path)
+        target_sub_dir = 'param_{}'.format(key_position)
+        download_dir = os.path.join(storage_dir, target_sub_dir)
+        os.mkdir(download_dir)
         return artifact_utils._download_artifact_from_uri(artifact_uri=user_param_value,
-                                                          output_path=storage_dir)
+                                                          output_path=download_dir)
 
-    def compute_value(self, param_value, storage_dir):
+    def compute_value(self, param_value, storage_dir, key_position):
         if storage_dir and self.type == "path":
-            return self._compute_path_value(param_value, storage_dir)
+            return self._compute_path_value(param_value, storage_dir, key_position)
         elif self.type == "uri":
             return self._compute_uri_value(param_value)
         else:

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -155,7 +155,12 @@ class EntryPoint(object):
 
         for key, param_obj in self.parameters.items():
             value = user_parameters[key] if key in user_parameters else self.parameters[key].default
-            final_params[key] = param_obj.compute_value(value, storage_dir)
+            target_sub_dir = 'param_{}'.format(list(self.parameters.keys()).index(key))
+            download_dir = None
+            if storage_dir:
+                download_dir = os.path.join(storage_dir, target_sub_dir)
+                os.mkdir(download_dir)
+            final_params[key] = param_obj.compute_value(value, download_dir)
         for key in user_parameters:
             if key not in final_params:
                 extra_params[key] = user_parameters[key]
@@ -198,11 +203,9 @@ class Parameter(object):
                                          "directory was found." % (user_param_value, self.name))
             return os.path.abspath(local_path)
         basename = os.path.basename(user_param_value)
-        dest_path = os.path.join(storage_dir, basename)
-        if dest_path != user_param_value:
-            artifact_utils._download_artifact_from_uri(artifact_uri=user_param_value,
-                                                       output_path=dest_path)
-        return os.path.abspath(dest_path)
+        artifact_utils._download_artifact_from_uri(artifact_uri=user_param_value,
+                                                   output_path=storage_dir)
+        return os.path.abspath(os.path.join(storage_dir, basename))
 
     def compute_value(self, param_value, storage_dir):
         if storage_dir and self.type == "path":

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -7,6 +7,7 @@ from six.moves import shlex_quote
 
 from mlflow import data
 from mlflow.exceptions import ExecutionException
+from mlflow.tracking import artifact_utils
 from mlflow.utils.file_utils import get_local_path_or_none
 from mlflow.utils.string_utils import is_string_type
 
@@ -199,7 +200,7 @@ class Parameter(object):
         basename = os.path.basename(user_param_value)
         dest_path = os.path.join(storage_dir, basename)
         if dest_path != user_param_value:
-            data.download_uri(uri=user_param_value, output_path=dest_path)
+            artifact_utils._download_artifact_from_uri(artifact_uri=user_param_value, output_path=dest_path)
         return os.path.abspath(dest_path)
 
     def compute_value(self, param_value, storage_dir):

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -202,10 +202,8 @@ class Parameter(object):
                 raise ExecutionException("Got value %s for parameter %s, but no such file or "
                                          "directory was found." % (user_param_value, self.name))
             return os.path.abspath(local_path)
-        basename = os.path.basename(user_param_value)
-        artifact_utils._download_artifact_from_uri(artifact_uri=user_param_value,
-                                                   output_path=storage_dir)
-        return os.path.abspath(os.path.join(storage_dir, basename))
+        return artifact_utils._download_artifact_from_uri(artifact_uri=user_param_value,
+                                                          output_path=storage_dir)
 
     def compute_value(self, param_value, storage_dir):
         if storage_dir and self.type == "path":

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -45,7 +45,8 @@ def get_artifact_uri(run_id, artifact_path=None):
         return append_to_uri_path(run.info.artifact_uri, artifact_path)
 
 
-# TODO: This would be much simpler if artifact_repo.download_artifacts could take the absolute path or no path.
+# TODO: This would be much simpler if artifact_repo.download_artifacts could take the absolute path
+# or no path.
 def _download_artifact_from_uri(artifact_uri, output_path=None):
     """
     :param artifact_uri: The *absolute* URI of the artifact to download.

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -45,10 +45,7 @@ def get_artifact_uri(run_id, artifact_path=None):
         return append_to_uri_path(run.info.artifact_uri, artifact_path)
 
 
-# TODO: This method does not require a Run and its internals should be moved to
-#  data.download_uri (requires confirming that Projects will not break with this change).
-# Also this would be much simpler if artifact_repo.download_artifacts could take the absolute path
-# or no path.
+# TODO: This would be much simpler if artifact_repo.download_artifacts could take the absolute path or no path.
 def _download_artifact_from_uri(artifact_uri, output_path=None):
     """
     :param artifact_uri: The *absolute* URI of the artifact to download.

--- a/tests/projects/test_entry_point.py
+++ b/tests/projects/test_entry_point.py
@@ -56,7 +56,7 @@ def test_path_parameter():
     """
     project = load_project()
     entry_point = project.get_entry_point("line_count")
-    with mock.patch("mlflow.data.download_uri") as download_uri_mock:
+    with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") as download_uri_mock:
         download_uri_mock.return_value = 0
         # Verify that we don't attempt to call download_uri when passing a local file to a
         # parameter of type "path"
@@ -97,7 +97,8 @@ def test_uri_parameter():
     """Tests parameter resolution for parameters of type `uri`."""
     project = load_project()
     entry_point = project.get_entry_point("download_uri")
-    with mock.patch("mlflow.data.download_uri") as download_uri_mock, TempDir() as tmp:
+    with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") as download_uri_mock, \
+            TempDir() as tmp:
         dst_dir = tmp.path()
         # Test that we don't attempt to locally download parameters of type URI
         entry_point.compute_command(user_parameters={"uri": "file://%s" % dst_dir},
@@ -168,20 +169,20 @@ def test_path_params():
         }
         entry_point = EntryPoint("entry_point_name", defaults, "command_name script.py")
 
-        with mock.patch("mlflow.data.download_uri") as download_uri_mock:
+        with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") as download_uri_mock:
             final_1, extra_1 = entry_point.compute_parameters({}, None)
             assert (final_1 == {"constants": "s3://path.test/b1", "data": data_file})
             assert (extra_1 == {})
             assert download_uri_mock.call_count == 0
 
-        with mock.patch("mlflow.data.download_uri") as download_uri_mock:
+        with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") as download_uri_mock:
             user_2 = {"alpha": 0.001, "constants": "s3://path.test/b_two"}
             final_2, extra_2 = entry_point.compute_parameters(user_2, None)
             assert (final_2 == {"constants": "s3://path.test/b_two", "data": data_file})
             assert (extra_2 == {"alpha": "0.001"})
             assert download_uri_mock.call_count == 0
 
-        with mock.patch("mlflow.data.download_uri") as download_uri_mock:
+        with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") as download_uri_mock:
             user_3 = {"alpha": 0.001}
             final_3, extra_3 = entry_point.compute_parameters(user_3, dest_path)
             assert (final_3 == {"constants": "s3://path.test/b1",
@@ -189,7 +190,7 @@ def test_path_params():
             assert (extra_3 == {"alpha": "0.001"})
             assert download_uri_mock.call_count == 1
 
-        with mock.patch("mlflow.data.download_uri") as download_uri_mock:
+        with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") as download_uri_mock:
             user_4 = {"data": "s3://another.example.test/data_stash/images.tgz"}
             final_4, extra_4 = entry_point.compute_parameters(user_4, dest_path)
             assert (final_4 == {"constants": "s3://path.test/b1",

--- a/tests/projects/test_entry_point.py
+++ b/tests/projects/test_entry_point.py
@@ -56,7 +56,8 @@ def test_path_parameter():
     """
     project = load_project()
     entry_point = project.get_entry_point("line_count")
-    with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") as download_uri_mock:
+    with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") \
+            as download_uri_mock:
         download_uri_mock.return_value = 0
         # Verify that we don't attempt to call download_uri when passing a local file to a
         # parameter of type "path"
@@ -97,8 +98,8 @@ def test_uri_parameter():
     """Tests parameter resolution for parameters of type `uri`."""
     project = load_project()
     entry_point = project.get_entry_point("download_uri")
-    with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") as download_uri_mock, \
-            TempDir() as tmp:
+    with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") \
+            as download_uri_mock, TempDir() as tmp:
         dst_dir = tmp.path()
         # Test that we don't attempt to locally download parameters of type URI
         entry_point.compute_command(user_parameters={"uri": "file://%s" % dst_dir},
@@ -169,20 +170,23 @@ def test_path_params():
         }
         entry_point = EntryPoint("entry_point_name", defaults, "command_name script.py")
 
-        with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") as download_uri_mock:
+        with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") \
+                as download_uri_mock:
             final_1, extra_1 = entry_point.compute_parameters({}, None)
             assert (final_1 == {"constants": "s3://path.test/b1", "data": data_file})
             assert (extra_1 == {})
             assert download_uri_mock.call_count == 0
 
-        with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") as download_uri_mock:
+        with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") \
+                as download_uri_mock:
             user_2 = {"alpha": 0.001, "constants": "s3://path.test/b_two"}
             final_2, extra_2 = entry_point.compute_parameters(user_2, None)
             assert (final_2 == {"constants": "s3://path.test/b_two", "data": data_file})
             assert (extra_2 == {"alpha": "0.001"})
             assert download_uri_mock.call_count == 0
 
-        with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") as download_uri_mock:
+        with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") \
+                as download_uri_mock:
             user_3 = {"alpha": 0.001}
             final_3, extra_3 = entry_point.compute_parameters(user_3, dest_path)
             assert (final_3 == {"constants": "s3://path.test/b1",
@@ -190,7 +194,8 @@ def test_path_params():
             assert (extra_3 == {"alpha": "0.001"})
             assert download_uri_mock.call_count == 1
 
-        with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") as download_uri_mock:
+        with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") \
+                as download_uri_mock:
             user_4 = {"data": "s3://another.example.test/data_stash/images.tgz"}
             final_4, extra_4 = entry_point.compute_parameters(user_4, dest_path)
             assert (final_4 == {"constants": "s3://path.test/b1",

--- a/tests/projects/test_entry_point.py
+++ b/tests/projects/test_entry_point.py
@@ -87,10 +87,12 @@ def test_path_parameter():
         for i, prefix in enumerate(["dbfs:/", "s3://", "gs://"]):
             with TempDir() as tmp:
                 dst_dir = tmp.path()
+                file_to_download = 'images.tgz'
+                download_path = "%s/%s" % dst_dir, file_to_download
                 params, _ = entry_point.compute_parameters(
-                    user_parameters={"path": os.path.join(prefix, "some/path")},
+                    user_parameters={"path": os.path.join(prefix, file_to_download)},
                     storage_dir=dst_dir)
-                assert os.path.dirname(params["path"]) == dst_dir
+                assert params["path"] == download_path
                 assert download_uri_mock.call_count == i + 1
 
 
@@ -187,18 +189,22 @@ def test_path_params():
 
         with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") \
                 as download_uri_mock:
+            download_path = "%s/data_file.csv" % dest_path
+            download_uri_mock.return_value = download_path
             user_3 = {"alpha": 0.001}
             final_3, extra_3 = entry_point.compute_parameters(user_3, dest_path)
             assert (final_3 == {"constants": "s3://path.test/b1",
-                                "data": "%s/data_file.csv" % dest_path})
+                                "data": download_path})
             assert (extra_3 == {"alpha": "0.001"})
             assert download_uri_mock.call_count == 1
 
         with mock.patch("mlflow.tracking.artifact_utils._download_artifact_from_uri") \
                 as download_uri_mock:
+            download_path = "%s/images.tgz" % dest_path
+            download_uri_mock.return_value = download_path
             user_4 = {"data": "s3://another.example.test/data_stash/images.tgz"}
             final_4, extra_4 = entry_point.compute_parameters(user_4, dest_path)
             assert (final_4 == {"constants": "s3://path.test/b1",
-                                "data": "%s/images.tgz" % dest_path})
+                                "data": download_path})
             assert (extra_4 == {})
             assert download_uri_mock.call_count == 1

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -216,6 +216,18 @@ def test_run_with_parent(tmpdir):  # pylint: disable=unused-argument
     assert run.data.tags[MLFLOW_PARENT_RUN_ID] == parent_run_id
 
 
+def test_run_with_artifact_path(tmpdir):
+    artifact_file = tmpdir.join("model.pkl")
+    artifact_file.write("Hello world")
+    with mlflow.start_run() as run:
+        mlflow.log_artifact(artifact_file)
+        submitted_run = mlflow.projects.run(
+            TEST_PROJECT_DIR, entry_point="test_artifact_path",
+            parameters={"model": "runs:/%s/model.pkl" % run.info.run_id},
+            use_conda=False, experiment_id=FileStore.DEFAULT_EXPERIMENT_ID)
+        validate_exit_status(submitted_run.get_status(), RunStatus.FINISHED)
+
+
 def test_run_async():
     submitted_run0 = mlflow.projects.run(
         TEST_PROJECT_DIR, entry_point="sleep", parameters={"duration": 2},

--- a/tests/resources/example_project/MLproject
+++ b/tests/resources/example_project/MLproject
@@ -28,3 +28,7 @@ entry_points:
     parameters:
       conda_env_name: string
     command: "python check_conda_env.py {conda_env_name}"
+  test_artifact_path:
+    parameters:
+      model: {type: path}
+    command: "echo success"


### PR DESCRIPTION
## What changes are proposed in this pull request?

This is a proposed fix to #2233 regarding path parameters in projects. The `data.download_uri` method is out of date and appears to have been subsumed by other utilities. As such, the proposal is to remove usage of it from the project handling, deprecate it, and replace it with calls to `tracking.artifact_utils._download_artifact_from_uri`, which has the ability to dynamically determine how to download a provided uri.

## How is this patch tested?

Using the automated tests that are already in place.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Deprecating `mlflow.data.download_uri`. Recommendation is to use `mlflow.store.artifact.artifact_repo.ArtifactRepo.download_artifacts` instead.

Expands Project entry point parameter capabilities. Path parameters can support download from all available artifact schemes.

### What component(s) does this PR affect?

- [ ] UI
- [ ] Command Line Interface
- [ ] API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [x] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
