### PR TITLE
DatabricksArtifactRepository: Fix list artifacts bug.

### DIFF
--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -252,7 +252,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
             # If `path` is a file, ListArtifacts returns a single list element with the
             # same name as `path`. The list_artifacts API expects us to return an empty list in this
             # case, so we do so here.
-            if len(artifact_list) == 1 and artifact_list[0].path == path \
+            if len(artifact_list) == 1 and artifact_list[0].path == run_relative_path \
                     and not artifact_list[0].is_dir:
                 return []
             for output_file in artifact_list:

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -310,6 +310,8 @@ class TestDatabricksArtifactRepository(object):
             assert len(artifacts) == 0
 
     def test_list_artifacts_with_relative_path(self):
+        list_artifact_file_proto_mock = [FileInfo(path=posixpath.join(MOCK_SUBDIR, 'a.txt'),
+                                                  is_dir=False, file_size=0)]
         list_artifacts_dir_proto_mock = [
             FileInfo(path=posixpath.join(MOCK_SUBDIR, 'test/a.txt'), is_dir=False, file_size=100),
             FileInfo(path=posixpath.join(MOCK_SUBDIR, 'test/dir'), is_dir=True, file_size=0)
@@ -339,6 +341,14 @@ class TestDatabricksArtifactRepository(object):
             assert artifacts[1].file_size is None
             message_mock.assert_called_with(
                 ListArtifacts(run_id=MOCK_RUN_ID, path=posixpath.join(MOCK_SUBDIR, "test")))
+
+            # Calling list_artifacts() on a relative path that's a file should return an empty list
+            list_artifact_response_proto = \
+                ListArtifacts.Response(root_uri='', files=list_artifact_file_proto_mock,
+                                       next_page_token=None)
+            call_endpoint_mock.return_value = list_artifact_response_proto
+            artifacts = databricks_artifact_repo.list_artifacts('a.txt')
+            assert len(artifacts) == 0
 
     def test_paginated_list_artifacts(self, databricks_artifact_repo):
         list_artifacts_proto_mock_1 = [


### PR DESCRIPTION
## What changes are proposed in this pull request?
List_artifacts must return an empty list if the path is a file. This fix ensures that the condition to check if the path is a file is done using a comparison with the root run relative path.

## How is this patch tested?

Unit tests have been added.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
