### PR TITLE
Fix react-plotly import statements

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { AllHtmlEntities } from 'html-entities';
 import { Switch } from 'antd';
-import Plot from '../../../node_modules/react-plotly.js/react-plotly';
+import Plot from 'react-plotly.js';
 import PropTypes from 'prop-types';
 import { getParams, getRunInfo } from '../reducers/Reducers';
 import { connect } from 'react-redux';

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunScatter.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunScatter.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import { AllHtmlEntities } from 'html-entities';
-import Plot from '../../../node_modules/react-plotly.js/react-plotly';
+import Plot from 'react-plotly.js';
 import PropTypes from 'prop-types';
 import { getParams, getRunInfo } from '../reducers/Reducers';
 import { connect } from 'react-redux';

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
@@ -4,7 +4,7 @@ import _ from 'lodash';
 import PropTypes from 'prop-types';
 import { X_AXIS_STEP, X_AXIS_RELATIVE, MAX_LINE_SMOOTHNESS } from './MetricsPlotControls';
 import { CHART_TYPE_BAR } from './MetricsPlotPanel';
-import Plot from '../../../node_modules/react-plotly.js/react-plotly';
+import Plot from 'react-plotly.js';
 
 const MAX_RUN_NAME_DISPLAY_LENGTH = 24;
 

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.test.js
@@ -4,7 +4,7 @@ import { MetricsPlotView } from './MetricsPlotView';
 import { X_AXIS_RELATIVE, X_AXIS_WALL } from './MetricsPlotControls';
 import { CHART_TYPE_BAR, CHART_TYPE_LINE } from './MetricsPlotPanel';
 import Utils from '../../common/utils/Utils';
-import Plot from '../../../node_modules/react-plotly.js/react-plotly';
+import Plot from 'react-plotly.js';
 
 const metricsForLine = [
   {

--- a/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotView.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import Plot from '../../../node_modules/react-plotly.js/react-plotly';
+import Plot from 'react-plotly.js';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix the import statements for `react-ploly`.

```javascript
# before
import Plot from '../../../node_modules/react-plotly.js/react-plotly';

# after
import Plot from 'react-plotly.js';
``` 

## How is this patch tested?

Verify the tests pass.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
