### PR TITLE
Remove use of too-new Pandas API

### DIFF
--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -5,8 +5,6 @@ import numpy as np
 import pandas as pd
 from typing import Dict, Any, List, Union, Optional
 
-from pandas.core.dtypes.dtypes import PandasExtensionDtype
-
 from mlflow.exceptions import MlflowException
 
 
@@ -58,7 +56,7 @@ class DataType(Enum):
         """Get equivalent numpy data type. """
         return self._numpy_type
 
-    def to_pandas(self) -> Union[np.dtype, PandasExtensionDtype]:
+    def to_pandas(self) -> np.dtype:
         """Get equivalent pandas data type. """
         return self._pandas_type
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

When we added schema, we accidentally added a dependency on `pandas.core.dtypes.dtypes. PandasExtensionDtype`, which was added in Pandas 1.0. Since we don't really need this type, we simply remove the import here.

## How is this patch tested?

Followed the same steps as #2975 -- ran [this file](https://github.com/mlflow/mlflow-example/blob/master/train.py) using a conda env that had pandas 0.22. Without this change, it failed, and with this change it works.

