### PR TITLE
Remove imports from `__future__`

### DIFF
--- a/examples/hyperparam/train.py
+++ b/examples/hyperparam/train.py
@@ -6,8 +6,6 @@ Validation data is used to select the best hyperparameters, test set performance
 at epochs which improved performance on the validation dataset. The model with best validation set
 performance is logged with MLflow.
 """
-from __future__ import print_function
-
 import warnings
 
 import math

--- a/examples/keras/train.py
+++ b/examples/keras/train.py
@@ -1,8 +1,6 @@
 '''Trains and evaluate a simple MLP
 on the Reuters newswire topic classification task.
 '''
-from __future__ import print_function
-
 import numpy as np
 import keras
 from keras.datasets import reuters

--- a/examples/multistep_workflow/etl_data.py
+++ b/examples/multistep_workflow/etl_data.py
@@ -1,9 +1,6 @@
 """
 Converts the raw CSV form to a Parquet form with just the columns we want
 """
-
-from __future__ import print_function
-
 import tempfile
 import os
 import pyspark

--- a/examples/multistep_workflow/load_raw_data.py
+++ b/examples/multistep_workflow/load_raw_data.py
@@ -1,10 +1,6 @@
 """
 Downloads the MovieLens dataset and saves it as an artifact
 """
-
-
-from __future__ import print_function
-
 import requests
 import tempfile
 import os

--- a/examples/pytorch/mnist_tensorboard_artifact.py
+++ b/examples/pytorch/mnist_tensorboard_artifact.py
@@ -8,8 +8,6 @@
 #
 # Code based on https://github.com/lanpa/tensorboard-pytorch-examples/blob/master/mnist/main.py.
 #
-
-from __future__ import print_function
 import argparse
 import os
 import mlflow

--- a/examples/remote_store/remote_server.py
+++ b/examples/remote_store/remote_server.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import shutil
 import sys

--- a/examples/sklearn_logistic_regression/train.py
+++ b/examples/sklearn_logistic_regression/train.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import numpy as np
 from sklearn.linear_model import LogisticRegression
 

--- a/examples/spacy/train.py
+++ b/examples/spacy/train.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import random
 
 import spacy

--- a/examples/tensorflow/tf1/train_predict.py
+++ b/examples/tensorflow/tf1/train_predict.py
@@ -1,8 +1,4 @@
 # in case this is run outside of conda environment with python2
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import mlflow
 from mlflow import pyfunc
 import pandas as pd

--- a/examples/tensorflow/tf2/train_predict_2.py
+++ b/examples/tensorflow/tf2/train_predict_2.py
@@ -1,8 +1,4 @@
 # in case this is run outside of conda environment with python2
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import mlflow
 import argparse
 import sys

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -2,8 +2,6 @@
 The ``mlflow.azureml`` module provides an API for deploying MLflow models to Azure
 Machine Learning.
 """
-from __future__ import print_function
-
 import sys
 import os
 import shutil

--- a/mlflow/azureml/cli.py
+++ b/mlflow/azureml/cli.py
@@ -1,8 +1,6 @@
 """
 CLI for azureml module.
 """
-from __future__ import print_function
-
 import json
 
 import click

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import json
 import os
 import sys

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import re
 

--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 
 import click

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -12,9 +12,6 @@ fastai (native) format
 .. _fastai.Learner.export:
     https://docs.fast.ai/basic_train.html#Learner.export
 """
-
-from __future__ import absolute_import
-
 import os
 import yaml
 import pandas as pd

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -7,9 +7,6 @@ H20 (native) format
 :py:mod:`mlflow.pyfunc`
     Produced for use by generic pyfunc-based deployment tools and batch inference.
 """
-
-from __future__ import absolute_import
-
 import os
 import yaml
 

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -7,9 +7,6 @@ Keras (native) format
 :py:mod:`mlflow.pyfunc`
     Produced for use by generic pyfunc-based deployment tools and batch inference.
 """
-
-from __future__ import absolute_import
-
 import importlib
 import os
 import yaml

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -17,9 +17,6 @@ LightGBM (native) format
 .. _scikit-learn API:
     https://lightgbm.readthedocs.io/en/latest/Python-API.html#scikit-learn-api
 """
-
-from __future__ import absolute_import
-
 import os
 import yaml
 import json

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -8,9 +8,6 @@ NOTE:
     Java API method ``downloadArtifacts(String runId)`` and load the model
     using the method ``MLeapLoader.loadPipeline(String modelRootPath)``.
 """
-
-from __future__ import absolute_import
-
 import os
 import sys
 import traceback

--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -4,8 +4,6 @@ Initialize the environment and start model serving in a Docker container.
 To be executed only during the model deployment.
 
 """
-from __future__ import print_function
-
 import multiprocessing
 import os
 import signal

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -7,9 +7,6 @@ ONNX (native) format
 :py:mod:`mlflow.pyfunc`
     Produced for use by generic pyfunc-based deployment tools and batch inference.
 """
-
-from __future__ import absolute_import
-
 import os
 import yaml
 import numpy as np

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -1,9 +1,6 @@
 """
 The ``mlflow.projects`` module provides an API for running MLflow projects locally or remotely.
 """
-
-from __future__ import print_function
-
 import hashlib
 import json
 import yaml

--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import logging
 import docker
 import time

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -10,8 +10,6 @@ Defines two endpoints:
     /ping used for health check
     /invocations used for scoring
 """
-from __future__ import print_function
-
 from collections import OrderedDict
 import flask
 import json

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -7,9 +7,6 @@ PyTorch (native) format
 :py:mod:`mlflow.pyfunc`
     Produced for use by generic pyfunc-based deployment tools and batch inference.
 """
-
-from __future__ import absolute_import
-
 import importlib
 import logging
 import os

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -1,8 +1,6 @@
 """
 CLI for runs
 """
-from __future__ import print_function
-
 import click
 import json
 import mlflow.tracking

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -1,8 +1,6 @@
 """
 The ``mlflow.sagemaker`` module provides an API for deploying MLflow models to Amazon SageMaker.
 """
-from __future__ import print_function
-
 import os
 from subprocess import Popen, PIPE, STDOUT
 from six.moves import urllib

--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import json
 

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -8,9 +8,6 @@ Python (native) `pickle <https://scikit-learn.org/stable/modules/model_persisten
 :py:mod:`mlflow.pyfunc`
     Produced for use by generic pyfunc-based deployment tools and batch inference.
 """
-
-from __future__ import absolute_import
-
 import os
 import pickle
 import yaml

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -7,9 +7,6 @@ spaCy (native) format
 :py:mod:`mlflow.pyfunc`
     Produced for use by generic pyfunc-based deployment tools and batch inference.
 """
-
-from __future__ import absolute_import
-
 import logging
 import os
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -18,9 +18,6 @@ Spark MLlib (native) format
     ``mlflow/java`` package. This flavor is produced only if you specify
     MLeap-compatible arguments.
 """
-
-from __future__ import absolute_import
-
 import os
 import yaml
 import logging

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -7,9 +7,6 @@ TensorFlow (native) format
 :py:mod:`mlflow.pyfunc`
     Produced for use by generic pyfunc-based deployment tools and batch inference.
 """
-
-from __future__ import absolute_import
-
 import os
 import shutil
 import yaml

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2,9 +2,6 @@
 Internal module implementing the fluent API, allowing management of an active
 MLflow run. This module is exposed to users at the top-level :py:mod:`mlflow` module.
 """
-
-from __future__ import print_function
-
 import os
 
 import atexit

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import logging
 import logging.config

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -16,9 +16,6 @@ XGBoost (native) format
 .. _scikit-learn API:
     https://xgboost.readthedocs.io/en/latest/python/python_api.html#module-xgboost.sklearn
 """
-
-from __future__ import absolute_import
-
 import os
 import shutil
 import json

--- a/tests/azureml/test_deploy.py
+++ b/tests/azureml/test_deploy.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import os
 import pytest

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import os
 import json

--- a/tests/fastai/test_fastai_model_export.py
+++ b/tests/fastai/test_fastai_model_export.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import mock
 import os
 import pytest

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -1,7 +1,5 @@
 # pep8: disable=E501
 
-from __future__ import print_function
-
 import os
 import pytest
 import yaml

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import random
 import mock

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -1,7 +1,5 @@
 # pep8: disable=E501
 
-from __future__ import print_function
-
 import h5py
 import os
 import json

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import mock
 import os

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import os
 import pytest

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import cloudpickle
 import os
 import json

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import pickle
 import yaml

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import time
 import json
 from collections import namedtuple

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import os
 import pytest
 import time

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import mock
 import os

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -1,7 +1,5 @@
 # pep8: disable=E501
 
-from __future__ import print_function
-
 import collections
 import mock
 import os

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -1,7 +1,5 @@
 # pep8: disable=E501
 
-from __future__ import print_function
-
 import collections
 import mock
 import os

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -1,7 +1,5 @@
 # pep8: disable=E501
 
-from __future__ import print_function
-
 import collections
 import pytest
 

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -1,7 +1,5 @@
 # pep8: disable=E501
 
-from __future__ import print_function
-
 import collections
 import shutil
 import pytest

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import filecmp
 import os
 import random

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import mock
 import os


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove imports from `__future__` because we no longer support Python 2.

## How is this patch tested?

Verified `git grep "from __future__ import" | wc -l` returns `0`.


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] Command Line Interface
- [ ] API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
