### PR TITLE
Remove margins around icon buttons

### DIFF
--- a/mlflow/server/js/src/common/components/IconButton.js
+++ b/mlflow/server/js/src/common/components/IconButton.js
@@ -1,0 +1,20 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'antd';
+
+export class IconButton extends Component {
+  static propTypes = {
+    children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+    style: PropTypes.object,
+    restProps: PropTypes.object,
+  };
+
+  render() {
+    const { style, children, ...restProps } = this.props;
+    return (
+      <Button type='link' style={{ padding: 0, ...style }} {...restProps}>
+        {children}
+      </Button>
+    );
+  }
+}

--- a/mlflow/server/js/src/common/components/IconButton.js
+++ b/mlflow/server/js/src/common/components/IconButton.js
@@ -1,20 +1,18 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { Button } from 'antd';
 
-export class IconButton extends Component {
-  static propTypes = {
-    children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
-    style: PropTypes.object,
-    restProps: PropTypes.object,
-  };
+export const IconButton = ({ icon, className, style, ...restProps }) => {
+  return (
+    <Button type='link' className={className} style={{ padding: 0, ...style }} {...restProps}>
+      {icon}
+    </Button>
+  );
+};
 
-  render() {
-    const { style, children, ...restProps } = this.props;
-    return (
-      <Button type='link' style={{ padding: 0, ...style }} {...restProps}>
-        {children}
-      </Button>
-    );
-  }
-}
+IconButton.propTypes = {
+  icon: PropTypes.node.isRequired,
+  style: PropTypes.object,
+  className: PropTypes.string,
+  restProps: PropTypes.object,
+};

--- a/mlflow/server/js/src/common/components/IconButton.test.js
+++ b/mlflow/server/js/src/common/components/IconButton.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import { Button, Icon } from 'antd';
+import { IconButton } from './IconButton';
+
+describe('IconButton', () => {
+  let wrapper;
+  let mockOnClick;
+  let minimalProps;
+
+  beforeEach(() => {
+    minimalProps = { children: <Icon type='edit' /> };
+  });
+
+  test('should render with minimal props without exploding', () => {
+    wrapper = shallow(<IconButton {...minimalProps} />);
+    expect(wrapper.length).toBe(1);
+  });
+
+  test('should not have padding', () => {
+    wrapper = shallow(<IconButton {...minimalProps} />);
+    expect(wrapper.find(Button).get(0).props.style).toHaveProperty('padding', 0);
+  });
+
+  test('should pass style to Button', () => {
+    wrapper = shallow(<IconButton {...minimalProps} style={{ margin: 5 }} />);
+    expect(wrapper.find(Button).get(0).props.style).toHaveProperty('margin', 5);
+  });
+
+  test('should trigger onClick when clicked', () => {
+    mockOnClick = jest.fn();
+    wrapper = mount(<IconButton {...minimalProps} onClick={mockOnClick} />);
+    wrapper.find('button').simulate('click');
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mlflow/server/js/src/common/components/IconButton.test.js
+++ b/mlflow/server/js/src/common/components/IconButton.test.js
@@ -9,7 +9,7 @@ describe('IconButton', () => {
   let minimalProps;
 
   beforeEach(() => {
-    minimalProps = { children: <Icon type='edit' /> };
+    minimalProps = { icon: <Icon type='edit' /> };
   });
 
   test('should render with minimal props without exploding', () => {
@@ -22,8 +22,13 @@ describe('IconButton', () => {
     expect(wrapper.find(Button).get(0).props.style).toHaveProperty('padding', 0);
   });
 
-  test('should pass style to Button', () => {
-    wrapper = shallow(<IconButton {...minimalProps} style={{ margin: 5 }} />);
+  test('should propagate props to Button', () => {
+    const props = {
+      className: 'class',
+      style: { margin: 5 },
+    };
+    wrapper = shallow(<IconButton {...{ ...minimalProps, ...props }} />);
+    expect(wrapper.find(Button).get(0).props).toHaveProperty('className', 'class');
     expect(wrapper.find(Button).get(0).props.style).toHaveProperty('margin', 5);
   });
 

--- a/mlflow/server/js/src/common/components/tables/EditableFormTable.js
+++ b/mlflow/server/js/src/common/components/tables/EditableFormTable.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import { Table, Input, Form, Icon, Popconfirm, Button } from 'antd';
+import { Table, Input, Form, Icon, Popconfirm } from 'antd';
 import PropTypes from 'prop-types';
+import { IconButton } from '../../components/IconButton';
 
 import './EditableFormTable.css';
 
@@ -96,32 +97,31 @@ export class EditableTable extends React.Component {
         }
         return editing ? (
           <span>
-            <Button type='link' onClick={() => this.save(record.key)} style={{ marginRight: 10 }}>
+            <IconButton onClick={() => this.save(record.key)} style={{ marginRight: 10 }}>
               Save
-            </Button>
-            <Button type='link' onClick={() => this.cancel(record.key)}>
+            </IconButton>
+            <IconButton type='link' onClick={() => this.cancel(record.key)}>
               Cancel
-            </Button>
+            </IconButton>
           </span>
         ) : (
           <span>
-            <Button
-              type='link'
+            <IconButton
               disabled={editingKey !== ''}
               onClick={() => this.edit(record.key)}
               style={{ marginRight: 10 }}
             >
               <Icon type='edit' />
-            </Button>
+            </IconButton>
             <Popconfirm
               title='Are you sure you want to delete this tag？'
               okText='Confirm'
               cancelText='Cancel'
               onConfirm={() => this.delete(record.key)}
             >
-              <Button type='link' disabled={editingKey !== ''}>
+              <IconButton disabled={editingKey !== ''}>
                 <i className='far fa-trash-alt' />
-              </Button>
+              </IconButton>
             </Popconfirm>
           </span>
         );

--- a/mlflow/server/js/src/common/components/tables/EditableFormTable.js
+++ b/mlflow/server/js/src/common/components/tables/EditableFormTable.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Table, Input, Form, Icon, Popconfirm } from 'antd';
+import { Table, Input, Form, Icon, Popconfirm, Button } from 'antd';
 import PropTypes from 'prop-types';
 import { IconButton } from '../../components/IconButton';
 
@@ -97,31 +97,28 @@ export class EditableTable extends React.Component {
         }
         return editing ? (
           <span>
-            <IconButton onClick={() => this.save(record.key)} style={{ marginRight: 10 }}>
+            <Button type='link' onClick={() => this.save(record.key)} style={{ marginRight: 10 }}>
               Save
-            </IconButton>
-            <IconButton type='link' onClick={() => this.cancel(record.key)}>
+            </Button>
+            <Button type='link' onClick={() => this.cancel(record.key)}>
               Cancel
-            </IconButton>
+            </Button>
           </span>
         ) : (
           <span>
             <IconButton
+              icon={<Icon type='edit' />}
               disabled={editingKey !== ''}
               onClick={() => this.edit(record.key)}
               style={{ marginRight: 10 }}
-            >
-              <Icon type='edit' />
-            </IconButton>
+            />
             <Popconfirm
               title='Are you sure you want to delete this tag？'
               okText='Confirm'
               cancelText='Cancel'
               onConfirm={() => this.delete(record.key)}
             >
-              <IconButton disabled={editingKey !== ''}>
-                <i className='far fa-trash-alt' />
-              </IconButton>
+              <IconButton icon={<i className='far fa-trash-alt' />} disabled={editingKey !== ''} />
             </Popconfirm>
           </span>
         );

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -180,22 +180,19 @@ export class ExperimentListView extends Component {
                     </Link>
                     {/* Edit/Rename Experiment Option */}
                     <IconButton
+                      icon={<Icon type='edit' />}
                       onClick={this.handleRenameExperiment}
                       data-experimentid={experiment_id}
                       data-experimentname={name}
                       style={{ marginRight: 10 }}
-                    >
-                      <Icon type='edit' />
-                    </IconButton>
+                    />
                     {/* Delete Experiment option */}
                     <IconButton
-                      type='link'
+                      icon={<i className='far fa-trash-alt' />}
                       onClick={this.handleDeleteExperiment}
                       data-experimentid={experiment_id}
                       data-experimentname={name}
-                    >
-                      <i className='far fa-trash-alt' />
-                    </IconButton>
+                    />
                   </div>
                 );
               })}

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -10,6 +10,7 @@ import { Link } from 'react-router-dom';
 import { CreateExperimentModal } from './modals/CreateExperimentModal';
 import { DeleteExperimentModal } from './modals/DeleteExperimentModal';
 import { RenameExperimentModal } from './modals/RenameExperimentModal';
+import { IconButton } from '../../common/components/IconButton';
 import Utils from '../../common/utils/Utils';
 
 export class ExperimentListView extends Component {
@@ -178,24 +179,23 @@ export class ExperimentListView extends Component {
                       <div style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{name}</div>
                     </Link>
                     {/* Edit/Rename Experiment Option */}
-                    <Button
-                      type='link'
+                    <IconButton
                       onClick={this.handleRenameExperiment}
                       data-experimentid={experiment_id}
                       data-experimentname={name}
                       style={{ marginRight: 10 }}
                     >
                       <Icon type='edit' />
-                    </Button>
+                    </IconButton>
                     {/* Delete Experiment option */}
-                    <Button
+                    <IconButton
                       type='link'
                       onClick={this.handleDeleteExperiment}
                       data-experimentid={experiment_id}
                       data-experimentname={name}
                     >
                       <i className='far fa-trash-alt' />
-                    </Button>
+                    </IconButton>
                   </div>
                 );
               })}

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { Icon, Button } from 'antd';
+import { Icon } from 'antd';
 import './ExperimentListView.css';
 import { getExperiments } from '../reducers/Reducers';
 import { Experiment } from '../sdk/MlflowMessages';

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
@@ -26,7 +26,7 @@ import RestoreRunModal from './modals/RestoreRunModal';
 import { NoteInfo, NOTE_CONTENT_TAG } from '../utils/NoteUtils';
 import LocalStorageUtils from '../../common/utils/LocalStorageUtils';
 import { ExperimentViewPersistedState } from '../sdk/MlflowLocalStorageMessages';
-import { Icon, Popover, Descriptions, Button as AntdButton } from 'antd';
+import { Icon, Popover, Descriptions } from 'antd';
 import { CollapsibleSection } from '../../common/components/CollapsibleSection';
 import { EditableNote } from '../../common/components/EditableNote';
 import classNames from 'classnames';
@@ -36,6 +36,7 @@ import { RunsTableColumnSelectionDropdown } from './RunsTableColumnSelectionDrop
 import _ from 'lodash';
 import { ColumnTypes } from '../constants';
 import { getUUID } from '../../common/utils/ActionUtils';
+import { IconButton } from '../../common/components/IconButton';
 
 export const DEFAULT_EXPANDED_VALUE = false;
 
@@ -310,9 +311,7 @@ export class ExperimentView extends Component {
     const { showNotesEditor } = this.state;
 
     const editIcon = (
-      <AntdButton type='link' onClick={this.startEditingDescription}>
-        <Icon type='form' />
-      </AntdButton>
+      <IconButton icon={<Icon type='form' />} onClick={this.startEditingDescription} />
     );
 
     return (

--- a/mlflow/server/js/src/experiment-tracking/components/RunLinksPopover.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunLinksPopover.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { Popover, Button } from 'antd';
+import { Popover } from 'antd';
 import Routes from '../routes';
+import { IconButton } from '../../common/components/IconButton';
 import Utils from '../../common/utils/Utils';
 
 export class RunLinksPopover extends React.Component {
@@ -50,9 +51,9 @@ export class RunLinksPopover extends React.Component {
     return (
       <div>
         <span>Jump to individual runs</span>
-        <Button type='link' onClick={handleClose} style={{ float: 'right', marginLeft: '7px' }}>
+        <IconButton onClick={handleClose} style={{ float: 'right', marginLeft: '7px' }}>
           <i className='fas fa-times' />
-        </Button>
+        </IconButton>
       </div>
     );
   };

--- a/mlflow/server/js/src/experiment-tracking/components/RunLinksPopover.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunLinksPopover.js
@@ -51,9 +51,11 @@ export class RunLinksPopover extends React.Component {
     return (
       <div>
         <span>Jump to individual runs</span>
-        <IconButton onClick={handleClose} style={{ float: 'right', marginLeft: '7px' }}>
-          <i className='fas fa-times' />
-        </IconButton>
+        <IconButton
+          icon={<i className='fas fa-times' />}
+          onClick={handleClose}
+          style={{ float: 'right', marginLeft: '7px' }}
+        />
       </div>
     );
   };

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -122,9 +122,10 @@ export class RunViewImpl extends Component {
     };
     const runCommand = this.getRunCommand();
     const editIcon = (
-      <IconButton onClick={this.startEditingDescription}>
-        <Icon className='edit-icon' type='form' />
-      </IconButton>
+      <IconButton
+        icon={<Icon className='edit-icon' type='form' />}
+        onClick={this.startEditingDescription}
+      />
     );
     return (
       <div className='RunView'>

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -15,9 +15,10 @@ import { NOTE_CONTENT_TAG, NoteInfo } from '../utils/NoteUtils';
 import { BreadcrumbTitle } from './BreadcrumbTitle';
 import { RenameRunModal } from './modals/RenameRunModal';
 import EditableTagsTableView from './EditableTagsTableView';
-import { Icon, Descriptions, Button } from 'antd';
+import { Icon, Descriptions } from 'antd';
 import { CollapsibleSection } from '../../common/components/CollapsibleSection';
 import { EditableNote } from '../../common/components/EditableNote';
+import { IconButton } from '../../common/components/IconButton';
 
 export class RunViewImpl extends Component {
   static propTypes = {
@@ -121,9 +122,9 @@ export class RunViewImpl extends Component {
     };
     const runCommand = this.getRunCommand();
     const editIcon = (
-      <Button type='link' onClick={this.startEditingDescription}>
+      <IconButton onClick={this.startEditingDescription}>
         <Icon className='edit-icon' type='form' />
-      </Button>
+      </IconButton>
     );
     return (
       <div className='RunView'>

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.js
@@ -4,7 +4,7 @@ import { Link } from 'react-router-dom';
 import { modelListPageRoute, getModelPageRoute } from '../routes';
 import Utils from '../../common/utils/Utils';
 import { ModelStageTransitionDropdown } from './ModelStageTransitionDropdown';
-import { Dropdown, Icon, Menu, Modal, Alert, Descriptions, Tooltip, Button } from 'antd';
+import { Dropdown, Icon, Menu, Modal, Alert, Descriptions, Tooltip } from 'antd';
 import {
   ModelVersionStatus,
   StageTagComponents,
@@ -16,6 +16,7 @@ import {
 import Routers from '../../experiment-tracking/routes';
 import { CollapsibleSection } from '../../common/components/CollapsibleSection';
 import { EditableNote } from '../../common/components/EditableNote';
+import { IconButton } from '../../common/components/IconButton';
 
 export class ModelVersionView extends React.Component {
   static propTypes = {
@@ -127,9 +128,9 @@ export class ModelVersionView extends React.Component {
 
   renderDescriptionEditIcon() {
     return (
-      <Button type='link' onClick={this.startEditingDescription}>
+      <IconButton onClick={this.startEditingDescription}>
         <Icon type='form' />
-      </Button>
+      </IconButton>
     );
   }
 

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.js
@@ -127,11 +127,7 @@ export class ModelVersionView extends React.Component {
   }
 
   renderDescriptionEditIcon() {
-    return (
-      <IconButton onClick={this.startEditingDescription}>
-        <Icon type='form' />
-      </IconButton>
-    );
+    return <IconButton icon={<Icon type='form' />} onClick={this.startEditingDescription} />;
   }
 
   render() {

--- a/mlflow/server/js/src/model-registry/components/ModelView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelView.js
@@ -4,7 +4,7 @@ import { ModelVersionTable } from './ModelVersionTable';
 import Utils from '../../common/utils/Utils';
 import { Link } from 'react-router-dom';
 import { modelListPageRoute, getCompareModelVersionsPageRoute } from '../routes';
-import { Radio, Icon, Descriptions, Menu, Dropdown, Modal, Tooltip, Button } from 'antd';
+import { Radio, Icon, Descriptions, Menu, Dropdown, Modal, Tooltip } from 'antd';
 import {
   ACTIVE_STAGES,
   REGISTERED_MODEL_DELETE_MENU_ITEM_DISABLED_TOOLTIP_TEXT,
@@ -12,6 +12,7 @@ import {
 import { CollapsibleSection } from '../../common/components/CollapsibleSection';
 import { EditableNote } from '../../common/components/EditableNote';
 import { Button as BootstrapButton } from 'react-bootstrap';
+import { IconButton } from '../../common/components/IconButton';
 
 export const StageFilters = {
   ALL: 'ALL',
@@ -151,9 +152,9 @@ export class ModelView extends React.Component {
 
   renderDescriptionEditIcon() {
     return (
-      <Button type='link' onClick={this.startEditingDescription}>
+      <IconButton onClick={this.startEditingDescription}>
         <Icon type='form' />
-      </Button>
+      </IconButton>
     );
   }
 

--- a/mlflow/server/js/src/model-registry/components/ModelView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelView.js
@@ -151,11 +151,7 @@ export class ModelView extends React.Component {
   }
 
   renderDescriptionEditIcon() {
-    return (
-      <IconButton onClick={this.startEditingDescription}>
-        <Icon type='form' />
-      </IconButton>
-    );
+    return <IconButton icon={<Icon type='form' />} onClick={this.startEditingDescription} />;
   }
 
   renderDetails = () => {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #2807 and Fixes #2818 

Before:

<img width="359" alt="Screen Shot 2020-05-15 at 0 37 45" src="https://user-images.githubusercontent.com/17039389/81954865-566abe00-9644-11ea-81ed-ba6e34406d0d.png">

After:

<img width="359" alt="Screen Shot 2020-05-15 at 0 35 45" src="https://user-images.githubusercontent.com/17039389/81954889-5ff42600-9644-11ea-897d-65e92aee88c6.png">


## How is this patch tested?

- Unit test
- Manually verified margins around icon buttons are removed.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
