### PR TITLE
Fix integer experimentId to string to remove invalid-prop-type warnings.

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/RunPage.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunPage.test.js
@@ -31,7 +31,7 @@ describe('RunPage', () => {
       match: {
         params: {
           runUuid: 'uuid-1234-5678-9012',
-          experimentId: 12345,
+          experimentId: '12345',
         },
       },
       history: {
@@ -59,8 +59,8 @@ describe('RunPage', () => {
         },
         artifactsByRunUuid: { 'uuid-1234-5678-9012': new ArtifactNode(true) },
         experimentsById: {
-          12345: {
-            experiment_id: 12345,
+          '12345': {
+            experiment_id: '12345',
             name: 'my experiment',
             artifact_location: 'dbfs:/databricks/abc',
             lifecycle_stage: 'active',

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
@@ -21,7 +21,7 @@ describe('RunView', () => {
   beforeEach(() => {
     minimalProps = {
       runUuid: 'uuid-1234-5678-9012',
-      experimentId: 12345,
+      experimentId: '12345',
       getMetricPagePath: jest.fn(),
       handleSetRunTag: jest.fn(),
     };

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
@@ -45,8 +45,8 @@ describe('RunView', () => {
         },
         artifactsByRunUuid: { 'uuid-1234-5678-9012': new ArtifactNode(true) },
         experimentsById: {
-          12345: Experiment.fromJs({
-            experiment_id: 12345,
+          '12345': Experiment.fromJs({
+            experiment_id: '12345',
             name: 'my experiment',
             artifact_location: 'dbfs:/databricks/abc',
             lifecycle_stage: 'active',

--- a/mlflow/server/js/src/experiment-tracking/components/modals/RenameExperimentModal.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/RenameExperimentModal.test.js
@@ -14,7 +14,7 @@ describe('RenameExperimentModal', () => {
     mockGetExperimentApi = jest.fn(() => Promise.resolve({}));
     minimalProps = {
       isOpen: false,
-      experimentId: 123,
+      experimentId: '123',
       experimentName: 'testName',
       experimentNames: ['arrayName1', 'arrayName2'],
       onClose: jest.fn(() => Promise.resolve({})),

--- a/mlflow/server/js/src/experiment-tracking/components/modals/RenameExperimentModal.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/RenameExperimentModal.test.js
@@ -35,7 +35,7 @@ describe('RenameExperimentModal', () => {
     const promise = wrapper.find(GenericInputModal).prop('handleSubmit')(values);
     promise.finally(() => {
       expect(mockUpdateExperimentApi).toHaveBeenCalledTimes(1);
-      expect(mockUpdateExperimentApi).toHaveBeenCalledWith(123, 'renamed');
+      expect(mockUpdateExperimentApi).toHaveBeenCalledWith('123', 'renamed');
       expect(mockGetExperimentApi).toHaveBeenCalledTimes(1);
       done();
     });
@@ -60,7 +60,7 @@ describe('RenameExperimentModal', () => {
     );
     failUpdatePromise.catch(() => {
       expect(mockFailUpdateExperimentApi).toHaveBeenCalledTimes(1);
-      expect(mockFailUpdateExperimentApi).toHaveBeenCalledWith(123, 'renamed');
+      expect(mockFailUpdateExperimentApi).toHaveBeenCalledWith('123', 'renamed');
       expect(mockGetExperimentApi).toHaveBeenCalledTimes(0);
       done();
     });
@@ -83,7 +83,7 @@ describe('RenameExperimentModal', () => {
     const failGetPromise = failGetWrapper.find(GenericInputModal).prop('handleSubmit')(values);
     failGetPromise.catch(() => {
       expect(mockUpdateExperimentApi).toHaveBeenCalledTimes(1);
-      expect(mockUpdateExperimentApi).toHaveBeenCalledWith(123, 'renamed');
+      expect(mockUpdateExperimentApi).toHaveBeenCalledWith('123', 'renamed');
       expect(mockFailGetExperimentApi).toHaveBeenCalledTimes(1);
       done();
     });


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix integer `experimentId` to string to remove invalid-prop-type warnings.

![Screen Shot 2020-06-16 at 11 21 25](https://user-images.githubusercontent.com/17039389/84724608-8d295080-afc3-11ea-86bb-afa8f554e40d.png)

https://github.com/mlflow/mlflow/runs/773520817#step:6:22

## How is this patch tested?

- Verified the existing tests succeed.
- Verified the warnings are removed.

![Screen Shot 2020-06-16 at 17 41 04](https://user-images.githubusercontent.com/17039389/84752347-97b20d00-aff8-11ea-82ae-40d9d336f40e.png)

https://github.com/mlflow/mlflow/pull/2940/checks?check_run_id=775083046#step:6:22


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
