### PR TITLE
[R] fix duplicate stderr logging

### DIFF
--- a/mlflow/R/mlflow/R/cli.R
+++ b/mlflow/R/mlflow/R/cli.R
@@ -5,8 +5,8 @@
 #   Defaults to \code{FALSE}.
 # @param echo Print the standard output and error to the screen? Defaults to
 #   \code{TRUE}, does not apply to background tasks.
-# @param stderr_callback NULL, or a function to call for every chunk of the standard error.
-#   Defaults to a function that prints chunks to standard error.
+# @param stderr_callback \code{NULL} (the default), or a function to call for 
+#   every chunk of the standard error, passed to \code{\link[=processx:run]{processx::run()}}.
 # @param client Mlflow client to provide environment for the cli process.
 #
 # @return A \code{processx} task.

--- a/mlflow/R/mlflow/R/cli.R
+++ b/mlflow/R/mlflow/R/cli.R
@@ -30,11 +30,6 @@ mlflow_cli <- function(...,
     MLFLOW_BIN = mlflow_bin,
     MLFLOW_PYTHON_BIN = python_bin()
   ), env)
-  if (is.null(stderr_callback)) {
-    stderr_callback <- function(x, p) {
-      cat(x, file = stderr())
-    }
-  }
   with_envvar(env, {
     if (background) {
       result <- process$new(mlflow_bin, args = unlist(args), echo_cmd = verbose, supervise = TRUE)


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>

## What changes are proposed in this pull request?

This PR deletes a callback that is duplicating content of stderr of a child process in the parent process.

Because processx by default already pipes back the child process's stderr to parent (as in `stderr = "|"` in processx nomenclature), the additional stderr callback is unnecessary.

## How is this patch tested?

Ran through the same simple repro steps described in https://github.com/mlflow/mlflow/issues/2673 and observed there was no duplicate stderr from parent process any more.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
