### PR TITLE
[Tests] Avoid installing python deps during js tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,6 +67,9 @@ jobs:
 
   js:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mlflow/server/js
     steps:
     - uses: actions/checkout@v2
     - name: Set up Node
@@ -75,14 +78,13 @@ jobs:
         node-version: 10.x
     - name: Install dependencies
       run: |
-        source ./travis/install-common-deps.sh
+        npm i
+    - name: Run lint
+      run: |
+        npm run lint
     - name: Run tests
       run: |
-        cd mlflow/server/js
-        npm i
-        npm run lint
-        set -e
-        for file in $(find src | grep test.js | sort) ; do npm run test -- $file; done
+        npm run test
 
   protos:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Stop running `source ./travis/install-common-deps.sh`.
- Separate package installation, lint, and tests.


## How is this patch tested?

Verified the new job config works fine.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
