### PR TITLE
Fix pytest `--cov` option to ignore mlfow in site-packages

### DIFF
--- a/travis/run-small-python-tests.sh
+++ b/travis/run-small-python-tests.sh
@@ -7,6 +7,6 @@ trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
 # NB: Also add --ignore'd tests to run-large-python-tests.sh
-pytest --cov=mlflow --verbose --ignore-flavors
+pytest --cov=./mlflow --verbose --ignore-flavors
 
 test $err = 0


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix pytest `--cov` option to ignore mllfow in site-packages.

Before:

Both `mlflow` in site-packages and `mlflow` in the project root are included in the coverate report generated by pytest-cov.

<img width="758" alt="Screen Shot 2020-05-23 at 14 44 51" src="https://user-images.githubusercontent.com/17039389/82723404-92b7b180-9d09-11ea-8e60-60ee9d455a8d.png">

After:

<img width="758" alt="Screen Shot 2020-05-23 at 15 24 06" src="https://user-images.githubusercontent.com/17039389/82723399-8df2fd80-9d09-11ea-88d6-dffab74aa53a.png">


## How is this patch tested?

Manually verified that `mllfow` in site-packages is not included in the coverage report.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
