### PR TITLE
[Model Registry Tags] Backend store implementation and tests

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -594,7 +594,7 @@ def _set_registered_model_tag():
 @catch_mlflow_exception
 def _delete_registered_model_tag():
     request_message = _get_request_message(DeleteRegisteredModelTag())
-    _get_model_registry_store().set_registered_model_tag(
+    _get_model_registry_store().delete_registered_model_tag(
         name=request_message.name,
         key=request_message.key)
     return _wrap_response(DeleteRegisteredModelTag.Response())

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -497,7 +497,7 @@ def _wrap_response(response_message):
 def _create_registered_model():
     request_message = _get_request_message(CreateRegisteredModel())
     registered_model = _get_model_registry_store().create_registered_model(
-        name=request_message.name)
+        name=request_message.name, tags=request_message.tags)
     response_message = CreateRegisteredModel.Response(registered_model=registered_model.to_proto())
     return _wrap_response(response_message)
 
@@ -584,7 +584,7 @@ def _get_latest_versions():
 @catch_mlflow_exception
 def _set_registered_model_tag():
     request_message = _get_request_message(SetRegisteredModelTag())
-    tag = RegisteredModelTag(request_message.key, request_message.value)
+    tag = RegisteredModelTag(key=request_message.key, value=request_message.value)
     _get_model_registry_store().set_registered_model_tag(
         name=request_message.name,
         tag=tag)
@@ -605,7 +605,8 @@ def _create_model_version():
     request_message = _get_request_message(CreateModelVersion())
     model_version = _get_model_registry_store().create_model_version(name=request_message.name,
                                                                      source=request_message.source,
-                                                                     run_id=request_message.run_id)
+                                                                     run_id=request_message.run_id,
+                                                                     tags=request_message.tags)
     response_message = CreateModelVersion.Response(model_version=model_version.to_proto())
     return _wrap_response(response_message)
 
@@ -672,7 +673,7 @@ def _search_model_versions():
 @catch_mlflow_exception
 def _set_model_version_tag():
     request_message = _get_request_message(SetModelVersionTag())
-    tag = ModelVersionTag(request_message.key, request_message.value)
+    tag = ModelVersionTag(key=request_message.key, value=request_message.value)
     _get_model_registry_store().set_model_version_tag(
         name=request_message.name,
         version=request_message.version,
@@ -773,4 +774,8 @@ HANDLERS = {
     TransitionModelVersionStage: _transition_stage,
     GetModelVersionDownloadUri: _get_model_version_download_uri,
     SearchModelVersions: _search_model_versions,
+    SetRegisteredModelTag: _set_registered_model_tag,
+    DeleteRegisteredModelTag: _delete_registered_model_tag,
+    SetModelVersionTag: _set_model_version_tag,
+    DeleteModelVersionTag: _delete_model_version_tag,
 }

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -11,7 +11,6 @@ from google.protobuf import descriptor
 from querystring_parser import parser
 
 from mlflow.entities import Metric, Param, RunTag, ViewType, ExperimentTag
-from mlflow.entities.model_registry import RegisteredModelTag, ModelVersionTag
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos import databricks_pb2
@@ -25,7 +24,8 @@ from mlflow.protos.model_registry_pb2 import ModelRegistryService, CreateRegiste
     GetLatestVersions, CreateModelVersion, UpdateModelVersion, DeleteModelVersion, \
     GetModelVersion, GetModelVersionDownloadUri, SearchModelVersions, RenameRegisteredModel, \
     TransitionModelVersionStage, SearchRegisteredModels, SetRegisteredModelTag, \
-    DeleteRegisteredModelTag, SetModelVersionTag, DeleteModelVersionTag
+    DeleteRegisteredModelTag, SetModelVersionTag, DeleteModelVersionTag, \
+    RegisteredModelTag, ModelVersionTag
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, INVALID_PARAMETER_VALUE
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.db.db_types import DATABASE_ENGINES

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -11,6 +11,7 @@ from google.protobuf import descriptor
 from querystring_parser import parser
 
 from mlflow.entities import Metric, Param, RunTag, ViewType, ExperimentTag
+from mlflow.entities.model_registry import RegisteredModelTag, ModelVersionTag
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos import databricks_pb2
@@ -24,8 +25,7 @@ from mlflow.protos.model_registry_pb2 import ModelRegistryService, CreateRegiste
     GetLatestVersions, CreateModelVersion, UpdateModelVersion, DeleteModelVersion, \
     GetModelVersion, GetModelVersionDownloadUri, SearchModelVersions, RenameRegisteredModel, \
     TransitionModelVersionStage, SearchRegisteredModels, SetRegisteredModelTag, \
-    DeleteRegisteredModelTag, SetModelVersionTag, DeleteModelVersionTag, \
-    RegisteredModelTag, ModelVersionTag
+    DeleteRegisteredModelTag, SetModelVersionTag, DeleteModelVersionTag
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, INVALID_PARAMETER_VALUE
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.db.db_types import DATABASE_ENGINES

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -11,6 +11,7 @@ from google.protobuf import descriptor
 from querystring_parser import parser
 
 from mlflow.entities import Metric, Param, RunTag, ViewType, ExperimentTag
+from mlflow.entities.model_registry import RegisteredModelTag, ModelVersionTag
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.protos import databricks_pb2
@@ -23,7 +24,8 @@ from mlflow.protos.model_registry_pb2 import ModelRegistryService, CreateRegiste
     UpdateRegisteredModel, DeleteRegisteredModel, ListRegisteredModels, GetRegisteredModel, \
     GetLatestVersions, CreateModelVersion, UpdateModelVersion, DeleteModelVersion, \
     GetModelVersion, GetModelVersionDownloadUri, SearchModelVersions, RenameRegisteredModel, \
-    TransitionModelVersionStage, SearchRegisteredModels
+    TransitionModelVersionStage, SearchRegisteredModels, SetRegisteredModelTag, \
+    DeleteRegisteredModelTag, SetModelVersionTag, DeleteModelVersionTag
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, INVALID_PARAMETER_VALUE
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.db.db_types import DATABASE_ENGINES
@@ -580,6 +582,25 @@ def _get_latest_versions():
 
 
 @catch_mlflow_exception
+def _set_registered_model_tag():
+    request_message = _get_request_message(SetRegisteredModelTag())
+    tag = RegisteredModelTag(request_message.key, request_message.value)
+    _get_model_registry_store().set_registered_model_tag(
+        name=request_message.name,
+        tag=tag)
+    return _wrap_response(SetRegisteredModelTag.Response())
+
+
+@catch_mlflow_exception
+def _delete_registered_model_tag():
+    request_message = _get_request_message(DeleteRegisteredModelTag())
+    _get_model_registry_store().set_registered_model_tag(
+        name=request_message.name,
+        key=request_message.key)
+    return _wrap_response(DeleteRegisteredModelTag.Response())
+
+
+@catch_mlflow_exception
 def _create_model_version():
     request_message = _get_request_message(CreateModelVersion())
     model_version = _get_model_registry_store().create_model_version(name=request_message.name,
@@ -646,6 +667,27 @@ def _search_model_versions():
     response_message = SearchModelVersions.Response()
     response_message.model_versions.extend([e.to_proto() for e in model_versions])
     return _wrap_response(response_message)
+
+
+@catch_mlflow_exception
+def _set_model_version_tag():
+    request_message = _get_request_message(SetModelVersionTag())
+    tag = ModelVersionTag(request_message.key, request_message.value)
+    _get_model_registry_store().set_model_version_tag(
+        name=request_message.name,
+        version=request_message.version,
+        tag=tag)
+    return _wrap_response(SetModelVersionTag.Response())
+
+
+@catch_mlflow_exception
+def _delete_model_version_tag():
+    request_message = _get_request_message(DeleteModelVersionTag())
+    _get_model_registry_store().delete_model_version_tag(
+        name=request_message.name,
+        version=request_message.version,
+        key=request_message.key)
+    return _wrap_response(DeleteModelVersionTag.Response())
 
 
 def _add_static_prefix(route):

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -24,10 +24,8 @@ class AbstractStore:
         Create a new registered model in backend store.
 
         :param name: Name of the new model. This is expected to be unique in the backend store.
-
         :param tags: A list of :py:class:`mlflow.entities.model_registry.RegisteredModelTag`
         instances associated with this registered model.
-
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
         created in the backend.
         """
@@ -39,9 +37,7 @@ class AbstractStore:
         Update description of the registered model.
 
         :param name: Registered model name.
-
         :param description: New description.
-
         :return: A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
         pass
@@ -52,9 +48,7 @@ class AbstractStore:
         Rename the registered model.
 
         :param name: Registered model name.
-
         :param new_name: New proposed name.
-
         :return: A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
         pass
@@ -66,7 +60,6 @@ class AbstractStore:
         Backend raises exception if a registered model with given name does not exist.
 
         :param name: Registered model name.
-
         :return: None
         """
         pass
@@ -77,10 +70,8 @@ class AbstractStore:
         List of all registered models.
 
         :param max_results: Maximum number of registered models desired.
-
         :param page_token: Token specifying the next page of results. It should be obtained from
                             a ``list_registered_models`` call.
-
         :return: A PagedList of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
                 that satisfy the search expressions. The pagination token for the next page can be
                 obtained via the ``token`` attribute of the object.
@@ -94,15 +85,11 @@ class AbstractStore:
         Search for registered models in backend that satisfy the filter criteria.
 
         :param filter_string: Filter query string, defaults to searching all registered models.
-
         :param max_results: Maximum number of registered models desired.
-
         :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
                          matching search results.
-
         :param page_token: Token specifying the next page of results. It should be obtained from
                             a ``search_registered_models`` call.
-
         :return: A PagedList of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
                 that satisfy the search expressions. The pagination token for the next page can be
                 obtained via the ``token`` attribute of the object.
@@ -115,7 +102,6 @@ class AbstractStore:
         Get registered model instance by name.
 
         :param name: Registered model name.
-
         :return: A single :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
         pass
@@ -127,10 +113,8 @@ class AbstractStore:
         returns the latest version for each stage.
 
         :param name: Registered model name.
-
         :param stages: List of desired stages. If input list is None, return latest versions for
                        for 'Staging' and 'Production' stages.
-
         :return: List of :py:class:`mlflow.entities.model_registry.ModelVersion` objects.
         """
         pass
@@ -141,9 +125,7 @@ class AbstractStore:
         Set a tag for the registered model.
 
         :param name: Registered model name.
-
         :param tag: :py:class:`mlflow.entities.model_registry.RegisteredModelTag` instance to log.
-
         :return: None
         """
         pass
@@ -154,9 +136,7 @@ class AbstractStore:
         Delete a tag associated with the registered model.
 
         :param name: Registered model name.
-
         :param key: Registered model tag key.
-
         :return: None
         """
         pass
@@ -169,14 +149,10 @@ class AbstractStore:
         Create a new model version from given source and run ID.
 
         :param name: Registered model name.
-
         :param source: Source path where the MLflow model is stored.
-
         :param run_id: Run ID from MLflow tracking server that generated the model.
-
         :param tags: A list of :py:class:`mlflow.entities.model_registry.ModelVersionTag`
         instances associated with this model version.
-
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
         created in the backend.
         """
@@ -188,11 +164,8 @@ class AbstractStore:
         Update metadata associated with a model version in backend.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :param description: New model description.
-
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
         pass
@@ -204,14 +177,10 @@ class AbstractStore:
         Update model version stage.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :param new_stage: New desired stage for this model version.
-
         :param archive_existing_versions: If this flag is set, all existing model
         versions in the stage will be atomically moved to the "archived" stage.
-
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
         pass
@@ -222,9 +191,7 @@ class AbstractStore:
         Delete model version in backend.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :return: None
         """
         pass
@@ -235,9 +202,7 @@ class AbstractStore:
         Get the model version instance by name and version.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
         pass
@@ -250,9 +215,7 @@ class AbstractStore:
               location, download URI points to input source path.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :return: A single URI location that allows reads for downloading.
         """
         pass
@@ -265,7 +228,6 @@ class AbstractStore:
         :param filter_string: A filter string expression. Currently supports a single filter
                               condition either name of model like ``name = 'model_name'`` or
                               ``run_id = '...'``.
-
         :return: PagedList of :py:class:`mlflow.entities.model_registry.ModelVersion`
                  objects.
         """
@@ -277,11 +239,8 @@ class AbstractStore:
         Set a tag for the model version.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :param tag: :py:class:`mlflow.entities.model_registry.ModelVersionTag` instance to log.
-
         :return: None
         """
         pass
@@ -292,11 +251,8 @@ class AbstractStore:
         Delete a tag associated with the model version.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :param key: Tag key.
-
         :return: None
         """
         pass

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -19,12 +19,12 @@ class AbstractStore:
     # CRUD API for RegisteredModel objects
 
     @abstractmethod
-    def create_registered_model(self, name):
+    def create_registered_model(self, name, tags=None):
         """
         Create a new registered model in backend store.
 
         :param name: Name of the new model. This is expected to be unique in the backend store.
-
+        :param tags: tags associated with this registered model
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
         created in the backend.
         """
@@ -123,17 +123,37 @@ class AbstractStore:
         """
         pass
 
+    @abstractmethod
+    def set_registered_model_tag(self, name, tag):
+        """
+        Set a tag for the registered model
+        :param name: Registered model name.
+        :param tag: RegisteredModelTag instance to log
+        :return: None
+        """
+        pass
+
+    @abstractmethod
+    def delete_registered_model_tag(self, name, key):
+        """
+        Delete a tag associated with the registered model
+        :param name: Registered model name.
+        :param key: Tag key
+        :return: None
+        """
+        pass
+
     # CRUD API for ModelVersion objects
 
     @abstractmethod
-    def create_model_version(self, name, source, run_id):
+    def create_model_version(self, name, source, run_id, tags=None):
         """
         Create a new model version from given source and run ID.
 
         :param name: Registered model name.
         :param source: Source path where the MLflow model is stored.
         :param run_id: Run ID from MLflow tracking server that generated the model
-
+        :param tags: tags associated with this model version
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
         created in the backend.
         """
@@ -203,5 +223,27 @@ class AbstractStore:
 
         :return: PagedList of :py:class:`mlflow.entities.model_registry.ModelVersion`
                  objects.
+        """
+        pass
+
+    @abstractmethod
+    def set_model_version_tag(self, name, version, tag):
+        """
+        Set a tag for the model version
+        :param name: Registered model name.
+        :param version: Registered model version.
+        :param tag: ModelVersionTag instance to log
+        :return: None
+        """
+        pass
+
+    @abstractmethod
+    def delete_model_version_tag(self, name, version, key):
+        """
+        Delete a tag associated with the model version
+        :param name: Registered model name.
+        :param version: Registered model version.
+        :param key: Tag key
+        :return: None
         """
         pass

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -24,7 +24,10 @@ class AbstractStore:
         Create a new registered model in backend store.
 
         :param name: Name of the new model. This is expected to be unique in the backend store.
-        :param tags: tags associated with this registered model
+
+        :param tags: A list of :py:class:`mlflow.entities.model_registry.RegisteredModelTag`
+        instances associated with this registered model.
+
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
         created in the backend.
         """
@@ -72,7 +75,9 @@ class AbstractStore:
     def list_registered_models(self, max_results, page_token):
         """
         List of all registered models.
+
         :param max_results: Maximum number of registered models desired.
+
         :param page_token: Token specifying the next page of results. It should be obtained from
                             a ``list_registered_models`` call.
 
@@ -89,11 +94,15 @@ class AbstractStore:
         Search for registered models in backend that satisfy the filter criteria.
 
         :param filter_string: Filter query string, defaults to searching all registered models.
+
         :param max_results: Maximum number of registered models desired.
+
         :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
                          matching search results.
+
         :param page_token: Token specifying the next page of results. It should be obtained from
                             a ``search_registered_models`` call.
+
         :return: A PagedList of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
                 that satisfy the search expressions. The pagination token for the next page can be
                 obtained via the ``token`` attribute of the object.
@@ -103,6 +112,8 @@ class AbstractStore:
     @abstractmethod
     def get_registered_model(self, name):
         """
+        Get registered model instance by name.
+
         :param name: Registered model name.
 
         :return: A single :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
@@ -116,6 +127,7 @@ class AbstractStore:
         returns the latest version for each stage.
 
         :param name: Registered model name.
+
         :param stages: List of desired stages. If input list is None, return latest versions for
                        for 'Staging' and 'Production' stages.
 
@@ -126,9 +138,12 @@ class AbstractStore:
     @abstractmethod
     def set_registered_model_tag(self, name, tag):
         """
-        Set a tag for the registered model
+        Set a tag for the registered model.
+
         :param name: Registered model name.
-        :param tag: RegisteredModelTag instance to log
+
+        :param tag: :py:class:`mlflow.entities.model_registry.RegisteredModelTag` instance to log.
+
         :return: None
         """
         pass
@@ -136,9 +151,12 @@ class AbstractStore:
     @abstractmethod
     def delete_registered_model_tag(self, name, key):
         """
-        Delete a tag associated with the registered model
+        Delete a tag associated with the registered model.
+
         :param name: Registered model name.
-        :param key: Tag key
+
+        :param key: Registered model tag key.
+
         :return: None
         """
         pass
@@ -151,9 +169,14 @@ class AbstractStore:
         Create a new model version from given source and run ID.
 
         :param name: Registered model name.
+
         :param source: Source path where the MLflow model is stored.
-        :param run_id: Run ID from MLflow tracking server that generated the model
-        :param tags: tags associated with this model version
+
+        :param run_id: Run ID from MLflow tracking server that generated the model.
+
+        :param tags: A list of :py:class:`mlflow.entities.model_registry.ModelVersionTag`
+        instances associated with this model version.
+
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
         created in the backend.
         """
@@ -165,7 +188,9 @@ class AbstractStore:
         Update metadata associated with a model version in backend.
 
         :param name: Registered model name.
+
         :param version: Registered model version.
+
         :param description: New model description.
 
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
@@ -179,8 +204,11 @@ class AbstractStore:
         Update model version stage.
 
         :param name: Registered model name.
+
         :param version: Registered model version.
+
         :param new_stage: New desired stage for this model version.
+
         :param archive_existing_versions: If this flag is set, all existing model
         versions in the stage will be atomically moved to the "archived" stage.
 
@@ -194,6 +222,7 @@ class AbstractStore:
         Delete model version in backend.
 
         :param name: Registered model name.
+
         :param version: Registered model version.
 
         :return: None
@@ -201,11 +230,27 @@ class AbstractStore:
         pass
 
     @abstractmethod
+    def get_model_version(self, name, version):
+        """
+        Get the model version instance by name and version.
+
+        :param name: Registered model name.
+
+        :param version: Registered model version.
+
+        :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
+        """
+        pass
+
+    @abstractmethod
     def get_model_version_download_uri(self, name, version):
         """
         Get the download location in Model Registry for this model version.
+        NOTE: For first version of Model Registry, since the models are not copied over to another
+              location, download URI points to input source path.
 
         :param name: Registered model name.
+
         :param version: Registered model version.
 
         :return: A single URI location that allows reads for downloading.
@@ -229,10 +274,14 @@ class AbstractStore:
     @abstractmethod
     def set_model_version_tag(self, name, version, tag):
         """
-        Set a tag for the model version
+        Set a tag for the model version.
+
         :param name: Registered model name.
+
         :param version: Registered model version.
-        :param tag: ModelVersionTag instance to log
+
+        :param tag: :py:class:`mlflow.entities.model_registry.ModelVersionTag` instance to log.
+
         :return: None
         """
         pass
@@ -240,10 +289,14 @@ class AbstractStore:
     @abstractmethod
     def delete_model_version_tag(self, name, version, key):
         """
-        Delete a tag associated with the model version
+        Delete a tag associated with the model version.
+
         :param name: Registered model name.
+
         :param version: Registered model version.
-        :param key: Tag key
+
+        :param key: Tag key.
+
         :return: None
         """
         pass

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -46,7 +46,10 @@ class RestStore(AbstractStore):
         Create a new registered model in backend store.
 
         :param name: Name of the new model. This is expected to be unique in the backend store.
-        :param tags: tags associated with this registered model
+
+        :param tags: A list of :py:class:`mlflow.entities.model_registry.RegisteredModelTag`
+        instances associated with this registered model.
+
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
         created in the backend.
         """
@@ -57,11 +60,11 @@ class RestStore(AbstractStore):
 
     def update_registered_model(self, name, description):
         """
-        Updates metadata for RegisteredModel entity.
+        Update description of the registered model.
 
-        :param name: :py:string: Registered model name.
+        :param name: Registered model name.
 
-        :param description: New model description.
+        :param description: New description.
 
         :return: A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
@@ -72,11 +75,11 @@ class RestStore(AbstractStore):
 
     def rename_registered_model(self, name, new_name):
         """
-        Renames the registered model.
+        Rename the registered model.
 
         :param name: Registered model name.
 
-        :param new_name: New proposed name for the registered model.
+        :param new_name: New proposed name.
 
         :return: A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
@@ -87,10 +90,10 @@ class RestStore(AbstractStore):
 
     def delete_registered_model(self, name):
         """
-        Delete registered model.
+        Delete the registered model.
         Backend raises exception if a registered model with given name does not exist.
 
-        :param registered_model: :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
+        :param name: Registered model name.
 
         :return: None
         """
@@ -101,11 +104,15 @@ class RestStore(AbstractStore):
     def list_registered_models(self, max_results, page_token):
         """
         List of all registered models.
+
         :param max_results: Maximum number of registered models desired.
+
         :param page_token: Token specifying the next page of results. It should be obtained from
                             a ``list_registered_models`` call.
 
-        :return: PagedList of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects.
+        :return: A PagedList of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
+                that satisfy the search expressions. The pagination token for the next page can be
+                obtained via the ``token`` attribute of the object.
         """
         req_body = message_to_json(ListRegisteredModels(
             page_token=page_token,
@@ -121,12 +128,16 @@ class RestStore(AbstractStore):
         """
         Search for registered models in backend that satisfy the filter criteria.
 
-        :param filter_string: Filter query string supported by backend implementation.
+        :param filter_string: Filter query string, defaults to searching all registered models.
+
         :param max_results: Maximum number of registered models desired.
+
         :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
                          matching search results.
+
         :param page_token: Token specifying the next page of results. It should be obtained from
                             a ``search_registered_models`` call.
+
         :return: A PagedList of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
                 that satisfy the search expressions. The pagination token for the next page can be
                 obtained via the ``token`` attribute of the object.
@@ -142,6 +153,8 @@ class RestStore(AbstractStore):
 
     def get_registered_model(self, name):
         """
+        Get registered model instance by name.
+
         :param name: Registered model name.
 
         :return: A single :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
@@ -156,6 +169,7 @@ class RestStore(AbstractStore):
         returns the latest version for each stage.
 
         :param name: Registered model name.
+
         :param stages: List of desired stages. If input list is None, return latest versions for
                        for 'Staging' and 'Production' stages.
 
@@ -168,9 +182,12 @@ class RestStore(AbstractStore):
 
     def set_registered_model_tag(self, name, tag):
         """
-        Set a tag for the registered model
+        Set a tag for the registered model.
+
         :param name: Registered model name.
-        :param tag: RegisteredModelTag instance to log
+
+        :param tag: :py:class:`mlflow.entities.model_registry.RegisteredModelTag` instance to log.
+
         :return: None
         """
         req_body = message_to_json(SetRegisteredModelTag(name=name, key=tag.key, value=tag.value))
@@ -178,9 +195,12 @@ class RestStore(AbstractStore):
 
     def delete_registered_model_tag(self, name, key):
         """
-        Delete a tag associated with the registered model
+        Delete a tag associated with the registered model.
+
         :param name: Registered model name.
-        :param key: Tag key
+
+        :param key: Registered model tag key.
+
         :return: None
         """
         req_body = message_to_json(DeleteRegisteredModelTag(name=name, key=key))
@@ -193,9 +213,14 @@ class RestStore(AbstractStore):
         Create a new model version from given source and run ID.
 
         :param name: Registered model name.
+
         :param source: Source path where the MLflow model is stored.
-        :param run_id: Run ID from MLflow tracking server that generated the model
-        :param tags: tags associated with this model version
+
+        :param run_id: Run ID from MLflow tracking server that generated the model.
+
+        :param tags: A list of :py:class:`mlflow.entities.model_registry.ModelVersionTag`
+        instances associated with this model version.
+
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
         created in the backend.
         """
@@ -211,8 +236,11 @@ class RestStore(AbstractStore):
         Update model version stage.
 
         :param name: Registered model name.
+
         :param version: Registered model version.
+
         :param new_stage: New desired stage for this model version.
+
         :param archive_existing_versions: If this flag is set, all existing model
         versions in the stage will be atomically moved to the "archived" stage.
 
@@ -230,10 +258,12 @@ class RestStore(AbstractStore):
         Update metadata associated with a model version in backend.
 
         :param name: Registered model name.
-        :param version: Registered model version.
-        :param description: New description.
 
-        :return: None.
+        :param version: Registered model version.
+
+        :param description: New model description.
+
+        :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
         req_body = message_to_json(UpdateModelVersion(name=name, version=str(version),
                                                       description=description))
@@ -245,6 +275,7 @@ class RestStore(AbstractStore):
         Delete model version in backend.
 
         :param name: Registered model name.
+
         :param version: Registered model version.
 
         :return: None
@@ -254,7 +285,10 @@ class RestStore(AbstractStore):
 
     def get_model_version(self, name, version):
         """
+        Get the model version instance by name and version.
+
         :param name: Registered model name.
+
         :param version: Registered model version.
 
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
@@ -266,8 +300,11 @@ class RestStore(AbstractStore):
     def get_model_version_download_uri(self, name, version):
         """
         Get the download location in Model Registry for this model version.
+        NOTE: For first version of Model Registry, since the models are not copied over to another
+              location, download URI points to input source path.
 
         :param name: Registered model name.
+
         :param version: Registered model version.
 
         :return: A single URI location that allows reads for downloading.
@@ -295,10 +332,14 @@ class RestStore(AbstractStore):
 
     def set_model_version_tag(self, name, version, tag):
         """
-        Set a tag for the model version
+        Set a tag for the model version.
+
         :param name: Registered model name.
+
         :param version: Registered model version.
-        :param tag: ModelVersionTag instance to log
+
+        :param tag: :py:class:`mlflow.entities.model_registry.ModelVersionTag` instance to log.
+
         :return: None
         """
         req_body = message_to_json(SetModelVersionTag(name=name, version=version,
@@ -307,10 +348,14 @@ class RestStore(AbstractStore):
 
     def delete_model_version_tag(self, name, version, key):
         """
-        Delete a tag associated with the model version
+        Delete a tag associated with the model version.
+
         :param name: Registered model name.
+
         :param version: Registered model version.
-        :param key: Tag key
+
+        :param key: Tag key.
+
         :return: None
         """
         req_body = message_to_json(DeleteModelVersionTag(name=name, version=version, key=key))

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -46,10 +46,8 @@ class RestStore(AbstractStore):
         Create a new registered model in backend store.
 
         :param name: Name of the new model. This is expected to be unique in the backend store.
-
         :param tags: A list of :py:class:`mlflow.entities.model_registry.RegisteredModelTag`
         instances associated with this registered model.
-
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
         created in the backend.
         """
@@ -63,9 +61,7 @@ class RestStore(AbstractStore):
         Update description of the registered model.
 
         :param name: Registered model name.
-
         :param description: New description.
-
         :return: A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
         req_body = message_to_json(UpdateRegisteredModel(
@@ -78,9 +74,7 @@ class RestStore(AbstractStore):
         Rename the registered model.
 
         :param name: Registered model name.
-
         :param new_name: New proposed name.
-
         :return: A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
         req_body = message_to_json(RenameRegisteredModel(
@@ -94,7 +88,6 @@ class RestStore(AbstractStore):
         Backend raises exception if a registered model with given name does not exist.
 
         :param name: Registered model name.
-
         :return: None
         """
         req_body = message_to_json(DeleteRegisteredModel(
@@ -106,10 +99,8 @@ class RestStore(AbstractStore):
         List of all registered models.
 
         :param max_results: Maximum number of registered models desired.
-
         :param page_token: Token specifying the next page of results. It should be obtained from
                             a ``list_registered_models`` call.
-
         :return: A PagedList of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
                 that satisfy the search expressions. The pagination token for the next page can be
                 obtained via the ``token`` attribute of the object.
@@ -129,15 +120,11 @@ class RestStore(AbstractStore):
         Search for registered models in backend that satisfy the filter criteria.
 
         :param filter_string: Filter query string, defaults to searching all registered models.
-
         :param max_results: Maximum number of registered models desired.
-
         :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
                          matching search results.
-
         :param page_token: Token specifying the next page of results. It should be obtained from
                             a ``search_registered_models`` call.
-
         :return: A PagedList of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
                 that satisfy the search expressions. The pagination token for the next page can be
                 obtained via the ``token`` attribute of the object.
@@ -156,7 +143,6 @@ class RestStore(AbstractStore):
         Get registered model instance by name.
 
         :param name: Registered model name.
-
         :return: A single :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
         req_body = message_to_json(GetRegisteredModel(name=name))
@@ -169,10 +155,8 @@ class RestStore(AbstractStore):
         returns the latest version for each stage.
 
         :param name: Registered model name.
-
         :param stages: List of desired stages. If input list is None, return latest versions for
                        for 'Staging' and 'Production' stages.
-
         :return: List of :py:class:`mlflow.entities.model_registry.ModelVersion` objects.
         """
         req_body = message_to_json(GetLatestVersions(name=name, stages=stages))
@@ -185,9 +169,7 @@ class RestStore(AbstractStore):
         Set a tag for the registered model.
 
         :param name: Registered model name.
-
         :param tag: :py:class:`mlflow.entities.model_registry.RegisteredModelTag` instance to log.
-
         :return: None
         """
         req_body = message_to_json(SetRegisteredModelTag(name=name, key=tag.key, value=tag.value))
@@ -198,9 +180,7 @@ class RestStore(AbstractStore):
         Delete a tag associated with the registered model.
 
         :param name: Registered model name.
-
         :param key: Registered model tag key.
-
         :return: None
         """
         req_body = message_to_json(DeleteRegisteredModelTag(name=name, key=key))
@@ -213,14 +193,10 @@ class RestStore(AbstractStore):
         Create a new model version from given source and run ID.
 
         :param name: Registered model name.
-
         :param source: Source path where the MLflow model is stored.
-
         :param run_id: Run ID from MLflow tracking server that generated the model.
-
         :param tags: A list of :py:class:`mlflow.entities.model_registry.ModelVersionTag`
         instances associated with this model version.
-
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
         created in the backend.
         """
@@ -236,14 +212,10 @@ class RestStore(AbstractStore):
         Update model version stage.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :param new_stage: New desired stage for this model version.
-
         :param archive_existing_versions: If this flag is set, all existing model
         versions in the stage will be atomically moved to the "archived" stage.
-
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
         req_body = message_to_json(TransitionModelVersionStage(
@@ -258,11 +230,8 @@ class RestStore(AbstractStore):
         Update metadata associated with a model version in backend.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :param description: New model description.
-
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
         req_body = message_to_json(UpdateModelVersion(name=name, version=str(version),
@@ -275,9 +244,7 @@ class RestStore(AbstractStore):
         Delete model version in backend.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :return: None
         """
         req_body = message_to_json(DeleteModelVersion(name=name, version=str(version)))
@@ -288,9 +255,7 @@ class RestStore(AbstractStore):
         Get the model version instance by name and version.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
         req_body = message_to_json(GetModelVersion(name=name, version=str(version)))
@@ -304,9 +269,7 @@ class RestStore(AbstractStore):
               location, download URI points to input source path.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :return: A single URI location that allows reads for downloading.
         """
         req_body = message_to_json(GetModelVersionDownloadUri(name=name, version=str(version)))
@@ -320,7 +283,6 @@ class RestStore(AbstractStore):
         :param filter_string: A filter string expression. Currently supports a single filter
                               condition either name of model like ``name = 'model_name'`` or
                               ``run_id = '...'``.
-
         :return: PagedList of :py:class:`mlflow.entities.model_registry.ModelVersion`
                  objects.
         """
@@ -335,11 +297,8 @@ class RestStore(AbstractStore):
         Set a tag for the model version.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :param tag: :py:class:`mlflow.entities.model_registry.ModelVersionTag` instance to log.
-
         :return: None
         """
         req_body = message_to_json(SetModelVersionTag(name=name, version=version,
@@ -351,11 +310,8 @@ class RestStore(AbstractStore):
         Delete a tag associated with the model version.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :param key: Tag key.
-
         :return: None
         """
         req_body = message_to_json(DeleteModelVersionTag(name=name, version=version, key=key))

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -50,7 +50,8 @@ class RestStore(AbstractStore):
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
         created in the backend.
         """
-        req_body = message_to_json(CreateRegisteredModel(name=name, tags=tags))
+        proto_tags = [tag.to_proto() for tag in tags or []]
+        req_body = message_to_json(CreateRegisteredModel(name=name, tags=proto_tags))
         response_proto = self._call_endpoint(CreateRegisteredModel, req_body)
         return RegisteredModel.from_proto(response_proto.registered_model)
 
@@ -198,8 +199,9 @@ class RestStore(AbstractStore):
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
         created in the backend.
         """
+        proto_tags = [tag.to_proto() for tag in tags or []]
         req_body = message_to_json(CreateModelVersion(name=name, source=source,
-                                                      run_id=run_id, tags=tags))
+                                                      run_id=run_id, tags=proto_tags))
         response_proto = self._call_endpoint(CreateModelVersion, req_body)
         return ModelVersion.from_proto(response_proto.model_version)
 

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -149,7 +149,7 @@ class SqlAlchemyStore(AbstractStore):
                 registered_model = SqlRegisteredModel(name=name, creation_time=creation_time,
                                                       last_updated_time=creation_time)
                 tags_dict = {}
-                for tag in tags:
+                for tag in tags or []:
                     tags_dict[tag.key] = tag.value
                 registered_model.registered_model_tags = [SqlRegisteredModelTag(key=key,
                                                                                 value=value)
@@ -480,7 +480,7 @@ class SqlAlchemyStore(AbstractStore):
                                                     last_updated_time=creation_time,
                                                     source=source, run_id=run_id)
                     tags_dict = {}
-                    for tag in tags:
+                    for tag in tags or []:
                         tags_dict[tag.key] = tag.value
                     model_version.model_version_tags = [SqlModelVersionTag(key=key,
                                                                            value=value)

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -142,7 +142,8 @@ class SqlAlchemyStore(AbstractStore):
         """
         if name is None or name == "":
             raise MlflowException('Registered model name cannot be empty.', INVALID_PARAMETER_VALUE)
-
+        for tag in tags or []:
+            _validate_registered_model_tag(tag.key, tag.value)
         with self.ManagedSessionMaker() as session:
             try:
                 creation_time = now()
@@ -214,6 +215,8 @@ class SqlAlchemyStore(AbstractStore):
 
         :return: A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
+        if new_name is None or new_name == "":
+            raise MlflowException('Registered model name cannot be empty.', INVALID_PARAMETER_VALUE)
         with self.ManagedSessionMaker() as session:
             sql_registered_model = self._get_registered_model(session, name)
             try:
@@ -467,6 +470,10 @@ class SqlAlchemyStore(AbstractStore):
             else:
                 return 1
 
+        if name is None or name == "":
+            raise MlflowException('Model version name cannot be empty.', INVALID_PARAMETER_VALUE)
+        for tag in tags or []:
+            _validate_registered_model_tag(tag.key, tag.value)
         with self.ManagedSessionMaker() as session:
             creation_time = now()
             for attempt in range(self.CREATE_MODEL_VERSION_RETRIES):

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -172,7 +172,7 @@ class SqlAlchemyStore(AbstractStore):
         query_options = cls._get_eager_registered_model_query_options() if eager else []
         rms = session \
             .query(SqlRegisteredModel) \
-            .option(*query_options) \
+            .options(*query_options) \
             .filter(SqlRegisteredModel.name == name) \
             .all()
 
@@ -514,7 +514,7 @@ class SqlAlchemyStore(AbstractStore):
             SqlModelVersion.version == version,
             SqlModelVersion.current_stage != STAGE_DELETED_INTERNAL
         ]
-        versions = session.query(SqlModelVersion).option(*query_options).filter(*conditions).all()
+        versions = session.query(SqlModelVersion).options(*query_options).filter(*conditions).all()
 
         if len(versions) == 0:
             raise MlflowException('Model Version (name={}, version={}) '

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -403,7 +403,8 @@ class SqlAlchemyStore(AbstractStore):
     @classmethod
     def _get_registered_model_tag(cls, session, name, key):
         tags = session.query(SqlRegisteredModelTag).filter(
-            SqlRegisteredModelTag.name == name and SqlRegisteredModelTag.key == key
+            SqlRegisteredModelTag.name == name,
+            SqlRegisteredModelTag.key == key
         ).all()
         if len(tags) == 0:
             return None
@@ -424,6 +425,8 @@ class SqlAlchemyStore(AbstractStore):
                                   INVALID_PARAMETER_VALUE)
         _validate_registered_model_tag(tag.key, tag.value)
         with self.ManagedSessionMaker() as session:
+            # check if registered model exists
+            self._get_registered_model(session, name)
             session.merge(SqlRegisteredModelTag(
                 name=name,
                 key=tag.key,
@@ -672,8 +675,8 @@ class SqlAlchemyStore(AbstractStore):
     @classmethod
     def _get_model_version_tag(cls, session, name, version, key):
         tags = session.query(SqlModelVersionTag).filter(
-            SqlModelVersionTag.name == name and
-            SqlModelVersionTag.version == version and
+            SqlModelVersionTag.name == name,
+            SqlModelVersionTag.version == version,
             SqlModelVersionTag.key == key
         ).all()
         if len(tags) == 0:
@@ -702,6 +705,8 @@ class SqlAlchemyStore(AbstractStore):
                                   .format(version), error_code=INVALID_PARAMETER_VALUE)
         _validate_model_version_tag(tag.key, tag.value)
         with self.ManagedSessionMaker() as session:
+            # check if model version exists
+            self._get_sql_model_version(session, name, version)
             session.merge(SqlModelVersionTag(
                 name=name,
                 version=version,

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -136,10 +136,8 @@ class SqlAlchemyStore(AbstractStore):
         Create a new registered model in backend store.
 
         :param name: Name of the new model. This is expected to be unique in the backend store.
-
         :param tags: A list of :py:class:`mlflow.entities.model_registry.RegisteredModelTag`
         instances associated with this registered model.
-
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
         created in the backend.
         """
@@ -193,9 +191,7 @@ class SqlAlchemyStore(AbstractStore):
         Update description of the registered model.
 
         :param name: Registered model name.
-
         :param description: New description.
-
         :return: A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
         with self.ManagedSessionMaker() as session:
@@ -213,9 +209,7 @@ class SqlAlchemyStore(AbstractStore):
         Rename the registered model.
 
         :param name: Registered model name.
-
         :param new_name: New proposed name.
-
         :return: A single updated :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
         _validate_model_name(new_name)
@@ -242,7 +236,6 @@ class SqlAlchemyStore(AbstractStore):
         Backend raises exception if a registered model with given name does not exist.
 
         :param name: Registered model name.
-
         :return: None
         """
         with self.ManagedSessionMaker() as session:
@@ -254,10 +247,8 @@ class SqlAlchemyStore(AbstractStore):
         List of all registered models.
 
         :param max_results: Maximum number of registered models desired.
-
         :param page_token: Token specifying the next page of results. It should be obtained from
                             a ``list_registered_models`` call.
-
         :return: A PagedList of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
                 that satisfy the search expressions. The pagination token for the next page can be
                 obtained via the ``token`` attribute of the object.
@@ -274,15 +265,11 @@ class SqlAlchemyStore(AbstractStore):
         Search for registered models in backend that satisfy the filter criteria.
 
         :param filter_string: Filter query string, defaults to searching all registered models.
-
         :param max_results: Maximum number of registered models desired.
-
         :param order_by: List of column names with ASC|DESC annotation, to be used for ordering
                          matching search results.
-
         :param page_token: Token specifying the next page of results. It should be obtained from
                             a ``search_registered_models`` call.
-
         :return: A PagedList of :py:class:`mlflow.entities.model_registry.RegisteredModel` objects
                 that satisfy the search expressions. The pagination token for the next page can be
                 obtained via the ``token`` attribute of the object.
@@ -379,7 +366,6 @@ class SqlAlchemyStore(AbstractStore):
         Get registered model instance by name.
 
         :param name: Registered model name.
-
         :return: A single :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
         """
         with self.ManagedSessionMaker() as session:
@@ -391,10 +377,8 @@ class SqlAlchemyStore(AbstractStore):
         returns the latest version for each stage.
 
         :param name: Registered model name.
-
         :param stages: List of desired stages. If input list is None, return latest versions for
                        for 'Staging' and 'Production' stages.
-
         :return: List of :py:class:`mlflow.entities.model_registry.ModelVersion` objects.
         """
         with self.ManagedSessionMaker() as session:
@@ -426,9 +410,7 @@ class SqlAlchemyStore(AbstractStore):
         Set a tag for the registered model.
 
         :param name: Registered model name.
-
         :param tag: :py:class:`mlflow.entities.model_registry.RegisteredModelTag` instance to log.
-
         :return: None
         """
         _validate_model_name(name)
@@ -447,9 +429,7 @@ class SqlAlchemyStore(AbstractStore):
         Delete a tag associated with the registered model.
 
         :param name: Registered model name.
-
         :param key: Registered model tag key.
-
         :return: None
         """
         _validate_model_name(name)
@@ -468,14 +448,10 @@ class SqlAlchemyStore(AbstractStore):
         Create a new model version from given source and run ID.
 
         :param name: Registered model name.
-
         :param source: Source path where the MLflow model is stored.
-
         :param run_id: Run ID from MLflow tracking server that generated the model.
-
         :param tags: A list of :py:class:`mlflow.entities.model_registry.ModelVersionTag`
         instances associated with this model version.
-
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
         created in the backend.
         """
@@ -548,11 +524,8 @@ class SqlAlchemyStore(AbstractStore):
         Update metadata associated with a model version in backend.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :param description: New model description.
-
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
         with self.ManagedSessionMaker() as session:
@@ -569,14 +542,10 @@ class SqlAlchemyStore(AbstractStore):
         Update model version stage.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :param new_stage: New desired stage for this model version.
-
         :param archive_existing_versions: If this flag is set, all existing model
         versions in the stage will be atomically moved to the "archived" stage.
-
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
         if archive_existing_versions:
@@ -599,9 +568,7 @@ class SqlAlchemyStore(AbstractStore):
         Delete model version in backend.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :return: None
         """
         # currently delete model version still keeps the tags associated with the version
@@ -624,9 +591,7 @@ class SqlAlchemyStore(AbstractStore):
         Get the model version instance by name and version.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
         with self.ManagedSessionMaker() as session:
@@ -640,9 +605,7 @@ class SqlAlchemyStore(AbstractStore):
               location, download URI points to input source path.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :return: A single URI location that allows reads for downloading.
         """
         with self.ManagedSessionMaker() as session:
@@ -656,7 +619,6 @@ class SqlAlchemyStore(AbstractStore):
         :param filter_string: A filter string expression. Currently supports a single filter
                               condition either name of model like ``name = 'model_name'`` or
                               ``run_id = '...'``.
-
         :return: PagedList of :py:class:`mlflow.entities.model_registry.ModelVersion`
                  objects.
         """
@@ -711,11 +673,8 @@ class SqlAlchemyStore(AbstractStore):
         Set a tag for the model version.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :param tag: :py:class:`mlflow.entities.model_registry.ModelVersionTag` instance to log.
-
         :return: None
         """
         _validate_model_name(name)
@@ -736,11 +695,8 @@ class SqlAlchemyStore(AbstractStore):
         Delete a tag associated with the model version.
 
         :param name: Registered model name.
-
         :param version: Registered model version.
-
         :param key: Tag key.
-
         :return: None
         """
         _validate_model_name(name)

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -476,7 +476,7 @@ class SqlAlchemyStore(AbstractStore):
         if name is None or name == "":
             raise MlflowException('Model version name cannot be empty.', INVALID_PARAMETER_VALUE)
         for tag in tags or []:
-            _validate_registered_model_tag(tag.key, tag.value)
+            _validate_model_version_tag(tag.key, tag.value)
         with self.ManagedSessionMaker() as session:
             creation_time = now()
             for attempt in range(self.CREATE_MODEL_VERSION_RETRIES):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -31,6 +31,8 @@ MAX_TAG_VAL_LENGTH = 5000
 MAX_EXPERIMENT_TAG_KEY_LENGTH = 250
 MAX_EXPERIMENT_TAG_VAL_LENGTH = 5000
 MAX_ENTITY_KEY_LENGTH = 250
+MAX_MODEL_REGISTRY_TAG_KEY_LENGTH = 250
+MAX_MODEL_REGISTRY_TAG_VALUE_LENGTH = 5000
 
 _UNSUPPORTED_DB_TYPE_MSG = "Supported database engines are {%s}" % ', '.join(DATABASE_ENGINES)
 
@@ -108,6 +110,24 @@ def _validate_experiment_tag(key, value):
     _validate_tag_name(key)
     _validate_length_limit("Tag key", MAX_EXPERIMENT_TAG_KEY_LENGTH, key)
     _validate_length_limit("Tag value", MAX_EXPERIMENT_TAG_VAL_LENGTH, value)
+
+
+def _validate_registered_model_tag(key, value):
+    """
+    Check that a tag with the specified key & value is valid and raise an exception if it isn't.
+    """
+    _validate_tag_name(key)
+    _validate_length_limit("Registered model key", MAX_MODEL_REGISTRY_TAG_KEY_LENGTH, key)
+    _validate_length_limit("Registered model value", MAX_MODEL_REGISTRY_TAG_VALUE_LENGTH, value)
+
+
+def _validate_model_version_tag(key, value):
+    """
+    Check that a tag with the specified key & value is valid and raise an exception if it isn't.
+    """
+    _validate_tag_name(key)
+    _validate_length_limit("Model version key", MAX_MODEL_REGISTRY_TAG_KEY_LENGTH, key)
+    _validate_length_limit("Model version value", MAX_MODEL_REGISTRY_TAG_VALUE_LENGTH, value)
 
 
 def _validate_param_name(name):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -155,7 +155,7 @@ def _validate_length_limit(entity_name, limit, value):
     if len(value) > limit:
         raise MlflowException(
             "%s '%s' had length %s, which exceeded length limit of %s" %
-            (entity_name, value[:250], len(value), limit))
+            (entity_name, value[:250], len(value), limit), error_code=INVALID_PARAMETER_VALUE)
 
 
 def _validate_run_id(run_id):

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -223,6 +223,19 @@ def _validate_experiment_name(experiment_name):
                               error_code=INVALID_PARAMETER_VALUE)
 
 
+def _validate_model_name(model_name):
+    if model_name is None or model_name == "":
+        raise MlflowException('Registered model name cannot be empty.', INVALID_PARAMETER_VALUE)
+
+
+def _validate_model_version(model_version):
+    try:
+        model_version = int(model_version)
+    except ValueError:
+        raise MlflowException("Model version must be an integer, got '{}'"
+                              .format(model_version), error_code=INVALID_PARAMETER_VALUE)
+
+
 def _validate_experiment_artifact_location(artifact_location):
     if artifact_location is not None and artifact_location.startswith("runs:"):
         raise MlflowException("Artifact location cannot be a runs:/ URI. Given: '%s'"

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -51,7 +51,7 @@ def path_not_unique(name):
 
 def _validate_metric_name(name):
     """Check that `name` is a valid metric name and raise an exception if it isn't."""
-    if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
+    if name is None or not _VALID_PARAM_AND_METRIC_NAMES.match(name):
         raise MlflowException("Invalid metric name: '%s'. %s" % (name, _BAD_CHARACTERS_MESSAGE),
                               INVALID_PARAMETER_VALUE)
     if path_not_unique(name):
@@ -132,7 +132,7 @@ def _validate_model_version_tag(key, value):
 
 def _validate_param_name(name):
     """Check that `name` is a valid parameter name and raise an exception if it isn't."""
-    if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
+    if name is None or not _VALID_PARAM_AND_METRIC_NAMES.match(name):
         raise MlflowException("Invalid parameter name: '%s'. %s" % (name, _BAD_CHARACTERS_MESSAGE),
                               INVALID_PARAMETER_VALUE)
     if path_not_unique(name):
@@ -143,7 +143,7 @@ def _validate_param_name(name):
 def _validate_tag_name(name):
     """Check that `name` is a valid tag name and raise an exception if it isn't."""
     # Reuse param & metric check.
-    if not _VALID_PARAM_AND_METRIC_NAMES.match(name):
+    if name is None or not _VALID_PARAM_AND_METRIC_NAMES.match(name):
         raise MlflowException("Invalid tag name: '%s'. %s" % (name, _BAD_CHARACTERS_MESSAGE),
                               INVALID_PARAMETER_VALUE)
     if path_not_unique(name):

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -220,7 +220,8 @@ def test_create_registered_model(mock_get_request_message, mock_model_registry_s
     mock_model_registry_store.create_registered_model.return_value = rm
     resp = _create_registered_model()
     _, args = mock_model_registry_store.create_registered_model.call_args
-    assert args == {"name": "model_1", "tags": jsonify(tags)}
+    assert args["name"] == "model_1"
+    assert args["tags"] == tags
     assert json.loads(resp.get_data()) == {"registered_model": jsonify(rm)}
 
 
@@ -380,8 +381,10 @@ def test_create_model_version(mock_get_request_message, mock_model_registry_stor
     mock_model_registry_store.create_model_version.return_value = mv
     resp = _create_model_version()
     _, args = mock_model_registry_store.create_model_version.call_args
-    assert args == {"name": "model_1", "source": "A/B",
-                    "run_id": run_id, "tags": jsonify(tags)}
+    assert args["name"] == "model_1"
+    assert args["source"] == "A/B"
+    assert args["run_id"] == run_id
+    assert args["tags"] == tags
     assert json.loads(resp.get_data()) == {"model_version": jsonify(mv)}
 
 
@@ -481,7 +484,7 @@ def test_set_registered_model_tag(mock_get_request_message, mock_model_registry_
                                                                   value=tag.value)
     _set_registered_model_tag()
     _, args = mock_model_registry_store.set_registered_model_tag.call_args
-    assert args == {"name": name, "tag": {"key": tag.key, "value": tag.value}}
+    assert args == {"name": name, "tag": tag}
 
 
 def test_delete_registered_model_tag(mock_get_request_message, mock_model_registry_store):
@@ -501,7 +504,7 @@ def test_set_model_version_tag(mock_get_request_message, mock_model_registry_sto
                                                                key=tag.key, value=tag.value)
     _set_model_version_tag()
     _, args = mock_model_registry_store.set_model_version_tag.call_args
-    assert args == {"name": name, "version": version, "tag": {"key": tag.key, "value": tag.value}}
+    assert args == {"name": name, "version": version, "tag": tag}
 
 
 def test_delete_model_version_tag(mock_get_request_message, mock_model_registry_store):

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -214,11 +214,11 @@ def test_create_registered_model(mock_get_request_message, mock_model_registry_s
     tags = [RegisteredModelTag(key="key", value="value"),
             RegisteredModelTag(key="anotherKey", value="some other value")]
     mock_get_request_message.return_value = CreateRegisteredModel(name="model_1", tags=tags)
-    rm = RegisteredModel("model_1")
+    rm = RegisteredModel("model_1", tags=tags)
     mock_model_registry_store.create_registered_model.return_value = rm
     resp = _create_registered_model()
     _, args = mock_model_registry_store.create_registered_model.call_args
-    assert args == {"name": "model_1", "tags": jsonify(tags)}
+    assert args == {"name": "model_1", "tags": tags}
     assert json.loads(resp.get_data()) == {"registered_model": jsonify(rm)}
 
 
@@ -371,11 +371,12 @@ def test_create_model_version(mock_get_request_message, mock_model_registry_stor
             ModelVersionTag(key="anotherKey", value="some other value")]
     mock_get_request_message.return_value = CreateModelVersion(name="model_1", source="A/B",
                                                                run_id=run_id, tags=tags)
-    mv = ModelVersion(name="model_1", version="12", creation_timestamp=123)
+    mv = ModelVersion(name="model_1", version="12", creation_timestamp=123, tags=tags)
     mock_model_registry_store.create_model_version.return_value = mv
     resp = _create_model_version()
     _, args = mock_model_registry_store.create_model_version.call_args
-    assert args == {"name": "model_1", "source": "A/B", "run_id": run_id, "tags": jsonify(tags)}
+    assert args == {"name": "model_1", "source": "A/B",
+                    "run_id": run_id, "tags": tags}
     assert json.loads(resp.get_data()) == {"model_version": jsonify(mv)}
 
 
@@ -475,7 +476,7 @@ def test_set_registered_model_tag(mock_get_request_message, mock_model_registry_
     mock_get_request_message.return_value = SetRegisteredModelTag(name=name, key=key, value=value)
     _set_registered_model_tag()
     _, args = mock_model_registry_store.set_registered_model_tag.call_args
-    assert args == {"name": name, "key": key, "value": value}
+    assert args == {"name": name, "tag": {"key": key, "value": value}}
 
 
 def test_delete_registered_model_tag(mock_get_request_message, mock_model_registry_store):
@@ -496,7 +497,7 @@ def test_set_model_version_tag(mock_get_request_message, mock_model_registry_sto
                                                                key=key, value=value)
     _set_model_version_tag()
     _, args = mock_model_registry_store.set_model_version_tag.call_args
-    assert args == {"name": name, "version": version, "key": key, "value": value}
+    assert args == {"name": name, "version": version, "tag": {"key": key, "value": value}}
 
 
 def test_delete_model_version_tag(mock_get_request_message, mock_model_registry_store):

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -213,7 +213,9 @@ def jsonify(obj):
 def test_create_registered_model(mock_get_request_message, mock_model_registry_store):
     tags = [RegisteredModelTag(key="key", value="value"),
             RegisteredModelTag(key="anotherKey", value="some other value")]
-    mock_get_request_message.return_value = CreateRegisteredModel(name="model_1", tags=tags)
+    mock_get_request_message.return_value = CreateRegisteredModel(name="model_1",
+                                                                  tags=[tag.to_proto()
+                                                                        for tag in tags])
     rm = RegisteredModel("model_1", tags=tags)
     mock_model_registry_store.create_registered_model.return_value = rm
     resp = _create_registered_model()
@@ -369,8 +371,11 @@ def test_create_model_version(mock_get_request_message, mock_model_registry_stor
     run_id = uuid.uuid4().hex
     tags = [ModelVersionTag(key="key", value="value"),
             ModelVersionTag(key="anotherKey", value="some other value")]
-    mock_get_request_message.return_value = CreateModelVersion(name="model_1", source="A/B",
-                                                               run_id=run_id, tags=tags)
+    mock_get_request_message.return_value = CreateModelVersion(name="model_1",
+                                                               source="A/B",
+                                                               run_id=run_id,
+                                                               tags=[tag.to_proto()
+                                                                     for tag in tags])
     mv = ModelVersion(name="model_1", version="12", creation_timestamp=123, tags=tags)
     mock_model_registry_store.create_model_version.return_value = mv
     resp = _create_model_version()
@@ -476,7 +481,7 @@ def test_set_registered_model_tag(mock_get_request_message, mock_model_registry_
                                                                   value=tag.value)
     _set_registered_model_tag()
     _, args = mock_model_registry_store.set_registered_model_tag.call_args
-    assert args == {"name": name, "tag": jsonify(tag)}
+    assert args == {"name": name, "tag": {"key": tag.key, "value": tag.value}}
 
 
 def test_delete_registered_model_tag(mock_get_request_message, mock_model_registry_store):
@@ -496,7 +501,7 @@ def test_set_model_version_tag(mock_get_request_message, mock_model_registry_sto
                                                                key=tag.key, value=tag.value)
     _set_model_version_tag()
     _, args = mock_model_registry_store.set_model_version_tag.call_args
-    assert args == {"name": name, "version": version, "tag": jsonify(tag)}
+    assert args == {"name": name, "version": version, "tag": {"key": tag.key, "value": tag.value}}
 
 
 def test_delete_model_version_tag(mock_get_request_message, mock_model_registry_store):

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -12,8 +12,7 @@ from mlflow.protos.model_registry_pb2 import CreateRegisteredModel, \
     DeleteModelVersion, GetModelVersion, GetModelVersionDownloadUri, SearchModelVersions, \
     RenameRegisteredModel, TransitionModelVersionStage, SearchRegisteredModels, \
     SetRegisteredModelTag, SetModelVersionTag, DeleteRegisteredModelTag, \
-    DeleteModelVersionTag
-from mlflow.entities.model_registry import RegisteredModelTag, ModelVersionTag
+    DeleteModelVersionTag, RegisteredModelTag, ModelVersionTag
 from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import MlflowHostCreds
@@ -138,7 +137,7 @@ class TestRestStore(unittest.TestCase):
         tag = RegisteredModelTag("key", "value")
         self.store.set_registered_model_tag(name=name, tag=tag)
         self._verify_requests(mock_http, "registered-models/set-tag", "POST",
-                              SetRegisteredModelTag(name=name, tag=tag))
+                              SetRegisteredModelTag(name=name, key=tag.key, value=tag.value))
 
     @mock.patch('mlflow.utils.rest_utils.http_request')
     def test_delete_registered_model_tag(self, mock_http):
@@ -214,7 +213,8 @@ class TestRestStore(unittest.TestCase):
         tag = ModelVersionTag("key", "value")
         self.store.set_model_version_tag(name=name, version="1", tag=tag)
         self._verify_requests(mock_http, "model-versions/set-tag", "POST",
-                              SetModelVersionTag(name=name, version="1", tag=tag))
+                              SetModelVersionTag(name=name, version="1",
+                                                 key=tag.key, value=tag.value))
 
     @mock.patch('mlflow.utils.rest_utils.http_request')
     def test_delete_model_version_tag(self, mock_http):

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -6,13 +6,14 @@ import mock
 import pytest
 import uuid
 
+from mlflow.entities.model_registry import RegisteredModelTag, ModelVersionTag
 from mlflow.protos.model_registry_pb2 import CreateRegisteredModel, \
     UpdateRegisteredModel, DeleteRegisteredModel, ListRegisteredModels, \
     GetRegisteredModel, GetLatestVersions, CreateModelVersion, UpdateModelVersion, \
     DeleteModelVersion, GetModelVersion, GetModelVersionDownloadUri, SearchModelVersions, \
     RenameRegisteredModel, TransitionModelVersionStage, SearchRegisteredModels, \
     SetRegisteredModelTag, SetModelVersionTag, DeleteRegisteredModelTag, \
-    DeleteModelVersionTag, RegisteredModelTag, ModelVersionTag
+    DeleteModelVersionTag
 from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import MlflowHostCreds

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -59,7 +59,8 @@ class TestRestStore(unittest.TestCase):
                 RegisteredModelTag(key="anotherKey", value="some other value")]
         self.store.create_registered_model("model_1", tags)
         self._verify_requests(mock_http, "registered-models/create", "POST",
-                              CreateRegisteredModel(name="model_1", tags=tags))
+                              CreateRegisteredModel(name="model_1",
+                                                    tags=[tag.to_proto() for tag in tags]))
 
     @mock.patch('mlflow.utils.rest_utils.http_request')
     def test_update_registered_model_name(self, mock_http):
@@ -155,7 +156,8 @@ class TestRestStore(unittest.TestCase):
         self.store.create_model_version("model_1", "path/to/source", run_id, tags)
         self._verify_requests(mock_http, "model-versions/create", "POST",
                               CreateModelVersion(name="model_1", source="path/to/source",
-                                                 run_id=run_id, tags=tags))
+                                                 run_id=run_id,
+                                                 tags=[tag.to_proto() for tag in tags]))
 
     @mock.patch('mlflow.utils.rest_utils.http_request')
     def test_transition_model_version_stage(self, mock_http):

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -54,8 +54,8 @@ class TestRestStore(unittest.TestCase):
 
     @mock.patch('mlflow.utils.rest_utils.http_request')
     def test_create_registered_model(self, mock_http):
-        tags = [RegisteredModelTag("key", "value"),
-                RegisteredModelTag("anotherKey", "some other value")]
+        tags = [RegisteredModelTag(key="key", value="value"),
+                RegisteredModelTag(key="anotherKey", value="some other value")]
         self.store.create_registered_model("model_1", tags)
         self._verify_requests(mock_http, "registered-models/create", "POST",
                               CreateRegisteredModel(name="model_1", tags=tags))
@@ -134,7 +134,7 @@ class TestRestStore(unittest.TestCase):
     @mock.patch('mlflow.utils.rest_utils.http_request')
     def test_set_registered_model_tag(self, mock_http):
         name = "model_1"
-        tag = RegisteredModelTag("key", "value")
+        tag = RegisteredModelTag(key="key", value="value")
         self.store.set_registered_model_tag(name=name, tag=tag)
         self._verify_requests(mock_http, "registered-models/set-tag", "POST",
                               SetRegisteredModelTag(name=name, key=tag.key, value=tag.value))
@@ -148,8 +148,8 @@ class TestRestStore(unittest.TestCase):
 
     @mock.patch('mlflow.utils.rest_utils.http_request')
     def test_create_model_version(self, mock_http):
-        tags = [ModelVersionTag("key", "value"),
-                ModelVersionTag("anotherKey", "some other value")]
+        tags = [ModelVersionTag(key="key", value="value"),
+                ModelVersionTag(key="anotherKey", value="some other value")]
         run_id = uuid.uuid4().hex
         self.store.create_model_version("model_1", "path/to/source", run_id, tags)
         self._verify_requests(mock_http, "model-versions/create", "POST",
@@ -210,7 +210,7 @@ class TestRestStore(unittest.TestCase):
     @mock.patch('mlflow.utils.rest_utils.http_request')
     def test_set_model_version_tag(self, mock_http):
         name = "model_1"
-        tag = ModelVersionTag("key", "value")
+        tag = ModelVersionTag(key="key", value="value")
         self.store.set_model_version_tag(name=name, version="1", tag=tag)
         self._verify_requests(mock_http, "model-versions/set-tag", "POST",
                               SetModelVersionTag(name=name, version="1",

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -10,7 +10,10 @@ from mlflow.protos.model_registry_pb2 import CreateRegisteredModel, \
     UpdateRegisteredModel, DeleteRegisteredModel, ListRegisteredModels, \
     GetRegisteredModel, GetLatestVersions, CreateModelVersion, UpdateModelVersion, \
     DeleteModelVersion, GetModelVersion, GetModelVersionDownloadUri, SearchModelVersions, \
-    RenameRegisteredModel, TransitionModelVersionStage, SearchRegisteredModels
+    RenameRegisteredModel, TransitionModelVersionStage, SearchRegisteredModels, \
+    SetRegisteredModelTag, SetModelVersionTag, DeleteRegisteredModelTag, \
+    DeleteModelVersionTag
+from mlflow.entities.model_registry import RegisteredModelTag, ModelVersionTag
 from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import MlflowHostCreds
@@ -52,9 +55,11 @@ class TestRestStore(unittest.TestCase):
 
     @mock.patch('mlflow.utils.rest_utils.http_request')
     def test_create_registered_model(self, mock_http):
-        self.store.create_registered_model("model_1")
+        tags = [RegisteredModelTag("key", "value"),
+                RegisteredModelTag("anotherKey", "some other value")]
+        self.store.create_registered_model("model_1", tags)
         self._verify_requests(mock_http, "registered-models/create", "POST",
-                              CreateRegisteredModel(name="model_1"))
+                              CreateRegisteredModel(name="model_1", tags=tags))
 
     @mock.patch('mlflow.utils.rest_utils.http_request')
     def test_update_registered_model_name(self, mock_http):
@@ -128,12 +133,29 @@ class TestRestStore(unittest.TestCase):
                               GetLatestVersions(name=name, stages=["blaah"]))
 
     @mock.patch('mlflow.utils.rest_utils.http_request')
+    def test_set_registered_model_tag(self, mock_http):
+        name = "model_1"
+        tag = RegisteredModelTag("key", "value")
+        self.store.set_registered_model_tag(name=name, tag=tag)
+        self._verify_requests(mock_http, "registered-models/set-tag", "POST",
+                              SetRegisteredModelTag(name=name, tag=tag))
+
+    @mock.patch('mlflow.utils.rest_utils.http_request')
+    def test_delete_registered_model_tag(self, mock_http):
+        name = "model_1"
+        self.store.delete_registered_model_tag(name=name, key="key")
+        self._verify_requests(mock_http, "registered-models/delete-tag", "DELETE",
+                              DeleteRegisteredModelTag(name=name, key="key"))
+
+    @mock.patch('mlflow.utils.rest_utils.http_request')
     def test_create_model_version(self, mock_http):
+        tags = [ModelVersionTag("key", "value"),
+                ModelVersionTag("anotherKey", "some other value")]
         run_id = uuid.uuid4().hex
-        self.store.create_model_version("model_1", "path/to/source", run_id)
+        self.store.create_model_version("model_1", "path/to/source", run_id, tags)
         self._verify_requests(mock_http, "model-versions/create", "POST",
                               CreateModelVersion(name="model_1", source="path/to/source",
-                                                 run_id=run_id))
+                                                 run_id=run_id, tags=tags))
 
     @mock.patch('mlflow.utils.rest_utils.http_request')
     def test_transition_model_version_stage(self, mock_http):
@@ -185,3 +207,18 @@ class TestRestStore(unittest.TestCase):
         self.store.search_model_versions(filter_string="name='model_12'")
         self._verify_requests(mock_http, "model-versions/search", "GET",
                               SearchModelVersions(filter="name='model_12'"))
+
+    @mock.patch('mlflow.utils.rest_utils.http_request')
+    def test_set_model_version_tag(self, mock_http):
+        name = "model_1"
+        tag = ModelVersionTag("key", "value")
+        self.store.set_model_version_tag(name=name, version="1", tag=tag)
+        self._verify_requests(mock_http, "model-versions/set-tag", "POST",
+                              SetModelVersionTag(name=name, version="1", tag=tag))
+
+    @mock.patch('mlflow.utils.rest_utils.http_request')
+    def test_delete_model_version_tag(self, mock_http):
+        name = "model_1"
+        self.store.delete_model_version_tag(name=name, version="1", key="key")
+        self._verify_requests(mock_http, "model-versions/delete-tag", "DELETE",
+                              DeleteModelVersionTag(name=name, version="1", key="key"))

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -60,12 +60,15 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             self.assertEqual(rm2.name, name2)
 
         # test create model with tags
-        name2 = random_str()
+        name2 = random_str() + "tags"
         tags = [RegisteredModelTag("key", "value"),
                 RegisteredModelTag("anotherKey", "some other value")]
         rm2 = self._rm_maker(name2, tags)
+        rmd2 = self.store.get_registered_model(name2)
         self.assertEqual(rm2.name, name2)
-        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in (tags or [])})
+        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in tags or []})
+        self.assertEqual(rmd2.name, name2)
+        self.assertEqual(rmd2.tags, {tag.key: tag.value for tag in tags or []})
 
         # invalid model name will fail
         with self.assertRaises(MlflowException) as exception_context:
@@ -988,14 +991,14 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         rm1mv1 = self.store.get_model_version(name1, 1)
         rm1mv2 = self.store.get_model_version(name1, 2)
         rm2mv1 = self.store.get_model_version(name2, 1)
-        self.assertEqual(rm1mv1, {"anotherKey": "some other value"})
-        self.assertEqual(rm1mv2, {tag.key: tag.value for tag in (initial_tags or [])})
-        self.assertEqual(rm2mv1, {tag.key: tag.value for tag in (initial_tags or [])})
+        self.assertEqual(rm1mv1.tags, {"anotherKey": "some other value"})
+        self.assertEqual(rm1mv2.tags, {tag.key: tag.value for tag in (initial_tags or [])})
+        self.assertEqual(rm2mv1.tags, {tag.key: tag.value for tag in (initial_tags or [])})
 
         # delete tag that is already deleted does nothing
         self.store.delete_model_version_tag(name1, 1, "key")
         rm1mv1 = self.store.get_model_version(name1, 1)
-        self.assertEqual(rm1mv1, {"anotherKey": "some other value"})
+        self.assertEqual(rm1mv1.tags, {"anotherKey": "some other value"})
 
         # can not delete tag on deleted (non-existed) model version
         self.store.delete_model_version(name2, 1)

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -66,9 +66,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         rm2 = self._rm_maker(name2, tags)
         rmd2 = self.store.get_registered_model(name2)
         self.assertEqual(rm2.name, name2)
-        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in tags or []})
+        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in tags})
         self.assertEqual(rmd2.name, name2)
-        self.assertEqual(rmd2.tags, {tag.key: tag.value for tag in tags or []})
+        self.assertEqual(rmd2.tags, {tag.key: tag.value for tag in tags})
 
         # invalid model name will fail
         with self.assertRaises(MlflowException) as exception_context:
@@ -93,7 +93,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(rmd.last_updated_timestamp, 1234000)
         self.assertEqual(rmd.description, None)
         self.assertEqual(rmd.latest_versions, [])
-        self.assertEqual(rmd.tags, {tag.key: tag.value for tag in (tags or [])})
+        self.assertEqual(rmd.tags, {tag.key: tag.value for tag in tags})
 
     def test_update_registered_model(self):
         name = "model_for_update_RM"
@@ -317,17 +317,17 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_registered_model_tag(name1, new_tag)
         rm1 = self.store.get_registered_model(name=name1)
         all_tags = initial_tags + [new_tag]
-        self.assertEqual(rm1.tags, {tag.key: tag.value for tag in (all_tags or [])})
+        self.assertEqual(rm1.tags, {tag.key: tag.value for tag in all_tags})
 
         # test overriding a tag with the same key
         overriding_tag = RegisteredModelTag("key", "overriding")
         self.store.set_registered_model_tag(name1, overriding_tag)
         all_tags = [tag for tag in all_tags if tag.key != "key"] + [overriding_tag]
         rm1 = self.store.get_registered_model(name=name1)
-        self.assertEqual(rm1.tags, {tag.key: tag.value for tag in (all_tags or [])})
+        self.assertEqual(rm1.tags, {tag.key: tag.value for tag in all_tags})
         # does not affect other models with the same key
         rm2 = self.store.get_registered_model(name=name2)
-        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in (initial_tags or [])})
+        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in initial_tags})
 
         # can not set tag on deleted (non-existed) registered model
         self.store.delete_registered_model(name1)
@@ -362,14 +362,14 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_registered_model_tag(name1, new_tag)
         self.store.delete_registered_model_tag(name1, "randomTag")
         rm1 = self.store.get_registered_model(name=name1)
-        self.assertEqual(rm1.tags, {tag.key: tag.value for tag in (initial_tags or [])})
+        self.assertEqual(rm1.tags, {tag.key: tag.value for tag in initial_tags})
 
         # testing deleting a key does not affect other models with the same key
         self.store.delete_registered_model_tag(name1, "key")
         rm1 = self.store.get_registered_model(name=name1)
         rm2 = self.store.get_registered_model(name=name2)
         self.assertEqual(rm1.tags, {"anotherKey": "some other value"})
-        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in (initial_tags or [])})
+        self.assertEqual(rm2.tags, {tag.key: tag.value for tag in initial_tags})
 
         # delete tag that is already deleted does nothing
         self.store.delete_registered_model_tag(name1, "key")
@@ -425,9 +425,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         mv3 = self._mv_maker(name, tags=tags)
         mvd3 = self.store.get_model_version(name=mv3.name, version=mv3.version)
         self.assertEqual(mv3.version, 3)
-        self.assertEqual(mv3.tags, {tag.key: tag.value for tag in (tags or [])})
+        self.assertEqual(mv3.tags, {tag.key: tag.value for tag in tags})
         self.assertEqual(mvd3.version, 3)
-        self.assertEqual(mvd3.tags, {tag.key: tag.value for tag in (tags or [])})
+        self.assertEqual(mvd3.tags, {tag.key: tag.value for tag in tags})
 
     def test_update_model_version(self):
         name = "test_for_update_MV"
@@ -927,19 +927,19 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_model_version_tag(name1, 1, new_tag)
         all_tags = initial_tags + [new_tag]
         rm1mv1 = self.store.get_model_version(name1, 1)
-        self.assertEqual(rm1mv1.tags, {tag.key: tag.value for tag in (all_tags or [])})
+        self.assertEqual(rm1mv1.tags, {tag.key: tag.value for tag in all_tags})
 
         # test overriding a tag with the same key
         overriding_tag = ModelVersionTag("key", "overriding")
         self.store.set_model_version_tag(name1, 1, overriding_tag)
         all_tags = [tag for tag in all_tags if tag.key != "key"] + [overriding_tag]
         rm1mv1 = self.store.get_model_version(name1, 1)
-        self.assertEqual(rm1mv1.tags, {tag.key: tag.value for tag in (all_tags or [])})
+        self.assertEqual(rm1mv1.tags, {tag.key: tag.value for tag in all_tags})
         # does not affect other model versions with the same key
         rm1mv2 = self.store.get_model_version(name1, 2)
         rm2mv1 = self.store.get_model_version(name2, 1)
-        self.assertEqual(rm1mv2.tags, {tag.key: tag.value for tag in (initial_tags or [])})
-        self.assertEqual(rm2mv1.tags, {tag.key: tag.value for tag in (initial_tags or [])})
+        self.assertEqual(rm1mv2.tags, {tag.key: tag.value for tag in initial_tags})
+        self.assertEqual(rm2mv1.tags, {tag.key: tag.value for tag in initial_tags})
 
         # can not set tag on deleted (non-existed) model version
         self.store.delete_model_version(name1, 2)
@@ -984,7 +984,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.store.set_model_version_tag(name1, 1, new_tag)
         self.store.delete_model_version_tag(name1, 1, "randomTag")
         rm1mv1 = self.store.get_model_version(name1, 1)
-        self.assertEqual(rm1mv1.tags, {tag.key: tag.value for tag in (initial_tags or [])})
+        self.assertEqual(rm1mv1.tags, {tag.key: tag.value for tag in initial_tags})
 
         # testing deleting a key does not affect other model versions with the same key
         self.store.delete_model_version_tag(name1, 1, "key")
@@ -992,8 +992,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         rm1mv2 = self.store.get_model_version(name1, 2)
         rm2mv1 = self.store.get_model_version(name2, 1)
         self.assertEqual(rm1mv1.tags, {"anotherKey": "some other value"})
-        self.assertEqual(rm1mv2.tags, {tag.key: tag.value for tag in (initial_tags or [])})
-        self.assertEqual(rm2mv1.tags, {tag.key: tag.value for tag in (initial_tags or [])})
+        self.assertEqual(rm1mv2.tags, {tag.key: tag.value for tag in initial_tags})
+        self.assertEqual(rm2mv1.tags, {tag.key: tag.value for tag in initial_tags})
 
         # delete tag that is already deleted does nothing
         self.store.delete_model_version_tag(name1, 1, "key")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Series of PR to add model registry tags into OSS mlflow backend.

This PR proposes store level changes including all the relevant unit tests

## How is this patch tested?

Unit test, manual tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
