### PR TITLE
Fix order by parsing when name contains a space

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -368,7 +368,6 @@ class SearchUtils(object):
         token_value = cls._validate_order_by_and_generate_token(order_by)
         is_ascending = True
         tokens = shlex.split(token_value.replace("`", "\""))
-        print(tokens)
         if len(tokens) > 2:
             raise MlflowException(f"Invalid order_by clause '{order_by}'. Could not be parsed.",
                                   error_code=INVALID_PARAMETER_VALUE)

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -2,6 +2,7 @@ import base64
 import json
 import operator
 import re
+import shlex
 
 import sqlparse
 from sqlparse.sql import Identifier, Token, Comparison, Statement
@@ -366,7 +367,8 @@ class SearchUtils(object):
     def _parse_order_by_string(cls, order_by):
         token_value = cls._validate_order_by_and_generate_token(order_by)
         is_ascending = True
-        tokens = token_value.split()
+        tokens = shlex.split(token_value.replace("`", "\""))
+        print(tokens)
         if len(tokens) > 2:
             raise MlflowException(f"Invalid order_by clause '{order_by}'. Could not be parsed.",
                                   error_code=INVALID_PARAMETER_VALUE)

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -328,6 +328,14 @@ def test_invalid_order_by_search_runs(order_by, error_message):
     assert error_message in e.value.message
 
 
+def test_space_order_by_search_runs():
+    identifier_type, identifier_name, ascending = SearchUtils.parse_order_by_for_search_runs(
+        "metrics.`Mean Square Error`")
+    assert identifier_type == "metric"
+    assert identifier_name == "Mean Square Error"
+    assert ascending
+
+
 @pytest.mark.parametrize("order_by, error_message", [
     ("creation_timestamp DESC", "Invalid order by key"),
     ('last_updated_timestamp DESC blah', "Invalid order_by clause"),

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -328,12 +328,17 @@ def test_invalid_order_by_search_runs(order_by, error_message):
     assert error_message in e.value.message
 
 
-def test_space_order_by_search_runs():
+@pytest.mark.parametrize("order_by, ascending_expected", [
+    ("metrics.`Mean Square Error`", True),
+    ("metrics.`Mean Square Error` ASC", True),
+    ("metrics.`Mean Square Error` DESC", False),
+])
+def test_space_order_by_search_runs(order_by, ascending_expected):
     identifier_type, identifier_name, ascending = SearchUtils.parse_order_by_for_search_runs(
-        "metrics.`Mean Square Error`")
+        order_by)
     assert identifier_type == "metric"
     assert identifier_name == "Mean Square Error"
-    assert ascending
+    assert ascending == ascending_expected
 
 
 @pytest.mark.parametrize("order_by, error_message", [


### PR DESCRIPTION
## What changes are proposed in this pull request?

A fix to https://github.com/mlflow/mlflow/issues/3117. (parse orderby clause with a space in name)

The solution is to use shlex.split instead of string split that is able to manage quotes.

## How is this patch tested?

* Adding a unit test for this case
* Test ordering from the UI (columns with space or not)

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
