### PR TITLE
Fix bug in remote project execution

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -239,6 +239,17 @@ def _get_tracking_uri_for_run():
     return uri
 
 
+def _get_cluster_mlflow_run_cmd(project_dir, run_id, entry_point, parameters):
+    mlflow_run_arr = list(map(shlex_quote, ["mlflow", "run", project_dir,
+                                            "--entry-point", entry_point]))
+    if run_id:
+        mlflow_run_arr.extend(["-c", json.dumps({_MLFLOW_LOCAL_BACKEND_RUN_ID_CONFIG: run_id})])
+    if parameters:
+        for key, value in parameters.items():
+            mlflow_run_arr.extend(["-P", "%s=%s" % (key, value)])
+    return mlflow_run_arr
+
+
 def _get_databricks_run_cmd(dbfs_fuse_tar_uri, run_id, entry_point, parameters):
     """
     Generate MLflow CLI command to run on Databricks cluster in order to launch a run on Databricks.
@@ -248,14 +259,9 @@ def _get_databricks_run_cmd(dbfs_fuse_tar_uri, run_id, entry_point, parameters):
     container_tar_path = posixpath.abspath(posixpath.join(DB_TARFILE_BASE,
                                            posixpath.basename(dbfs_fuse_tar_uri)))
     project_dir = posixpath.join(DB_PROJECTS_BASE, tar_hash)
-    mlflow_run_arr = list(map(shlex_quote, ["mlflow", "run", project_dir,
-                                            "--entry-point", entry_point]))
-    if run_id:
-        mlflow_run_arr.extend(["-c", json.dumps({_MLFLOW_LOCAL_BACKEND_RUN_ID_CONFIG: run_id})])
-    if parameters:
-        for key, value in parameters.items():
-            mlflow_run_arr.extend(["-P", "%s=%s" % (key, value)])
-    mlflow_run_cmd = " ".join(mlflow_run_arr)
+
+    mlflow_run_cmd = " ".join(_get_cluster_mlflow_run_cmd(
+        project_dir, run_id, entry_point, parameters))
     shell_command = textwrap.dedent("""
     export PATH=$PATH:$DB_HOME/python/bin &&
     mlflow --version &&

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -251,7 +251,7 @@ def _get_databricks_run_cmd(dbfs_fuse_tar_uri, run_id, entry_point, parameters):
     mlflow_run_arr = list(map(shlex_quote, ["mlflow", "run", project_dir,
                                             "--entry-point", entry_point]))
     if run_id:
-        mlflow_run_arr.extend(["-C", json.dumps({_MLFLOW_LOCAL_BACKEND_RUN_ID_CONFIG: run_id})])
+        mlflow_run_arr.extend(["-c", json.dumps({_MLFLOW_LOCAL_BACKEND_RUN_ID_CONFIG: run_id})])
     if parameters:
         for key, value in parameters.items():
             mlflow_run_arr.extend(["-P", "%s=%s" % (key, value)])


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes bug where we incorrectly passed the backend config argument (as `-C` instead of `-c`) while executing projects remotely on Databricks & adds regression test

## How is this patch tested?

Tested manually + added regression test

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] Command Line Interface
- [ ] API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
