### PR TITLE
[ML-9924] remove deprecated RM and MV detail APIs

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -422,9 +422,6 @@ class MlflowClient(object):
         """
         return self._get_registry_client().list_registered_models()
 
-    @deprecated(alternative="mlflow.tracking.client.get_registered_model", since="1.7")
-    def get_registered_model_details(self, name):
-        return self.get_registered_model(name)
 
     @experimental
     def get_registered_model(self, name):
@@ -514,15 +511,6 @@ class MlflowClient(object):
         :param version: Version number of the model version.
         """
         self._get_registry_client().delete_model_version(name, version)
-
-    @deprecated("mlflow.tracking.client.get_model_version", "1.7")
-    def get_model_version_details(self, name, version):
-        """
-        :param name: Name of the containing registered model.
-        :param version: Version number of the model version.
-        :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
-        """
-        return self._get_registry_client().get_model_version(name, version)
 
     @experimental
     def get_model_version(self, name, version):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -14,7 +14,7 @@ from mlflow.tracking._model_registry.client import ModelRegistryClient
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.tracking._tracking_service import utils
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
-from mlflow.utils import experimental, deprecated
+from mlflow.utils import experimental
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -422,7 +422,6 @@ class MlflowClient(object):
         """
         return self._get_registry_client().list_registered_models()
 
-
     @experimental
     def get_registered_model(self, name):
         """


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR drops the deprecrated APIs `get_registered_model_detailed` and `get_model_version_details`.

## How is this patch tested?

No tests used these methods. Went through Model Registry docs on the Databricks side (https://docs.databricks.com/applications/mlflow/model-registry.html) and Azure Databricks side (https://docs.microsoft.com/en-us/azure/databricks/applications/mlflow/model-registry?toc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fazure-databricks%2Ftoc.json&bc=https%3A%2F%2Fdocs.microsoft.com%2Fen-us%2Fazure%2Fbread%2Ftoc.json)

No reference to these appears in R/Java docs as far as I could tell, so no visible docs change either (but confirmed removing the function removes the reference for these functions in the docs that are generated for MLflow OSS Python)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Deprecated model registry APIs for registered models and model versions were removed.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
