### PR TITLE
[docs] Fetching a MLflow model from the registry

### DIFF
--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -196,7 +196,6 @@ After you have registered an MLflow model, you can serve the model as a service 
 
     #!/usr/bin/env sh
 
-    echo "Deploying Production model name=sk-learn-random-forest-reg-model"
     # Set environment variable for the tracking URL where the Model Registry resides
     export MLFLOW_TRACKING_URI=http://localhost:5000
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -193,6 +193,7 @@ Serve a MLflow Model from Model Registry
 After you have registered an MLflow model, you can serve the model as a service on your host.
 
 .. code-block:: bash
+
     #!/usr/bin/env sh
 
     echo "Deploying Production model name=sk-learn-random-forest-reg-model"

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -155,7 +155,7 @@ While the method above creates an empty registered model with no version associa
 Fetching an MLflow Model from the Model Registry
 ------------------------------------------------
 
-After you have registered an MLflow model, you can fetch that model using :meth:`~mlflow.pyfunc.load_model`. 
+After you have registered an MLflow model, you can fetch that model using :meth:`~mlflow.<model_flavor>.load_model`, or more generally, :meth:`~mlflow.pyfunc.load_model`. 
 
 **Fetch a specific model version**
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -157,7 +157,7 @@ Run a MLflow Model from the Model Registry
 
 After you have registered an MLflow model, you can run that model using :meth:`~mlflow.sklearn.load_model`. 
 
-**Run a specific model version**
+**Load a specific model version**
 
 To fetch a specific model version, just supply that version name as part of the model URI.
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -172,6 +172,8 @@ To fetch a specific model version, just supply that version number as part of th
         model_uri=f"models:/{model_name}/{model_version}
     )
 
+    model.predict(data)
+
 **Fetch the latest model version in a specific stage**
 
 To fetch a model version by stage, simply provide the model stage as part of the model URI, and it will fetch the most recent version of the model in that stage.
@@ -186,6 +188,8 @@ To fetch a model version by stage, simply provide the model stage as part of the
     model = mlflow.pyfunc.load_model(
         model_uri=f"models:/{model_name}/{stage}
     )
+
+    model.predict(data)
 
 Serving an MLflow Model from Model Registry
 -------------------------------------------

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -155,7 +155,7 @@ While the method above creates an empty registered model with no version associa
 Run a MLflow Model from the Model Registry
 ------------------------------------------
 
-After you have registered an MLflow model, you can run that model using :meth:`~mlflow.sklearn.load_model`. 
+After you have registered an MLflow model, you can load to run that model using :meth:`~mlflow.<model_flavor>.load_model`. 
 
 **Load a specific model version**
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -219,7 +219,7 @@ You can download the model by using :meth:`~mlflow.tracking.MlflowClient.get_mod
    print(model_artifact_uri)
 
 
-After obtaining the download uri, you can download it via the Click
+After obtaining the download uri, you can download it via the MLflow CLI.
 
 .. code-block:: py
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -155,7 +155,7 @@ While the method above creates an empty registered model with no version associa
 Fetching an MLflow Model from the Model Registry
 ------------------------------------------------
 
-After you have registered an MLflow model, you can fetch that model using :meth:`~mlflow.<model_flavor>.load_model`, or more generally, :meth:`~mlflow.pyfunc.load_model`. 
+After you have registered an MLflow model, you can fetch that model using ``mlflow.<model_flavor>.load_model()``, or more generally, :meth:`~mlflow.pyfunc.load_model`. 
 
 **Fetch a specific model version**
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -174,7 +174,7 @@ To fetch a specific model version, just supply that version name as part of the 
 
 **Run the latest model version in a specific stage**
 
-Model Registry allows you to transition multiple versions of the model into the same or different stages. To fetch the model in its stage name, simply provide the model stage label as part of the model URI, and it will fetch the most recent version of the model in that stage.
+To fetch a model version by stage, simply provide the model stage as part of the model URI, and it will fetch the most recent version of the model in that stage.
 
 .. code-block:: py
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -152,43 +152,43 @@ While the method above creates an empty registered model with no version associa
         run_id="d16076a3ec534311817565e6527539c0"
     )
 
-Use an MLflow Model from the Model Registry
-------------------------------------------
+Fetching an MLflow Model from the Model Registry
+------------------------------------------------
 
-After you have registered an MLflow model, you can load to run that model using :meth:`~mlflow.<model_flavor>.load_model`. 
+After you have registered an MLflow model, you can fetch that model using :meth:`~mlflow.pyfunc.load_model`. 
 
-**Load a specific model version**
+**Fetch a specific model version**
 
 To fetch a specific model version, just supply that version number as part of the model URI.
 
 .. code-block:: py
 
-    import mlflow.sklearn
+    import mlflow.pyfunc
 
     model_name = "sk-learn-random-forest-reg-model"
     model_version = 1
 
-    model = mlflow.sklearn.load_model(
+    model = mlflow.pyfunc.load_model(
         model_uri=f"models:/{model_name}/{model_version}
     )
 
-**Load the latest model version in a specific stage**
+**Fetch the latest model version in a specific stage**
 
 To fetch a model version by stage, simply provide the model stage as part of the model URI, and it will fetch the most recent version of the model in that stage.
 
 .. code-block:: py
 
-    import mlflow.sklearn
+    import mlflow.pyfunc
 
     model_name = "sk-learn-random-forest-reg-model"
     stage = 'Staging'
 
-    model = mlflow.sklearn.load_model(
+    model = mlflow.pyfunc.load_model(
         model_uri=f"models:/{model_name}/{stage}
     )
 
-Serve an MLflow Model from Model Registry
------------------------------------------
+Serving an MLflow Model from Model Registry
+-------------------------------------------
 
 After you have registered an MLflow model, you can serve the model as a service on your host.
 
@@ -201,31 +201,6 @@ After you have registered an MLflow model, you can serve the model as a service 
 
     # Serve the production model from the model registry
     mlflow models serve -m "models:/sk-learn-random-forest-reg-model/Production"
-
-Download MLflow model from Model Registry
------------------------------------------
-
-You can download the model by using :meth:`~mlflow.tracking.MlflowClient.get_model_version_download_uri`.
-
-.. code-block:: py
-
-   from mlflow.tracking import MlflowClient
-
-   model_name = "sk-learn-random-forest-reg-model"
-   model_version = 1
-
-   client = MlflowClient()
-   model_artifact_uri = client.get_model_version_download_uri(model_name, model_version)
-   print(model_artifact_uri)
-
-
-After obtaining the download uri, you can download it via the MLflow CLI.
-
-.. code-block:: py
-
-    #!/usr/bin/env sh
-
-    mlflow artifacts download --artifact-uri <model_artifact_uri>
 
 Adding or Updating an MLflow Model Descriptions
 -----------------------------------------------

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -172,7 +172,7 @@ To fetch a specific model version, just supply that version name as part of the 
         model_uri=f"models:/{model_name}/{model_version}
     )
 
-**Run the latest model version in a specific stage**
+**Load the latest model version in a specific stage**
 
 To fetch a model version by stage, simply provide the model stage as part of the model URI, and it will fetch the most recent version of the model in that stage.
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -188,7 +188,7 @@ To fetch a model version by stage, simply provide the model stage as part of the
     )
 
 Serve an MLflow Model from Model Registry
-----------------------------------------
+-----------------------------------------
 
 After you have registered an MLflow model, you can serve the model as a service on your host.
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -202,6 +202,31 @@ After you have registered an MLflow model, you can serve the model as a service 
     # Serve the production model from the model registry
     mlflow models serve -m "models:/sk-learn-random-forest-reg-model/Production"
 
+Download MLflow model from Model Registry
+-----------------------------------------
+
+You can download the model by using :meth:`~mlflow.tracking.MlflowClient.get_model_version_download_uri`.
+
+.. code-block:: py
+
+   from mlflow.tracking import MlflowClient
+
+   model_name = "sk-learn-random-forest-reg-model"
+   model_version = 1
+
+   client = MlflowClient()
+   model_artifact_uri = client.get_model_version_download_uri(model_name, model_version)
+   print(model_artifact_uri)
+
+
+After obtaining the download uri, you can download it via the Click
+
+.. code-block:: py
+
+    #!/usr/bin/env sh
+
+    mlflow artifacts download --artifact-uri <model_artifact_uri>
+
 Adding or Updating an MLflow Model Descriptions
 -----------------------------------------------
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -153,7 +153,7 @@ While the method above creates an empty registered model with no version associa
     )
 
 Run a MLflow model from the Model Registry
---------------------------
+------------------------------------------
 
 Once you have added a model to the registry, you can run that model using :meth:`~mlflow.sklearn.load_model`. 
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -187,7 +187,7 @@ To fetch a model version by stage, simply provide the model stage as part of the
         model_uri=f"models:/{model_name}/{stage}
     )
 
-Serve a MLflow Model from Model Registry
+Serve an MLflow Model from Model Registry
 ----------------------------------------
 
 After you have registered an MLflow model, you can serve the model as a service on your host.

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -152,12 +152,10 @@ While the method above creates an empty registered model with no version associa
         run_id="d16076a3ec534311817565e6527539c0"
     )
 
-Run a MLflow model from the Model Registry
-------------------------------------------
+Retrieve the model by stage
+---------------------------
 
-Once you have added a model to the registry, you can run that model using :meth:`~mlflow.sklearn.load_model`. 
-
-**Run a specific model version**
+Model Registry allows you to transition multiple versions of the model into the same or different stages.To fetch the model in its stage name, simply provide the model stage label as part of the model URI, and it will fetch the most recent version of the model in that stage.
 
 .. code-block:: py
 
@@ -170,7 +168,12 @@ Once you have added a model to the registry, you can run that model using :meth:
         model_uri=f"models:/{model_name}/{model_version}
     )
 
-**Run the latest model version in a specific stage**
+Run a specific model version
+----------------------------
+
+By contrast, to fetch a specific model version, just supply that version name as part of the model URI. Alternatively, if  you want the most recent version and don’t know its version number, you can query the model’s details and fetch the maximum version of the model.
+
+
 
 .. code-block:: py
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -152,10 +152,10 @@ While the method above creates an empty registered model with no version associa
         run_id="d16076a3ec534311817565e6527539c0"
     )
 
-Run a MLflow model from the Model Registry
+Run a MLflow Model from the Model Registry
 ------------------------------------------
 
-After you  have registered an MLflow model, you can run that model using :meth:`~mlflow.sklearn.load_model`. 
+After you have registered an MLflow model, you can run that model using :meth:`~mlflow.sklearn.load_model`. 
 
 **Run a specific model version**
 
@@ -186,6 +186,21 @@ Model Registry allows you to transition multiple versions of the model into the 
     model = mlflow.sklearn.load_model(
         model_uri=f"models:/{model_name}/{stage}
     )
+
+Serve a MLflow Model from Model Registry
+----------------------------------------
+
+After you have registered an MLflow model, you can serve the model as a service on your host.
+
+.. code-block:: bash
+    #!/usr/bin/env sh
+
+    echo "Deploying Production model name=sk-learn-random-forest-reg-model"
+    # Set environment variable for the tracking URL where the Model Registry resides
+    export MLFLOW_TRACKING_URI=http://localhost:5000
+
+    # Serve the production model from the model registry
+    mlflow models serve -m "models:/sk-learn-random-forest-reg-model/Production"
 
 Adding or Updating an MLflow Model Descriptions
 -----------------------------------------------

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -152,7 +152,7 @@ While the method above creates an empty registered model with no version associa
         run_id="d16076a3ec534311817565e6527539c0"
     )
 
-Run a MLflow Model from the Model Registry
+Use an MLflow Model from the Model Registry
 ------------------------------------------
 
 After you have registered an MLflow model, you can load to run that model using :meth:`~mlflow.<model_flavor>.load_model`. 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -159,7 +159,7 @@ After you have registered an MLflow model, you can load to run that model using 
 
 **Load a specific model version**
 
-To fetch a specific model version, just supply that version name as part of the model URI.
+To fetch a specific model version, just supply that version number as part of the model URI.
 
 .. code-block:: py
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -152,6 +152,37 @@ While the method above creates an empty registered model with no version associa
         run_id="d16076a3ec534311817565e6527539c0"
     )
 
+Run a MLflow model from the Model Registry
+--------------------------
+
+Once you have added a model to the registry, you can run that model using :meth:`~mlflow.sklearn.load_model`. 
+
+**Run a specific model version**
+
+.. code-block:: py
+
+    import mlflow.sklearn
+
+    model_name = "sk-learn-random-forest-reg-model"
+    model_version = 1
+
+    model = mlflow.sklearn.load_model(
+        model_uri=f"models:/{model_name}/{model_version}
+    )
+
+**Run the latest model version in a specific stage**
+
+.. code-block:: py
+
+    import mlflow.sklearn
+
+    model_name = "sk-learn-random-forest-reg-model"
+    stage = 'Staging'
+
+    model = mlflow.sklearn.load_model(
+        model_uri=f"models:/{model_name}/{stage}
+    )
+
 Adding or Updating an MLflow Model Descriptions
 -----------------------------------------------
 

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -152,10 +152,14 @@ While the method above creates an empty registered model with no version associa
         run_id="d16076a3ec534311817565e6527539c0"
     )
 
-Retrieve the model by stage
----------------------------
+Run a MLflow model from the Model Registry
+------------------------------------------
 
-Model Registry allows you to transition multiple versions of the model into the same or different stages.To fetch the model in its stage name, simply provide the model stage label as part of the model URI, and it will fetch the most recent version of the model in that stage.
+After you  have registered an MLflow model, you can run that model using :meth:`~mlflow.sklearn.load_model`. 
+
+**Run a specific model version**
+
+To fetch a specific model version, just supply that version name as part of the model URI.
 
 .. code-block:: py
 
@@ -168,12 +172,9 @@ Model Registry allows you to transition multiple versions of the model into the 
         model_uri=f"models:/{model_name}/{model_version}
     )
 
-Run a specific model version
-----------------------------
+**Run the latest model version in a specific stage**
 
-By contrast, to fetch a specific model version, just supply that version name as part of the model URI. Alternatively, if  you want the most recent version and don’t know its version number, you can query the model’s details and fetch the maximum version of the model.
-
-
+Model Registry allows you to transition multiple versions of the model into the same or different stages. To fetch the model in its stage name, simply provide the model stage label as part of the model URI, and it will fetch the most recent version of the model in that stage.
 
 .. code-block:: py
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Updated the model registry documentation to show how to fetch a registered model using `load_model` and the `models:/` model_uri syntax. Secondly, added documentation about how to serve a model registry model via the CLI.


## How is this patch tested?

<img width="1353" alt="Screen Shot 2020-06-29 at 4 56 59 PM" src="https://user-images.githubusercontent.com/58712524/86162884-545da100-bac4-11ea-8e7c-fdc3b61392ee.png">


<img width="1310" alt="Screen Shot 2020-06-29 at 4 53 35 PM" src="https://user-images.githubusercontent.com/58712524/86067205-2b3c0280-ba29-11ea-88c9-5d2988df77de.png">


## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
