### PR TITLE
[ML-11010] add a search registered models database query and tests

### DIFF
--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -238,12 +238,12 @@ class SqlAlchemyStore(AbstractStore):
                 raise MlflowException('Invalid filter string: %s' % filter_string,
                                       error_code=INVALID_PARAMETER_VALUE)
         else:
-            supported_ops = f'"name ' \
-                f'{"/".join(SearchUtils.VALID_REGISTERED_MODEL_SEARCH_COMPARATORS)} ' \
-                f'\'<model_name>\''
+            supported_ops = ''.join(['(' + op + ')' for op in
+                                     SearchUtils.VALID_REGISTERED_MODEL_SEARCH_COMPARATORS])
+            sample_query = f'name {supported_ops} "<model_name>"'
             raise MlflowException(f'Invalid filter string: {filter_string}'
                                   'Search registered models supports filter expressions like:' +
-                                  supported_ops, error_code=INVALID_PARAMETER_VALUE)
+                                  sample_query, error_code=INVALID_PARAMETER_VALUE)
         with self.ManagedSessionMaker() as session:
             if self.db_type == SQLITE:
                 session.execute("PRAGMA case_sensitive_like = true;")

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -215,9 +215,7 @@ class SqlAlchemyStore(AbstractStore):
         :return: PagedList of :py:class:`mlflow.entities.model_registry.ModelVersion`
                  objects.
         """
-        print(filter_string)
         parsed_filter = SearchUtils.parse_filter_for_model_registry(filter_string)
-        print(parsed_filter)
         if len(parsed_filter) == 0:
             conditions = []
         elif len(parsed_filter) == 1:
@@ -244,12 +242,9 @@ class SqlAlchemyStore(AbstractStore):
                                   '"name (=)(LIKE)(ILIKE) \'<model_name>\'"'
                                   'Input filter string: %s. ' % filter_string,
                                   error_code=INVALID_PARAMETER_VALUE)
-        # print(*conditions)
         with self.ManagedSessionMaker() as session:
-            # print(session.query(SqlRegisteredModel).filter(SqlRegisteredModel.name.like("test%")).all())
             sql_registered_models = session.query(SqlRegisteredModel).filter(*conditions).all()
             registered_models = [rm.to_mlflow_entity() for rm in sql_registered_models]
-            # print(registered_models)
             return registered_models
 
     def get_registered_model(self, name):

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -208,13 +208,12 @@ class SqlAlchemyStore(AbstractStore):
 
     def search_registered_models(self, filter_string):
         """
-        Search for model versions in backend that satisfy the filter criteria.
+        Search for registered models in backend that satisfy the filter criteria.
 
         :param filter_string: A filter string expression. Currently supports a single filter
                               condition either name of model like ``name = 'model_name'``
 
-        :return: PagedList of :py:class:`mlflow.entities.model_registry.ModelVersion`
-                 objects.
+        :return: List of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects.
         """
         parsed_filter = SearchUtils.parse_filter_for_model_registry(filter_string)
         if len(parsed_filter) == 0:

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -20,6 +20,7 @@ class SearchUtils(object):
     VALID_TAG_COMPARATORS = set(['!=', '=', 'LIKE', 'ILIKE'])
     VALID_STRING_ATTRIBUTE_COMPARATORS = set(['!=', '=', 'LIKE', 'ILIKE'])
     CASE_INSENSITIVE_STRING_COMPARISON_OPERATORS = set(['LIKE', 'ILIKE'])
+    VALID_REGISTERED_MODEL_SEARCH_COMPARATORS = CASE_INSENSITIVE_STRING_COMPARISON_OPERATORS.union({'='})
     VALID_SEARCH_ATTRIBUTE_KEYS = set(RunInfo.get_searchable_attributes())
     VALID_ORDER_BY_ATTRIBUTE_KEYS = set(RunInfo.get_orderable_attributes())
     _METRIC_IDENTIFIER = "metric"
@@ -488,3 +489,4 @@ class SearchUtils(object):
                                   error_code=INVALID_PARAMETER_VALUE)
         return [cls._get_comparison_for_model_registry(si)
                 for si in statement.tokens if isinstance(si, Comparison)]
+

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -20,7 +20,8 @@ class SearchUtils(object):
     VALID_TAG_COMPARATORS = set(['!=', '=', 'LIKE', 'ILIKE'])
     VALID_STRING_ATTRIBUTE_COMPARATORS = set(['!=', '=', 'LIKE', 'ILIKE'])
     CASE_INSENSITIVE_STRING_COMPARISON_OPERATORS = set(['LIKE', 'ILIKE'])
-    VALID_REGISTERED_MODEL_SEARCH_COMPARATORS = CASE_INSENSITIVE_STRING_COMPARISON_OPERATORS.union({'='})
+    VALID_REGISTERED_MODEL_SEARCH_COMPARATORS = \
+        CASE_INSENSITIVE_STRING_COMPARISON_OPERATORS.union({'='})
     VALID_SEARCH_ATTRIBUTE_KEYS = set(RunInfo.get_searchable_attributes())
     VALID_ORDER_BY_ATTRIBUTE_KEYS = set(RunInfo.get_orderable_attributes())
     _METRIC_IDENTIFIER = "metric"
@@ -489,4 +490,3 @@ class SearchUtils(object):
                                   error_code=INVALID_PARAMETER_VALUE)
         return [cls._get_comparison_for_model_registry(si)
                 for si in statement.tokens if isinstance(si, Comparison)]
-

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -420,12 +420,11 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                          set([name1, name2, name3, name4, name5, name6]))
 
         # case-sensitive prefix search using LIKE with surrounding % should return all the RMs
+        # _e% matches test_for_search_ , so all
         self.assertEqual(set(search_registered_model(f"name LIKE '_e%'")),
                          set([name1, name2, name3, name4, name5, name6]))
 
-        # case-sensitive prefix search using LIKE should return just rm5 and rm6
-        # note that this test case returns both because the test DB is in sqlite. In sqlite,
-        # LIKE is NOT case-sensitive.
+        # case-sensitive prefix search using LIKE should return just rm5
         self.assertEqual(set(search_registered_model(f"name LIKE '{prefix + 'RM4A'}%'")),
                          set([name5]))
 

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -402,7 +402,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             return [rm.name for rm in self.store.search_registered_models(filter_string)]
 
         # search with no filter should return all registered models
-        self.assertEqual(set(search_registered_model("")),
+        self.assertEqual(set(search_registered_model(None)),
                          set([name1, name2, name3, name4, name5, name6]))
 
         # equality search using name should return exactly the 1 name
@@ -427,7 +427,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # note that this test case returns both because the test DB is in sqlite. In sqlite,
         # LIKE is NOT case-sensitive.
         self.assertEqual(set(search_registered_model(f"name LIKE '{prefix + 'RM4A'}%'")),
-                         set([name5, name6]))
+                         set([name5]))
 
         # case-sensitive prefix search using LIKE should return no models if no match
         self.assertEqual(set(search_registered_model(f"name LIKE '{prefix + 'cats'}%'")),

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -420,7 +420,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                          set([name1, name2, name3, name4, name5, name6]))
 
         # case-sensitive prefix search using LIKE with surrounding % should return all the RMs
-        # _e% matches test_for_search_ , so all
+        # _e% matches test_for_search_ , so all RMs should match
         self.assertEqual(set(search_registered_model(f"name LIKE '_e%'")),
                          set([name1, name2, name3, name4, name5, name6]))
 

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -381,3 +381,100 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert mvds[0].run_id == run_id_1
         assert mvds[0].source == "A/B"
         assert mvds[0].description == "Online prediction model!"
+
+    def test_search_registered_models(self):
+        # create some registered models
+        prefix = "test_for_search_"
+        name1 = prefix + "RM1"
+        name2 = prefix + "RM2"
+        name3 = prefix + "RM3"
+        name4 = prefix + "RM4"
+        name5 = prefix + "RM4A"
+        name6 = prefix + "RM4a"
+        self._rm_maker(name1)
+        self._rm_maker(name2)
+        self._rm_maker(name3)
+        self._rm_maker(name4)
+        self._rm_maker(name5)
+        self._rm_maker(name6)
+
+        def search_registered_model(filter_string):
+            return [rm.name for rm in self.store.search_registered_models(filter_string)]
+
+        # search with no filter should return all registered models
+        self.assertEqual(set(search_registered_model("")),
+                         set([name1, name2, name3, name4, name5, name6]))
+
+        # equality search using name should return exactly the 1 name
+        self.assertEqual(set(search_registered_model(f"name='{name1}'")), set([name1]))
+
+        # equality search using name that is not valid should return nothing
+        self.assertEqual(set(search_registered_model(f"name='{name1+'cats'}'")), set([]))
+
+        # case-sensitive prefix search using LIKE should return all the RMs
+        self.assertEqual(set(search_registered_model(f"name LIKE '{prefix}%'")),
+                         set([name1, name2, name3, name4, name5, name6]))
+
+        # case-sensitive prefix search using LIKE with surrounding % should return all the RMs
+        self.assertEqual(set(search_registered_model(f"name LIKE '%RM%'")),
+                         set([name1, name2, name3, name4, name5, name6]))
+
+        # case-sensitive prefix search using LIKE with surrounding % should return all the RMs
+        self.assertEqual(set(search_registered_model(f"name LIKE '_e%'")),
+                         set([name1, name2, name3, name4, name5, name6]))
+
+        # case-sensitive prefix search using LIKE should return just rm5 and rm6
+        # note that this test case returns both because the test DB is in sqlite. In sqlite,
+        # LIKE is NOT case-sensitive.
+        self.assertEqual(set(search_registered_model(f"name LIKE '{prefix + 'RM4A'}%'")),
+                         set([name5, name6]))
+
+        # case-sensitive prefix search using LIKE should return no models if no match
+        self.assertEqual(set(search_registered_model(f"name LIKE '{prefix + 'cats'}%'")),
+                         set([]))
+
+        # case-insensitive prefix search using ILIKE should return both rm5 and rm6
+        self.assertEqual(set(search_registered_model(f"name ILIKE '{prefix + 'RM4A'}%'")),
+                         set([name5, name6]))
+
+        # case-insensitive postfix search with ILIKE
+        self.assertEqual(set(search_registered_model(f"name ILIKE '%RM4a'")),
+                         set([name5, name6]))
+
+        # case-insensitive prefix search using ILIKE should return both rm5 and rm6
+        self.assertEqual(set(search_registered_model(f"name ILIKE '{prefix + 'cats'}%'")),
+                         set([]))
+
+        # cannot search by invalid comparator types
+        with self.assertRaises(MlflowException) as exception_context:
+            search_registered_model("name!=something")
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+        # cannot search by run_id
+        with self.assertRaises(MlflowException) as exception_context:
+            search_registered_model("run_id='%s'" % "somerunID")
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+        # cannot search by source_path
+        with self.assertRaises(MlflowException) as exception_context:
+            search_registered_model("source_path = 'A/D'")
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+        # cannot search by other params
+        with self.assertRaises(MlflowException) as exception_context:
+            search_registered_model("evilhax = true")
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+        # delete rm6. search should not return RM 6
+        self.store.delete_registered_model(name=name6)
+
+        # equality search using name should return no names
+        self.assertEqual(set(search_registered_model("name='%s'" % name6)), set([]))
+
+        # case-sensitive prefix search using LIKE should return all the RMs
+        self.assertEqual(set(search_registered_model(f"name LIKE '{prefix}%'")),
+                         set([name1, name2, name3, name4, name5]))
+
+        # case-insensitive prefix search using ILIKE should return both rm5 and rm6
+        self.assertEqual(set(search_registered_model(f"name ILIKE '{prefix + 'RM4A'}%'")),
+                         set([name5]))


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR introduces a database query that can search for registered models via an equality operator, `LIKE`, and `ILIKE`. This is going to eventually be a part of a new API introduced to search for registered models.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
