### PR TITLE
Fix Azure Blob Artifact Repo not returning single files

### DIFF
--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -109,6 +109,11 @@ class AzureBlobArtifactRepository(ArtifactRepository):
             else:  # Just a plain old blob
                 file_name = posixpath.relpath(path=r.name, start=artifact_path)
                 infos.append(FileInfo(file_name, False, r.size))
+        # The list_artifacts API expects us to return an empty list if the
+        # the path references a single file.
+        rel_path = dest_path[len(artifact_path)+1:]
+        if (len(infos) == 1) and not infos[0].is_dir and (infos[0].path == rel_path):
+            return []
         return sorted(infos, key=lambda f: f.path)
 
     def _download_file(self, remote_file_path, local_path):

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -86,6 +86,17 @@ def test_list_artifacts_empty(mock_client):
     assert repo.list_artifacts() == []
 
 
+def test_list_artifacts_single_file(mock_client):
+    repo = AzureBlobArtifactRepository(TEST_URI, mock_client)
+
+    # Evaluate single file
+    blob_props = BlobProperties()
+    blob_props.name = posixpath.join(TEST_ROOT_PATH, "file")
+    mock_client.get_container_client().walk_blobs.return_value = MockBlobList(
+        [blob_props])
+    assert repo.list_artifacts("file") == []
+
+
 def test_list_artifacts(mock_client):
     repo = AzureBlobArtifactRepository(TEST_URI, mock_client)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

The `list_artifact()` method in the Azure Blob Artifact Repo did not conform with the ArtifactRepository's `list_artifact()` specifications. More precisely, it did not return an empty list when the target was a single file. This resulted in the inability to download and view individual artifacts from the UI (see https://github.com/mlflow/mlflow/issues/2991).

## How is this patch tested?

Local testing with private azure repository.
Unittest.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [x] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
