### PR TITLE
Add ability to build Docker image for experiment run from Dockerfile

### DIFF
--- a/docs/source/projects.rst
+++ b/docs/source/projects.rst
@@ -162,9 +162,10 @@ file in YAML syntax, to the project's root directory. The following is an exampl
     name: My Project
 
     conda_env: my_env.yaml
-    # Can have a docker_env instead of a conda_env, e.g.
+    # Can have a docker_env image xor dockerfile instead of a conda_env, e.g.
     # docker_env:
     #    image:  mlflow-docker-example
+    #    dockerfile: /path-to-dockerfile/Dockerfile.my-image
 
     entry_points:
       main:
@@ -247,6 +248,19 @@ Docker container environment
   `Amazon ECR registry <https://docs.aws.amazon.com/AmazonECR/latest/userguide/Registries.html>`_.
   When the MLflow project is run, Docker attempts to pull the image from the specified registry. 
   The system executing the MLflow project must have credentials to pull this image from  the specified registry.
+
+  .. rubric:: Example 4: Dockerfile
+
+  .. code-block:: yaml
+
+    docker_env:
+      dockerfile: /path-to-dockerfile/Dockerfile.my_image
+
+  In this example, ``/path-to-dockerfile/Dockerfile.my_image`` refers to a Dockerfile that builds a Docker image.
+  The Docker image will be built and the suffix ``my_name`` will be used as the iamge tag. If Dockerfile does not
+  have a suffix, then a hash is generated based on the Dockerfile contents.
+  When the MLflow project is run, Docker attempts to build the image from the specified Dockerfile.
+  Other values, such as ``volumes`` and ``environments`` can be entered too.
 
 .. _mlproject-command-syntax:
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -135,6 +135,7 @@ def _run(uri, experiment_id, entry_point, version, parameters,
             image = _build_docker_image(work_dir=work_dir,
                                         repository_uri=project.name,
                                         base_image=project.docker_env.get('image'),
+                                        dockerfile_uri=project.docker_env.get('dockerfile'),
                                         run_id=active_run.info.run_id)
             command_args += _get_docker_command(image=image, active_run=active_run,
                                                 docker_args=docker_args,
@@ -171,6 +172,7 @@ def _run(uri, experiment_id, entry_point, version, parameters,
         image = _build_docker_image(work_dir=work_dir,
                                     repository_uri=kube_config["repository-uri"],
                                     base_image=project.docker_env.get('image'),
+                                    dockerfile_uri=project.docker_env.get('dockerfile'),
                                     run_id=active_run.info.run_id)
         image_digest = kb.push_image_to_registry(image.tags[0])
         submitted_run = kb.run_kubernetes_job(
@@ -586,9 +588,10 @@ def _validate_docker_env(project):
     if not project.name:
         raise ExecutionException("Project name in MLProject must be specified when using docker "
                                  "for image tagging.")
-    if not project.docker_env.get('image'):
+    if not (project.docker_env.get('image') or project.docker_env.get('dockerfile')):
         raise ExecutionException("Project with docker environment must specify the docker image "
-                                 "to use via an 'image' field under the 'docker_env' field.")
+                                 "to use via an 'image' field or a dockerfile via a 'dockerfile' "
+                                 "field under the 'docker_env' field.")
 
 
 def _parse_kubernetes_config(backend_config):
@@ -637,18 +640,30 @@ def _create_docker_build_ctx(work_dir, dockerfile_contents):
     return result_path
 
 
-def _build_docker_image(work_dir, repository_uri, base_image, run_id):
+def _build_docker_image(work_dir, repository_uri, base_image, run_id, dockerfile_uri):
     """
-    Build a docker image containing the project in `work_dir`, using the base image.
+    Build a docker image containing the project in `work_dir`, using the base image or Dockerfile.
     """
-    image_uri = _get_docker_image_uri(repository_uri=repository_uri, work_dir=work_dir)
-    dockerfile = (
-        "FROM {imagename}\n"
-        "COPY {build_context_path}/ {workdir}\n"
-        "WORKDIR {workdir}\n"
-    ).format(imagename=base_image,
-             build_context_path=_PROJECT_TAR_ARCHIVE_NAME,
-             workdir=_MLFLOW_DOCKER_WORKDIR_PATH)
+    if dockerfile_uri is not None:
+        with open(dockerfile_uri, 'r') as f:
+            dockerfile = f.read()
+        dockerfile += (
+            "COPY {build_context_path}/ {workdir}\n"
+            "WORKDIR {workdir}\n"
+            ).format(build_context_path=_PROJECT_TAR_ARCHIVE_NAME,
+                     workdir=_MLFLOW_DOCKER_WORKDIR_PATH)
+        basename = os.path.basename(os.path.normpath(dockerfile_uri))
+        hash = hashlib.md5(dockerfile.encode('utf-8')).hexdigest()
+        image_uri = dockerfile_uri.split('.')[-1] if '.' in basename else 'image_' + hash
+    elif base_image is not None:
+        image_uri = _get_docker_image_uri(repository_uri=repository_uri, work_dir=work_dir)
+        dockerfile = (
+            "FROM {imagename}\n"
+            "COPY {build_context_path}/ {workdir}\n"
+            "WORKDIR {workdir}\n"
+        ).format(imagename=base_image,
+                 build_context_path=_PROJECT_TAR_ARCHIVE_NAME,
+                 workdir=_MLFLOW_DOCKER_WORKDIR_PATH)
     build_ctx_path = _create_docker_build_ctx(work_dir, dockerfile)
     with open(build_ctx_path, 'rb') as docker_build_ctx:
         _logger.info("=== Building docker image %s ===", image_uri)

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -653,8 +653,8 @@ def _build_docker_image(work_dir, repository_uri, base_image, run_id, dockerfile
             ).format(build_context_path=_PROJECT_TAR_ARCHIVE_NAME,
                      workdir=_MLFLOW_DOCKER_WORKDIR_PATH)
         basename = os.path.basename(os.path.normpath(dockerfile_uri))
-        hash = hashlib.md5(dockerfile.encode('utf-8')).hexdigest()
-        image_uri = dockerfile_uri.split('.')[-1] if '.' in basename else 'image_' + hash
+        dockerfile_md5 = hashlib.md5(dockerfile.encode('utf-8')).hexdigest()
+        image_uri = dockerfile_uri.split('.')[-1] if '.' in basename else 'image_' + dockerfile_md5
     elif base_image is not None:
         image_uri = _get_docker_image_uri(repository_uri=repository_uri, work_dir=work_dir)
         dockerfile = (

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -38,9 +38,12 @@ def load_project(directory):
     # Validate config if docker_env parameter is present
     docker_env = yaml_obj.get("docker_env")
     if docker_env:
-        if not docker_env.get("image"):
+        if not (docker_env.get("image") or docker_env.get("dockerfile")):
             raise ExecutionException("Project configuration (MLproject file) was invalid: Docker "
-                                     "environment specified but no image attribute found.")
+                                     "environment specified but no image or dockerfile attribute found.")
+        if docker_env.get("image") and docker_env.get("dockerfile"):
+            raise ExecutionException("Project configuration (MLproject file) was invalid: both an image and "
+                                     "a dockerfile attribute were specified.")
         if docker_env.get("volumes"):
             if not (isinstance(docker_env["volumes"], list)
                     and all([isinstance(i, str) for i in docker_env["volumes"]])):

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -40,10 +40,11 @@ def load_project(directory):
     if docker_env:
         if not (docker_env.get("image") or docker_env.get("dockerfile")):
             raise ExecutionException("Project configuration (MLproject file) was invalid: Docker "
-                                     "environment specified but no image or dockerfile attribute found.")
+                                     "environment specified but no image or dockerfile attribute "
+                                     "found.")
         if docker_env.get("image") and docker_env.get("dockerfile"):
-            raise ExecutionException("Project configuration (MLproject file) was invalid: both an image and "
-                                     "a dockerfile attribute were specified.")
+            raise ExecutionException("Project configuration (MLproject file) was invalid: both an "
+                                     "image and a dockerfile attribute were specified.")
         if docker_env.get("volumes"):
             if not (isinstance(docker_env["volumes"], list)
                     and all([isinstance(i, str) for i in docker_env["volumes"]])):

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -70,7 +70,7 @@ def test_dockerfile_project_execution(
         use_start_run,
         tmpdir, docker_example_base_image):  # pylint: disable=unused-argument
     shutil.move(os.path.join(TEST_DOCKER_PROJECT_DIR, 'MLproject'),
-                 os.path.join(TEST_DOCKER_PROJECT_DIR, 'backup'))
+                os.path.join(TEST_DOCKER_PROJECT_DIR, 'backup'))
     shutil.copy2(os.path.join(TEST_DOCKER_PROJECT_DIR, 'MLproject_dockerfile'),
                  os.path.join(TEST_DOCKER_PROJECT_DIR, 'MLproject'))
     expected_params = {"use_start_run": use_start_run}
@@ -105,7 +105,7 @@ def test_dockerfile_project_execution(
     artifacts = mlflow_service.list_artifacts(run_id=run_id)
     assert len(artifacts) == 1
     shutil.move(os.path.join(TEST_DOCKER_PROJECT_DIR, 'backup'),
-                 os.path.join(TEST_DOCKER_PROJECT_DIR, 'MLproject'))
+                os.path.join(TEST_DOCKER_PROJECT_DIR, 'MLproject'))
 
 
 @pytest.mark.parametrize("tracking_uri, expected_command_segment", [

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -94,7 +94,7 @@ def test_dockerfile_project_execution(
         MLFLOW_PROJECT_BACKEND: "local",
     }
     approx_expected_tags = {
-        MLFLOW_DOCKER_IMAGE_URI: "docker-example",
+        MLFLOW_DOCKER_IMAGE_URI: "image_",
         MLFLOW_DOCKER_IMAGE_ID: "sha256:",
     }
     run_tags = run.data.tags

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 import mock
 import pytest
@@ -61,6 +62,50 @@ def test_docker_project_execution(
         assert run_tags[k].startswith(v)
     artifacts = mlflow_service.list_artifacts(run_id=run_id)
     assert len(artifacts) == 1
+
+
+@pytest.mark.parametrize("use_start_run", map(str, [0, 1]))
+@pytest.mark.large
+def test_dockerfile_project_execution(
+        use_start_run,
+        tmpdir, docker_example_base_image):  # pylint: disable=unused-argument
+    shutil.move(os.path.join(TEST_DOCKER_PROJECT_DIR, 'MLproject'),
+                 os.path.join(TEST_DOCKER_PROJECT_DIR, 'backup'))
+    shutil.copy2(os.path.join(TEST_DOCKER_PROJECT_DIR, 'MLproject_dockerfile'),
+                 os.path.join(TEST_DOCKER_PROJECT_DIR, 'MLproject'))
+    expected_params = {"use_start_run": use_start_run}
+    submitted_run = mlflow.projects.run(
+        TEST_DOCKER_PROJECT_DIR, experiment_id=file_store.FileStore.DEFAULT_EXPERIMENT_ID,
+        parameters=expected_params, entry_point="test_tracking")
+    # Validate run contents in the FileStore
+    run_id = submitted_run.run_id
+    mlflow_service = mlflow.tracking.MlflowClient()
+    run_infos = mlflow_service.list_run_infos(
+        experiment_id=file_store.FileStore.DEFAULT_EXPERIMENT_ID,
+        run_view_type=ViewType.ACTIVE_ONLY)
+    assert len(run_infos) == 1
+    store_run_id = run_infos[0].run_id
+    assert run_id == store_run_id
+    run = mlflow_service.get_run(run_id)
+    assert run.data.params == expected_params
+    assert run.data.metrics == {"some_key": 3}
+    exact_expected_tags = {
+        MLFLOW_PROJECT_ENV: "docker",
+        MLFLOW_PROJECT_BACKEND: "local",
+    }
+    approx_expected_tags = {
+        MLFLOW_DOCKER_IMAGE_URI: "docker-example",
+        MLFLOW_DOCKER_IMAGE_ID: "sha256:",
+    }
+    run_tags = run.data.tags
+    for k, v in exact_expected_tags.items():
+        assert run_tags[k] == v
+    for k, v in approx_expected_tags.items():
+        assert run_tags[k].startswith(v)
+    artifacts = mlflow_service.list_artifacts(run_id=run_id)
+    assert len(artifacts) == 1
+    shutil.move(os.path.join(TEST_DOCKER_PROJECT_DIR, 'backup'),
+                 os.path.join(TEST_DOCKER_PROJECT_DIR, 'MLproject'))
 
 
 @pytest.mark.parametrize("tracking_uri, expected_command_segment", [

--- a/tests/projects/test_project_spec.py
+++ b/tests/projects/test_project_spec.py
@@ -86,8 +86,13 @@ def test_load_docker_project(tmpdir):
     (textwrap.dedent("""
     docker_env:
         not-image-attribute: blah
-    """), "no image attribute found"),
-])
+    """), "no image or dockerfile attribute found"),
+    (textwrap.dedent("""
+    docker_env:
+        image: some-image
+        dockerfile: /path-to-dockerfile
+    """), "both an image and a dockerfile attribute were specified"),
+    ])
 def test_load_invalid_project(tmpdir, invalid_project_contents, expected_error_msg):
     tmpdir.join("MLproject").write(invalid_project_contents)
     with pytest.raises(ExecutionException) as e:

--- a/tests/resources/example_docker_project/MLproject_dockerfile
+++ b/tests/resources/example_docker_project/MLproject_dockerfile
@@ -1,0 +1,12 @@
+name: docker-example
+
+docker_env:
+  dockerfile: tests/resources/example_docker_project/Dockerfile
+
+entry_points:
+  main:
+    command: "echo 'Main entry point'"
+  test_tracking:
+    parameters:
+      use_start_run: bool
+    command: "python scripts/docker_tracking_test.py {use_start_run}"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Motivation: we found that using a Dockerfile to build the Docker image for our experiment runs fits our workflow better than a pulling a built image from a registry.

Description: This PR enables `mlflow run` to optionally use a Dockerfile to build the image for an experiment run. Adds a `dockerfile` field to the MLproject yaml specifying the path to the dockerfile. If both an `image` and a `dockerfile` field are specified, then we raise an exception. Also adds a test and an example in the documentation for easier reference. 

Since we’re building an image from a Dockerfile, there’s no way to tell what the desired image tag is. So, added the option to either suffix the Dockerfile name `Dockerfile.image-name` and use the suffix as the image name, or automatically name the as `image_` + the hash of the Dockerfile if no suffix exists.

## How is this patch tested?

Added a test named `test_dockerfile_project_execution` under `tests/projects/test_docker_projects.py` to test proper building. The test is (heavily) based on `test_docker_project_execution`. The main difference is that test first generates a new MLproject based on `tests/resources/example_docker_project/MLproject_dockerfile` that specifies a `dockerfile` instead of an image. Then, the rest of the regular tests continues, where the image is built and an MLflow run is performed in the spirit of the original test.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add ability to build Docker image for experiment run from Dockerfile

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
