### PR TITLE
Fix mleap model persistence with newly-released mleap 0.16.0

### DIFF
--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -25,6 +25,7 @@ FLAVOR_NAME = "mleap"
 
 _logger = logging.getLogger(__name__)
 
+
 @keyword_only
 def log_model(spark_model, sample_input, artifact_path, registered_model_name=None,
               signature: ModelSignature=None, input_example: ModelInputExample=None):

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -8,6 +8,7 @@ NOTE:
     Java API method ``downloadArtifacts(String runId)`` and load the model
     using the method ``MLeapLoader.loadPipeline(String modelRootPath)``.
 """
+import logging
 import os
 import sys
 import traceback
@@ -22,6 +23,7 @@ from mlflow.utils import keyword_only
 
 FLAVOR_NAME = "mleap"
 
+_logger = logging.getLogger(__name__)
 
 @keyword_only
 def log_model(spark_model, sample_input, artifact_path, registered_model_name=None,
@@ -223,8 +225,16 @@ def add_to_model(mlflow_model, path, spark_model, sample_input):
                 "MLeap encountered an error while serializing the model. Ensure that the model is"
                 " compatible with MLeap (i.e does not contain any custom transformers).")
 
+    try:
+        mleap_version = mleap.version.__version__
+        _logger.warning(
+            "Detected old mleap version %s. Support for logging models in mleap format with "
+            "mleap versions 0.15.0 and below is deprecated and will be removed in a future "
+            "MLflow release. Please upgrade to a newer mleap version." % mleap_version)
+    except AttributeError:
+        mleap_version = mleap.version
     mlflow_model.add_flavor(FLAVOR_NAME,
-                            mleap_version=mleap.version.__version__,
+                            mleap_version=mleap_version,
                             model_data=mleap_datapath_sub)
 
 

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -231,7 +231,7 @@ def add_to_model(mlflow_model, path, spark_model, sample_input):
         _logger.warning(
             "Detected old mleap version %s. Support for logging models in mleap format with "
             "mleap versions 0.15.0 and below is deprecated and will be removed in a future "
-            "MLflow release. Please upgrade to a newer mleap version." % mleap_version)
+            "MLflow release. Please upgrade to a newer mleap version.", mleap_version)
     except AttributeError:
         mleap_version = mleap.version
     mlflow_model.add_flavor(FLAVOR_NAME,

--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -9,7 +9,7 @@ h2o==3.22.1.4
 onnx==1.4.1;
 onnxmltools==1.4.0;
 onnxruntime==0.3.0;
-mleap==0.8.1
+mleap==0.16.0
 mxnet==1.5.0
 pandas<=0.23.4
 pyarrow==0.17.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes breakage in `mlflow.mleap.log_model` API when using the newly-released mleap 0.16.0, and deprecates logging models with older versions of mleap

## How is this patch tested?

Existing tests + updated tests to run against the latest mleap (0.16.0) Also manually verified that model persistence continues to work with mleap 0.8.1 (the version we previously tested against) by running `pytest tests/spark/test_spark_model_export.py --large`

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
