### PR TITLE
[FIX] Run example from Github command

### DIFF
--- a/docs/source/tutorials-and-examples/tutorial.rst
+++ b/docs/source/tutorials-and-examples/tutorial.rst
@@ -205,7 +205,7 @@ Now that you have your training code, you can package it so that other data scie
       specified in ``conda.yaml``.
 
       If the repository has an ``MLproject`` file in the root you can also run a project directly from GitHub. This tutorial is duplicated in the https://github.com/mlflow/mlflow-example repository
-      which you can run with ``mlflow run git@github.com:mlflow/mlflow-example.git -P alpha=0.42``.
+      which you can run with ``mlflow run https://github.com/mlflow/mlflow-example.git -P alpha=5``.
 
     .. container:: R
 


### PR DESCRIPTION
Github uses https per default. I got an error with the git@ command.

```
zeth@master ~/P/m/e/sklearn_elasticnet_wine (master) [1]> mlflow run git@github.com:mlflow/mlflow-example.git -P alpha=0.42                                                            (base) 
2020/05/07 12:29:48 INFO mlflow.projects: === Fetching project from git@github.com:mlflow/mlflow-example.git into /tmp/tmpxe4wf3u3 ===
Traceback (most recent call last):
  File "/home/zeth/anaconda3/bin/mlflow", line 8, in <module>
    sys.exit(cli())
  File "/home/zeth/anaconda3/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/zeth/anaconda3/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/zeth/anaconda3/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/zeth/anaconda3/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/zeth/anaconda3/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/zeth/anaconda3/lib/python3.7/site-packages/mlflow/cli.py", line 133, in run
    run_id=run_id
  File "/home/zeth/anaconda3/lib/python3.7/site-packages/mlflow/projects/__init__.py", line 291, in run
    synchronous=synchronous, run_id=run_id)
  File "/home/zeth/anaconda3/lib/python3.7/site-packages/mlflow/projects/__init__.py", line 105, in _run
    work_dir = _fetch_project(uri=uri, force_tempdir=False, version=version)
  File "/home/zeth/anaconda3/lib/python3.7/site-packages/mlflow/projects/__init__.py", line 345, in _fetch_project
    _fetch_git_repo(parsed_uri, version, dst_dir)
  File "/home/zeth/anaconda3/lib/python3.7/site-packages/mlflow/projects/__init__.py", line 385, in _fetch_git_repo
    origin.fetch()
  File "/home/zeth/anaconda3/lib/python3.7/site-packages/GitPython-3.1.1-py3.7.egg/git/remote.py", line 793, in fetch
    res = self._get_fetch_info_from_stderr(proc, progress)
  File "/home/zeth/anaconda3/lib/python3.7/site-packages/GitPython-3.1.1-py3.7.egg/git/remote.py", line 676, in _get_fetch_info_from_stderr
    proc.wait(stderr=stderr_text)
  File "/home/zeth/anaconda3/lib/python3.7/site-packages/GitPython-3.1.1-py3.7.egg/git/cmd.py", line 408, in wait
    raise GitCommandError(self.args, status, errstr)
git.exc.GitCommandError: Cmd('git') failed due to: exit code(128)
  cmdline: git fetch -v origin
  stderr: 'fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.'
```

## What changes are proposed in this pull request?

https instead of git@

## How is this patch tested?

tested with git@ and https. https works.

## Release Notes

### Is this a user-facing change?

- [x ] No. You can skip the rest of this section.
