### PR TITLE
Fix a bug for `_enforce_type` in pandas >= 1.0

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -292,16 +292,6 @@ def _enforce_type(name, values: pandas.Series, t: DataType):
     if values.dtype == np.object and t not in (DataType.binary, DataType.string):
         values = values.infer_objects()
 
-    if values.dtype in (t.to_pandas(), t.to_numpy()):
-        # The types are already compatible => conversion is not necessary.
-        return values
-
-    if t == DataType.binary and values.dtype.kind == t.binary.to_numpy().kind:
-        # NB: bytes in numpy have variable itemsize depending on the length of the longest
-        # element in the array (column). Since MLflow binary type is length agnostic, we ignore
-        # itemsize when matching binary columns.
-        return values
-
     if t == DataType.string and values.dtype == np.object:
         #  NB: strings are by default parsed and inferred as objects, but it is
         # recommended to use StringDtype extension type if available. See
@@ -316,6 +306,16 @@ def _enforce_type(name, values: pandas.Series, t: DataType):
                 "Failed to convert column {0} from type {1} to {2}.".format(
                   name, values.dtype, t)
             )
+
+    if values.dtype in (t.to_pandas(), t.to_numpy()):
+        # The types are already compatible => conversion is not necessary.
+        return values
+
+    if t == DataType.binary and values.dtype.kind == t.binary.to_numpy().kind:
+        # NB: bytes in numpy have variable itemsize depending on the length of the longest
+        # element in the array (column). Since MLflow binary type is length agnostic, we ignore
+        # itemsize when matching binary columns.
+        return values
 
     numpy_type = t.to_numpy()
     is_compatible_type = values.dtype.kind == numpy_type.kind

--- a/travis/large-requirements.txt
+++ b/travis/large-requirements.txt
@@ -11,7 +11,6 @@ onnxmltools==1.4.0;
 onnxruntime==0.3.0;
 mleap==0.16.0
 mxnet==1.5.0
-pandas<=0.23.4
 pyarrow==0.17.0
 pyspark==2.4.0
 pytest==3.2.1

--- a/travis/small-requirements.txt
+++ b/travis/small-requirements.txt
@@ -6,7 +6,6 @@ boto3==1.9.84      # pinned for moto
 mock==2.0.0
 moto==1.3.7
 mxnet==1.5.0
-pandas<=0.23.4
 scikit-learn==0.20.2
 scipy==1.2.1
 pyarrow==0.17.0


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fixes #3006 

## How is this patch tested?

Run the tests with `pandas>=1.0` and `pandas==0.23.4`.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
