### PR TITLE
Fix incorrect usage of nested `PropTypes`

### DIFF
--- a/mlflow/server/js/src/common/components/tables/EditableFormTable.js
+++ b/mlflow/server/js/src/common/components/tables/EditableFormTable.js
@@ -54,8 +54,8 @@ class EditableCell extends React.Component {
 
 export class EditableTable extends React.Component {
   static propTypes = {
-    columns: PropTypes.arrayOf(Object).isRequired,
-    data: PropTypes.arrayOf(Object).isRequired,
+    columns: PropTypes.arrayOf(PropTypes.object).isRequired,
+    data: PropTypes.arrayOf(PropTypes.object).isRequired,
     onSaveEdit: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
     form: PropTypes.object.isRequired,

--- a/mlflow/server/js/src/experiment-tracking/components/BreadcrumbTitle.js
+++ b/mlflow/server/js/src/experiment-tracking/components/BreadcrumbTitle.js
@@ -12,7 +12,8 @@ import './BreadcrumbTitle.css';
 export class BreadcrumbTitle extends Component {
   static propTypes = {
     experiment: PropTypes.instanceOf(Experiment).isRequired,
-    runUuids: PropTypes.arrayOf(PropTypes.string), // Optional because not all pages are nested under runs
+    // Optional because not all pages are nested under runs
+    runUuids: PropTypes.arrayOf(PropTypes.string),
     runNames: PropTypes.arrayOf(PropTypes.string),
     title: PropTypes.any.isRequired,
   };

--- a/mlflow/server/js/src/experiment-tracking/components/BreadcrumbTitle.js
+++ b/mlflow/server/js/src/experiment-tracking/components/BreadcrumbTitle.js
@@ -12,8 +12,8 @@ import './BreadcrumbTitle.css';
 export class BreadcrumbTitle extends Component {
   static propTypes = {
     experiment: PropTypes.instanceOf(Experiment).isRequired,
-    runUuids: PropTypes.arrayOf(String), // Optional because not all pages are nested under runs
-    runNames: PropTypes.arrayOf(String),
+    runUuids: PropTypes.arrayOf(PropTypes.string), // Optional because not all pages are nested under runs
+    runNames: PropTypes.arrayOf(PropTypes.string),
     title: PropTypes.any.isRequired,
   };
 

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.js
@@ -14,10 +14,10 @@ import CompareRunUtil from './CompareRunUtil';
 
 export class CompareRunContour extends Component {
   static propTypes = {
-    runInfos: PropTypes.arrayOf(RunInfo).isRequired,
-    metricLists: PropTypes.arrayOf(Array).isRequired,
-    paramLists: PropTypes.arrayOf(Array).isRequired,
-    runDisplayNames: PropTypes.arrayOf(String).isRequired,
+    runInfos: PropTypes.arrayOf(PropTypes.instanceOf(RunInfo)).isRequired,
+    metricLists: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
+    paramLists: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
+    runDisplayNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 
   // Size limits for displaying keys and values in our plot axes and tooltips

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunContour.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { CompareRunContour } from './CompareRunContour';
+import { RunInfo } from '../sdk/MlflowMessages';
 
 describe('unit tests', () => {
   let wrapper;
@@ -9,7 +10,12 @@ describe('unit tests', () => {
   const runUuids = ['run_uuid_0', 'run_uuid_1', 'run_uuid_2'];
   const commonProps = {
     runUuids,
-    runInfos: runUuids.map((run_uuid) => ({ run_uuid })),
+    runInfos: runUuids.map((run_uuid) =>
+      RunInfo.fromJs({
+        run_uuid,
+        experiment_id: '1',
+      }),
+    ),
     runDisplayNames: runUuids,
   };
 

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.js
@@ -10,7 +10,7 @@ import { getUUID } from '../../common/utils/ActionUtils';
 class CompareRunPage extends Component {
   static propTypes = {
     experimentId: PropTypes.string.isRequired,
-    runUuids: PropTypes.arrayOf(String).isRequired,
+    runUuids: PropTypes.arrayOf(PropTypes.string).isRequired,
     dispatch: PropTypes.func.isRequired,
   };
 

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunScatter.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunScatter.js
@@ -13,11 +13,11 @@ import CompareRunUtil from './CompareRunUtil';
 
 export class CompareRunScatterImpl extends Component {
   static propTypes = {
-    runUuids: PropTypes.arrayOf(String).isRequired,
-    runInfos: PropTypes.arrayOf(RunInfo).isRequired,
-    metricLists: PropTypes.arrayOf(Array).isRequired,
-    paramLists: PropTypes.arrayOf(Array).isRequired,
-    runDisplayNames: PropTypes.arrayOf(String).isRequired,
+    runUuids: PropTypes.arrayOf(PropTypes.string).isRequired,
+    runInfos: PropTypes.arrayOf(PropTypes.instanceOf(RunInfo)).isRequired,
+    metricLists: PropTypes.arrayOf(PropTypes.array).isRequired,
+    paramLists: PropTypes.arrayOf(PropTypes.array).isRequired,
+    runDisplayNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 
   // Size limits for displaying keys and values in our plot axes and tooltips

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunScatter.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunScatter.js
@@ -15,8 +15,8 @@ export class CompareRunScatterImpl extends Component {
   static propTypes = {
     runUuids: PropTypes.arrayOf(PropTypes.string).isRequired,
     runInfos: PropTypes.arrayOf(PropTypes.instanceOf(RunInfo)).isRequired,
-    metricLists: PropTypes.arrayOf(PropTypes.array).isRequired,
-    paramLists: PropTypes.arrayOf(PropTypes.array).isRequired,
+    metricLists: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
+    paramLists: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
     runDisplayNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.js
@@ -20,18 +20,18 @@ const TabPane = Tabs.TabPane;
 export class CompareRunView extends Component {
   static propTypes = {
     experiment: PropTypes.instanceOf(Experiment).isRequired,
-    experimentId: PropTypes.number.isRequired,
-    runInfos: PropTypes.arrayOf(RunInfo).isRequired,
-    runUuids: PropTypes.arrayOf(String).isRequired,
-    metricLists: PropTypes.arrayOf(Array).isRequired,
-    paramLists: PropTypes.arrayOf(Array).isRequired,
+    experimentId: PropTypes.string.isRequired,
+    runInfos: PropTypes.arrayOf(PropTypes.instanceOf(RunInfo)).isRequired,
+    runUuids: PropTypes.arrayOf(PropTypes.string).isRequired,
+    metricLists: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
+    paramLists: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
     // Array of user-specified run names. Elements may be falsy (e.g. empty string or undefined) if
     // a run was never given a name.
-    runNames: PropTypes.arrayOf(String).isRequired,
+    runNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     // Array of names to use when displaying runs. No element in this array should be falsy;
     // we expect this array to contain user-specified run names, or default display names
     // ("Run <uuid>") for runs without names.
-    runDisplayNames: PropTypes.arrayOf(String).isRequired,
+    runDisplayNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 
   componentDidMount() {

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.test.js
@@ -9,8 +9,8 @@ const getCompareRunViewMock = () => {
     <CompareRunView
       runInfos={[Fixtures.createRunInfo(), Fixtures.createRunInfo()]}
       experiment={Fixtures.createExperiment()}
-      experimentId={0}
-      runUuids={[0]}
+      experimentId={'0'}
+      runUuids={['0']}
       metricLists={[]}
       paramLists={[]}
       runNames={['run1']}

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableCompactView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableCompactView.js
@@ -76,13 +76,13 @@ export class ExperimentRunsTableCompactView extends React.Component {
   }
 
   static propTypes = {
-    runInfos: PropTypes.arrayOf(RunInfo).isRequired,
+    runInfos: PropTypes.arrayOf(PropTypes.instanceOf(RunInfo)).isRequired,
     // List of list of params in all the visible runs
-    paramsList: PropTypes.arrayOf(Array).isRequired,
+    paramsList: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
     // List of list of metrics in all the visible runs
-    metricsList: PropTypes.arrayOf(Array).isRequired,
+    metricsList: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
     // List of tags dictionary in all the visible runs.
-    tagsList: PropTypes.arrayOf(Object).isRequired,
+    tagsList: PropTypes.arrayOf(PropTypes.object).isRequired,
     // Function which takes one parameter (runId)
     onCheckbox: PropTypes.func.isRequired,
     onCheckAll: PropTypes.func.isRequired,
@@ -93,8 +93,8 @@ export class ExperimentRunsTableCompactView extends React.Component {
     orderByAsc: PropTypes.bool.isRequired,
     runsSelected: PropTypes.object.isRequired,
     runsExpanded: PropTypes.object.isRequired,
-    paramKeyList: PropTypes.arrayOf(String).isRequired,
-    metricKeyList: PropTypes.arrayOf(String).isRequired,
+    paramKeyList: PropTypes.arrayOf(PropTypes.string).isRequired,
+    metricKeyList: PropTypes.arrayOf(PropTypes.string).isRequired,
     metricRanges: PropTypes.object.isRequired,
     // Handler for adding a metric or parameter to the set of bagged columns. All bagged metrics
     // are displayed in a single column, while each unbagged metric has its own column. Similar
@@ -103,9 +103,9 @@ export class ExperimentRunsTableCompactView extends React.Component {
     // Handler for removing a metric or parameter from the set of bagged columns.
     onRemoveBagged: PropTypes.func.isRequired,
     // Array of keys corresponding to unbagged params
-    unbaggedParams: PropTypes.arrayOf(String).isRequired,
+    unbaggedParams: PropTypes.arrayOf(PropTypes.string).isRequired,
     // Array of keys corresponding to unbagged metrics
-    unbaggedMetrics: PropTypes.arrayOf(String).isRequired,
+    unbaggedMetrics: PropTypes.arrayOf(PropTypes.string).isRequired,
 
     nextPageToken: PropTypes.string,
     handleLoadMoreRuns: PropTypes.func.isRequired,

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -33,16 +33,16 @@ const EMPTY_CELL_PLACEHOLDER = '-';
 export class ExperimentRunsTableMultiColumnView2 extends React.Component {
   static propTypes = {
     experimentId: PropTypes.string,
-    runInfos: PropTypes.arrayOf(RunInfo).isRequired,
+    runInfos: PropTypes.arrayOf(PropTypes.instanceOf(RunInfo)).isRequired,
     // List of list of params in all the visible runs
-    paramsList: PropTypes.arrayOf(Array).isRequired,
+    paramsList: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
     // List of list of metrics in all the visible runs
-    metricsList: PropTypes.arrayOf(Array).isRequired,
+    metricsList: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
     paramKeyList: PropTypes.arrayOf(PropTypes.string),
     metricKeyList: PropTypes.arrayOf(PropTypes.string),
     visibleTagKeyList: PropTypes.arrayOf(PropTypes.string),
     // List of tags dictionary in all the visible runs.
-    tagsList: PropTypes.arrayOf(Object).isRequired,
+    tagsList: PropTypes.arrayOf(PropTypes.object).isRequired,
     onSelectionChange: PropTypes.func.isRequired,
     onExpand: PropTypes.func.isRequired,
     onSortBy: PropTypes.func.isRequired,

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
@@ -79,23 +79,23 @@ export class ExperimentView extends Component {
 
   static propTypes = {
     onSearch: PropTypes.func.isRequired,
-    runInfos: PropTypes.arrayOf(RunInfo).isRequired,
+    runInfos: PropTypes.arrayOf(PropTypes.instanceOf(RunInfo)).isRequired,
     experiment: PropTypes.instanceOf(Experiment).isRequired,
     history: PropTypes.any,
 
     // List of all parameter keys available in the runs we're viewing
-    paramKeyList: PropTypes.arrayOf(String).isRequired,
+    paramKeyList: PropTypes.arrayOf(PropTypes.string).isRequired,
     // List of all metric keys available in the runs we're viewing
-    metricKeyList: PropTypes.arrayOf(String).isRequired,
+    metricKeyList: PropTypes.arrayOf(PropTypes.string).isRequired,
 
     // List of list of params in all the visible runs
-    paramsList: PropTypes.arrayOf(Array).isRequired,
+    paramsList: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
     // List of list of metrics in all the visible runs
-    metricsList: PropTypes.arrayOf(Array).isRequired,
+    metricsList: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
     // List of tags dictionary in all the visible runs.
-    tagsList: PropTypes.arrayOf(Object).isRequired,
+    tagsList: PropTypes.arrayOf(PropTypes.object).isRequired,
     // Object of experiment tags
-    experimentTags: PropTypes.instanceOf(Object).isRequired,
+    experimentTags: PropTypes.object.isRequired,
 
     // Input to the paramKeyFilter field
     paramKeyFilter: PropTypes.instanceOf(KeyFilter).isRequired,

--- a/mlflow/server/js/src/experiment-tracking/components/MetricPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricPage.js
@@ -10,7 +10,7 @@ import { getUUID } from '../../common/utils/ActionUtils';
 
 export class MetricPageImpl extends Component {
   static propTypes = {
-    runUuids: PropTypes.arrayOf(String).isRequired,
+    runUuids: PropTypes.arrayOf(PropTypes.string).isRequired,
     metricKey: PropTypes.string.isRequired,
     experimentId: PropTypes.string,
     dispatch: PropTypes.func.isRequired,

--- a/mlflow/server/js/src/experiment-tracking/components/MetricView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricView.js
@@ -12,8 +12,8 @@ import { withRouter } from 'react-router-dom';
 export class MetricViewImpl extends Component {
   static propTypes = {
     experiment: PropTypes.instanceOf(Experiment).isRequired,
-    runUuids: PropTypes.arrayOf(String).isRequired,
-    runNames: PropTypes.arrayOf(String).isRequired,
+    runUuids: PropTypes.arrayOf(PropTypes.string).isRequired,
+    runNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     metricKey: PropTypes.string.isRequired,
     location: PropTypes.object.isRequired,
   };

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotControls.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotControls.js
@@ -14,9 +14,9 @@ export const MAX_LINE_SMOOTHNESS = 100;
 export class MetricsPlotControls extends React.Component {
   static propTypes = {
     // An array of distinct metric keys to be shown as options
-    distinctMetricKeys: PropTypes.arrayOf(String).isRequired,
+    distinctMetricKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
     // An array of metric keys selected by user or indicated by URL
-    selectedMetricKeys: PropTypes.arrayOf(String).isRequired,
+    selectedMetricKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
     selectedXAxis: PropTypes.string.isRequired,
     handleXAxisChange: PropTypes.func.isRequired,
     handleShowPointChange: PropTypes.func.isRequired,

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotPanel.js
@@ -25,18 +25,18 @@ export const CHART_TYPE_BAR = 'bar';
 export class MetricsPlotPanel extends React.Component {
   static propTypes = {
     experimentId: PropTypes.string.isRequired,
-    runUuids: PropTypes.arrayOf(String).isRequired,
+    runUuids: PropTypes.arrayOf(PropTypes.string).isRequired,
     metricKey: PropTypes.string.isRequired,
     // A map of { runUuid : { metricKey: value } }
     latestMetricsByRunUuid: PropTypes.object.isRequired,
     // An array of distinct metric keys across all runUuids
-    distinctMetricKeys: PropTypes.arrayOf(String).isRequired,
+    distinctMetricKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
     // An array of { metricKey, history, runUuid, runDisplayName }
-    metricsWithRunInfoAndHistory: PropTypes.arrayOf(Object).isRequired,
+    metricsWithRunInfoAndHistory: PropTypes.arrayOf(PropTypes.object).isRequired,
     getMetricHistoryApi: PropTypes.func.isRequired,
     location: PropTypes.object.isRequired,
     history: PropTypes.object.isRequired,
-    runDisplayNames: PropTypes.arrayOf(String).isRequired,
+    runDisplayNames: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 
   // The fields below are exposed as instance attributes rather than component state so that they

--- a/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/MetricsPlotView.js
@@ -37,11 +37,11 @@ const EMA = (mArray, smoothingWeight) => {
 
 export class MetricsPlotView extends React.Component {
   static propTypes = {
-    runUuids: PropTypes.arrayOf(String).isRequired,
-    runDisplayNames: PropTypes.arrayOf(String).isRequired,
-    metrics: PropTypes.arrayOf(Object).isRequired,
+    runUuids: PropTypes.arrayOf(PropTypes.string).isRequired,
+    runDisplayNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+    metrics: PropTypes.arrayOf(PropTypes.object).isRequired,
     xAxis: PropTypes.string.isRequired,
-    metricKeys: PropTypes.arrayOf(String).isRequired,
+    metricKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
     // Whether or not to show point markers on the line chart
     showPoint: PropTypes.bool.isRequired,
     chartType: PropTypes.string.isRequired,
@@ -52,7 +52,7 @@ export class MetricsPlotView extends React.Component {
     onClick: PropTypes.func.isRequired,
     onLegendClick: PropTypes.func.isRequired,
     onLegendDoubleClick: PropTypes.func.isRequired,
-    deselectedCurves: PropTypes.arrayOf(String).isRequired,
+    deselectedCurves: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 
   static getLineLegend = (metricKey, runDisplayName, isComparing) => {

--- a/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotControls.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotControls.js
@@ -5,11 +5,11 @@ import { TreeSelect } from 'antd';
 export class ParallelCoordinatesPlotControls extends React.Component {
   static propTypes = {
     // An array of available parameter keys to select
-    paramKeys: PropTypes.arrayOf(String).isRequired,
+    paramKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
     // An array of available metric keys to select
-    metricKeys: PropTypes.arrayOf(String).isRequired,
-    selectedParamKeys: PropTypes.arrayOf(String).isRequired,
-    selectedMetricKeys: PropTypes.arrayOf(String).isRequired,
+    metricKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
+    selectedParamKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
+    selectedMetricKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
     handleParamsSelectChange: PropTypes.func.isRequired,
     handleMetricsSelectChange: PropTypes.func.isRequired,
   };

--- a/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotPanel.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotPanel.js
@@ -16,15 +16,15 @@ import './ParallelCoordinatesPlotPanel.css';
 
 export class ParallelCoordinatesPlotPanel extends React.Component {
   static propTypes = {
-    runUuids: PropTypes.arrayOf(String).isRequired,
+    runUuids: PropTypes.arrayOf(PropTypes.string).isRequired,
     // An array of all parameter keys across runs
-    allParamKeys: PropTypes.arrayOf(String).isRequired,
+    allParamKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
     // An array of all metric keys across runs
-    allMetricKeys: PropTypes.arrayOf(String).isRequired,
+    allMetricKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
     // An array of parameter keys shared by all runs
-    sharedParamKeys: PropTypes.arrayOf(String).isRequired,
+    sharedParamKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
     // An array of metric keys shared by all runs
-    sharedMetricKeys: PropTypes.arrayOf(String).isRequired,
+    sharedMetricKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
   };
 
   state = {

--- a/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotView.js
@@ -8,11 +8,11 @@ const AXIS_LABEL_CLS = '.pcp-plot .parcoords .y-axis .axis-heading .axis-title';
 
 export class ParallelCoordinatesPlotView extends React.Component {
   static propTypes = {
-    runUuids: PropTypes.arrayOf(String).isRequired,
-    paramKeys: PropTypes.arrayOf(String).isRequired,
-    metricKeys: PropTypes.arrayOf(String).isRequired,
-    paramDimensions: PropTypes.arrayOf(Object).isRequired,
-    metricDimensions: PropTypes.arrayOf(Object).isRequired,
+    runUuids: PropTypes.arrayOf(PropTypes.string).isRequired,
+    paramKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
+    metricKeys: PropTypes.arrayOf(PropTypes.string).isRequired,
+    paramDimensions: PropTypes.arrayOf(PropTypes.object).isRequired,
+    metricDimensions: PropTypes.arrayOf(PropTypes.object).isRequired,
   };
 
   state = {

--- a/mlflow/server/js/src/experiment-tracking/components/RunPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunPage.js
@@ -15,7 +15,7 @@ export class RunPageImpl extends Component {
   static propTypes = {
     runUuid: PropTypes.string.isRequired,
     experimentId: PropTypes.string.isRequired,
-    modelVersions: PropTypes.arrayOf(Object),
+    modelVersions: PropTypes.arrayOf(PropTypes.object),
     getRunApi: PropTypes.func.isRequired,
     getExperimentApi: PropTypes.func.isRequired,
     searchModelVersionsApi: PropTypes.func.isRequired,

--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentModal.js
@@ -16,7 +16,7 @@ export class CreateExperimentModalImpl extends Component {
   static propTypes = {
     isOpen: PropTypes.bool,
     onClose: PropTypes.func.isRequired,
-    experimentNames: PropTypes.arrayOf(String).isRequired,
+    experimentNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     createExperimentApi: PropTypes.func.isRequired,
     listExperimentsApi: PropTypes.func.isRequired,
     history: PropTypes.object.isRequired,

--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.js
@@ -14,7 +14,7 @@ export class DeleteRunModalImpl extends Component {
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    selectedRunIds: PropTypes.arrayOf(String).isRequired,
+    selectedRunIds: PropTypes.arrayOf(PropTypes.string).isRequired,
     openErrorModal: PropTypes.func.isRequired,
     deleteRunApi: PropTypes.func.isRequired,
   };

--- a/mlflow/server/js/src/experiment-tracking/components/modals/RenameExperimentModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/RenameExperimentModal.js
@@ -15,7 +15,7 @@ export class RenameExperimentModalImpl extends Component {
     isOpen: PropTypes.bool,
     experimentId: PropTypes.string,
     experimentName: PropTypes.string,
-    experimentNames: PropTypes.arrayOf(String).isRequired,
+    experimentNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     onClose: PropTypes.func.isRequired,
     updateExperimentApi: PropTypes.func.isRequired,
     getExperimentApi: PropTypes.func.isRequired,

--- a/mlflow/server/js/src/experiment-tracking/components/modals/RestoreRunModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/RestoreRunModal.js
@@ -14,7 +14,7 @@ export class RestoreRunModalImpl extends Component {
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
     onClose: PropTypes.func.isRequired,
-    selectedRunIds: PropTypes.arrayOf(String).isRequired,
+    selectedRunIds: PropTypes.arrayOf(PropTypes.string).isRequired,
     openErrorModal: PropTypes.func.isRequired,
     restoreRunApi: PropTypes.func.isRequired,
   };

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.js
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.js
@@ -21,8 +21,8 @@ export class CompareModelVersionsView extends Component {
   static propTypes = {
     runInfos: PropTypes.arrayOf(PropTypes.instanceOf(RunInfo)).isRequired,
     runUuids: PropTypes.arrayOf(PropTypes.string).isRequired,
-    metricLists: PropTypes.arrayOf(PropTypes.array).isRequired,
-    paramLists: PropTypes.arrayOf(PropTypes.array).isRequired,
+    metricLists: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
+    paramLists: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.object)).isRequired,
     // Array of user-specified run names. Elements may be falsy (e.g. empty string or undefined) if
     // a run was never given a name.
     runNames: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -238,7 +238,6 @@ const mapStateToProps = (state, ownProps) => {
       runUuids.push(runUuid);
     }
   }
-
   return { runInfos, metricLists, paramLists, runNames, runDisplayNames, runUuids, modelName };
 };
 

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.js
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.js
@@ -19,17 +19,17 @@ const TabPane = Tabs.TabPane;
 
 export class CompareModelVersionsView extends Component {
   static propTypes = {
-    runInfos: PropTypes.arrayOf(RunInfo).isRequired,
-    runUuids: PropTypes.arrayOf(String).isRequired,
-    metricLists: PropTypes.arrayOf(Array).isRequired,
-    paramLists: PropTypes.arrayOf(Array).isRequired,
+    runInfos: PropTypes.arrayOf(PropTypes.instanceOf(RunInfo)).isRequired,
+    runUuids: PropTypes.arrayOf(PropTypes.string).isRequired,
+    metricLists: PropTypes.arrayOf(PropTypes.array).isRequired,
+    paramLists: PropTypes.arrayOf(PropTypes.array).isRequired,
     // Array of user-specified run names. Elements may be falsy (e.g. empty string or undefined) if
     // a run was never given a name.
-    runNames: PropTypes.arrayOf(String).isRequired,
+    runNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     // Array of names to use when displaying runs. No element in this array should be falsy;
     // we expect this array to contain user-specified run names, or default display names
     // ("Run <uuid>") for runs without names.
-    runDisplayNames: PropTypes.arrayOf(String).isRequired,
+    runDisplayNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     modelName: PropTypes.string.isRequired,
     runsToVersions: PropTypes.object.isRequired,
   };

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.test.js
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.test.js
@@ -41,8 +41,8 @@ describe('unconnected tests', () => {
           lifecycle_stage: 'active',
         }),
       ],
-      metricLists: [['test_metric', 0.0, '321', '42']],
-      paramLists: [['test_param', '0.0']],
+      metricLists: [[{ key: 'test_metric', value: 0.0 }]],
+      paramLists: [[{ key: 'test_param', value: '0.0' }]],
     };
   });
 
@@ -80,9 +80,11 @@ describe('connected tests', () => {
     minimalStore = mockStore({
       entities: {
         runInfosByUuid: { '123': RunInfo.fromJs({ dummy_key: 'dummy_value' }) },
-        latestMetricsByRunUuid: { '123': 'dummy' },
-        paramsByRunUuid: { '123': 'dummy' },
-        tagsByRunUuid: { '123': 'dummy' },
+        latestMetricsByRunUuid: {
+          '123': [{ key: 'test_metric', value: 0.0 }],
+        },
+        paramsByRunUuid: { '123': [{ key: 'test_param', value: '0.0' }] },
+        tagsByRunUuid: { '123': [{ key: 'test_tag', value: 'test.user' }] },
       },
       apis: {},
     });
@@ -102,10 +104,10 @@ describe('connected tests', () => {
           }),
         },
         latestMetricsByRunUuid: {
-          '123': { key: 'test_metric', value: 0.0, timestamp: '321', step: '42' },
+          '123': [{ key: 'test_metric', value: 0.0, timestamp: '321', step: '42' }],
         },
-        paramsByRunUuid: { '123': { key: 'test_param', value: '0.0' } },
-        tagsByRunUuid: { '123': { key: 'test_tag', value: 'test.user' } },
+        paramsByRunUuid: { '123': [{ key: 'test_param', value: '0.0' }] },
+        tagsByRunUuid: { '123': [{ key: 'test_tag', value: 'test.user' }] },
       },
       apis: {},
     });

--- a/mlflow/server/js/src/model-registry/components/ModelListPage.js
+++ b/mlflow/server/js/src/model-registry/components/ModelListPage.js
@@ -8,7 +8,7 @@ import { getUUID } from '../../common/utils/ActionUtils';
 
 class ModelListPage extends React.Component {
   static propTypes = {
-    models: PropTypes.arrayOf(Object),
+    models: PropTypes.arrayOf(PropTypes.object),
     listRegisteredModelsApi: PropTypes.func.isRequired,
   };
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix incorrect usage of nested `PropTypes`.

```javascript
class Example extends Component {
  static proptypes = {

    // wrong: this does not raise a warning for an invalid prop type
    strArray: PropTypes.arrayOf(String).isRequired;

    // correct
    strArray: PropTypes.arrayOf(PropTypes.string).isRequired;
  }
}
```


## How is this patch tested?

- The existing tests pass.
- Manually verify that invalid-prop warnings are not raised in the dev console when running the UI

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
