### PR TITLE
Fix undefined-prop warnings

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.test.js
@@ -38,6 +38,7 @@ describe('ArtifactView', () => {
     minimalProps = {
       runUuid: 'fakeUuid',
       artifactNode: node,
+      artifactRootUri: 'test_root',
       listArtifactsApi: jest.fn(() => Promise.resolve({})),
       modelVersionsBySource: {},
       handleActiveNodeChange: jest.fn(),

--- a/mlflow/server/js/src/model-registry/components/ModelVersionTable.test.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionTable.test.js
@@ -13,6 +13,7 @@ describe('ModelVersionTable', () => {
     minimalProps = {
       modelName: 'Model A',
       modelVersions: [],
+      onChange: jest.fn(),
     };
   });
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix undefined-prop warnings in:

- `ArtifactView.test.js`
- `ModelVersionTable.test.js`

![Screen Shot 2020-06-16 at 11 30 09](https://user-images.githubusercontent.com/17039389/84725141-e0e86980-afc4-11ea-8cb1-e8dfd73b14ce.png)

https://github.com/mlflow/mlflow/runs/773520817#step:6:13

## How is this patch tested?

- Verified the existing tests succeed.
- Verified the warnings are removed.


![Screen Shot 2020-06-16 at 12 59 08](https://user-images.githubusercontent.com/17039389/84730472-34f94b00-afd1-11ea-98ef-1de34367eb7e.png)

https://github.com/mlflow/mlflow/pull/2941/checks?check_run_id=774990703#step:6:13


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
