### PR TITLE
Make Jest throw error on invalid prop type warning

### DIFF
--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -90,7 +90,8 @@
       "lcov"
     ],
     "setupFiles": [
-      "jest-canvas-mock"
+      "jest-canvas-mock",
+      "<rootDir>/scripts/throw-on-prop-type-warning.js"
     ]
   },
   "browserslist": [

--- a/mlflow/server/js/scripts/throw-on-prop-type-warning.js
+++ b/mlflow/server/js/scripts/throw-on-prop-type-warning.js
@@ -1,0 +1,10 @@
+// See: https://medium.com/shark-bytes/type-checking-with-prop-types-in-jest-e0cd0dc92d5
+const originalConsoleError = console.error;
+
+console.error = (message, ...optionalParams) => {
+  if (/^Warning: Failed prop type: Invalid prop/.test(message)) {
+    throw new Error(message);
+  }
+
+  originalConsoleError(message, ...optionalParams);
+};

--- a/mlflow/server/js/scripts/throw-on-prop-type-warning.js
+++ b/mlflow/server/js/scripts/throw-on-prop-type-warning.js
@@ -1,4 +1,4 @@
-// See: https://medium.com/shark-bytes/type-checking-with-prop-types-in-jest-e0cd0dc92d5
+// Based on: https://medium.com/shark-bytes/type-checking-with-prop-types-in-jest-e0cd0dc92d5
 const originalConsoleError = console.error;
 
 console.error = (message, ...optionalParams) => {

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
@@ -21,7 +21,7 @@ describe('RunView', () => {
   beforeEach(() => {
     minimalProps = {
       runUuid: 'uuid-1234-5678-9012',
-      experimentId: 12345,
+      experimentId: '12345',
       getMetricPagePath: jest.fn(),
       handleSetRunTag: jest.fn(),
     };

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.test.js
@@ -21,7 +21,7 @@ describe('RunView', () => {
   beforeEach(() => {
     minimalProps = {
       runUuid: 'uuid-1234-5678-9012',
-      experimentId: '12345',
+      experimentId: 12345,
       getMetricPagePath: jest.fn(),
       handleSetRunTag: jest.fn(),
     };


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make Jest throw an error on an invalid prop type warning to prevent us from running tests with incorrect props.

## How is this patch tested?

Verify that an error is thrown on an invalid prop type warning and the JS test fails.

![Screen Shot 2020-06-18 at 15 58 03](https://user-images.githubusercontent.com/17039389/84988208-8d208080-b17c-11ea-8824-bec9c6ddae71.png)

https://github.com/mlflow/mlflow/pull/2960/checks?check_run_id=783275738#step:6:16

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
