### PR TITLE
Further improvements to model registry error message & docs

### DIFF
--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -7,7 +7,7 @@ MLflow Model Registry
 The MLflow Model Registry component is a centralized model store, set of APIs, and UI, to
 collaboratively manage the full lifecycle of an MLflow Model. It provides model lineage (which
 MLflow experiment and run produced the model), model versioning, stage transitions (for example from
-staging to productƒion), and annotations.
+staging to production), and annotations.
 
 .. contents:: Table of Contents
   :local:
@@ -35,6 +35,9 @@ Annotations and Descriptions
 
 Model Registry Workflows
 ========================
+In order to use model registry functionality via the UI or API, ensure you're running
+an MLflow server using a database-backed backend store. `See here <../tracking.html#backend-stores>`_
+for more information.
 
 Before you can add a model to the Model Registry, you must log it using the ``log_model`` methods
 of the corresponding model flavors. Once a model has been logged, you can add, modify, update, transition,

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -35,9 +35,8 @@ Annotations and Descriptions
 
 Model Registry Workflows
 ========================
-In order to use model registry functionality via the UI or API, ensure you're running
-an MLflow server using a database-backed backend store. `See here <../tracking.html#backend-stores>`_
-for more information.
+If running your own MLflow server, you must use a database-backed backend store in order to access
+model registry functionality. `See here <../tracking.html#backend-stores>`_ for more information.
 
 Before you can add a model to the Model Registry, you must log it using the ``log_model`` methods
 of the corresponding model flavors. Once a model has been logged, you can add, modify, update, transition,

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -36,7 +36,7 @@ Annotations and Descriptions
 Model Registry Workflows
 ========================
 If running your own MLflow server, you must use a database-backed backend store in order to access
-model registry functionality. `See here <../tracking.html#backend-stores>`_ for more information.
+the model registry via the UI or API. `See here <../tracking.html#backend-stores>`_ for more information.
 
 Before you can add a model to the Model Registry, you must log it using the ``log_model`` methods
 of the corresponding model flavors. Once a model has been logged, you can add, modify, update, transition,

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -453,16 +453,24 @@ Storage
 
 An MLflow tracking server has two components for storage: a *backend store* and an *artifact store*.
 
+Backend Stores
+~~~~~~~~~~~~~~
 The backend store is where MLflow Tracking Server stores experiment and run metadata as well as
 params, metrics, and tags for runs. MLflow supports two types of backend stores: *file store* and
 *database-backed store*.
 
-Use ``--backend-store-uri`` to configure the type of backend store. You specify a *file store*
-backend as ``./path_to_store`` or ``file:/path_to_store`` and a *database-backed store* as
-`SQLAlchemy database URI <https://docs.sqlalchemy.org/en/latest/core/engines
-.html#database-urls>`_. The database URI typically takes the format ``<dialect>+<driver>://<username>:<password>@<host>:<port>/<database>``.
-MLflow supports the database dialects ``mysql``, ``mssql``, ``sqlite``, and ``postgresql``.
-Drivers are optional. If you do not specify a driver, SQLAlchemy uses a dialect's default driver. For example, ``--backend-store-uri sqlite:///mlflow.db`` would use a local SQLite database.
+.. note::
+    In order to use model registry functionality, you must run your server using a database-backed store.
+
+
+Use ``--backend-store-uri`` to configure the type of backend store. You specify:
+
+- A file store backend as ``./path_to_store`` or ``file:/path_to_store``
+- A database-backed store as `SQLAlchemy database URI <https://docs.sqlalchemy.org/en/latest/core/engines.html#database-urls>`_.
+  The database URI typically takes the format ``<dialect>+<driver>://<username>:<password>@<host>:<port>/<database>``.
+  MLflow supports the database dialects ``mysql``, ``mssql``, ``sqlite``, and ``postgresql``.
+  Drivers are optional. If you do not specify a driver, SQLAlchemy uses a dialect's default driver. For example, ``--backend-store-uri sqlite:///mlflow.db`` would use a local SQLite database.
+
 
 .. important::
 
@@ -478,7 +486,8 @@ By default ``--backend-store-uri`` is set to the local ``./mlruns`` directory (t
 running ``mlflow run`` locally), but when running a server, make sure that this points to a
 persistent (that is, non-ephemeral) file system location.
 
-
+Artifact Stores
+~~~~~~~~~~~~~~~
 The artifact store is a location suitable for large data (such as an S3 bucket or shared NFS
 file system) and is where clients log their artifact output (for example, models).
 ``artifact_location`` is a property recorded on :py:class:`mlflow.entities.Experiment` for

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -10,9 +10,11 @@ from mlflow.utils.uri import get_uri_scheme
 class UnsupportedModelRegistryStoreURIException(MlflowException):
     """Exception thrown when building a model registry store with an unsupported URI"""
     def __init__(self, unsupported_uri, supported_uri_schemes):
-        message = ("Unsupported URI '{}' for model registry store. Supported schemes are: {}."
-                   " See https://www.mlflow.org/docs/latest/tracking.html#storage for how to"
-                   " setup a compatible server.").format(
+        message = (" Model registry functionality is unavailable; got unsupported URI '{}' for"
+                   " model registry data storage. Supported URI schemes are: {}."
+                   " See https://www.mlflow.org/docs/latest/tracking.html#storage for"
+                   " how to run an MLflow server against one of the supported backend storage"
+                   " locations.").format(
             unsupported_uri, supported_uri_schemes)
         super(UnsupportedModelRegistryStoreURIException, self).__init__(
             message, error_code=INVALID_PARAMETER_VALUE)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Addresses #2857 - updates model registry error message & docs to explicitly state that a database backend store must be used to access model registry functionality. Also improves the formatting/organization of the MLflow server "storage" docs section, which was getting a bit bloated:

### Screenshots of updated docs
![image](https://user-images.githubusercontent.com/2358483/82510059-7aa02200-9abe-11ea-95c1-681dcf58e1f3.png)

![image](https://user-images.githubusercontent.com/2358483/82510366-306b7080-9abf-11ea-8c16-0538fd667658.png)

## How is this patch tested?

Existing tests + docs tests + manually viewing docs

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
