### PR TITLE
Hotfix on deployment plugin implementation

### DIFF
--- a/mlflow/deployments/cli.py
+++ b/mlflow/deployments/cli.py
@@ -185,4 +185,5 @@ def run_local(flavor, model_uri, target, name, config):
     """
     Deploy the model locally. This has very similar signature to ``create`` API
     """
-    interface.run_local(target, name, model_uri, flavor, config)
+    config_dict = _user_args_to_dict(config)
+    interface.run_local(target, name, model_uri, flavor, config_dict)

--- a/mlflow/deployments/interface.py
+++ b/mlflow/deployments/interface.py
@@ -42,8 +42,9 @@ def get_deploy_client(target_uri):
     target = parse_target_uri(target_uri)
     plugin = plugin_store[target]
     for _, obj in inspect.getmembers(plugin):
-        if issubclass(obj, BaseDeploymentClient) and not obj == BaseDeploymentClient:
-            return obj(target_uri)
+        if inspect.isclass(obj):
+            if issubclass(obj, BaseDeploymentClient) and not obj == BaseDeploymentClient:
+                return obj(target_uri)
 
 
 @experimental

--- a/tests/deployments/test_cli.py
+++ b/tests/deployments/test_cli.py
@@ -75,3 +75,5 @@ def test_run_local():
     res = runner.invoke(cli.run_local,
                         ['-f', f_flavor, '-m', f_model_uri, '-t', f_target, '--name', f_name])
     assert f"Deployed locally at the key {f_name}" in res.stdout
+    assert f"using the model from {f_model_uri}." in res.stdout
+    assert f"It's flavor is {f_flavor} and config is {str({})}" in res.stdout

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/fake_deployment_plugin.py
@@ -29,7 +29,8 @@ class PluginDeploymentClient(BaseDeploymentClient):
 
 
 def run_local(name, model_uri, flavor=None, config=None):
-    print(f"Deployed locally at the key {name} using the model from {model_uri}")
+    print(f"Deployed locally at the key {name} using the model from {model_uri}. "
+          f"It's flavor is {flavor} and config is {config}")
 
 
 def target_help():


### PR DESCRIPTION
## What changes are proposed in this pull request?
This is a hotfix for the deployment plugin implementation merged with #2327. This implements a sanity check while fetching the plugin whether the fetched plugin is a class or not

## How is this patch tested?
Existing tests cover this implementation

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
