### PR TITLE
[Search Registered Models Pagination] order_by in search

### DIFF
--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -240,7 +240,7 @@ class SqlAlchemyStore(AbstractStore):
                                           max_results),
                                   INVALID_PARAMETER_VALUE)
 
-        parsed_filter = SearchUtils.parse_filter_for_model_registry(filter_string)
+        parsed_filter = SearchUtils.parse_filter_for_registered_models(filter_string)
         parsed_orderby = self._parse_search_registered_models_order_by(order_by)
         offset = SearchUtils.parse_start_offset_from_page_token(page_token)
         # we query for max_results + 1 items to check whether there is another page to return.

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -308,13 +308,14 @@ class SqlAlchemyStore(AbstractStore):
                     SearchUtils.parse_order_by_for_search_registered_models(order_by_clause)
                 if attribute_token == SqlRegisteredModel.name.key:
                     field = SqlRegisteredModel.name
-                elif attribute_token == SqlRegisteredModel.last_updated_time.key:
+                elif attribute_token in SearchUtils.VALID_TIMESTAMP_ORDER_BY_KEYS:
                     field = SqlRegisteredModel.last_updated_time
                 else:
-                    raise MlflowException(f"Invalid order by key '{attribute_token}' specified."
-                                          f"Valid keys are "
-                                          f"'{SearchUtils.VALID_ORDER_BY_KEYS_REGISTERED_MODELS}'",
-                                          error_code=INVALID_PARAMETER_VALUE)
+                    raise MlflowException(
+                        f"Invalid order by key '{attribute_token}' specified."
+                        f"Valid keys are "
+                        f"'{SearchUtils.RECOMMENDED_ORDER_BY_KEYS_REGISTERED_MODELS}'",
+                        error_code=INVALID_PARAMETER_VALUE)
                 if ascending:
                     clauses.append(field.asc())
                 else:

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -264,7 +264,7 @@ class SqlAlchemyStore(AbstractStore):
                                       'partial match (LIKE), and case-insensitive partial '
                                       'match (ILIKE). Input filter string: %s' % filter_string,
                                       error_code=INVALID_PARAMETER_VALUE)
-            if filter_dict["key"] == "name":
+            if filter_dict["key"] == SqlRegisteredModel.name.key:
                 if filter_dict["comparator"] == "LIKE":
                     conditions = [SqlRegisteredModel.name.like(filter_dict["value"])]
                 elif filter_dict["comparator"] == "ILIKE":
@@ -304,11 +304,11 @@ class SqlAlchemyStore(AbstractStore):
         clauses = []
         if order_by_list:
             for order_by_clause in order_by_list:
-                attribute_token, ascending = SearchUtils.parse_order_by_registered_models(
-                    order_by_clause)
-                if attribute_token == 'name':
+                attribute_token, ascending = \
+                    SearchUtils.parse_order_by_for_search_registered_models(order_by_clause)
+                if attribute_token == SqlRegisteredModel.name.key:
                     field = SqlRegisteredModel.name
-                elif attribute_token == 'last_updated_timestamp':
+                elif attribute_token == SqlRegisteredModel.last_updated_time.key:
                     field = SqlRegisteredModel.last_updated_time
                 else:
                     raise MlflowException(f"Invalid order by key '{attribute_token}' specified."

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -313,7 +313,8 @@ class SqlAlchemyStore(AbstractStore):
                 else:
                     raise MlflowException(f"Invalid order by key '{attribute_token}' specified."
                                           f"Valid keys are "
-                                          f"'{SearchUtils.VALID_ORDER_BY_KEYS_REGISTERED_MODELS}'")
+                                          f"'{SearchUtils.VALID_ORDER_BY_KEYS_REGISTERED_MODELS}'",
+                                          error_code=INVALID_PARAMETER_VALUE)
                 if ascending:
                     clauses.append(field.asc())
                 else:

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -304,7 +304,7 @@ class SqlAlchemyStore(AbstractStore):
         clauses = []
         if order_by_list:
             for order_by_clause in order_by_list:
-                (attribute_token, ascending) = SearchUtils.parse_order_by_registered_models(
+                attribute_token, ascending = SearchUtils.parse_order_by_registered_models(
                     order_by_clause)
                 if attribute_token == 'name':
                     field = SqlRegisteredModel.name

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -777,7 +777,7 @@ def _get_orderby_clauses(order_by_list, session):
     if order_by_list:
         for order_by_clause in order_by_list:
             clause_id += 1
-            (key_type, key, ascending) = SearchUtils.parse_order_by_runs(order_by_clause)
+            (key_type, key, ascending) = SearchUtils.parse_order_by_for_search_runs(order_by_clause)
             if SearchUtils.is_attribute(key_type, '='):
                 order_value = getattr(SqlRun, SqlRun.get_attribute_name(key))
             else:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -777,7 +777,7 @@ def _get_orderby_clauses(order_by_list, session):
     if order_by_list:
         for order_by_clause in order_by_list:
             clause_id += 1
-            (key_type, key, ascending) = SearchUtils.parse_order_by(order_by_clause)
+            (key_type, key, ascending) = SearchUtils.parse_order_by_runs(order_by_clause)
             if SearchUtils.is_attribute(key_type, '='):
                 order_value = getattr(SqlRun, SqlRun.get_attribute_name(key))
             else:

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -322,15 +322,15 @@ class SearchUtils(object):
         try:
             parsed = sqlparse.parse(order_by)
         except Exception:
-            raise MlflowException("Error on parsing order_by clause '%s'" % order_by,
-                          error_code=INVALID_PARAMETER_VALUE)
+            raise MlflowException(f"Error on parsing order_by clause '{order_by}'",
+                                  error_code=INVALID_PARAMETER_VALUE)
         if len(parsed) != 1 or not isinstance(parsed[0], Statement):
-            raise MlflowException("Invalid order_by clause '%s'. Could not be parsed." %
-                          order_by, error_code=INVALID_PARAMETER_VALUE)
+            raise MlflowException(f"Invalid order_by clause '{order_by}'. Could not be parsed.",
+                                  error_code=INVALID_PARAMETER_VALUE)
         statement = parsed[0]
         if len(statement.tokens) != 1 or not isinstance(statement[0], Identifier):
-            raise MlflowException("Invalid order_by clause '%s'. Could not be parsed." %
-                                  order_by, error_code=INVALID_PARAMETER_VALUE)
+            raise MlflowException(f"Invalid order_by clause '{order_by}'. Could not be parsed.",
+                                  error_code=INVALID_PARAMETER_VALUE)
         token_value = statement.tokens[0].value
         is_ascending = True
         if token_value.lower().endswith(" desc"):

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -352,7 +352,8 @@ class SearchUtils(object):
         token_value = token_value.strip()
         if token_value not in cls.VALID_ORDER_BY_KEYS_REGISTERED_MODELS:
             raise MlflowException(f"Invalid order by key '{token_value}' specified. Valid keys "
-                                  f"are '{cls.VALID_ORDER_BY_KEYS_REGISTERED_MODELS}'")
+                                  f"are '{cls.VALID_ORDER_BY_KEYS_REGISTERED_MODELS}'",
+                                  error_code=INVALID_PARAMETER_VALUE)
         return token_value, is_ascending
 
     @classmethod

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -353,7 +353,7 @@ class SearchUtils(object):
                                        values=[cls.ORDER_BY_KEY_TIMESTAMP])\
                 and all([token.is_whitespace for token in statement.tokens[1:-1]])\
                 and statement.tokens[-1].ttype == TokenType.Keyword.Order:
-            token_value = cls.ORDER_BY_KEY_TIMESTAMP + ' ' + statement.tokens[2].value
+            token_value = cls.ORDER_BY_KEY_TIMESTAMP + ' ' + statement.tokens[-1].value
         else:
             raise MlflowException(f"Invalid order_by clause '{order_by}'. Could not be parsed.",
                                   error_code=INVALID_PARAMETER_VALUE)

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -539,6 +539,50 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(self._search_registered_models(f"name ILIKE '{prefix + 'RM4A'}%'"),
                          ([names[4]], None))
 
+    def test_search_registered_model_pagination(self):
+        rms = [self._rm_maker(f"RM{i:03}").name for i in range(50)]
+
+        # test flow with fixed max_results
+        returned_rms = []
+        query = "name LIKE 'RM%'"
+        result, token = self._search_registered_models(query, page_token=None, max_results=5)
+        returned_rms.extend(result)
+        while token:
+            result, token = self._search_registered_models(query, page_token=token, max_results=5)
+            returned_rms.extend(result)
+        self.assertEqual(rms, returned_rms)
+
+        # test that pagination will return all valid results in sorted order
+        # by name ascending
+        result, token1 = self._search_registered_models(query, max_results=5)
+        self.assertNotEqual(token1, None)
+        self.assertEqual(result, rms[0:5])
+
+        result, token2 = self._search_registered_models(query, page_token=token1, max_results=10)
+        self.assertNotEqual(token2, None)
+        self.assertEqual(result, rms[5:15])
+
+        result, token3 = self._search_registered_models(query, page_token=token2, max_results=20)
+        self.assertNotEqual(token3, None)
+        self.assertEqual(result, rms[15:35])
+
+        result, token4 = self._search_registered_models(query, page_token=token3, max_results=100)
+        # assert that page token is None
+        self.assertEqual(token4, None)
+        self.assertEqual(result, rms[35:])
+
+        # test that providing a completely invalid page token throws
+        with self.assertRaises(MlflowException) as exception_context:
+            self._search_registered_models(query, page_token="evilhax", max_results=20)
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+        # test that providing too large of a max_results throws
+        with self.assertRaises(MlflowException) as exception_context:
+            self._search_registered_models(query, page_token="evilhax", max_results=1e15)
+            assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        self.assertIn("Invalid value for request parameter max_results",
+                      exception_context.exception.message)
+
     def test_search_registered_model_pagination_order_by(self):
         rms = [self._rm_maker(f"RM{i:03}").name for i in range(50)]
 
@@ -589,6 +633,3 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                                                    order_by=['last_updated_timestamp'],
                                                    max_results=100)
         self.assertEqual(rms, result)
-        # rm1a = self._rm_maker(f"MR1a").name
-        # rm1b = self._rm_maker(f"MR1b").name
-        # rm2 = self._rm_maker(f"MR2").name

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -665,7 +665,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         result, _ = self._search_registered_models(query,
                                                    page_token=None,
                                                    order_by=['timestamp ASC',
-                                                             'name DESC'],
+                                                             'name   DESC'],
                                                    max_results=100)
         self.assertEqual([rm2, rm1, rm4, rm3], result)
         # confirm that name ascending is the default, even if ties exist on other fields
@@ -680,6 +680,27 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                                                    order_by=['last_updated_timestamp DESC'],
                                                    max_results=100)
         self.assertEqual([rm3, rm4, rm1, rm2], result)
+        # test timestamp parsing
+        result, _ = self._search_registered_models(query,
+                                                   page_token=None,
+                                                   order_by=['timestamp\tASC'],
+                                                   max_results=100)
+        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        result, _ = self._search_registered_models(query,
+                                                   page_token=None,
+                                                   order_by=['timestamp\r\rASC'],
+                                                   max_results=100)
+        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        result, _ = self._search_registered_models(query,
+                                                   page_token=None,
+                                                   order_by=['timestamp\nASC'],
+                                                   max_results=100)
+        self.assertEqual([rm1, rm2, rm3, rm4], result)
+        result, _ = self._search_registered_models(query,
+                                                   page_token=None,
+                                                   order_by=['timestamp  ASC'],
+                                                   max_results=100)
+        self.assertEqual([rm1, rm2, rm3, rm4], result)
 
     def test_search_registered_model_order_by_errors(self):
         query = "name LIKE 'RM%'"

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -384,10 +384,12 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
     def _search_registered_models(self,
                                   filter_string,
-                                  page_token=None,
-                                  max_results=10):
+                                  max_results=10,
+                                  order_by=None,
+                                  page_token=None):
         result = self.store.search_registered_models(filter_string=filter_string,
                                                      max_results=max_results,
+                                                     order_by=order_by,
                                                      page_token=page_token)
         return [registered_model.name for registered_model in result], result.token
 
@@ -477,46 +479,56 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(self._search_registered_models(f"name ILIKE '{prefix + 'RM4A'}%'"),
                          ([names[4]], None))
 
-    def test_search_registered_model_pagination(self):
+    def test_search_registered_model_pagination_order_by(self):
         rms = [self._rm_maker(f"RM{i:03}").name for i in range(50)]
 
-        # test flow with fixed max_results
+        # test flow with fixed max_results and order_by (test stable order across pages)
         returned_rms = []
         query = "name LIKE 'RM%'"
-        result, token = self._search_registered_models(query, page_token=None, max_results=5)
+        result, token = self._search_registered_models(query,
+                                                       page_token=None,
+                                                       order_by=['name DESC'],
+                                                       max_results=5)
         returned_rms.extend(result)
         while token:
-            result, token = self._search_registered_models(query, page_token=token, max_results=5)
+            result, token = self._search_registered_models(query,
+                                                           page_token=token,
+                                                           order_by=['name DESC'],
+                                                           max_results=5)
             returned_rms.extend(result)
-        self.assertEqual(rms, returned_rms)
-
-        # test that pagination will return all valid results in sorted order
-        # by name ascending
-        result, token1 = self._search_registered_models(query, max_results=5)
-        self.assertNotEqual(token1, None)
-        self.assertEqual(result, rms[0:5])
-
-        result, token2 = self._search_registered_models(query, page_token=token1, max_results=10)
-        self.assertNotEqual(token2, None)
-        self.assertEqual(result, rms[5:15])
-
-        result, token3 = self._search_registered_models(query, page_token=token2, max_results=20)
-        self.assertNotEqual(token3, None)
-        self.assertEqual(result, rms[15:35])
-
-        result, token4 = self._search_registered_models(query, page_token=token3, max_results=100)
-        # assert that page token is None
-        self.assertEqual(token4, None)
-        self.assertEqual(result, rms[35:])
-
-        # test that providing a completely invalid page token throws
-        with self.assertRaises(MlflowException) as exception_context:
-            self._search_registered_models(query, page_token="evilhax", max_results=20)
-        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-
-        # test that providing too large of a max_results throws
-        with self.assertRaises(MlflowException) as exception_context:
-            self._search_registered_models(query, page_token="evilhax", max_results=1e15)
-            assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        self.assertIn("Invalid value for request parameter max_results",
-                      exception_context.exception.message)
+        # name descending should be the opposite order of the current order
+        self.assertEqual(rms[::-1], returned_rms)
+        # last_updated_timestamp descending should have the newest RMs first
+        result, _ = self._search_registered_models(query,
+                                                   page_token=None,
+                                                   order_by=['last_updated_timestamp DESC'],
+                                                   max_results=100)
+        self.assertEqual(rms[::-1], result)
+        # last_updated_timestamp ascending should have the oldest RMs first
+        result, _ = self._search_registered_models(query,
+                                                   page_token=None,
+                                                   order_by=['last_updated_timestamp ASC'],
+                                                   max_results=100)
+        self.assertEqual(rms, result)
+        # name ascending should have the original order
+        result, _ = self._search_registered_models(query,
+                                                   page_token=None,
+                                                   order_by=['name ASC'],
+                                                   max_results=100)
+        self.assertEqual(rms, result)
+        # test with multiple clauses
+        result, _ = self._search_registered_models(query,
+                                                   page_token=None,
+                                                   order_by=['name DESC',
+                                                             'last_updated_timestamp ASC'],
+                                                   max_results=100)
+        self.assertEqual(rms[::-1], result)
+        # test that no ASC/DESC defaults to ASC
+        result, _ = self._search_registered_models(query,
+                                                   page_token=None,
+                                                   order_by=['last_updated_timestamp'],
+                                                   max_results=100)
+        self.assertEqual(rms, result)
+        # rm1a = self._rm_maker(f"MR1a").name
+        # rm1b = self._rm_maker(f"MR1b").name
+        # rm2 = self._rm_maker(f"MR2").name

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -584,7 +584,11 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                       exception_context.exception.message)
 
     def test_search_registered_model_order_by(self):
-        rms = [self._rm_maker(f"RM{i:03}").name for i in range(50)]
+        rms = []
+        # explicitly mock the creation_timestamps because timestamps seem to be unstable in Windows
+        for i in range(50):
+            with mock.patch("mlflow.store.model_registry.sqlalchemy_store.now", return_value=i):
+                rms.append(self._rm_maker(f"RM{i:03}").name)
 
         # test flow with fixed max_results and order_by (test stable order across pages)
         returned_rms = []

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -612,10 +612,28 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                                                    order_by=['last_updated_timestamp DESC'],
                                                    max_results=100)
         self.assertEqual(rms[::-1], result)
+        # timestamp returns same result as last_updated_timestamp
+        result, _ = self._search_registered_models(query,
+                                                   page_token=None,
+                                                   order_by=['timestamp DESC'],
+                                                   max_results=100)
+        self.assertEqual(rms[::-1], result)
         # last_updated_timestamp ascending should have the oldest RMs first
         result, _ = self._search_registered_models(query,
                                                    page_token=None,
                                                    order_by=['last_updated_timestamp ASC'],
+                                                   max_results=100)
+        self.assertEqual(rms, result)
+        # timestamp returns same result as last_updated_timestamp
+        result, _ = self._search_registered_models(query,
+                                                   page_token=None,
+                                                   order_by=['timestamp ASC'],
+                                                   max_results=100)
+        self.assertEqual(rms, result)
+        # timestamp returns same result as last_updated_timestamp
+        result, _ = self._search_registered_models(query,
+                                                   page_token=None,
+                                                   order_by=['timestamp'],
                                                    max_results=100)
         self.assertEqual(rms, result)
         # name ascending should have the original order
@@ -641,6 +659,12 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         result, _ = self._search_registered_models(query,
                                                    page_token=None,
                                                    order_by=['last_updated_timestamp ASC',
+                                                             'name DESC'],
+                                                   max_results=100)
+        self.assertEqual([rm2, rm1, rm4, rm3], result)
+        result, _ = self._search_registered_models(query,
+                                                   page_token=None,
+                                                   order_by=['timestamp ASC',
                                                              'name DESC'],
                                                    max_results=100)
         self.assertEqual([rm2, rm1, rm4, rm3], result)
@@ -687,5 +711,20 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
                                            page_token=None,
                                            order_by=['name ASC',
                                                      ''],
+                                           max_results=5)
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        # test timestamp with garbage between valid tokens works
+        with self.assertRaises(MlflowException) as exception_context:
+            self._search_registered_models(query,
+                                           page_token=None,
+                                           order_by=['timestamp somerandomstuff ASC'],
+                                           max_results=5)
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+
+        # test that timestamp with random strings is invalid
+        with self.assertRaises(MlflowException) as exception_context:
+            self._search_registered_models(query,
+                                           page_token=None,
+                                           order_by=['timestamp somerandomstuff'],
                                            max_results=5)
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -456,8 +456,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase, AbstractStoreTest):
             experiment_id = self._experiment_factory('test exp')
             config["experiment_id"] = experiment_id
 
-        return self.store.create
-        _run(**config)
+        return self.store.create_run(**config)
 
     def test_create_run_with_tags(self):
         experiment_id = self._experiment_factory('test_create_run')

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -456,7 +456,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase, AbstractStoreTest):
             experiment_id = self._experiment_factory('test exp')
             config["experiment_id"] = experiment_id
 
-        return self.store.create_run(**config)
+        return self.store.create
+        _run(**config)
 
     def test_create_run_with_tags(self):
         experiment_id = self._experiment_factory('test_create_run')

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -322,7 +322,7 @@ def test_order_by_metric_with_nans_and_infs():
 ])
 def test_invalid_order_by(order_by, error_message):
     with pytest.raises(MlflowException) as e:
-        SearchUtils.parse_order_by_runs(order_by)
+        SearchUtils.parse_order_by_for_search_runs(order_by)
     assert error_message in e.value.message
 
 

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -322,7 +322,7 @@ def test_order_by_metric_with_nans_and_infs():
 ])
 def test_invalid_order_by(order_by, error_message):
     with pytest.raises(MlflowException) as e:
-        SearchUtils.parse_order_by(order_by)
+        SearchUtils.parse_order_by_runs(order_by)
     assert error_message in e.value.message
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR includes an implementation that parses a list of `order_by` clauses that can be passed into `search-registered-models`. 

## How is this patch tested?

Unit testing

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
