### PR TITLE
fix broken link in tutorial table of contents page

### DIFF
--- a/docs/source/tutorials-and-examples/index.rst
+++ b/docs/source/tutorials-and-examples/index.rst
@@ -14,7 +14,7 @@ Below, you can find a number of tutorials and examples for various MLflow use ca
   - `Packaging Training Code in a Docker Environment <https://github.com/mlflow/mlflow/tree/master/examples/docker>`_
 
   - :ref:`conda-example`
-* `Write & Use MLflow Plugins <https://github.com/mlflow/mlflow/tree/master/examples/plugins>`_
+* `Write & Use MLflow Plugins <https://mlflow.org/docs/latest/plugins.html#writing-your-own-mlflow-plugins>`_
 * Instrument ML training code with MLflow
 
   - `Gluon <https://github.com/mlflow/mlflow/tree/master/examples/gluon>`_


### PR DESCRIPTION
https://github.com/mlflow/mlflow/tree/master/examples/plugins is a dead link, replacing with relevant live link:

https://mlflow.org/docs/latest/plugins.html#writing-your-own-mlflow-plugins