### PR TITLE
Add support for `archive_existing_versions` [Backend API]

### DIFF
--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -457,8 +457,12 @@ class SqlAlchemyStore(AbstractStore):
 
             model_versions = []
             if archive_existing_versions:
-                in_same_stage = SqlModelVersion.current_stage == stage
-                model_versions = session.query(SqlModelVersion).filter(in_same_stage).all()
+                conditions = [
+                    SqlModelVersion.name == name,
+                    SqlModelVersion.version != version,
+                    SqlModelVersion.current_stage == stage,
+                ]
+                model_versions = session.query(SqlModelVersion).filter(*conditions).all()
                 for mv in model_versions:
                     mv.current_stage = STAGE_ARCHIVED
                     mv.last_updated_time = last_updated_time

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -454,11 +454,14 @@ class SqlAlchemyStore(AbstractStore):
 
         with self.ManagedSessionMaker() as session:
             last_updated_time = now()
-            in_same_stage = SqlModelVersion.current_stage == stage
-            model_versions = session.query(SqlModelVersion).filter(in_same_stage).all()
-            for mv in model_versions:
-                mv.current_stage = STAGE_ARCHIVED
-                mv.last_updated_time = last_updated_time
+
+            model_versions = []
+            if archive_existing_versions:
+                in_same_stage = SqlModelVersion.current_stage == stage
+                model_versions = session.query(SqlModelVersion).filter(in_same_stage).all()
+                for mv in model_versions:
+                    mv.current_stage = STAGE_ARCHIVED
+                    mv.last_updated_time = last_updated_time
 
             sql_model_version = self._get_sql_model_version(session=session,
                                                             name=name,

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -446,9 +446,6 @@ class SqlAlchemyStore(AbstractStore):
 
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
-        if archive_existing_versions:
-            raise MlflowException("'archive_existing_versions' flag is not supported in "
-                                  "SqlAlchemyStore. Set it to 'False'")
         with self.ManagedSessionMaker() as session:
             sql_model_version = self._get_sql_model_version(session=session,
                                                             name=name,

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -446,6 +446,12 @@ class SqlAlchemyStore(AbstractStore):
 
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
+        is_active_stage = get_canonical_stage(stage) in DEFAULT_STAGES_FOR_GET_LATEST_VERSIONS
+        if archive_existing_versions and not is_active_stage:
+            msg_tpl = ("Model version transition cannot archive existing model versions "
+                       "because '{}' is not an Active stage. Valid stages are {}")
+            raise MlflowException(msg_tpl.format(stage, DEFAULT_STAGES_FOR_GET_LATEST_VERSIONS))
+
         with self.ManagedSessionMaker() as session:
             sql_model_version = self._get_sql_model_version(session=session,
                                                             name=name,

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -396,7 +396,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         msg = (r"Model version transition cannot archive existing model versions "
                r"because .+ is not an Active stage. Valid stages are .+")
 
-        # test that when `archive_existing_versions` is False, transitioning a model version
+        # test that when `archive_existing_versions` is True, transitioning a model version
         # to the inactive stages ("Archived" and "None") throws.
         for stage in ["Archived", "None"]:
             with self.assertRaisesRegex(MlflowException, msg):

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -352,6 +352,16 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
             mvd5 = self.store.get_model_version(name=mv1.name, version=mv1.version)
             self.assertEqual(mvd5.current_stage, "Staging")
 
+    def test_transition_model_version_stage(self):
+        msg = (r"Model version transition cannot archive existing model versions "
+               r"because .+ is not an Active stage. Valid stages are .+")
+
+        with self.assertRaisesRegex(MlflowException, msg):
+            self.store.transition_model_version_stage("model", "1", "None", True)
+
+        with self.assertRaisesRegex(MlflowException, msg):
+            self.store.transition_model_version_stage("model", "1", "Archived", True)
+
     def test_delete_model_version(self):
         name = "test_for_update_MV"
         self._rm_maker(name)

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -358,7 +358,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         for stage in ["None", "Archived"]:
             with self.assertRaisesRegex(MlflowException, msg):
-                self.store.transition_model_version_stage("model", "1", "None", True)
+                self.store.transition_model_version_stage("model", "1", stage, True)
 
         name = "model"
         self._rm_maker(name)

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -356,11 +356,9 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         msg = (r"Model version transition cannot archive existing model versions "
                r"because .+ is not an Active stage. Valid stages are .+")
 
-        with self.assertRaisesRegex(MlflowException, msg):
-            self.store.transition_model_version_stage("model", "1", "None", True)
-
-        with self.assertRaisesRegex(MlflowException, msg):
-            self.store.transition_model_version_stage("model", "1", "Archived", True)
+        for stage in ["None", "Archived"]:
+            with self.assertRaisesRegex(MlflowException, msg):
+                self.store.transition_model_version_stage("model", "1", "None", True)
 
     def test_delete_model_version(self):
         name = "test_for_update_MV"


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Add support for  `archive_existing_versions` in `transition_model_version_stage`.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`transition_model_verstion_stage` now supports the `archive_existing_versions` flag which allows archiving all existing models in the stage.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
