### PR TITLE
[V2] Enable registering models to a Databricks workspace from outside

### DIFF
--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -59,7 +59,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
         artifact_uri_no_db_profile = remove_databricks_profile_info_from_artifact_uri(artifact_uri)
         super(DatabricksArtifactRepository, self).__init__(artifact_uri_no_db_profile)
         self.databricks_profile_uri = get_databricks_profile_uri_from_artifact_uri(artifact_uri) \
-                                      or mlflow.tracking.get_tracking_uri()
+            or mlflow.tracking.get_tracking_uri()
 
         self.run_id = self._extract_run_id(self.artifact_uri)
         # Fetch the artifact root for the MLflow Run associated with `artifact_uri` and compute

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -22,7 +22,7 @@ from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import call_endpoint, extract_api_info_for_service
 from mlflow.utils.uri import extract_and_normalize_path, \
     get_databricks_profile_uri_from_artifact_uri, is_databricks_acled_artifacts_uri, \
-    remove_databricks_profile_info_from_artifact_uri
+    is_valid_dbfs_uri, remove_databricks_profile_info_from_artifact_uri
 
 _logger = logging.getLogger(__name__)
 _PATH_PREFIX = "/api/2.0"
@@ -47,20 +47,21 @@ class DatabricksArtifactRepository(ArtifactRepository):
     """
 
     def __init__(self, artifact_uri):
-        if not artifact_uri.startswith('dbfs:/'):
-            raise MlflowException(message='DatabricksArtifactRepository URI must start with dbfs:/',
+        if not is_valid_dbfs_uri(artifact_uri):
+            raise MlflowException(message="DBFS URI must be of the form dbfs:/<path> or " +
+                                  "dbfs://profile@databricks/<path>",
                                   error_code=INVALID_PARAMETER_VALUE)
         if not is_databricks_acled_artifacts_uri(artifact_uri):
             raise MlflowException(message=('Artifact URI incorrect. Expected path prefix to be'
                                            ' databricks/mlflow-tracking/path/to/artifact/..'),
                                   error_code=INVALID_PARAMETER_VALUE)
         # The dbfs:/ path ultimately used for artifact operations should not contain the
-        # Databricks profile info.
-        artifact_uri_no_db_profile = remove_databricks_profile_info_from_artifact_uri(artifact_uri)
-        super(DatabricksArtifactRepository, self).__init__(artifact_uri_no_db_profile)
+        # Databricks profile info, so strip it before setting ``artifact_uri``.
+        super(DatabricksArtifactRepository, self).__init__(
+            remove_databricks_profile_info_from_artifact_uri(artifact_uri))
+
         self.databricks_profile_uri = get_databricks_profile_uri_from_artifact_uri(artifact_uri) \
             or mlflow.tracking.get_tracking_uri()
-
         self.run_id = self._extract_run_id(self.artifact_uri)
         # Fetch the artifact root for the MLflow Run associated with `artifact_uri` and compute
         # the path of `artifact_uri` relative to the MLflow Run's artifact root

--- a/mlflow/store/artifact/dbfs_artifact_repo.py
+++ b/mlflow/store/artifact/dbfs_artifact_repo.py
@@ -10,7 +10,6 @@ from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.store.artifact.databricks_artifact_repo import DatabricksArtifactRepository
 from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
 from mlflow.tracking._tracking_service import utils
-import mlflow.utils.databricks_utils
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.file_utils import relative_path_to_artifact_path
 from mlflow.utils.rest_utils import http_request, http_request_safe, RESOURCE_DOES_NOT_EXIST
@@ -18,6 +17,7 @@ from mlflow.utils.string_utils import strip_prefix
 from mlflow.utils.uri import get_databricks_profile_uri_from_artifact_uri, get_uri_scheme, \
     is_databricks_acled_artifacts_uri, is_valid_dbfs_uri, \
     remove_databricks_profile_info_from_artifact_uri
+import mlflow.utils.databricks_utils
 
 LIST_API_ENDPOINT = '/api/2.0/dbfs/list'
 GET_STATUS_ENDPOINT = '/api/2.0/dbfs/get-status'

--- a/mlflow/store/artifact/dbfs_artifact_repo.py
+++ b/mlflow/store/artifact/dbfs_artifact_repo.py
@@ -1,7 +1,6 @@
 import json
 import os
 import posixpath
-from six.moves import urllib
 
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException
@@ -14,7 +13,7 @@ from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.file_utils import relative_path_to_artifact_path
 from mlflow.utils.rest_utils import http_request, http_request_safe, RESOURCE_DOES_NOT_EXIST
 from mlflow.utils.string_utils import strip_prefix
-from mlflow.utils.uri import get_databricks_profile_uri_from_artifact_uri, get_uri_scheme, \
+from mlflow.utils.uri import get_databricks_profile_uri_from_artifact_uri, \
     is_databricks_acled_artifacts_uri, is_valid_dbfs_uri, \
     remove_databricks_profile_info_from_artifact_uri
 import mlflow.utils.databricks_utils

--- a/mlflow/store/artifact/dbfs_artifact_repo.py
+++ b/mlflow/store/artifact/dbfs_artifact_repo.py
@@ -190,6 +190,8 @@ def dbfs_artifact_repo_factory(artifact_uri):
         # If the DBFS FUSE mount is available, write artifacts directly to /dbfs/... using
         # local filesystem APIs
         # TODO(sueann): remove databricks profile info
+        # TODO(sueann): check that the host_uri is not default -> use DbfsRestArtifactRepository
+        # TODO(sueann): add tests for these cases
         file_uri = "file:///dbfs/{}".format(strip_prefix(cleaned_artifact_uri, "dbfs:/"))
         return LocalArtifactRepository(file_uri)
     return DbfsRestArtifactRepository(cleaned_artifact_uri)

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -70,7 +70,6 @@ class ModelsArtifactRepository(ArtifactRepository):
             version = latest[0].version
         databricks_profile_uri = get_databricks_profile_uri_from_artifact_uri(uri)
         download_uri = client.get_model_version_download_uri(name, version)
-        # TODO(sueann): write unit tests for databricks_profile_uri
         return add_databricks_profile_info_to_artifact_uri(download_uri, databricks_profile_uri)
 
     def log_artifact(self, local_file, artifact_path=None):

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -17,8 +17,8 @@ class ModelsArtifactRepository(ArtifactRepository):
 
     def __init__(self, artifact_uri):
         from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
-        uri = ModelsArtifactRepository.get_underlying_uri(artifact_uri)
         super(ModelsArtifactRepository, self).__init__(artifact_uri)
+        uri = ModelsArtifactRepository.get_underlying_uri(artifact_uri)
         # TODO: it may be nice to fall back to the source URI explicitly here if for some reason
         #  we don't get a download URI here, or fail during the download itself.
         self.repo = get_artifact_repository(uri)
@@ -60,7 +60,8 @@ class ModelsArtifactRepository(ArtifactRepository):
         # Note: to support a registry URI that is different from the tracking URI here,
         # we'll need to add setting of registry URIs via environment variables.
         from mlflow.tracking import MlflowClient
-        client = MlflowClient()
+        databricks_profile_uri = get_databricks_profile_uri_from_artifact_uri(uri)
+        client = MlflowClient(registry_uri=databricks_profile_uri)
         (name, version, stage) = ModelsArtifactRepository._parse_uri(uri)
         if stage is not None:
             latest = client.get_latest_versions(name, [stage])
@@ -68,7 +69,6 @@ class ModelsArtifactRepository(ArtifactRepository):
                 raise MlflowException("No versions of model with name '{name}' and "
                                       "stage '{stage}' found".format(name=name, stage=stage))
             version = latest[0].version
-        databricks_profile_uri = get_databricks_profile_uri_from_artifact_uri(uri)
         download_uri = client.get_model_version_download_uri(name, version)
         return add_databricks_profile_info_to_artifact_uri(download_uri, databricks_profile_uri)
 

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -2,6 +2,8 @@ from six.moves import urllib
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
+from mlflow.utils.uri import add_databricks_profile_info_to_artifact_uri, \
+    get_databricks_profile_uri_from_artifact_uri
 
 
 class ModelsArtifactRepository(ArtifactRepository):
@@ -66,7 +68,10 @@ class ModelsArtifactRepository(ArtifactRepository):
                 raise MlflowException("No versions of model with name '{name}' and "
                                       "stage '{stage}' found".format(name=name, stage=stage))
             version = latest[0].version
-        return client.get_model_version_download_uri(name, version)
+        databricks_profile_uri = get_databricks_profile_uri_from_artifact_uri(uri)
+        download_uri = client.get_model_version_download_uri(name, version)
+        # TODO(sueann): write unit tests for databricks_profile_uri
+        return add_databricks_profile_info_to_artifact_uri(download_uri, databricks_profile_uri)
 
     def log_artifact(self, local_file, artifact_path=None):
         """

--- a/mlflow/store/artifact/runs_artifact_repo.py
+++ b/mlflow/store/artifact/runs_artifact_repo.py
@@ -2,6 +2,8 @@ from six.moves import urllib
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
+from mlflow.utils.uri import add_databricks_profile_info_to_artifact_uri, \
+    get_databricks_profile_uri_from_artifact_uri
 
 
 class RunsArtifactRepository(ArtifactRepository):
@@ -29,9 +31,11 @@ class RunsArtifactRepository(ArtifactRepository):
     def get_underlying_uri(runs_uri):
         from mlflow.tracking.artifact_utils import get_artifact_uri
         (run_id, artifact_path) = RunsArtifactRepository.parse_runs_uri(runs_uri)
-        uri = get_artifact_uri(run_id, artifact_path)
+        tracking_uri = get_databricks_profile_uri_from_artifact_uri(runs_uri)
+        uri = get_artifact_uri(run_id, artifact_path, tracking_uri)
         assert not RunsArtifactRepository.is_runs_uri(uri)  # avoid an infinite loop
-        return uri
+        # TODO(sueann): write unit tests for tracking_uri
+        return add_databricks_profile_info_to_artifact_uri(uri, tracking_uri)
 
     @staticmethod
     def parse_runs_uri(run_uri):

--- a/mlflow/store/artifact/runs_artifact_repo.py
+++ b/mlflow/store/artifact/runs_artifact_repo.py
@@ -19,8 +19,8 @@ class RunsArtifactRepository(ArtifactRepository):
 
     def __init__(self, artifact_uri):
         from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
-        uri = RunsArtifactRepository.get_underlying_uri(artifact_uri)
         super(RunsArtifactRepository, self).__init__(artifact_uri)
+        uri = RunsArtifactRepository.get_underlying_uri(artifact_uri)
         self.repo = get_artifact_repository(uri)
 
     @staticmethod

--- a/mlflow/store/artifact/runs_artifact_repo.py
+++ b/mlflow/store/artifact/runs_artifact_repo.py
@@ -34,7 +34,6 @@ class RunsArtifactRepository(ArtifactRepository):
         tracking_uri = get_databricks_profile_uri_from_artifact_uri(runs_uri)
         uri = get_artifact_uri(run_id, artifact_path, tracking_uri)
         assert not RunsArtifactRepository.is_runs_uri(uri)  # avoid an infinite loop
-        # TODO(sueann): write unit tests for tracking_uri
         return add_databricks_profile_info_to_artifact_uri(uri, tracking_uri)
 
     @staticmethod
@@ -44,7 +43,6 @@ class RunsArtifactRepository(ArtifactRepository):
             raise MlflowException(
                 "Not a proper runs:/ URI: %s. " % run_uri +
                 "Runs URIs must be of the form 'runs:/<run_id>/run-relative/path/to/artifact'")
-        # hostname = parsed.netloc  # TODO: support later
 
         path = parsed.path
         if not path.startswith('/') or len(path) <= 1:

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -158,7 +158,7 @@ class ModelRegistryClient(object):
 
     def create_model_version(self, name, source, run_id, tags=None, run_link=None):
         """
-        Create a new model version from given source or run ID.
+        Create a new model version from given source.
 
         :param name: Name of the containing registered model.
         :param source: Source path where the MLflow model is stored.

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -264,6 +264,8 @@ class TrackingServiceClient(object):
         :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
         """
         run = self.get_run(run_id)
+        # TODO: use add_databricks_profile_info_to_artifact_uri(artifact_root, self.tracking_uri)
+        #   for DBFS artifact repositories to use the correct tracking URI.
         artifact_repo = get_artifact_repository(run.info.artifact_uri)
         artifact_repo.log_artifacts(local_dir, artifact_path)
 
@@ -278,6 +280,8 @@ class TrackingServiceClient(object):
         """
         run = self.get_run(run_id)
         artifact_root = run.info.artifact_uri
+        # TODO: use add_databricks_profile_info_to_artifact_uri(artifact_root, self.tracking_uri)
+        #   for DBFS artifact repositories to use the correct tracking URI.
         artifact_repo = get_artifact_repository(artifact_root)
         return artifact_repo.list_artifacts(path)
 
@@ -297,6 +301,8 @@ class TrackingServiceClient(object):
         """
         run = self.get_run(run_id)
         artifact_root = run.info.artifact_uri
+        # TODO: use add_databricks_profile_info_to_artifact_uri(artifact_root, self.tracking_uri)
+        #   for DBFS artifact repositories to use the correct tracking URI.
         artifact_repo = get_artifact_repository(artifact_root)
         return artifact_repo.download_artifacts(path, dst_path)
 

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -247,6 +247,8 @@ class TrackingServiceClient(object):
         :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
         """
         run = self.get_run(run_id)
+        # TODO: use add_databricks_profile_info_to_artifact_uri(artifact_root, self.tracking_uri)
+        #   for DBFS artifact repositories to use the correct tracking URI.
         artifact_repo = get_artifact_repository(run.info.artifact_uri)
         if os.path.isdir(local_path):
             dir_name = os.path.basename(os.path.normpath(local_path))

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -93,14 +93,14 @@ def _upload_artifacts_to_databricks(source, run_id, source_host_uri=None,
     :return: The DBFS location in the target Databricks workspace the model files have been
         uploaded to.
     """
-    import uuid
+    from uuid import uuid1
     local_dir = tempfile.mkdtemp()
     try:
         source_with_profile = add_databricks_profile_info_to_artifact_uri(source, source_host_uri)
         _download_artifact_from_uri(source_with_profile, local_dir)
         dest_root = 'dbfs:/databricks/mlflow/tmp-external-source/'
         dest_repo = DbfsRestArtifactRepository(dest_root, target_databricks_profile_uri)
-        dest_dir = run_id if run_id else str(uuid.uuid1())
+        dest_dir = run_id if run_id else str(uuid1())
         dest_repo.log_artifacts(local_dir, artifact_path=dest_dir)
         return dest_root + dest_dir  # new source
     finally:

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -100,7 +100,7 @@ def _upload_artifacts_to_databricks(source, run_id, source_host_uri=None,
         _download_artifact_from_uri(source_with_profile, local_dir)
         dest_root = 'dbfs:/databricks/mlflow/tmp-external-source/'
         dest_repo = DbfsRestArtifactRepository(dest_root, target_databricks_profile_uri)
-        dest_dir = run_id if run_id else uuid.uuid1()
+        dest_dir = run_id if run_id else str(uuid.uuid1())
         dest_repo.log_artifacts(local_dir, artifact_path=dest_dir)
         return dest_root + dest_dir  # new source
     finally:

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -106,5 +106,3 @@ def _upload_artifacts_to_databricks(source, run_id, source_host_uri=None,
         return dest_root + dest_dir  # new source
     finally:
         shutil.rmtree(local_dir)
-    # NOTE: we can't easily delete the target temp location due to the async nature
-    # of the model version creation.

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -96,10 +96,9 @@ def _upload_artifacts_to_databricks(source, run_id, source_host_uri=None,
     import uuid
     local_dir = tempfile.mkdtemp()
     try:
-        # TODO: might want to throw if `source` is a models URI??
         source_with_profile = add_databricks_profile_info_to_artifact_uri(source, source_host_uri)
         _download_artifact_from_uri(source_with_profile, local_dir)
-        dest_root = 'dbfs:/databricks/mlflow/tmp-external-source/'  # TODO: "/" or "-"?
+        dest_root = 'dbfs:/databricks/mlflow/tmp-external-source/'
         dest_repo = DbfsRestArtifactRepository(dest_root, target_databricks_profile_uri)
         dest_dir = run_id if run_id else uuid.uuid1()
         dest_repo.log_artifacts(local_dir, artifact_path=dest_dir)

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -541,8 +541,21 @@ class MlflowClient(object):
         new_source = source
         tracking_uri = self._tracking_client.tracking_uri
         if is_databricks_uri(self._registry_uri) and tracking_uri != self._registry_uri:
+            # Print out some info for user since the copy may take a while for large models.
+            _logger.info("=== Copying model files from the source location to the model " +
+                         " registry workspace ===")
             new_source = _upload_artifacts_to_databricks(source, run_id, tracking_uri,
                                                          self._registry_uri)
+            # NOTE: we can't easily delete the target temp location due to the async nature
+            # of the model version creation.
+            _logger.info(
+                """
+                === Source model files were copied to %s 
+                    in the model registry workspace. You may want to delete the files once the 
+                    model version is in 'READY' status. You can also find this location in the
+                    `source` field of the created model version. ===
+                """,
+                new_source)
         return self._get_registry_client().create_model_version(name, new_source, run_id, tags)
 
     @experimental

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -550,8 +550,8 @@ class MlflowClient(object):
             # of the model version creation.
             _logger.info(
                 """
-                === Source model files were copied to %s 
-                    in the model registry workspace. You may want to delete the files once the 
+                === Source model files were copied to %s
+                    in the model registry workspace. You may want to delete the files once the
                     model version is in 'READY' status. You can also find this location in the
                     `source` field of the created model version. ===
                 """,

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -96,6 +96,9 @@ def add_databricks_profile_info_to_artifact_uri(artifact_uri, databricks_profile
             if ':' in profile:
                 raise MlflowException("Unsupported Databricks profile name: %s." % profile +
                                       " Profile names cannot contain ':'.")
+            if key_prefix and '/' in key_prefix:
+                raise MlflowException("Unsupported Databricks profile key prefix: %s."
+                                      % key_prefix + " Key prefixes cannot contain '/'.")
             prefix = ":" + key_prefix if key_prefix else ""
             netloc = profile + prefix + "@databricks"
         new_parsed = artifact_uri_parsed._replace(netloc=netloc)

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -45,6 +45,44 @@ def get_db_info_from_uri(uri):
     return None, None
 
 
+# TODO(sueann): write unit tests
+def get_databricks_profile_uri_from_artifact_uri(uri):
+    parsed = urllib.parse.urlparse(uri).netloc
+    if not parsed.netloc or parsed.host != 'databricks':
+        return None
+    key_prefix = '/' + parsed.password if parsed.password else ''
+    return 'databricks://' + parsed.username + key_prefix
+
+
+# TODO(sueann): write lots of unit tests
+def remove_databricks_profile_info_from_artifact_uri(artifact_uri):
+    # TODO(sueann): implement
+    return artifact_uri
+
+
+# TODO(sueann): write lots of unit tests
+def add_databricks_profile_info_to_artifact_uri(artifact_uri, databricks_profile_uri):
+    """
+    TODO(sueann)
+    :param artifact_uri:
+    :param databricks_profile_uri:
+    :return:
+    """
+    if not databricks_profile_uri or not is_databricks_uri(databricks_profile_uri):
+        return artifact_uri
+    artifact_uri_parsed = urllib.parse.urlparse(artifact_uri)
+    scheme = artifact_uri_parsed.scheme
+    if artifact_uri_parsed.netloc:
+        return artifact_uri
+    if scheme == 'dbfs' or scheme == 'runs' or scheme == 'models':
+        db_profile_parts = urllib.parse.urlparse(databricks_profile_uri)
+        # TODO(sueann): validate path --
+        netloc = db_profile_parts.netloc + ":" + db_profile_parts.path + "@databricks"
+        artifact_uri_parsed._replace(netloc=netloc)
+        return urllib.parse.urlunparse(artifact_uri_parsed)
+    return artifact_uri
+
+
 def extract_db_type_from_uri(db_uri):
     """
     Parse the specified DB URI to extract the database type. Confirm the database type is

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -49,6 +49,11 @@ def get_db_info_from_uri(uri):
 
 
 def get_databricks_profile_uri_from_artifact_uri(uri):
+    """
+    Retrieves the netloc portion of the URI as a ``databricks://`` URI,
+    if it is a proper Databricks profile specification, e.g.
+    ``profile@databricks`` or ``secret_scope:key_prefix@databricks``.
+    """
     parsed = urllib.parse.urlparse(uri)
     if not parsed.netloc or parsed.hostname != 'databricks':
         return None
@@ -60,6 +65,11 @@ def get_databricks_profile_uri_from_artifact_uri(uri):
 
 
 def remove_databricks_profile_info_from_artifact_uri(artifact_uri):
+    """
+    Only removes the netloc portion of the URI if it is a Databricks
+    profile specification, e.g.
+    ``profile@databricks`` or ``secret_scope:key_prefix@databricks``.
+    """
     parsed = urllib.parse.urlparse(artifact_uri)
     if not parsed.netloc or parsed.hostname != 'databricks':
         return artifact_uri
@@ -67,6 +77,9 @@ def remove_databricks_profile_info_from_artifact_uri(artifact_uri):
 
 
 def add_databricks_profile_info_to_artifact_uri(artifact_uri, databricks_profile_uri):
+    """
+    Throws an exception if ``databricks_profile_uri`` is not valid.
+    """
     if not databricks_profile_uri or not is_databricks_uri(databricks_profile_uri):
         return artifact_uri
     artifact_uri_parsed = urllib.parse.urlparse(artifact_uri)
@@ -206,3 +219,11 @@ def construct_run_url(hostname, experiment_id, run_id, workspace_id=None):
     return prefix + '#mlflow/experiments/{experiment_id}/runs/{run_id}'.format(
         experiment_id=experiment_id,
         run_id=run_id)
+
+
+def is_valid_dbfs_uri(uri):
+    parsed = urllib.parse.urlparse(uri)
+    if parsed.scheme != 'dbfs':
+        return False
+    db_profile_uri = get_databricks_profile_uri_from_artifact_uri(uri)
+    return not parsed.netloc or db_profile_uri is not None

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -461,3 +461,9 @@ class TestDatabricksArtifactRepository(object):
             with pytest.raises(MlflowException):
                 databricks_artifact_repo.download_artifacts(test_file.strpath)
             read_credentials_mock.assert_called_with(MOCK_RUN_ID, test_file.strpath)
+
+
+## TODO(sueann): add tests for
+#   - self.databricks_profile_uri set correctly (empty, profile, scope:key, error)
+#   - also add the URI with profile case to other method unit tests,
+#     especially one that uses _call_endpoint

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -78,6 +78,9 @@ class TestDatabricksArtifactRepository(object):
                 DatabricksArtifactRepository('s3://test')
             with pytest.raises(MlflowException):
                 DatabricksArtifactRepository('dbfs:/databricks/mlflow/EXP/RUN/artifact')
+            with pytest.raises(MlflowException):
+                DatabricksArtifactRepository(
+                    'dbfs://scope:key@notdatabricks/databricks/mlflow-tracking/experiment/1/run/2')
 
     @pytest.mark.parametrize("artifact_uri, expected_uri, expected_db_uri", [
         ('dbfs:/databricks/mlflow-tracking/experiment/1/run/2',

--- a/tests/store/artifact/test_dbfs_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_artifact_repo.py
@@ -1,0 +1,90 @@
+import pytest
+import mock
+
+from mlflow.exceptions import MlflowException
+from mlflow.store.artifact.dbfs_artifact_repo import dbfs_artifact_repo_factory, \
+    DbfsRestArtifactRepository
+from mlflow.store.artifact.local_artifact_repo import LocalArtifactRepository
+from mlflow.store.artifact.databricks_artifact_repo import DatabricksArtifactRepository
+
+
+@pytest.mark.parametrize("artifact_uri, uri_at_init", [
+    ('dbfs:/path', 'file:///dbfs/path'),
+    ('dbfs://databricks/path', 'file:///dbfs/path'),
+])
+def test_dbfs_artifact_repo_factory_local_repo(artifact_uri, uri_at_init):
+    with mock.patch('mlflow.utils.databricks_utils.is_dbfs_fuse_available', return_value=True), \
+         mock.patch('mlflow.store.artifact.dbfs_artifact_repo.LocalArtifactRepository',
+                    autospec=True) as mock_repo:
+        repo = dbfs_artifact_repo_factory(artifact_uri)
+        assert isinstance(repo, LocalArtifactRepository)
+        mock_repo.assert_called_once_with(uri_at_init)
+
+
+@pytest.mark.parametrize("artifact_uri", [
+    ('dbfs://someProfile@databricks/path'),
+    ('dbfs://somewhere:else@databricks/path'),
+])
+def test_dbfs_artifact_repo_factory_dbfs_rest_repo(artifact_uri):
+    with mock.patch('mlflow.utils.databricks_utils.is_dbfs_fuse_available', return_value=True), \
+            mock.patch('mlflow.store.artifact.dbfs_artifact_repo.DbfsRestArtifactRepository',
+                       autospec=True) as mock_repo:
+        repo = dbfs_artifact_repo_factory(artifact_uri)
+        assert isinstance(repo, DbfsRestArtifactRepository)
+        mock_repo.assert_called_once_with(artifact_uri)
+
+
+################
+# # TODO(sueann): mock the Repo class and just check for the uri_at_init like ^
+# @pytest.mark.parametrize("artifact_uri, expected_uri, expected_databricks_uri", [
+#     ('dbfs:/databricks/mlflow-tracking/experiment/1/run/2',
+#      'dbfs:/databricks/mlflow-tracking/experiment/1/run/2',
+#      'databricks://getTrackingUriDefault'),  # see test body for the mock
+#     ('dbfs://@databricks/databricks/mlflow-tracking/experiment/1/run/2',
+#      'dbfs:/databricks/mlflow-tracking/experiment/1/run/2',
+#      'databricks'),
+#     ('dbfs://someProfile@databricks/databricks/mlflow-tracking/experiment/1/run/2',
+#      'dbfs:/databricks/mlflow-tracking/experiment/1/run/2',
+#      'databricks://someProfile'),
+# ])
+# def test_dbfs_artifact_repo_factory_acled_paths(artifact_uri, expected_uri,
+#                                                 expected_databricks_uri):
+#     repo_pkg_path = "mlflow.store.artifact.databricks_artifact_repo"
+#     with mock.patch('mlflow.utils.databricks_utils.is_dbfs_fuse_available', return_value=True), \
+#             mock.patch(repo_pkg_path + ".get_databricks_host_creds",
+#                        return_value=None), \
+#             mock.patch(repo_pkg_path + ".DatabricksArtifactRepository._get_run_artifact_root",
+#                        return_value='whatever'), \
+#             mock.patch("mlflow.tracking.get_tracking_uri",
+#                        return_value='databricks://getTrackingUriDefault'):
+#         repo = dbfs_artifact_repo_factory(artifact_uri)
+#         assert isinstance(repo, DatabricksArtifactRepository)
+#         assert repo.artifact_uri == expected_uri
+#         assert repo.databricks_profile_uri == expected_databricks_uri
+
+@pytest.mark.parametrize("artifact_uri", [
+    ('dbfs:/databricks/mlflow-tracking/experiment/1/run/2'),
+    ('dbfs://@databricks/databricks/mlflow-tracking/experiment/1/run/2'),
+    ('dbfs://someProfile@databricks/databricks/mlflow-tracking/experiment/1/run/2'),
+])
+def test_dbfs_artifact_repo_factory_acled_paths(artifact_uri):
+    repo_pkg_path = "mlflow.store.artifact.databricks_artifact_repo"
+    with mock.patch('mlflow.utils.databricks_utils.is_dbfs_fuse_available', return_value=True), \
+         mock.patch('mlflow.store.artifact.dbfs_artifact_repo.DatabricksArtifactRepository',
+                    autospec=True) as mock_repo, \
+            mock.patch(repo_pkg_path + ".get_databricks_host_creds",
+                       return_value=None), \
+            mock.patch(repo_pkg_path + ".DatabricksArtifactRepository._get_run_artifact_root",
+                       return_value='whatever'):
+        repo = dbfs_artifact_repo_factory(artifact_uri)
+        assert isinstance(repo, DatabricksArtifactRepository)
+        mock_repo.assert_called_once_with(artifact_uri)
+
+
+@pytest.mark.parametrize("artifact_uri", [
+    ('notdbfs:/path'),
+    ('dbfs://some:where@notdatabricks/path'),
+])
+def test_dbfs_artifact_repo_factory_errors(artifact_uri):
+    with pytest.raises(MlflowException):
+        dbfs_artifact_repo_factory(artifact_uri)

--- a/tests/store/artifact/test_dbfs_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_artifact_repo.py
@@ -34,34 +34,6 @@ def test_dbfs_artifact_repo_factory_dbfs_rest_repo(artifact_uri):
         mock_repo.assert_called_once_with(artifact_uri)
 
 
-################
-# # TODO(sueann): mock the Repo class and just check for the uri_at_init like ^
-# @pytest.mark.parametrize("artifact_uri, expected_uri, expected_databricks_uri", [
-#     ('dbfs:/databricks/mlflow-tracking/experiment/1/run/2',
-#      'dbfs:/databricks/mlflow-tracking/experiment/1/run/2',
-#      'databricks://getTrackingUriDefault'),  # see test body for the mock
-#     ('dbfs://@databricks/databricks/mlflow-tracking/experiment/1/run/2',
-#      'dbfs:/databricks/mlflow-tracking/experiment/1/run/2',
-#      'databricks'),
-#     ('dbfs://someProfile@databricks/databricks/mlflow-tracking/experiment/1/run/2',
-#      'dbfs:/databricks/mlflow-tracking/experiment/1/run/2',
-#      'databricks://someProfile'),
-# ])
-# def test_dbfs_artifact_repo_factory_acled_paths(artifact_uri, expected_uri,
-#                                                 expected_databricks_uri):
-#     repo_pkg_path = "mlflow.store.artifact.databricks_artifact_repo"
-#     with mock.patch('mlflow.utils.databricks_utils.is_dbfs_fuse_available', return_value=True), \
-#             mock.patch(repo_pkg_path + ".get_databricks_host_creds",
-#                        return_value=None), \
-#             mock.patch(repo_pkg_path + ".DatabricksArtifactRepository._get_run_artifact_root",
-#                        return_value='whatever'), \
-#             mock.patch("mlflow.tracking.get_tracking_uri",
-#                        return_value='databricks://getTrackingUriDefault'):
-#         repo = dbfs_artifact_repo_factory(artifact_uri)
-#         assert isinstance(repo, DatabricksArtifactRepository)
-#         assert repo.artifact_uri == expected_uri
-#         assert repo.databricks_profile_uri == expected_databricks_uri
-
 @pytest.mark.parametrize("artifact_uri", [
     ('dbfs:/databricks/mlflow-tracking/experiment/1/run/2'),
     ('dbfs://@databricks/databricks/mlflow-tracking/experiment/1/run/2'),
@@ -70,8 +42,8 @@ def test_dbfs_artifact_repo_factory_dbfs_rest_repo(artifact_uri):
 def test_dbfs_artifact_repo_factory_acled_paths(artifact_uri):
     repo_pkg_path = "mlflow.store.artifact.databricks_artifact_repo"
     with mock.patch('mlflow.utils.databricks_utils.is_dbfs_fuse_available', return_value=True), \
-         mock.patch('mlflow.store.artifact.dbfs_artifact_repo.DatabricksArtifactRepository',
-                    autospec=True) as mock_repo, \
+            mock.patch('mlflow.store.artifact.dbfs_artifact_repo.DatabricksArtifactRepository',
+                       autospec=True) as mock_repo, \
             mock.patch(repo_pkg_path + ".get_databricks_host_creds",
                        return_value=None), \
             mock.patch(repo_pkg_path + ".DatabricksArtifactRepository._get_run_artifact_root",

--- a/tests/store/artifact/test_dbfs_rest_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_rest_artifact_repo.py
@@ -80,6 +80,8 @@ class TestDbfsArtifactRepository(object):
             assert repo.artifact_uri == 'dbfs:/test'
             with pytest.raises(MlflowException):
                 DbfsRestArtifactRepository('s3://test')
+            with pytest.raises(MlflowException):
+                DbfsRestArtifactRepository('dbfs://profile@notdatabricks/test/')
 
     def test_init_get_host_creds_with_databricks_profile_uri(self):
         databricks_host = 'https://something.databricks.com'

--- a/tests/store/artifact/test_dbfs_rest_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_rest_artifact_repo.py
@@ -8,8 +8,8 @@ from mock import Mock
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
-from mlflow.store.artifact.dbfs_artifact_repo import _get_host_creds_from_default_store
-from mlflow.store.artifact.dbfs_artifact_repo import DbfsRestArtifactRepository
+from mlflow.store.artifact.dbfs_artifact_repo import _get_host_creds_from_default_store, \
+    DbfsRestArtifactRepository
 from mlflow.store.tracking.file_store import FileStore
 from mlflow.store.tracking.rest_store import RestStore
 from mlflow.utils.rest_utils import MlflowHostCreds
@@ -80,6 +80,22 @@ class TestDbfsArtifactRepository(object):
             assert repo.artifact_uri == 'dbfs:/test'
             with pytest.raises(MlflowException):
                 DbfsRestArtifactRepository('s3://test')
+
+    def test_init_get_host_creds_with_databricks_profile_uri(self):
+        databricks_host = 'https://something.databricks.com'
+        default_host = 'http://host'
+        with mock.patch(DBFS_ARTIFACT_REPOSITORY_PACKAGE + '._get_host_creds_from_default_store',
+                        return_value=lambda: MlflowHostCreds(default_host)), \
+                mock.patch(DBFS_ARTIFACT_REPOSITORY_PACKAGE + '.get_databricks_host_creds',
+                           return_value=MlflowHostCreds(databricks_host)):
+            repo = DbfsRestArtifactRepository('dbfs://profile@databricks/test/')
+            assert repo.artifact_uri == 'dbfs:/test/'
+            creds = repo.get_host_creds()
+            assert creds.host == databricks_host
+            # no databricks_profile_uri given
+            repo = DbfsRestArtifactRepository('dbfs:/test/')
+            creds = repo.get_host_creds()
+            assert creds.host == default_host
 
     @pytest.mark.parametrize("artifact_path,expected_endpoint", [
         (None, '/dbfs/test/test.txt'),
@@ -228,10 +244,3 @@ def test_get_host_creds_from_default_store_rest_store():
     with mock.patch('mlflow.tracking._tracking_service.utils._get_store') as get_store_mock:
         get_store_mock.return_value = RestStore(lambda: MlflowHostCreds('http://host'))
         assert isinstance(_get_host_creds_from_default_store()(), MlflowHostCreds)
-
-
-# TODO(sueann): add tests
-#   - the one from the original PR that tests self.get_host_creds
-
-
-# TODO(sueann): add tests for dbfs_artifact_repo_factory

--- a/tests/store/artifact/test_dbfs_rest_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_rest_artifact_repo.py
@@ -228,3 +228,10 @@ def test_get_host_creds_from_default_store_rest_store():
     with mock.patch('mlflow.tracking._tracking_service.utils._get_store') as get_store_mock:
         get_store_mock.return_value = RestStore(lambda: MlflowHostCreds('http://host'))
         assert isinstance(_get_host_creds_from_default_store()(), MlflowHostCreds)
+
+
+# TODO(sueann): add tests
+#   - the one from the original PR that tests self.get_host_creds
+
+
+# TODO(sueann): add tests for dbfs_artifact_repo_factory

--- a/tests/store/artifact/test_models_artifact_repo.py
+++ b/tests/store/artifact/test_models_artifact_repo.py
@@ -96,3 +96,10 @@ def test_models_artifact_repo_uses_repo_download_artifacts():
         models_repo.repo = Mock()
         models_repo.download_artifacts('artifact_path', 'dst_path')
         models_repo.repo.download_artifacts.assert_called_once()
+
+
+## TODO(sueann): add tests for - basically the same ones as test_runs_artifact_repo
+#   - get_underlying_uri (empty, profile, scope:key, error, non-dbfs)
+#   - on init, self.repo is set properly (empty, profile, scope:key, error, non-dbfs)
+#   - also add the URI with profile case to other method unit tests,
+#     especially ones that deal with URI

--- a/tests/store/artifact/test_models_artifact_repo.py
+++ b/tests/store/artifact/test_models_artifact_repo.py
@@ -16,6 +16,7 @@ from tests.store.artifact.test_dbfs_artifact_repo_delegation import host_creds_m
     ('models:/AdsModel1/0', 'AdsModel1', 0),
     ('models:/Ads Model 1/12345', 'Ads Model 1', 12345),
     ('models:/12345/67890', '12345', 67890),
+    ('models://profile@databricks/12345/67890', '12345', 67890),
 ])
 def test_parse_models_uri_with_version(uri, expected_name, expected_version):
     (name, version, stage) = ModelsArtifactRepository._parse_uri(uri)
@@ -27,6 +28,7 @@ def test_parse_models_uri_with_version(uri, expected_name, expected_version):
 @pytest.mark.parametrize("uri, expected_name, expected_stage", [
     ('models:/AdsModel1/Production', 'AdsModel1', "Production"),
     ('models:/Ads Model 1/None', 'Ads Model 1', "None"),
+    ('models://scope:key@databricks/Ads Model 1/None', 'Ads Model 1', "None"),
 ])
 def test_parse_models_uri_with_stage(uri, expected_name, expected_stage):
     (name, version, stage) = ModelsArtifactRepository._parse_uri(uri)
@@ -41,7 +43,7 @@ def test_parse_models_uri_with_stage(uri, expected_name, expected_stage):
     'models:/',                          # no model name
     'models:/Name/Stage/0',              # too many specifiers
     'models:Name/Stage',                 # missing slash
-    'models://Name/Stage',               # hostnames are not yet supported
+    'models://Name/Stage',               # hostnames are ignored, path too short
 ])
 def test_parse_models_uri_invalid_input(uri):
     with pytest.raises(MlflowException):
@@ -51,7 +53,7 @@ def test_parse_models_uri_invalid_input(uri):
 def test_models_artifact_repo_init_with_version_uri(
         host_creds_mock):  # pylint: disable=unused-argument
     model_uri = "models:/MyModel/12"
-    artifact_location = "dbfs://databricks/mlflow-registry/12345/models/keras-model"
+    artifact_location = "dbfs:/databricks/mlflow-registry/12345/models/keras-model"
     get_model_version_download_uri_patch = mock.patch.object(MlflowClient,
                                                              "get_model_version_download_uri",
                                                              return_value=artifact_location)
@@ -62,10 +64,26 @@ def test_models_artifact_repo_init_with_version_uri(
         assert models_repo.repo.artifact_uri == artifact_location
 
 
+def test_models_artifact_repo_init_with_version_uri_and_db_profile():
+    model_uri = "models://profile@databricks/MyModel/12"
+    artifact_location = "dbfs:/databricks/mlflow-registry/12345/models/keras-model"
+    final_uri = "dbfs://profile@databricks/databricks/mlflow-registry/12345/models/keras-model"
+    get_model_version_download_uri_patch = mock.patch.object(MlflowClient,
+                                                             "get_model_version_download_uri",
+                                                             return_value=artifact_location)
+    with get_model_version_download_uri_patch, \
+            mock.patch('mlflow.store.artifact.dbfs_artifact_repo.DbfsRestArtifactRepository',
+                       autospec=True) as mock_repo:
+        models_repo = ModelsArtifactRepository(model_uri)
+        assert models_repo.artifact_uri == model_uri
+        assert isinstance(models_repo.repo, DbfsRestArtifactRepository)
+        mock_repo.assert_called_once_with(final_uri)
+
+
 def test_models_artifact_repo_init_with_stage_uri(
         host_creds_mock):  # pylint: disable=unused-argument
     model_uri = "models:/MyModel/Production"
-    artifact_location = "dbfs://databricks/mlflow-registry/12345/models/keras-model"
+    artifact_location = "dbfs:/databricks/mlflow-registry/12345/models/keras-model"
     model_version_detailed = ModelVersion("MyModel", "10", "2345671890", "234567890",
                                           "some description", "UserID",
                                           "Production", "source", "run12345")
@@ -79,6 +97,27 @@ def test_models_artifact_repo_init_with_stage_uri(
         assert models_repo.artifact_uri == model_uri
         assert isinstance(models_repo.repo, DbfsRestArtifactRepository)
         assert models_repo.repo.artifact_uri == artifact_location
+
+
+def test_models_artifact_repo_init_with_stage_uri_and_db_profile():
+    model_uri = "models://profile@databricks/MyModel/Staging"
+    artifact_location = "dbfs:/databricks/mlflow-registry/12345/models/keras-model"
+    final_uri = "dbfs://profile@databricks/databricks/mlflow-registry/12345/models/keras-model"
+    model_version_detailed = ModelVersion("MyModel", "10", "2345671890", "234567890",
+                                          "some description", "UserID",
+                                          "Production", "source", "run12345")
+    get_latest_versions_patch = mock.patch.object(MlflowClient, "get_latest_versions",
+                                                  return_value=[model_version_detailed])
+    get_model_version_download_uri_patch = mock.patch.object(MlflowClient,
+                                                             "get_model_version_download_uri",
+                                                             return_value=artifact_location)
+    with get_latest_versions_patch, get_model_version_download_uri_patch, \
+            mock.patch('mlflow.store.artifact.dbfs_artifact_repo.DbfsRestArtifactRepository',
+                       autospec=True) as mock_repo:
+        models_repo = ModelsArtifactRepository(model_uri)
+        assert models_repo.artifact_uri == model_uri
+        assert isinstance(models_repo.repo, DbfsRestArtifactRepository)
+        mock_repo.assert_called_once_with(final_uri)
 
 
 def test_models_artifact_repo_uses_repo_download_artifacts():
@@ -96,10 +135,3 @@ def test_models_artifact_repo_uses_repo_download_artifacts():
         models_repo.repo = Mock()
         models_repo.download_artifacts('artifact_path', 'dst_path')
         models_repo.repo.download_artifacts.assert_called_once()
-
-
-## TODO(sueann): add tests for - basically the same ones as test_runs_artifact_repo
-#   - get_underlying_uri (empty, profile, scope:key, error, non-dbfs)
-#   - on init, self.repo is set properly (empty, profile, scope:key, error, non-dbfs)
-#   - also add the URI with profile case to other method unit tests,
-#     especially ones that deal with URI

--- a/tests/store/artifact/test_runs_artifact_repo.py
+++ b/tests/store/artifact/test_runs_artifact_repo.py
@@ -58,3 +58,10 @@ def test_runs_artifact_repo_uses_repo_download_artifacts():
     runs_repo.repo = Mock()
     runs_repo.download_artifacts('artifact_path', 'dst_path')
     runs_repo.repo.download_artifacts.assert_called_once()
+
+
+## TODO(sueann): add tests for
+#   - get_underlying_uri (empty, profile, scope:key, error, non-dbfs)
+#   - on init, self.repo is set properly (empty, profile, scope:key, error, non-dbfs)
+#   - also add the URI with profile case to other method unit tests,
+#     especially ones that deal with URI

--- a/tests/store/artifact/test_runs_artifact_repo.py
+++ b/tests/store/artifact/test_runs_artifact_repo.py
@@ -1,4 +1,5 @@
 import pytest
+import mock
 from mock import Mock
 
 import mlflow
@@ -10,9 +11,11 @@ from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 @pytest.mark.parametrize("uri, expected_run_id, expected_artifact_path", [
     ('runs:/1234abcdf1394asdfwer33/path/to/model', '1234abcdf1394asdfwer33', 'path/to/model'),
     ('runs:/1234abcdf1394asdfwer33/path/to/model/', '1234abcdf1394asdfwer33', 'path/to/model/'),
+    ('runs://profile@databricks/1234abcdf1394asdfwer33/path', '1234abcdf1394asdfwer33', 'path'),
     ('runs:/1234abcdf1394asdfwer33', '1234abcdf1394asdfwer33', None),
     ('runs:/1234abcdf1394asdfwer33/', '1234abcdf1394asdfwer33', None),
     ('runs:///1234abcdf1394asdfwer33/', '1234abcdf1394asdfwer33', None),
+    ('runs://profile@databricks/1234abcdf1394asdfwer33/', '1234abcdf1394asdfwer33', None),
 ])
 def test_parse_runs_uri_valid_input(uri, expected_run_id, expected_artifact_path):
     (run_id, artifact_path) = RunsArtifactRepository.parse_runs_uri(uri)
@@ -31,7 +34,28 @@ def test_parse_runs_uri_invalid_input(uri):
         RunsArtifactRepository.parse_runs_uri(uri)
 
 
-def test_runs_artifact_repo_init():
+@pytest.mark.parametrize(
+    "uri, expected_tracking_uri, mock_uri, expected_result_uri", [
+        ('runs:/1234abcdf1394asdfwer33/path/model', None, 's3:/some/path', 's3:/some/path'),
+        ('runs:/1234abcdf1394asdfwer33/path/model', None, 'dbfs:/some/path', 'dbfs:/some/path'),
+        ('runs://profile@databricks/1234abcdf1394asdfwer33/path/model', 'databricks://profile',
+         's3:/some/path', 's3:/some/path'),
+        ('runs://profile@databricks/1234abcdf1394asdfwer33/path/model', 'databricks://profile',
+         'dbfs:/some/path', 'dbfs://profile@databricks/some/path'),
+        ('runs://scope:key@databricks/1234abcdf1394asdfwer33/path/model', 'databricks://scope/key',
+         'dbfs:/some/path', 'dbfs://scope:key@databricks/some/path'),
+    ]
+)
+def test_get_artifact_uri(uri, expected_tracking_uri, mock_uri, expected_result_uri):
+    with mock.patch('mlflow.tracking.artifact_utils.get_artifact_uri',
+                    return_value=mock_uri) as get_artifact_uri_mock:
+        result_uri = RunsArtifactRepository.get_underlying_uri(uri)
+        get_artifact_uri_mock.assert_called_once_with('1234abcdf1394asdfwer33', 'path/model',
+                                                      expected_tracking_uri)
+        assert result_uri == expected_result_uri
+
+
+def test_runs_artifact_repo_init_with_real_run():
     artifact_location = "s3://blah_bucket/"
     experiment_id = mlflow.create_experiment("expr_abc", artifact_location)
     with mlflow.start_run(experiment_id=experiment_id):
@@ -58,10 +82,3 @@ def test_runs_artifact_repo_uses_repo_download_artifacts():
     runs_repo.repo = Mock()
     runs_repo.download_artifacts('artifact_path', 'dst_path')
     runs_repo.repo.download_artifacts.assert_called_once()
-
-
-## TODO(sueann): add tests for
-#   - get_underlying_uri (empty, profile, scope:key, error, non-dbfs)
-#   - on init, self.repo is set properly (empty, profile, scope:key, error, non-dbfs)
-#   - also add the URI with profile case to other method unit tests,
-#     especially ones that deal with URI

--- a/tests/tracking/test_artifact_utils.py
+++ b/tests/tracking/test_artifact_utils.py
@@ -80,5 +80,3 @@ def test_upload_artifacts_to_databricks_no_run_id():
             'dbfs://registry@databricks/databricks/mlflow/tmp-external-source/')
         assert new_source == 'dbfs:/databricks/mlflow/tmp-external-source/' \
             '4f746cdcc0374da2808917e81bb53323/sourcedir'
-
-

--- a/tests/tracking/test_artifact_utils.py
+++ b/tests/tracking/test_artifact_utils.py
@@ -1,7 +1,11 @@
 import os
 
+import mock
+from unittest.mock import ANY
+
 import mlflow
-from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri, \
+    _upload_artifacts_to_databricks
 
 
 def test_artifact_can_be_downloaded_from_absolute_uri_successfully(tmpdir):
@@ -45,3 +49,36 @@ def test_download_artifact_from_absolute_uri_persists_data_to_specified_output_d
     with open(os.path.join(
             artifact_output_path, logged_artifact_subdir, artifact_file_name), "r") as f:
         assert f.read() == artifact_text
+
+
+def test_upload_artifacts_to_databricks():
+    import_root = 'mlflow.tracking.artifact_utils'
+    with mock.patch(import_root + "._download_artifact_from_uri") as download_mock, \
+            mock.patch(import_root + ".DbfsRestArtifactRepository") as repo_mock:
+        new_source = _upload_artifacts_to_databricks('dbfs:/original/sourcedir/', 'runid12345',
+                                                     'databricks://tracking',
+                                                     'databricks://registry/ws')
+        download_mock.assert_called_once_with('dbfs://tracking@databricks/original/sourcedir/',
+                                              ANY)
+        repo_mock.assert_called_once_with(
+            'dbfs://registry:ws@databricks/databricks/mlflow/tmp-external-source/')
+        assert new_source == 'dbfs:/databricks/mlflow/tmp-external-source/runid12345/sourcedir'
+
+
+def test_upload_artifacts_to_databricks_no_run_id():
+    from uuid import UUID
+    import_root = 'mlflow.tracking.artifact_utils'
+    with mock.patch(import_root + "._download_artifact_from_uri") as download_mock, \
+            mock.patch(import_root + ".DbfsRestArtifactRepository") as repo_mock, \
+            mock.patch("uuid.uuid4", return_value=UUID("4f746cdcc0374da2808917e81bb53323")):
+        new_source = _upload_artifacts_to_databricks('dbfs:/original/sourcedir/', None,
+                                                     'databricks://tracking/ws',
+                                                     'databricks://registry')
+        download_mock.assert_called_once_with('dbfs://tracking:ws@databricks/original/sourcedir/',
+                                              ANY)
+        repo_mock.assert_called_once_with(
+            'dbfs://registry@databricks/databricks/mlflow/tmp-external-source/')
+        assert new_source == 'dbfs:/databricks/mlflow/tmp-external-source/' \
+            '4f746cdcc0374da2808917e81bb53323/sourcedir'
+
+

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -279,8 +279,8 @@ def test_create_model_version_explicitly_set_run_link(mock_registry_store):
     # mocks to make sure that even if you're in a notebook, this setting is respected.
     with mock.patch('mlflow.tracking.client.is_in_databricks_notebook',
                     return_value=True), \
-        mock.patch('mlflow.tracking.client.get_workspace_info_from_dbutils',
-                   return_value=(hostname, workspace_id)):
+            mock.patch('mlflow.tracking.client.get_workspace_info_from_dbutils',
+                       return_value=(hostname, workspace_id)):
         client = MlflowClient(tracking_uri='databricks', registry_uri='otherplace')
         model_version = client.create_model_version('name', 'source', 'runid', run_link=run_link)
         assert(model_version.run_link == run_link)
@@ -300,8 +300,8 @@ def test_create_model_version_run_link_in_notebook_with_default_profile(mock_reg
                                     None)
     with mock.patch('mlflow.tracking.client.is_in_databricks_notebook',
                     return_value=True), \
-        mock.patch('mlflow.tracking.client.get_workspace_info_from_dbutils',
-                   return_value=(hostname, workspace_id)):
+            mock.patch('mlflow.tracking.client.get_workspace_info_from_dbutils',
+                       return_value=(hostname, workspace_id)):
         client = MlflowClient(tracking_uri='databricks', registry_uri='otherplace')
         client.get_run = get_run_mock
         mock_registry_store.create_model_version.return_value = \
@@ -322,9 +322,9 @@ def test_create_model_version_run_link_with_configured_profile(mock_registry_sto
     get_run_mock = mock.MagicMock()
     get_run_mock.return_value = Run(RunInfo(run_id, experiment_id, 'userid', 'status', 0, 1, None),
                                     None)
-    with mock.patch('mlflow.tracking.client.is_in_databricks_notebook', return_value=False), mock\
-            .patch('mlflow.tracking.client.get_workspace_info_from_databricks_secrets',
-                   return_value=(hostname, workspace_id)):
+    with mock.patch('mlflow.tracking.client.is_in_databricks_notebook', return_value=False), \
+            mock.patch('mlflow.tracking.client.get_workspace_info_from_databricks_secrets',
+                       return_value=(hostname, workspace_id)):
         client = MlflowClient(tracking_uri='databricks', registry_uri='otherplace')
         client.get_run = get_run_mock
         mock_registry_store.create_model_version.return_value = \
@@ -339,10 +339,11 @@ def test_create_model_version_run_link_with_configured_profile(mock_registry_sto
 def test_create_model_version_copy_called_db_to_db(mock_registry_store):
     client = MlflowClient(tracking_uri="databricks://tracking",
                           registry_uri="databricks://registry:workspace")
-    mock_registry_store.create_model_version.return_value = ""
+    # mock_registry_store.create_model_version.return_value = ""
     with mock.patch("mlflow.tracking.client._upload_artifacts_to_databricks") \
             as upload_mock:
-        client.create_model_version("model name", "dbfs:/source", "run_12345")
+        client.create_model_version("model name", "dbfs:/source", "run_12345",
+                                    run_link='not:/important/for/test')
         upload_mock.assert_called_once_with("dbfs:/source", "run_12345", "databricks://tracking",
                                             "databricks://registry:workspace")
 
@@ -353,7 +354,8 @@ def test_create_model_version_copy_called_nondb_to_db(mock_registry_store):
     mock_registry_store.create_model_version.return_value = ""
     with mock.patch("mlflow.tracking.client._upload_artifacts_to_databricks") \
             as upload_mock:
-        client.create_model_version("model name", "s3:/source", "run_12345")
+        client.create_model_version("model name", "s3:/source", "run_12345",
+                                    run_link='not:/important/for/test')
         upload_mock.assert_called_once_with("s3:/source", "run_12345", "https://tracking",
                                             "databricks://registry:workspace")
 
@@ -364,7 +366,8 @@ def test_create_model_version_copy_not_called_to_db(mock_registry_store):
     mock_registry_store.create_model_version.return_value = ""
     with mock.patch("mlflow.tracking.client._upload_artifacts_to_databricks") \
             as upload_mock:
-        client.create_model_version("model name", "dbfs:/source", "run_12345")
+        client.create_model_version("model name", "dbfs:/source", "run_12345",
+                                    run_link='not:/important/for/test')
         upload_mock.assert_not_called()
 
 
@@ -374,6 +377,6 @@ def test_create_model_version_copy_not_called_to_nondb(mock_registry_store):
     mock_registry_store.create_model_version.return_value = ""
     with mock.patch("mlflow.tracking.client._upload_artifacts_to_databricks") \
             as upload_mock:
-        client.create_model_version("model name", "dbfs:/source", "run_12345")
+        client.create_model_version("model name", "dbfs:/source", "run_12345",
+                                    run_link='not:/important/for/test')
         upload_mock.assert_not_called()
-

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -339,6 +339,7 @@ def test_create_model_version_run_link_with_configured_profile(mock_registry_sto
 def test_create_model_version_copy_called_db_to_db(mock_registry_store):
     client = MlflowClient(tracking_uri="databricks://tracking",
                           registry_uri="databricks://registry:workspace")
+    mock_registry_store.create_model_version.return_value = ""
     with mock.patch("mlflow.tracking.client._upload_artifacts_to_databricks") \
             as upload_mock:
         client.create_model_version("model name", "dbfs:/source", "run_12345",
@@ -350,6 +351,7 @@ def test_create_model_version_copy_called_db_to_db(mock_registry_store):
 def test_create_model_version_copy_called_nondb_to_db(mock_registry_store):
     client = MlflowClient(tracking_uri="https://tracking",
                           registry_uri="databricks://registry:workspace")
+    mock_registry_store.create_model_version.return_value = ""
     with mock.patch("mlflow.tracking.client._upload_artifacts_to_databricks") \
             as upload_mock:
         client.create_model_version("model name", "s3:/source", "run_12345",
@@ -361,6 +363,7 @@ def test_create_model_version_copy_called_nondb_to_db(mock_registry_store):
 def test_create_model_version_copy_not_called_to_db(mock_registry_store):
     client = MlflowClient(tracking_uri="databricks://registry:workspace",
                           registry_uri="databricks://registry:workspace")
+    mock_registry_store.create_model_version.return_value = ""
     with mock.patch("mlflow.tracking.client._upload_artifacts_to_databricks") \
             as upload_mock:
         client.create_model_version("model name", "dbfs:/source", "run_12345",
@@ -371,6 +374,7 @@ def test_create_model_version_copy_not_called_to_db(mock_registry_store):
 def test_create_model_version_copy_not_called_to_nondb(mock_registry_store):
     client = MlflowClient(tracking_uri="databricks://tracking",
                           registry_uri="https://registry")
+    mock_registry_store.create_model_version.return_value = ""
     with mock.patch("mlflow.tracking.client._upload_artifacts_to_databricks") \
             as upload_mock:
         client.create_model_version("model name", "dbfs:/source", "run_12345",

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -339,7 +339,6 @@ def test_create_model_version_run_link_with_configured_profile(mock_registry_sto
 def test_create_model_version_copy_called_db_to_db(mock_registry_store):
     client = MlflowClient(tracking_uri="databricks://tracking",
                           registry_uri="databricks://registry:workspace")
-    # mock_registry_store.create_model_version.return_value = ""
     with mock.patch("mlflow.tracking.client._upload_artifacts_to_databricks") \
             as upload_mock:
         client.create_model_version("model name", "dbfs:/source", "run_12345",
@@ -351,7 +350,6 @@ def test_create_model_version_copy_called_db_to_db(mock_registry_store):
 def test_create_model_version_copy_called_nondb_to_db(mock_registry_store):
     client = MlflowClient(tracking_uri="https://tracking",
                           registry_uri="databricks://registry:workspace")
-    mock_registry_store.create_model_version.return_value = ""
     with mock.patch("mlflow.tracking.client._upload_artifacts_to_databricks") \
             as upload_mock:
         client.create_model_version("model name", "s3:/source", "run_12345",
@@ -363,7 +361,6 @@ def test_create_model_version_copy_called_nondb_to_db(mock_registry_store):
 def test_create_model_version_copy_not_called_to_db(mock_registry_store):
     client = MlflowClient(tracking_uri="databricks://registry:workspace",
                           registry_uri="databricks://registry:workspace")
-    mock_registry_store.create_model_version.return_value = ""
     with mock.patch("mlflow.tracking.client._upload_artifacts_to_databricks") \
             as upload_mock:
         client.create_model_version("model name", "dbfs:/source", "run_12345",
@@ -374,7 +371,6 @@ def test_create_model_version_copy_not_called_to_db(mock_registry_store):
 def test_create_model_version_copy_not_called_to_nondb(mock_registry_store):
     client = MlflowClient(tracking_uri="databricks://tracking",
                           registry_uri="https://registry")
-    mock_registry_store.create_model_version.return_value = ""
     with mock.patch("mlflow.tracking.client._upload_artifacts_to_databricks") \
             as upload_mock:
         client.create_model_version("model name", "dbfs:/source", "run_12345",

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -295,7 +295,7 @@ def test_get_databricks_profile_uri_from_artifact_uri(uri, result):
     ('ftp://user:pass@realhost:port/path/nowhere', 'ftp://user:pass@realhost:port/path/nowhere'),
     ('dbfs:/path/to/nowhere', 'dbfs:/path/to/nowhere'),
     ('dbfs://nondatabricks/path/to/nowhere', 'dbfs://nondatabricks/path/to/nowhere'),
-    ('dbfs://incorrect:netloc:format/path/to/nowhere', 'dbfs://incorrect:netloc:format/path/to/nowhere'),
+    ('dbfs://incorrect:netloc:format/path/', 'dbfs://incorrect:netloc:format/path/'),
     # URIs with legit databricks profile info
     ('dbfs://databricks', 'dbfs:'),
     ('dbfs://databricks/', 'dbfs:/'),

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -5,10 +5,10 @@ from mlflow.exceptions import MlflowException
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.utils.uri import (
     add_databricks_profile_info_to_artifact_uri, append_to_uri_path, construct_run_url,
-    extract_and_normalize_path, extract_db_type_from_uri, 
+    extract_and_normalize_path, extract_db_type_from_uri,
     get_databricks_profile_uri_from_artifact_uri, get_db_info_from_uri, get_uri_scheme,
     is_databricks_acled_artifacts_uri, is_databricks_uri, is_http_uri,
-    is_local_uri, remove_databricks_profile_info_from_artifact_uri
+    is_local_uri, is_valid_dbfs_uri, remove_databricks_profile_info_from_artifact_uri,
 )
 
 

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -322,16 +322,15 @@ def test_remove_databricks_profile_info_from_artifact_uri(uri, result):
     # test various profile URIs
     ('dbfs:/path/a/b', 'databricks', 'dbfs://databricks/path/a/b'),
     ('dbfs:/path/a/b/', 'databricks', 'dbfs://databricks/path/a/b/'),
-    ('dbfs:/path/a/b/', 'databricks://', 'dbfs://databricks/path/a/b/'),
+    ('dbfs:/path/a/b/', 'databricks://', 'dbfs://@databricks/path/a/b/'),
     ('dbfs:/path/a/b/', 'databricks://Profile', 'dbfs://Profile@databricks/path/a/b/'),
     ('dbfs:/path/a/b/', 'databricks://profile/', 'dbfs://profile@databricks/path/a/b/'),
     ('dbfs:/path/a/b/', 'databricks://scope/key', 'dbfs://scope:key@databricks/path/a/b/'),
-    ('dbfs:/path/a/b/', 'databricks://scope/key/', 'dbfs://scope:key@databricks/path/a/b/'),
     ('dbfs:/path/a/b/', 'nondatabricks://profile', 'dbfs:/path/a/b/'),
     # test various artifact schemes
     ('runs:/path/a/b/', 'databricks://Profile', 'runs://Profile@databricks/path/a/b/'),
     ('runs:/path/a/b/', 'nondatabricks://profile', 'runs:/path/a/b/'),
-    ('models:/path/a/b/', 'databricks://profile', 'models://Profile@databricks/path/a/b/'),
+    ('models:/path/a/b/', 'databricks://profile', 'models://profile@databricks/path/a/b/'),
     ('models:/path/a/b/', 'nondatabricks://Profile', 'models:/path/a/b/'),
     ('s3:/path/a/b/', 'databricks://Profile', 's3:/path/a/b/'),
     ('s3:/path/a/b/', 'nondatabricks://profile', 's3:/path/a/b/'),
@@ -351,11 +350,12 @@ def test_remove_databricks_profile_info_from_artifact_uri(uri, result):
     ('dbfs://profile@databricks/path', 'nondatabricks://Profile', 'dbfs://profile@databricks/path')
 ])
 def test_add_databricks_profile_info_to_artifact_uri(artifact_uri, profile_uri, result):
-    add_databricks_profile_info_to_artifact_uri(artifact_uri, profile_uri) == result
+    assert add_databricks_profile_info_to_artifact_uri(artifact_uri, profile_uri) == result
 
 
 @pytest.mark.parametrize("artifact_uri, profile_uri", [
-    ('dbfs:/path/a/b', 'databricks://not:legit:auth')
+    ('dbfs:/path/a/b', 'databricks://not:legit:auth'),
+    ('dbfs:/path/a/b/', 'databricks://scope/key/'),
 ])
 def test_add_databricks_profile_info_to_artifact_uri_errors(artifact_uri, profile_uri):
     with pytest.raises(MlflowException):

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -369,6 +369,7 @@ def test_add_databricks_profile_info_to_artifact_uri_errors(artifact_uri, profil
     ('dbfs://profile@databricks/a/b', True),
     ('dbfs://scope:key@databricks/a/b', True),
     ('dbfs://profile@notdatabricks/a/b', False),
+    ('dbfs://scope:key@notdatabricks/a/b', False),
     ('dbfs://scope:key/a/b', False),
     ('dbfs://notdatabricks/a/b', False),
     ('s3:/path/a/b', False),

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -3,11 +3,13 @@ import pytest
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.db.db_types import DATABASE_ENGINES
-from mlflow.utils.uri import is_databricks_uri, is_http_uri, is_local_uri, \
-    extract_db_type_from_uri, get_uri_scheme, append_to_uri_path, \
-    extract_and_normalize_path, is_databricks_acled_artifacts_uri, \
-    get_db_info_from_uri, construct_run_url
-
+from mlflow.utils.uri import (
+    add_databricks_profile_info_to_artifact_uri, append_to_uri_path, construct_run_url,
+    extract_and_normalize_path, extract_db_type_from_uri, 
+    get_databricks_profile_uri_from_artifact_uri, get_db_info_from_uri, get_uri_scheme,
+    is_databricks_acled_artifacts_uri, is_databricks_uri, is_http_uri,
+    is_local_uri, remove_databricks_profile_info_from_artifact_uri
+)
 
 def test_extract_db_type_from_uri():
     uri = "{}://username:password@host:port/database"
@@ -24,14 +26,15 @@ def test_extract_db_type_from_uri():
             extract_db_type_from_uri(unsupported_db)
 
 
+# TODO(sueann): make sure 'databricks' tracking URI works okay with the new factor
 @pytest.mark.parametrize("server_uri, result", [
     ('databricks://aAbB', ('aAbB', None)),
+    ('databricks://aAbB/', ('aAbB', None)),
     ('databricks://profile/prefix', ('profile', 'prefix')),
     ('nondatabricks://profile/prefix', (None, None)),
     ('databricks://profile', ('profile', None)),
     ('databricks://profile/', ('profile', None)),
-    ('databricks://', ('', None)),
-    ('databricks://aAbB/', ('aAbB', None))
+    ('databricks://', ('', None))
 ])
 def test_get_db_info_from_uri(server_uri, result):
     assert get_db_info_from_uri(server_uri) == result
@@ -257,3 +260,92 @@ def test_is_databricks_acled_artifacts_uri():
         'dbfs:databricks///mlflow-tracking//EXP_ID//RUN_ID///artifacts//')
     assert not is_databricks_acled_artifacts_uri(
         'dbfs:/databricks/mlflow//EXP_ID//RUN_ID///artifacts//')
+
+
+# TODO(sueann): any error cases?
+@pytest.mark.parametrize("uri, result", [
+    ('ftp://user:pass@realhost:port/path/to/nowhere', None),
+    ('dbfs:/path/to/nowhere', None),
+    ('dbfs://databricks', 'databricks'),
+    ('dbfs://databricks/', 'databricks'),
+    ('dbfs://databricks/path/to/nowhere', 'databricks'),
+    ('dbfs://databricks:port/path/to/nowhere', 'databricks'),
+    ('dbfs://@databricks/path/to/nowhere', 'databricks'),
+    ('dbfs://@databricks:port/path/to/nowhere', 'databricks'),
+    ('dbfs://profile@databricks/path/to/nowhere', 'databricks://profile'),
+    ('dbfs://profile@databricks:port/path/to/nowhere', 'databricks://profile'),
+    ('dbfs://scope:key_prefix@databricks/path/abc', 'databricks://scope/key_prefix'),
+    ('dbfs://scope:key_prefix@databricks:port/path/abc', 'databricks://scope/key_prefix'),
+    ('runs://scope:key_prefix@databricks/path/abc', 'databricks://scope/key_prefix'),
+    ('models://scope:key_prefix@databricks/path/abc', 'databricks://scope/key_prefix'),
+    ('s3://scope:key_prefix@databricks/path/abc', 'databricks://scope/key_prefix')
+])
+def test_get_databricks_profile_uri_from_artifact_uri(uri, result):
+    assert get_databricks_profile_uri_from_artifact_uri(uri) == result
+
+
+# TODO(sueann): any error cases?
+@pytest.mark.parametrize("uri, result", [
+    ('ftp://user:pass@realhost:port/path/nowhere', 'ftp://user:pass@realhost:port/path/nowhere'),
+    ('dbfs:/path/to/nowhere', 'dbfs:/path/to/nowhere'),
+    ('dbfs://databricks', 'dbfs:/'),
+    ('dbfs://databricks/', 'dbfs:'),
+    ('dbfs://databricks/path/to/nowhere', 'dbfs:/path/to/nowhere'),
+    ('dbfs://databricks:port/path/to/nowhere', 'dbfs:/path/to/nowhere'),
+    ('dbfs://@databricks/path/to/nowhere', 'dbfs:/path/to/nowhere'),
+    ('dbfs://@databricks:port/path/to/nowhere', 'dbfs:/path/to/nowhere'),
+    ('dbfs://profile@databricks/path/to/nowhere', 'dbfs:/path/to/nowhere'),
+    ('dbfs://profile@databricks:port/path/to/nowhere', 'dbfs:/path/to/nowhere'),
+    ('dbfs://scope:key_prefix@databricks/path/abc', 'dbfs:/path/abc'),
+    ('dbfs://scope:key_prefix@databricks:port/path/abc', 'dbfs:/path/abc'),
+    ('runs://scope:key_prefix@databricks/path/abc', 'runs:/path/abc'),
+    ('models://scope:key_prefix@databricks/path/abc', 'models:/path/abc'),
+    ('s3://scope:key_prefix@databricks/path/abc', 's3:/path/abc')
+])
+def test_remove_databricks_profile_info_from_artifact_uri(uri, result):
+    assert remove_databricks_profile_info_from_artifact_uri(uri) == result
+
+
+@pytest.mark.parametrize("artifact_uri, profile_uri, result", [
+    # test various profile URIs
+    ('dbfs:/path/a/b', 'databricks', 'dbfs://databricks/path/a/b'),
+    ('dbfs:/path/a/b/', 'databricks', 'dbfs://databricks/path/a/b/'),
+    ('dbfs:/path/a/b/', 'databricks://', 'dbfs://databricks/path/a/b/'),
+    ('dbfs:/path/a/b/', 'databricks://Profile', 'dbfs://Profile@databricks/path/a/b/'),
+    ('dbfs:/path/a/b/', 'databricks://profile/', 'dbfs://profile@databricks/path/a/b/'),
+    ('dbfs:/path/a/b/', 'databricks://scope/key', 'dbfs://scope:key@databricks/path/a/b/'),
+    ('dbfs:/path/a/b/', 'databricks://scope/key/', 'dbfs://scope:key@databricks/path/a/b/'),
+    ('dbfs:/path/a/b/', 'nondatabricks://profile', 'dbfs:/path/a/b/'),
+    # test various artifact schemes
+    ('runs:/path/a/b/', 'databricks://Profile', 'runs://Profile@databricks/path/a/b/'),
+    ('runs:/path/a/b/', 'nondatabricks://profile', 'runs:/path/a/b/'),
+    ('models:/path/a/b/', 'databricks://profile', 'models://Profile@databricks/path/a/b/'),
+    ('models:/path/a/b/', 'nondatabricks://Profile', 'models:/path/a/b/'),
+    ('s3:/path/a/b/', 'databricks://Profile', 's3:/path/a/b/'),
+    ('s3:/path/a/b/', 'nondatabricks://profile', 's3:/path/a/b/'),
+    ('ftp:/path/a/b/', 'databricks://profile', 'ftp:/path/a/b/'),
+    ('ftp:/path/a/b/', 'nondatabricks://Profile', 'ftp:/path/a/b/'),
+    # test artifact URIs already with authority
+    ('ftp://user:pass@host:port/a/b', 'databricks://Profile', 'ftp://user:pass@host:port/a/b'),
+    ('ftp://user:pass@host:port/a/b', 'nothing://Profile', 'ftp://user:pass@host:port/a/b'),
+    ('dbfs://databricks', 'databricks://OtherProfile', 'dbfs://databricks'),
+    ('dbfs://databricks', 'nondatabricks://Profile', 'dbfs://databricks'),
+    ('dbfs://databricks/path/a/b', 'databricks://OtherProfile', 'dbfs://databricks/path/a/b'),
+    ('dbfs://databricks/path/a/b', 'nondatabricks://Profile', 'dbfs://databricks/path/a/b'),
+    ('dbfs://@databricks/path/a/b', 'databricks://OtherProfile', 'dbfs://@databricks/path/a/b'),
+    ('dbfs://@databricks/path/a/b', 'nondatabricks://Profile', 'dbfs://@databricks/path/a/b'),
+    ('dbfs://profile@databricks/pp', 'databricks://OtherProfile', 'dbfs://profile@databricks/pp'),
+    ('dbfs://profile@databricks/path', 'databricks://profile', 'dbfs://profile@databricks/path'),
+    ('dbfs://profile@databricks/path', 'nondatabricks://Profile', 'dbfs://profile@databricks/path')
+])
+def test_add_databricks_profile_info_to_artifact_uri(artifact_uri, profile_uri, result):
+    add_databricks_profile_info_to_artifact_uri(artifact_uri, profile_uri) == result
+
+
+# TODO(sueann): any other error cases?
+@pytest.mark.parametrize("artifact_uri, profile_uri", [
+    ('dbfs:/path/a/b', 'databricks://not:legit:auth')
+])
+def test_add_databricks_profile_info_to_artifact_uri_errors(artifact_uri, profile_uri):
+    with pytest.raises(MlflowException):
+        add_databricks_profile_info_to_artifact_uri(artifact_uri, profile_uri)

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -34,7 +34,7 @@ def test_extract_db_type_from_uri():
     ('nondatabricks://profile/prefix', (None, None)),
     ('databricks://profile', ('profile', None)),
     ('databricks://profile/', ('profile', None)),
-    ('databricks://', ('', None))
+    ('databricks://', ('', None)),
 ])
 def test_get_db_info_from_uri(server_uri, result):
     assert get_db_info_from_uri(server_uri) == result


### PR DESCRIPTION
## What changes are proposed in this pull request?

Allow registering models to a Databricks workspace with a source (tracking server) from outside the workspace (e.g. another Databricks workspace ). To do so, we need to copy the source to the local filesystem and upload it to the target Databricks workspace, then create the model version there. The PR contains two main changes:

1. Modifications to `MlflowClient.create_model_version` to support the cross-workspace model version creation.
2. Enable passing in the tracking URI to `ArtifactRepository` classes that deal with DBFS paths, since DBFS locations are tied to Databricks workspaces.

## How is this patch tested?

- Unit tests 
  - for the `[Databricks|DbfsRest|Models|Runs]ArtifactRepository` changes
  - for `MlflowClient.create_model_version` verify the artifact copy method is called under proper conditions
  - for `artifact_utils._upload_artifacts_to_databricks`
- Manual tests - for verifying that cross-workspace model version creation works (tested with both ACL'd and unACL's source locations)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

You can now register models to a Databricks workspace with a source from outside the workspace. 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
