### PR TITLE
Add prepare-commit-msg hook to prevent commits without sign-off

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -113,7 +113,7 @@ you can `sign your work`_ when committing code changes and opening pull requests
     git config --global user.name "Your Name"
     git config --global user.email yourname@example.com
 
-We proivde a git hook that blocks an unsigned commit. You can enable it by running:
+We proivde a git hook to block an unsigned-off commit. You can enable it by running:
 
 .. code-block:: bash
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -113,6 +113,12 @@ you can `sign your work`_ when committing code changes and opening pull requests
     git config --global user.name "Your Name"
     git config --global user.email yourname@example.com
 
+We proivde a git hook that blocks an unsigned commit. You can enable it by running:
+
+.. code-block:: bash
+
+    git config core.hooksPath hooks
+
 Then, install the Python MLflow package from source - this is required for developing & testing
 changes across all languages and APIs. We recommend installing MLflow in its own conda environment
 by running the following from your checkout of MLflow:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -113,7 +113,8 @@ you can `sign your work`_ when committing code changes and opening pull requests
     git config --global user.name "Your Name"
     git config --global user.email yourname@example.com
 
-We proivde a git hook to block an unsigned-off commit. You can enable it by running:
+For convenience, we provide a pre-commit git hook that validates that commits are signed-off.
+Enable it by running:
 
 .. code-block:: bash
 

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,0 +1,14 @@
+# A hook to abort `git commit` if it's not signed-off
+
+COMMIT_MSG_FILE=$1
+
+signoff_pattern="Signed-off-by: .+ <.+@.+>"
+commit_message="$(cat $COMMIT_MSG_FILE)"
+
+if [[ ! "$commit_message" =~ $signoff_pattern ]]; then
+  echo "Aborted \`git commit\` because it's not signed-off."
+  echo "You can sign-off your commit using the \`-s\` flag as follows:"
+  echo
+  echo "git commit -s -m <commit message>"
+  exit 1
+fi

--- a/hooks/prepare-commit-msg
+++ b/hooks/prepare-commit-msg
@@ -1,4 +1,4 @@
-# A hook to abort `git commit` if it's not signed-off
+# A git hook to block an unsigned-off commit
 
 COMMIT_MSG_FILE=$1
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

Manually verfied that the prepare-commit-msg works by running:

```
> git commit --allow-empty -m test
Aborted `git commit` because it's not signed-off.
You can sign-off your commit using the `-s` flag as follows:

git commit -s -m <commit message>
```

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
