### PR TITLE
Propagate credentials when running MLflow projects within a notebook

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -795,7 +795,7 @@ def _get_databricks_env_vars(tracking_uri):
     if config.token:
         env_vars['DATABRICKS_TOKEN'] = config.token
     if config.ignore_tls_verification:
-        env_vars['DATABRICKS_INSECURE'] = config.ignore_tls_verification
+        env_vars['DATABRICKS_INSECURE'] = str(config.ignore_tls_verification)
     return env_vars
 
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -38,7 +38,8 @@ from mlflow.utils.file_utils import path_to_local_sqlite_uri, path_to_local_file
 from mlflow.utils.mlflow_tags import (
     MLFLOW_PROJECT_ENV, MLFLOW_DOCKER_IMAGE_URI, MLFLOW_DOCKER_IMAGE_ID, MLFLOW_PROJECT_BACKEND,
 )
-from mlflow.utils.uri import get_db_profile_from_uri, is_databricks_uri
+from mlflow.utils.uri import get_db_profile_from_uri
+import mlflow.utils.uri
 
 # Environment variable indicating a path to a conda installation. MLflow will default to running
 # "conda" if unset
@@ -484,7 +485,7 @@ def _invoke_mlflow_run_subprocess(
     env_vars = _get_run_env_vars(run_id, experiment_id)
     env_vars.update(_get_databricks_env_vars(mlflow.get_tracking_uri()))
     mlflow_run_subprocess = _run_mlflow_run_cmd(
-        mlflow_run_arr, _get_run_env_vars(run_id, experiment_id))
+        mlflow_run_arr, env_vars)
     return LocalSubmittedRun(run_id, mlflow_run_subprocess)
 
 
@@ -776,7 +777,7 @@ def _get_docker_artifact_storage_cmd_and_envs(artifact_uri):
 
 
 def _get_databricks_env_vars(tracking_uri):
-    if not is_databricks_uri(tracking_uri):
+    if not mlflow.utils.uri.is_databricks_uri(tracking_uri):
         return {}
 
     db_profile = get_db_profile_from_uri(tracking_uri)

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -413,6 +413,7 @@ def _run_entry_point(command, work_dir, experiment_id, run_id):
     """
     env = os.environ.copy()
     env.update(_get_run_env_vars(run_id, experiment_id))
+    env.update(_get_databricks_env_vars(tracking_uri=mlflow.get_tracking_uri()))
     _logger.info("=== Running command '%s' in run with ID '%s' === ", command, run_id)
     # in case os name is not 'nt', we are not running on windows. It introduces
     # bash command otherwise.
@@ -480,6 +481,8 @@ def _invoke_mlflow_run_subprocess(
     mlflow_run_arr = _build_mlflow_run_cmd(
         uri=work_dir, entry_point=entry_point, storage_dir=storage_dir, use_conda=use_conda,
         run_id=run_id, parameters=parameters)
+    env_vars = _get_run_env_vars(run_id, experiment_id)
+    env_vars.update(_get_databricks_env_vars(mlflow.get_tracking_uri()))
     mlflow_run_subprocess = _run_mlflow_run_cmd(
         mlflow_run_arr, _get_run_env_vars(run_id, experiment_id))
     return LocalSubmittedRun(run_id, mlflow_run_subprocess)
@@ -772,6 +775,29 @@ def _get_docker_artifact_storage_cmd_and_envs(artifact_uri):
         return [], {}
 
 
+def _get_databricks_env_vars(tracking_uri):
+    if not is_databricks_uri(tracking_uri):
+        return {}
+
+    db_profile = get_db_profile_from_uri(tracking_uri)
+    config = databricks_utils.get_databricks_host_creds(db_profile)
+    # We set these via environment variables so that only the current profile is exposed, rather
+    # than all profiles in ~/.databrickscfg; maybe better would be to mount the necessary
+    # part of ~/.databrickscfg into the container
+    env_vars = {}
+    env_vars[tracking._TRACKING_URI_ENV_VAR] = 'databricks'
+    env_vars['DATABRICKS_HOST'] = config.host
+    if config.username:
+        env_vars['DATABRICKS_USERNAME'] = config.username
+    if config.password:
+        env_vars['DATABRICKS_PASSWORD'] = config.password
+    if config.token:
+        env_vars['DATABRICKS_TOKEN'] = config.token
+    if config.ignore_tls_verification:
+        env_vars['DATABRICKS_INSECURE'] = config.ignore_tls_verification
+    return env_vars
+
+
 def _get_docker_tracking_cmd_and_envs(tracking_uri):
     cmds = []
     env_vars = dict()
@@ -780,22 +806,7 @@ def _get_docker_tracking_cmd_and_envs(tracking_uri):
     if local_path is not None:
         cmds = ["-v", "%s:%s" % (local_path, _MLFLOW_DOCKER_TRACKING_DIR_PATH)]
         env_vars[tracking._TRACKING_URI_ENV_VAR] = container_tracking_uri
-    if is_databricks_uri(tracking_uri):
-        db_profile = get_db_profile_from_uri(tracking_uri)
-        config = databricks_utils.get_databricks_host_creds(db_profile)
-        # We set these via environment variables so that only the current profile is exposed, rather
-        # than all profiles in ~/.databrickscfg; maybe better would be to mount the necessary
-        # part of ~/.databrickscfg into the container
-        env_vars[tracking._TRACKING_URI_ENV_VAR] = 'databricks'
-        env_vars['DATABRICKS_HOST'] = config.host
-        if config.username:
-            env_vars['DATABRICKS_USERNAME'] = config.username
-        if config.password:
-            env_vars['DATABRICKS_PASSWORD'] = config.password
-        if config.token:
-            env_vars['DATABRICKS_TOKEN'] = config.token
-        if config.ignore_tls_verification:
-            env_vars['DATABRICKS_INSECURE'] = config.ignore_tls_verification
+    env_vars.update(_get_databricks_env_vars(tracking_uri))
     return cmds, env_vars
 
 

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -235,7 +235,7 @@ def test_docker_databricks_tracking_cmd_and_envs(ProfileConfigProvider):
     assert envs == {"DATABRICKS_HOST": "host",
                     "DATABRICKS_USERNAME": "user",
                     "DATABRICKS_PASSWORD": "pass",
-                    "DATABRICKS_INSECURE": True,
+                    "DATABRICKS_INSECURE": "True",
                     mlflow.tracking._TRACKING_URI_ENV_VAR: "databricks"}
     assert cmds == []
 

--- a/tests/projects/test_projects.py
+++ b/tests/projects/test_projects.py
@@ -14,7 +14,7 @@ from mlflow.entities import RunStatus, ViewType, SourceType
 from mlflow.exceptions import ExecutionException, MlflowException
 from mlflow.projects import _resolve_experiment_id
 from mlflow.store.tracking.file_store import FileStore
-from mlflow.utils import env, databricks_utils
+from mlflow.utils import env
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_USER, MLFLOW_SOURCE_NAME, \
     MLFLOW_SOURCE_TYPE, MLFLOW_GIT_BRANCH, MLFLOW_GIT_REPO_URL, LEGACY_MLFLOW_GIT_BRANCH_NAME, \
     LEGACY_MLFLOW_GIT_REPO_URL, MLFLOW_PROJECT_ENTRY_POINT, MLFLOW_PROJECT_BACKEND, \


### PR DESCRIPTION
## What changes are proposed in this pull request?

Propagate credentials to the subprocesses used to run MLflow projects when running them locally in a Databricks notebook, borrowing the same technique used for artifact logging from the Java client in #3001. There are some limitations - notably, attempting to use Spark in the executed project fails.

## How is this patch tested?

Added new unit tests + tested manually

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
