### PR TITLE
Fix incorrect parameter names for `test_mlflow_run_example`

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -18,7 +18,7 @@ EXAMPLES_DIR = 'examples'
     ('hyperparam', ['-e', 'random']),
     ('hyperparam', ['-e', 'gpyopt']),
     ('hyperparam', ['-e', 'hyperopt', '-P', 'epochs=1']),
-    ('lightgbm', ['-P', 'learning-rate=0.1', '-P', 'colsample-bytree=0.8', '-P', 'subsample=0.9']),
+    ('lightgbm', ['-P', 'learning_rate=0.1', '-P', 'colsample_bytree=0.8', '-P', 'subsample=0.9']),
     ('prophet', []),
     ('pytorch', ['-P', 'epochs=2']),
     ('sklearn_logistic_regression', []),
@@ -26,7 +26,7 @@ EXAMPLES_DIR = 'examples'
     (os.path.join('sklearn_elasticnet_diabetes', 'linux'), []),
     ('spacy', []),
     (os.path.join('tensorflow', 'tf1'), ['-P', 'steps=10']),
-    ('xgboost', ['-P', 'learning-rate=0.3', '-P', 'colsample-bytree=0.8', '-P', 'subsample=0.9'])
+    ('xgboost', ['-P', 'learning_rate=0.3', '-P', 'colsample_bytree=0.8', '-P', 'subsample=0.9'])
 ])
 def test_mlflow_run_example(directory, params):
     cli_run_list = [os.path.join(EXAMPLES_DIR, directory)] + params


### PR DESCRIPTION
## What changes are proposed in this pull request?

A follow-up for #2875. Fix incorrect parameter names for `test_mlflow_run_example` which causes the test to fail.

## How is this patch tested?

Manually verified the test passes with the fixed parameter names.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
