### PR TITLE
Update with more informative message when users run 'mlflow ui' with …

### DIFF
--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -64,13 +64,14 @@ def serve():
     package.
 
     If you are a developer making MLflow source code changes and intentionally running a source
-    installation of MLflow, you can view the UI by running the Javascript dev server: 
+    installation of MLflow, you can view the UI by running the Javascript dev server:
     https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#running-the-javascript-dev-server
 
-    Otherwise, uninstall MLflow via 'pip uninstall mlflow', reinstall an official MLflow release from
-    PyPI via 'pip install mlflow', and rerun the MLflow server. 
+    Otherwise, uninstall MLflow via 'pip uninstall mlflow', reinstall an official MLflow release
+    from PyPI via 'pip install mlflow', and rerun the MLflow server.
     ''')
     return Response(text, mimetype='text/plain')
+
 
 def _build_waitress_command(waitress_opts, host, port):
     opts = shlex.split(waitress_opts) if waitress_opts else []

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -1,8 +1,9 @@
 import os
 import shlex
 import sys
+import textwrap
 
-from flask import Flask, send_from_directory
+from flask import Flask, send_from_directory, Response
 
 from mlflow.server import handlers
 from mlflow.server.handlers import get_artifact_handler, STATIC_PREFIX_ENV_VAR, _add_static_prefix
@@ -53,8 +54,27 @@ def serve_static_file(path):
 # Serve the index.html for the React App for all other routes.
 @app.route(_add_static_prefix('/'))
 def serve():
-    return send_from_directory(STATIC_DIR, 'index.html')
+    if os.path.exists(os.path.join(STATIC_DIR, "index.html")):
+        return send_from_directory(STATIC_DIR, 'index.html')
 
+    text = textwrap.dedent('''
+    Unable to display MLflow UI - landing page (index.html) not found.
+    
+    You are very likely running the MLflow server using a source installation of the Python MLflow package.
+    
+    If you are a developer attempting to make MLflow source code changes and intentionally running a source
+    installation of MLflow,
+    
+    First install the node modules:
+    https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#install-node-modules
+    
+    And then run the Javascript dev server to view the UI: 
+    https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#running-the-javascript-dev-server
+    
+    Otherwise, uninstall MLflow via [pip uninstall mlflow] and reinstall an official MLflow release from PyPI via [pip install mlflow], 
+    and rerun the MLflow server. 
+    ''')
+    return Response(text, mimetype='text/plain')
 
 def _build_waitress_command(waitress_opts, host, port):
     opts = shlex.split(waitress_opts) if waitress_opts else []

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -62,10 +62,9 @@ def serve():
     
     You are very likely running the MLflow server using a source installation of the Python MLflow package.
     
-    If you are a developer attempting to make MLflow source code changes and intentionally running a source
-    installation of MLflow, run the Javascript dev server as described in 
-    https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#running-the-javascript-dev-server to view
-    the UI.
+    If you are a developer making MLflow source code changes and intentionally running a source
+    installation of MLflow, you can view the UI by running the Javascript dev server: 
+    https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#running-the-javascript-dev-server
     
     Otherwise, uninstall MLflow via 'pip uninstall mlflow', reinstall an official MLflow release from PyPI via 
     'pip install mlflow', and rerun the MLflow server. 

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -63,16 +63,12 @@ def serve():
     You are very likely running the MLflow server using a source installation of the Python MLflow package.
     
     If you are a developer attempting to make MLflow source code changes and intentionally running a source
-    installation of MLflow,
+    installation of MLflow, run the Javascript dev server as described in 
+    https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#running-the-javascript-dev-server to view
+    the UI.
     
-    First install the node modules:
-    https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#install-node-modules
-    
-    And then run the Javascript dev server to view the UI: 
-    https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#running-the-javascript-dev-server
-    
-    Otherwise, uninstall MLflow via [pip uninstall mlflow] and reinstall an official MLflow release from PyPI via [pip install mlflow], 
-    and rerun the MLflow server. 
+    Otherwise, uninstall MLflow via 'pip uninstall mlflow', reinstall an official MLflow release from PyPI via 
+    'pip install mlflow', and rerun the MLflow server. 
     ''')
     return Response(text, mimetype='text/plain')
 

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -59,15 +59,16 @@ def serve():
 
     text = textwrap.dedent('''
     Unable to display MLflow UI - landing page (index.html) not found.
-    
-    You are very likely running the MLflow server using a source installation of the Python MLflow package.
-    
+
+    You are very likely running the MLflow server using a source installation of the Python MLflow
+    package.
+
     If you are a developer making MLflow source code changes and intentionally running a source
     installation of MLflow, you can view the UI by running the Javascript dev server: 
     https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#running-the-javascript-dev-server
-    
-    Otherwise, uninstall MLflow via 'pip uninstall mlflow', reinstall an official MLflow release from PyPI via 
-    'pip install mlflow', and rerun the MLflow server. 
+
+    Otherwise, uninstall MLflow via 'pip uninstall mlflow', reinstall an official MLflow release from
+    PyPI via 'pip install mlflow', and rerun the MLflow server. 
     ''')
     return Response(text, mimetype='text/plain')
 


### PR DESCRIPTION
…source installation of MLFlow

## What changes are proposed in this pull request?

After users run 'mlflow ui' with source installation of MLFlow, when they visit localhost:5000, instead of showing "404 not found", we display a more informative message that guides users to install and run the JS server component to run  'mlflow ui'.

<img width="1342" alt="Screen Shot 2020-05-28 at 2 53 20 PM" src="https://user-images.githubusercontent.com/65613067/83182156-e8b69b80-a0f3-11ea-8ab4-289971cc9237.png">


## How is this patch tested?

Manually verify the message that guides users who run 'mlflow ui' with source-installation MLFlow shows up under the correct scenario.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes