### PR TITLE
Fix sklearn deserialization with latest cloudpickle when pickle5 is installed

### DIFF
--- a/examples/sklearn_elasticnet_wine/train.py
+++ b/examples/sklearn_elasticnet_wine/train.py
@@ -83,4 +83,6 @@ if __name__ == "__main__":
             # https://mlflow.org/docs/latest/model-registry.html#api-workflow
             mlflow.sklearn.log_model(lr, "model", registered_model_name="ElasticnetWineModel")
         else:
-            mlflow.sklearn.log_model(lr, "model")
+            print("runs:/"+mlflow.active_run().info.run_id+"/model")
+            mlflow.sklearn.log_model(lr, "model", serialization_format="cloudpickle")
+            # mlflow.sklearn.log_model(lr, "model", serialization_format="pickle")

--- a/examples/sklearn_elasticnet_wine/train.py
+++ b/examples/sklearn_elasticnet_wine/train.py
@@ -83,6 +83,4 @@ if __name__ == "__main__":
             # https://mlflow.org/docs/latest/model-registry.html#api-workflow
             mlflow.sklearn.log_model(lr, "model", registered_model_name="ElasticnetWineModel")
         else:
-            print("runs:/"+mlflow.active_run().info.run_id+"/model")
-            mlflow.sklearn.log_model(lr, "model", serialization_format="cloudpickle")
-            # mlflow.sklearn.log_model(lr, "model", serialization_format="pickle")
+            mlflow.sklearn.log_model(lr, "model")

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -309,7 +309,7 @@ def _load_pyfunc(path):
         # specify the ``data`` field within the pyfunc flavor configuration. For these newer
         # models, the ``path`` parameter of ``load_pyfunc()`` refers to the top-level MLflow
         # Model directory. In this case, we parse the model path from the MLmodel's pyfunc
-        # flavor configuration and attempt to fetch the serialization format from the 
+        # flavor configuration and attempt to fetch the serialization format from the
         # scikit-learn flavor configuration
         pyfunc_flavor_conf = _get_flavor_configuration(
             model_path=path, flavor_name=pyfunc.FLAVOR_NAME)

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -169,8 +169,8 @@ def save_model(sk_model, path, conda_env=None, mlflow_model=None,
     with open(os.path.join(path, conda_env_subpath), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
-    pyfunc.add_to_model(mlflow_model, loader_module="mlflow.sklearn", model_path=model_data_subpath,
-                        env=conda_env_subpath, serialization_format=serialization_format)
+    pyfunc.add_to_model(mlflow_model, loader_module="mlflow.sklearn",
+                        model_path=model_data_subpath, env=conda_env_subpath)
     mlflow_model.add_flavor(FLAVOR_NAME,
                             pickled_model=model_data_subpath,
                             sklearn_version=sklearn.__version__,
@@ -311,9 +311,6 @@ def _load_pyfunc(path):
         # Model directory. In this case, we parse the model path from the MLmodel's pyfunc
         # flavor configuration and attempt to fetch the serialization format from the
         # scikit-learn flavor configuration
-        pyfunc_flavor_conf = _get_flavor_configuration(
-            model_path=path, flavor_name=pyfunc.FLAVOR_NAME)
-        path = os.path.join(path, pyfunc_flavor_conf['model_path'])
         try:
             sklearn_flavor_conf = _get_flavor_configuration(
                 model_path=path, flavor_name=FLAVOR_NAME)
@@ -324,6 +321,10 @@ def _load_pyfunc(path):
                 "Could not find scikit-learn flavor configuration during model loading process."
                 " Assuming 'pickle' serialization format.")
             serialization_format = SERIALIZATION_FORMAT_PICKLE
+
+        pyfunc_flavor_conf = _get_flavor_configuration(
+            model_path=path, flavor_name=pyfunc.FLAVOR_NAME)
+        path = os.path.join(path, pyfunc_flavor_conf['model_path'])
 
     return _load_model_from_local_file(
         path=path,

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -282,10 +282,10 @@ def _load_model_from_local_file(path, serialization_format):
         # Models serialized with Cloudpickle cannot necessarily be deserialized using Pickle;
         # That's why we check the serialization format of the model before deserializing
         if serialization_format == SERIALIZATION_FORMAT_PICKLE:
-            pickle.load(f)
+            return pickle.load(f)
         elif serialization_format == SERIALIZATION_FORMAT_CLOUDPICKLE:
             import cloudpickle
-            cloudpickle.load(f)
+            return cloudpickle.load(f)
 
 
 def _load_pyfunc(path, serialization_format=SERIALIZATION_FORMAT_CLOUDPICKLE):

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -322,7 +322,7 @@ def _save_model(sk_model, output_path, serialization_format):
                     error_code=INTERNAL_ERROR)
 
 
-def load_model(model_uri, serialization_format=SERIALIZATION_FORMAT_CLOUDPICKLE):
+def load_model(model_uri):
     """
     Load a scikit-learn model from a local file or a run.
 
@@ -338,10 +338,6 @@ def load_model(model_uri, serialization_format=SERIALIZATION_FORMAT_CLOUDPICKLE)
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
-    :param serialization_format: The format in which the model was serialized. This should be one of
-                                 the formats listed in
-                                 ``mlflow.sklearn.SUPPORTED_SERIALIZATION_FORMATS``. The Cloudpickle
-                                 format, ``mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE``.
 
     :return: A scikit-learn model.
 
@@ -358,4 +354,7 @@ def load_model(model_uri, serialization_format=SERIALIZATION_FORMAT_CLOUDPICKLE)
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
     sklearn_model_artifacts_path = os.path.join(local_model_path, flavor_conf['pickled_model'])
-    return _load_model_from_local_file(path=sklearn_model_artifacts_path, serialization_format=serialization_format)
+    serialization_format = flavor_conf.get('serialization_format', SERIALIZATION_FORMAT_PICKLE)
+    return _load_model_from_local_file(
+        path=sklearn_model_artifacts_path,
+        serialization_format=serialization_format)


### PR DESCRIPTION
In the latest version of [cloudpickle](https://github.com/cloudpipe/cloudpickle/blob/v1.5.0/CHANGES.md) a [feature was added](https://github.com/cloudpipe/cloudpickle/pull/370) to optionally use [pickle5](https://pypi.org/project/pickle5/) (a backport of all features and APIs added in the pickle module in Python 3.8.3 ) when installed. This currently works fine for serialization, but when deserializing
an sklearn model the following exception is raised:

```python
ValueError: unsupported pickle protocol: 5
```

## What changes are proposed in this pull request?

This PR adds an optional serialization_format argument to the functions used to load an sklearn model that is set to use 
cloudpickle by default. There shouldn't be any issues with this issues since the default serialization format is already set to cloudpickle.

## How is this patch tested?

Since the exception only happens when pickle5, an optional dependency, is installed, I tested the changes manually using the following reproducer (Make sure to install [pickle5](https://pypi.org/project/pickle5/)):

```python
import os
import tempfile

import mlflow.sklearn
import mlflow.pyfunc
import sklearn.datasets as datasets
import sklearn.neighbors as knn

if __name__ == "__main__":
    iris = datasets.load_iris()
    X = iris.data[:, :2]  # we only take the first two features.
    y = iris.target
    knn_model = knn.KNeighborsClassifier()
    knn_model.fit(X, y)
    with tempfile.TemporaryDirectory() as tmp_dir:
        model_path = os.path.join(tmp_dir, "model")
        mlflow.sklearn.save_model(sk_model=knn_model, path=model_path)
        reloaded_knn_model = mlflow.sklearn.load_model(model_uri=model_path)
        reloaded_knn_pyfunc_model = mlflow.pyfunc.load_model(model_uri=model_path)

```

On the current Master branch it raises this exception:

```python
Traceback (most recent call last):
  File "reproducer.py", line 17, in <module>
    reloaded_knn_model = mlflow.sklearn.load_model(model_uri=model_path)
  File "/home/mlflow/mlflow/sklearn.py", line 336, in load_model
    return _load_model_from_local_file(path=sklearn_model_artifacts_path)
  File "/home/mlflow/mlflow/sklearn.py", line 271, in _load_model_from_local_file
    return pickle.load(f)
ValueError: unsupported pickle protocol: 5
```

Whereas on this branch it runs successfully.


## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
