### PR TITLE
updated AzureML deployment method

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -601,7 +601,7 @@ accepts the following data formats as input:
 
 * JSON-serialized pandas DataFrames in the ``split`` orientation. For example, ``data = pandas_df.to_json(orient='split')``. This format is specified using a ``Content-Type`` request header value of ``application/json``.
 
-* :py:func:`build_image <mlflow.azureml.deploy>` registers an MLflow Model with an existing Azure ML workspace, builds an Azure ML container image and deploys the model to AKS and ACI. The `Azure ML SDK`_ is required in order to use this function. *The Azure ML SDK requires Python 3. It cannot be installed with earlier versions of Python.*
+* :py:func:`mlflow.azureml.deploy` registers an MLflow Model with an existing Azure ML workspace, builds an Azure ML container image and deploys the model to AKS and ACI. The `Azure ML SDK`_ is required in order to use this function. *The Azure ML SDK requires Python 3. It cannot be installed with earlier versions of Python.*
 
 .. _Azure ML SDK: https://docs.microsoft.com/python/api/overview/azure/ml/intro?view=azure-ml-py
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -533,9 +533,6 @@ MLflow can deploy models locally as local REST API endpoints or to directly scor
 MLflow can package models as self-contained Docker images with the REST API endpoint. The image can
 be used to safely deploy the model to various environments such as Kubernetes.
 
-You deploy MLflow model locally or generate a Docker image using the CLI interface to the
-:py:mod:`mlflow.models` module.
-
 The REST API server accepts the following data formats as POST input to the ``/invocations`` path:
 
 * JSON-serialized pandas DataFrames in the ``split`` orientation. For example,
@@ -569,26 +566,6 @@ Example requests:
 
 For more information about serializing pandas DataFrames, see
 `pandas.DataFrame.to_json <https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_json.html>`_.
-
-The predict command accepts the same input formats. The format is specified as command line arguments.
-
-Commands
-~~~~~~~~
-
-* `serve <cli.html#mlflow-models-serve>`_ deploys the model as a local REST API server.
-* `build_docker <cli.html#mlflow-models-build-docker>`_ packages a REST API endpoint serving the
-  model as a docker image.
-* `predict <cli.html#mlflow-models-predict>`_ uses the model to generate a prediction for a local
-  CSV or JSON file.
-
-For more info, see:
-
-.. code-block:: bash
-
-    mlflow models --help
-    mlflow models serve --help
-    mlflow models predict --help
-    mlflow models build-docker --help
 
 .. _azureml_deployment:
 
@@ -628,14 +605,15 @@ accepts the following data formats as input:
                                        location=location,
                                        create_resource_group=True,
                                        exist_okay=True)
+    # Create a deployment config
+    aci_config = AciWebservice.deploy_configuration(cpu_cores=1, memory_gb=1)                                       
 
     # Register and deploy model to Azure Container Instance (ACI)
-    (webservice,model) = mlflow.azureml.deploy(model_uri='runs:/{}/{}'.format(run.id, model_path),
+    (webservice, model) = mlflow.azureml.deploy(model_uri='runs:/{}/{}'.format(run.id, model_path),
                                                workspace=ws,
                                                model_name='mymodelname', 
                                                service_name='myservice', 
-                                               deployment_config=aci_config, 
-                                               tags=None, mlflow_home=None, synchronous=True)
+                                               deployment_config=aci_config)
     webservice.wait_for_deployment(show_output=True)
     # After the model deployment completes, requests can be posted via HTTP to the new ACI
     # webservice's scoring URI. The following example posts a sample input from the wine dataset

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -631,7 +631,7 @@ accepts the following data formats as input:
     aci_config = AciWebservice.deploy_configuration(cpu_cores=1, memory_gb=1)                                       
 
     # Register and deploy model to Azure Container Instance (ACI)
-    (webservice, model) = mlflow.azureml.deploy(model_uri='runs:/{}/{}'.format(run.id, model_path),
+    (webservice, model) = mlflow.azureml.deploy(model_uri='<your-model-uri>',
                                                 workspace=azure_workspace,
                                                 model_name='mymodelname', 
                                                 service_name='myservice', 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -644,7 +644,7 @@ accepts the following data formats as input:
 
     import requests
     import json
-
+    
     # `sample_input` is a JSON-serialized pandas DataFrame with the `split` orientation
     sample_input = {
         "columns": [
@@ -669,6 +669,57 @@ accepts the following data formats as input:
                   headers={"Content-type": "application/json"})
     response_json = json.loads(response.text)
     print(response_json)
+    
+.. rubric:: Example workflow using the MLflow CLI
+    
+.. code-block:: bash
+
+    # note: mlflow azureml build-image is being deprecated, it will be replaced with a new command for model deployment soon
+    
+    mlflow azureml build-image -w <workspace-name> -m <model-path> -d "Wine regression model 1"
+    
+    az ml service create aci -n <deployment-name> --image-id <image-name>:<image-version>
+    
+    # After the image deployment completes, requests can be posted via HTTP to the new ACI
+    # webservice's scoring URI. The following example posts a sample input from the wine dataset
+    # used in the MLflow ElasticNet example:
+    # https://github.com/mlflow/mlflow/tree/master/examples/sklearn_elasticnet_wine
+    
+    scoring_uri=$(az ml service show --name <deployment-name> -v | jq -r ".scoringUri")
+
+    
+        # `sample_input` is a JSON-serialized pandas DataFrame with the `split` orientation
+    sample_input='
+    {
+        "columns": [
+            "alcohol",
+            "chlorides",
+            "citric acid",
+            "density",
+            "fixed acidity",
+            "free sulfur dioxide",
+            "pH",
+            "residual sugar",
+            "sulphates",
+            "total sulfur dioxide",
+            "volatile acidity"
+        ],
+        "data": [
+            [8.8, 0.045, 0.36, 1.001, 7, 45, 3, 20.7, 0.45, 170, 0.27]
+        ]
+    }'
+    
+    echo $sample_input | curl -s -X POST $scoring_uri\
+    -H 'Cache-Control: no-cache'\
+    -H 'Content-Type: application/json'\
+    -d @-
+    
+For more info, see:
+
+.. code-block:: bash
+
+    mlflow azureml --help
+    mlflow azureml build-image --help
 
 .. _sagemaker_deployment:
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -533,6 +533,9 @@ MLflow can deploy models locally as local REST API endpoints or to directly scor
 MLflow can package models as self-contained Docker images with the REST API endpoint. The image can
 be used to safely deploy the model to various environments such as Kubernetes.
 
+You deploy MLflow model locally or generate a Docker image using the CLI interface to the
+:py:mod:`mlflow.models` module.
+
 The REST API server accepts the following data formats as POST input to the ``/invocations`` path:
 
 * JSON-serialized pandas DataFrames in the ``split`` orientation. For example,
@@ -567,19 +570,38 @@ Example requests:
 For more information about serializing pandas DataFrames, see
 `pandas.DataFrame.to_json <https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_json.html>`_.
 
+The predict command accepts the same input formats. The format is specified as command line arguments.
+
+Commands
+~~~~~~~~
+
+* `serve <cli.html#mlflow-models-serve>`_ deploys the model as a local REST API server.
+* `build_docker <cli.html#mlflow-models-build-docker>`_ packages a REST API endpoint serving the
+  model as a docker image.
+* `predict <cli.html#mlflow-models-predict>`_ uses the model to generate a prediction for a local
+  CSV or JSON file.
+
+For more info, see:
+
+.. code-block:: bash
+
+    mlflow models --help
+    mlflow models serve --help
+    mlflow models predict --help
+    mlflow models build-docker --help
+
 .. _azureml_deployment:
 
 Deploy a ``python_function`` model on Microsoft Azure ML
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:mod:`mlflow.azureml` module can package ``python_function`` models into Azure ML container images.
-These images can be deployed to Azure Kubernetes Service (AKS) and the Azure Container Instances (ACI)
+The :py:mod:`mlflow.azureml` module can package ``python_function`` models into Azure ML container images and deploy them as a webservice. Models can be deployed to Azure Kubernetes Service (AKS) and the Azure Container Instances (ACI)
 platform for real-time serving. The resulting Azure ML ContainerImage contains a web server that
 accepts the following data formats as input:
 
 * JSON-serialized pandas DataFrames in the ``split`` orientation. For example, ``data = pandas_df.to_json(orient='split')``. This format is specified using a ``Content-Type`` request header value of ``application/json``.
 
-* :py:func:`build_image <mlflow.azureml.build_image>` registers an MLflow Model with an existing Azure ML workspace and builds an Azure ML container image for deployment to AKS and ACI. The `Azure ML SDK`_ is required in order to use this function. *The Azure ML SDK requires Python 3. It cannot be installed with earlier versions of Python.*
+* :py:func:`build_image <mlflow.azureml.deploy>` registers an MLflow Model with an existing Azure ML workspace, builds an Azure ML container image and deploys the model to AKS and ACI. The `Azure ML SDK`_ is required in order to use this function. *The Azure ML SDK requires Python 3. It cannot be installed with earlier versions of Python.*
 
 .. _Azure ML SDK: https://docs.microsoft.com/python/api/overview/azure/ml/intro?view=azure-ml-py
 
@@ -610,11 +632,10 @@ accepts the following data formats as input:
 
     # Register and deploy model to Azure Container Instance (ACI)
     (webservice, model) = mlflow.azureml.deploy(model_uri='runs:/{}/{}'.format(run.id, model_path),
-                                               workspace=ws,
-                                               model_name='mymodelname', 
-                                               service_name='myservice', 
-                                               deployment_config=aci_config)
-    webservice.wait_for_deployment(show_output=True)
+                                                workspace=azure_workspace,
+                                                model_name='mymodelname', 
+                                                service_name='myservice', 
+                                                deployment_config=aci_config)
     # After the model deployment completes, requests can be posted via HTTP to the new ACI
     # webservice's scoring URI. The following example posts a sample input from the wine dataset
     # used in the MLflow ElasticNet example:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Removed the build image method for deploying an MLflow model to AzureML since it is deprecated. I added the new azureml.mlflow.deploy method. 

## How is this patch tested?

Azure ML team developed and validated this method with internal tests 

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Model Deployments to Azure Machine Learning do not require an image build step anymore, there's a new azureml.mlflow.deploy method. 

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ x] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

