### PR TITLE
Update mleap version in extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
             # scikit-learn 0.20 is the last version to support Python 2.x  & Python 3.4.
             "scikit-learn==0.20; python_version < '3.5'",
             'boto3>=1.7.12',
-            'mleap>=0.8.1',
+            'mleap>=0.16.0',
             'azure-storage-blob>=12.0',
             'google-cloud-storage',
             'azureml-core>=1.2.0'


### PR DESCRIPTION
## What changes are proposed in this pull request?

Update the default of the mleap version so when installing mlflow[extras] so you don't use a version of mleap for which support is going to be removed.

I was unable to serialize a spark model to mleap when using mlflow[extras] and kept getting the following error.

```
Traceback (most recent call last):
  File "/tmp/fc04ab8b32f4409ba816ab644cca8860/train.py", line 168, in <module>
    mlflow.mleap.save_model(spark_model=model, sample_input=test, path=output_location)
  File "/opt/conda/default/lib/python3.6/site-packages/mlflow/utils/annotations.py", line 58, in wrapper
    return func(**kwargs)
  File "/opt/conda/default/lib/python3.6/site-packages/mlflow/mleap.py", line 107, in save_model
    sample_input=sample_input)
  File "/opt/conda/default/lib/python3.6/site-packages/mlflow/utils/annotations.py", line 58, in wrapper
    return func(**kwargs)
  File "/opt/conda/default/lib/python3.6/site-packages/mlflow/mleap.py", line 161, in add_to_model
    mleap_version=mleap.version.__version__,
AttributeError: 'str' object has no attribute '__version__'
```
This has been fixed in https://github.com/mlflow/mlflow/pull/2880 with code to deal with backwards compatibility of different versions of MLeap. However it seems to make sense to use the newer versiuon so you can remove the code supporting these older versions.

## How is this patch tested?

I've used these versions to save a sparkML model.

## Release Notes

### Is this a user-facing change?

- [] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Version of mleap required by MLflow has been bumped to 0.16.0. This version of MLflow still works with older versions, but future versions may not.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
