### PR TITLE
[Search RM Pagination] case insensitive operators and parameter validation

### DIFF
--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -266,9 +266,9 @@ class SqlAlchemyStore(AbstractStore):
                                       'partial match (LIKE), and case-insensitive partial '
                                       'match (ILIKE). Input filter string: %s' % filter_string,
                                       error_code=INVALID_PARAMETER_VALUE)
-            if comparator == "LIKE":
+            if comparator == SearchUtils.LIKE_OPERATOR:
                 conditions = [SqlRegisteredModel.name.like(filter_dict["value"])]
-            elif comparator == "ILIKE":
+            elif comparator == SearchUtils.ILIKE_OPERATOR:
                 conditions = [SqlRegisteredModel.name.ilike(filter_dict["value"])]
             else:
                 conditions = [SqlRegisteredModel.name == filter_dict["value"]]

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -499,6 +499,8 @@ class SearchUtils(object):
                 si,
                 cls.VALID_SEARCH_KEYS_FOR_MODEL_VERSIONS)
                     for si in statement.tokens if isinstance(si, Comparison)]
+        else:
+            return []
 
     @classmethod
     def parse_filter_for_registered_models(cls, filter_string):
@@ -508,3 +510,5 @@ class SearchUtils(object):
                 si,
                 cls.VALID_SEARCH_KEYS_FOR_REGISTERED_MODELS)
                     for si in statement.tokens if isinstance(si, Comparison)]
+        else:
+            return []

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -452,7 +452,8 @@ class SearchUtils(object):
         key = stripped_comparison[0].value
         if key not in valid_search_keys:
             raise MlflowException("Invalid attribute key '{}' specified. Valid keys "
-                                  " are '{}'".format(key, valid_search_keys))
+                                  " are '{}'".format(key, valid_search_keys),
+                                  error_code=INVALID_PARAMETER_VALUE)
         value_token = stripped_comparison[2]
         if value_token.ttype not in cls.STRING_VALUE_TYPES:
             raise MlflowException("Expected a quoted string value for attributes. "

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -490,6 +490,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         rms, _ = self._search_registered_models(f"name LIKE '{prefix + 'cats'}%'")
         self.assertEqual(rms, [])
 
+        # confirm that LIKE is not case-sensitive
+        rms, _ = self._search_registered_models(f"name like '{prefix + 'RM4A'}%'")
+        self.assertEqual(rms, [names[4]])
+
         # case-insensitive prefix search using ILIKE should return both rm5 and rm6
         rms, _ = self._search_registered_models(f"name ILIKE '{prefix + 'RM4A'}%'")
         self.assertEqual(rms, names[4:])
@@ -501,6 +505,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         # case-insensitive prefix search using ILIKE should return both rm5 and rm6
         rms, _ = self._search_registered_models(f"name ILIKE '{prefix + 'cats'}%'")
         self.assertEqual(rms, [])
+
+        # confirm that ILIKE is not case-sensitive
+        rms, _ = self._search_registered_models(f"name ilike '%RM4a'")
+        self.assertEqual(rms, names[4:])
 
         # cannot search by invalid comparator types
         with self.assertRaises(MlflowException) as exception_context:

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -491,6 +491,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(rms, [])
 
         # confirm that LIKE is not case-sensitive
+        rms, _ = self._search_registered_models(f"name lIkE '%blah%'")
+        self.assertEqual(rms, [])
+
         rms, _ = self._search_registered_models(f"name like '{prefix + 'RM4A'}%'")
         self.assertEqual(rms, [names[4]])
 
@@ -507,6 +510,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(rms, [])
 
         # confirm that ILIKE is not case-sensitive
+        rms, _ = self._search_registered_models(f"name iLike '%blah%'")
+        self.assertEqual(rms, [])
+
         rms, _ = self._search_registered_models(f"name ilike '%RM4a'")
         self.assertEqual(rms, names[4:])
 
@@ -517,7 +523,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # cannot search by run_id
         with self.assertRaises(MlflowException) as exception_context:
-            self._search_registered_models("run_id='%s'" % "somerunID")
+            print(self._search_registered_models("run_id='%s'" % "somerunID"))
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # cannot search by source_path

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -523,7 +523,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # cannot search by run_id
         with self.assertRaises(MlflowException) as exception_context:
-            print(self._search_registered_models("run_id='%s'" % "somerunID"))
+            self._search_registered_models("run_id='%s'" % "somerunID")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
         # cannot search by source_path


### PR DESCRIPTION
## What changes are proposed in this pull request?

Mani highlighted some slight issues with the initial PR for the DB implementation of pagination for `search-registered-models`. This PR fixes those issues.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
