### PR TITLE
get-login is deprecated since v1. Using  get-login-password instead

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -131,11 +131,11 @@ def push_image_to_ecr(image=DEFAULT_IMAGE_NAME):
         os_command_separator = " && "
         # In order to execute the outcome of aws ecr get-login
         # in cmd, we need to save it in a temp file first
-        docker_login_cmd = "aws ecr get-login --no-include-email > docker_login_url_temp.cmd" \
+        docker_login_cmd = "aws ecr get-login-password > docker_login_url_temp.cmd" \
             "{os_command_separator} call docker_login_url_temp.cmd {os_command_separator}" \
             "del docker_login_url_temp.cmd".format(os_command_separator=os_command_separator)
     else:
-        docker_login_cmd = "$(aws ecr get-login --no-include-email)"
+        docker_login_cmd = "$(aws ecr get-login-password)"
     docker_tag_cmd = "docker tag {image} {fullname}".format(
         image=image, fullname=fullname)
     docker_push_cmd = "docker push {}".format(fullname)


### PR DESCRIPTION
## What changes are proposed in this pull request?

get-login is deprecated since v1. 

Using  get-login-password instead. The command was tested in Windows and MacOs

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [x ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
