### PR TITLE
[WIP] Enable registering models to a Databricks workspace from outside

### DIFF
--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -21,6 +21,16 @@ class ArtifactRepository:
     def __init__(self, artifact_uri):
         self.artifact_uri = artifact_uri
 
+    @classmethod
+    def requires_host_uri(cls):
+        """
+        :return: Whether this Repository class requires a host URI (e.g. a
+            tracking URI that can bre passed in, or by using the default tracking
+            or registry URI). For example, DBFS repositories require a Databricks
+            host to connect to.
+        """
+        return False
+
     @abstractmethod
     def log_artifact(self, local_file, artifact_path=None):
         """

--- a/mlflow/store/artifact/artifact_repository_registry.py
+++ b/mlflow/store/artifact/artifact_repository_registry.py
@@ -49,7 +49,7 @@ class ArtifactRepositoryRegistry:
                     stacklevel=2
                 )
 
-    def get_artifact_repository(self, artifact_uri):
+    def get_artifact_repository(self, artifact_uri, host_uri=None):
         """Get an artifact repository from the registry based on the scheme of artifact_uri
 
         :param store_uri: The store URI. This URI is used to select which artifact repository
@@ -68,7 +68,12 @@ class ArtifactRepositoryRegistry:
                     artifact_uri, list(self._registry.keys())
                 )
             )
-        return repository(artifact_uri)
+        # TODO: alternatively, we can make dbfs and runs repositories take in URIs of the form
+        #   runs:/profile:key_prefix/run_id/...
+        #   dbfs:/profile:key_prefix/path/...
+        #  and have the repository classes parse that.
+        return repository(artifact_uri, host_uri) if repository.requires_host_uri() \
+            else repository(artifact_uri)
 
 
 _artifact_repository_registry = ArtifactRepositoryRegistry()
@@ -89,7 +94,7 @@ _artifact_repository_registry.register('models', ModelsArtifactRepository)
 _artifact_repository_registry.register_entrypoints()
 
 
-def get_artifact_repository(artifact_uri):
+def get_artifact_repository(artifact_uri, host_uri=None):
     """Get an artifact repository from the registry based on the scheme of artifact_uri
 
     :param store_uri: The store URI. This URI is used to select which artifact repository
@@ -99,4 +104,4 @@ def get_artifact_repository(artifact_uri):
     :return: An instance of `mlflow.store.ArtifactRepository` that fulfills the artifact URI
              requirements.
     """
-    return _artifact_repository_registry.get_artifact_repository(artifact_uri)
+    return _artifact_repository_registry.get_artifact_repository(artifact_uri, host_uri)

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -69,6 +69,8 @@ class DatabricksArtifactRepository(ArtifactRepository):
         self.run_relative_artifact_repo_root_path = \
             "" if run_artifact_root_path == artifact_repo_root_path else run_relative_root_path
 
+        self.databricks_profile_uri = databricks_profile_uri or mlflow.tracking.get_tracking_uri()
+
     @classmethod
     def requires_host_uri(cls):
         return True
@@ -90,7 +92,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
         return artifact_path.split('/')[3]
 
     def _call_endpoint(self, service, api, json_body):
-        db_creds = get_databricks_host_creds(mlflow.tracking.get_tracking_uri())
+        db_creds = get_databricks_host_creds(self.databricks_profile_uri)
         endpoint, method = _SERVICE_AND_METHOD_TO_INFO[service][api]
         response_proto = api.Response()
         return call_endpoint(db_creds, endpoint, method, json_body, response_proto)

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -44,7 +44,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
     dbfs:/databricks/mlflow-tracking/<EXP_ID>/<RUN_ID>/
     """
 
-    def __init__(self, artifact_uri):
+    def __init__(self, artifact_uri, databricks_profile_uri=None):
         super(DatabricksArtifactRepository, self).__init__(artifact_uri)
         if not artifact_uri.startswith('dbfs:/'):
             raise MlflowException(message='DatabricksArtifactRepository URI must start with dbfs:/',
@@ -68,6 +68,10 @@ class DatabricksArtifactRepository(ArtifactRepository):
         # If the paths are equal, then use empty string over "./" for ListArtifact compatibility.
         self.run_relative_artifact_repo_root_path = \
             "" if run_artifact_root_path == artifact_repo_root_path else run_relative_root_path
+
+    @classmethod
+    def requires_host_uri(cls):
+        return True
 
     @staticmethod
     def _extract_run_id(artifact_uri):

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -13,13 +13,17 @@ class ModelsArtifactRepository(ArtifactRepository):
     and uses the artifact repository for that URI.
     """
 
-    def __init__(self, artifact_uri):
+    def __init__(self, artifact_uri, databricks_profile_uri=None):
         from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
         uri = ModelsArtifactRepository.get_underlying_uri(artifact_uri)
         super(ModelsArtifactRepository, self).__init__(artifact_uri)
         # TODO: it may be nice to fall back to the source URI explicitly here if for some reason
         #  we don't get a download URI here, or fail during the download itself.
         self.repo = get_artifact_repository(uri)
+
+    @classmethod
+    def requires_host_uri(cls):
+        return True
 
     @staticmethod
     def _improper_model_uri_msg(uri):

--- a/mlflow/store/artifact/runs_artifact_repo.py
+++ b/mlflow/store/artifact/runs_artifact_repo.py
@@ -15,11 +15,15 @@ class RunsArtifactRepository(ArtifactRepository):
     users should take special care when constructing the URI.
     """
 
-    def __init__(self, artifact_uri):
+    def __init__(self, artifact_uri, databricks_profile_uri=None):
         from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
         uri = RunsArtifactRepository.get_underlying_uri(artifact_uri)
         super(RunsArtifactRepository, self).__init__(artifact_uri)
-        self.repo = get_artifact_repository(uri)
+        self.repo = get_artifact_repository(uri, databricks_profile_uri)
+
+    @classmethod
+    def requires_host_uri(cls):
+        return True
 
     @staticmethod
     def is_runs_uri(uri):

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -158,7 +158,7 @@ class ModelRegistryClient(object):
 
     def create_model_version(self, name, source, run_id, tags=None):
         """
-        Create a new model version from given source or run ID.
+        Create a new model version from given source.
 
         :param name: Name ID for containing registered model.
         :param source: Source path where the MLflow model is stored.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -9,14 +9,16 @@ from mlflow.entities import ViewType
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import FEATURE_DISABLED
-from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.model_registry import SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT
+from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.tracking._model_registry.client import ModelRegistryClient
 from mlflow.tracking._model_registry import utils as registry_utils
-from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.tracking._tracking_service import utils
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
+from mlflow.tracking.artifact_utils import _upload_artifacts_to_databricks
+from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.utils import experimental
+from mlflow.utils.uri import is_databricks_uri
 
 _logger = logging.getLogger(__name__)
 
@@ -490,9 +492,9 @@ class MlflowClient(object):
     @experimental
     def create_model_version(self, name, source, run_id, tags=None):
         """
-        Create a new model version from given source or run ID.
+        Create a new model version from given source.
 
-        :param name: Name ID for containing registered model.
+        :param name: Name for the containing registered model.
         :param source: Source path where the MLflow model is stored.
         :param run_id: Run ID from MLflow tracking server that generated the model
         :param tags: A dictionary of key-value pairs that are converted into
@@ -500,7 +502,16 @@ class MlflowClient(object):
         :return: Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by
                  backend.
         """
-        return self._get_registry_client().create_model_version(name, source, run_id, tags)
+        :param run_id: Run ID from MLflow tracking server that generated the model.
+        :return: Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by
+                 backend.
+        """
+        if (is_databricks_uri(self._registry_uri) and
+                self._tracking_client.tracking_uri != self._registry_uri):
+            new_source = _upload_artifacts_to_databricks(source, run_id, self._registry_uri)
+        else:
+            new_source = source
+        return self._get_registry_client().create_model_version(name, new_source, run_id, tags)
 
     @experimental
     def update_model_version(self, name, version, description=None):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -502,15 +502,11 @@ class MlflowClient(object):
         :return: Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by
                  backend.
         """
-        :param run_id: Run ID from MLflow tracking server that generated the model.
-        :return: Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by
-                 backend.
-        """
-        if (is_databricks_uri(self._registry_uri) and
-                self._tracking_client.tracking_uri != self._registry_uri):
-            new_source = _upload_artifacts_to_databricks(source, run_id, self._registry_uri)
-        else:
-            new_source = source
+        new_source = source
+        tracking_uri = self._tracking_client.tracking_uri
+        if is_databricks_uri(self._registry_uri) and tracking_uri != self._registry_uri:
+            new_source = _upload_artifacts_to_databricks(source, run_id, tracking_uri,
+                                                         self._registry_uri)
         return self._get_registry_client().create_model_version(name, new_source, run_id, tags)
 
     @experimental

--- a/tests/store/artifact/test_dbfs_rest_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_rest_artifact_repo.py
@@ -84,7 +84,7 @@ class TestDbfsArtifactRepository(object):
     def test_init_get_host_creds_with_databricks_profile_uri(self):
         with mock.patch(DBFS_ARTIFACT_REPOSITORY_PACKAGE + '._get_host_creds_from_default_store') \
                 as get_creds_mock, \
-                mock.patch(DBFS_ARTIFACT_REPOSITORY_PACKAGE + 'get_databricks_host_creds') \
+                mock.patch(DBFS_ARTIFACT_REPOSITORY_PACKAGE + '.get_databricks_host_creds') \
                 as get_db_creds_mock:
             databricks_host = 'https://something.databricks.com'
             get_db_creds_mock.return_value = MlflowHostCreds(databricks_host)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Allow registering models to a Databricks workspace with a source from outside the workspace. To do so, we need to copy the source to the local filesystem and upload it to the target Databricks workspace, then create the model version there.

## How is this patch tested?

- Unit tests - for the `DbfsRestArtifactRepository` changes only
- Manual tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

You can now register models to a Databricks workspace with a source from outside the workspace. 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
