### PR TITLE
Use posix path for pyfunc artifact subpaths.

### DIFF
--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -4,6 +4,7 @@ models with a user-defined ``PythonModel`` subclass.
 """
 
 import os
+import posixpath
 import shutil
 import yaml
 from abc import ABCMeta, abstractmethod
@@ -156,7 +157,7 @@ def _save_model_with_class_artifacts_params(path, python_model, artifacts=None, 
                 tmp_artifact_path = _download_artifact_from_uri(
                     artifact_uri=artifact_uri, output_path=tmp_artifacts_dir.path())
                 tmp_artifacts_config[artifact_name] = tmp_artifact_path
-                saved_artifact_subpath = os.path.join(
+                saved_artifact_subpath = posixpath.join(
                     saved_artifacts_dir_subpath,
                     os.path.relpath(path=tmp_artifact_path, start=tmp_artifacts_dir.path()))
                 saved_artifacts_config[artifact_name] = {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Simple fix to use posix paths rather than OS dependent paths for artifact subpaths. 

Fixes #2759: 

```
flavors:
  python_function:
    artifacts:
      artifact:
        path: artifacts/some_artifact
        uri: some_artifact
```

## How is this patch tested?

Manually. Unable to run tests on Windows due to #2783 

## Release Notes

Fix pyfunc artifact paths on Windows. 

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix pyfunc artifact paths on Windows. 

### What component(s) does this PR affect?

- [ ] UI
- [ ] Command Line Interface
- [ ] API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [x] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] R
- [ ] Java
- [x] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mlflow/mlflow/2784)
<!-- Reviewable:end -->
