### PR TITLE
Fix duplicate-key warnings in `ModelView.test.js`

### DIFF
--- a/mlflow/server/js/src/model-registry/test-utils.js
+++ b/mlflow/server/js/src/model-registry/test-utils.js
@@ -10,7 +10,8 @@ export const mockRegisteredModelDetailed = (name, latestVersions = []) => {
 export const mockModelVersionDetailed = (name, version, stage, status) => {
   return {
     name,
-    // Use version-based timestamp to make creation_timestamp differ across model versions.
+    // Use version-based timestamp to make creation_timestamp differ across model versions
+    // and prevent React duplicate key warning.
     creation_timestamp: version,
     last_updated_timestamp: version + 1,
     user_id: 'richard@example.com',

--- a/mlflow/server/js/src/model-registry/test-utils.js
+++ b/mlflow/server/js/src/model-registry/test-utils.js
@@ -10,7 +10,7 @@ export const mockRegisteredModelDetailed = (name, latestVersions = []) => {
 export const mockModelVersionDetailed = (name, version, stage, status) => {
   return {
     name,
-    // Use version-based timestamp to make creation_timestamp differ across model versions.    
+    // Use version-based timestamp to make creation_timestamp differ across model versions.
     creation_timestamp: version,
     last_updated_timestamp: version + 1,
     user_id: 'richard@example.com',

--- a/mlflow/server/js/src/model-registry/test-utils.js
+++ b/mlflow/server/js/src/model-registry/test-utils.js
@@ -10,8 +10,8 @@ export const mockRegisteredModelDetailed = (name, latestVersions = []) => {
 export const mockModelVersionDetailed = (name, version, stage, status) => {
   return {
     name,
-    creation_timestamp: 1571344731614,
-    last_updated_timestamp: 1573581360069,
+    creation_timestamp: version,
+    last_updated_timestamp: version + 1,
     user_id: 'richard@example.com',
     current_stage: stage,
     description: '',

--- a/mlflow/server/js/src/model-registry/test-utils.js
+++ b/mlflow/server/js/src/model-registry/test-utils.js
@@ -10,6 +10,7 @@ export const mockRegisteredModelDetailed = (name, latestVersions = []) => {
 export const mockModelVersionDetailed = (name, version, stage, status) => {
   return {
     name,
+    // Use version-based timestamp to make creation_timestamp differ across model versions.    
     creation_timestamp: version,
     last_updated_timestamp: version + 1,
     user_id: 'richard@example.com',


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix duplicate-key warnings in `ModelView.test.js`.
 
![Screen Shot 2020-06-16 at 12 16 26](https://user-images.githubusercontent.com/17039389/84728030-548d7500-afcb-11ea-8062-6d745909a18b.png)

https://github.com/mlflow/mlflow/runs/773520817#step:6:139


## How is this patch tested?

![Screen Shot 2020-06-16 at 12 24 20](https://user-images.githubusercontent.com/17039389/84728500-56a40380-afcc-11ea-9de0-e07f88d23f97.png)


https://github.com/mlflow/mlflow/pull/2942/checks?check_run_id=775077343#step:6:139

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
