### PR TITLE
add support for StructType return in spark_udf

### DIFF
--- a/dev/large-requirements.txt
+++ b/dev/large-requirements.txt
@@ -12,7 +12,7 @@ onnxruntime==0.3.0;
 mleap==0.16.0
 mxnet==1.5.0
 pyarrow==0.17.0
-pyspark==2.4.0
+pyspark==3.0.0
 pytest==3.2.1
 pytest-cov==2.6.0
 scikit-learn==0.23.2

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -59,7 +59,8 @@
     <mlflow-version>1.10.1-SNAPSHOT</mlflow-version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <scala.version>2.11.12</scala.version>
+    <scala.version>2.12.10</scala.version>
+    <scala.binary.version>2.12</scala.binary.version>
     <httpclient.version>4.5.6</httpclient.version>
     <git-commit.version>2.2.4</git-commit.version>
     <protobuf.version>3.6.0</protobuf.version>
@@ -107,13 +108,13 @@
       </dependency>
       <dependency>
         <groupId>ml.combust.mleap</groupId>
-        <artifactId>mleap-spark_2.11</artifactId>
-        <version>0.10.3</version>
+        <artifactId>mleap-spark_${scala.binary.version}</artifactId>
+        <version>0.16.0</version>
       </dependency>
       <dependency>
         <groupId>ml.combust.mleap</groupId>
-        <artifactId>mleap-runtime_2.11</artifactId>
-        <version>0.10.3</version>
+        <artifactId>mleap-runtime_${scala.binary.version}</artifactId>
+        <version>0.16.0</version>
       </dependency>
       <dependency>
         <groupId>org.apache.maven.plugins</groupId>

--- a/mlflow/java/scoring/pom.xml
+++ b/mlflow/java/scoring/pom.xml
@@ -41,11 +41,11 @@
     </dependency>
     <dependency>
       <groupId>ml.combust.mleap</groupId>
-      <artifactId>mleap-spark_2.11</artifactId>
+      <artifactId>mleap-spark_${scala.binary.version}</artifactId>
     </dependency>
     <dependency>
       <groupId>ml.combust.mleap</groupId>
-      <artifactId>mleap-runtime_2.11</artifactId>
+      <artifactId>mleap-runtime_${scala.binary.version}</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.plugins</groupId>

--- a/mlflow/java/spark/pom.xml
+++ b/mlflow/java/spark/pom.xml
@@ -37,17 +37,17 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-sql_${scala.compat.version}</artifactId>
-      <version>3.0.0-preview</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.compat.version}</artifactId>
-      <version>3.0.0-preview</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-catalyst_${scala.compat.version}</artifactId>
-      <version>3.0.0-preview</version>
+      <version>3.0.0</version>
     </dependency>
 
     <!-- Test -->

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
@@ -6,7 +6,7 @@ import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, File
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
-import org.apache.spark.sql.sources.{BaseRelation, DataSourceRegister}
+import org.apache.spark.sql.sources.DataSourceRegister
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.util.control.NonFatal
@@ -37,14 +37,6 @@ private[autologging] trait DatasourceAttributeExtractorBase {
     }
   }
 
-  private def getSparkTableInfoFromBaseRelation: BaseRelation => Option[SparkTableInfo] = {
-    case relation@ HadoopFsRelation(location, _, _, _, format, _) =>
-      val path = location.rootPaths.headOption.map(_.toString).getOrElse("")
-      val formatOpt = Option(format.toString.toLowerCase())
-      Option(SparkTableInfo(path, None, formatOpt))
-    case other => None
-  }
-
   protected def maybeGetDeltaTableInfo(plan: LogicalPlan): Option[SparkTableInfo]
 
   /**
@@ -59,8 +51,6 @@ private[autologging] trait DatasourceAttributeExtractorBase {
       leafNode match {
         case relation: DataSourceV2Relation =>
           getSparkTableInfoFromTable(relation.table)
-        case relation: LogicalRelation =>
-          getSparkTableInfoFromBaseRelation(relation.relation)
         case other =>
           None
       }

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
@@ -6,7 +6,7 @@ import org.apache.spark.sql.execution.datasources.v2.{DataSourceV2Relation, File
 import org.apache.spark.sql.execution.datasources.{HadoopFsRelation, LogicalRelation}
 import org.apache.spark.sql.connector.catalog.Table
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
-import org.apache.spark.sql.sources.DataSourceRegister
+import org.apache.spark.sql.sources.{BaseRelation, DataSourceRegister}
 import org.slf4j.{Logger, LoggerFactory}
 
 import scala.util.control.NonFatal
@@ -37,6 +37,14 @@ private[autologging] trait DatasourceAttributeExtractorBase {
     }
   }
 
+  private def getSparkTableInfoFromBaseRelation: BaseRelation => Option[SparkTableInfo] = {
+    case relation@ HadoopFsRelation(location, _, _, _, format, _) =>
+      val path = location.rootPaths.headOption.map(_.toString).getOrElse("")
+      val formatOpt = Option(format.toString.toLowerCase())
+      Option(SparkTableInfo(path, None, formatOpt))
+    case other => None
+  }
+
   protected def maybeGetDeltaTableInfo(plan: LogicalPlan): Option[SparkTableInfo]
 
   /**
@@ -51,6 +59,8 @@ private[autologging] trait DatasourceAttributeExtractorBase {
       leafNode match {
         case relation: DataSourceV2Relation =>
           getSparkTableInfoFromTable(relation.table)
+        case relation: LogicalRelation =>
+          getSparkTableInfoFromBaseRelation(relation.relation)
         case other =>
           None
       }

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
@@ -6,6 +6,7 @@ import java.util.UUID
 
 import org.apache.spark.mlflow.MlflowSparkAutologgingTestUtils
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
+import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.mockito.Matchers.any
@@ -53,6 +54,7 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
       .builder()
       .appName("MLflow Spark Autologging Tests")
       .config("spark.master", "local")
+      .config(SQLConf.USE_V1_SOURCE_LIST.key, "")
       .getOrCreate()
   }
 
@@ -212,9 +214,7 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
     df.collect()
     Thread.sleep(1000)
 
-    // because spark load csv datasource will trigger a filescan job,
-    // the subscriber will receive two notify message, which one is scan csv job, other is scan text job.
-    verify(subscriber, times(2)).notify(any(), any(), any())
+    verify(subscriber, times(1)).notify(any(), any(), any())
     verify(subscriber, times(1)).notify(
       getFileUri(path), "unknown", format)
   }

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/SparkAutologgingIntegrationSuite.scala
@@ -211,7 +211,10 @@ class SparkAutologgingSuite extends FunSuite with Matchers with BeforeAndAfterAl
     subscriberSeq.foreach(MockPublisher.register)
     df.collect()
     Thread.sleep(1000)
-    verify(subscriber, times(1)).notify(any(), any(), any())
+
+    // because spark load csv datasource will trigger a filescan job,
+    // the subscriber will receive two notify message, which one is scan csv job, other is scan text job.
+    verify(subscriber, times(2)).notify(any(), any(), any())
     verify(subscriber, times(1)).notify(
       getFileUri(path), "unknown", format)
   }

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -602,7 +602,9 @@ def spark_udf(spark, model_uri, result_type="double"):
     from pyspark.sql.functions import pandas_udf
     from pyspark.sql.types import _parse_datatype_string
     from pyspark.sql.types import ArrayType, DataType as SparkDataType
-    from pyspark.sql.types import DoubleType, IntegerType, FloatType, LongType, StringType, StructType
+    from pyspark.sql.types import ArrayType, DataType
+    from pyspark.sql.types import DoubleType, IntegerType, FloatType, LongType, StringType, \
+        StructType
 
     if not isinstance(result_type, SparkDataType):
         result_type = _parse_datatype_string(result_type)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -602,7 +602,6 @@ def spark_udf(spark, model_uri, result_type="double"):
     from pyspark.sql.functions import pandas_udf
     from pyspark.sql.types import _parse_datatype_string
     from pyspark.sql.types import ArrayType, DataType as SparkDataType
-    from pyspark.sql.types import ArrayType, DataType
     from pyspark.sql.types import DoubleType, IntegerType, FloatType, LongType, StringType, \
         StructType
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -602,7 +602,7 @@ def spark_udf(spark, model_uri, result_type="double"):
     from pyspark.sql.functions import pandas_udf
     from pyspark.sql.types import _parse_datatype_string
     from pyspark.sql.types import ArrayType, DataType as SparkDataType
-    from pyspark.sql.types import DoubleType, IntegerType, FloatType, LongType, StringType
+    from pyspark.sql.types import DoubleType, IntegerType, FloatType, LongType, StringType, StructType
 
     if not isinstance(result_type, SparkDataType):
         result_type = _parse_datatype_string(result_type)
@@ -611,7 +611,7 @@ def spark_udf(spark, model_uri, result_type="double"):
     if isinstance(elem_type, ArrayType):
         elem_type = elem_type.elementType
 
-    supported_types = [IntegerType, LongType, FloatType, DoubleType, StringType]
+    supported_types = [IntegerType, LongType, FloatType, DoubleType, StringType, StructType]
 
     if not any([isinstance(elem_type, x) for x in supported_types]):
         raise MlflowException(
@@ -690,6 +690,8 @@ def spark_udf(spark, model_uri, result_type="double"):
 
         if type(result_type) == ArrayType:
             return pandas.Series([row[1].values for row in result.iterrows()])
+        elif type(result_type) == StructType:
+            return result
         else:
             return result[result.columns[0]]
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -602,8 +602,14 @@ def spark_udf(spark, model_uri, result_type="double"):
     from pyspark.sql.functions import pandas_udf
     from pyspark.sql.types import _parse_datatype_string
     from pyspark.sql.types import ArrayType, DataType as SparkDataType
-    from pyspark.sql.types import DoubleType, IntegerType, FloatType, LongType, StringType, \
-        StructType
+    from pyspark.sql.types import (
+        DoubleType,
+        IntegerType,
+        FloatType,
+        LongType,
+        StringType,
+        StructType,
+    )
 
     if not isinstance(result_type, SparkDataType):
         result_type = _parse_datatype_string(result_type)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import pyspark
-from py4j.protocol import Py4JJavaError
+from pyspark.sql.utils import PythonException
 from pyspark.sql.types import ArrayType, DoubleType, LongType, StringType, FloatType, IntegerType
 
 import mlflow
@@ -54,11 +54,6 @@ def configure_environment():
 
 
 def get_spark_session(conf):
-    # setting this env variable is needed when using Spark with Arrow >= 0.15.0
-    # because of a change in Arrow IPC format
-    # https://spark.apache.org/docs/latest/sql-pyspark-pandas-with-arrow.html# \
-    # compatibiliy-setting-for-pyarrow--0150-and-spark-23x-24x
-    os.environ["ARROW_PRE_0_15_IPC_FORMAT"] = "1"
     conf.set(key="spark_session.python.worker.reuse", value=True)
     return (
         pyspark.sql.SparkSession.builder.config(conf=conf)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -137,7 +137,7 @@ def test_spark_udf_autofills_column_names_with_schema(spark):
                 columns=["a", "b", "c", "d"], data={"a": [1], "b": [2], "c": [3], "d": [4]}
             )
         )
-        with pytest.raises(Py4JJavaError):
+        with pytest.raises(PythonException, match="Model input is missing columns."):
             res = data.withColumn("res1", udf("a", "b")).select("res1").toPandas()
 
         res = data.withColumn("res2", udf("a", "b", "c")).select("res2").toPandas()

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -7,8 +7,16 @@ import pytest
 import pyspark
 from pyspark.sql import Row
 from pyspark.sql.utils import PythonException
-from pyspark.sql.types import ArrayType, DoubleType, LongType, StringType, FloatType, IntegerType, \
-    StructField, StructType
+from pyspark.sql.types import (
+    ArrayType,
+    DoubleType,
+    LongType,
+    StringType,
+    FloatType,
+    IntegerType,
+    StructField,
+    StructType,
+)
 
 import mlflow
 import mlflow.pyfunc
@@ -78,7 +86,9 @@ def model_path(tmpdir):
 @pytest.mark.large
 def test_spark_udf(spark, model_path):
     mlflow.pyfunc.save_model(
-        path=model_path, loader_module=__name__, code_path=[os.path.dirname(tests.__file__)],
+        path=model_path,
+        loader_module=__name__,
+        code_path=[os.path.dirname(tests.__file__)],
     )
     reloaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(model_path)
 
@@ -153,27 +163,27 @@ def test_struct_type_for_spark_udf(spark):
 
     with mlflow.start_run() as run:
         mlflow.pyfunc.log_model("model", python_model=TestModel())
-        return_type = StructType([
-            StructField('a', StringType()),
-            StructField('b', IntegerType())
-            ])
-        udf = mlflow.pyfunc.spark_udf(spark, "runs:/{}/model".format(run.info.run_id),
-                                      result_type=return_type)
+        return_type = StructType([StructField("a", StringType()), StructField("b", IntegerType())])
+        udf = mlflow.pyfunc.spark_udf(
+            spark, "runs:/{}/model".format(run.info.run_id), result_type=return_type
+        )
 
         input_data = list(Row(a=str(i), b=i) for i in range(10))
-        data = [Row(input=row)for row in input_data]
+        data = [Row(input=row) for row in input_data]
         spark_df = spark.createDataFrame(data)
-        res = spark_df.withColumn('res', udf("input")).select("res")
+        res = spark_df.withColumn("res", udf("input")).select("res")
         pdres = res.toPandas()
         expected = input_data
-        actual = list(row for row in pdres['res'])
+        actual = list(row for row in pdres["res"])
         assert expected == actual
 
 
 @pytest.mark.large
 def test_model_cache(spark, model_path):
     mlflow.pyfunc.save_model(
-        path=model_path, loader_module=__name__, code_path=[os.path.dirname(tests.__file__)],
+        path=model_path,
+        loader_module=__name__,
+        code_path=[os.path.dirname(tests.__file__)],
     )
 
     archive_path = SparkModelCache.add_local_model(spark, model_path)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -7,7 +7,8 @@ import pytest
 import pyspark
 from pyspark.sql import Row
 from pyspark.sql.utils import PythonException
-from pyspark.sql.types import ArrayType, DoubleType, LongType, StringType, FloatType, IntegerType, StructField, StructType
+from pyspark.sql.types import ArrayType, DoubleType, LongType, StringType, FloatType, IntegerType, \
+    StructField, StructType
 
 import mlflow
 import mlflow.pyfunc
@@ -143,6 +144,7 @@ def test_spark_udf_autofills_column_names_with_schema(spark):
         assert res["res2"][0] == ["a", "b", "c"]
         res = data.withColumn("res4", udf("a", "b", "c", "d")).select("res4").toPandas()
         assert res["res4"][0] == ["a", "b", "c"]
+
 
 def test_struct_type_for_spark_udf(spark):
     class TestModel(PythonModel):

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -86,9 +86,7 @@ def model_path(tmpdir):
 @pytest.mark.large
 def test_spark_udf(spark, model_path):
     mlflow.pyfunc.save_model(
-        path=model_path,
-        loader_module=__name__,
-        code_path=[os.path.dirname(tests.__file__)],
+        path=model_path, loader_module=__name__, code_path=[os.path.dirname(tests.__file__)],
     )
     reloaded_pyfunc_model = mlflow.pyfunc.load_pyfunc(model_path)
 
@@ -181,9 +179,7 @@ def test_struct_type_for_spark_udf(spark):
 @pytest.mark.large
 def test_model_cache(spark, model_path):
     mlflow.pyfunc.save_model(
-        path=model_path,
-        loader_module=__name__,
-        code_path=[os.path.dirname(tests.__file__)],
+        path=model_path, loader_module=__name__, code_path=[os.path.dirname(tests.__file__)],
     )
 
     archive_path = SparkModelCache.add_local_model(spark, model_path)

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -57,11 +57,9 @@ SparkModelWithData = namedtuple(
 @pytest.fixture(scope="session", autouse=True)
 def spark_context():
     conf = pyspark.SparkConf()
-    conf.set(
-        key="spark.jars.packages",
-        value="ml.combust.mleap:mleap-spark-base_2.11:0.12.0,"
-        "ml.combust.mleap:mleap-spark_2.11:0.12.0",
-    )
+    conf.set(key="spark.jars.packages",
+             value='ml.combust.mleap:mleap-spark-base_2.12:0.16.0,'
+                   'ml.combust.mleap:mleap-spark_2.12:0.16.0')
     max_tries = 3
     for num_tries in range(max_tries):
         try:

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -57,9 +57,11 @@ SparkModelWithData = namedtuple(
 @pytest.fixture(scope="session", autouse=True)
 def spark_context():
     conf = pyspark.SparkConf()
-    conf.set(key="spark.jars.packages",
-             value='ml.combust.mleap:mleap-spark-base_2.12:0.16.0,'
-                   'ml.combust.mleap:mleap-spark_2.12:0.16.0')
+    conf.set(
+        key="spark.jars.packages",
+        value="ml.combust.mleap:mleap-spark-base_2.12:0.16.0,"
+        "ml.combust.mleap:mleap-spark_2.12:0.16.0",
+    )
     max_tries = 3
     for num_tries in range(max_tries):
         try:

--- a/tests/spark_autologging/utils.py
+++ b/tests/spark_autologging/utils.py
@@ -41,21 +41,23 @@ def _assert_spark_data_logged(run, path, data_format, version=None):
 
 def _get_or_create_spark_session(jars=None):
     jar_path = jars if jars is not None else _get_mlflow_spark_jar_path()
-    return SparkSession.builder \
-        .config("spark.jars", jar_path) \
-        .config("spark.sql.sources.useV1SourceList", "") \
-        .master("local[*]") \
+    return (
+        SparkSession.builder.config("spark.jars", jar_path)
+        .config("spark.sql.sources.useV1SourceList", "")
+        .master("local[*]")
         .getOrCreate()
+    )
 
 
 @pytest.fixture(scope="session")
 def spark_session():
     jar_path = _get_mlflow_spark_jar_path()
-    session = SparkSession.builder \
-        .config("spark.jars", jar_path) \
-        .config("spark.sql.sources.useV1SourceList", "") \
-        .master("local[*]") \
+    session = (
+        SparkSession.builder.config("spark.jars", jar_path)
+        .config("spark.sql.sources.useV1SourceList", "")
+        .master("local[*]")
         .getOrCreate()
+    )
     yield session
     session.stop()
 

--- a/tests/spark_autologging/utils.py
+++ b/tests/spark_autologging/utils.py
@@ -41,13 +41,21 @@ def _assert_spark_data_logged(run, path, data_format, version=None):
 
 def _get_or_create_spark_session(jars=None):
     jar_path = jars if jars is not None else _get_mlflow_spark_jar_path()
-    return SparkSession.builder.config("spark.jars", jar_path).master("local[*]").getOrCreate()
+    return SparkSession.builder \
+        .config("spark.jars", jar_path) \
+        .config("spark.sql.sources.useV1SourceList", "") \
+        .master("local[*]") \
+        .getOrCreate()
 
 
 @pytest.fixture(scope="session")
 def spark_session():
     jar_path = _get_mlflow_spark_jar_path()
-    session = SparkSession.builder.config("spark.jars", jar_path).master("local[*]").getOrCreate()
+    session = SparkSession.builder \
+        .config("spark.jars", jar_path) \
+        .config("spark.sql.sources.useV1SourceList", "") \
+        .master("local[*]") \
+        .getOrCreate()
     yield session
     session.stop()
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

 in spark 3.0, StructType return is added for pandas udf, this pr make a new feature, add support for StructType return in spark_udf

## How is this patch tested?

I tested it manually.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
