### PR TITLE
Bug-fix: Tags table doesn't refresh after deleting a tag

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/actions.js
+++ b/mlflow/server/js/src/experiment-tracking/actions.js
@@ -176,7 +176,7 @@ export const deleteTagApi = (runUuid, tagName, id = getUUID()) => {
       run_id: runUuid,
       key: tagName,
     }),
-    meta: { id: id, run_id: runUuid, key: tagName },
+    meta: { id: id, runUuid: runUuid, key: tagName },
   };
 };
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fix -when deleting a tag that the tag table counts error. Need to reload the page and then can make sure the tag already delete.

## How is this patch tested?
Just delete a tag. And You can see the tags table will have correct tags count.

## Release Notes

### Is this a user-facing change?

- [ x ] Yes. Give a description of this change to be included in the release notes for MLflow users.



### What component(s), interfaces, languages, and integrations does this PR affect?

Interface 
- [ X ] `area/uiux`: Front-end, user experience, JavaScript, plotting

### How should the PR be classified in the release notes? Choose one:

- [ x ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section


tips: It's my first commit. And English not my mother tongue
