### PR TITLE
Add to_dictionary() method for mlflow.entities.model_registry.registe…

### DIFF
--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -155,3 +155,23 @@ class ModelVersion(_ModelRegistryEntity):
         model_version.tags.extend([ProtoModelVersionTag(key=key, value=value)
                                    for key, value in self._tags.items()])
         return model_version
+
+    def to_dictionary(self):
+        """
+        Converts mlflow.entities.model_registry.model_version.ModelVersion
+        contents into a python dictionary
+        """
+        model_version_dict = {
+            "creation_timestamp": self.creation_timestamp,
+            "current_stage": self.current_stage,
+            "description": self.description,
+            "last_updated_timestamp": self.last_updated_timestamp,
+            "name": self.name,
+            "run_id": self.run_id,
+            "source": self.source,
+            "status": self.status,
+            "status_message": self.status_message,
+            "tags": self.tags,
+            "user_id": self.user_id,
+            "version": self.version}
+        return model_version_dict

--- a/mlflow/entities/model_registry/registered_model.py
+++ b/mlflow/entities/model_registry/registered_model.py
@@ -94,3 +94,24 @@ class RegisteredModel(_ModelRegistryEntity):
         rmd.tags.extend([ProtoRegisteredModelTag(key=key, value=value)
                         for key, value in self._tags.items()])
         return rmd
+
+    def to_dictionary(self):
+        """
+        Converts mlflow.entities.model_registry.registered_model.RegisteredModel contents into a python dictionary
+        """
+        model_version_dict = {
+            "creation_timestamp": self.creation_timestamp,
+            "current_stage": self.current_stage,
+            "description": self.description,
+            "last_updated_timestamp": self.last_updated_timestamp,
+            "name": self.name,
+            "run_id": self.run_id,
+            "source": self.source,
+            "status": self.status,
+            "status_message": self.status_message,
+            "tags": self.tags,
+            "user_id": self.user_id,
+            "version": self.version}
+        return model_version_dict
+
+

--- a/mlflow/entities/model_registry/registered_model.py
+++ b/mlflow/entities/model_registry/registered_model.py
@@ -97,7 +97,8 @@ class RegisteredModel(_ModelRegistryEntity):
 
     def to_dictionary(self):
         """
-        Converts mlflow.entities.model_registry.registered_model.RegisteredModel contents into a python dictionary
+        Converts mlflow.entities.model_registry.registered_model.RegisteredModel
+        contents into a python dictionary
         """
         model_version_dict = {
             "creation_timestamp": self.creation_timestamp,
@@ -113,5 +114,3 @@ class RegisteredModel(_ModelRegistryEntity):
             "user_id": self.user_id,
             "version": self.version}
         return model_version_dict
-
-

--- a/mlflow/entities/model_registry/registered_model.py
+++ b/mlflow/entities/model_registry/registered_model.py
@@ -94,23 +94,3 @@ class RegisteredModel(_ModelRegistryEntity):
         rmd.tags.extend([ProtoRegisteredModelTag(key=key, value=value)
                         for key, value in self._tags.items()])
         return rmd
-
-    def to_dictionary(self):
-        """
-        Converts mlflow.entities.model_registry.registered_model.RegisteredModel
-        contents into a python dictionary
-        """
-        model_version_dict = {
-            "creation_timestamp": self.creation_timestamp,
-            "current_stage": self.current_stage,
-            "description": self.description,
-            "last_updated_timestamp": self.last_updated_timestamp,
-            "name": self.name,
-            "run_id": self.run_id,
-            "source": self.source,
-            "status": self.status,
-            "status_message": self.status_message,
-            "tags": self.tags,
-            "user_id": self.user_id,
-            "version": self.version}
-        return model_version_dict


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a to_dictionary() method for mlflow.entities.model_registry.registered_model.RegisteredModel

## How is this patch tested?

Called on various mlflow.entities.model_registry.registered_model.RegisteredModel objects.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Inclusion of to_dictionary() method that converts mlflow.entities.model_registry.registered_model.RegisteredModel contents into a python dictionary.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
