### PR TITLE
Make MLflow a bit more inclusive

### DIFF
--- a/mlflow/server/js/src/common/utils/MarkdownUtils.js
+++ b/mlflow/server/js/src/common/utils/MarkdownUtils.js
@@ -13,7 +13,7 @@ export const getConverter = () => {
 
 // Options for HTML sanitizer.
 // See https://www.npmjs.com/package/sanitize-html#what-are-the-default-options for usage.
-// These options were chosen to be similar to Github's whitelist but simpler (i.e. we don't
+// These options were chosen to be similar to Github's allowlist but simpler (i.e. we don't
 // do any transforms of the contained HTML and we disallow script entirely instead of
 // removing contents).
 const sanitizerOptions = {

--- a/pylintrc
+++ b/pylintrc
@@ -5,12 +5,12 @@
 # run arbitrary code
 extension-pkg-whitelist=
 
-# Add files or directories to the blacklist. They should be base names, not
+# Add files or directories to the denylist. They should be base names, not
 # paths.
 ignore=build,protos,sdk,db_migrations,temporary_db_migrations_for_pre_1_users
 
 
-# Add files or directories matching the regex patterns to the blacklist. The
+# Add files or directories matching the regex patterns to the denylist. The
 # regex matches against base names, not paths.
 ignore-patterns=
 


### PR DESCRIPTION
Removes some archaic terminology from the codebase in the interest of making MLflow more inclusive. We reference a lot of GitHub repositories, our own and others, so there is more work to be done, but this is a small step.