### PR TITLE
Add support for cluster library definition in MLflow project execution

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -394,7 +394,7 @@ If you do need to install libraries on the worker, use the "cluster specificatio
   .. code-block:: json
 
     {
-      "new-cluster": {
+      "new_cluster": {
         "spark_version": "6.4.x-scala2.11",
         "node_type_id": "i3.xlarge",
         "aws_attributes": {"availability": "ON_DEMAND"},

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -237,7 +237,7 @@ Docker container environment
   .. rubric:: Example 3: Image in a remote registry
 
   .. code-block:: yaml
-    
+
     docker_env:
       image: 012345678910.dkr.ecr.us-west-2.amazonaws.com/mlflow-docker-example-environment:7.0
 
@@ -375,17 +375,56 @@ in the Databricks docs
 of how to use the feature is as follows:
 
 1. Create a JSON file containing the
-`new cluster specification <https://docs.databricks.com/api/latest/jobs.html#jobsclusterspecnewcluster>`_
-for your run. For example:
+`new cluster specification <https://docs.databricks.com/dev-tools/api/latest/jobs.html#jobsclusterspecnewcluster>`_
+or `cluster specification <https://docs.databricks.com/dev-tools/api/latest/jobs.html#clusterspec>`_
+for your run. If you do not need to specify libraries installed on the Spark worker nodes, you can use the
+simpler "new cluster specification" format. For example:
 
   .. code-block:: json
 
     {
-      "spark_version": "5.5.x-scala2.11",
+      "spark_version": "6.4.x-scala2.11",
       "node_type_id": "i3.xlarge",
       "aws_attributes": {"availability": "ON_DEMAND"},
       "num_workers": 4
     }
+
+If you do need to install libraries on the worker, use the "cluster specification" format. For example:
+
+  .. code-block:: json
+    {
+      "new-cluster: {
+        "spark_version": "6.4.x-scala2.11",
+        "node_type_id": "i3.xlarge",
+        "aws_attributes": {"availability": "ON_DEMAND"},
+        "num_workers": 4
+      },
+      "libraries": [
+        {
+          "pypi": {
+            "package": "tensorflow"
+          }
+        },
+        {
+          "whl": "dbfs:/path_to_my_lib.whl"
+        }
+      ]
+    }
+
+If you need those same libraries available on the driver, you will also need to specify them in the
+Conda environment YAML file. You can reference wheels on DBFS using the "pip" section of the environment
+file. For example:
+
+  .. code-block:: yaml
+    dependencies:
+      - tensorflow
+      - pip:
+        - /dbfs/path_to_ml_lib.whl
+
+The path to the wheel is different in the Conda environment YAML file than the JSON specification used
+to install libraries on the Spark workers. This is because Conda does not support DBFS; you must instead
+use the `DBFS FUSE mount <https://docs.databricks.com/data/databricks-file-system.html#local-file-apis>`_
+to read the file as if it were a local file.
 
 2. Run your project using the following command:
 

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -394,7 +394,7 @@ If you do need to install libraries on the worker, use the "cluster specificatio
   .. code-block:: json
 
     {
-      "new-cluster: {
+      "new-cluster": {
         "spark_version": "6.4.x-scala2.11",
         "node_type_id": "i3.xlarge",
         "aws_attributes": {"availability": "ON_DEMAND"},

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -377,7 +377,7 @@ of how to use the feature is as follows:
 1. Create a JSON file containing the
 `new cluster specification <https://docs.databricks.com/dev-tools/api/latest/jobs.html#jobsclusterspecnewcluster>`_
 or `cluster specification <https://docs.databricks.com/dev-tools/api/latest/jobs.html#clusterspec>`_
-for your run. If you do not need to specify libraries installed on the Spark worker nodes, you can use the
+for your run. Note that running projects against an existing cluster is not supported. If you do not need to specify libraries installed on the Spark worker nodes, you can use the
 simpler "new cluster specification" format. For example:
 
   .. code-block:: json

--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -237,7 +237,7 @@ Docker container environment
   .. rubric:: Example 3: Image in a remote registry
 
   .. code-block:: yaml
-
+  
     docker_env:
       image: 012345678910.dkr.ecr.us-west-2.amazonaws.com/mlflow-docker-example-environment:7.0
 
@@ -392,6 +392,7 @@ simpler "new cluster specification" format. For example:
 If you do need to install libraries on the worker, use the "cluster specification" format. For example:
 
   .. code-block:: json
+
     {
       "new-cluster: {
         "spark_version": "6.4.x-scala2.11",
@@ -412,10 +413,11 @@ If you do need to install libraries on the worker, use the "cluster specificatio
     }
 
 If you need those same libraries available on the driver, you will also need to specify them in the
-Conda environment YAML file. You can reference wheels on DBFS using the "pip" section of the environment
+Conda environment YAML file. You can reference wheels on DBFS using the ``pip`` section of the environment
 file. For example:
 
   .. code-block:: yaml
+  
     dependencies:
       - tensorflow
       - pip:

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -177,9 +177,11 @@ class DatabricksJobRunner(object):
         # Also note, that we escape this so '<' is not treated as a shell pipe.
         libraries = [{"pypi": {"package": "'mlflow<=%s'" % VERSION}}]
 
-        # Check syntax of JSON - if it contains a libraries and a cluster_spec, pull those out
-        if 'libraries' in cluster_spec and 'new_cluster' in cluster_spec:
-            libraries.extend(cluster_spec['libraries'])
+        # Check syntax of JSON - if it contains libraries and new_cluster, pull those out
+        if 'new_cluster' in cluster_spec:
+            # Libraries are optional, so we don't require that this be specified
+            if 'libraries' in cluster_spec:
+                libraries.extend(cluster_spec['libraries'])
             cluster_spec = cluster_spec['new_cluster']
 
         # Make jobs API request to launch run.

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -162,12 +162,26 @@ class DatabricksJobRunner(object):
         :param command: Shell command to run.
         :param env_vars: Environment variables to set in the process running ``command``.
         :param cluster_spec: Dictionary containing a `Databricks cluster specification
-                             <https://docs.databricks.com/api/latest/jobs.html#clusterspec>`_
-                             to use when launching a run.
+                             <https://docs.databricks.com/dev-tools/api/latest/jobs.html#clusterspec>`_
+                             or a `Databricks new cluster specification
+                             <https://docs.databricks.com/dev-tools/api/latest/jobs.html#jobsclusterspecnewcluster>`_
+                             to use when launching a run. If you specify libraries, this function
+                             will add MLflow to the library list. This function does not support
+                             installation of conda environment libraries on the workers.
         :return: ID of the Databricks job run. Can be used to query the run's status via the
                  Databricks
                  `Runs Get <https://docs.databricks.com/api/latest/jobs.html#runs-get>`_ API.
         """
+        # NB: We use <= on the version specifier to allow running projects on pre-release
+        # versions, where we will select the most up-to-date mlflow version available.
+        # Also note, that we escape this so '<' is not treated as a shell pipe.
+        libraries = [{"pypi": {"package": "'mlflow<=%s'" % VERSION}}]
+
+        # Check syntax of JSON - if it contains a libraries and a cluster_spec, pull those out
+        if 'libraries' in cluster_spec and 'new_cluster' in cluster_spec:
+            libraries.extend(cluster_spec['libraries'])
+            cluster_spec = cluster_spec['new_cluster']
+
         # Make jobs API request to launch run.
         req_body_json = {
             'run_name': 'MLflow Run for %s' % project_uri,
@@ -176,10 +190,7 @@ class DatabricksJobRunner(object):
                 'command': command,
                 "env_vars": env_vars
             },
-            # NB: We use <= on the version specifier to allow running projects on pre-release
-            # versions, where we will select the most up-to-date mlflow version available.
-            # Also note, that we escape this so '<' is not treated as a shell pipe.
-            "libraries": [{"pypi": {"package": "'mlflow<=%s'" % VERSION}}],
+            "libraries": libraries,
         }
         run_submit_res = self._jobs_runs_submit(req_body_json)
         databricks_run_id = run_submit_res["run_id"]

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -268,6 +268,34 @@ def test_run_databricks_cluster_spec_json(
         assert req_body["new_cluster"] == cluster_spec
 
 
+@pytest.mark.usefixtures("before_run_validations_mock", "runs_cancel_mock",
+                         "dbfs_mocks", "cluster_spec_mock", "set_tag_mock")
+def test_run_databricks_extended_cluster_spec_json(
+        runs_submit_mock, runs_get_mock):
+    with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
+        runs_get_mock.return_value = mock_runs_get_result(succeeded=True)
+        new_cluster_spec = {
+            "spark_version": "6.5.x-scala2.11",
+            "num_workers": 2,
+            "node_type_id": "i3.xlarge",
+        }
+        extra_library = {"pypi": {"package": "tensorflow"}}
+
+        cluster_spec = {
+            "new_cluster": new_cluster_spec,
+            "libraries": [extra_library]
+        }
+
+        # Run project synchronously, verify that it succeeds (doesn't throw)
+        run_databricks_project(cluster_spec=cluster_spec, synchronous=True)
+        assert runs_submit_mock.call_count == 1
+        runs_submit_args, _ = runs_submit_mock.call_args_list[0]
+        req_body = runs_submit_args[0]
+        assert req_body["new_cluster"] == new_cluster_spec
+        # This does test deep object equivalence
+        assert extra_library in req_body["libraries"]
+
+
 def test_run_databricks_throws_exception_when_spec_uses_existing_cluster():
     with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
         existing_cluster_spec = {

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -295,6 +295,7 @@ def test_run_databricks_extended_cluster_spec_json(
         # This does test deep object equivalence
         assert extra_library in req_body["libraries"]
 
+
 @pytest.mark.usefixtures("before_run_validations_mock", "runs_cancel_mock",
                          "dbfs_mocks", "cluster_spec_mock", "set_tag_mock")
 def test_run_databricks_extended_cluster_spec_json_without_libraries(
@@ -317,6 +318,7 @@ def test_run_databricks_extended_cluster_spec_json_without_libraries(
         runs_submit_args, _ = runs_submit_mock.call_args_list[0]
         req_body = runs_submit_args[0]
         assert req_body["new_cluster"] == new_cluster_spec
+
 
 def test_run_databricks_throws_exception_when_spec_uses_existing_cluster():
     with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -295,6 +295,28 @@ def test_run_databricks_extended_cluster_spec_json(
         # This does test deep object equivalence
         assert extra_library in req_body["libraries"]
 
+@pytest.mark.usefixtures("before_run_validations_mock", "runs_cancel_mock",
+                         "dbfs_mocks", "cluster_spec_mock", "set_tag_mock")
+def test_run_databricks_extended_cluster_spec_json_without_libraries(
+        runs_submit_mock, runs_get_mock):
+    with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
+        runs_get_mock.return_value = mock_runs_get_result(succeeded=True)
+        new_cluster_spec = {
+            "spark_version": "6.5.x-scala2.11",
+            "num_workers": 2,
+            "node_type_id": "i3.xlarge",
+        }
+
+        cluster_spec = {
+            "new_cluster": new_cluster_spec,
+        }
+
+        # Run project synchronously, verify that it succeeds (doesn't throw)
+        run_databricks_project(cluster_spec=cluster_spec, synchronous=True)
+        assert runs_submit_mock.call_count == 1
+        runs_submit_args, _ = runs_submit_mock.call_args_list[0]
+        req_body = runs_submit_args[0]
+        assert req_body["new_cluster"] == new_cluster_spec
 
 def test_run_databricks_throws_exception_when_spec_uses_existing_cluster():
     with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add support for Databricks cluster specification, including libraries, to Databricks backend configuration. Fixes #2800 using [Approach 2](https://github.com/mlflow/mlflow/issues/2800#issuecomment-629399933).

## How is this patch tested?

New test.
Manual verification of projects installing wheels on driver and workers on Databricks backend.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Extended support for library specification in Databricks backend config to match 
the syntax in [ClusterSpec](https://docs.databricks.com/dev-tools/api/latest/jobs.html#clusterspec) in addition to the previously supported syntax of [NewCluster](https://docs.databricks.com/dev-tools/api/latest/jobs.html#jobsclusterspecnewcluster)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
