### PR TITLE
Making the instructions clearer in the Exception description "Could n…

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -322,6 +322,8 @@ def _get_conda_bin_executable(executable_name):
     ``mlflow.projects.MLFLOW_CONDA_HOME`` is unspecified, this method simply returns the passed-in
     executable name.
     """
+    if MLFLOW_CONDA_HOME != "MLFLOW_CONDA_HOME":
+        return os.path.join(MLFLOW_CONDA_HOME, "/bin/%s" % executable_name)
     conda_home = os.environ.get(MLFLOW_CONDA_HOME)
     if conda_home:
         return os.path.join(conda_home, "bin/%s" % executable_name)
@@ -353,7 +355,8 @@ def _get_or_create_conda_env(conda_env_path, env_id=None):
                                  "user-guide/install/index.html. "
                                  "You can also configure MLflow to look for a specific "
                                  "Conda executable by setting the {1} environment variable "
-                                 "to the path of the Conda executable"
+                                 "to the path of the Conda executable, by doing "
+                                 "os.environ['MLFLOW_CONDA_HOME']= '/path/to/anaconda3/'" 
                                  .format(conda_path, MLFLOW_CONDA_HOME))
     (_, stdout, _) = process.exec_cmd([conda_path, "env", "list", "--json"])
     env_names = [os.path.basename(env) for env in json.loads(stdout)['envs']]


### PR DESCRIPTION
…ot find Conda executable" and fixing a small bug with MLFLOW_CONDA_HOME

The problem happens whenever the user runs in the exception line 350 inside "_get_or_create_conda_env", which corresponds to a failure to find the conda bin executable.

If the user has not yet modified the MLFLOW_CONDA_HOME environment variable, the exception message tells the user to modify the  MLFLOW_CONDA_HOME environment variable.

A user might be tempted to set it by using "mlflow.projects.MLFLOW_CONDA_HOME " after reading the description of '_get_conda_bin_executable' at line 315, but in fact doing this will not solve the problem because  at line 325 what will happen is that :  

os.environ.get(MLFLOW_CONDA_HOME) will return None

In fact the variable MLFLOW_CONDA_HOME is somewhat misleading because it cannot be anything else than the string 'MLFLOW_CONDA_HOME' otherwise the line of code 'conda_home = os.environ.get(MLFLOW_CONDA_HOME)' will not work .

So the current situtation is that we have a variable declared that in fact cannot be allowed to vary.

In fact the way to solve the conda bin not found problem is to do : 
os.environ['MLFLOW_CONDA_HOME']= "/path/to/anaconda3/"

I indicated that in the exception message, but I also added the capacity to read a path set by user through mlflow.projects.MLFLOW_CONDA_HOME

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
