### PR TITLE
Handle np.nan when inferring schema with np.object array

### DIFF
--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -116,7 +116,7 @@ def _infer_numpy_array(col: np.ndarray) -> DataType:
             self.seen_instances = 0
 
         def __call__(self, x):
-            if x is None:
+            if x is None or np.isnan(x):
                 return True
             elif any(map(lambda c: isinstance(x, c), self.classes)):
                 self.seen_instances += 1

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -82,28 +82,27 @@ def test_schema_inference_on_numpy_array(pandas_df_with_all_types):
     assert schema == Schema([ColSpec(DataType.double)])
 
     # test bytes
-    schema = _infer_schema(np.array([bytes([1])], dtype=np.bytes_))
-
+    schema = _infer_schema(np.array([bytes([1]), np.nan], dtype=np.bytes_))
     assert schema == Schema([ColSpec(DataType.binary)])
-    schema = _infer_schema(np.array([bytearray([1])], dtype=np.bytes_))
+    schema = _infer_schema(np.array([bytearray([1]), np.nan], dtype=np.bytes_))
     assert schema == Schema([ColSpec(DataType.binary)])
 
     # test string
-    schema = _infer_schema(np.array(["a"], dtype=np.str))
+    schema = _infer_schema(np.array(["a", np.nan], dtype=np.str))
     assert schema == Schema([ColSpec(DataType.string)])
 
     # test boolean
-    schema = _infer_schema(np.array([True], dtype=np.bool))
+    schema = _infer_schema(np.array([True, np.nan], dtype=np.bool))
     assert schema == Schema([ColSpec(DataType.boolean)])
 
     # test ints
     for t in [np.uint8, np.uint16, np.int8, np.int16, np.int32]:
-        schema = _infer_schema(np.array([1, 2, 3], dtype=t))
+        schema = _infer_schema(np.array([1, 2, 3, np.nan], dtype=t))
         assert schema == Schema([ColSpec("integer")])
 
     # test longs
     for t in [np.uint32, np.int64]:
-        schema = _infer_schema(np.array([1, 2, 3], dtype=t))
+        schema = _infer_schema(np.array([1, 2, 3, np.nan], dtype=t))
         assert schema == Schema([ColSpec("long")])
 
     # unsigned long is unsupported
@@ -112,11 +111,11 @@ def test_schema_inference_on_numpy_array(pandas_df_with_all_types):
 
     # test floats
     for t in [np.float16, np.float32]:
-        schema = _infer_schema(np.array([1.1, 2.2, 3.3], dtype=t))
+        schema = _infer_schema(np.array([1.1, 2.2, 3.3, np.nan], dtype=t))
         assert schema == Schema([ColSpec("float")])
 
     # test doubles
-    schema = _infer_schema(np.array([1.1, 2.2, 3.3], dtype=np.float64))
+    schema = _infer_schema(np.array([1.1, 2.2, 3.3, np.nan], dtype=np.float64))
     assert schema == Schema([ColSpec("double")])
 
     # unsupported


### PR DESCRIPTION
## What changes are proposed in this pull request?

Expect `mlflow.types.utils._infer_schema(pd.Series(['a', 'a', np.nan])) => string`, but got `MlflowException: Unable to map 'np.object' type to MLflow DataType` instead.

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
