### PR TITLE
Add support for `archive_existing_versions` [UI]

### DIFF
--- a/mlflow/server/js/src/model-registry/actions.js
+++ b/mlflow/server/js/src/model-registry/actions.js
@@ -82,12 +82,19 @@ export const updateModelVersionApi = (modelName, version, description, id = getU
 });
 
 export const TRANSITION_MODEL_VERSION_STAGE = 'TRANSITION_MODEL_VERSION_STAGE';
-export const transitionModelVersionStageApi = (modelName, version, stage, id = getUUID()) => ({
+export const transitionModelVersionStageApi = (
+  modelName,
+  version,
+  stage,
+  archiveExistingVersions,
+  id = getUUID(),
+) => ({
   type: TRANSITION_MODEL_VERSION_STAGE,
   payload: wrapDeferred(Services.transitionModelVersionStage, {
     name: modelName,
     version,
     stage,
+    archive_existing_versions: archiveExistingVersions,
   }),
   meta: { id },
 });

--- a/mlflow/server/js/src/model-registry/components/DirectTransitionForm.js
+++ b/mlflow/server/js/src/model-registry/components/DirectTransitionForm.js
@@ -1,0 +1,51 @@
+import { Checkbox, Form, Input, Tooltip } from 'antd';
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  ACTIVE_STAGES,
+  archiveExistingVersionToolTipText,
+  Stages,
+  StageTagComponents,
+} from '../constants';
+
+const { TextArea } = Input;
+export class DirectTransitionFormImpl extends React.Component {
+  static propTypes = {
+    form: PropTypes.object,
+    toStage: PropTypes.string,
+  };
+
+  render() {
+    const { toStage, form } = this.props;
+    const { getFieldDecorator } = form;
+    const archiveExistingVersionsCheckbox =
+      toStage && ACTIVE_STAGES.includes(toStage) ? (
+        <Form.Item>
+          {getFieldDecorator('archiveExistingVersions', {
+            initialValue: true,
+            valuePropName: 'checked',
+          })(
+            <Checkbox>
+              <Tooltip title={archiveExistingVersionToolTipText(toStage)}>
+                Transition existing {StageTagComponents[toStage]}
+                model versions to {StageTagComponents[Stages.ARCHIVED]}
+              </Tooltip>
+            </Checkbox>,
+          )}
+        </Form.Item>
+      ) : (
+        ''
+      );
+
+    return (
+      <Form className='model-version-update-form'>
+        <Form.Item label='Comment'>
+          {getFieldDecorator('comment')(<TextArea rows={4} placeholder='Comment' />)}
+        </Form.Item>
+        {archiveExistingVersionsCheckbox}
+      </Form>
+    );
+  }
+}
+
+export const DirectTransitionForm = Form.create()(DirectTransitionFormImpl);

--- a/mlflow/server/js/src/model-registry/components/DirectTransitionForm.test.js
+++ b/mlflow/server/js/src/model-registry/components/DirectTransitionForm.test.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { DirectTransitionFormImpl } from './DirectTransitionForm';
+import { ACTIVE_STAGES, Stages } from '../constants';
+import { Checkbox } from 'antd';
+import _ from 'lodash';
+
+describe('DirectTransitionForm', () => {
+  let wrapper;
+  let minimalProps;
+
+  beforeEach(() => {
+    minimalProps = {
+      form: { getFieldDecorator: jest.fn(() => (c) => c) },
+    };
+  });
+
+  test('should render with minimal props without exploding', () => {
+    wrapper = shallow(<DirectTransitionFormImpl {...minimalProps} />);
+    expect(wrapper.length).toBe(1);
+  });
+
+  test('should render checkbox only for active stage', () => {
+    const [activeStages, nonActiveStages] = _.partition(Stages, (s) => ACTIVE_STAGES.includes(s));
+
+    activeStages.forEach((toStage) => {
+      const props = { ...minimalProps, toStage };
+      wrapper = shallow(<DirectTransitionFormImpl {...props} />);
+      expect(wrapper.find(Checkbox).length).toBe(1);
+    });
+
+    nonActiveStages.forEach((toStage) => {
+      const props = { ...minimalProps, toStage };
+      wrapper = shallow(<DirectTransitionFormImpl {...props} />);
+      expect(wrapper.find(Checkbox).length).toBe(0);
+    });
+  });
+});

--- a/mlflow/server/js/src/model-registry/components/ModelStageTransitionDropdown.js
+++ b/mlflow/server/js/src/model-registry/components/ModelStageTransitionDropdown.js
@@ -4,6 +4,8 @@ import PropTypes from 'prop-types';
 import { Stages, StageTagComponents, ActivityTypes } from '../constants';
 import _ from 'lodash';
 
+import { DirectTransitionForm } from './DirectTransitionForm';
+
 export class ModelStageTransitionDropdown extends React.Component {
   static propTypes = {
     currentStage: PropTypes.string,
@@ -20,6 +22,8 @@ export class ModelStageTransitionDropdown extends React.Component {
     handleConfirm: undefined,
   };
 
+  transitionFormRef = React.createRef();
+
   handleMenuItemClick = (activity) => {
     const { onSelect } = this.props;
     this.setState({
@@ -29,7 +33,11 @@ export class ModelStageTransitionDropdown extends React.Component {
         onSelect &&
         (() => {
           this.setState({ confirmModalVisible: false });
-          this.props.onSelect(activity);
+          const archiveExistingVersions = Boolean(
+            this.transitionFormRef.current.getFieldValue('archiveExistingVersions'),
+          );
+          this.transitionFormRef.current.resetFields();
+          this.props.onSelect(activity, archiveExistingVersions);
         }),
     });
   };
@@ -72,6 +80,10 @@ export class ModelStageTransitionDropdown extends React.Component {
   renderConfirmModal() {
     const { confirmModalVisible, confirmingActivity, handleConfirm } = this.state;
     if (confirmingActivity) {
+      const formComponent = (
+        <DirectTransitionForm ref={this.transitionFormRef} toStage={confirmingActivity.to_stage} />
+      );
+
       return (
         <Modal
           title='Stage Transition'
@@ -80,6 +92,7 @@ export class ModelStageTransitionDropdown extends React.Component {
           onCancel={this.handleConfirmModalCancel}
         >
           {renderActivityDescription(confirmingActivity)}
+          {formComponent}
         </Modal>
       );
     }

--- a/mlflow/server/js/src/model-registry/components/ModelStageTransitionDropdown.test.js
+++ b/mlflow/server/js/src/model-registry/components/ModelStageTransitionDropdown.test.js
@@ -4,6 +4,8 @@ import { ModelStageTransitionDropdown } from './ModelStageTransitionDropdown';
 import { Stages } from '../constants';
 import { Dropdown } from 'antd';
 
+import { mockGetFieldValue } from '../test-utils';
+
 describe('ModelStageTransitionDropdown', () => {
   let wrapper;
   let minimalProps;
@@ -38,7 +40,7 @@ describe('ModelStageTransitionDropdown', () => {
     expect(menuHtml).toContain(Stages.ARCHIVED);
   });
 
-  test('handleMenuItemClick', () => {
+  test('handleMenuItemClick - archiveExistingVersions', () => {
     const mockOnSelect = jest.fn();
     const props = {
       ...commonProps,
@@ -46,9 +48,19 @@ describe('ModelStageTransitionDropdown', () => {
     };
     const activity = {};
     wrapper = shallow(<ModelStageTransitionDropdown {...props} />);
-    const instance = wrapper.instance();
-    instance.handleMenuItemClick(activity);
-    instance.state.handleConfirm();
-    expect(mockOnSelect).toHaveBeenCalledWith(activity);
+    const mockArchiveFieldValues = [true, false, undefined];
+    mockArchiveFieldValues.forEach((fieldValue) => {
+      const expectArchiveFieldValue = Boolean(fieldValue); // undefined should become false also
+      const instance = wrapper.instance();
+      instance.transitionFormRef = {
+        current: {
+          getFieldValue: mockGetFieldValue('', fieldValue),
+          resetFields: () => {},
+        },
+      };
+      instance.handleMenuItemClick(activity);
+      instance.state.handleConfirm();
+      expect(mockOnSelect).toHaveBeenCalledWith(activity, expectArchiveFieldValue);
+    });
   });
 });

--- a/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
@@ -81,7 +81,7 @@ export class ModelVersionPageImpl extends React.Component {
       });
   }
 
-  handleStageTransitionDropdownSelect = (activity) => {
+  handleStageTransitionDropdownSelect = (activity, archiveExistingVersions) => {
     const { modelName, version } = this.props;
     const toStage = activity.to_stage;
     if (activity.type === ActivityTypes.APPLIED_TRANSITION) {
@@ -90,6 +90,7 @@ export class ModelVersionPageImpl extends React.Component {
           modelName,
           version,
           toStage,
+          archiveExistingVersions,
           this.transitionModelVersionStageRequestId,
         )
         .then(this.loadData)


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
