### PR TITLE
Fix model version description update in UI

### DIFF
--- a/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
@@ -27,7 +27,7 @@ export class ModelVersionPageImpl extends React.Component {
     match: PropTypes.object.isRequired,
     // connected props
     modelName: PropTypes.string.isRequired,
-    version: PropTypes.number.isRequired,
+    version: PropTypes.string.isRequired,
     modelVersion: PropTypes.object,
     runInfo: PropTypes.object,
     runDisplayName: PropTypes.string,
@@ -103,12 +103,7 @@ export class ModelVersionPageImpl extends React.Component {
   handleEditDescription = (description) => {
     const { modelName, version } = this.props;
     return this.props
-      .updateModelVersionApi(
-        modelName,
-        version,
-        description,
-        this.updateModelVersionRequestId,
-      )
+      .updateModelVersionApi(modelName, version, description, this.updateModelVersionRequestId)
       .then(this.loadData)
       .catch(console.error);
   };

--- a/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
@@ -104,10 +104,10 @@ export class ModelVersionPageImpl extends React.Component {
     const { modelName, version } = this.props;
     return this.props
       .updateModelVersionApi(
-        modelName, 
-        version.toString(), 
-        description, 
-        this.updateModelVersionRequestId
+        modelName,
+        version.toString(),
+        description,
+        this.updateModelVersionRequestId,
       )
       .then(this.loadData)
       .catch(console.error);

--- a/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
@@ -91,7 +91,7 @@ export class ModelVersionPageImpl extends React.Component {
       this.props
         .transitionModelVersionStageApi(
           modelName,
-          version.toString(),
+          version,
           toStage,
           this.transitionModelVersionStageRequestId,
         )
@@ -105,7 +105,7 @@ export class ModelVersionPageImpl extends React.Component {
     return this.props
       .updateModelVersionApi(
         modelName,
-        version.toString(),
+        version,
         description,
         this.updateModelVersionRequestId,
       )
@@ -191,7 +191,7 @@ const mapStateToProps = (state, ownProps) => {
   const { apis } = state;
   return {
     modelName,
-    version: Number(version),
+    version,
     modelVersion,
     runInfo,
     runDisplayName,

--- a/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
@@ -103,7 +103,12 @@ export class ModelVersionPageImpl extends React.Component {
   handleEditDescription = (description) => {
     const { modelName, version } = this.props;
     return this.props
-      .updateModelVersionApi(modelName, version, description, this.updateModelVersionRequestId)
+      .updateModelVersionApi(
+        modelName, 
+        version.toString(), 
+        description, 
+        this.updateModelVersionRequestId
+      )
       .then(this.loadData)
       .catch(console.error);
   };

--- a/mlflow/server/js/src/model-registry/components/ModelVersionPage.test.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionPage.test.js
@@ -45,7 +45,7 @@ describe('ModelVersionPage', () => {
           'Model A': {
             '1': mockModelVersionDetailed(
               'Model A',
-              1,
+              '1',
               Stages.PRODUCTION,
               ModelVersionStatus.READY,
               [],


### PR DESCRIPTION
Current behavior:
Request to `https://mlflow.modiface.com/ajax-api/2.0/preview/mlflow/model-versions/update` fails with status code 500.
Server error:

... protobuf/json_format.py", line 732, in _ConvertScalarFieldValue
    if _UNPAIRED_SURROGATE_PATTERN.search(value):
TypeError: expected string or bytes-like object  

Caused by version not being passed as a string.

Proposed fix: stringify version, in the same way that's done in `handleStageTransitionDropdownSelect`

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
