### PR TITLE
translate after_success and after_failure steps from travis to github action

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -69,12 +69,24 @@ jobs:
         cd tests
         Rscript ../.travis.R
     - name: Calculate code coverage
+      if: ${{ success() }}
       run: |
         export MLFLOW_HOME=$(pwd)
         cd mlflow/R/mlflow/tests
-        Rscript -e 'covr::codecov()'
+        Rscript -e 'covr::codecov()' || :
       env:
         COVR_RUNNING: true
+    - name: Show 00check.log on failure
+      if: ${{ failure() }}
+      run: |
+        LOG_FILE="${HOME}/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
+        [ -r "${LOG_FILE}" ] && cat "${LOG_FILE}"
+        cp "${LOG_FILE}" /tmp
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: 00check.log
+        path: /tmp/00check.log
   python-small:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR makes 2 minor changes to the Github Actions workflow introduced in https://github.com/mlflow/mlflow/pull/3048 so that its behavior conforms to that of the original Travis CI workflow a bit more.

Specifically:

- In Travis, `after_success` effectively means "if all previous steps succeeded, then run another command **and ignore its exit code**, and consider the build successful". In GH Action it looks like the closest equivalent of that is `${{ success() }}` followed by the bash ` || :` construct for ignoring exit code. This is applied to the `covr::codecov()` step for computing coverage.

- Previous Travis CI workflow also included an `after_failure` step. This PR implements the equivalent of that in GH Action. In addition, it also makes check00.log available as a downloadable artifact upon failure.

## How is this patch tested?

GH Action workflow

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

Signed-off-by: Yitao Li <yitao@rstudio.com>