### PR TITLE
Check to make sure user doesn't delete last experiment

### DIFF
--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -66,7 +66,7 @@ def delete_experiment(experiment_id):
     Mark an active experiment for deletion. This also applies to experiment's metadata, runs and
     associated data, and artifacts if they are store in default location. Use ``list`` command to
     view artifact location. Command will throw an error if experiment is not found or already
-    marked for deletion.
+    marked for deletion or it would leave the zeroth experiment.
 
     Experiments marked for deletion can be restored using ``restore`` command, unless they are
     permanently deleted.
@@ -78,8 +78,12 @@ def delete_experiment(experiment_id):
     workflow mechanism to clear ``.trash`` folder.
     """
     store = _get_store()
-    store.delete_experiment(experiment_id)
-    print("Experiment with ID %s has been deleted." % str(experiment_id))
+    experiments_list=store.list_experiments(ViewType.ACTIVE_ONLY)
+    if len(experiments_list)>1:
+        store.delete_experiment(experiment_id)
+        print("Experiment with ID %s has been deleted." % str(experiment_id))
+    else:
+        print("Not allowed to delete last experiment")
 
 
 @commands.command("restore")

--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -78,8 +78,8 @@ def delete_experiment(experiment_id):
     workflow mechanism to clear ``.trash`` folder.
     """
     store = _get_store()
-    experiments_list=store.list_experiments(ViewType.ACTIVE_ONLY)
-    if len(experiments_list)>1:
+    experiments_list = store.list_experiments(ViewType.ACTIVE_ONLY)
+    if len(experiments_list) > 1:
         store.delete_experiment(experiment_id)
         print("Experiment with ID %s has been deleted." % str(experiment_id))
     else:


### PR DESCRIPTION
## What changes are proposed in this pull request?
The change allows for the user to only delete an experiment if there is more than one experiment. This is the fix to the issue number #2690.

## How is this patch tested?
This patch was tested by creating a second experiment and being able to delete it. When trying to delete the default experiment, we get an error saying the experiment cannot be deleted.

## Release Notes
Don't allow user to delete the last experiment.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The change allows for the user to only delete an experiment if there is more than one experiment. This is the fix to the issue number #2690.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
