### PR TITLE
Migrate the windows test to GitHub Actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -217,6 +217,24 @@ jobs:
           source activate test-environment
           ./travis/run-python-sagemaker-tests.sh;
 
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install dependecies
+        # export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
+        run: |
+          pip install -r dev-requirements.txt
+          pip install -r travis/small-requirements.txt
+          pip install -e .
+      - name: Run tests
+        run: |
+          pytest --verbose --ignore-flavors --ignore=tests/projects tests
+
   docs:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -224,9 +224,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-
       - name: Install dependecies
-        # export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
         run: |
           pip install -r dev-requirements.txt
           pip install -r travis/small-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     # Nightly builds run the tests/examples end-to-end test suite.
     - stage: Nightly
       if: type == cron
+    - stage: Large
+      if: type != cron
 
 # Travis runs an extra top-level job for each build stage - depending on the build stage, we either
 # run small or large Python tests below.

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,36 +8,15 @@ services:
 matrix:
   include:
     # Nightly builds run the tests/examples end-to-end test suite.
-    # Does not include Windows since Projects/Models are mostly not compatible with Windows as of now.
     - stage: Nightly
       if: type == cron
-    - stage: Large
-      if: type != cron
-    # Run Windows tests in the "large" test builder so that we don't spend Travis executor
-    # time running Windows tests if Python 3 small tests fail.
-    - os: windows
-      name: "Windows"
-      if: type != cron
-      language: sh
-      before_install:
-        - choco install python3 --version=3.7.4
-      install:
-        - export PATH="/c/Python37:/c/Python37/Scripts:$PATH"
-        - pip install -r dev-requirements.txt
-        - pip install -r travis/small-requirements.txt
-        - pip install -e .
-      script:
-        - pytest --verbose --ignore-flavors --ignore=tests/projects tests
-
 
 # Travis runs an extra top-level job for each build stage - depending on the build stage, we either
 # run small or large Python tests below.
 install:
   - echo "Build stage $TRAVIS_BUILD_STAGE_NAME";
   - CHANGED_FILES=$(git diff --name-only master..HEAD | grep "tests/examples\|examples") || true;
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-      echo "skipping this step on windows.";
-    elif [[ "$TRAVIS_BUILD_STAGE_NAME" == "Nightly" ]] && ! [[ "$TRAVIS_EVENT_TYPE" == "cron" || ! -z "$CHANGED_FILES" ]]; then
+  - if [[ "$TRAVIS_BUILD_STAGE_NAME" == "Nightly" ]] && ! [[ "$TRAVIS_EVENT_TYPE" == "cron" || ! -z "$CHANGED_FILES" ]]; then
       echo "skipping the nightly stage because this build is not nightly and there are no changed files associated with nightly tests.";
     else
       INSTALL_LARGE_PYTHON_DEPS=true source ./travis/install-common-deps.sh;

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -30,9 +30,8 @@ from mlflow.protos.databricks_pb2 import ErrorCode, MALFORMED_REQUEST
 from mlflow.pyfunc.scoring_server import CONTENT_TYPE_JSON_SPLIT_ORIENTED, \
     CONTENT_TYPE_JSON, CONTENT_TYPE_CSV
 
-in_travis = 'TRAVIS' in os.environ
-# NB: for now, windows tests on Travis do not have conda available.
-no_conda = ["--no-conda"] if in_travis and sys.platform == "win32" else []
+# NB: for now, windows tests do not have conda available.
+no_conda = ["--no-conda"] if sys.platform == "win32" else []
 
 # NB: need to install mlflow since the pip version does not have mlflow models cli.
 install_mlflow = ["--install-mlflow"] if not no_conda else []

--- a/travis/stage-python3.sh
+++ b/travis/stage-python3.sh
@@ -2,14 +2,9 @@
 set -ex
 if ! [[ "$TRAVIS_EVENT_TYPE" == "cron" || "$TRAVIS_BUILD_STAGE_NAME" == "Nightly" ]]
 then
-  if [[ "$TRAVIS_OS_NAME" == "windows" ]]
-  then
-     echo "skipping this step on windows."
-  else
-    ./travis/run-large-python-tests.sh
-    ./travis/test-anaconda-compatibility.sh "anaconda3:2020.02"
-    ./travis/test-anaconda-compatibility.sh "anaconda3:2019.03"
-  fi
+  ./travis/run-large-python-tests.sh
+  ./travis/test-anaconda-compatibility.sh "anaconda3:2020.02"
+  ./travis/test-anaconda-compatibility.sh "anaconda3:2019.03"
 fi
 CHANGED_FILES=$(git diff --name-only master..HEAD | grep "tests/examples\|examples") || true
 if [[ "$TRAVIS_EVENT_TYPE" == "cron" || "$CHANGED_FILES" == *"examples"* ]] && [[ "$TRAVIS_BUILD_STAGE_NAME" == "Nightly" ]]


### PR DESCRIPTION
## What changes are proposed in this pull request?

Migrate the windows test to GitHub Actions

## How is this patch tested?

The migrated windows test runs successfully.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [x] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
