### PR TITLE
Fix invalid prop type of `children` in `CollapsibleSection.js`

### DIFF
--- a/mlflow/server/js/src/common/components/CollapsibleSection.js
+++ b/mlflow/server/js/src/common/components/CollapsibleSection.js
@@ -25,7 +25,7 @@ export function CollapsibleSection(props) {
 CollapsibleSection.propTypes = {
   title: PropTypes.oneOfType([PropTypes.string, PropTypes.object]).isRequired,
   forceOpen: PropTypes.bool,
-  children: PropTypes.object,
+  children: PropTypes.node.isRequired,
 };
 
 CollapsibleSection.defaultProps = {


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix the following error in `CollapsibleSection.js`.

https://github.com/mlflow/mlflow/pull/2914/checks?check_run_id=762832608#step:6:1190

![Screen Shot 2020-06-12 at 17 24 40](https://user-images.githubusercontent.com/17039389/84482437-afc11e00-acd2-11ea-9d02-8672bee75fc8.png)

## How is this patch tested?

https://github.com/mlflow/mlflow/pull/2929/checks?check_run_id=764750718#step:6:2950
![Screen Shot 2020-06-12 at 17 37 23](https://user-images.githubusercontent.com/17039389/84482869-6fae6b00-acd3-11ea-9bd1-056070d01f93.png)

The warning is removed.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
