### PR TITLE
Add option to specify run name in mlflow project execution

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -83,8 +83,10 @@ def cli():
               help="If specified, the given run ID will be used instead of creating a new run. "
                    "Note: this argument is used internally by the MLflow project APIs "
                    "and should not be specified.")
+@click.option("--run-name", metavar="RUN_NAME",
+              help="If specified, the given name will be associated with run created during project execution.")
 def run(uri, entry_point, version, param_list, docker_args, experiment_name, experiment_id, backend,
-        backend_config, no_conda, storage_dir, run_id):
+        backend_config, no_conda, storage_dir, run_id, run_name):
     """
     Run an MLflow project from the given URI.
 
@@ -128,7 +130,8 @@ def run(uri, entry_point, version, param_list, docker_args, experiment_name, exp
             use_conda=(not no_conda),
             storage_dir=storage_dir,
             synchronous=backend in ("local", "kubernetes") or backend is None,
-            run_id=run_id
+            run_id=run_id,
+            run_name=run_name
         )
     except projects.ExecutionException as e:
         _logger.error("=== %s ===", e)

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -84,7 +84,8 @@ def cli():
                    "Note: this argument is used internally by the MLflow project APIs "
                    "and should not be specified.")
 @click.option("--run-name", metavar="RUN_NAME",
-              help="If specified, the given name will be associated with run created during project execution.")
+              help="If specified, the given name will be associated with run "
+                   "created during project execution.")
 def run(uri, entry_point, version, param_list, docker_args, experiment_name, experiment_id, backend,
         backend_config, no_conda, storage_dir, run_id, run_name):
     """

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -116,7 +116,7 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
     active_run = get_or_create_run(existing_run_id, uri, experiment_id, work_dir, version,
                                    entry_point, parameters)
 
-    tracking.MlflowClient().set_tag(active_run.run_id, MLFLOW_RUN_NAME,
+    tracking.MlflowClient().set_tag(active_run.info.run_id, MLFLOW_RUN_NAME,
                                     run_name)
 
     if backend_name == "databricks":

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -116,7 +116,7 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
     active_run = get_or_create_run(existing_run_id, uri, experiment_id, work_dir, version,
                                    entry_point, parameters)
 
-    tracking.MlflowClient().set_tag(submitted_run.run_id, MLFLOW_RUN_NAME,
+    tracking.MlflowClient().set_tag(active_run.run_id, MLFLOW_RUN_NAME,
                                     run_name)
 
     if backend_name == "databricks":
@@ -203,7 +203,7 @@ def _run(uri, experiment_id, entry_point="main", version=None, parameters=None,
 def run(uri, entry_point="main", version=None, parameters=None,
         docker_args=None, experiment_name=None, experiment_id=None,
         backend=None, backend_config=None, use_conda=True,
-        storage_dir=None, synchronous=True, run_id=None):
+        storage_dir=None, synchronous=True, run_id=None, run_name=None):
     """
     Run an MLflow project. The project can be local or stored at a Git URI.
 
@@ -284,7 +284,7 @@ def run(uri, entry_point="main", version=None, parameters=None,
         uri=uri, experiment_id=experiment_id, entry_point=entry_point, version=version,
         parameters=parameters, docker_args=docker_args, backend_name=backend,
         backend_config=cluster_spec_dict, use_conda=use_conda, storage_dir=storage_dir,
-        synchronous=synchronous)
+        synchronous=synchronous, run_name=run_name)
     if synchronous:
         _wait_for(submitted_run_obj)
     return submitted_run_obj


### PR DESCRIPTION
## What changes are proposed in this pull request?

This change adds a new command line option `--run-name` to provide name for run generated during project execution. Fix for https://github.com/mlflow/mlflow/issues/2804

## How is this patch tested?

Manually

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
