### PR TITLE
Pin isort to unblock the lint check

### DIFF
--- a/travis/lint-requirements.txt
+++ b/travis/lint-requirements.txt
@@ -3,3 +3,4 @@ pep8==1.7.1
 pyarrow==0.17.0
 pylint==1.8.2
 rstcheck==3.2
+isort<5.0.0

--- a/travis/lint-requirements.txt
+++ b/travis/lint-requirements.txt
@@ -3,6 +3,6 @@ pep8==1.7.1
 pyarrow==0.17.0
 pylint==1.8.2
 rstcheck==3.2
-# With isort >= 5.0.0, pylint raises the following error:
+# Pin isort version to prevent pylint from raising the following error:
 # AttributeError: module 'isort' has no attribute 'SortImports'
 isort<5.0.0

--- a/travis/lint-requirements.txt
+++ b/travis/lint-requirements.txt
@@ -3,4 +3,6 @@ pep8==1.7.1
 pyarrow==0.17.0
 pylint==1.8.2
 rstcheck==3.2
+# With isort >= 5.0.0, pylint raises the following error:
+# AttributeError: module 'isort' has no attribute 'SortImports'
 isort<5.0.0

--- a/travis/lint-requirements.txt
+++ b/travis/lint-requirements.txt
@@ -3,6 +3,5 @@ pep8==1.7.1
 pyarrow==0.17.0
 pylint==1.8.2
 rstcheck==3.2
-# Pin isort version to prevent pylint from raising the following error:
-# AttributeError: module 'isort' has no attribute 'SortImports'
+# Pin isort version to prevent pylint from raising an error
 isort<5.0.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

The lint check fails due to a [new version of `isort`](https://pypi.org/project/isort/5.0.0/) (`pylint` internally use `isort`).

![Screen Shot 2020-07-04 at 20 19 56](https://user-images.githubusercontent.com/17039389/86511407-ca9b3400-be33-11ea-8e9d-293027ce3970.png)

https://github.com/mlflow/mlflow/pull/3049/checks?check_run_id=836523836#step:5:28


## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
