### PR TITLE
Pin cloudpickle to 1.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     install_requires=[
         'alembic',
         'click>=7.0',
-        'cloudpickle',
+        'cloudpickle == 1.4.1',  # Pinned default version: issues-2429
         'databricks-cli>=0.8.7',
         'requests>=2.17.3',
         'six>=1.10.0',


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously, MLflow expected users to stay with one version of
cloudpickle when loading and saving models within their conda
environment.

Feedback from the community has shown that this is not common. Many
users will upgrade to the latest version available. We originally tried
to allievate this problem by throwing a warning that the cloudpickle
versions between the save and load were different but that has proven
still unfavorable.

This PR is intended to further address this user pain by pinning a
default cloudpickle version to 1.4.1. Users should be free to select
their own cloudpickle version but with a default, this issue will be
less of a footgun for most users.

## How is this patch tested?

TBD

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow is pinning CloudPickle to version 1.4.1 as a default. Users can switch to another CloudPickle version if needed. 

### What component(s) does this PR affect?

- [ ] UI
- [ ] Command Line Interface
- [ ] API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [x] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
