### PR TITLE
Remove unnecessary line breaks in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.md
@@ -4,14 +4,12 @@ about: Use this template for reporting bugs encountered while using MLflow.
 labels: 'bug'
 title: "[BUG]"
 ---
-Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
-for additional information about bug reports. For help with debugging your code, please refer to [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
+Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md) for additional information about bug reports. For help with debugging your code, please refer to [Stack Overflow](https://stackoverflow.com/questions/tagged/mlflow).
 
 **Please fill in this bug report template to ensure a timely and thorough response.**
 
 ### Willingness to contribute
-The MLflow Community encourages bug fix contributions. Would you or another member of your organization be willing to contribute a fix
-for this bug to the MLflow code base?
+The MLflow Community encourages bug fix contributions. Would you or another member of your organization be willing to contribute a fix for this bug to the MLflow code base?
 
 - [ ] Yes. I can contribute a fix for this bug independently.
 - [ ] Yes. I would be willing to contribute a fix for this bug with guidance from the MLflow community.
@@ -33,8 +31,7 @@ Describe the problem clearly here. Include descriptions of the expected behavior
 Provide a reproducible test case that is the bare minimum necessary to generate the problem.
 
 ### Other info / logs
-Include any logs or source code that would be helpful to diagnose the problem. If including tracebacks,
-please include the full traceback. Large logs and files should be attached.
+Include any logs or source code that would be helpful to diagnose the problem. If including tracebacks, please include the full traceback. Large logs and files should be attached.
 
 
 ### What component(s), interfaces, languages, and integrations does this bug affect?

--- a/.github/ISSUE_TEMPLATE/doc_fix_template.md
+++ b/.github/ISSUE_TEMPLATE/doc_fix_template.md
@@ -4,14 +4,12 @@ about: Use this template for proposing documentation fixes/improvements.
 labels: 'area/docs'
 title: "[DOC-FIX]"
 ---
-Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
-for information on what types of issues we address.
+Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md) for information on what types of issues we address.
 
 **Please fill in this documentation issue template to ensure a timely and thorough response.**
 
 ### Willingness to contribute
-The MLflow Community encourages documentation fix contributions. Would you or another member of your organization be willing to
-contribute a fix for this documentation issue to the MLflow code base?
+The MLflow Community encourages documentation fix contributions. Would you or another member of your organization be willing to contribute a fix for this documentation issue to the MLflow code base?
 
 - [ ] Yes. I can contribute a documentation fix independently.
 - [ ] Yes. I would be willing to contribute a document fix with guidance from the MLflow community.
@@ -22,5 +20,4 @@ contribute a fix for this documentation issue to the MLflow code base?
 Please provide a link to the documentation entry in question.
 
 ### Description of proposal (what needs changing):
-Provide a clear description. Why is the proposed documentation
-better?
+Provide a clear description. Why is the proposed documentation better?

--- a/.github/ISSUE_TEMPLATE/feature_request_template.md
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.md
@@ -4,9 +4,7 @@ about: Use this template for feature and enhancement proposals.
 labels: 'enhancement'
 title: "[FR]"
 ---
-Thank you for submitting a feature request. **Before proceeding, please review MLflow's
-[Issue Policy for feature requests](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md#feature-requests)
-and the [MLflow Contributing Guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst)**.
+Thank you for submitting a feature request. **Before proceeding, please review MLflow's [Issue Policy for feature requests](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md#feature-requests) and the [MLflow Contributing Guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst)**.
 
 **Please fill in this feature request template to ensure a timely and thorough response.**
 
@@ -56,6 +54,4 @@ Integrations
 
 ## Details
 
-(Use this section to include any additional information about the feature. If you have a proposal
-for how to implement this feature, please include it here. For implementation guidelines, please
-refer to the [Contributing Guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#contribution-guidelines).)
+(Use this section to include any additional information about the feature. If you have a proposal for how to implement this feature, please include it here. For implementation guidelines, please refer to the [Contributing Guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#contribution-guidelines).)

--- a/.github/ISSUE_TEMPLATE/installation_issue_template.md
+++ b/.github/ISSUE_TEMPLATE/installation_issue_template.md
@@ -4,8 +4,7 @@ about: Use this template for reporting bugs encountered while installing MLflow.
 labels: 'bug'
 title: "[SETUP-BUG]"
 ---
-Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md)
-for information on what types of issues we address.
+Thank you for submitting an issue. Please refer to our [issue policy](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md) for information on what types of issues we address.
 
 **Please fill in this installation issue template to ensure a timely and thorough response.**
 
@@ -20,5 +19,4 @@ for information on what types of issues we address.
 Provide the exact sequence of commands / steps that you executed before running into the problem.
 
 ### Other info / logs
-Include any logs or source code that would be helpful to diagnose the problem. If including tracebacks,
-please include the full traceback. Large logs and files should be attached.
+Include any logs or source code that would be helpful to diagnose the problem. If including tracebacks, please include the full traceback. Large logs and files should be attached.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Remove unnecessary line breaks in issue templates.

Before:

<img width="850" alt="Screen Shot 2020-05-12 at 1 11 00" src="https://user-images.githubusercontent.com/17039389/81584244-7785a180-93ed-11ea-8401-de564b319302.png">

After:

<img width="850" alt="Screen Shot 2020-05-12 at 1 10 53" src="https://user-images.githubusercontent.com/17039389/81584264-7d7b8280-93ed-11ea-9dab-17716dd37412.png">



## How is this patch tested?

Manually verified the templates are rendered fine.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
