### PR TITLE
Fix docstring for `clinet.list_registered_models`

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -405,12 +405,13 @@ class MlflowClient(object):
                                page_token=None):
         """
         List of all registered models
+
         :param max_results: Maximum number of registered models desired.
         :param page_token: Token specifying the next page of results. It should be obtained from
-        a ``list_registered_models`` call.
+                           a ``list_registered_models`` call.
         :return: A PagedList of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
-        that can satisfy the search expressions. The pagination token for the next page can be
-        obtained via the ``token`` attribute of the object.
+                 that can satisfy the search expressions. The pagination token for the next page
+                 can be obtained via the ``token`` attribute of the object.
         """
         return self._get_registry_client().list_registered_models(max_results, page_token)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix docstring for `clinet.list_registered_models`.

## How is this patch tested?

### Before

<img width="1020" alt="Screen Shot 2020-06-21 at 23 47 38" src="https://user-images.githubusercontent.com/17039389/85227673-e0632f00-b419-11ea-8cd2-2b689c3cab94.png">

### After

<img width="1020" alt="Screen Shot 2020-06-21 at 23 47 59" src="https://user-images.githubusercontent.com/17039389/85227669-db9e7b00-b419-11ea-8814-c5f8f879d352.png">


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
