### PR TITLE
Run autolabeling action less frequently & only scan past week's worth of issues to avoid hitting rate limits

### DIFF
--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -2,8 +2,8 @@ name: Labeling
 
 on:
   schedule:
-    # Run this action every one hour
-    - cron: "0 * * * *"
+    # Run this action daily at 7:00 UTC
+    - cron: "0 7 * * *"
 
 jobs:
   labeling:
@@ -14,3 +14,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           label-pattern: '- \[(.*?)\] ?`(.+?)`'
+          # Label issues from last day
+          offset: '1d'

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           label-pattern: '- \[(.*?)\] ?`(.+?)`'
-          # Label issues from last day
-          offset: '1d'
+          # Label issues from last week
+          offset: '7d'


### PR DESCRIPTION
## What changes are proposed in this pull request?

Runs the autolabeling action introduced in #3070 less frequently & only scan past day's worth of issues to avoid hitting rate limits (see that the labeling workflow failed in https://github.com/mlflow/mlflow/actions/runs/165088333)

## How is this patch tested?

It's not 😬 - I think I could test it by merging this commit into the master branch of my MLflow fork? I did verify though that my updated offset param was valid by looking at https://github.com/harupy/auto-labeling/blob/master/src/enums.ts#L8

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
