### PR TITLE
[docs] fix information hierarchy in model registry workflow page

### DIFF
--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -11,7 +11,7 @@ staging to production), and annotations.
 
 .. contents:: Table of Contents
   :local:
-  :depth: 2
+  :depth: 3
 
 Concepts
 ========
@@ -43,7 +43,10 @@ of the corresponding model flavors. Once a model has been logged, you can add, m
 or delete model in the Model Registry through the UI or the API.
 
 UI Workflow
-===========
+-----------
+
+Registering a Model
+^^^^^^^^^^^^^^^^^^
 
 #. From the MLflow Runs detail page, select a logged MLflow Model in the **Artifacts** section.
 
@@ -55,7 +58,8 @@ UI Workflow
 
   .. figure:: _static/images/oss_registry_2_dialog.png
 
-Once the model is added to the Model Registry you can:
+Using the Model Registry
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Navigate to the **Registered Models** page and view the model properties.
 
@@ -81,13 +85,13 @@ version to one of the other valid stages.
 
 
 API Workflow
-============
+------------
 
 An alternative way to interact with Model Registry is using the :ref:`MLflow model flavor <python-api>` or :ref:`MLflow Client Tracking API <mlflow.tracking>` interface.
 In particular, you can register a model during an MLflow experiment run or after all your experiment runs.
 
 Adding an MLflow Model to the Model Registry
---------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 There are three programmatic ways to add a model to the registry. First, you can use the ``mlflow.<model_flavor>.log_model()`` method. For example, in your code:
 
@@ -153,7 +157,7 @@ While the method above creates an empty registered model with no version associa
     )
 
 Fetching an MLflow Model from the Model Registry
-------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 After you have registered an MLflow model, you can fetch that model using ``mlflow.<model_flavor>.load_model()``, or more generally, :meth:`~mlflow.pyfunc.load_model`. 
 
@@ -192,7 +196,7 @@ To fetch a model version by stage, simply provide the model stage as part of the
     model.predict(data)
 
 Serving an MLflow Model from Model Registry
--------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 After you have registered an MLflow model, you can serve the model as a service on your host.
 
@@ -207,7 +211,7 @@ After you have registered an MLflow model, you can serve the model as a service 
     mlflow models serve -m "models:/sk-learn-random-forest-reg-model/Production"
 
 Adding or Updating an MLflow Model Descriptions
------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 At any point in a model’s lifecycle development, you can update a model version's description using :meth:`~mlflow.tracking.MlflowClient.update_model_version`.
 
@@ -221,7 +225,7 @@ At any point in a model’s lifecycle development, you can update a model versio
     )
 
 Renaming an MLflow Model
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 As well as adding or updating a description of a specific version of the model, you can rename an existing registered model using :meth:`~mlflow.tracking.MlflowClient.rename_registered_model`.
 
@@ -234,7 +238,7 @@ As well as adding or updating a description of a specific version of the model, 
     )
 
 Transitioning an MLflow Model’s Stage
--------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Over the course of the model’s lifecycle, a model evolves—from development to staging to production.
 You can transition a registered model to one of the stages: **Staging**, **Production** or **Archived**.
 
@@ -250,7 +254,7 @@ You can transition a registered model to one of the stages: **Staging**, **Produ
 The accepted values for <stage> are: Staging|Archived|Production|None.
 
 Listing and Searching MLflow Models
------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 You can fetch a list of all registered models in the registry with a simple method.
 
 .. code-block:: py
@@ -313,7 +317,7 @@ This outputs:
 
 
 Archiving an MLflow Model
--------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^
 You can move models versions out of a **Production** stage into an **Archived** stage.
 At a later point, if that archived model is not needed, you can delete it.
 
@@ -328,7 +332,7 @@ At a later point, if that archived model is not needed, you can delete it.
     )
 
 Deleting MLflow Models
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^
 
 .. note::
     Deleting registered models or model versions is irrevocable, so use it judiciously.

--- a/docs/source/model-registry.rst
+++ b/docs/source/model-registry.rst
@@ -46,7 +46,7 @@ UI Workflow
 -----------
 
 Registering a Model
-^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^
 
 #. From the MLflow Runs detail page, select a logged MLflow Model in the **Artifacts** section.
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently, the table of contents looks like this:
![image](https://user-images.githubusercontent.com/52183359/88118190-db58e300-cb71-11ea-99d3-a33b071f1f82.png)

This is incorrect, since the UI workflow and the API workflow should be subheadings of Model Registry workflows

This PR adjusts this so that the UI/API workflows fall under the Model Registry workflows section

## How is this patch tested?

Go to docs/ and run make livehtml

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
