### PR TITLE
Don't shell-escape PyPI library version lower-bounds when running projects on Databricks

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -175,7 +175,7 @@ class DatabricksJobRunner(object):
         # NB: We use <= on the version specifier to allow running projects on pre-release
         # versions, where we will select the most up-to-date mlflow version available.
         # Also note, that we escape this so '<' is not treated as a shell pipe.
-        libraries = [{"pypi": {"package": "'mlflow<=%s'" % VERSION}}]
+        libraries = [{"pypi": {"package": "mlflow<=%s" % VERSION}}]
 
         # Check syntax of JSON - if it contains libraries and new_cluster, pull those out
         if 'new_cluster' in cluster_spec:

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -172,6 +172,16 @@ class DatabricksJobRunner(object):
                  Databricks
                  `Runs Get <https://docs.databricks.com/api/latest/jobs.html#runs-get>`_ API.
         """
+        # Allow specifying either
+        # (1) A ClusterSpec
+        # (https://docs.databricks.com/dev-tools/api/latest/jobs.html#jobsclusterspec) containing
+        # a new_cluster and optionally libraries, e.g:
+        # {
+        #   "new_cluster": {...},
+        #   "libraries": [...], <-- cluster-wide libraries are optional
+        # }
+        # or (2) a NewCluster object
+        # (https://docs.databricks.com/dev-tools/api/latest/jobs.html#jobsclusterspecnewcluster)
         if 'new_cluster' in cluster_spec:
             final_cluster_spec = cluster_spec['new_cluster']
         else:

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -269,15 +269,9 @@ def test_run_databricks_cluster_spec_json(
         runs_submit_args, _ = runs_submit_mock.call_args_list[0]
         req_body = runs_submit_args[0]
         assert req_body["new_cluster"] == cluster_spec
-        expected_mlflow_lib = "'mlflow<=%s'" % mlflow.__version__
-        if runtime_version.startswith("5"):
-            assert req_body["libraries"] == [
-                {"pypi": {"package": "'mlflow<=%s'" % mlflow.__version__}},
-            ]
-        else:
-            assert req_body["libraries"] == [
-                {"pypi": {"package": "mlflow<=%s" % mlflow.__version__}},
-            ]
+        assert req_body["libraries"] == [
+            {"pypi": {"package": "mlflow<=%s" % mlflow.__version__}},
+        ]
 
 
 @pytest.mark.usefixtures("before_run_validations_mock", "runs_cancel_mock",

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -251,12 +251,15 @@ def test_run_databricks(runs_submit_mock, runs_get_mock, cluster_spec_mock, set_
 
 @pytest.mark.usefixtures("before_run_validations_mock", "runs_cancel_mock",
                          "dbfs_mocks", "cluster_spec_mock", "set_tag_mock")
+@pytest.mark.parametrize("runtime_version", [
+    '5.5.x-scala2.11', '6.6.x-scala2.11', '7.0.x-cpu-ml-scala2.12', 'latest-experimental-scala2.12'
+])
 def test_run_databricks_cluster_spec_json(
-        runs_submit_mock, runs_get_mock):
+        runs_submit_mock, runs_get_mock, runtime_version):
     with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
         runs_get_mock.return_value = mock_runs_get_result(succeeded=True)
         cluster_spec = {
-            "spark_version": "5.0.x-scala2.11",
+            "spark_version": runtime_version,
             "num_workers": 2,
             "node_type_id": "i3.xlarge",
         }
@@ -266,40 +269,22 @@ def test_run_databricks_cluster_spec_json(
         runs_submit_args, _ = runs_submit_mock.call_args_list[0]
         req_body = runs_submit_args[0]
         assert req_body["new_cluster"] == cluster_spec
+        expected_mlflow_lib = "'mlflow<=%s'" % mlflow.__version__
+        if runtime_version.startswith("5"):
+            assert req_body["libraries"] == [
+                {"pypi": {"package": "'mlflow<=%s'" % mlflow.__version__}},
+            ]
+        else:
+            assert req_body["libraries"] == [
+                {"pypi": {"package": "mlflow<=%s" % mlflow.__version__}},
+            ]
 
 
 @pytest.mark.usefixtures("before_run_validations_mock", "runs_cancel_mock",
                          "dbfs_mocks", "cluster_spec_mock", "set_tag_mock")
+@pytest.mark.parametrize('libraries', [[{"pypi": {"package": "tensorflow"}}], None])
 def test_run_databricks_extended_cluster_spec_json(
-        runs_submit_mock, runs_get_mock):
-    with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
-        runs_get_mock.return_value = mock_runs_get_result(succeeded=True)
-        new_cluster_spec = {
-            "spark_version": "6.5.x-scala2.11",
-            "num_workers": 2,
-            "node_type_id": "i3.xlarge",
-        }
-        extra_library = {"pypi": {"package": "tensorflow"}}
-
-        cluster_spec = {
-            "new_cluster": new_cluster_spec,
-            "libraries": [extra_library]
-        }
-
-        # Run project synchronously, verify that it succeeds (doesn't throw)
-        run_databricks_project(cluster_spec=cluster_spec, synchronous=True)
-        assert runs_submit_mock.call_count == 1
-        runs_submit_args, _ = runs_submit_mock.call_args_list[0]
-        req_body = runs_submit_args[0]
-        assert req_body["new_cluster"] == new_cluster_spec
-        # This does test deep object equivalence
-        assert extra_library in req_body["libraries"]
-
-
-@pytest.mark.usefixtures("before_run_validations_mock", "runs_cancel_mock",
-                         "dbfs_mocks", "cluster_spec_mock", "set_tag_mock")
-def test_run_databricks_extended_cluster_spec_json_without_libraries(
-        runs_submit_mock, runs_get_mock):
+        runs_submit_mock, runs_get_mock, libraries):
     with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
         runs_get_mock.return_value = mock_runs_get_result(succeeded=True)
         new_cluster_spec = {
@@ -311,6 +296,8 @@ def test_run_databricks_extended_cluster_spec_json_without_libraries(
         cluster_spec = {
             "new_cluster": new_cluster_spec,
         }
+        if libraries is not None:
+            cluster_spec["libraries"] = libraries
 
         # Run project synchronously, verify that it succeeds (doesn't throw)
         run_databricks_project(cluster_spec=cluster_spec, synchronous=True)
@@ -318,6 +305,9 @@ def test_run_databricks_extended_cluster_spec_json_without_libraries(
         runs_submit_args, _ = runs_submit_mock.call_args_list[0]
         req_body = runs_submit_args[0]
         assert req_body["new_cluster"] == new_cluster_spec
+        if libraries is not None:
+            for library in libraries:
+                assert library in req_body["libraries"]
 
 
 def test_run_databricks_throws_exception_when_spec_uses_existing_cluster():

--- a/tests/projects/test_databricks.py
+++ b/tests/projects/test_databricks.py
@@ -251,15 +251,11 @@ def test_run_databricks(runs_submit_mock, runs_get_mock, cluster_spec_mock, set_
 
 @pytest.mark.usefixtures("before_run_validations_mock", "runs_cancel_mock",
                          "dbfs_mocks", "cluster_spec_mock", "set_tag_mock")
-@pytest.mark.parametrize("runtime_version", [
-    '5.5.x-scala2.11', '6.6.x-scala2.11', '7.0.x-cpu-ml-scala2.12', 'latest-experimental-scala2.12'
-])
-def test_run_databricks_cluster_spec_json(
-        runs_submit_mock, runs_get_mock, runtime_version):
+def test_run_databricks_cluster_spec_json(runs_submit_mock, runs_get_mock):
     with mock.patch.dict(os.environ, {'DATABRICKS_HOST': 'test-host', 'DATABRICKS_TOKEN': 'foo'}):
         runs_get_mock.return_value = mock_runs_get_result(succeeded=True)
         cluster_spec = {
-            "spark_version": runtime_version,
+            "spark_version": '7.0.x-cpu-ml-scala2.12',
             "num_workers": 2,
             "node_type_id": "i3.xlarge",
         }


### PR DESCRIPTION
## What changes are proposed in this pull request?

**Note**: We should hold off on merging this PR until the release of corresponding server-side changes in early August

Updates logic for remote MLflow project execution on Databricks to not shell-escape PyPI library version lower-bounds when running projects

## How is this patch tested?
Added unit tests, plus manual tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
