### PR TITLE
Add support for boolean flags for arguments

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -144,8 +144,8 @@ def _user_args_to_dict(arguments, argument_type='P'):
         # Docker arguments such as `t` don't require a value
         # -> set them to True if specified
         if len(split) == 1:
-                name = split[0]
-                value = True
+            name = split[0]
+            value = True
         elif len(split) == 2:
             name = split[0]
             value = split[1]

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -53,7 +53,8 @@ def cli():
                    "corresponding entry point as command-line arguments in the form `--name value`")
 @click.option("--docker-args", "-A", metavar="NAME=VALUE", multiple=True,
               help="A `docker run` flag or argument, of the form -A name=value. Where `name` "
-              "will then be propagated as `docker run --name value`.")
+              "will then be propagated as `docker run --name value`. "
+              "Pass -A tty=true to allocate a pseudo-TTY.")
 @click.option("--experiment-name", envvar=tracking._EXPERIMENT_NAME_ENV_VAR,
               help="Name of the experiment under which to launch the run. If not "
                    "specified, 'experiment-id' option will be used to launch run.")

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -54,7 +54,7 @@ def cli():
 @click.option("--docker-args", "-A", metavar="NAME=VALUE", multiple=True,
               help="A `docker run` flag or argument, of the form -A name=value. Where `name` "
               "will then be propagated as `docker run --name value`. "
-              "Pass -A tty=true to allocate a pseudo-TTY.")
+              "Pass -A t=true to allocate a pseudo-TTY.")
 @click.option("--experiment-name", envvar=tracking._EXPERIMENT_NAME_ENV_VAR,
               help="Name of the experiment under which to launch the run. If not "
                    "specified, 'experiment-id' option will be used to launch run.")

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -53,8 +53,8 @@ def cli():
                    "corresponding entry point as command-line arguments in the form `--name value`")
 @click.option("--docker-args", "-A", metavar="NAME=VALUE", multiple=True,
               help="A `docker run` argument or flag, of the form -A name=value (e.g. -A gpus=all) "
-                   "or -A name (e.g. -A t). The argument will then be passed as `docker run --name value` "
-                   "or `docker run -name` respectively. ")
+                   "or -A name (e.g. -A t). The argument will then be passed as "
+                   "`docker run --name value` or `docker run -name` respectively. ")
 @click.option("--experiment-name", envvar=tracking._EXPERIMENT_NAME_ENV_VAR,
               help="Name of the experiment under which to launch the run. If not "
                    "specified, 'experiment-id' option will be used to launch run.")

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -54,7 +54,7 @@ def cli():
 @click.option("--docker-args", "-A", metavar="NAME=VALUE", multiple=True,
               help="A `docker run` flag or argument, of the form -A name=value. Where `name` "
               "will then be propagated as `docker run --name value`. "
-              "Pass -A t=true to allocate a pseudo-TTY.")
+              "Pass -A t to allocate a pseudo-TTY.")
 @click.option("--experiment-name", envvar=tracking._EXPERIMENT_NAME_ENV_VAR,
               help="Name of the experiment under which to launch the run. If not "
                    "specified, 'experiment-id' option will be used to launch run.")
@@ -104,7 +104,7 @@ def run(uri, entry_point, version, param_list, docker_args, experiment_name, exp
         sys.exit(1)
 
     param_dict = _user_args_to_dict(param_list)
-    args_dict = _user_args_to_dict(docker_args, flag_name='A')
+    args_dict = _user_args_to_dict(docker_args, argument_type='A')
 
     if backend_config is not None and os.path.splitext(backend_config)[-1] != ".json":
         try:
@@ -137,16 +137,23 @@ def run(uri, entry_point, version, param_list, docker_args, experiment_name, exp
         sys.exit(1)
 
 
-def _user_args_to_dict(user_list, flag_name='P'):
+def _user_args_to_dict(arguments, argument_type='P'):
     user_dict = {}
-    for s in user_list:
-        index = s.find("=")
-        if index == -1:
+    for arg in arguments:
+        split = arg.split('=')
+        # Docker arguments such as `t` don't require a value
+        # -> set them to True if specified
+        if len(split) == 1:
+            if argument_type == 'A':
+                name = split[0]
+                value = True
+        elif len(split) == 2:
+            name = split[0]
+            value = split[1]
+        else:
             eprint("Invalid format for -%s parameter: '%s'. "
-                   "Use -%s name=value." % (flag_name, s, flag_name))
+            "Use -%s name=value." % (argument_type, arg, argument_type))        
             sys.exit(1)
-        name = s[:index]
-        value = s[index + 1:]
         if name in user_dict:
             eprint("Repeated parameter: '%s'" % name)
             sys.exit(1)

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -52,9 +52,9 @@ def cli():
                    "are not in the list of parameters for an entry point will be passed to the "
                    "corresponding entry point as command-line arguments in the form `--name value`")
 @click.option("--docker-args", "-A", metavar="NAME=VALUE", multiple=True,
-              help="A `docker run` flag or argument, of the form -A name=value. Where `name` "
-              "will then be propagated as `docker run --name value`. "
-              "Pass -A t to allocate a pseudo-TTY.")
+              help="A `docker run` argument or flag, of the form -A name=value (e.g. -A gpus=all) "
+                   "or -A name (e.g. -A t). The argument will then be passed as `docker run --name value` "
+                   "or `docker run -name` respectively. ")
 @click.option("--experiment-name", envvar=tracking._EXPERIMENT_NAME_ENV_VAR,
               help="Name of the experiment under which to launch the run. If not "
                    "specified, 'experiment-id' option will be used to launch run.")
@@ -144,7 +144,6 @@ def _user_args_to_dict(arguments, argument_type='P'):
         # Docker arguments such as `t` don't require a value
         # -> set them to True if specified
         if len(split) == 1:
-            if argument_type == 'A':
                 name = split[0]
                 value = True
         elif len(split) == 2:

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -152,7 +152,7 @@ def _user_args_to_dict(arguments, argument_type='P'):
             value = split[1]
         else:
             eprint("Invalid format for -%s parameter: '%s'. "
-            "Use -%s name=value." % (argument_type, arg, argument_type))        
+                   "Use -%s name=value." % (argument_type, arg, argument_type))
             sys.exit(1)
         if name in user_dict:
             eprint("Repeated parameter: '%s'" % name)

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -54,7 +54,7 @@ def cli():
 @click.option("--docker-args", "-A", metavar="NAME=VALUE", multiple=True,
               help="A `docker run` argument or flag, of the form -A name=value (e.g. -A gpus=all) "
                    "or -A name (e.g. -A t). The argument will then be passed as "
-                   "`docker run --name value` or `docker run -name` respectively. ")
+                   "`docker run --name value` or `docker run --name` respectively. ")
 @click.option("--experiment-name", envvar=tracking._EXPERIMENT_NAME_ENV_VAR,
               help="Name of the experiment under which to launch the run. If not "
                    "specified, 'experiment-id' option will be used to launch run.")
@@ -141,9 +141,8 @@ def _user_args_to_dict(arguments, argument_type='P'):
     user_dict = {}
     for arg in arguments:
         split = arg.split('=')
-        # Docker arguments such as `t` don't require a value
-        # -> set them to True if specified
-        if len(split) == 1:
+        # Docker arguments such as `t` don't require a value -> set to True if specified
+        if len(split) == 1 and argument_type == 'A':
             name = split[0]
             value = True
         elif len(split) == 2:

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -543,7 +543,10 @@ def _get_docker_command(image, active_run, docker_args=None, volumes=None, user_
                     cmd += ['--' + name]
             else:
                 # Passed name=value
-                cmd += ['--' + name, value]
+                if len(name) == 1:
+                    cmd += ['-' + name, value]
+                else:
+                    cmd += ['--' + name, value]
 
     env_vars = _get_run_env_vars(run_id=active_run.info.run_id,
                                  experiment_id=active_run.info.experiment_id)

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -532,7 +532,7 @@ def _get_local_uri_or_none(uri):
 def _get_docker_command(image, active_run, docker_args=None, volumes=None, user_env_vars=None):
     docker_path = "docker"
     cmd = [docker_path, "run", "--rm"]
-    
+
     if docker_args:
         # Allocate a pseudo-TTY support if specified
         if 'tty' in docker_args:

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -534,7 +534,7 @@ def _get_docker_command(image, active_run, docker_args=None, volumes=None, user_
     cmd = [docker_path, "run", "--rm"]
 
     if docker_args:
-        # Allocate a pseudo-TTY support if specified
+        # Allocate a pseudo-TTY if specified
         if 't' in docker_args:
             if docker_args['t'] == 'true':
                 cmd.append('-t')

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -534,15 +534,13 @@ def _get_docker_command(image, active_run, docker_args=None, volumes=None, user_
     cmd = [docker_path, "run", "--rm"]
 
     if docker_args:
-        # Allocate a pseudo-TTY if specified
-        if 't' in docker_args:
-            if docker_args['t']:
-                cmd.append('-t')
-                # Delete tty from docker args, since it is not supposed to be appended later again
-                del docker_args['t']
-
-        for key, value in docker_args.items():
-            cmd += ['--' + key, value]
+        for name, value in docker_args.items():
+            # Passed just the name as boolean flag
+            if isinstance(value, bool) and value:
+                cmd += ['-' + name]
+            else:
+                # Passed name=value
+                cmd += ['--' + name, value]
 
     env_vars = _get_run_env_vars(run_id=active_run.info.run_id,
                                  experiment_id=active_run.info.experiment_id)

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -537,7 +537,10 @@ def _get_docker_command(image, active_run, docker_args=None, volumes=None, user_
         for name, value in docker_args.items():
             # Passed just the name as boolean flag
             if isinstance(value, bool) and value:
-                cmd += ['-' + name]
+                if len(name) == 1:
+                    cmd += ['-' + name]
+                else:
+                    cmd += ['--' + name]
             else:
                 # Passed name=value
                 cmd += ['--' + name, value]

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -532,14 +532,15 @@ def _get_local_uri_or_none(uri):
 def _get_docker_command(image, active_run, docker_args=None, volumes=None, user_env_vars=None):
     docker_path = "docker"
     cmd = [docker_path, "run", "--rm"]
-    # Allocate a pseudo-TTY support if specified
-    if 'tty' in docker_args:
-        if docker_args['tty'] == 'true':
-            cmd.append('-t')
-            # Delete tty from docker args, since it is not supposed to be appended later again
-            del docker_args['tty']
-
+    
     if docker_args:
+        # Allocate a pseudo-TTY support if specified
+        if 'tty' in docker_args:
+            if docker_args['tty'] == 'true':
+                cmd.append('-t')
+                # Delete tty from docker args, since it is not supposed to be appended later again
+                del docker_args['tty']
+
         for key, value in docker_args.items():
             cmd += ['--' + key, value]
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -532,6 +532,12 @@ def _get_local_uri_or_none(uri):
 def _get_docker_command(image, active_run, docker_args=None, volumes=None, user_env_vars=None):
     docker_path = "docker"
     cmd = [docker_path, "run", "--rm"]
+    # Allocate a pseudo-TTY support if specified
+    if 'tty' in docker_args:
+        if docker_args['tty'] == 'true':
+            cmd.append('-t')
+            # Delete tty from docker args, since it is not supposed to be appended later again
+            del docker_args['tty']
 
     if docker_args:
         for key, value in docker_args.items():

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -535,11 +535,11 @@ def _get_docker_command(image, active_run, docker_args=None, volumes=None, user_
 
     if docker_args:
         # Allocate a pseudo-TTY support if specified
-        if 'tty' in docker_args:
-            if docker_args['tty'] == 'true':
+        if 't' in docker_args:
+            if docker_args['t'] == 'true':
                 cmd.append('-t')
                 # Delete tty from docker args, since it is not supposed to be appended later again
-                del docker_args['tty']
+                del docker_args['t']
 
         for key, value in docker_args.items():
             cmd += ['--' + key, value]

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -536,7 +536,7 @@ def _get_docker_command(image, active_run, docker_args=None, volumes=None, user_
     if docker_args:
         # Allocate a pseudo-TTY if specified
         if 't' in docker_args:
-            if docker_args['t'] == 'true':
+            if docker_args['t']:
                 cmd.append('-t')
                 # Delete tty from docker args, since it is not supposed to be appended later again
                 del docker_args['t']


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes #2898 

Added a special docker argument 'tty', which can be passed as all other Docker arguments via `-A tty=true`.
This enables pseudo TTY support -> color support for example.
I did not want to add a parameter somewhere else, since I think this would get confusing quickly and require more code changes. 

## How is this patch tested?

Tested locally with a container that has colored output. 

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Enabled pseudo TTY support for Docker based projects via special Docker argument `-A tty=true`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [X] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
