### PR TITLE
Adding client API for searching registered models

### DIFF
--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -88,8 +88,7 @@ class AbstractStore:
         """
         Search for registered models in backend that satisfy the filter criteria.
 
-        :param filter_string: A filter string expression. Currently supports a single filter
-                              condition either name of model like ``name = 'model_name'``
+        :param filter_string: Filter query string, defaults to searching all registered models.
         :param max_results: Maximum number of registered models desired.
         :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
                          matching search results.

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -119,8 +119,7 @@ class RestStore(AbstractStore):
         """
         Search for registered models in backend that satisfy the filter criteria.
 
-        :param filter_string: A filter string expression. Currently supports a single filter
-                              condition either name of model like ``name = 'model_name'``
+        :param filter_string: Filter query string supported by backend implementation.
         :param max_results: Maximum number of registered models desired.
         :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
                          matching search results.

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -220,8 +220,9 @@ class SqlAlchemyStore(AbstractStore):
         """
         Search for registered models in backend that satisfy the filter criteria.
 
-        :param filter_string: A filter string expression. Currently supports a single filter
-                              condition either name of model like ``name = 'model_name'``
+        :param filter_string: Filter query string, defaults to searching all registered models.
+                              Currently supports a single filter condition based on
+                              the name of the model like ``name = 'model_name'``
         :param max_results: Maximum number of registered models desired.
         :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
                          matching search results.

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -97,8 +97,7 @@ class ModelRegistryClient(object):
         """
         Search for registered models in backend that satisfy the filter criteria.
 
-        :param filter_string: A filter string expression. Currently supports a single filter
-                              condition either name of model like ``name = 'model_name'``
+        :param filter_string: Filter query string, defaults to searching all registered models.
         :param max_results: Maximum number of registered models desired.
         :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
                          matching search results.

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -89,6 +89,27 @@ class ModelRegistryClient(object):
         """
         return self.store.list_registered_models(max_results, page_token)
 
+    def search_registered_models(self,
+                                 filter_string=None,
+                                 max_results=SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
+                                 order_by=None,
+                                 page_token=None):
+        """
+        Search for registered models in backend that satisfy the filter criteria.
+
+        :param filter_string: A filter string expression. Currently supports a single filter
+                              condition either name of model like ``name = 'model_name'``
+        :param max_results: Maximum number of registered models desired.
+        :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
+                         matching search results.
+        :param page_token: Token specifying the next page of results. It should be obtained from
+                            a ``search_registered_models`` call.
+        :return: A PagedList of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
+                that satisfy the search expressions. The pagination token for the next page can be
+                obtained via the ``token`` attribute of the object.
+        """
+        return self.store.search_registered_models(filter_string, max_results, order_by, page_token)
+
     def get_registered_model(self, name):
         """
         :param name: Name of the registered model to update.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -423,8 +423,7 @@ class MlflowClient(object):
         """
         Search for registered models in backend that satisfy the filter criteria.
 
-        :param filter_string: A filter string expression. Currently supports a single filter
-                              condition either name of model like ``name = 'model_name'``
+        :param filter_string: Filter query string, defaults to searching all registered models.
         :param max_results: Maximum number of registered models desired.
         :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
                          matching search results.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -415,6 +415,29 @@ class MlflowClient(object):
         return self._get_registry_client().list_registered_models(max_results, page_token)
 
     @experimental
+    def search_registered_models(self,
+                                 filter_string=None,
+                                 max_results=SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
+                                 order_by=None,
+                                 page_token=None):
+        """
+        Search for registered models in backend that satisfy the filter criteria.
+
+        :param filter_string: A filter string expression. Currently supports a single filter
+                              condition either name of model like ``name = 'model_name'``
+        :param max_results: Maximum number of registered models desired.
+        :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
+                         matching search results.
+        :param page_token: Token specifying the next page of results. It should be obtained from
+                            a ``search_registered_models`` call.
+        :return: A PagedList of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
+                that satisfy the search expressions. The pagination token for the next page can be
+                obtained via the ``token`` attribute of the object.
+        """
+        return self._get_registry_client().search_registered_models(filter_string, max_results,
+                                                                    order_by, page_token)
+
+    @experimental
     def get_registered_model(self, name):
         """
         :param name: Name of the registered model to update.

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -109,25 +109,83 @@ def test_create_and_query_registered_model_flow(mlflow_client, backend_store_uri
     assert_is_between(start_time, end_time, registered_model_detailed.creation_timestamp)
     assert_is_between(start_time, end_time, registered_model_detailed.last_updated_timestamp)
     assert [name] == [rm.name for rm in mlflow_client.list_registered_models() if rm.name == name]
+    assert [name] == [rm.name for rm in mlflow_client.search_registered_models() if rm.name == name]
+    assert [name] == [rm.name for rm in mlflow_client.search_registered_models(filter_string="")
+                      if rm.name == name]
+    assert [name] == [rm.name
+                      for rm in mlflow_client.search_registered_models("name = 'CreateRMTest'")
+                      if rm.name == name]
     # clean up test
     mlflow_client.delete_registered_model(name)
 
 
-def test_create_and_query_registered_model_flow_paginated(mlflow_client, backend_store_uri):
-    names = [f'CreateRM{i:03}' for i in range(50)]
+def _verify_pagination(rm_getter_with_token, expected_rms):
+    result_rms = []
+    result = rm_getter_with_token(None)
+    result_rms.extend(result)
+    while result.token:
+        result = rm_getter_with_token(result.token)
+        result_rms.extend(result)
+    assert [rm.name for rm in expected_rms] == [rm.name for rm in result_rms]
+
+
+@pytest.mark.parametrize("max_results", [1, 5, 100])
+def test_list_registered_model_flow_paginated(mlflow_client, backend_store_uri, max_results):
+    names = [f'CreateRMlist{i:03}' for i in range(20)]
     rms = [mlflow_client.create_registered_model(name) for name in names]
     for rm in rms:
         assert isinstance(rm, RegisteredModel)
-    result_rms = []
-    result = mlflow_client.list_registered_models(max_results=15, page_token=None)
-    result_rms.extend(result)
-    while result.token:
-        result = mlflow_client.list_registered_models(max_results=15, page_token=result.token)
+
+    try:
+        _verify_pagination(lambda tok: mlflow_client.list_registered_models(max_results=max_results,
+                                                                            page_token=tok), rms)
+    except Exception as e:
+        raise e
+    finally:
+        # clean up test
+        for name in names:
+            mlflow_client.delete_registered_model(name)
+
+
+@pytest.mark.parametrize("max_results", [1, 8, 100])
+@pytest.mark.parametrize(("filter_string", "filter_func"), [
+    (None, lambda rm: True),
+    ("", lambda rm: True),
+    ("name LIKE '%7'", lambda rm: rm.name.endswith("7")),
+    ("name ILIKE '%rm%00%'", lambda rm: "00" in rm.name),
+    ("name LIKE '%rm%00%'", lambda rm: False),
+    ("name = 'badname'", lambda rm: False),
+    ("name = 'CreateRMsearch023'", lambda rm: rm.name == "CreateRMsearch023"),
+])
+def test_create_and_query_registered_model_flow_paginated(mlflow_client, backend_store_uri,
+                                                          max_results, filter_string,
+                                                          filter_func):
+    names = [f'CreateRMsearch{i:03}' for i in range(29)]
+    rms = [mlflow_client.create_registered_model(name) for name in names]
+    for rm in rms:
+        assert isinstance(rm, RegisteredModel)
+
+    def verify_pagination(rm_getter_with_token, expected_rms):
+        result_rms = []
+        result = rm_getter_with_token(None)
         result_rms.extend(result)
-    assert [rm.name for rm in rms] == [rm.name for rm in result_rms]
-    # clean up test
-    for name in names:
-        mlflow_client.delete_registered_model(name)
+        while result.token:
+            result = rm_getter_with_token(result.token)
+            result_rms.extend(result)
+        assert [rm.name for rm in expected_rms] == [rm.name for rm in result_rms]
+
+    try:
+        verify_pagination(
+            lambda tok: mlflow_client.search_registered_models(filter_string=filter_string,
+                                                               max_results=max_results,
+                                                               page_token=tok),
+            filter(filter_func, rms))
+    except Exception as e:
+        raise e
+    finally:
+        # clean up test
+        for name in names:
+            mlflow_client.delete_registered_model(name)
 
 
 def test_update_registered_model_flow(mlflow_client, backend_store_uri):

--- a/tests/tracking/test_model_registry.py
+++ b/tests/tracking/test_model_registry.py
@@ -123,13 +123,15 @@ def _verify_pagination(rm_getter_with_token, expected_rms):
     result_rms = []
     result = rm_getter_with_token(None)
     result_rms.extend(result)
+    first_page_size = len(result)
     while result.token:
         result = rm_getter_with_token(result.token)
         result_rms.extend(result)
+        assert(len(result) == first_page_size or result.token is "")
     assert [rm.name for rm in expected_rms] == [rm.name for rm in result_rms]
 
 
-@pytest.mark.parametrize("max_results", [1, 5, 100])
+@pytest.mark.parametrize("max_results", [1, 6, 100])
 def test_list_registered_model_flow_paginated(mlflow_client, backend_store_uri, max_results):
     names = [f'CreateRMlist{i:03}' for i in range(20)]
     rms = [mlflow_client.create_registered_model(name) for name in names]
@@ -157,9 +159,8 @@ def test_list_registered_model_flow_paginated(mlflow_client, backend_store_uri, 
     ("name = 'badname'", lambda rm: False),
     ("name = 'CreateRMsearch023'", lambda rm: rm.name == "CreateRMsearch023"),
 ])
-def test_create_and_query_registered_model_flow_paginated(mlflow_client, backend_store_uri,
-                                                          max_results, filter_string,
-                                                          filter_func):
+def test_search_registered_model_flow_paginated(mlflow_client, backend_store_uri,
+                                                max_results, filter_string, filter_func):
     names = [f'CreateRMsearch{i:03}' for i in range(29)]
     rms = [mlflow_client.create_registered_model(name) for name in names]
     for rm in rms:


### PR DESCRIPTION
## What changes are proposed in this pull request?
- Added `search_registered_models` method
- tests

## How is this patch tested?
Tested with mocks and db backend with all flavors and argument options. Tested with pagination.

## Release Notes
Added a new REST and client API for searching registered models. Users can search based on model names. The APIs supports pagination and ordering semantics.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
