### PR TITLE
Use pre-installed miniconda on GitHub Actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  CONDA_DIR: /usr/share/miniconda
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -24,7 +27,7 @@ jobs:
         pip install -r ./travis/lint-requirements.txt
     - name: Run tests
       run: |
-        export PATH="$HOME/miniconda/bin:$PATH"
+        export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
         ./lint.sh
   r:
@@ -61,7 +64,7 @@ jobs:
     - name: Run tests
       run: |
         source ./travis/install-common-deps.sh
-        export PATH="$HOME/miniconda/bin:$PATH"
+        export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
         cd mlflow/R/mlflow
         R CMD build .
@@ -102,7 +105,7 @@ jobs:
         source ./travis/install-common-deps.sh
     - name: Run tests
       run: |
-        export PATH="$HOME/miniconda/bin:$PATH"
+        export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
         ./travis/run-small-python-tests.sh
 
@@ -119,7 +122,7 @@ jobs:
         source ./travis/install-common-deps.sh
     - name: Run tests
       run: |
-        export PATH="$HOME/miniconda/bin:$PATH"
+        export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
         cd mlflow/java
         mvn clean package -q
@@ -173,7 +176,7 @@ jobs:
           source ./travis/install-common-deps.sh
       - name: Run tests
         run: |
-          export PATH="$HOME/miniconda/bin:$PATH"
+          export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
           ./travis/run-python-flavor-tests.sh;
 
@@ -193,7 +196,7 @@ jobs:
           source ./travis/install-common-deps.sh
       - name: Run tests
         run: |
-          export PATH="$HOME/miniconda/bin:$PATH"
+          export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
           ./travis/run-python-tf-tests.sh;
 
@@ -213,7 +216,7 @@ jobs:
           source ./travis/install-common-deps.sh
       - name: Run tests
         run: |
-          export PATH="$HOME/miniconda/bin:$PATH"
+          export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
           ./travis/run-python-sagemaker-tests.sh;
 
@@ -238,7 +241,7 @@ jobs:
           pip install sphinx==2.2.1 sphinx-click==2.3.1
       - name: Run tests
         run: |
-          export PATH="$HOME/miniconda/bin:$PATH"
+          export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
           cd docs
           make rsthtml SPHINXOPTS="-W --keep-going" # Interpret Sphinx warnings as errors via the `-W` flag

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,7 +24,7 @@ jobs:
         pip install -r ./travis/lint-requirements.txt
     - name: Run tests
       run: |
-        source activate test-environment
+        conda activate test-environment
         ./lint.sh
   r:
     runs-on: ubuntu-latest

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -44,15 +44,15 @@ jobs:
         writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
       shell: Rscript {0}
 
-    - name: Cache R packages
-      if: runner.os != 'Windows'
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.R_LIBS_USER }}
-        # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
-        # R dependencies
-        key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-        restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+    # - name: Cache R packages
+    #   if: runner.os != 'Windows'
+    #   uses: actions/cache@v2
+    #   with:
+    #     path: ${{ env.R_LIBS_USER }}
+    #     # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
+    #     # R dependencies
+    #     key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+    #     restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
     - name: Install system dependencies
       run: |
         sudo apt-get install -y libcurl4-openssl-dev
@@ -66,13 +66,13 @@ jobs:
         source ./travis/install-common-deps.sh
         set -ex
         ls /usr/share/miniconda/bin
-        # export PATH="$CONDA_DIR/bin:$PATH"
-        # source activate test-environment
-        # cd mlflow/R/mlflow
-        # R CMD build .
-        # export LINTR_COMMENT_BOT=false
-        # cd tests
-        # Rscript ../.travis.R
+        export PATH="$CONDA_DIR/bin:$PATH"
+        source activate test-environment
+        cd mlflow/R/mlflow
+        R CMD build .
+        export LINTR_COMMENT_BOT=false
+        cd tests
+        Rscript ../.travis.R
     - name: Calculate code coverage
       if: ${{ success() }}
       run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,9 +6,6 @@ on:
   pull_request:
     branches: [ master ]
 
-env:
-  CONDA_DIR: /usr/share/miniconda
-
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -27,7 +24,6 @@ jobs:
         pip install -r ./travis/lint-requirements.txt
     - name: Run tests
       run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
         ./lint.sh
   r:
@@ -44,15 +40,15 @@ jobs:
         writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
       shell: Rscript {0}
 
-    # - name: Cache R packages
-    #   if: runner.os != 'Windows'
-    #   uses: actions/cache@v2
-    #   with:
-    #     path: ${{ env.R_LIBS_USER }}
-    #     # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
-    #     # R dependencies
-    #     key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-    #     restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+    - name: Cache R packages
+      if: runner.os != 'Windows'
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.R_LIBS_USER }}
+        # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
+        # R dependencies
+        key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+        restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
     - name: Install system dependencies
       run: |
         sudo apt-get install -y libcurl4-openssl-dev
@@ -64,9 +60,6 @@ jobs:
     - name: Run tests
       run: |
         source ./travis/install-common-deps.sh
-        set -ex
-        ls /usr/share/miniconda/bin
-        # export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
         cd mlflow/R/mlflow
         R CMD build .
@@ -107,7 +100,6 @@ jobs:
         source ./travis/install-common-deps.sh
     - name: Run tests
       run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
         ./travis/run-small-python-tests.sh
 
@@ -124,7 +116,6 @@ jobs:
         source ./travis/install-common-deps.sh
     - name: Run tests
       run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
         cd mlflow/java
         mvn clean package -q
@@ -178,7 +169,6 @@ jobs:
           source ./travis/install-common-deps.sh
       - name: Run tests
         run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
           ./travis/run-python-flavor-tests.sh;
 
@@ -198,7 +188,6 @@ jobs:
           source ./travis/install-common-deps.sh
       - name: Run tests
         run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
           ./travis/run-python-tf-tests.sh;
 
@@ -218,7 +207,6 @@ jobs:
           source ./travis/install-common-deps.sh
       - name: Run tests
         run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
           ./travis/run-python-sagemaker-tests.sh;
 
@@ -243,7 +231,6 @@ jobs:
           pip install sphinx==2.2.1 sphinx-click==2.3.1
       - name: Run tests
         run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
           cd docs
           make rsthtml SPHINXOPTS="-W --keep-going" # Interpret Sphinx warnings as errors via the `-W` flag

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ master ]
 
+env:
+  CONDA_DIR: /usr/share/miniconda
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -24,7 +27,8 @@ jobs:
         pip install -r ./travis/lint-requirements.txt
     - name: Run tests
       run: |
-        conda activate test-environment
+        export PATH="$CONDA_DIR/bin:$PATH"
+        source activate test-environment
         ./lint.sh
   r:
     runs-on: ubuntu-latest
@@ -100,6 +104,7 @@ jobs:
         source ./travis/install-common-deps.sh
     - name: Run tests
       run: |
+        export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
         ./travis/run-small-python-tests.sh
 
@@ -116,6 +121,7 @@ jobs:
         source ./travis/install-common-deps.sh
     - name: Run tests
       run: |
+        export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
         cd mlflow/java
         mvn clean package -q
@@ -169,6 +175,7 @@ jobs:
           source ./travis/install-common-deps.sh
       - name: Run tests
         run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
           ./travis/run-python-flavor-tests.sh;
 
@@ -188,6 +195,7 @@ jobs:
           source ./travis/install-common-deps.sh
       - name: Run tests
         run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
           ./travis/run-python-tf-tests.sh;
 
@@ -207,6 +215,7 @@ jobs:
           source ./travis/install-common-deps.sh
       - name: Run tests
         run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
           ./travis/run-python-sagemaker-tests.sh;
 
@@ -231,6 +240,7 @@ jobs:
           pip install sphinx==2.2.1 sphinx-click==2.3.1
       - name: Run tests
         run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
           cd docs
           make rsthtml SPHINXOPTS="-W --keep-going" # Interpret Sphinx warnings as errors via the `-W` flag

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -66,7 +66,7 @@ jobs:
         source ./travis/install-common-deps.sh
         set -ex
         ls /usr/share/miniconda/bin
-        export PATH="$CONDA_DIR/bin:$PATH"
+        # export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
         cd mlflow/R/mlflow
         R CMD build .

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -64,6 +64,8 @@ jobs:
     - name: Run tests
       run: |
         source ./travis/install-common-deps.sh
+        set -ex
+        ls /usr/share/miniconda/bin
         export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
         cd mlflow/R/mlflow

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -66,13 +66,13 @@ jobs:
         source ./travis/install-common-deps.sh
         set -ex
         ls /usr/share/miniconda/bin
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        cd mlflow/R/mlflow
-        R CMD build .
-        export LINTR_COMMENT_BOT=false
-        cd tests
-        Rscript ../.travis.R
+        # export PATH="$CONDA_DIR/bin:$PATH"
+        # source activate test-environment
+        # cd mlflow/R/mlflow
+        # R CMD build .
+        # export LINTR_COMMENT_BOT=false
+        # cd tests
+        # Rscript ../.travis.R
     - name: Calculate code coverage
       if: ${{ success() }}
       run: |

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -9,20 +9,20 @@ df -h
 sudo mkdir -p /travis-install
 # GITHUB_WORKFLOW is set by default during GitHub workflows
 if [[ -z $GITHUB_WORKFLOW ]]; then
-  CONDA_DIR=$HOME
+  CONDA_DIR=$HOME/miniconda
   sudo chown travis /travis-install
   # (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
-  wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $CONDA_DIR/miniconda.sh
-  bash $CONDA_DIR/miniconda.sh -b -p $CONDA_DIR/miniconda
+  wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $HOME/miniconda.sh
+  bash $HOME/miniconda.sh -b -p $CONDA_DIR
 else
   # Miniconda is pre-installed in the virtual-environments for GitHub Actions.
   # See this repository: https://github.com/actions/virtual-environments
-  CONDA_DIR=/usr/share
+  CONDA_DIR=/usr/share/miniconda
 fi
 
-export PATH="$CONDA_DIR/miniconda/bin:$PATH"
+export PATH="$CONDA_DIR/bin:$PATH"
 hash -r
 conda config --set always_yes yes --set changeps1 no
 # Useful for debugging any issues with conda

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -14,7 +14,7 @@ if [[ -z $GITHUB_WORKFLOW ]]; then
   # (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)
   # We do this conditionally because it saves us some downloading if the
   # version is the same.
-  wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $HOME/miniconda.sh
+  wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $CONDA_DIR/miniconda.sh
   bash $CONDA_DIR/miniconda.sh -b -p $CONDA_DIR/miniconda
 else
   # Miniconda is pre-installed in the virtual-environments for GitHub Actions.
@@ -44,9 +44,9 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   # Hack: make sure all spark-* scripts are executable. 
   # Conda installs 2 version spark-* scripts and makes the ones spark
   # uses not executable. This is a temporary fix to unblock the tests.
-  ls -lha $(find $HOME/miniconda/envs/test-environment/ -path "*bin/spark-*")
-  chmod 777 $(find $HOME/miniconda/envs/test-environment/ -path "*bin/spark-*")
-  ls -lha $(find $HOME/miniconda/envs/test-environment/ -path "*bin/spark-*")
+  ls -lha $(find $CONDA_DIR/miniconda/envs/test-environment/ -path "*bin/spark-*")
+  chmod 777 $(find $CONDA_DIR/miniconda/envs/test-environment/ -path "*bin/spark-*")
+  ls -lha $(find $CONDA_DIR/miniconda/envs/test-environment/ -path "*bin/spark-*")
 fi
 pip install .
 export MLFLOW_HOME=$(pwd)

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -9,15 +9,20 @@ df -h
 sudo mkdir -p /travis-install
 # GITHUB_WORKFLOW is set by default during GitHub workflows
 if [[ -z $GITHUB_WORKFLOW ]]; then
+  CONDA_DIR=$HOME
   sudo chown travis /travis-install
+  # (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)
+  # We do this conditionally because it saves us some downloading if the
+  # version is the same.
+  wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $HOME/miniconda.sh
+  bash $CONDA_DIR/miniconda.sh -b -p $CONDA_DIR/miniconda
+else
+  # Miniconda is pre-installed in the virtual-environments for GitHub Actions.
+  # See this repository: https://github.com/actions/virtual-environments
+  CONDA_DIR=/usr/share
 fi
-# (The conda installation steps below are taken from http://conda.pydata.org/docs/travis.html)
-# We do this conditionally because it saves us some downloading if the
-# version is the same.
-wget -q https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O $HOME/miniconda.sh
 
-bash $HOME/miniconda.sh -b -p $HOME/miniconda
-export PATH="$HOME/miniconda/bin:$PATH"
+export PATH="$CONDA_DIR/miniconda/bin:$PATH"
 hash -r
 conda config --set always_yes yes --set changeps1 no
 # Useful for debugging any issues with conda

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -44,9 +44,9 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   # Hack: make sure all spark-* scripts are executable. 
   # Conda installs 2 version spark-* scripts and makes the ones spark
   # uses not executable. This is a temporary fix to unblock the tests.
-  ls -lha $(find $CONDA_DIR/miniconda/envs/test-environment/ -path "*bin/spark-*")
-  chmod 777 $(find $CONDA_DIR/miniconda/envs/test-environment/ -path "*bin/spark-*")
-  ls -lha $(find $CONDA_DIR/miniconda/envs/test-environment/ -path "*bin/spark-*")
+  ls -lha $(find $CONDA_DIR/envs/test-environment/ -path "*bin/spark-*")
+  chmod 777 $(find $CONDA_DIR/envs/test-environment/ -path "*bin/spark-*")
+  ls -lha $(find $CONDA_DIR/envs/test-environment/ -path "*bin/spark-*")
 fi
 pip install .
 export MLFLOW_HOME=$(pwd)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Miniconda is pre-installed in the virtual-environments for GitHub Actions. This PR fixes `install-common-deps.sh` to use it.

## How is this patch tested?

The existing tests.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
