### PR TITLE
[docs] Link and text does not correlate in tutorials-and-examples

### DIFF
--- a/docs/source/tutorials-and-examples/index.rst
+++ b/docs/source/tutorials-and-examples/index.rst
@@ -5,7 +5,7 @@ Tutorials and Examples
 
 Below, you can find a number of tutorials and examples for various MLflow use cases.
 
-* :doc:`Train, Serve, and Score an Image-Classification Model <tutorial>`
+* :doc:`Train, Serve, and Score a Linear Regression Model <tutorial>`
 * `Hyperparameter Tuning <https://github.com/mlflow/mlflow/tree/master/examples/hyperparam>`_
 * `Orchestrating Multistep Workflows <https://github.com/mlflow/mlflow/tree/master/examples/multistep_workflow>`_
 * `Using the MLflow REST API Directly <https://github.com/mlflow/mlflow/tree/master/examples/rest_api>`_

--- a/docs/source/tutorials-and-examples/index.rst
+++ b/docs/source/tutorials-and-examples/index.rst
@@ -5,7 +5,7 @@ Tutorials and Examples
 
 Below, you can find a number of tutorials and examples for various MLflow use cases.
 
-* :doc:`Train, Serve, and Score a Linear Regression Model  <tutorial>`
+* :doc:`Train, Serve, and Score a Linear Regression Model <tutorial>`
 * `Hyperparameter Tuning <https://github.com/mlflow/mlflow/tree/master/examples/hyperparam>`_
 * `Orchestrating Multistep Workflows <https://github.com/mlflow/mlflow/tree/master/examples/multistep_workflow>`_
 * `Using the MLflow REST API Directly <https://github.com/mlflow/mlflow/tree/master/examples/rest_api>`_

--- a/docs/source/tutorials-and-examples/index.rst
+++ b/docs/source/tutorials-and-examples/index.rst
@@ -5,7 +5,7 @@ Tutorials and Examples
 
 Below, you can find a number of tutorials and examples for various MLflow use cases.
 
-* :doc:`Train, Serve, and Score a Linear Regression Model <tutorial>`
+* :doc:`Train, Serve, and Score a Linear Regression Model  <tutorial>`
 * `Hyperparameter Tuning <https://github.com/mlflow/mlflow/tree/master/examples/hyperparam>`_
 * `Orchestrating Multistep Workflows <https://github.com/mlflow/mlflow/tree/master/examples/multistep_workflow>`_
 * `Using the MLflow REST API Directly <https://github.com/mlflow/mlflow/tree/master/examples/rest_api>`_


### PR DESCRIPTION
A link points to a linear regression tutorial, but the text indicates that it should be an image classification tutorial.
The text or the link should be changed so that they match.

See first link on this page: https://mlflow.org/docs/latest/tutorials-and-examples/index.html


### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for


### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
