### PR TITLE
Add set_registry_uri, get_registry_uri

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -68,9 +68,11 @@ end_run = mlflow.tracking.fluent.end_run
 search_runs = mlflow.tracking.fluent.search_runs
 get_artifact_uri = mlflow.tracking.fluent.get_artifact_uri
 set_tracking_uri = tracking.set_tracking_uri
+set_registry_uri = tracking.set_registry_uri
 get_experiment = mlflow.tracking.fluent.get_experiment
 get_experiment_by_name = mlflow.tracking.fluent.get_experiment_by_name
 get_tracking_uri = tracking.get_tracking_uri
+get_registry_uri = tracking.get_registry_uri
 create_experiment = mlflow.tracking.fluent.create_experiment
 set_experiment = mlflow.tracking.fluent.set_experiment
 log_params = mlflow.tracking.fluent.log_params
@@ -87,4 +89,5 @@ __all__ = ["ActiveRun", "log_param", "log_params", "log_metric", "log_metrics", 
            "set_tags", "delete_tag", "log_artifacts", "log_artifact", "active_run", "start_run",
            "end_run", "search_runs", "get_artifact_uri", "get_tracking_uri", "set_tracking_uri",
            "get_experiment", "get_experiment_by_name", "create_experiment", "set_experiment",
-           "delete_experiment", "get_run", "delete_run", "run", "register_model"]
+           "delete_experiment", "get_run", "delete_run", "run", "register_model",
+           "get_registry_uri", "set_registry_uri"]

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -13,6 +13,10 @@ from mlflow.tracking._tracking_service.utils import (
     _get_store,
     _TRACKING_URI_ENV_VAR
 )
+from mlflow.tracking._model_registry.utils import (
+    set_registry_uri,
+    get_registry_uri,
+)
 from mlflow.tracking.fluent import _EXPERIMENT_ID_ENV_VAR, _EXPERIMENT_NAME_ENV_VAR, \
     _RUN_ID_ENV_VAR
 
@@ -22,6 +26,8 @@ __all__ = [
     "set_tracking_uri",
     "is_tracking_uri_set",
     "_get_store",
+    "get_registry_uri",
+    "set_registry_uri",
     "_EXPERIMENT_ID_ENV_VAR",
     "_RUN_ID_ENV_VAR",
     "_TRACKING_URI_ENV_VAR",

--- a/mlflow/tracking/_model_registry/registry.py
+++ b/mlflow/tracking/_model_registry/registry.py
@@ -29,7 +29,7 @@ class ModelRegistryStoreRegistry(StoreRegistry):
         :return: An instance of `mlflow.store.model_registry.AbstractStore` that fulfills the
                  store URI requirements.
         """
-        from mlflow.tracking._tracking_service import utils
-        store_uri = store_uri if store_uri is not None else utils.get_tracking_uri()
+        from mlflow.tracking._model_registry import utils
+        store_uri = utils._resolve_registry_uri(store_uri)
         builder = self.get_store_builder(store_uri)
         return builder(store_uri=store_uri)

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -4,7 +4,8 @@ from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.tracking._model_registry.registry import ModelRegistryStoreRegistry
 from mlflow.tracking._tracking_service.utils import _TRACKING_USERNAME_ENV_VAR, \
-    _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, _TRACKING_INSECURE_TLS_ENV_VAR
+    _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, _TRACKING_INSECURE_TLS_ENV_VAR, \
+    _resolve_tracking_uri, get_tracking_uri
 from mlflow.utils import rest_utils
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.uri import get_db_profile_from_uri
@@ -46,14 +47,23 @@ def set_registry_uri(uri):
     _registry_uri = uri
 
 
+def _get_registry_uri_from_context():
+    global _registry_uri
+    # in the future, REGISTRY_URI env var support can go here
+    return _registry_uri
+
+
 def get_registry_uri():
     """
-    Get the current registry URI specified by `set_registry_uri`.
+    Get the current registry URI. If none has been specified, defaults to the tracking URI.
 
     :return: The registry URI.
     """
-    global _registry_uri
-    return _registry_uri
+    return _get_registry_uri_from_context() or get_tracking_uri()
+
+
+def _resolve_registry_uri(registry_uri=None, tracking_uri=None):
+    return registry_uri or _get_registry_uri_from_context() or _resolve_tracking_uri(tracking_uri)
 
 
 def _get_sqlalchemy_store(store_uri):

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -31,7 +31,8 @@ _registry_uri = None
 
 def set_registry_uri(uri):
     """
-    Set the registry server URI.
+    Set the registry server URI. This method is especially useful if you have a registry server
+    that's different from the tracking server.
 
     :param uri:
 

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -12,11 +12,11 @@ from mlflow.utils.uri import get_db_profile_from_uri
 
 # NOTE: in contrast to tracking, we do not support the following ways to specify
 # the model registry URI:
-#  - via a utility method like tracking.tracking.utils.set_tracking_uri
 #  - via environment variables like MLFLOW_TRACKING_URI, MLFLOW_TRACKING_USERNAME, ...
 # We do support specifying it
 #  - via the ``model_registry_uri`` parameter when creating an ``MlflowClient`` or
 #    ``ModelRegistryClient``.
+#  - via a utility method ``mlflow.set_registry_uri``
 #  - by not specifying anything: in this case we assume the model registry store URI is
 #    the same as the tracking store URI. This means Tracking and Model Registry are
 #    backed by the same backend DB/Rest server. However, note that we access them via
@@ -25,7 +25,36 @@ from mlflow.utils.uri import get_db_profile_from_uri
 # This means the following combinations are not supported:
 #  - Tracking RestStore & Model Registry RestStore that use different credentials.
 
-# NOTE: SqlAlchemyStore code is commented out here - we can add it back once it's available
+_registry_uri = None
+
+
+def set_registry_uri(uri):
+    """
+    Set the registry server URI.
+
+    :param uri:
+
+                - An empty string, or a local file path, prefixed with ``file:/``. Data is stored
+                  locally at the provided file (or ``./mlruns`` if empty).
+                - An HTTP URI like ``https://my-tracking-server:5000``.
+                - A Databricks workspace, provided as the string "databricks" or, to use a
+                  Databricks CLI
+                  `profile <https://github.com/databricks/databricks-cli#installation>`_,
+                  "databricks://<profileName>".
+    """
+    global _registry_uri
+    _registry_uri = uri
+
+
+def get_registry_uri():
+    """
+    Get the current registry URI.
+
+    :return: The tracking URI.
+    """
+    global _registry_uri
+    return _registry_uri
+
 
 def _get_sqlalchemy_store(store_uri):
     from mlflow.store.model_registry.sqlalchemy_store import SqlAlchemyStore

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -4,7 +4,8 @@ from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.tracking._model_registry.registry import ModelRegistryStoreRegistry
 from mlflow.tracking._tracking_service.utils import _TRACKING_USERNAME_ENV_VAR, \
-    _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, _TRACKING_INSECURE_TLS_ENV_VAR
+    _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, _TRACKING_INSECURE_TLS_ENV_VAR, \
+    get_tracking_uri
 from mlflow.utils import rest_utils
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.uri import get_db_profile_from_uri
@@ -48,9 +49,9 @@ def set_registry_uri(uri):
 
 def get_registry_uri():
     """
-    Get the current registry URI.
+    Get the current registry URI specified by `set_registry_uri`.
 
-    :return: The tracking URI.
+    :return: The registry URI.
     """
     global _registry_uri
     return _registry_uri

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -4,8 +4,7 @@ from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.tracking._model_registry.registry import ModelRegistryStoreRegistry
 from mlflow.tracking._tracking_service.utils import _TRACKING_USERNAME_ENV_VAR, \
-    _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, _TRACKING_INSECURE_TLS_ENV_VAR, \
-    get_tracking_uri
+    _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, _TRACKING_INSECURE_TLS_ENV_VAR
 from mlflow.utils import rest_utils
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.uri import get_db_profile_from_uri

--- a/mlflow/tracking/_tracking_service/registry.py
+++ b/mlflow/tracking/_tracking_service/registry.py
@@ -32,6 +32,6 @@ class TrackingStoreRegistry(StoreRegistry):
                  requirements.
         """
         from mlflow.tracking._tracking_service import utils
-        store_uri = store_uri if store_uri is not None else utils.get_tracking_uri()
+        store_uri = utils._resolve_tracking_uri(store_uri)
         builder = self.get_store_builder(store_uri)
         return builder(store_uri=store_uri, artifact_uri=artifact_uri)

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -58,6 +58,10 @@ def set_tracking_uri(uri):
     _tracking_uri = uri
 
 
+def _resolve_tracking_uri(tracking_uri=None):
+    return tracking_uri or get_tracking_uri()
+
+
 def get_tracking_uri():
     """
     Get the current tracking URI. This may not correspond to the tracking URI of

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -39,8 +39,8 @@ class MlflowClient(object):
                              defaults to the service set by ``mlflow.tracking.set_registry_uri``. If
                              no such service was set, defaults to the tracking uri of the client.
         """
-        final_tracking_uri = tracking_uri or utils.get_tracking_uri()
-        self._registry_uri = registry_uri or registry_utils.get_registry_uri() or final_tracking_uri
+        final_tracking_uri = utils._resolve_tracking_uri(tracking_uri)
+        self._registry_uri = registry_utils._resolve_registry_uri(registry_uri, tracking_uri)
         self._tracking_client = TrackingServiceClient(final_tracking_uri)
         # `MlflowClient` also references a `ModelRegistryClient` instance that is provided by the
         # `MlflowClient._get_registry_client()` method. This `ModelRegistryClient` is not explicitly

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -12,6 +12,7 @@ from mlflow.protos.databricks_pb2 import FEATURE_DISABLED
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.model_registry import SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT
 from mlflow.tracking._model_registry.client import ModelRegistryClient
+from mlflow.tracking._model_registry import utils as registry_utils
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.tracking._tracking_service import utils
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
@@ -35,10 +36,11 @@ class MlflowClient(object):
                              `Where Runs Get Recorded <../tracking.html#where-runs-get-recorded>`_
                              for more info.
         :param registry_uri: Address of local or remote model registry server. If not provided,
-                             defaults to the service set by ``mlflow.tracking.set_tracking_uri``.
+                             defaults to the service set by ``mlflow.tracking.set_registry_uri``. If
+                             no such service was set, defaults to the tracking uri of the client.
         """
         final_tracking_uri = tracking_uri or utils.get_tracking_uri()
-        self._registry_uri = registry_uri or final_tracking_uri
+        self._registry_uri = registry_uri or registry_utils.get_registry_uri() or final_tracking_uri
         self._tracking_client = TrackingServiceClient(final_tracking_uri)
         # `MlflowClient` also references a `ModelRegistryClient` instance that is provided by the
         # `MlflowClient._get_registry_client()` method. This `ModelRegistryClient` is not explicitly

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -1,7 +1,7 @@
 import mock
 import pytest
 
-from mlflow import register_model, set_tracking_uri, get_tracking_uri
+from mlflow import register_model, set_registry_uri, get_registry_uri
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import (
@@ -19,14 +19,14 @@ def test_register_model_raises_exception_with_unsupported_registry_store():
     features (e.g., FileStore).
     """
     with TempDir() as tmp:
-        old_tracking_uri = get_tracking_uri() if is_tracking_uri_set() else None
+        old_registry_uri = get_registry_uri()
         try:
-            set_tracking_uri(tmp.path())
+            set_registry_uri(tmp.path())
             with pytest.raises(MlflowException) as exc:
                 register_model(model_uri="runs:/1234/some_model", name="testmodel")
                 assert exc.value.error_code == ErrorCode.Name(FEATURE_DISABLED)
         finally:
-            set_tracking_uri(old_tracking_uri)
+            set_registry_uri(old_registry_uri)
 
 
 def test_register_model_with_runs_uri():

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -7,7 +7,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.model_registry.sqlalchemy_store import SqlAlchemyStore
 from mlflow.store.model_registry.rest_store import RestStore
-from mlflow.tracking._model_registry.utils import _get_store
+from mlflow.tracking._model_registry.utils import _get_store, get_registry_uri, set_registry_uri
 from mlflow.tracking._tracking_service.utils import _TRACKING_URI_ENV_VAR
 
 # Disable mocking tracking URI here, as we want to test setting the tracking URI via
@@ -16,6 +16,17 @@ from mlflow.tracking._tracking_service.utils import _TRACKING_URI_ENV_VAR
 # and https://github.com/mlflow/mlflow/blob/master/CONTRIBUTING.rst#writing-python-tests
 # for more information.
 pytestmark = pytest.mark.notrackingurimock
+
+
+def test_set_get_registry_uri():
+    uri = "databricks://registry/path"
+    set_registry_uri(uri)
+    assert get_registry_uri() == uri
+
+
+def test_set_get_empty_registry_uri():
+    set_registry_uri("")
+    assert get_registry_uri() == ""
 
 
 def test_get_store_rest_store_from_arg():

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -1,6 +1,5 @@
 import mock
 import os
-
 import pytest
 
 from mlflow.exceptions import MlflowException
@@ -9,6 +8,7 @@ from mlflow.store.model_registry.sqlalchemy_store import SqlAlchemyStore
 from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.tracking._model_registry.utils import _get_store, get_registry_uri, set_registry_uri
 from mlflow.tracking._tracking_service.utils import _TRACKING_URI_ENV_VAR
+
 
 # Disable mocking tracking URI here, as we want to test setting the tracking URI via
 # environment variable. See
@@ -19,14 +19,39 @@ pytestmark = pytest.mark.notrackingurimock
 
 
 def test_set_get_registry_uri():
-    uri = "databricks://registry/path"
-    set_registry_uri(uri)
-    assert get_registry_uri() == uri
+    with mock.patch("mlflow.tracking._model_registry.utils.get_tracking_uri") \
+            as get_tracking_uri_mock:
+        get_tracking_uri_mock.return_value = "databricks://tracking_sldkfj"
+        uri = "databricks://registry/path"
+        set_registry_uri(uri)
+        assert get_registry_uri() == uri
+        set_registry_uri(None)
 
 
 def test_set_get_empty_registry_uri():
-    set_registry_uri("")
-    assert get_registry_uri() == ""
+    with mock.patch("mlflow.tracking._model_registry.utils.get_tracking_uri") \
+            as get_tracking_uri_mock:
+        get_tracking_uri_mock.return_value = None
+        set_registry_uri("")
+        assert get_registry_uri() is None
+        set_registry_uri(None)
+
+
+def test_default_get_registry_uri_no_tracking_uri():
+    with mock.patch("mlflow.tracking._model_registry.utils.get_tracking_uri") \
+            as get_tracking_uri_mock:
+        get_tracking_uri_mock.return_value = None
+        set_registry_uri(None)
+        assert get_registry_uri() is None
+
+
+def test_default_get_registry_uri_with_tracking_uri_set():
+    tracking_uri = "databricks://tracking_werohoz"
+    with mock.patch("mlflow.tracking._model_registry.utils.get_tracking_uri") \
+            as get_tracking_uri_mock:
+        get_tracking_uri_mock.return_value = tracking_uri
+        set_registry_uri(None)
+        assert get_registry_uri() == tracking_uri
 
 
 def test_get_store_rest_store_from_arg():

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -10,9 +10,9 @@ from mlflow.store.tracking.rest_store import RestStore
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
-from mlflow.tracking._tracking_service.utils import _get_store, _TRACKING_URI_ENV_VAR, \
-    _TRACKING_USERNAME_ENV_VAR, _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, \
-    _TRACKING_INSECURE_TLS_ENV_VAR
+from mlflow.tracking._tracking_service.utils import _get_store, _resolve_tracking_uri, \
+    _TRACKING_INSECURE_TLS_ENV_VAR, _TRACKING_PASSWORD_ENV_VAR, _TRACKING_TOKEN_ENV_VAR, \
+    _TRACKING_URI_ENV_VAR, _TRACKING_USERNAME_ENV_VAR
 
 # pylint: disable=unused-argument
 
@@ -290,3 +290,19 @@ def test_get_store_for_unregistered_scheme():
 
     with pytest.raises(UnsupportedModelRegistryStoreURIException):
         tracking_store.get_store("unknown-scheme://")
+
+
+def test_resolve_tracking_uri_with_param():
+    with mock.patch("mlflow.tracking._tracking_service.utils.get_tracking_uri") \
+            as get_tracking_uri_mock:
+        get_tracking_uri_mock.return_value = "databricks://tracking_qoeirj"
+        overriding_uri = "databricks://tracking_poiwerow"
+        assert _resolve_tracking_uri(overriding_uri) == overriding_uri
+
+
+def test_resolve_tracking_uri_with_no_param():
+    with mock.patch("mlflow.tracking._tracking_service.utils.get_tracking_uri") \
+            as get_tracking_uri_mock:
+        default_uri = "databricks://tracking_zlkjdas"
+        get_tracking_uri_mock.return_value = default_uri
+        assert _resolve_tracking_uri() == default_uri

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1,11 +1,11 @@
-import pytest
 import mock
+import pytest
 
 from mlflow.entities import SourceType, ViewType, RunTag
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import ErrorCode, FEATURE_DISABLED
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
-from mlflow.tracking import get_registry_uri, set_registry_uri, MlflowClient
+from mlflow.tracking import set_registry_uri, MlflowClient
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.mlflow_tags import MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, \
     MLFLOW_PARENT_RUN_ID, MLFLOW_GIT_COMMIT, MLFLOW_PROJECT_ENTRY_POINT
@@ -213,24 +213,26 @@ def test_registry_uri_set_as_param():
 
 
 def test_registry_uri_from_set_registry_uri():
-    old_registry_uri = get_registry_uri()
     uri = "sqlite:///somedb.db"
     set_registry_uri(uri)
     client = MlflowClient(tracking_uri="databricks://tracking")
     assert client._registry_uri == uri
-    set_registry_uri(old_registry_uri)
+    set_registry_uri(None)
 
 
 def test_registry_uri_from_tracking_uri_param():
-    tracking_uri = "databricks://tracking"
-    client = MlflowClient(tracking_uri=tracking_uri)
-    assert client._registry_uri == tracking_uri
+    with mock.patch("mlflow.tracking._tracking_service.utils.get_tracking_uri") \
+            as get_tracking_uri_mock:
+        get_tracking_uri_mock.return_value = "databricks://default_tracking"
+        tracking_uri = "databricks://tracking_vhawoierj"
+        client = MlflowClient(tracking_uri=tracking_uri)
+        assert client._registry_uri == tracking_uri
 
 
-def test_registry_uri_from_final_tracking_uri():
-    tracking_uri = "databricks://tracking"
+def test_registry_uri_from_implicit_tracking_uri():
     with mock.patch("mlflow.tracking._tracking_service.utils.get_tracking_uri")\
             as get_tracking_uri_mock:
+        tracking_uri = "databricks://tracking_wierojasdf"
         get_tracking_uri_mock.return_value = tracking_uri
         client = MlflowClient()
         assert client._registry_uri == tracking_uri

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -227,7 +227,7 @@ def test_registry_uri_from_tracking_uri_param():
     assert client._registry_uri == tracking_uri
 
 
-def test_registry_uri_from_final_tracking_uri(mock_get_tracking_uri):
+def test_registry_uri_from_final_tracking_uri():
     tracking_uri = "databricks://tracking"
     with mock.patch("mlflow.tracking._tracking_service.utils.get_tracking_uri")\
             as get_tracking_uri_mock:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Similarly to `set_tracking_uri` and `get_tracking_uri`, provide a way to set the registry URI for fluent APIs.

Note that we are not adding support for this in R here (and do not plan to unless there is community feedback).

## How is this patch tested?

New unit tests added

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Now you can set the model registry URI for fluent APIs via `mlflow.set_registry_uri`, if you want it to to be different from the tracking URI. You can also retrieve the current value of the registry URI via `mlflow.get_registry_uri`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
