### PR TITLE
Start a mlflow model serve by config file

### DIFF
--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -31,7 +31,8 @@ def commands():
 @cli_args.WORKERS
 @cli_args.NO_CONDA
 @cli_args.INSTALL_MLFLOW
-def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False):
+@cli_args.CONFIG
+def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False, config=None):
     """
     Serve a model saved with MLflow by launching a webserver on the specified host and port. For
     information about the input data formats accepted by the webserver, see the following
@@ -54,7 +55,7 @@ def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False):
                                no_conda=no_conda,
                                workers=workers,
                                install_mlflow=install_mlflow).serve(model_uri=model_uri, port=port,
-                                                                    host=host)
+                                                                    host=host, config=config)
 
 
 @commands.command("predict")

--- a/mlflow/models/flavor_backend.py
+++ b/mlflow/models/flavor_backend.py
@@ -35,13 +35,14 @@ class FlavorBackend(object):
         pass
 
     @abstractmethod
-    def serve(self, model_uri, port, host):
+    def serve(self, model_uri, port, host, config):
         """
         Serve the specified MLflow model locally.
 
         :param model_uri: URI pointing to the MLflow model to be used for scoring.
         :param port: Port to use for the model deployment.
         :param host: Host to use for the model deployment. Defaults to ``localhost``.
+        :param config: config FILE for gunicorn.
         """
         pass
 

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -153,6 +153,19 @@ def init(model):
     """
     Initialize the server. Loads pyfunc model from the path.
     """
+
+    # do feature engineering if need.
+    need_feature = False  # feature engineering flag: need or not
+    try:
+        from dependency.feature_engineering import FeatureEngineering
+        need_feature = True
+    except ImportError as ie:
+        if ie.__str__() == "No module named 'dependency'":
+            _logger.warning("There is no need to do feature engineering! ")
+        else:
+            _logger.error(ie)
+        pass
+
     app = flask.Flask(__name__)
 
     @app.route('/ping', methods=['GET'])
@@ -200,16 +213,6 @@ def init(model):
                 mimetype='text/plain')
 
         # do feature engineering if need.
-        need_feature = False  # feature engineering flag: need or not
-        try:
-            from dependency.feature_engineering import FeatureEngineering
-            need_feature = True
-        except ImportError as ie:
-            if ie.__str__() == "No module named 'dependency'":
-                _logger.warning("There is no need to do feature engineering! ")
-            else:
-                _logger.error(ie)
-            pass
         if need_feature:
             if FeatureEngineering.UDF_output:  # user define out put or not.
                 try:

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -136,6 +136,12 @@ def _handle_serving_error(error_message, error_code):
     """
     traceback_buf = StringIO()
     traceback.print_exc(file=traceback_buf)
+
+    # return bad request to console.
+    _logger.error(error_code)
+    _logger.error(error_message)
+    _logger.error(traceback_buf.getvalue())
+
     reraise(MlflowException,
             MlflowException(
                 message=error_message,
@@ -198,8 +204,11 @@ def init(model):
         try:
             from dependency.feature_engineering import FeatureEngineering
             need_feature = True
-        except ImportError:
-            print("There is no need to do feature engineering! ")
+        except ImportError as ie:
+            if ie.__str__() == "No module named 'dependency'":
+                _logger.warning("There is no need to do feature engineering! ")
+            else:
+                _logger.error(ie)
             pass
         if need_feature:
             if FeatureEngineering.UDF_output:  # user define out put or not.

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -43,3 +43,10 @@ PORT = click.option("--port", "-p", default=5000,
 # We use None to disambiguate manually selecting "4"
 WORKERS = click.option("--workers", "-w", default=None,
                        help="Number of gunicorn worker processes to handle requests (default: 4).")
+
+# default disable
+CONFIG = click.option("--config", "-c", default=None, metavar="FILE",
+                      help="The Gunicorn config file is a .py file (default: None). "
+                           "You'd better add the file by absolute root. "
+                           "What can you write in this file reference: https://www.jianshu.com/p/260f18aa5462. "
+                           "This option has higher priority than any other gunicorn option.")

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,4 +1,4 @@
 # Copyright 2018 Databricks, Inc.
 
 
-VERSION = '1.8.1.dev0'
+VERSION = '1.8.1.dev_umetrip'

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     zip_safe=False,
     author='Databricks',
     description='MLflow: An ML Workflow Tool',
-    long_description=open('README.rst').read(),
+    long_description=open('README.md').read(),
     license='Apache License 2.0',
     classifiers=[
         'Intended Audience :: Developers',


### PR DESCRIPTION
Thank you for submitting a feature request. **Before proceeding, please review MLflow's [Issue Policy for feature requests](https://www.github.com/mlflow/mlflow/blob/master/ISSUE_POLICY.md#feature-requests) and the [MLflow Contributing Guide](https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst)**.

**Please fill in this feature request template to ensure a timely and thorough response.**

## Willingness to contribute
The MLflow Community encourages new feature contributions. Would you or another member of your organization be willing to contribute an implementation of this feature (either as an MLflow Plugin or an enhancement to the MLflow code base)?

- [ ] Yes. I can contribute this feature independently.
- [x] Yes. I would be willing to contribute this feature with guidance from the MLflow community.
- [ ] No. I cannot contribute this feature at this time.

## Proposal Summary

We can deployment model by command line `mlflow models serve [OPTIONS: --model-uri, --host, --port, --workers, --no-conda]`. We can't use raw gunicorn option like `--config`, so `access.log` or `error.log` can't be seen if we want.

## Motivation
I found out `mlflow models serve` use gunicorn to create models service in linux. Howere the options for users is limited. When I request the models service by api, I can't see access.log or error.log in  models service. If the `--config FILE` options is supported , we can define own 's gunicorn option more flexible.

### What component(s), interfaces, languages, and integrations does this feature affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interfaces
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Languages 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

## Details
- add command line mlflow modes serve option，When use mlflow models serve --help`--config`option describe：
 ` -c, --config FILE    The Gunicorn config file is a .py file (default: None).
                       You'd better add the file by absolute root. What can
                       you write in this file reference:
                       https://www.jianshu.com/p/260f18aa5462. This option has
                       higher priority than any other gunicorn option.`
- We contribute the raw gunicorn option to users. how to use gunicorn option, check the reference in gunicorn official website.
- When users use config file, they can specify path of model service's log, log  format ect.（fixed bug that users can't explore log, when request the  model service.）

