### PR TITLE
Fix a typo (`LIST_REGISTRED_MODELS` -> `LIST_REGISTERED_MODELS`)

### DIFF
--- a/mlflow/server/js/src/model-registry/actions.js
+++ b/mlflow/server/js/src/model-registry/actions.js
@@ -8,9 +8,9 @@ export const createRegisteredModelApi = (name, id = getUUID()) => ({
   meta: { id, name },
 });
 
-export const LIST_REGISTRED_MODELS = 'LIST_REGISTRED_MODELS';
+export const LIST_REGISTERED_MODELS = 'LIST_REGISTERED_MODELS';
 export const listRegisteredModelsApi = (id = getUUID()) => ({
-  type: LIST_REGISTRED_MODELS,
+  type: LIST_REGISTERED_MODELS,
   payload: wrapDeferred(Services.listRegisteredModels, {}),
   meta: { id },
 });

--- a/mlflow/server/js/src/model-registry/reducers.js
+++ b/mlflow/server/js/src/model-registry/reducers.js
@@ -1,5 +1,5 @@
 import {
-  LIST_REGISTRED_MODELS,
+  LIST_REGISTERED_MODELS,
   SEARCH_MODEL_VERSIONS,
   GET_REGISTERED_MODEL,
   GET_MODEL_VERSION,
@@ -12,7 +12,7 @@ import { fulfilled } from '../common/utils/ActionUtils';
 
 const modelByName = (state = {}, action) => {
   switch (action.type) {
-    case fulfilled(LIST_REGISTRED_MODELS): {
+    case fulfilled(LIST_REGISTERED_MODELS): {
       const models = action.payload[getProtoField('registered_models')];
       const nameToModelMap = {};
       if (models) {

--- a/mlflow/server/js/src/model-registry/reducers.test.js
+++ b/mlflow/server/js/src/model-registry/reducers.test.js
@@ -9,7 +9,7 @@ import {
   DELETE_REGISTERED_MODEL,
   GET_MODEL_VERSION,
   GET_REGISTERED_MODEL,
-  LIST_REGISTRED_MODELS,
+  LIST_REGISTERED_MODELS,
   SEARCH_MODEL_VERSIONS,
 } from './actions';
 import { fulfilled } from '../common/utils/ActionUtils';
@@ -21,12 +21,12 @@ describe('test modelByName', () => {
     expect(modelByName(undefined, {})).toEqual({});
   });
 
-  test('LIST_REGISTRED_MODELS handles empty state correctly', () => {
+  test('LIST_REGISTERED_MODELS handles empty state correctly', () => {
     const modelA = mockRegisteredModelDetailed('modelA');
     const modelB = mockRegisteredModelDetailed('modelB');
     const state = {};
     const action = {
-      type: fulfilled(LIST_REGISTRED_MODELS),
+      type: fulfilled(LIST_REGISTERED_MODELS),
       payload: {
         registered_models: [modelA, modelB],
       },
@@ -34,13 +34,13 @@ describe('test modelByName', () => {
     expect(modelByName(state, action)).toEqual({ modelA, modelB });
   });
 
-  test('LIST_REGISTRED_MODELS flushes previous loaded models in state (1)', () => {
+  test('LIST_REGISTERED_MODELS flushes previous loaded models in state (1)', () => {
     const modelA = mockRegisteredModelDetailed('modelA');
     const modelB = mockRegisteredModelDetailed('modelB');
     const modelC = mockRegisteredModelDetailed('modelC');
     const state = { modelA };
     const action = {
-      type: fulfilled(LIST_REGISTRED_MODELS),
+      type: fulfilled(LIST_REGISTERED_MODELS),
       payload: {
         registered_models: [modelB, modelC],
       },
@@ -48,13 +48,13 @@ describe('test modelByName', () => {
     expect(modelByName(state, action)).toEqual({ modelB, modelC });
   });
 
-  test('LIST_REGISTRED_MODELS flushes previous loaded models in state (2)', () => {
+  test('LIST_REGISTERED_MODELS flushes previous loaded models in state (2)', () => {
     const modelA = mockRegisteredModelDetailed('modelA');
     const modelB = mockRegisteredModelDetailed('modelB');
     const modelC = mockRegisteredModelDetailed('modelC');
     const state = { modelA, modelB };
     const action = {
-      type: fulfilled(LIST_REGISTRED_MODELS),
+      type: fulfilled(LIST_REGISTERED_MODELS),
       payload: {
         registered_models: [modelB, modelC],
       },
@@ -62,12 +62,12 @@ describe('test modelByName', () => {
     expect(modelByName(state, action)).toEqual({ modelB, modelC });
   });
 
-  test('LIST_REGISTRED_MODELS flushes previous loaded models in state (3)', () => {
+  test('LIST_REGISTERED_MODELS flushes previous loaded models in state (3)', () => {
     const modelA = mockRegisteredModelDetailed('modelA');
     const modelB = mockRegisteredModelDetailed('modelB');
     const state = { modelA, modelB };
     const action = {
-      type: fulfilled(LIST_REGISTRED_MODELS),
+      type: fulfilled(LIST_REGISTERED_MODELS),
       payload: {
         registered_models: [],
       },
@@ -75,12 +75,12 @@ describe('test modelByName', () => {
     expect(modelByName(state, action)).toEqual({});
   });
 
-  test('LIST_REGISTRED_MODELS should have no effect on valid state', () => {
+  test('LIST_REGISTERED_MODELS should have no effect on valid state', () => {
     const modelA = mockRegisteredModelDetailed('modelA');
     const modelB = mockRegisteredModelDetailed('modelB');
     const state = { modelA, modelB };
     const action = {
-      type: fulfilled(LIST_REGISTRED_MODELS),
+      type: fulfilled(LIST_REGISTERED_MODELS),
       payload: {
         registered_models: [modelB, modelA],
       },


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix `LIST_REGISTRED_MODELS` to `LIST_REGISTERED_MODELS`

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
