### PR TITLE
Allow a different tracking URI in kubernetes job

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -563,6 +563,7 @@ execution. Replaced fields are indicated using bracketed text.
         - name: "{replaced with MLflow Project name}"
           image: "{replaced with URI of Docker image created during Project execution}"
           command: ["{replaced with MLflow Project entry point command}"]
+          env: ["{appended with MLFLOW_TRACKING_URI, MLFLOW_RUN_ID and MLFLOW_EXPERIMENT_ID}"]
         resources:
           limits:
             memory: 512Mi
@@ -571,8 +572,10 @@ execution. Replaced fields are indicated using bracketed text.
         restartPolicy: Never
 
 The ``container.name``, ``container.image``, and ``container.command`` fields are only replaced for
-the *first* container defined in the Job Spec. All subsequent container definitions are applied
-without modification.
+the *first* container defined in the Job Spec. Further, the ``MLFLOW_TRACKING_URI``, ``MLFLOW_RUN_ID``
+and ``MLFLOW_EXPERIMENT_ID`` are appended to ``container.env``. Use ``KUBE_MLFLOW_TRACKING_URI`` to
+pass a different tracking URI to the job container from the standard ``MLFLOW_TRACKING_URI``. All
+subsequent container definitions are applied without modification.
 
 Iterating Quickly
 -----------------

--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -1,6 +1,7 @@
 import logging
 import docker
 import time
+import os
 from threading import RLock
 from datetime import datetime
 
@@ -33,6 +34,8 @@ def _get_kubernetes_job_definition(project_name, image_tag, image_digest,
     timestamp = datetime.now().strftime('%Y-%m-%d-%H-%M-%S-%f')
     job_name = "{}-{}".format(project_name, timestamp)
     _logger.info("=== Creating Job %s ===", job_name)
+    if os.environ.get('KUBE_MLFLOW_TRACKING_URI') is not None:
+        env_vars['MLFLOW_TRACKING_URI'] = os.environ['KUBE_MLFLOW_TRACKING_URI']
     environment_variables = [{'name': k, 'value': v} for k, v in env_vars.items()]
     job_template['metadata']['name'] = job_name
     job_template['spec']['template']['spec']['containers'][0]['name'] = project_name


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #1874, #2025 
Enables submitting jobs to kubernetes when the tracking URI for the kubernetes job is different from the tracking URI (see description in #1874). For example, the fix allows submitting jobs to Docker Desktop kubernetes for local development of kubernetes projects.

## How is this patch tested?

OS Platform and Distribution (e.g., Linux Ubuntu 16.04): Mac OS Catalina 10.15.4 (19E287)
Tested on kubernetes Docker Desktop for Mac 2.3.0.2.
MLflow version: 1.8.1
Python version: 3.6.5
Command to test: mlflow run examples/docker -P alpha=0.5 --backend kubernetes --backend-config examples/docker/kubernetes_config.json

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Allows adding an environment variable to distinguish between the tracking URI for kubernetes jobs (MLflow Project) and the tracking URI for the UI (MLflow Tracking). Useful for local development.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
