### PR TITLE
Fix bug where H2O model is not correctly saved to S3 in a distributed setting

### DIFF
--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -101,7 +101,7 @@ def save_model(h2o_model, path, conda_env=None, mlflow_model=None, settings=None
         _save_example(mlflow_model, input_example, path)
 
     # Save h2o-model
-    h2o_save_location = h2o.save_model(model=h2o_model, path=model_data_path, force=True)
+    h2o_save_location = h2o.download_model(model=h2o_model, path=model_data_path)
     model_file = os.path.basename(h2o_save_location)
 
     # Save h2o-settings


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes stale issue https://github.com/mlflow/mlflow/issues/1997

The problem is still present, I have been facing it with the latest version of Sparkling Water (sparkling-water-3.30.0.3-1-2.4)

It appears to be an easily fixed bug in the way H2O is called to serialize the model, the S3 backend of Mlflow works flawlessly.

**Here is what I have found:**
It works correctly in standalone H2O without Spark and the model is correctly serialized to S3.

However, the reported behavior appears when using H2O in distributed mode over a Spark cluster with pysparkling. Mlflow uses h2o.save_model internally to serialize the model, according to the source code. Unfortunately, in pysparkling this call is executed in the worker node. The file is correctly saved but in the worker (!?), not in the driver node, as it should instead.

The solution is to save the H2O model with h2o.download_model instead of h2o.save_model which saves the model in the driver node instead of in the worker.

## How is this patch tested?

- sparkling-water-3.30.0.3-1-2.4
- pysparkling

## Release Notes

### Is this a user-facing change?

- No.

### What component(s), interfaces, languages, and integrations does this PR affect?

H2O integration (mlflow/h2o.py).

### How should the PR be classified in the release notes? Choose one:

Bug fix.