### PR TITLE
Fix example tests and add spacy example test to CRON job

### DIFF
--- a/examples/flower_classifier/conda.yaml
+++ b/examples/flower_classifier/conda.yaml
@@ -2,6 +2,7 @@ name: flower_classifier
 channels:
   - defaults
   - anaconda
+  - conda-forge
 dependencies:
   - python=3.7
   - pandas=1.0.3

--- a/examples/flower_classifier/conda.yaml
+++ b/examples/flower_classifier/conda.yaml
@@ -3,12 +3,12 @@ channels:
   - defaults
   - anaconda
 dependencies:
-  - python==3.7
-  - pandas==1.0.3
-  - scikit-learn==0.22.1
-  - tensorflow==1.13.1
-  - keras==2.3.1
-  - pillow==7.0.0
-  - pip==20.0.2
+  - python=3.7
+  - pandas=1.0.3
+  - scikit-learn=0.22.1
+  - tensorflow=1.13.1
+  - keras=2.3.1
+  - pillow=7.0.0
+  - pip=20.0.2
   - pip:
     - mlflow>=1.6

--- a/examples/h2o/conda.yaml
+++ b/examples/h2o/conda.yaml
@@ -2,6 +2,7 @@ name: h2o_example
 channels:
   - defaults
   - anaconda
+  - conda-forge
 dependencies:
   - python=3.6
   - numpy=1.14.2

--- a/examples/h2o/conda.yaml
+++ b/examples/h2o/conda.yaml
@@ -3,8 +3,8 @@ channels:
   - defaults
   - anaconda
 dependencies:
-  - python==3.6
-  - numpy==1.14.2
+  - python=3.6
+  - numpy=1.14.2
   - pandas
   - pip:
     - h2o

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -1,6 +1,8 @@
 name: hyperparam_example
 channels:
   - defaults
+  - anaconda
+  - conda-forge
 dependencies:
   - python=3.6
   - numpy=1.14.3

--- a/examples/lightgbm/conda.yaml
+++ b/examples/lightgbm/conda.yaml
@@ -1,6 +1,7 @@
 name: lightgbm-example
 channels:
   - defaults
+  - anaconda
   - conda-forge
 dependencies:
   - python=3.6

--- a/examples/multistep_workflow/conda.yaml
+++ b/examples/multistep_workflow/conda.yaml
@@ -1,6 +1,8 @@
 name: multistep
 channels:
   - defaults
+  - anaconda
+  - conda-forge
 dependencies:
   - python=3.6
   - pyspark

--- a/examples/prophet/conda.yaml
+++ b/examples/prophet/conda.yaml
@@ -1,6 +1,7 @@
 name: tutorial
 channels:
   - defaults
+  - anaconda
   - conda-forge
 dependencies:
   - python=3.6

--- a/examples/pytorch/conda.yaml
+++ b/examples/pytorch/conda.yaml
@@ -2,6 +2,8 @@ name: pytorch_example
 channels:
   - defaults
   - pytorch
+  - anaconda
+  - conda-forge
 dependencies:
   - python=3.6
   - pip:

--- a/examples/sklearn_elasticnet_diabetes/linux/conda.yaml
+++ b/examples/sklearn_elasticnet_diabetes/linux/conda.yaml
@@ -1,6 +1,8 @@
 name: tutorial
 channels:
   - defaults
+  - anaconda
+  - conda-forge
 dependencies:
   - cloudpickle=0.6.1
   - python=3.6

--- a/examples/sklearn_elasticnet_diabetes/osx/conda.yaml
+++ b/examples/sklearn_elasticnet_diabetes/osx/conda.yaml
@@ -1,6 +1,8 @@
 name: tutorial
 channels:
   - defaults
+  - anaconda
+  - conda-forge
 dependencies:
   - cloudpickle=0.6.1
   - python=3.6

--- a/examples/sklearn_elasticnet_wine/conda.yaml
+++ b/examples/sklearn_elasticnet_wine/conda.yaml
@@ -1,6 +1,8 @@
 name: tutorial
 channels:
   - defaults
+  - anaconda
+  - conda-forge
 dependencies:
   - python=3.6
   - scikit-learn=0.19.1

--- a/examples/sklearn_logistic_regression/conda.yaml
+++ b/examples/sklearn_logistic_regression/conda.yaml
@@ -2,6 +2,7 @@ name: sklearn-example
 channels:
   - defaults
   - anaconda
+  - conda-forge
 dependencies:
   - python=3.6
   - scikit-learn=0.19.1

--- a/examples/sklearn_logistic_regression/conda.yaml
+++ b/examples/sklearn_logistic_regression/conda.yaml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - anaconda
 dependencies:
-  - python==3.6
+  - python=3.6
   - scikit-learn=0.19.1
   - pip:
     - mlflow>=1.0

--- a/examples/spacy/conda.yaml
+++ b/examples/spacy/conda.yaml
@@ -2,6 +2,7 @@ name: spacy-example
 channels:
   - defaults
   - anaconda
+  - conda-forge
 dependencies:
   - python=3.6
   - spacy=2.2.3

--- a/examples/spacy/conda.yaml
+++ b/examples/spacy/conda.yaml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - anaconda
 dependencies:
-  - python==3.6
+  - python=3.6
   - spacy=2.2.3
   - pip:
     - mlflow>=1.0

--- a/examples/tensorflow/tf1/conda.yaml
+++ b/examples/tensorflow/tf1/conda.yaml
@@ -3,8 +3,8 @@ channels:
   - defaults
   - anaconda
 dependencies:
-  - python==3.6
-  - tensorflow==1.13.1
+  - python=3.6
+  - tensorflow=1.13.1
   - pip:
     - mlflow
 

--- a/examples/tensorflow/tf1/conda.yaml
+++ b/examples/tensorflow/tf1/conda.yaml
@@ -2,6 +2,7 @@ name: tensorflow-example
 channels:
   - defaults
   - anaconda
+  - conda-forge
 dependencies:
   - python=3.6
   - tensorflow=1.13.1

--- a/examples/tensorflow/tf2/conda.yaml
+++ b/examples/tensorflow/tf2/conda.yaml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - anaconda
 dependencies:
-  - python==3.6
+  - python=3.6
   - pip:
     - mlflow
     - tensorflow==2.0.0

--- a/examples/tensorflow/tf2/conda.yaml
+++ b/examples/tensorflow/tf2/conda.yaml
@@ -2,6 +2,7 @@ name: tensorflow-example
 channels:
   - defaults
   - anaconda
+  - conda-forge
 dependencies:
   - python=3.6
   - pip:

--- a/examples/xgboost/conda.yaml
+++ b/examples/xgboost/conda.yaml
@@ -1,6 +1,7 @@
 name: xgboost-example
 channels:
   - defaults
+  - anaconda
   - conda-forge
 dependencies:
   - python=3.6

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -24,6 +24,7 @@ EXAMPLES_DIR = 'examples'
     ('sklearn_logistic_regression', []),
     ('sklearn_elasticnet_wine', ['-P', 'alpha=0.5']),
     (os.path.join('sklearn_elasticnet_diabetes', 'linux'), []),
+    ('spacy', []),
     (os.path.join('tensorflow', 'tf1'), ['-P', 'steps=10']),
     ('xgboost', ['-P', 'colsample-bytree=0.8', '-P', 'subsample=0.9'])
 ])


### PR DESCRIPTION
## What changes are proposed in this pull request?
Addresses https://github.com/mlflow/mlflow/issues/2789

Several examples have been broken due to conda yamls suddenly not accepting `python==3.6`. These have been changed to `python=3.6`. Currently do not know why this is the case, but this hopefully fixes the examples.

This PR also adds the `spacy` example to the suite of nightly tests.

## How is this patch tested?

Travis tests.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] Command Line Interface
- [ ] API
- [ ] Examples
- [ ] Docs
- [ ] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
