### PR TITLE
Fix a test that was failing due to ordering of calls.

### DIFF
--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -56,7 +56,7 @@ def test_dir(tmpdir):
         f.write(test_file_content)
     with open(tmpdir.join('test.txt').strpath, 'wb') as f:
         f.write(bytes(test_file_content))
-    with open(tmpdir.join('empty-file').strpath, 'w'):
+    with open(tmpdir.join('empty-file.txt').strpath, 'w'):
         pass
     return tmpdir
 
@@ -272,14 +272,14 @@ class TestDatabricksArtifactRepository(object):
             log_artifact_mock.return_value = None
             databricks_artifact_repo.log_artifacts(test_dir.strpath, artifact_path)
             artifact_path = artifact_path or ''
-            expected_calls = [mock.call(os.path.join(test_dir.strpath, 'empty-file'),
+            expected_calls = [mock.call(os.path.join(test_dir.strpath, 'empty-file.txt'),
                               os.path.join(artifact_path, '')),
                               mock.call(os.path.join(test_dir.strpath, 'test.txt'),
                               os.path.join(artifact_path, '')),
                               mock.call(os.path.join(test_dir.strpath,
                                                      os.path.join('subdir', 'test.txt')),
                               os.path.join(artifact_path, 'subdir'))]
-            assert log_artifact_mock.mock_calls == expected_calls
+            log_artifact_mock.assert_has_calls(expected_calls, any_order=True)
 
     def test_list_artifacts(self, databricks_artifact_repo):
         list_artifact_file_proto_mock = [FileInfo(path='a.txt', is_dir=False, file_size=0)]

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -379,7 +379,7 @@ class TestDatabricksArtifactRepository(object):
                 mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token='4')),
                 mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token='6'))
             ]
-            message_mock.assert_has_calls(calls)
+            message_mock.assert_has_calls(calls, any_order=True)
 
     @pytest.mark.parametrize(
         "remote_file_path, local_path, cloud_credential_type", [

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -379,7 +379,7 @@ class TestDatabricksArtifactRepository(object):
                 mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token='4')),
                 mock.call(ListArtifacts(run_id=MOCK_RUN_ID, path="", page_token='6'))
             ]
-            message_mock.assert_has_calls(calls, any_order=True)
+            message_mock.assert_has_calls(calls)
 
     @pytest.mark.parametrize(
         "remote_file_path, local_path, cloud_credential_type", [


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fixing test_log_artifacts in test_databricks_artifact_repo.py by making assert_has_calls agnostic to the order in which the calls are made.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
