### PR TITLE
[Multi-Workspace Registry] server-side changes for adding runlink to model version

### DIFF
--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -15,7 +15,8 @@ class ModelVersion(_ModelRegistryEntity):
 
     def __init__(self, name, version, creation_timestamp,
                  last_updated_timestamp=None, description=None, user_id=None, current_stage=None,
-                 source=None, run_id=None, status=None, status_message=None, tags=None):
+                 source=None, run_id=None, status=None, status_message=None, tags=None,
+                 run_link=None):
         super(ModelVersion, self).__init__()
         self._name = name
         self._version = version
@@ -26,6 +27,7 @@ class ModelVersion(_ModelRegistryEntity):
         self._current_stage = current_stage
         self._source = source
         self._run_id = run_id
+        self._run_link = run_link
         self._status = status
         self._status_message = status_message
         self._tags = {tag.key: tag.value for tag in (tags or [])}
@@ -75,6 +77,11 @@ class ModelVersion(_ModelRegistryEntity):
     def run_id(self):
         """String. MLflow run ID that generated this model."""
         return self._run_id
+
+    @property
+    def run_link(self):
+        """String. MLflow run link referring to the exact run that generated this model version."""
+        return self._run_link
 
     @property
     def status(self):

--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -121,7 +121,8 @@ class ModelVersion(_ModelRegistryEntity):
                             proto.source,
                             proto.run_id,
                             ModelVersionStatus.to_string(proto.status),
-                            proto.status_message)
+                            proto.status_message,
+                            run_link=proto.run_link)
         for tag in proto.tags:
             model_version._add_tag(ModelVersionTag.from_proto(tag))
         return model_version
@@ -145,6 +146,8 @@ class ModelVersion(_ModelRegistryEntity):
             model_version.source = str(self.source)
         if self.run_id is not None:
             model_version.run_id = str(self.run_id)
+        if self.run_link is not None:
+            model_version.run_link = str(self.run_link)
         if self.status is not None:
             model_version.status = ModelVersionStatus.from_string(self.status)
         if self.status_message:

--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
@@ -2756,6 +2756,32 @@ public final class ModelRegistry {
      */
     org.mlflow.api.proto.ModelRegistry.ModelVersionTagOrBuilder getTagsOrBuilder(
         int index);
+
+    /**
+     * <pre>
+     * Run Link: Direct link to the run that generated this version
+     * </pre>
+     *
+     * <code>optional string run_link = 13;</code>
+     */
+    boolean hasRunLink();
+    /**
+     * <pre>
+     * Run Link: Direct link to the run that generated this version
+     * </pre>
+     *
+     * <code>optional string run_link = 13;</code>
+     */
+    java.lang.String getRunLink();
+    /**
+     * <pre>
+     * Run Link: Direct link to the run that generated this version
+     * </pre>
+     *
+     * <code>optional string run_link = 13;</code>
+     */
+    com.google.protobuf.ByteString
+        getRunLinkBytes();
   }
   /**
    * <pre>
@@ -2787,6 +2813,7 @@ public final class ModelRegistry {
       status_ = 1;
       statusMessage_ = "";
       tags_ = java.util.Collections.emptyList();
+      runLink_ = "";
     }
 
     @java.lang.Override
@@ -2890,6 +2917,12 @@ public final class ModelRegistry {
               }
               tags_.add(
                   input.readMessage(org.mlflow.api.proto.ModelRegistry.ModelVersionTag.PARSER, extensionRegistry));
+              break;
+            }
+            case 106: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000800;
+              runLink_ = bs;
               break;
             }
             default: {
@@ -3489,6 +3522,60 @@ public final class ModelRegistry {
       return tags_.get(index);
     }
 
+    public static final int RUN_LINK_FIELD_NUMBER = 13;
+    private volatile java.lang.Object runLink_;
+    /**
+     * <pre>
+     * Run Link: Direct link to the run that generated this version
+     * </pre>
+     *
+     * <code>optional string run_link = 13;</code>
+     */
+    public boolean hasRunLink() {
+      return ((bitField0_ & 0x00000800) == 0x00000800);
+    }
+    /**
+     * <pre>
+     * Run Link: Direct link to the run that generated this version
+     * </pre>
+     *
+     * <code>optional string run_link = 13;</code>
+     */
+    public java.lang.String getRunLink() {
+      java.lang.Object ref = runLink_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runLink_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Run Link: Direct link to the run that generated this version
+     * </pre>
+     *
+     * <code>optional string run_link = 13;</code>
+     */
+    public com.google.protobuf.ByteString
+        getRunLinkBytes() {
+      java.lang.Object ref = runLink_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runLink_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -3539,6 +3626,9 @@ public final class ModelRegistry {
       for (int i = 0; i < tags_.size(); i++) {
         output.writeMessage(12, tags_.get(i));
       }
+      if (((bitField0_ & 0x00000800) == 0x00000800)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 13, runLink_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -3587,6 +3677,9 @@ public final class ModelRegistry {
       for (int i = 0; i < tags_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(12, tags_.get(i));
+      }
+      if (((bitField0_ & 0x00000800) == 0x00000800)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(13, runLink_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -3660,6 +3753,11 @@ public final class ModelRegistry {
       }
       result = result && getTagsList()
           .equals(other.getTagsList());
+      result = result && (hasRunLink() == other.hasRunLink());
+      if (hasRunLink()) {
+        result = result && getRunLink()
+            .equals(other.getRunLink());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -3720,6 +3818,10 @@ public final class ModelRegistry {
       if (getTagsCount() > 0) {
         hash = (37 * hash) + TAGS_FIELD_NUMBER;
         hash = (53 * hash) + getTagsList().hashCode();
+      }
+      if (hasRunLink()) {
+        hash = (37 * hash) + RUN_LINK_FIELD_NUMBER;
+        hash = (53 * hash) + getRunLink().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -3888,6 +3990,8 @@ public final class ModelRegistry {
         } else {
           tagsBuilder_.clear();
         }
+        runLink_ = "";
+        bitField0_ = (bitField0_ & ~0x00001000);
         return this;
       }
 
@@ -3969,6 +4073,10 @@ public final class ModelRegistry {
         } else {
           result.tags_ = tagsBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00001000) == 0x00001000)) {
+          to_bitField0_ |= 0x00000800;
+        }
+        result.runLink_ = runLink_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -4092,6 +4200,11 @@ public final class ModelRegistry {
               tagsBuilder_.addAllMessages(other.tags_);
             }
           }
+        }
+        if (other.hasRunLink()) {
+          bitField0_ |= 0x00001000;
+          runLink_ = other.runLink_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -5388,6 +5501,106 @@ public final class ModelRegistry {
           tags_ = null;
         }
         return tagsBuilder_;
+      }
+
+      private java.lang.Object runLink_ = "";
+      /**
+       * <pre>
+       * Run Link: Direct link to the run that generated this version
+       * </pre>
+       *
+       * <code>optional string run_link = 13;</code>
+       */
+      public boolean hasRunLink() {
+        return ((bitField0_ & 0x00001000) == 0x00001000);
+      }
+      /**
+       * <pre>
+       * Run Link: Direct link to the run that generated this version
+       * </pre>
+       *
+       * <code>optional string run_link = 13;</code>
+       */
+      public java.lang.String getRunLink() {
+        java.lang.Object ref = runLink_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runLink_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Run Link: Direct link to the run that generated this version
+       * </pre>
+       *
+       * <code>optional string run_link = 13;</code>
+       */
+      public com.google.protobuf.ByteString
+          getRunLinkBytes() {
+        java.lang.Object ref = runLink_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runLink_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Run Link: Direct link to the run that generated this version
+       * </pre>
+       *
+       * <code>optional string run_link = 13;</code>
+       */
+      public Builder setRunLink(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00001000;
+        runLink_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Run Link: Direct link to the run that generated this version
+       * </pre>
+       *
+       * <code>optional string run_link = 13;</code>
+       */
+      public Builder clearRunLink() {
+        bitField0_ = (bitField0_ & ~0x00001000);
+        runLink_ = getDefaultInstance().getRunLink();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Run Link: Direct link to the run that generated this version
+       * </pre>
+       *
+       * <code>optional string run_link = 13;</code>
+       */
+      public Builder setRunLinkBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00001000;
+        runLink_ = value;
+        onChanged();
+        return this;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -18456,6 +18669,35 @@ public final class ModelRegistry {
      */
     org.mlflow.api.proto.ModelRegistry.ModelVersionTagOrBuilder getTagsOrBuilder(
         int index);
+
+    /**
+     * <pre>
+     * MLflow run link - this is the exact link of the run that generated this model version,
+     * potentially hosted at another instance of MLflow.
+     * </pre>
+     *
+     * <code>optional string run_link = 5;</code>
+     */
+    boolean hasRunLink();
+    /**
+     * <pre>
+     * MLflow run link - this is the exact link of the run that generated this model version,
+     * potentially hosted at another instance of MLflow.
+     * </pre>
+     *
+     * <code>optional string run_link = 5;</code>
+     */
+    java.lang.String getRunLink();
+    /**
+     * <pre>
+     * MLflow run link - this is the exact link of the run that generated this model version,
+     * potentially hosted at another instance of MLflow.
+     * </pre>
+     *
+     * <code>optional string run_link = 5;</code>
+     */
+    com.google.protobuf.ByteString
+        getRunLinkBytes();
   }
   /**
    * Protobuf type {@code mlflow.CreateModelVersion}
@@ -18474,6 +18716,7 @@ public final class ModelRegistry {
       source_ = "";
       runId_ = "";
       tags_ = java.util.Collections.emptyList();
+      runLink_ = "";
     }
 
     @java.lang.Override
@@ -18525,6 +18768,12 @@ public final class ModelRegistry {
               }
               tags_.add(
                   input.readMessage(org.mlflow.api.proto.ModelRegistry.ModelVersionTag.PARSER, extensionRegistry));
+              break;
+            }
+            case 42: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000008;
+              runLink_ = bs;
               break;
             }
             default: {
@@ -19460,6 +19709,63 @@ public final class ModelRegistry {
       return tags_.get(index);
     }
 
+    public static final int RUN_LINK_FIELD_NUMBER = 5;
+    private volatile java.lang.Object runLink_;
+    /**
+     * <pre>
+     * MLflow run link - this is the exact link of the run that generated this model version,
+     * potentially hosted at another instance of MLflow.
+     * </pre>
+     *
+     * <code>optional string run_link = 5;</code>
+     */
+    public boolean hasRunLink() {
+      return ((bitField0_ & 0x00000008) == 0x00000008);
+    }
+    /**
+     * <pre>
+     * MLflow run link - this is the exact link of the run that generated this model version,
+     * potentially hosted at another instance of MLflow.
+     * </pre>
+     *
+     * <code>optional string run_link = 5;</code>
+     */
+    public java.lang.String getRunLink() {
+      java.lang.Object ref = runLink_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runLink_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * MLflow run link - this is the exact link of the run that generated this model version,
+     * potentially hosted at another instance of MLflow.
+     * </pre>
+     *
+     * <code>optional string run_link = 5;</code>
+     */
+    public com.google.protobuf.ByteString
+        getRunLinkBytes() {
+      java.lang.Object ref = runLink_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runLink_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -19486,6 +19792,9 @@ public final class ModelRegistry {
       for (int i = 0; i < tags_.size(); i++) {
         output.writeMessage(4, tags_.get(i));
       }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 5, runLink_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -19507,6 +19816,9 @@ public final class ModelRegistry {
       for (int i = 0; i < tags_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(4, tags_.get(i));
+      }
+      if (((bitField0_ & 0x00000008) == 0x00000008)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, runLink_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -19541,6 +19853,11 @@ public final class ModelRegistry {
       }
       result = result && getTagsList()
           .equals(other.getTagsList());
+      result = result && (hasRunLink() == other.hasRunLink());
+      if (hasRunLink()) {
+        result = result && getRunLink()
+            .equals(other.getRunLink());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -19567,6 +19884,10 @@ public final class ModelRegistry {
       if (getTagsCount() > 0) {
         hash = (37 * hash) + TAGS_FIELD_NUMBER;
         hash = (53 * hash) + getTagsList().hashCode();
+      }
+      if (hasRunLink()) {
+        hash = (37 * hash) + RUN_LINK_FIELD_NUMBER;
+        hash = (53 * hash) + getRunLink().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -19714,6 +20035,8 @@ public final class ModelRegistry {
         } else {
           tagsBuilder_.clear();
         }
+        runLink_ = "";
+        bitField0_ = (bitField0_ & ~0x00000010);
         return this;
       }
 
@@ -19763,6 +20086,10 @@ public final class ModelRegistry {
         } else {
           result.tags_ = tagsBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000010) == 0x00000010)) {
+          to_bitField0_ |= 0x00000008;
+        }
+        result.runLink_ = runLink_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -19852,6 +20179,11 @@ public final class ModelRegistry {
               tagsBuilder_.addAllMessages(other.tags_);
             }
           }
+        }
+        if (other.hasRunLink()) {
+          bitField0_ |= 0x00000010;
+          runLink_ = other.runLink_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -20499,6 +20831,112 @@ public final class ModelRegistry {
           tags_ = null;
         }
         return tagsBuilder_;
+      }
+
+      private java.lang.Object runLink_ = "";
+      /**
+       * <pre>
+       * MLflow run link - this is the exact link of the run that generated this model version,
+       * potentially hosted at another instance of MLflow.
+       * </pre>
+       *
+       * <code>optional string run_link = 5;</code>
+       */
+      public boolean hasRunLink() {
+        return ((bitField0_ & 0x00000010) == 0x00000010);
+      }
+      /**
+       * <pre>
+       * MLflow run link - this is the exact link of the run that generated this model version,
+       * potentially hosted at another instance of MLflow.
+       * </pre>
+       *
+       * <code>optional string run_link = 5;</code>
+       */
+      public java.lang.String getRunLink() {
+        java.lang.Object ref = runLink_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runLink_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * MLflow run link - this is the exact link of the run that generated this model version,
+       * potentially hosted at another instance of MLflow.
+       * </pre>
+       *
+       * <code>optional string run_link = 5;</code>
+       */
+      public com.google.protobuf.ByteString
+          getRunLinkBytes() {
+        java.lang.Object ref = runLink_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runLink_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * MLflow run link - this is the exact link of the run that generated this model version,
+       * potentially hosted at another instance of MLflow.
+       * </pre>
+       *
+       * <code>optional string run_link = 5;</code>
+       */
+      public Builder setRunLink(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+        runLink_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * MLflow run link - this is the exact link of the run that generated this model version,
+       * potentially hosted at another instance of MLflow.
+       * </pre>
+       *
+       * <code>optional string run_link = 5;</code>
+       */
+      public Builder clearRunLink() {
+        bitField0_ = (bitField0_ & ~0x00000010);
+        runLink_ = getDefaultInstance().getRunLink();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * MLflow run link - this is the exact link of the run that generated this model version,
+       * potentially hosted at another instance of MLflow.
+       * </pre>
+       *
+       * <code>optional string run_link = 5;</code>
+       */
+      public Builder setRunLinkBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000010;
+        runLink_ = value;
+        onChanged();
+        return this;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -38628,7 +39066,7 @@ public final class ModelRegistry {
       "\003 \001(\003\022\017\n\007user_id\030\004 \001(\t\022\023\n\013description\030\005 " +
       "\001(\t\022-\n\017latest_versions\030\006 \003(\0132\024.mlflow.Mo" +
       "delVersion\022(\n\004tags\030\007 \003(\0132\032.mlflow.Regist" +
-      "eredModelTag\"\261\002\n\014ModelVersion\022\014\n\004name\030\001 " +
+      "eredModelTag\"\303\002\n\014ModelVersion\022\014\n\004name\030\001 " +
       "\001(\t\022\017\n\007version\030\002 \001(\t\022\032\n\022creation_timesta" +
       "mp\030\003 \001(\003\022\036\n\026last_updated_timestamp\030\004 \001(\003" +
       "\022\017\n\007user_id\030\005 \001(\t\022\025\n\rcurrent_stage\030\006 \001(\t" +
@@ -38636,183 +39074,184 @@ public final class ModelRegistry {
       "\006run_id\030\t \001(\t\022*\n\006status\030\n \001(\0162\032.mlflow.M" +
       "odelVersionStatus\022\026\n\016status_message\030\013 \001(" +
       "\t\022%\n\004tags\030\014 \003(\0132\027.mlflow.ModelVersionTag" +
-      "\"\301\001\n\025CreateRegisteredModel\022\022\n\004name\030\001 \001(\t" +
-      "B\004\370\206\031\001\022(\n\004tags\030\002 \003(\0132\032.mlflow.Registered" +
-      "ModelTag\032=\n\010Response\0221\n\020registered_model" +
-      "\030\001 \001(\0132\027.mlflow.RegisteredModel:+\342?(\n&co" +
-      "m.databricks.rpc.RPC[$this.Response]\"\251\001\n" +
-      "\025RenameRegisteredModel\022\022\n\004name\030\001 \001(\tB\004\370\206" +
-      "\031\001\022\020\n\010new_name\030\002 \001(\t\032=\n\010Response\0221\n\020regi" +
-      "stered_model\030\001 \001(\0132\027.mlflow.RegisteredMo" +
-      "del:+\342?(\n&com.databricks.rpc.RPC[$this.R" +
-      "esponse]\"\254\001\n\025UpdateRegisteredModel\022\022\n\004na" +
-      "me\030\001 \001(\tB\004\370\206\031\001\022\023\n\013description\030\002 \001(\t\032=\n\010R" +
-      "esponse\0221\n\020registered_model\030\001 \001(\0132\027.mlfl" +
-      "ow.RegisteredModel:+\342?(\n&com.databricks." +
-      "rpc.RPC[$this.Response]\"d\n\025DeleteRegiste" +
-      "redModel\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\032\n\n\010Response" +
-      ":+\342?(\n&com.databricks.rpc.RPC[$this.Resp" +
-      "onse]\"\224\001\n\022GetRegisteredModel\022\022\n\004name\030\001 \001" +
-      "(\tB\004\370\206\031\001\032=\n\010Response\0221\n\020registered_model" +
-      "\030\001 \001(\0132\027.mlflow.RegisteredModel:+\342?(\n&co" +
-      "m.databricks.rpc.RPC[$this.Response]\"\312\001\n" +
-      "\024ListRegisteredModels\022\030\n\013max_results\030\001 \001" +
-      "(\003:\003100\022\022\n\npage_token\030\002 \001(\t\032W\n\010Response\022" +
-      "2\n\021registered_models\030\001 \003(\0132\027.mlflow.Regi" +
-      "steredModel\022\027\n\017next_page_token\030\002 \001(\t:+\342?" +
+      "\022\020\n\010run_link\030\r \001(\t\"\301\001\n\025CreateRegisteredM" +
+      "odel\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022(\n\004tags\030\002 \003(\0132\032" +
+      ".mlflow.RegisteredModelTag\032=\n\010Response\0221" +
+      "\n\020registered_model\030\001 \001(\0132\027.mlflow.Regist" +
+      "eredModel:+\342?(\n&com.databricks.rpc.RPC[$" +
+      "this.Response]\"\251\001\n\025RenameRegisteredModel" +
+      "\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\020\n\010new_name\030\002 \001(\t\032=" +
+      "\n\010Response\0221\n\020registered_model\030\001 \001(\0132\027.m" +
+      "lflow.RegisteredModel:+\342?(\n&com.databric" +
+      "ks.rpc.RPC[$this.Response]\"\254\001\n\025UpdateReg" +
+      "isteredModel\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\023\n\013desc" +
+      "ription\030\002 \001(\t\032=\n\010Response\0221\n\020registered_" +
+      "model\030\001 \001(\0132\027.mlflow.RegisteredModel:+\342?" +
       "(\n&com.databricks.rpc.RPC[$this.Response" +
-      "]\"\356\001\n\026SearchRegisteredModels\022\016\n\006filter\030\001" +
-      " \001(\t\022\030\n\013max_results\030\002 \001(\003:\003100\022\020\n\010order_" +
-      "by\030\003 \003(\t\022\022\n\npage_token\030\004 \001(\t\032W\n\010Response" +
-      "\0222\n\021registered_models\030\001 \003(\0132\027.mlflow.Reg" +
-      "isteredModel\022\027\n\017next_page_token\030\002 \001(\t:+\342" +
-      "?(\n&com.databricks.rpc.RPC[$this.Respons" +
-      "e]\"\236\001\n\021GetLatestVersions\022\022\n\004name\030\001 \001(\tB\004" +
-      "\370\206\031\001\022\016\n\006stages\030\002 \003(\t\0328\n\010Response\022,\n\016mode" +
-      "l_versions\030\001 \003(\0132\024.mlflow.ModelVersion:+" +
-      "\342?(\n&com.databricks.rpc.RPC[$this.Respon" +
-      "se]\"\333\001\n\022CreateModelVersion\022\022\n\004name\030\001 \001(\t" +
-      "B\004\370\206\031\001\022\024\n\006source\030\002 \001(\tB\004\370\206\031\001\022\016\n\006run_id\030\003" +
-      " \001(\t\022%\n\004tags\030\004 \003(\0132\027.mlflow.ModelVersion" +
-      "Tag\0327\n\010Response\022+\n\rmodel_version\030\001 \001(\0132\024" +
-      ".mlflow.ModelVersion:+\342?(\n&com.databrick" +
-      "s.rpc.RPC[$this.Response]\"\272\001\n\022UpdateMode" +
-      "lVersion\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030" +
-      "\002 \001(\tB\004\370\206\031\001\022\023\n\013description\030\003 \001(\t\0327\n\010Resp" +
-      "onse\022+\n\rmodel_version\030\001 \001(\0132\024.mlflow.Mod" +
-      "elVersion:+\342?(\n&com.databricks.rpc.RPC[$" +
-      "this.Response]\"\354\001\n\033TransitionModelVersio" +
-      "nStage\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 " +
-      "\001(\tB\004\370\206\031\001\022\023\n\005stage\030\003 \001(\tB\004\370\206\031\001\022\'\n\031archiv" +
-      "e_existing_versions\030\004 \001(\010B\004\370\206\031\001\0327\n\010Respo" +
-      "nse\022+\n\rmodel_version\030\001 \001(\0132\024.mlflow.Mode" +
-      "lVersion:+\342?(\n&com.databricks.rpc.RPC[$t" +
-      "his.Response]\"x\n\022DeleteModelVersion\022\022\n\004n" +
-      "ame\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\032\n" +
-      "\n\010Response:+\342?(\n&com.databricks.rpc.RPC[" +
-      "$this.Response]\"\242\001\n\017GetModelVersion\022\022\n\004n" +
-      "ame\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\0327" +
-      "\n\010Response\022+\n\rmodel_version\030\001 \001(\0132\024.mlfl" +
-      "ow.ModelVersion:+\342?(\n&com.databricks.rpc" +
-      ".RPC[$this.Response]\"\350\001\n\023SearchModelVers" +
-      "ions\022\016\n\006filter\030\001 \001(\t\022\033\n\013max_results\030\002 \001(" +
-      "\003:\006200000\022\020\n\010order_by\030\003 \003(\t\022\022\n\npage_toke" +
-      "n\030\004 \001(\t\032Q\n\010Response\022,\n\016model_versions\030\001 " +
-      "\003(\0132\024.mlflow.ModelVersion\022\027\n\017next_page_t" +
-      "oken\030\002 \001(\t:+\342?(\n&com.databricks.rpc.RPC[" +
-      "$this.Response]\"\226\001\n\032GetModelVersionDownl" +
-      "oadUri\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 " +
-      "\001(\tB\004\370\206\031\001\032 \n\010Response\022\024\n\014artifact_uri\030\001 " +
-      "\001(\t:+\342?(\n&com.databricks.rpc.RPC[$this.R" +
-      "esponse]\"-\n\017ModelVersionTag\022\013\n\003key\030\001 \001(\t" +
-      "\022\r\n\005value\030\002 \001(\t\"0\n\022RegisteredModelTag\022\013\n" +
-      "\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"\214\001\n\025SetRegiste" +
-      "redModelTag\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002" +
-      " \001(\tB\004\370\206\031\001\022\023\n\005value\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Respo" +
-      "nse:+\342?(\n&com.databricks.rpc.RPC[$this.R" +
-      "esponse]\"\240\001\n\022SetModelVersionTag\022\022\n\004name\030" +
-      "\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\022\021\n\003ke" +
-      "y\030\003 \001(\tB\004\370\206\031\001\022\023\n\005value\030\004 \001(\tB\004\370\206\031\001\032\n\n\010Re" +
+      "]\"d\n\025DeleteRegisteredModel\022\022\n\004name\030\001 \001(\t" +
+      "B\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.databricks." +
+      "rpc.RPC[$this.Response]\"\224\001\n\022GetRegistere" +
+      "dModel\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\032=\n\010Response\0221" +
+      "\n\020registered_model\030\001 \001(\0132\027.mlflow.Regist" +
+      "eredModel:+\342?(\n&com.databricks.rpc.RPC[$" +
+      "this.Response]\"\312\001\n\024ListRegisteredModels\022" +
+      "\030\n\013max_results\030\001 \001(\003:\003100\022\022\n\npage_token\030" +
+      "\002 \001(\t\032W\n\010Response\0222\n\021registered_models\030\001" +
+      " \003(\0132\027.mlflow.RegisteredModel\022\027\n\017next_pa" +
+      "ge_token\030\002 \001(\t:+\342?(\n&com.databricks.rpc." +
+      "RPC[$this.Response]\"\356\001\n\026SearchRegistered" +
+      "Models\022\016\n\006filter\030\001 \001(\t\022\030\n\013max_results\030\002 " +
+      "\001(\003:\003100\022\020\n\010order_by\030\003 \003(\t\022\022\n\npage_token" +
+      "\030\004 \001(\t\032W\n\010Response\0222\n\021registered_models\030" +
+      "\001 \003(\0132\027.mlflow.RegisteredModel\022\027\n\017next_p" +
+      "age_token\030\002 \001(\t:+\342?(\n&com.databricks.rpc" +
+      ".RPC[$this.Response]\"\236\001\n\021GetLatestVersio" +
+      "ns\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\016\n\006stages\030\002 \003(\t\0328" +
+      "\n\010Response\022,\n\016model_versions\030\001 \003(\0132\024.mlf" +
+      "low.ModelVersion:+\342?(\n&com.databricks.rp" +
+      "c.RPC[$this.Response]\"\355\001\n\022CreateModelVer" +
+      "sion\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\024\n\006source\030\002 \001(\t" +
+      "B\004\370\206\031\001\022\016\n\006run_id\030\003 \001(\t\022%\n\004tags\030\004 \003(\0132\027.m" +
+      "lflow.ModelVersionTag\022\020\n\010run_link\030\005 \001(\t\032" +
+      "7\n\010Response\022+\n\rmodel_version\030\001 \001(\0132\024.mlf" +
+      "low.ModelVersion:+\342?(\n&com.databricks.rp" +
+      "c.RPC[$this.Response]\"\272\001\n\022UpdateModelVer" +
+      "sion\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(" +
+      "\tB\004\370\206\031\001\022\023\n\013description\030\003 \001(\t\0327\n\010Response" +
+      "\022+\n\rmodel_version\030\001 \001(\0132\024.mlflow.ModelVe" +
+      "rsion:+\342?(\n&com.databricks.rpc.RPC[$this" +
+      ".Response]\"\354\001\n\033TransitionModelVersionSta" +
+      "ge\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB" +
+      "\004\370\206\031\001\022\023\n\005stage\030\003 \001(\tB\004\370\206\031\001\022\'\n\031archive_ex" +
+      "isting_versions\030\004 \001(\010B\004\370\206\031\001\0327\n\010Response\022" +
+      "+\n\rmodel_version\030\001 \001(\0132\024.mlflow.ModelVer" +
+      "sion:+\342?(\n&com.databricks.rpc.RPC[$this." +
+      "Response]\"x\n\022DeleteModelVersion\022\022\n\004name\030" +
+      "\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\032\n\n\010Re" +
       "sponse:+\342?(\n&com.databricks.rpc.RPC[$thi" +
-      "s.Response]\"z\n\030DeleteRegisteredModelTag\022" +
-      "\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\032\n" +
-      "\n\010Response:+\342?(\n&com.databricks.rpc.RPC[" +
-      "$this.Response]\"\216\001\n\025DeleteModelVersionTa" +
-      "g\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004" +
-      "\370\206\031\001\022\021\n\003key\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(" +
-      "\n&com.databricks.rpc.RPC[$this.Response]" +
-      "*R\n\022ModelVersionStatus\022\030\n\024PENDING_REGIST" +
-      "RATION\020\001\022\027\n\023FAILED_REGISTRATION\020\002\022\t\n\005REA" +
-      "DY\020\0032\307\033\n\024ModelRegistryService\022\266\001\n\025create" +
-      "RegisteredModel\022\035.mlflow.CreateRegistere" +
-      "dModel\032&.mlflow.CreateRegisteredModel.Re" +
-      "sponse\"V\362\206\031R\n6\n\004POST\022(/preview/mlflow/re" +
-      "gistered-models/create\032\004\010\002\020\000\020\001*\026Create R" +
-      "egisteredModel\022\266\001\n\025renameRegisteredModel" +
-      "\022\035.mlflow.RenameRegisteredModel\032&.mlflow" +
-      ".RenameRegisteredModel.Response\"V\362\206\031R\n6\n" +
-      "\004POST\022(/preview/mlflow/registered-models" +
-      "/rename\032\004\010\002\020\000\020\001*\026Rename RegisteredModel\022" +
-      "\267\001\n\025updateRegisteredModel\022\035.mlflow.Updat" +
-      "eRegisteredModel\032&.mlflow.UpdateRegister" +
-      "edModel.Response\"W\362\206\031S\n7\n\005PATCH\022(/previe" +
-      "w/mlflow/registered-models/update\032\004\010\002\020\000\020" +
-      "\001*\026Update RegisteredModel\022\270\001\n\025deleteRegi" +
-      "steredModel\022\035.mlflow.DeleteRegisteredMod" +
-      "el\032&.mlflow.DeleteRegisteredModel.Respon" +
-      "se\"X\362\206\031T\n8\n\006DELETE\022(/preview/mlflow/regi" +
-      "stered-models/delete\032\004\010\002\020\000\020\001*\026Delete Reg" +
-      "isteredModel\022\246\001\n\022getRegisteredModel\022\032.ml" +
-      "flow.GetRegisteredModel\032#.mlflow.GetRegi" +
-      "steredModel.Response\"O\362\206\031K\n2\n\003GET\022%/prev" +
-      "iew/mlflow/registered-models/get\032\004\010\002\020\000\020\001" +
-      "*\023Get RegisteredModel\022\271\001\n\026searchRegister" +
-      "edModels\022\036.mlflow.SearchRegisteredModels" +
-      "\032\'.mlflow.SearchRegisteredModels.Respons" +
-      "e\"V\362\206\031R\n5\n\003GET\022(/preview/mlflow/register" +
-      "ed-models/search\032\004\010\002\020\000\020\001*\027Search Registe" +
-      "redModels\022\257\001\n\024listRegisteredModels\022\034.mlf" +
-      "low.ListRegisteredModels\032%.mlflow.ListRe" +
-      "gisteredModels.Response\"R\362\206\031N\n3\n\003GET\022&/p" +
-      "review/mlflow/registered-models/list\032\004\010\002" +
-      "\020\000\020\001*\025List RegisteredModels\022\270\001\n\021getLates" +
-      "tVersions\022\031.mlflow.GetLatestVersions\032\".m" +
-      "lflow.GetLatestVersions.Response\"d\362\206\031`\nB" +
-      "\n\003GET\0225/preview/mlflow/registered-models" +
-      "/get-latest-versions\032\004\010\002\020\000\020\001*\030Get Latest" +
-      " ModelVersions\022\247\001\n\022createModelVersion\022\032." +
-      "mlflow.CreateModelVersion\032#.mlflow.Creat" +
-      "eModelVersion.Response\"P\362\206\031L\n3\n\004POST\022%/p" +
-      "review/mlflow/model-versions/create\032\004\010\002\020" +
-      "\000\020\001*\023Create ModelVersion\022\250\001\n\022updateModel" +
-      "Version\022\032.mlflow.UpdateModelVersion\032#.ml" +
-      "flow.UpdateModelVersion.Response\"Q\362\206\031M\n4" +
-      "\n\005PATCH\022%/preview/mlflow/model-versions/" +
-      "update\032\004\010\002\020\000\020\001*\023Update ModelVersion\022\326\001\n\033" +
-      "transitionModelVersionStage\022#.mlflow.Tra" +
-      "nsitionModelVersionStage\032,.mlflow.Transi" +
-      "tionModelVersionStage.Response\"d\362\206\031`\n=\n\004" +
-      "POST\022//preview/mlflow/model-versions/tra" +
-      "nsition-stage\032\004\010\002\020\000\020\001*\035Transition ModelV" +
-      "ersion Stage\022\251\001\n\022deleteModelVersion\022\032.ml" +
-      "flow.DeleteModelVersion\032#.mlflow.DeleteM" +
-      "odelVersion.Response\"R\362\206\031N\n5\n\006DELETE\022%/p" +
-      "review/mlflow/model-versions/delete\032\004\010\002\020" +
-      "\000\020\001*\023Delete ModelVersion\022\227\001\n\017getModelVer" +
-      "sion\022\027.mlflow.GetModelVersion\032 .mlflow.G" +
-      "etModelVersion.Response\"I\362\206\031E\n/\n\003GET\022\"/p" +
-      "review/mlflow/model-versions/get\032\004\010\002\020\000\020\001" +
-      "*\020Get ModelVersion\022\252\001\n\023searchModelVersio" +
-      "ns\022\033.mlflow.SearchModelVersions\032$.mlflow" +
-      ".SearchModelVersions.Response\"P\362\206\031L\n2\n\003G" +
-      "ET\022%/preview/mlflow/model-versions/searc" +
-      "h\032\004\010\002\020\000\020\001*\024Search ModelVersions\022\340\001\n\032getM" +
-      "odelVersionDownloadUri\022\".mlflow.GetModel" +
-      "VersionDownloadUri\032+.mlflow.GetModelVers" +
-      "ionDownloadUri.Response\"q\362\206\031m\n<\n\003GET\022//p" +
-      "review/mlflow/model-versions/get-downloa" +
-      "d-uri\032\004\010\002\020\000\020\001*+Get Download URI For Mode" +
-      "lVersion Artifacts\022\271\001\n\025setRegisteredMode" +
-      "lTag\022\035.mlflow.SetRegisteredModelTag\032&.ml" +
-      "flow.SetRegisteredModelTag.Response\"Y\362\206\031" +
-      "U\n7\n\004POST\022)/preview/mlflow/registered-mo" +
-      "dels/set-tag\032\004\010\002\020\000\020\001*\030Set Registered Mod" +
-      "el Tag\022\252\001\n\022setModelVersionTag\022\032.mlflow.S" +
-      "etModelVersionTag\032#.mlflow.SetModelVersi" +
-      "onTag.Response\"S\362\206\031O\n4\n\004POST\022&/preview/m" +
-      "lflow/model-versions/set-tag\032\004\010\002\020\000\020\001*\025Se" +
-      "t Model Version Tag\022\312\001\n\030deleteRegistered" +
-      "ModelTag\022 .mlflow.DeleteRegisteredModelT" +
-      "ag\032).mlflow.DeleteRegisteredModelTag.Res" +
-      "ponse\"a\362\206\031]\n<\n\006DELETE\022,/preview/mlflow/r" +
-      "egistered-models/delete-tag\032\004\010\002\020\000\020\001*\033Del" +
-      "ete Registered Model Tag\022\273\001\n\025deleteModel" +
-      "VersionTag\022\035.mlflow.DeleteModelVersionTa" +
-      "g\032&.mlflow.DeleteModelVersionTag.Respons" +
-      "e\"[\362\206\031W\n9\n\006DELETE\022)/preview/mlflow/model" +
-      "-versions/delete-tag\032\004\010\002\020\000\020\001*\030Delete Mod" +
-      "el Version TagB!\n\024org.mlflow.api.proto\220\001" +
-      "\001\240\001\001\342?\002\020\001"
+      "s.Response]\"\242\001\n\017GetModelVersion\022\022\n\004name\030" +
+      "\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\0327\n\010Re" +
+      "sponse\022+\n\rmodel_version\030\001 \001(\0132\024.mlflow.M" +
+      "odelVersion:+\342?(\n&com.databricks.rpc.RPC" +
+      "[$this.Response]\"\350\001\n\023SearchModelVersions" +
+      "\022\016\n\006filter\030\001 \001(\t\022\033\n\013max_results\030\002 \001(\003:\0062" +
+      "00000\022\020\n\010order_by\030\003 \003(\t\022\022\n\npage_token\030\004 " +
+      "\001(\t\032Q\n\010Response\022,\n\016model_versions\030\001 \003(\0132" +
+      "\024.mlflow.ModelVersion\022\027\n\017next_page_token" +
+      "\030\002 \001(\t:+\342?(\n&com.databricks.rpc.RPC[$thi" +
+      "s.Response]\"\226\001\n\032GetModelVersionDownloadU" +
+      "ri\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB" +
+      "\004\370\206\031\001\032 \n\010Response\022\024\n\014artifact_uri\030\001 \001(\t:" +
+      "+\342?(\n&com.databricks.rpc.RPC[$this.Respo" +
+      "nse]\"-\n\017ModelVersionTag\022\013\n\003key\030\001 \001(\t\022\r\n\005" +
+      "value\030\002 \001(\t\"0\n\022RegisteredModelTag\022\013\n\003key" +
+      "\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"\214\001\n\025SetRegisteredM" +
+      "odelTag\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\t" +
+      "B\004\370\206\031\001\022\023\n\005value\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Response:" +
+      "+\342?(\n&com.databricks.rpc.RPC[$this.Respo" +
+      "nse]\"\240\001\n\022SetModelVersionTag\022\022\n\004name\030\001 \001(" +
+      "\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\022\021\n\003key\030\003 " +
+      "\001(\tB\004\370\206\031\001\022\023\n\005value\030\004 \001(\tB\004\370\206\031\001\032\n\n\010Respon" +
+      "se:+\342?(\n&com.databricks.rpc.RPC[$this.Re" +
+      "sponse]\"z\n\030DeleteRegisteredModelTag\022\022\n\004n" +
+      "ame\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\032\n\n\010Re" +
+      "sponse:+\342?(\n&com.databricks.rpc.RPC[$thi" +
+      "s.Response]\"\216\001\n\025DeleteModelVersionTag\022\022\n" +
+      "\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001" +
+      "\022\021\n\003key\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&co" +
+      "m.databricks.rpc.RPC[$this.Response]*R\n\022" +
+      "ModelVersionStatus\022\030\n\024PENDING_REGISTRATI" +
+      "ON\020\001\022\027\n\023FAILED_REGISTRATION\020\002\022\t\n\005READY\020\003" +
+      "2\307\033\n\024ModelRegistryService\022\266\001\n\025createRegi" +
+      "steredModel\022\035.mlflow.CreateRegisteredMod" +
+      "el\032&.mlflow.CreateRegisteredModel.Respon" +
+      "se\"V\362\206\031R\n6\n\004POST\022(/preview/mlflow/regist" +
+      "ered-models/create\032\004\010\002\020\000\020\001*\026Create Regis" +
+      "teredModel\022\266\001\n\025renameRegisteredModel\022\035.m" +
+      "lflow.RenameRegisteredModel\032&.mlflow.Ren" +
+      "ameRegisteredModel.Response\"V\362\206\031R\n6\n\004POS" +
+      "T\022(/preview/mlflow/registered-models/ren" +
+      "ame\032\004\010\002\020\000\020\001*\026Rename RegisteredModel\022\267\001\n\025" +
+      "updateRegisteredModel\022\035.mlflow.UpdateReg" +
+      "isteredModel\032&.mlflow.UpdateRegisteredMo" +
+      "del.Response\"W\362\206\031S\n7\n\005PATCH\022(/preview/ml" +
+      "flow/registered-models/update\032\004\010\002\020\000\020\001*\026U" +
+      "pdate RegisteredModel\022\270\001\n\025deleteRegister" +
+      "edModel\022\035.mlflow.DeleteRegisteredModel\032&" +
+      ".mlflow.DeleteRegisteredModel.Response\"X" +
+      "\362\206\031T\n8\n\006DELETE\022(/preview/mlflow/register" +
+      "ed-models/delete\032\004\010\002\020\000\020\001*\026Delete Registe" +
+      "redModel\022\246\001\n\022getRegisteredModel\022\032.mlflow" +
+      ".GetRegisteredModel\032#.mlflow.GetRegister" +
+      "edModel.Response\"O\362\206\031K\n2\n\003GET\022%/preview/" +
+      "mlflow/registered-models/get\032\004\010\002\020\000\020\001*\023Ge" +
+      "t RegisteredModel\022\271\001\n\026searchRegisteredMo" +
+      "dels\022\036.mlflow.SearchRegisteredModels\032\'.m" +
+      "lflow.SearchRegisteredModels.Response\"V\362" +
+      "\206\031R\n5\n\003GET\022(/preview/mlflow/registered-m" +
+      "odels/search\032\004\010\002\020\000\020\001*\027Search RegisteredM" +
+      "odels\022\257\001\n\024listRegisteredModels\022\034.mlflow." +
+      "ListRegisteredModels\032%.mlflow.ListRegist" +
+      "eredModels.Response\"R\362\206\031N\n3\n\003GET\022&/previ" +
+      "ew/mlflow/registered-models/list\032\004\010\002\020\000\020\001" +
+      "*\025List RegisteredModels\022\270\001\n\021getLatestVer" +
+      "sions\022\031.mlflow.GetLatestVersions\032\".mlflo" +
+      "w.GetLatestVersions.Response\"d\362\206\031`\nB\n\003GE" +
+      "T\0225/preview/mlflow/registered-models/get" +
+      "-latest-versions\032\004\010\002\020\000\020\001*\030Get Latest Mod" +
+      "elVersions\022\247\001\n\022createModelVersion\022\032.mlfl" +
+      "ow.CreateModelVersion\032#.mlflow.CreateMod" +
+      "elVersion.Response\"P\362\206\031L\n3\n\004POST\022%/previ" +
+      "ew/mlflow/model-versions/create\032\004\010\002\020\000\020\001*" +
+      "\023Create ModelVersion\022\250\001\n\022updateModelVers" +
+      "ion\022\032.mlflow.UpdateModelVersion\032#.mlflow" +
+      ".UpdateModelVersion.Response\"Q\362\206\031M\n4\n\005PA" +
+      "TCH\022%/preview/mlflow/model-versions/upda" +
+      "te\032\004\010\002\020\000\020\001*\023Update ModelVersion\022\326\001\n\033tran" +
+      "sitionModelVersionStage\022#.mlflow.Transit" +
+      "ionModelVersionStage\032,.mlflow.Transition" +
+      "ModelVersionStage.Response\"d\362\206\031`\n=\n\004POST" +
+      "\022//preview/mlflow/model-versions/transit" +
+      "ion-stage\032\004\010\002\020\000\020\001*\035Transition ModelVersi" +
+      "on Stage\022\251\001\n\022deleteModelVersion\022\032.mlflow" +
+      ".DeleteModelVersion\032#.mlflow.DeleteModel" +
+      "Version.Response\"R\362\206\031N\n5\n\006DELETE\022%/previ" +
+      "ew/mlflow/model-versions/delete\032\004\010\002\020\000\020\001*" +
+      "\023Delete ModelVersion\022\227\001\n\017getModelVersion" +
+      "\022\027.mlflow.GetModelVersion\032 .mlflow.GetMo" +
+      "delVersion.Response\"I\362\206\031E\n/\n\003GET\022\"/previ" +
+      "ew/mlflow/model-versions/get\032\004\010\002\020\000\020\001*\020Ge" +
+      "t ModelVersion\022\252\001\n\023searchModelVersions\022\033" +
+      ".mlflow.SearchModelVersions\032$.mlflow.Sea" +
+      "rchModelVersions.Response\"P\362\206\031L\n2\n\003GET\022%" +
+      "/preview/mlflow/model-versions/search\032\004\010" +
+      "\002\020\000\020\001*\024Search ModelVersions\022\340\001\n\032getModel" +
+      "VersionDownloadUri\022\".mlflow.GetModelVers" +
+      "ionDownloadUri\032+.mlflow.GetModelVersionD" +
+      "ownloadUri.Response\"q\362\206\031m\n<\n\003GET\022//previ" +
+      "ew/mlflow/model-versions/get-download-ur" +
+      "i\032\004\010\002\020\000\020\001*+Get Download URI For ModelVer" +
+      "sion Artifacts\022\271\001\n\025setRegisteredModelTag" +
+      "\022\035.mlflow.SetRegisteredModelTag\032&.mlflow" +
+      ".SetRegisteredModelTag.Response\"Y\362\206\031U\n7\n" +
+      "\004POST\022)/preview/mlflow/registered-models" +
+      "/set-tag\032\004\010\002\020\000\020\001*\030Set Registered Model T" +
+      "ag\022\252\001\n\022setModelVersionTag\022\032.mlflow.SetMo" +
+      "delVersionTag\032#.mlflow.SetModelVersionTa" +
+      "g.Response\"S\362\206\031O\n4\n\004POST\022&/preview/mlflo" +
+      "w/model-versions/set-tag\032\004\010\002\020\000\020\001*\025Set Mo" +
+      "del Version Tag\022\312\001\n\030deleteRegisteredMode" +
+      "lTag\022 .mlflow.DeleteRegisteredModelTag\032)" +
+      ".mlflow.DeleteRegisteredModelTag.Respons" +
+      "e\"a\362\206\031]\n<\n\006DELETE\022,/preview/mlflow/regis" +
+      "tered-models/delete-tag\032\004\010\002\020\000\020\001*\033Delete " +
+      "Registered Model Tag\022\273\001\n\025deleteModelVers" +
+      "ionTag\022\035.mlflow.DeleteModelVersionTag\032&." +
+      "mlflow.DeleteModelVersionTag.Response\"[\362" +
+      "\206\031W\n9\n\006DELETE\022)/preview/mlflow/model-ver" +
+      "sions/delete-tag\032\004\010\002\020\000\020\001*\030Delete Model V" +
+      "ersion TagB!\n\024org.mlflow.api.proto\220\001\001\240\001\001" +
+      "\342?\002\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -38839,7 +39278,7 @@ public final class ModelRegistry {
     internal_static_mlflow_ModelVersion_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_ModelVersion_descriptor,
-        new java.lang.String[] { "Name", "Version", "CreationTimestamp", "LastUpdatedTimestamp", "UserId", "CurrentStage", "Description", "Source", "RunId", "Status", "StatusMessage", "Tags", });
+        new java.lang.String[] { "Name", "Version", "CreationTimestamp", "LastUpdatedTimestamp", "UserId", "CurrentStage", "Description", "Source", "RunId", "Status", "StatusMessage", "Tags", "RunLink", });
     internal_static_mlflow_CreateRegisteredModel_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_mlflow_CreateRegisteredModel_fieldAccessorTable = new
@@ -38941,7 +39380,7 @@ public final class ModelRegistry {
     internal_static_mlflow_CreateModelVersion_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_CreateModelVersion_descriptor,
-        new java.lang.String[] { "Name", "Source", "RunId", "Tags", });
+        new java.lang.String[] { "Name", "Source", "RunId", "Tags", "RunLink", });
     internal_static_mlflow_CreateModelVersion_Response_descriptor =
       internal_static_mlflow_CreateModelVersion_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_CreateModelVersion_Response_fieldAccessorTable = new

--- a/mlflow/protos/model_registry.proto
+++ b/mlflow/protos/model_registry.proto
@@ -361,6 +361,9 @@ message ModelVersion {
 
   // Tags: Additional metadata key-value pairs for this ``model_version``.
   repeated ModelVersionTag tags = 12;
+
+  // Run Link: Direct link to the run that generated this version
+  optional string run_link = 13;
 }
 
 message CreateRegisteredModel {
@@ -502,6 +505,10 @@ message CreateModelVersion {
 
   // Additional metadata for model version.
   repeated ModelVersionTag tags = 4;
+
+  // MLflow run link - this is the exact link of the run that generated this model version,
+  // potentially hosted at another instance of MLflow.
+  optional string run_link = 5;
 
   message Response {
     // Return new version number generated for this model in registry.

--- a/mlflow/protos/model_registry_pb2.py
+++ b/mlflow/protos/model_registry_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\024org.mlflow.api.proto\220\001\001\240\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\x14model_registry.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xda\x01\n\x0fRegisteredModel\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x02 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x03 \x01(\x03\x12\x0f\n\x07user_id\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12-\n\x0flatest_versions\x18\x06 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12(\n\x04tags\x18\x07 \x03(\x0b\x32\x1a.mlflow.RegisteredModelTag\"\xb1\x02\n\x0cModelVersion\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x03 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x04 \x01(\x03\x12\x0f\n\x07user_id\x18\x05 \x01(\t\x12\x15\n\rcurrent_stage\x18\x06 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x07 \x01(\t\x12\x0e\n\x06source\x18\x08 \x01(\t\x12\x0e\n\x06run_id\x18\t \x01(\t\x12*\n\x06status\x18\n \x01(\x0e\x32\x1a.mlflow.ModelVersionStatus\x12\x16\n\x0estatus_message\x18\x0b \x01(\t\x12%\n\x04tags\x18\x0c \x03(\x0b\x32\x17.mlflow.ModelVersionTag\"\xc1\x01\n\x15\x43reateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12(\n\x04tags\x18\x02 \x03(\x0b\x32\x1a.mlflow.RegisteredModelTag\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa9\x01\n\x15RenameRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\x15UpdateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"d\n\x15\x44\x65leteRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x94\x01\n\x12GetRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xca\x01\n\x14ListRegisteredModels\x12\x18\n\x0bmax_results\x18\x01 \x01(\x03:\x03\x31\x30\x30\x12\x12\n\npage_token\x18\x02 \x01(\t\x1aW\n\x08Response\x12\x32\n\x11registered_models\x18\x01 \x03(\x0b\x32\x17.mlflow.RegisteredModel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xee\x01\n\x16SearchRegisteredModels\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x18\n\x0bmax_results\x18\x02 \x01(\x03:\x03\x31\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aW\n\x08Response\x12\x32\n\x11registered_models\x18\x01 \x03(\x0b\x32\x17.mlflow.RegisteredModel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9e\x01\n\x11GetLatestVersions\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06stages\x18\x02 \x03(\t\x1a\x38\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xdb\x01\n\x12\x43reateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x14\n\x06source\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12%\n\x04tags\x18\x04 \x03(\x0b\x32\x17.mlflow.ModelVersionTag\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x01\n\x12UpdateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xec\x01\n\x1bTransitionModelVersionStage\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05stage\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\'\n\x19\x61rchive_existing_versions\x18\x04 \x01(\x08\x42\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"x\n\x12\x44\x65leteModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa2\x01\n\x0fGetModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe8\x01\n\x13SearchModelVersions\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x1b\n\x0bmax_results\x18\x02 \x01(\x03:\x06\x32\x30\x30\x30\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aQ\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\x1aGetModelVersionDownloadUri\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a \n\x08Response\x12\x14\n\x0c\x61rtifact_uri\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"-\n\x0fModelVersionTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x12RegisteredModelTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x8c\x01\n\x15SetRegisteredModelTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa0\x01\n\x12SetModelVersionTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x04 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x18\x44\x65leteRegisteredModelTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8e\x01\n\x15\x44\x65leteModelVersionTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*R\n\x12ModelVersionStatus\x12\x18\n\x14PENDING_REGISTRATION\x10\x01\x12\x17\n\x13\x46\x41ILED_REGISTRATION\x10\x02\x12\t\n\x05READY\x10\x03\x32\xc7\x1b\n\x14ModelRegistryService\x12\xb6\x01\n\x15\x63reateRegisteredModel\x12\x1d.mlflow.CreateRegisteredModel\x1a&.mlflow.CreateRegisteredModel.Response\"V\xf2\x86\x19R\n6\n\x04POST\x12(/preview/mlflow/registered-models/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x43reate RegisteredModel\x12\xb6\x01\n\x15renameRegisteredModel\x12\x1d.mlflow.RenameRegisteredModel\x1a&.mlflow.RenameRegisteredModel.Response\"V\xf2\x86\x19R\n6\n\x04POST\x12(/preview/mlflow/registered-models/rename\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Rename RegisteredModel\x12\xb7\x01\n\x15updateRegisteredModel\x12\x1d.mlflow.UpdateRegisteredModel\x1a&.mlflow.UpdateRegisteredModel.Response\"W\xf2\x86\x19S\n7\n\x05PATCH\x12(/preview/mlflow/registered-models/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Update RegisteredModel\x12\xb8\x01\n\x15\x64\x65leteRegisteredModel\x12\x1d.mlflow.DeleteRegisteredModel\x1a&.mlflow.DeleteRegisteredModel.Response\"X\xf2\x86\x19T\n8\n\x06\x44\x45LETE\x12(/preview/mlflow/registered-models/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x44\x65lete RegisteredModel\x12\xa6\x01\n\x12getRegisteredModel\x12\x1a.mlflow.GetRegisteredModel\x1a#.mlflow.GetRegisteredModel.Response\"O\xf2\x86\x19K\n2\n\x03GET\x12%/preview/mlflow/registered-models/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Get RegisteredModel\x12\xb9\x01\n\x16searchRegisteredModels\x12\x1e.mlflow.SearchRegisteredModels\x1a\'.mlflow.SearchRegisteredModels.Response\"V\xf2\x86\x19R\n5\n\x03GET\x12(/preview/mlflow/registered-models/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x17Search RegisteredModels\x12\xaf\x01\n\x14listRegisteredModels\x12\x1c.mlflow.ListRegisteredModels\x1a%.mlflow.ListRegisteredModels.Response\"R\xf2\x86\x19N\n3\n\x03GET\x12&/preview/mlflow/registered-models/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x15List RegisteredModels\x12\xb8\x01\n\x11getLatestVersions\x12\x19.mlflow.GetLatestVersions\x1a\".mlflow.GetLatestVersions.Response\"d\xf2\x86\x19`\nB\n\x03GET\x12\x35/preview/mlflow/registered-models/get-latest-versions\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Get Latest ModelVersions\x12\xa7\x01\n\x12\x63reateModelVersion\x12\x1a.mlflow.CreateModelVersion\x1a#.mlflow.CreateModelVersion.Response\"P\xf2\x86\x19L\n3\n\x04POST\x12%/preview/mlflow/model-versions/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x43reate ModelVersion\x12\xa8\x01\n\x12updateModelVersion\x12\x1a.mlflow.UpdateModelVersion\x1a#.mlflow.UpdateModelVersion.Response\"Q\xf2\x86\x19M\n4\n\x05PATCH\x12%/preview/mlflow/model-versions/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Update ModelVersion\x12\xd6\x01\n\x1btransitionModelVersionStage\x12#.mlflow.TransitionModelVersionStage\x1a,.mlflow.TransitionModelVersionStage.Response\"d\xf2\x86\x19`\n=\n\x04POST\x12//preview/mlflow/model-versions/transition-stage\x1a\x04\x08\x02\x10\x00\x10\x01*\x1dTransition ModelVersion Stage\x12\xa9\x01\n\x12\x64\x65leteModelVersion\x12\x1a.mlflow.DeleteModelVersion\x1a#.mlflow.DeleteModelVersion.Response\"R\xf2\x86\x19N\n5\n\x06\x44\x45LETE\x12%/preview/mlflow/model-versions/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x44\x65lete ModelVersion\x12\x97\x01\n\x0fgetModelVersion\x12\x17.mlflow.GetModelVersion\x1a .mlflow.GetModelVersion.Response\"I\xf2\x86\x19\x45\n/\n\x03GET\x12\"/preview/mlflow/model-versions/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x10Get ModelVersion\x12\xaa\x01\n\x13searchModelVersions\x12\x1b.mlflow.SearchModelVersions\x1a$.mlflow.SearchModelVersions.Response\"P\xf2\x86\x19L\n2\n\x03GET\x12%/preview/mlflow/model-versions/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x14Search ModelVersions\x12\xe0\x01\n\x1agetModelVersionDownloadUri\x12\".mlflow.GetModelVersionDownloadUri\x1a+.mlflow.GetModelVersionDownloadUri.Response\"q\xf2\x86\x19m\n<\n\x03GET\x12//preview/mlflow/model-versions/get-download-uri\x1a\x04\x08\x02\x10\x00\x10\x01*+Get Download URI For ModelVersion Artifacts\x12\xb9\x01\n\x15setRegisteredModelTag\x12\x1d.mlflow.SetRegisteredModelTag\x1a&.mlflow.SetRegisteredModelTag.Response\"Y\xf2\x86\x19U\n7\n\x04POST\x12)/preview/mlflow/registered-models/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Set Registered Model Tag\x12\xaa\x01\n\x12setModelVersionTag\x12\x1a.mlflow.SetModelVersionTag\x1a#.mlflow.SetModelVersionTag.Response\"S\xf2\x86\x19O\n4\n\x04POST\x12&/preview/mlflow/model-versions/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x15Set Model Version Tag\x12\xca\x01\n\x18\x64\x65leteRegisteredModelTag\x12 .mlflow.DeleteRegisteredModelTag\x1a).mlflow.DeleteRegisteredModelTag.Response\"a\xf2\x86\x19]\n<\n\x06\x44\x45LETE\x12,/preview/mlflow/registered-models/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x1b\x44\x65lete Registered Model Tag\x12\xbb\x01\n\x15\x64\x65leteModelVersionTag\x12\x1d.mlflow.DeleteModelVersionTag\x1a&.mlflow.DeleteModelVersionTag.Response\"[\xf2\x86\x19W\n9\n\x06\x44\x45LETE\x12)/preview/mlflow/model-versions/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x18\x44\x65lete Model Version TagB!\n\x14org.mlflow.api.proto\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\x14model_registry.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xda\x01\n\x0fRegisteredModel\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x02 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x03 \x01(\x03\x12\x0f\n\x07user_id\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12-\n\x0flatest_versions\x18\x06 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12(\n\x04tags\x18\x07 \x03(\x0b\x32\x1a.mlflow.RegisteredModelTag\"\xc3\x02\n\x0cModelVersion\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x03 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x04 \x01(\x03\x12\x0f\n\x07user_id\x18\x05 \x01(\t\x12\x15\n\rcurrent_stage\x18\x06 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x07 \x01(\t\x12\x0e\n\x06source\x18\x08 \x01(\t\x12\x0e\n\x06run_id\x18\t \x01(\t\x12*\n\x06status\x18\n \x01(\x0e\x32\x1a.mlflow.ModelVersionStatus\x12\x16\n\x0estatus_message\x18\x0b \x01(\t\x12%\n\x04tags\x18\x0c \x03(\x0b\x32\x17.mlflow.ModelVersionTag\x12\x10\n\x08run_link\x18\r \x01(\t\"\xc1\x01\n\x15\x43reateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12(\n\x04tags\x18\x02 \x03(\x0b\x32\x1a.mlflow.RegisteredModelTag\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa9\x01\n\x15RenameRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\x15UpdateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"d\n\x15\x44\x65leteRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x94\x01\n\x12GetRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xca\x01\n\x14ListRegisteredModels\x12\x18\n\x0bmax_results\x18\x01 \x01(\x03:\x03\x31\x30\x30\x12\x12\n\npage_token\x18\x02 \x01(\t\x1aW\n\x08Response\x12\x32\n\x11registered_models\x18\x01 \x03(\x0b\x32\x17.mlflow.RegisteredModel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xee\x01\n\x16SearchRegisteredModels\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x18\n\x0bmax_results\x18\x02 \x01(\x03:\x03\x31\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aW\n\x08Response\x12\x32\n\x11registered_models\x18\x01 \x03(\x0b\x32\x17.mlflow.RegisteredModel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9e\x01\n\x11GetLatestVersions\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06stages\x18\x02 \x03(\t\x1a\x38\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xed\x01\n\x12\x43reateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x14\n\x06source\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12%\n\x04tags\x18\x04 \x03(\x0b\x32\x17.mlflow.ModelVersionTag\x12\x10\n\x08run_link\x18\x05 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x01\n\x12UpdateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xec\x01\n\x1bTransitionModelVersionStage\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05stage\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\'\n\x19\x61rchive_existing_versions\x18\x04 \x01(\x08\x42\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"x\n\x12\x44\x65leteModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa2\x01\n\x0fGetModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe8\x01\n\x13SearchModelVersions\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x1b\n\x0bmax_results\x18\x02 \x01(\x03:\x06\x32\x30\x30\x30\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aQ\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\x1aGetModelVersionDownloadUri\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a \n\x08Response\x12\x14\n\x0c\x61rtifact_uri\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"-\n\x0fModelVersionTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x12RegisteredModelTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x8c\x01\n\x15SetRegisteredModelTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa0\x01\n\x12SetModelVersionTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x04 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x18\x44\x65leteRegisteredModelTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8e\x01\n\x15\x44\x65leteModelVersionTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*R\n\x12ModelVersionStatus\x12\x18\n\x14PENDING_REGISTRATION\x10\x01\x12\x17\n\x13\x46\x41ILED_REGISTRATION\x10\x02\x12\t\n\x05READY\x10\x03\x32\xc7\x1b\n\x14ModelRegistryService\x12\xb6\x01\n\x15\x63reateRegisteredModel\x12\x1d.mlflow.CreateRegisteredModel\x1a&.mlflow.CreateRegisteredModel.Response\"V\xf2\x86\x19R\n6\n\x04POST\x12(/preview/mlflow/registered-models/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x43reate RegisteredModel\x12\xb6\x01\n\x15renameRegisteredModel\x12\x1d.mlflow.RenameRegisteredModel\x1a&.mlflow.RenameRegisteredModel.Response\"V\xf2\x86\x19R\n6\n\x04POST\x12(/preview/mlflow/registered-models/rename\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Rename RegisteredModel\x12\xb7\x01\n\x15updateRegisteredModel\x12\x1d.mlflow.UpdateRegisteredModel\x1a&.mlflow.UpdateRegisteredModel.Response\"W\xf2\x86\x19S\n7\n\x05PATCH\x12(/preview/mlflow/registered-models/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Update RegisteredModel\x12\xb8\x01\n\x15\x64\x65leteRegisteredModel\x12\x1d.mlflow.DeleteRegisteredModel\x1a&.mlflow.DeleteRegisteredModel.Response\"X\xf2\x86\x19T\n8\n\x06\x44\x45LETE\x12(/preview/mlflow/registered-models/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x44\x65lete RegisteredModel\x12\xa6\x01\n\x12getRegisteredModel\x12\x1a.mlflow.GetRegisteredModel\x1a#.mlflow.GetRegisteredModel.Response\"O\xf2\x86\x19K\n2\n\x03GET\x12%/preview/mlflow/registered-models/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Get RegisteredModel\x12\xb9\x01\n\x16searchRegisteredModels\x12\x1e.mlflow.SearchRegisteredModels\x1a\'.mlflow.SearchRegisteredModels.Response\"V\xf2\x86\x19R\n5\n\x03GET\x12(/preview/mlflow/registered-models/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x17Search RegisteredModels\x12\xaf\x01\n\x14listRegisteredModels\x12\x1c.mlflow.ListRegisteredModels\x1a%.mlflow.ListRegisteredModels.Response\"R\xf2\x86\x19N\n3\n\x03GET\x12&/preview/mlflow/registered-models/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x15List RegisteredModels\x12\xb8\x01\n\x11getLatestVersions\x12\x19.mlflow.GetLatestVersions\x1a\".mlflow.GetLatestVersions.Response\"d\xf2\x86\x19`\nB\n\x03GET\x12\x35/preview/mlflow/registered-models/get-latest-versions\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Get Latest ModelVersions\x12\xa7\x01\n\x12\x63reateModelVersion\x12\x1a.mlflow.CreateModelVersion\x1a#.mlflow.CreateModelVersion.Response\"P\xf2\x86\x19L\n3\n\x04POST\x12%/preview/mlflow/model-versions/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x43reate ModelVersion\x12\xa8\x01\n\x12updateModelVersion\x12\x1a.mlflow.UpdateModelVersion\x1a#.mlflow.UpdateModelVersion.Response\"Q\xf2\x86\x19M\n4\n\x05PATCH\x12%/preview/mlflow/model-versions/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Update ModelVersion\x12\xd6\x01\n\x1btransitionModelVersionStage\x12#.mlflow.TransitionModelVersionStage\x1a,.mlflow.TransitionModelVersionStage.Response\"d\xf2\x86\x19`\n=\n\x04POST\x12//preview/mlflow/model-versions/transition-stage\x1a\x04\x08\x02\x10\x00\x10\x01*\x1dTransition ModelVersion Stage\x12\xa9\x01\n\x12\x64\x65leteModelVersion\x12\x1a.mlflow.DeleteModelVersion\x1a#.mlflow.DeleteModelVersion.Response\"R\xf2\x86\x19N\n5\n\x06\x44\x45LETE\x12%/preview/mlflow/model-versions/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x44\x65lete ModelVersion\x12\x97\x01\n\x0fgetModelVersion\x12\x17.mlflow.GetModelVersion\x1a .mlflow.GetModelVersion.Response\"I\xf2\x86\x19\x45\n/\n\x03GET\x12\"/preview/mlflow/model-versions/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x10Get ModelVersion\x12\xaa\x01\n\x13searchModelVersions\x12\x1b.mlflow.SearchModelVersions\x1a$.mlflow.SearchModelVersions.Response\"P\xf2\x86\x19L\n2\n\x03GET\x12%/preview/mlflow/model-versions/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x14Search ModelVersions\x12\xe0\x01\n\x1agetModelVersionDownloadUri\x12\".mlflow.GetModelVersionDownloadUri\x1a+.mlflow.GetModelVersionDownloadUri.Response\"q\xf2\x86\x19m\n<\n\x03GET\x12//preview/mlflow/model-versions/get-download-uri\x1a\x04\x08\x02\x10\x00\x10\x01*+Get Download URI For ModelVersion Artifacts\x12\xb9\x01\n\x15setRegisteredModelTag\x12\x1d.mlflow.SetRegisteredModelTag\x1a&.mlflow.SetRegisteredModelTag.Response\"Y\xf2\x86\x19U\n7\n\x04POST\x12)/preview/mlflow/registered-models/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Set Registered Model Tag\x12\xaa\x01\n\x12setModelVersionTag\x12\x1a.mlflow.SetModelVersionTag\x1a#.mlflow.SetModelVersionTag.Response\"S\xf2\x86\x19O\n4\n\x04POST\x12&/preview/mlflow/model-versions/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x15Set Model Version Tag\x12\xca\x01\n\x18\x64\x65leteRegisteredModelTag\x12 .mlflow.DeleteRegisteredModelTag\x1a).mlflow.DeleteRegisteredModelTag.Response\"a\xf2\x86\x19]\n<\n\x06\x44\x45LETE\x12,/preview/mlflow/registered-models/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x1b\x44\x65lete Registered Model Tag\x12\xbb\x01\n\x15\x64\x65leteModelVersionTag\x12\x1d.mlflow.DeleteModelVersionTag\x1a&.mlflow.DeleteModelVersionTag.Response\"[\xf2\x86\x19W\n9\n\x06\x44\x45LETE\x12)/preview/mlflow/model-versions/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x18\x44\x65lete Model Version TagB!\n\x14org.mlflow.api.proto\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -49,8 +49,8 @@ _MODELVERSIONSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4002,
-  serialized_end=4084,
+  serialized_start=4038,
+  serialized_end=4120,
 )
 _sym_db.RegisterEnumDescriptor(_MODELVERSIONSTATUS)
 
@@ -225,6 +225,13 @@ _MODELVERSION = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='run_link', full_name='mlflow.ModelVersion.run_link', index=12,
+      number=13, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -238,7 +245,7 @@ _MODELVERSION = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=295,
-  serialized_end=600,
+  serialized_end=618,
 )
 
 
@@ -268,8 +275,8 @@ _CREATEREGISTEREDMODEL_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=690,
-  serialized_end=751,
+  serialized_start=708,
+  serialized_end=769,
 )
 
 _CREATEREGISTEREDMODEL = _descriptor.Descriptor(
@@ -305,8 +312,8 @@ _CREATEREGISTEREDMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=603,
-  serialized_end=796,
+  serialized_start=621,
+  serialized_end=814,
 )
 
 
@@ -336,8 +343,8 @@ _RENAMEREGISTEREDMODEL_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=690,
-  serialized_end=751,
+  serialized_start=708,
+  serialized_end=769,
 )
 
 _RENAMEREGISTEREDMODEL = _descriptor.Descriptor(
@@ -373,8 +380,8 @@ _RENAMEREGISTEREDMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=799,
-  serialized_end=968,
+  serialized_start=817,
+  serialized_end=986,
 )
 
 
@@ -404,8 +411,8 @@ _UPDATEREGISTEREDMODEL_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=690,
-  serialized_end=751,
+  serialized_start=708,
+  serialized_end=769,
 )
 
 _UPDATEREGISTEREDMODEL = _descriptor.Descriptor(
@@ -441,8 +448,8 @@ _UPDATEREGISTEREDMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=971,
-  serialized_end=1143,
+  serialized_start=989,
+  serialized_end=1161,
 )
 
 
@@ -465,8 +472,8 @@ _DELETEREGISTEREDMODEL_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=690,
-  serialized_end=700,
+  serialized_start=708,
+  serialized_end=718,
 )
 
 _DELETEREGISTEREDMODEL = _descriptor.Descriptor(
@@ -495,8 +502,8 @@ _DELETEREGISTEREDMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1145,
-  serialized_end=1245,
+  serialized_start=1163,
+  serialized_end=1263,
 )
 
 
@@ -526,8 +533,8 @@ _GETREGISTEREDMODEL_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=690,
-  serialized_end=751,
+  serialized_start=708,
+  serialized_end=769,
 )
 
 _GETREGISTEREDMODEL = _descriptor.Descriptor(
@@ -556,8 +563,8 @@ _GETREGISTEREDMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1248,
-  serialized_end=1396,
+  serialized_start=1266,
+  serialized_end=1414,
 )
 
 
@@ -594,8 +601,8 @@ _LISTREGISTEREDMODELS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1469,
-  serialized_end=1556,
+  serialized_start=1487,
+  serialized_end=1574,
 )
 
 _LISTREGISTEREDMODELS = _descriptor.Descriptor(
@@ -631,8 +638,8 @@ _LISTREGISTEREDMODELS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1399,
-  serialized_end=1601,
+  serialized_start=1417,
+  serialized_end=1619,
 )
 
 
@@ -669,8 +676,8 @@ _SEARCHREGISTEREDMODELS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1469,
-  serialized_end=1556,
+  serialized_start=1487,
+  serialized_end=1574,
 )
 
 _SEARCHREGISTEREDMODELS = _descriptor.Descriptor(
@@ -720,8 +727,8 @@ _SEARCHREGISTEREDMODELS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1604,
-  serialized_end=1842,
+  serialized_start=1622,
+  serialized_end=1860,
 )
 
 
@@ -751,8 +758,8 @@ _GETLATESTVERSIONS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1902,
-  serialized_end=1958,
+  serialized_start=1920,
+  serialized_end=1976,
 )
 
 _GETLATESTVERSIONS = _descriptor.Descriptor(
@@ -788,8 +795,8 @@ _GETLATESTVERSIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1845,
-  serialized_end=2003,
+  serialized_start=1863,
+  serialized_end=2021,
 )
 
 
@@ -819,8 +826,8 @@ _CREATEMODELVERSION_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2125,
-  serialized_end=2180,
+  serialized_start=2161,
+  serialized_end=2216,
 )
 
 _CREATEMODELVERSION = _descriptor.Descriptor(
@@ -858,6 +865,13 @@ _CREATEMODELVERSION = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='run_link', full_name='mlflow.CreateModelVersion.run_link', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -870,8 +884,8 @@ _CREATEMODELVERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2006,
-  serialized_end=2225,
+  serialized_start=2024,
+  serialized_end=2261,
 )
 
 
@@ -901,8 +915,8 @@ _UPDATEMODELVERSION_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2125,
-  serialized_end=2180,
+  serialized_start=2161,
+  serialized_end=2216,
 )
 
 _UPDATEMODELVERSION = _descriptor.Descriptor(
@@ -945,8 +959,8 @@ _UPDATEMODELVERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2228,
-  serialized_end=2414,
+  serialized_start=2264,
+  serialized_end=2450,
 )
 
 
@@ -976,8 +990,8 @@ _TRANSITIONMODELVERSIONSTAGE_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2125,
-  serialized_end=2180,
+  serialized_start=2161,
+  serialized_end=2216,
 )
 
 _TRANSITIONMODELVERSIONSTAGE = _descriptor.Descriptor(
@@ -1027,8 +1041,8 @@ _TRANSITIONMODELVERSIONSTAGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2417,
-  serialized_end=2653,
+  serialized_start=2453,
+  serialized_end=2689,
 )
 
 
@@ -1051,8 +1065,8 @@ _DELETEMODELVERSION_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=690,
-  serialized_end=700,
+  serialized_start=708,
+  serialized_end=718,
 )
 
 _DELETEMODELVERSION = _descriptor.Descriptor(
@@ -1088,8 +1102,8 @@ _DELETEMODELVERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2655,
-  serialized_end=2775,
+  serialized_start=2691,
+  serialized_end=2811,
 )
 
 
@@ -1119,8 +1133,8 @@ _GETMODELVERSION_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2125,
-  serialized_end=2180,
+  serialized_start=2161,
+  serialized_end=2216,
 )
 
 _GETMODELVERSION = _descriptor.Descriptor(
@@ -1156,8 +1170,8 @@ _GETMODELVERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2778,
-  serialized_end=2940,
+  serialized_start=2814,
+  serialized_end=2976,
 )
 
 
@@ -1194,8 +1208,8 @@ _SEARCHMODELVERSIONS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3049,
-  serialized_end=3130,
+  serialized_start=3085,
+  serialized_end=3166,
 )
 
 _SEARCHMODELVERSIONS = _descriptor.Descriptor(
@@ -1245,8 +1259,8 @@ _SEARCHMODELVERSIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2943,
-  serialized_end=3175,
+  serialized_start=2979,
+  serialized_end=3211,
 )
 
 
@@ -1276,8 +1290,8 @@ _GETMODELVERSIONDOWNLOADURI_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3251,
-  serialized_end=3283,
+  serialized_start=3287,
+  serialized_end=3319,
 )
 
 _GETMODELVERSIONDOWNLOADURI = _descriptor.Descriptor(
@@ -1313,8 +1327,8 @@ _GETMODELVERSIONDOWNLOADURI = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3178,
-  serialized_end=3328,
+  serialized_start=3214,
+  serialized_end=3364,
 )
 
 
@@ -1351,8 +1365,8 @@ _MODELVERSIONTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3330,
-  serialized_end=3375,
+  serialized_start=3366,
+  serialized_end=3411,
 )
 
 
@@ -1389,8 +1403,8 @@ _REGISTEREDMODELTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3377,
-  serialized_end=3425,
+  serialized_start=3413,
+  serialized_end=3461,
 )
 
 
@@ -1413,8 +1427,8 @@ _SETREGISTEREDMODELTAG_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=690,
-  serialized_end=700,
+  serialized_start=708,
+  serialized_end=718,
 )
 
 _SETREGISTEREDMODELTAG = _descriptor.Descriptor(
@@ -1457,8 +1471,8 @@ _SETREGISTEREDMODELTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3428,
-  serialized_end=3568,
+  serialized_start=3464,
+  serialized_end=3604,
 )
 
 
@@ -1481,8 +1495,8 @@ _SETMODELVERSIONTAG_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=690,
-  serialized_end=700,
+  serialized_start=708,
+  serialized_end=718,
 )
 
 _SETMODELVERSIONTAG = _descriptor.Descriptor(
@@ -1532,8 +1546,8 @@ _SETMODELVERSIONTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3571,
-  serialized_end=3731,
+  serialized_start=3607,
+  serialized_end=3767,
 )
 
 
@@ -1556,8 +1570,8 @@ _DELETEREGISTEREDMODELTAG_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=690,
-  serialized_end=700,
+  serialized_start=708,
+  serialized_end=718,
 )
 
 _DELETEREGISTEREDMODELTAG = _descriptor.Descriptor(
@@ -1593,8 +1607,8 @@ _DELETEREGISTEREDMODELTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3733,
-  serialized_end=3855,
+  serialized_start=3769,
+  serialized_end=3891,
 )
 
 
@@ -1617,8 +1631,8 @@ _DELETEMODELVERSIONTAG_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=690,
-  serialized_end=700,
+  serialized_start=708,
+  serialized_end=718,
 )
 
 _DELETEMODELVERSIONTAG = _descriptor.Descriptor(
@@ -1661,8 +1675,8 @@ _DELETEMODELVERSIONTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3858,
-  serialized_end=4000,
+  serialized_start=3894,
+  serialized_end=4036,
 )
 
 _REGISTEREDMODEL.fields_by_name['latest_versions'].message_type = _MODELVERSION
@@ -2101,8 +2115,8 @@ _MODELREGISTRYSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=4087,
-  serialized_end=7614,
+  serialized_start=4123,
+  serialized_end=7650,
   methods=[
   _descriptor.MethodDescriptor(
     name='createRegisteredModel',

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -605,10 +605,12 @@ def _delete_registered_model_tag():
 @catch_mlflow_exception
 def _create_model_version():
     request_message = _get_request_message(CreateModelVersion())
-    model_version = _get_model_registry_store().create_model_version(name=request_message.name,
-                                                                     source=request_message.source,
-                                                                     run_id=request_message.run_id,
-                                                                     tags=request_message.tags)
+    model_version = _get_model_registry_store().create_model_version(
+        name=request_message.name,
+        source=request_message.source,
+        run_id=request_message.run_id,
+        run_link=request_message.run_link,
+        tags=request_message.tags)
     response_message = CreateModelVersion.Response(model_version=model_version.to_proto())
     return _wrap_response(response_message)
 

--- a/mlflow/store/db_migrations/versions/84291f40a231_add_run_link_to_model_version.py
+++ b/mlflow/store/db_migrations/versions/84291f40a231_add_run_link_to_model_version.py
@@ -1,0 +1,25 @@
+"""add run_link to model_version
+
+Revision ID: 84291f40a231
+Revises: 27a6a02d2cf1
+Create Date: 2020-07-16 13:45:56.178092
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '84291f40a231'
+down_revision = '27a6a02d2cf1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('model_versions',
+                  sa.Column('run_link', sa.String(500), nullable=False, default=None))
+
+
+def downgrade():
+    pass

--- a/mlflow/store/db_migrations/versions/84291f40a231_add_run_link_to_model_version.py
+++ b/mlflow/store/db_migrations/versions/84291f40a231_add_run_link_to_model_version.py
@@ -18,7 +18,7 @@ depends_on = None
 
 def upgrade():
     op.add_column('model_versions',
-                  sa.Column('run_link', sa.String(500), nullable=False, default=None))
+                  sa.Column('run_link', sa.String(500), nullable=True, default=None))
 
 
 def downgrade():

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -144,16 +144,16 @@ class AbstractStore:
     # CRUD API for ModelVersion objects
 
     @abstractmethod
-    def create_model_version(self, name, source, run_id, run_link=None, tags=None):
+    def create_model_version(self, name, source, run_id, tags=None, run_link=None):
         """
         Create a new model version from given source and run ID.
 
         :param name: Registered model name.
         :param source: Source path where the MLflow model is stored.
         :param run_id: Run ID from MLflow tracking server that generated the model.
-        :param run_link: Link to the run from an MLflow tracking server that generated this model.
         :param tags: A list of :py:class:`mlflow.entities.model_registry.ModelVersionTag`
                      instances associated with this model version.
+        :param run_link: Link to the run from an MLflow tracking server that generated this model.
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
                  created in the backend.
         """

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -144,13 +144,14 @@ class AbstractStore:
     # CRUD API for ModelVersion objects
 
     @abstractmethod
-    def create_model_version(self, name, source, run_id, tags=None):
+    def create_model_version(self, name, source, run_id, run_link=None, tags=None):
         """
         Create a new model version from given source and run ID.
 
         :param name: Registered model name.
         :param source: Source path where the MLflow model is stored.
         :param run_id: Run ID from MLflow tracking server that generated the model.
+        :param run_link: Link to the run from an MLflow tracking server that generated this model.
         :param tags: A list of :py:class:`mlflow.entities.model_registry.ModelVersionTag`
                      instances associated with this model version.
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`

--- a/mlflow/store/model_registry/dbmodels/models.py
+++ b/mlflow/store/model_registry/dbmodels/models.py
@@ -67,6 +67,8 @@ class SqlModelVersion(Base):
 
     run_id = Column(String(32), nullable=False)
 
+    run_link = Column(String(500), nullable=True, default=None)
+
     status = Column(String(20),
                     default=ModelVersionStatus.to_string(ModelVersionStatus.READY))
 
@@ -87,7 +89,8 @@ class SqlModelVersion(Base):
                             self.creation_time, self.last_updated_time, self.description,
                             self.user_id, self.current_stage, self.source, self.run_id,
                             self.status, self.status_message,
-                            [tag.to_mlflow_entity() for tag in self.model_version_tags])
+                            [tag.to_mlflow_entity() for tag in self.model_version_tags],
+                            self.run_link)
 
 
 class SqlRegisteredModelTag(Base):

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -188,7 +188,7 @@ class RestStore(AbstractStore):
 
     # CRUD API for ModelVersion objects
 
-    def create_model_version(self, name, source, run_id, run_link=None, tags=None):
+    def create_model_version(self, name, source, run_id, tags=None, run_link=None):
         """
         Create a new model version from given source and run ID.
 

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -195,9 +195,9 @@ class RestStore(AbstractStore):
         :param name: Registered model name.
         :param source: Source path where the MLflow model is stored.
         :param run_id: Run ID from MLflow tracking server that generated the model.
-        :param run_link: Link to the run from an MLflow tracking server that generated this model.
         :param tags: A list of :py:class:`mlflow.entities.model_registry.ModelVersionTag`
                      instances associated with this model version.
+        :param run_link: Link to the run from an MLflow tracking server that generated this model.
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
                  created in the backend.
         """

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -188,13 +188,14 @@ class RestStore(AbstractStore):
 
     # CRUD API for ModelVersion objects
 
-    def create_model_version(self, name, source, run_id, tags=None):
+    def create_model_version(self, name, source, run_id, run_link=None, tags=None):
         """
         Create a new model version from given source and run ID.
 
         :param name: Registered model name.
         :param source: Source path where the MLflow model is stored.
         :param run_id: Run ID from MLflow tracking server that generated the model.
+        :param run_link: Link to the run from an MLflow tracking server that generated this model.
         :param tags: A list of :py:class:`mlflow.entities.model_registry.ModelVersionTag`
                      instances associated with this model version.
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
@@ -202,7 +203,8 @@ class RestStore(AbstractStore):
         """
         proto_tags = [tag.to_proto() for tag in tags or []]
         req_body = message_to_json(CreateModelVersion(name=name, source=source,
-                                                      run_id=run_id, tags=proto_tags))
+                                                      run_id=run_id, run_link=run_link,
+                                                      tags=proto_tags))
         response_proto = self._call_endpoint(CreateModelVersion, req_body)
         return ModelVersion.from_proto(response_proto.model_version)
 

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -528,7 +528,7 @@ class SqlAlchemyStore(AbstractStore):
     def _get_sql_model_version_including_deleted(self, name, version):
         """
         Private method to retrieve model versions including those that are internally deleted.
-        Used to verify redaction behavior on deletion.
+        Used in tests to verify redaction behavior on deletion.
         :param name: Registered model name.
         :param version: Registered model version.
         :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -443,7 +443,7 @@ class SqlAlchemyStore(AbstractStore):
 
     # CRUD API for ModelVersion objects
 
-    def create_model_version(self, name, source, run_id, run_link=None, tags=None):
+    def create_model_version(self, name, source, run_id, tags=None, run_link=None):
         """
         Create a new model version from given source and run ID.
 

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -526,6 +526,13 @@ class SqlAlchemyStore(AbstractStore):
         return cls._get_model_version_from_db(session, name, version, conditions, query_options)
 
     def _get_sql_model_version_including_deleted(self, name, version):
+        """
+        Private method to retrieve model versions including those that are internally deleted.
+        Used to verify redaction behavior on deletion.
+        :param name: Registered model name.
+        :param version: Registered model version.
+        :return: A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
+        """
         with self.ManagedSessionMaker() as session:
             conditions = [
                 SqlModelVersion.name == name,

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -450,9 +450,9 @@ class SqlAlchemyStore(AbstractStore):
         :param name: Registered model name.
         :param source: Source path where the MLflow model is stored.
         :param run_id: Run ID from MLflow tracking server that generated the model.
-        :param run_link: Link to the run from an MLflow tracking server that generated this model.
         :param tags: A list of :py:class:`mlflow.entities.model_registry.ModelVersionTag`
                      instances associated with this model version.
+        :param run_link: Link to the run from an MLflow tracking server that generated this model.
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
                  created in the backend.
         """

--- a/tests/entities/model_registry/test_model_version.py
+++ b/tests/entities/model_registry/test_model_version.py
@@ -33,9 +33,11 @@ class TestModelVersion(unittest.TestCase):
         t1, t2 = 100, 150
         source = "path/to/source"
         run_id = uuid.uuid4().hex
+        run_link = "http://localhost:5000/path/to/run"
         tags = [ModelVersionTag("key", "value"), ModelVersionTag("randomKey", "not a random value")]
         mvd = ModelVersion(name, "5", t1, t2, "version five", "user 1", "Production",
-                           source, run_id, "READY", "Model version #5 is ready to use.", tags)
+                           source, run_id, "READY", "Model version #5 is ready to use.", tags,
+                           run_link)
         self._check(mvd, name, "5", t1, t2, "version five", "user 1",
                     "Production", source, run_id, "READY",
                     "Model version #5 is ready to use.",
@@ -51,6 +53,7 @@ class TestModelVersion(unittest.TestCase):
             "current_stage": "Production",
             "source": source,
             "run_id": run_id,
+            "run_link": run_link,
             "status": "READY",
             "status_message": "Model version #5 is ready to use.",
             "tags": {tag.key: tag.value for tag in (tags or [])}}
@@ -90,6 +93,7 @@ class TestModelVersion(unittest.TestCase):
                                      current_stage="Archived",
                                      source="path/to/a/notebook",
                                      run_id="some run",
+                                     run_link="http://localhost:5000/path/to/run",
                                      status="PENDING_REGISTRATION",
                                      status_message="Copying!",
                                      tags=[])
@@ -98,6 +102,7 @@ class TestModelVersion(unittest.TestCase):
                                      "current_stage='Archived', description='This is a test " \
                                      "model.', last_updated_timestamp=100, " \
                                      "name='myname', " \
-                                     "run_id='some run', source='path/to/a/notebook', " \
+                                     "run_id='some run', run_link='http://localhost:5000/path/" \
+                                     "to/run', source='path/to/a/notebook', " \
                                      "status='PENDING_REGISTRATION', status_message='Copying!', " \
                                      "tags={}, user_id='user one', version='43'>"

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -47,6 +47,7 @@ CREATE TABLE model_versions (
 	run_id VARCHAR(32) NOT NULL,
 	status VARCHAR(20),
 	status_message VARCHAR(500),
+	run_link VARCHAR(500),
 	CONSTRAINT model_version_pk PRIMARY KEY (name, version),
 	FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
 )

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -372,12 +372,15 @@ def test_create_model_version(mock_get_request_message, mock_model_registry_stor
     run_id = uuid.uuid4().hex
     tags = [ModelVersionTag(key="key", value="value"),
             ModelVersionTag(key="anotherKey", value="some other value")]
+    run_link = "localhost:5000/path/to/run"
     mock_get_request_message.return_value = CreateModelVersion(name="model_1",
                                                                source="A/B",
                                                                run_id=run_id,
+                                                               run_link=run_link,
                                                                tags=[tag.to_proto()
                                                                      for tag in tags])
-    mv = ModelVersion(name="model_1", version="12", creation_timestamp=123, tags=tags)
+    mv = ModelVersion(name="model_1", version="12", creation_timestamp=123, tags=tags,
+                      run_link=run_link)
     mock_model_registry_store.create_model_version.return_value = mv
     resp = _create_model_version()
     _, args = mock_model_registry_store.create_model_version.call_args
@@ -385,6 +388,7 @@ def test_create_model_version(mock_get_request_message, mock_model_registry_stor
     assert args["source"] == "A/B"
     assert args["run_id"] == run_id
     assert {tag.key: tag.value for tag in args["tags"]} == {tag.key: tag.value for tag in tags}
+    assert args["run_link"] == run_link
     assert json.loads(resp.get_data()) == {"model_version": jsonify(mv)}
 
 

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -154,7 +154,8 @@ class TestRestStore(unittest.TestCase):
                 ModelVersionTag(key="anotherKey", value="some other value")]
         run_id = uuid.uuid4().hex
         run_link = "localhost:5000/path/to/run"
-        self.store.create_model_version("model_1", "path/to/source", run_id, run_link, tags)
+        self.store.create_model_version("model_1", "path/to/source", run_id, tags,
+                                        run_link=run_link)
         self._verify_requests(mock_http, "model-versions/create", "POST",
                               CreateModelVersion(name="model_1", source="path/to/source",
                                                  run_id=run_id, run_link=run_link,

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -153,10 +153,11 @@ class TestRestStore(unittest.TestCase):
         tags = [ModelVersionTag(key="key", value="value"),
                 ModelVersionTag(key="anotherKey", value="some other value")]
         run_id = uuid.uuid4().hex
-        self.store.create_model_version("model_1", "path/to/source", run_id, tags)
+        run_link = "localhost:5000/path/to/run"
+        self.store.create_model_version("model_1", "path/to/source", run_id, run_link, tags)
         self._verify_requests(mock_http, "model-versions/create", "POST",
                               CreateModelVersion(name="model_1", source="path/to/source",
-                                                 run_id=run_id,
+                                                 run_id=run_id, run_link=run_link,
                                                  tags=[tag.to_proto() for tag in tags]))
 
     @mock.patch('mlflow.utils.rest_utils.http_request')

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -40,7 +40,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
     def _mv_maker(self, name, source="path/to/source", run_id=uuid.uuid4().hex, tags=None,
                   run_link=None):
-        return self.store.create_model_version(name, source, run_id, run_link, tags)
+        return self.store.create_model_version(name, source, run_id, tags, run_link=run_link)
 
     def _extract_latest_by_stage(self, latest_versions):
         return {mvd.current_stage: mvd.version for mvd in latest_versions}


### PR DESCRIPTION
## What changes are proposed in this pull request?

We're adding a field runLink to the model version object. This will help with lineage tracking in a scenario where a different workspace or MLflow server than the server where the model is generated is hosting the model registry. For example, in Databricks, this field will identify the exact link of the run that generated the current model version. 

## How is this patch tested?

Unit testing

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
