### PR TITLE
Improve documentation of end_run() for distributed settings

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -155,7 +155,23 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False):
 
 
 def end_run(status=RunStatus.to_string(RunStatus.FINISHED)):
-    """End an active MLflow run (if there is one)."""
+    """End an active MLflow run (if there is one).
+
+    It removes the active run from the global variable keeping track of
+    active runs, unset the ``MLFLOW_RUN_ID`` environment variable and
+    send a termination signal with the ``MLFlowClient``, updating the
+    status on the tracking URI.
+
+    Note that ``end_run()`` is automatically called at exit time (when
+    your script completes).
+
+    In distributed situations, your master node may start a new MLFlow
+    run, forward the MLFlow ``run_id`` to an executor (using the
+    environment variable ``MLFLOW_RUN_ID`` for example), and terminate,
+    even though the executor has not completed. To avoid unwanted early
+    termination of the MLFlow run, use ``atexit.unregister(end_run)``
+    on the master node.
+    """
     global _active_run_stack
     if len(_active_run_stack) > 0:
         # Clear out the global existing run environment variable as well.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Simple update to the documentation of `end_run()` to help with mlflow integration in distributed settings.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s) does this PR affect?

- [ ] UI
- [ ] Command Line Interface
- [ ] API
- [ ] Examples
- [ ] Docs
- [x] Tracking
- [ ] Projects
- [ ] Artifacts
- [ ] Models
- [ ] Model Registry
- [ ] Scoring
- [ ] R
- [ ] Java
- [ ] Python

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
