### PR TITLE
Add `archive_existing_versions` to model registry client

### DIFF
--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -179,8 +179,10 @@ class AbstractStore:
         :param name: Registered model name.
         :param version: Registered model version.
         :param new_stage: New desired stage for this model version.
-        :param archive_existing_versions: If this flag is set, all existing model
-        versions in the stage will be atomically moved to the "archived" stage.
+        :param archive_existing_versions: If this flag is set to ``True``, all existing model
+            versions in the stage will be automically moved to the "archived" stage. Only valid
+            when ``stage`` is ``"staging"`` or ``"production"`` otherwise an error will be raised.
+
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
         pass

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -214,8 +214,10 @@ class RestStore(AbstractStore):
         :param name: Registered model name.
         :param version: Registered model version.
         :param new_stage: New desired stage for this model version.
-        :param archive_existing_versions: If this flag is set, all existing model
-        versions in the stage will be atomically moved to the "archived" stage.
+        :param archive_existing_versions: If this flag is set to ``True``, all existing model
+            versions in the stage will be automically moved to the "archived" stage. Only valid
+            when ``stage`` is ``"staging"`` or ``"production"`` otherwise an error will be raised.
+
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
         req_body = message_to_json(TransitionModelVersionStage(

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -544,8 +544,10 @@ class SqlAlchemyStore(AbstractStore):
         :param name: Registered model name.
         :param version: Registered model version.
         :param new_stage: New desired stage for this model version.
-        :param archive_existing_versions: If this flag is set, all existing model
-        versions in the stage will be atomically moved to the "archived" stage.
+        :param archive_existing_versions: If this flag is set to ``True``, all existing model
+            versions in the stage will be automically moved to the "archived" stage. Only valid
+            when ``stage`` is ``"staging"`` or ``"production"`` otherwise an error will be raised.
+
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
         is_active_stage = get_canonical_stage(stage) in DEFAULT_STAGES_FOR_GET_LATEST_VERSIONS

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -159,8 +159,9 @@ class ModelRegistryClient(object):
         :param name: Registered model name.
         :param version: Registered model version.
         :param stage: New desired stage for this model version.
-        :param archive_existing_versions: If this flag is set, all existing model
-               versions in the stage will be atomically moved to the "archived" stage.
+        :param archive_existing_versions: If this flag is set to ``True``, all existing model
+            versions in the stage will be automically moved to the "archived" stage. Only valid
+            when ``stage`` is ``"staging"`` or ``"production"`` otherwise an error will be raised.
 
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -501,7 +501,7 @@ class MlflowClient(object):
         :param version: Registered model version.
         :param stage: New desired stage for this model version.
         :param archive_existing_versions: If this flag is set, all existing model
-        versions in the stage will be atomically moved to the "archived" stage.
+            versions in the stage will be atomically moved to the "archived" stage.
 
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -500,8 +500,9 @@ class MlflowClient(object):
         :param name: Registered model name.
         :param version: Registered model version.
         :param stage: New desired stage for this model version.
-        :param archive_existing_versions: If this flag is set, all existing model
-            versions in the stage will be atomically moved to the "archived" stage.
+        :param archive_existing_versions: If this flag is set to ``True``, all existing model
+            versions in the stage will be automically moved to the "archived" stage. Only valid
+            when ``stage`` is ``"staging"`` or ``"production"`` otherwise an error will be raised.
 
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -493,17 +493,21 @@ class MlflowClient(object):
                                                                 description=description)
 
     @experimental
-    def transition_model_version_stage(self, name, version, stage):
+    def transition_model_version_stage(self, name, version, stage, archive_existing_versions=False):
         """
         Update model version stage.
 
         :param name: Registered model name.
         :param version: Registered model version.
         :param stage: New desired stage for this model version.
+        :param archive_existing_versions: If this flag is set, all existing model
+        versions in the stage will be atomically moved to the "archived" stage.
 
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
-        return self._get_registry_client().transition_model_version_stage(name, version, stage)
+        return self._get_registry_client().transition_model_version_stage(
+            name, version, stage, archive_existing_versions
+        )
 
     @experimental
     def delete_model_version(self, name, version):


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

A follow-up for #3076 

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
