### PR TITLE
Accessibility: Ensures elements with an ARIA role that require child roles contain them

### DIFF
--- a/mlflow/server/js/src/common/components/ag-grid/RunsTableCustomHeader.js
+++ b/mlflow/server/js/src/common/components/ag-grid/RunsTableCustomHeader.js
@@ -54,6 +54,7 @@ export class RunsTableCustomHeader extends React.Component {
 
     return (
       <div
+        role='columnheader'
         style={{ ...styles.headerLabelWrapper, ...JSON.parse(style) }}
         onClick={enableSorting ? () => onSortBy(canonicalSortKey, !orderByAsc) : undefined}
       >

--- a/mlflow/server/js/src/common/components/ag-grid/RunsTableCustomHeader.test.js
+++ b/mlflow/server/js/src/common/components/ag-grid/RunsTableCustomHeader.test.js
@@ -33,4 +33,9 @@ describe('RunsTableCustomHeader', () => {
     wrapper = mount(<RunsTableCustomHeader {...props} />);
     expect(wrapper.find(SortByIcon).length).toBe(0);
   });
+
+  test('should contain child accessibility role since ag-grid has aria parent', () => {
+    wrapper = shallow(<RunsTableCustomHeader {...minimalProps} />);
+    expect(wrapper.find("[role='columnheader']")).toBe(1);
+  });
 });

--- a/mlflow/server/js/src/common/components/ag-grid/RunsTableCustomHeader.test.js
+++ b/mlflow/server/js/src/common/components/ag-grid/RunsTableCustomHeader.test.js
@@ -36,6 +36,6 @@ describe('RunsTableCustomHeader', () => {
 
   test('should contain child accessibility role since ag-grid has aria parent', () => {
     wrapper = shallow(<RunsTableCustomHeader {...minimalProps} />);
-    expect(wrapper.find("[role='columnheader']")).toBe(1);
+    expect(wrapper.find("[role='columnheader']").length).toBe(1);
   });
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR is created to fix the following accessibility issue:
```
Title: WCAG 1.3.1: Ensures elements with an ARIA role that require child roles contain them (.ag-header-row[aria-rowindex="\32 "][role="row"])Tags: Accessibility, WCAG 1.3.1, aria-required-children
```
It looks like at the first glance to be ag-grid's issue on missing accessibility role. However, after checking ag-grid documentation, I found ag-grid actually has [pretty solid accessibility support](https://www.ag-grid.com/javascript-grid-accessibility/). It turns out that it's the customed column header we added missing accessibility role. This PR adds it.

## How is this patch tested?
- Unit test added.
- Manually tested with accessibility Insights plugin.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
