### PR TITLE
Remove deprecated fields on client APIs

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -587,8 +587,7 @@ def _update_model_version():
     if request_message.HasField("description"):
         new_description = request_message.description
     model_version = _get_model_registry_store().update_model_version(
-        name=request_message.name, version=request_message.version,
-        description=new_description)
+        name=request_message.name, version=request_message.version, description=new_description)
     return _wrap_response(UpdateModelVersion.Response(model_version=model_version.to_proto()))
 
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -373,35 +373,20 @@ class MlflowClient(object):
         self._get_registry_client().rename_registered_model(name, new_name)
 
     @experimental
-    def update_registered_model(self, name, new_name=None, description=None):
+    def update_registered_model(self, name, description=None):
         """
-        Updates metadata for RegisteredModel entity. Either ``new_name`` or ``description`` should
-        be non-None. Backend raises exception if a registered model with given name does not exist.
+        Updates metadata for RegisteredModel entity. Input field ``description`` should be non-None.
+        Backend raises exception if a registered model with given name does not exist.
 
         :param name: Name of the registered model to update.
-        :param new_name: (Deprecated) New proposed name for the registered model.
-                         This argument is deprecated. Use the
-                         :py:func:`rename_registered_model <MlflowClient.rename_registered_model>`
-                         method to rename registered models instead.
         :param description: (Optional) New description.
         :return: A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
-        if new_name is None and description is None:
+        if description is None:
             raise MlflowException("Attempting to update registered model with no new field values.")
 
-        if new_name is not None and new_name.strip() == "":
-            raise MlflowException("The new name must not be an empty string.")
-
-        res = None
-        if new_name is not None:
-            _logger.warning("The `new_name` argument in update_registered_model is deprecated."
-                            " Use the `rename_registered_model` method instead.")
-            res = self._get_registry_client().rename_registered_model(name=name, new_name=new_name)
-            name = new_name
-        if description is not None:
-            res = self._get_registry_client().update_registered_model(name=name,
-                                                                      description=description)
-        return res
+        return self._get_registry_client().update_registered_model(name=name,
+                                                                   description=description)
 
     @experimental
     def delete_registered_model(self, name):
@@ -459,34 +444,21 @@ class MlflowClient(object):
         return self._get_registry_client().create_model_version(name, source, run_id)
 
     @experimental
-    def update_model_version(self, name, version, stage=None, description=None):
+    def update_model_version(self, name, version, description=None):
         """
         Update metadata associated with a model version in backend.
 
         :param name: Name of the containing registered model.
         :param version: Version number of the model version.
-        :param stage: (Deprecated) New desired stage forthis model version. This field is deprecated
-                      as of mlflow 1.7. Use transition_model_version_stage instead to update stage.
         :param description: New description.
 
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
-        if stage is None and description is None:
+        if description is None:
             raise MlflowException("Attempting to update model version with no new field values.")
-        if stage is not None and stage.strip() == "":
-            raise MlflowException("The stage must not be an empty string.")
 
-        res = None
-        if stage is not None:
-            _logger.warning("'stage' field in update_model_version is deprecated. "
-                            "Use transition_model_stage instead.")
-            res = self._get_registry_client().transition_model_version_stage(name=name,
-                                                                             version=version,
-                                                                             stage=stage)
-        if description is not None:
-            res = self._get_registry_client().update_model_version(name=name, version=version,
-                                                                   description=description)
-        return res
+        return self._get_registry_client().update_model_version(name=name, version=version,
+                                                                description=description)
 
     @experimental
     def transition_model_version_stage(self, name, version, stage):

--- a/tests/tracking/_model_registry/test_model_registry_client.py
+++ b/tests/tracking/_model_registry/test_model_registry_client.py
@@ -35,7 +35,7 @@ def test_create_registered_model(mock_store):
     assert result.name == "Model 1"
 
 
-def test_update_and_rename_registered_model(mock_store):
+def test_update_registered_model(mock_store):
     name = "Model 1"
     new_description = "New Description"
     new_description_2 = "New Description 2"
@@ -46,13 +46,16 @@ def test_update_and_rename_registered_model(mock_store):
         name=name,
         description=new_description)
     mock_store.update_registered_model.assert_called_with(name=name, description=new_description)
-
     assert result.description == new_description
-    newModelRegistryClient().update_registered_model(
+
+    mock_store.update_registered_model.return_value = RegisteredModel(name,
+                                                                      description=new_description_2)
+    result = newModelRegistryClient().update_registered_model(
         name=name,
         description=new_description_2)
     mock_store.update_registered_model.assert_called_with(name=name,
                                                           description="New Description 2")
+    assert result.description == new_description_2
 
 
 def test_rename_registered_model(mock_store):
@@ -65,11 +68,12 @@ def test_rename_registered_model(mock_store):
     mock_store.rename_registered_model.assert_called_with(name=name, new_name=new_name)
     assert result.name == "New Name"
 
-    mock_store.update_registered_model.return_value = RegisteredModel("New Name 2")
-    newModelRegistryClient().rename_registered_model(
+    mock_store.rename_registered_model.return_value = RegisteredModel("New Name 2")
+    result = newModelRegistryClient().rename_registered_model(
         name=name,
         new_name="New Name 2")
     mock_store.rename_registered_model.assert_called_with(name=name, new_name="New Name 2")
+    assert result.name == "New Name 2"
 
 
 def test_update_registered_model_validation_errors_on_empty_new_name(mock_store):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -176,37 +176,31 @@ def test_client_registry_operations_raise_exception_with_unsupported_registry_st
             assert exc.value.error_code == ErrorCode.Name(FEATURE_DISABLED)
 
 
-def test_update_registered_model_compatibility_layer(mock_registry_store):
+def test_update_registered_model(mock_registry_store):
     """
-    This test makes sure that old (now deprecated) apis work as expected after api update.
-    Update registered model no longer accepts new name, but the client should translate it to
-    rename call.
+    Update registered model no longer supports name change.
     """
     expected_return_value = "some expected return value."
     mock_registry_store.rename_registered_model.return_value = expected_return_value
     expected_return_value_2 = "other expected return value."
     mock_registry_store.update_registered_model.return_value = expected_return_value_2
     res = MlflowClient(registry_uri="sqlite:///somedb.db").update_registered_model(
-        name="orig name", new_name="new name", description="new description")
+        name="orig name", description="new description")
     assert expected_return_value_2 == res
-    mock_registry_store.rename_registered_model.assert_called_once_with(
-        name="orig name", new_name="new name")
     mock_registry_store.update_registered_model.assert_called_once_with(
-        name="new name", description="new description")
+        name="orig name", description="new description")
+    mock_registry_store.rename_registered_model.assert_not_called()
 
 
-def test_update_model_version_compatibility_layer(mock_registry_store):
+def test_update_model_version(mock_registry_store):
     """
-    This test makes sure that old (now deprecated) apis work as expected after api update.
-    Update registered model no longer accepts new name, but the client should translate it to
-    rename call.
+    Update registered model no longer support state changes.
     """
     expected_return_value = "some expected return value."
     mock_registry_store.update_model_version.return_value = expected_return_value
     res = MlflowClient(registry_uri="sqlite:///somedb.db").update_model_version(
-        name="orig name", version="1", stage="Staging", description="desc")
+        name="orig name", version="1", description="desc")
     assert expected_return_value == res
-    mock_registry_store.transition_model_version_stage.assert_called_once_with(
-        name="orig name", version="1", stage="Staging", archive_existing_versions=False)
     mock_registry_store.update_model_version.assert_called_once_with(
         name="orig name", version="1", description="desc")
+    mock_registry_store.transition_model_version_stage.assert_not_called()

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -124,12 +124,12 @@ def test_update_registered_model_flow(mlflow_client, backend_store_uri):
 
     # update with no args is an error
     with pytest.raises(MlflowException):
-        mlflow_client.update_registered_model(name=name, new_name=None, description=None)
+        mlflow_client.update_registered_model(name=name, description=None)
 
     # update name
     new_name = "UpdateRMTest 2"
     start_time_2 = now()
-    mlflow_client.update_registered_model(name=name, new_name=new_name)
+    mlflow_client.rename_registered_model(name=name, new_name=new_name)
     end_time_2 = now()
     with pytest.raises(MlflowException):
         mlflow_client.get_registered_model(name)
@@ -152,7 +152,8 @@ def test_update_registered_model_flow(mlflow_client, backend_store_uri):
     # update name and description
     another_new = "UpdateRMTest 4"
     start_time_4 = now()
-    mlflow_client.update_registered_model(new_name, another_new, "4th update")
+    mlflow_client.update_registered_model(new_name, "4th update")
+    mlflow_client.rename_registered_model(new_name, another_new)
     end_time_4 = now()
     registered_model_detailed_4 = mlflow_client.get_registered_model(another_new)
     assert registered_model_detailed_4.name == another_new
@@ -202,7 +203,7 @@ def test_delete_registered_model_flow(mlflow_client, backend_store_uri):
 
     # cannot update a deleted model
     with pytest.raises(MlflowException):
-        mlflow_client.update_registered_model(name=name, new_name="something else")
+        mlflow_client.rename_registered_model(name=name, new_name="something else")
 
     # list does not include deleted model
     assert [] == [rm.name for rm in mlflow_client.list_registered_models() if rm.name == name]
@@ -293,7 +294,7 @@ def test_update_model_version_flow(mlflow_client, backend_store_uri):
                         for rm in mlflow_client.list_registered_models() if rm.name == name]
 
     start_time_2 = now()
-    mlflow_client.update_model_version(name=name, version=1, stage="Staging")
+    mlflow_client.transition_model_version_stage(name=name, version=1, stage="Staging")
     end_time_2 = now()
     mvd1b = mlflow_client.get_model_version(name, 1)
     assert_is_between(start_time_1, end_time_1, mvd1b.creation_timestamp)


### PR DESCRIPTION
What changes are proposed in this pull request?

These fields had been marked as deprecated since 1.7 after new APIs were added. Removing these fields in next release.

 - update_model_version: stage
 - update_registered_model: new_name

## How is this patch tested?

Fixed tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
