### PR TITLE
Fix flaky keras test

### DIFF
--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -6,6 +6,9 @@ import json
 import pytest
 import shutil
 import importlib
+import random
+
+import tensorflow as tf
 from keras.models import Sequential
 from keras.layers import Layer, Dense
 from keras import backend as K
@@ -33,6 +36,15 @@ from tests.helper_functions import score_model_in_sagemaker_docker_container
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 from tests.pyfunc.test_spark import score_model_as_udf
+
+
+@pytest.fixture(scope='module', autouse=True)
+def fix_random_seed():
+    SEED = 0
+    os.environ['PYTHONHASHSEED'] = str(SEED)
+    random.seed(SEED)
+    np.random.seed(SEED)
+    tf.random.set_seed(SEED)
 
 
 @pytest.fixture(scope='module')

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -187,7 +187,7 @@ def test_that_keras_module_arg_works(model_path):
 
 @pytest.mark.parametrize("build_model", [model, tf_keras_model])
 @pytest.mark.large
-def test_model_save_load(build_model, model_path, data, execution_number):
+def test_model_save_load(build_model, model_path, data):
     x, _ = data
     keras_model = build_model(data)
     if build_model == tf_keras_model:

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -10,6 +10,9 @@ import random
 from packaging import version
 
 import tensorflow as tf
+from tensorflow.keras.models import Sequential as TfSequential
+from tensorflow.keras.layers import Dense as TfDense
+from tensorflow.keras.optimizers import SGD as TfSGD
 from keras.models import Sequential
 from keras.layers import Layer, Dense
 from keras import backend as K
@@ -76,9 +79,6 @@ def model(data):
 @pytest.fixture(scope='module')
 def tf_keras_model(data):
     x, y = data
-    from tensorflow.keras.models import Sequential as TfSequential
-    from tensorflow.keras.layers import Dense as TfDense
-    from tensorflow.keras.optimizers import SGD as TfSGD
     model = TfSequential()
     model.add(TfDense(3, input_dim=4))
     model.add(TfDense(1))

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -183,6 +183,7 @@ def test_that_keras_module_arg_works(model_path):
             assert x == b
 
 
+@pytest.mark.parametrize('execution_number', range(100))
 @pytest.mark.parametrize("build_model", [model, tf_keras_model])
 @pytest.mark.large
 def test_model_save_load(build_model, model_path, data):

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -9,6 +9,7 @@ import importlib
 from keras.models import Sequential
 from keras.layers import Layer, Dense
 from keras import backend as K
+from keras.optimizers import SGD
 import sklearn.datasets as datasets
 import pandas as pd
 import numpy as np
@@ -50,7 +51,7 @@ def model(data):
     model = Sequential()
     model.add(Dense(3, input_dim=4))
     model.add(Dense(1))
-    model.compile(loss='mean_squared_error', optimizer='SGD')
+    model.compile(loss='mean_squared_error', optimizer=SGD(learning_rate=0.001))
     model.fit(x, y)
     return model
 
@@ -60,10 +61,11 @@ def tf_keras_model(data):
     x, y = data
     from tensorflow.keras.models import Sequential as TfSequential
     from tensorflow.keras.layers import Dense as TfDense
+    from tensorflow.keras.optimizers import SGD as TfSGD
     model = TfSequential()
     model.add(TfDense(3, input_dim=4))
     model.add(TfDense(1))
-    model.compile(loss='mean_squared_error', optimizer='SGD')
+    model.compile(loss='mean_squared_error', optimizer=TfSGD(learning_rate=0.001))
     model.fit(x, y)
     return model
 

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -71,6 +71,8 @@ def model(data):
     model = Sequential()
     model.add(Dense(3, input_dim=4))
     model.add(Dense(1))
+    # Use a small learning rate to prevent exploding gradients which may produce
+    # infinite prediction values
     model.compile(loss='mean_squared_error', optimizer=SGD(learning_rate=0.001))
     model.fit(x, y)
     return model

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -185,7 +185,6 @@ def test_that_keras_module_arg_works(model_path):
             assert x == b
 
 
-@pytest.mark.parametrize('execution_number', range(100))
 @pytest.mark.parametrize("build_model", [model, tf_keras_model])
 @pytest.mark.large
 def test_model_save_load(build_model, model_path, data, execution_number):

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -186,7 +186,7 @@ def test_that_keras_module_arg_works(model_path):
 @pytest.mark.parametrize('execution_number', range(100))
 @pytest.mark.parametrize("build_model", [model, tf_keras_model])
 @pytest.mark.large
-def test_model_save_load(build_model, model_path, data):
+def test_model_save_load(build_model, model_path, data, execution_number):
     x, _ = data
     keras_model = build_model(data)
     if build_model == tf_keras_model:

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -7,6 +7,7 @@ import pytest
 import shutil
 import importlib
 import random
+from packaging import version
 
 import tensorflow as tf
 from keras.models import Sequential
@@ -44,7 +45,11 @@ def fix_random_seed():
     os.environ['PYTHONHASHSEED'] = str(SEED)
     random.seed(SEED)
     np.random.seed(SEED)
-    tf.random.set_seed(SEED)
+
+    if version.parse(tf.__version__) >= version.parse('2.0.0'):
+        tf.random.set_seed(SEED)
+    else:
+        tf.set_random_seed(SEED)
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
## What changes are proposed in this pull request?

`test_model_save_load` in `test_keras_model_export.py` fails when the gradients of a model explode during training and the prediction values become infinity. This PR aims to fix this issue by using a smaller learning rate.

https://github.com/mlflow/mlflow/pull/2914/checks?check_run_id=762832699#step:5:347


![Screen Shot 2020-06-12 at 16 35 23](https://user-images.githubusercontent.com/17039389/84477568-c6fc0d80-acca-11ea-85c2-340933f16c3d.png)


## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
