### PR TITLE
Fix prop types for `creation_timestamp` and `last_updated_timestamp`

### DIFF
--- a/mlflow/server/js/src/model-registry/components/ModelView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelView.js
@@ -27,8 +27,8 @@ export class ModelView extends React.Component {
   static propTypes = {
     model: PropTypes.shape({
       name: PropTypes.string.isRequired,
-      creation_timestamp: PropTypes.number.isRequired,
-      last_updated_timestamp: PropTypes.number.isRequired,
+      creation_timestamp: PropTypes.string.isRequired,
+      last_updated_timestamp: PropTypes.string.isRequired,
     }),
     modelVersions: PropTypes.arrayOf(
       PropTypes.shape({

--- a/mlflow/server/js/src/model-registry/test-utils.js
+++ b/mlflow/server/js/src/model-registry/test-utils.js
@@ -1,7 +1,7 @@
 export const mockRegisteredModelDetailed = (name, latestVersions = []) => {
   return {
-    creation_timestamp: 1571344731467,
-    last_updated_timestamp: 1573581360069,
+    creation_timestamp: '1571344731467',
+    last_updated_timestamp: '1573581360069',
     latest_versions: latestVersions,
     name,
   };
@@ -12,8 +12,8 @@ export const mockModelVersionDetailed = (name, version, stage, status) => {
     name,
     // Use version-based timestamp to make creation_timestamp differ across model versions
     // and prevent React duplicate key warning.
-    creation_timestamp: version,
-    last_updated_timestamp: version + 1,
+    creation_timestamp: version.toString(),
+    last_updated_timestamp: (version + 1).toString(),
     user_id: 'richard@example.com',
     current_stage: stage,
     description: '',


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix prop types for `creation_timestamp` and `last_updated_timestamp`.

## How is this patch tested?

Before:

<img width="1047" alt="Screen Shot 2020-07-18 at 14 10 54" src="https://user-images.githubusercontent.com/17039389/87845256-bb6eb880-c900-11ea-8c8e-6686bdc8d358.png">

After:

<img width="1047" alt="Screen Shot 2020-07-18 at 14 11 57" src="https://user-images.githubusercontent.com/17039389/87845255-b873c800-c900-11ea-8b5d-76d7f682d90c.png">


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
