### PR TITLE
Removing container hostname from sagemaker, as it is ignored

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -842,7 +842,6 @@ def _create_sagemaker_model(model_name, model_s3_path, model_uri, flavor, vpc_co
     create_model_args = {
         "ModelName": model_name,
         "PrimaryContainer": {
-            'ContainerHostname': 'mfs-%s' % model_name,
             'Image': image_url,
             'ModelDataUrl': model_s3_path,
             'Environment': _get_deployment_config(flavor_name=flavor),


### PR DESCRIPTION
## What changes are proposed in this pull request?
See issue for details https://github.com/mlflow/mlflow/issues/2747

## How is this patch tested?

I created a sagemaker deployment and validated that the container hostname is set to a value described in the AWS documentation if it is left out.
<img width="1082" alt="Screen Shot 2020-05-21 at 10 36 19 AM" src="https://user-images.githubusercontent.com/9397454/82588735-1037c200-9b50-11ea-818e-2be8206f3e70.png">

- I built a docker image with mlflow installed at this revision. 
- I used [opctl](https://opctl.io/) to create a procedure around the `mlflow sagemaker deploy` command to deploy a simple trained model called `hello-model`


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [x] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

