### PR TITLE
[Multi-Workspace Registry] add client changes for populating registry lineage through run-link

### DIFF
--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -156,21 +156,22 @@ class ModelRegistryClient(object):
 
     # Model Version Methods
 
-    def create_model_version(self, name, source, run_id, tags=None):
+    def create_model_version(self, name, source, run_id, tags=None, run_link=None):
         """
         Create a new model version from given source or run ID.
 
-        :param name: Name ID for containing registered model.
+        :param name: Name of the containing registered model.
         :param source: Source path where the MLflow model is stored.
         :param run_id: Run ID from MLflow tracking server that generated the model.
         :param tags: A dictionary of key-value pairs that are converted into
                      :py:class:`mlflow.entities.model_registry.ModelVersionTag` objects.
+        :param run_link: Link to the run from an MLflow tracking server that generated this model.
         :return: Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by
                  backend.
         """
         tags = tags if tags else {}
         tags = [ModelVersionTag(key, str(value)) for key, value in tags.items()]
-        return self.store.create_model_version(name, source, run_id, tags)
+        return self.store.create_model_version(name, source, run_id, tags, run_link)
 
     def update_model_version(self, name, version, description):
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -522,10 +522,10 @@ class MlflowClient(object):
                     get_workspace_info_from_databricks_secrets(tracking_uri)
                 if not workspace_id:
                     print("No workspace ID specified; if your Databricks workspaces share the same"
-                          "host URL, you may want to specify the workspace ID (along with the host"
-                          "information in the secret manager) for run lineage tracking. For more"
-                          "details on how to specify this information in the secret manager,"
-                          "please refer to the model registry documentation.")
+                          " host URL, you may want to specify the workspace ID (along with the host"
+                          " information in the secret manager) for run lineage tracking. For more"
+                          " details on how to specify this information in the secret manager,"
+                          " please refer to the model registry documentation.")
             # retrieve experiment ID of the run for the URL
             experiment_id = self.get_run(run_id).info.experiment_id
             if workspace_host and run_id and experiment_id:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -520,6 +520,12 @@ class MlflowClient(object):
                 # Databricks Secret Manager with scope=<scope> and key=<prefix>-workspaceid.
                 workspace_host, workspace_id = \
                     get_workspace_info_from_databricks_secrets(tracking_uri)
+                if not workspace_id:
+                    print("No workspace ID specified; if your Databricks workspaces share the same"
+                          "host URL, you may want to specify the workspace ID (along with the host"
+                          "information in the secret manager) for run lineage tracking. For more"
+                          "details on how to specify this information in the secret manager,"
+                          "please refer to the model registry documentation.")
             # retrieve experiment ID of the run for the URL
             experiment_id = self.get_run(run_id).info.experiment_id
             if workspace_host and run_id and experiment_id:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -151,14 +151,14 @@ def get_workspace_info_from_dbutils():
         workspace_host = context['extraContext']['api_url']
         workspace_id = context['tags']['orgId']
         return workspace_host, workspace_id
+    return None, None
 
 
 def get_workspace_info_from_databricks_secrets(tracking_uri):
-    profile, path = get_db_info_from_uri(tracking_uri)
-    if path:
+    profile, key_prefix = get_db_info_from_uri(tracking_uri)
+    if key_prefix:
         dbutils = _get_dbutils()
         if dbutils:
-            key_prefix = path
             workspace_id = dbutils.secrets.get(scope=profile, key=key_prefix + "-workspace-id")
             workspace_host = dbutils.secrets.get(scope=profile, key=key_prefix + "-host")
             return workspace_host, workspace_id

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1,4 +1,5 @@
 import os
+import json
 import logging
 import subprocess
 
@@ -53,6 +54,10 @@ def _get_property_from_spark_context(key):
             return task_context.getLocalProperty(key)
     except Exception:  # pylint: disable=broad-except
         return None
+
+
+def is_databricks_default_tracking_uri(tracking_uri):
+    return tracking_uri.lower().strip() == "databricks"
 
 
 def is_in_databricks_notebook():
@@ -136,6 +141,28 @@ def get_webapp_url():
     if url is not None:
         return url
     return _get_extra_context("api_url")
+
+
+def get_workspace_info_from_dbutils():
+    dbutils = _get_dbutils()
+    if dbutils:
+        context = json.loads(
+            dbutils.notebook.entry_point.getDbutils().notebook().getContext().toJson())
+        workspace_host = context['extraContext']['api_url']
+        workspace_id = context['tags']['orgId']
+        return workspace_host, workspace_id
+
+
+def get_workspace_info_from_databricks_secrets(tracking_uri):
+    profile, path = get_db_info_from_uri(tracking_uri)
+    if path:
+        dbutils = _get_dbutils()
+        if dbutils:
+            key_prefix = path
+            workspace_id = dbutils.secrets.get(scope=profile, key=key_prefix + "-workspace-id")
+            workspace_host = dbutils.secrets.get(scope=profile, key=key_prefix + "-host")
+            return workspace_host, workspace_id
+    return None, None
 
 
 def _fail_malformed_databricks_auth(profile):

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -148,3 +148,15 @@ def is_databricks_acled_artifacts_uri(artifact_uri):
     _ACLED_ARTIFACT_URI = "databricks/mlflow-tracking/"
     artifact_uri_path = extract_and_normalize_path(artifact_uri)
     return artifact_uri_path.startswith(_ACLED_ARTIFACT_URI)
+
+
+def construct_run_url(hostname, experiment_id, run_id, workspace_id=None):
+    if not hostname or not experiment_id or not run_id:
+        raise MlflowException('Hostname, experiment ID, and run ID are all required to construct'
+                              'a run URL')
+    prefix = hostname
+    if workspace_id and workspace_id != '0':
+        prefix += "?o=" + workspace_id
+    return prefix + '#mlflow/experiments/{experiment_id}/runs/{run_id}'.format(
+        experiment_id=experiment_id,
+        run_id=run_id)

--- a/tests/tracking/_model_registry/test_model_registry_client.py
+++ b/tests/tracking/_model_registry/test_model_registry_client.py
@@ -185,11 +185,12 @@ def test_create_model_version(mock_store):
     }
     tags = [ModelVersionTag(key, value) for key, value in tags_dict.items()]
     mock_store.create_model_version.return_value = ModelVersion(name=name, version=version,
-                                                                creation_timestamp=123, tags=tags)
+                                                                creation_timestamp=123, tags=tags,
+                                                                run_link=None)
     result = newModelRegistryClient().create_model_version(name, "uri:/for/source",
                                                            "run123", tags_dict)
     mock_store.create_model_version.assert_called_once_with(name, "uri:/for/source",
-                                                            "run123", tags)
+                                                            "run123", tags, None)
     assert result.name == name
     assert result.version == version
     assert result.tags == tags_dict

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -257,7 +257,7 @@ def test_registry_uri_from_implicit_tracking_uri():
 
 def test_create_model_version_normal(mock_registry_store):
     run_id = 'runid'
-    client = MlflowClient(tracking_uri='localhost:5000')
+    client = MlflowClient(tracking_uri='http://10.123.1231.11')
     mock_registry_store.create_model_version.return_value = \
         ModelVersion('name', 1, 0, 1, source='source', run_id=run_id)
     model_version = client.create_model_version('name', 'source', 'runid')

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -299,7 +299,7 @@ def test_create_model_version_run_link_in_notebook_with_default_profile(mock_reg
     get_run_mock.return_value = Run(RunInfo(run_id, experiment_id, 'userid', 'status', 0, 1, None),
                                     None)
     with mock.patch('mlflow.tracking.client.is_in_databricks_notebook',
-                    return_value=True),\
+                    return_value=True), \
         mock.patch('mlflow.tracking.client.get_workspace_info_from_dbutils',
                    return_value=(hostname, workspace_id)):
         client = MlflowClient(tracking_uri='databricks', registry_uri='otherplace')

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -10,7 +10,6 @@ from mlflow.tracking import set_registry_uri, MlflowClient
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.mlflow_tags import MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, \
     MLFLOW_PARENT_RUN_ID, MLFLOW_GIT_COMMIT, MLFLOW_PROJECT_ENTRY_POINT
-from mlflow.utils import databricks_utils
 from mlflow.utils.uri import construct_run_url
 
 
@@ -257,8 +256,6 @@ def test_registry_uri_from_implicit_tracking_uri():
 
 
 def test_create_model_version_normal(mock_registry_store):
-    # mock lots of functions
-    experiment_id = 'test-exp-id'
     run_id = 'runid'
     client = MlflowClient(tracking_uri='localhost:5000')
     mock_registry_store.create_model_version.return_value = \
@@ -273,7 +270,6 @@ def test_create_model_version_normal(mock_registry_store):
 
 
 def test_create_model_version_run_link_in_notebook_with_default_profile(mock_registry_store):
-    # mock lots of functions
     experiment_id = 'test-exp-id'
     hostname = 'https://workspace.databricks.com/'
     workspace_id = '10002'
@@ -297,7 +293,6 @@ def test_create_model_version_run_link_in_notebook_with_default_profile(mock_reg
 
 
 def test_create_model_version_run_link_with_configured_profile(mock_registry_store):
-    # mock lots of functions
     experiment_id = 'test-exp-id'
     hostname = 'https://workspace.databricks.com/'
     workspace_id = '10002'

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1,7 +1,7 @@
 import mock
 import pytest
 
-from mlflow.entities import SourceType, ViewType, RunTag
+from mlflow.entities import SourceType, ViewType, RunTag, Run, RunInfo
 from mlflow.entities.model_registry import ModelVersion
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import ErrorCode, FEATURE_DISABLED
@@ -10,6 +10,8 @@ from mlflow.tracking import set_registry_uri, MlflowClient
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.mlflow_tags import MLFLOW_USER, MLFLOW_SOURCE_NAME, MLFLOW_SOURCE_TYPE, \
     MLFLOW_PARENT_RUN_ID, MLFLOW_GIT_COMMIT, MLFLOW_PROJECT_ENTRY_POINT
+from mlflow.utils import databricks_utils
+from mlflow.utils.uri import construct_run_url
 
 
 @pytest.fixture
@@ -252,3 +254,67 @@ def test_registry_uri_from_implicit_tracking_uri():
         get_tracking_uri_mock.return_value = tracking_uri
         client = MlflowClient()
         assert client._registry_uri == tracking_uri
+
+
+def test_create_model_version_normal(mock_registry_store):
+    # mock lots of functions
+    experiment_id = 'test-exp-id'
+    run_id = 'runid'
+    client = MlflowClient(tracking_uri='localhost:5000')
+    mock_registry_store.create_model_version.return_value = \
+        ModelVersion('name', 1, 0, 1, source='source', run_id=run_id)
+    model_version = client.create_model_version('name', 'source', 'runid')
+    assert(model_version.name == 'name')
+    assert(model_version.source == 'source')
+    assert(model_version.run_id == 'runid')
+    # verify that the store was not provided a run link
+    mock_registry_store.create_model_version.assert_called_once_with(
+        "name", 'source', 'runid', [], None)
+
+
+def test_create_model_version_run_link_in_notebook_with_default_profile(mock_registry_store):
+    # mock lots of functions
+    experiment_id = 'test-exp-id'
+    hostname = 'https://workspace.databricks.com/'
+    workspace_id = '10002'
+    run_id = 'runid'
+    workspace_url = construct_run_url(hostname, experiment_id, run_id, workspace_id)
+    get_run_mock = mock.MagicMock()
+    get_run_mock.return_value = Run(RunInfo(run_id, experiment_id, 'userid', 'status', 0, 1, None),
+                                    None)
+    with mock.patch('mlflow.tracking.client.is_in_databricks_notebook', return_value=True), mock\
+            .patch('mlflow.tracking.client.get_workspace_info_from_dbutils',
+                   return_value=(hostname, workspace_id)):
+        client = MlflowClient(tracking_uri='databricks', registry_uri='otherplace')
+        client.get_run = get_run_mock
+        mock_registry_store.create_model_version.return_value = \
+            ModelVersion('name', 1, 0, 1, source='source', run_id=run_id, run_link=workspace_url)
+        model_version = client.create_model_version('name', 'source', 'runid')
+        assert(model_version.run_link == workspace_url)
+        # verify that the client generated the right URL
+        mock_registry_store.create_model_version.assert_called_once_with(
+            "name", 'source', 'runid', [], workspace_url)
+
+
+def test_create_model_version_run_link_with_configured_profile(mock_registry_store):
+    # mock lots of functions
+    experiment_id = 'test-exp-id'
+    hostname = 'https://workspace.databricks.com/'
+    workspace_id = '10002'
+    run_id = 'runid'
+    workspace_url = construct_run_url(hostname, experiment_id, run_id, workspace_id)
+    get_run_mock = mock.MagicMock()
+    get_run_mock.return_value = Run(RunInfo(run_id, experiment_id, 'userid', 'status', 0, 1, None),
+                                    None)
+    with mock.patch('mlflow.tracking.client.is_in_databricks_notebook', return_value=False), mock\
+            .patch('mlflow.tracking.client.get_workspace_info_from_databricks_secrets',
+                   return_value=(hostname, workspace_id)):
+        client = MlflowClient(tracking_uri='databricks', registry_uri='otherplace')
+        client.get_run = get_run_mock
+        mock_registry_store.create_model_version.return_value = \
+            ModelVersion('name', 1, 0, 1, source='source', run_id=run_id, run_link=workspace_url)
+        model_version = client.create_model_version('name', 'source', 'runid')
+        assert(model_version.run_link == workspace_url)
+        # verify that the client generated the right URL
+        mock_registry_store.create_model_version.assert_called_once_with(
+            "name", 'source', 'runid', [], workspace_url)

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -113,8 +113,7 @@ def test_get_workspace_info_from_dbutils():
 
 def test_get_workspace_info_from_dbutils_when_no_dbutils_available():
     with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=None):
-        workspace_host, workspace_id = \
-            get_workspace_info_from_dbutils()
+        workspace_host, workspace_id = get_workspace_info_from_dbutils()
         assert workspace_host is None
         assert workspace_id is None
 

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -112,6 +112,14 @@ def test_get_workspace_info_from_dbutils():
         assert workspace_id == '1111'
 
 
+def test_get_workspace_info_from_dbutils_when_no_dbutils_available():
+    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=None):
+        workspace_host, workspace_id = \
+            get_workspace_info_from_dbutils()
+        assert workspace_host is None
+        assert workspace_id is None
+
+
 @pytest.mark.parametrize("tracking_uri, result", [
     ('databricks', True),
     ('databricks://profile/prefix', False),

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -106,8 +106,7 @@ def test_get_workspace_info_from_dbutils():
                                             '{"api_url": "https://mlflow.databricks.com"},' \
                                             '"tags": {"orgId" : "1111"}}'
     with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
-        workspace_host, workspace_id = \
-            get_workspace_info_from_dbutils()
+        workspace_host, workspace_id = get_workspace_info_from_dbutils()
         assert workspace_host == 'https://mlflow.databricks.com'
         assert workspace_id == '1111'
 

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -4,6 +4,8 @@ import pytest
 from mlflow.utils import databricks_utils
 from databricks_cli.configure.provider import DatabricksConfig
 
+from mlflow.utils.databricks_utils import get_workspace_info_from_dbutils, \
+    get_workspace_info_from_databricks_secrets, is_databricks_default_tracking_uri
 from mlflow.utils.uri import construct_db_uri_from_profile
 
 
@@ -83,6 +85,44 @@ def test_databricks_single_slash_in_uri_scheme_throws(get_config):
     get_config.return_value = None
     with pytest.raises(Exception):
         databricks_utils.get_databricks_host_creds("databricks:/profile/path")
+
+
+def test_get_workspace_info_from_databricks_secrets():
+    mock_dbutils = mock.MagicMock()
+    mock_dbutils.secrets.get.return_value = 'workspace-placeholder-info'
+    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+        workspace_host, workspace_id = \
+            get_workspace_info_from_databricks_secrets('databricks://profile/prefix')
+        mock_dbutils.secrets.get.assert_any_call(key='prefix-host', scope='profile')
+        mock_dbutils.secrets.get.assert_any_call(key='prefix-workspace-id', scope='profile')
+        assert workspace_host == 'workspace-placeholder-info'
+        assert workspace_id == 'workspace-placeholder-info'
+
+
+def test_get_workspace_info_from_dbutils():
+    mock_dbutils = mock.MagicMock()
+    mock_dbutils.notebook.entry_point.getDbutils.return_value.notebook.return_value.getContext\
+        .return_value.toJson.return_value = '{"extraContext":' \
+                                            '{"api_url": "https://mlflow.databricks.com"},' \
+                                            '"tags": {"orgId" : "1111"}}'
+    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+        workspace_host, workspace_id = \
+            get_workspace_info_from_dbutils()
+        assert workspace_host == 'https://mlflow.databricks.com'
+        assert workspace_id == '1111'
+
+
+@pytest.mark.parametrize("tracking_uri, result", [
+    ('databricks', True),
+    ('databricks://profile/prefix', False),
+    ('nondatabricks', False),
+    ('databricks\t\r', True),
+    ('databricks\n', True),
+    ('databricks://', False),
+    ('databricks://aAbB', False)
+])
+def test_is_databricks_default_tracking_uri(tracking_uri, result):
+    assert(is_databricks_default_tracking_uri(tracking_uri) == result)
 
 
 @mock.patch('databricks_cli.configure.provider.ProfileConfigProvider')

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -6,7 +6,7 @@ from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.utils.uri import is_databricks_uri, is_http_uri, is_local_uri, \
     extract_db_type_from_uri, get_uri_scheme, append_to_uri_path, \
     extract_and_normalize_path, is_databricks_acled_artifacts_uri, \
-    get_db_info_from_uri
+    get_db_info_from_uri, construct_run_url
 
 
 def test_extract_db_type_from_uri():
@@ -35,6 +35,27 @@ def test_extract_db_type_from_uri():
 ])
 def test_get_db_info_from_uri(server_uri, result):
     assert get_db_info_from_uri(server_uri) == result
+
+
+@pytest.mark.parametrize("hostname, experiment_id, run_id, workspace_id, result", [
+    ('https://www.databricks.com/', '19201', '2231', '12211',
+     'https://www.databricks.com/?o=12211#mlflow/experiments/19201/runs/2231'),
+    ('https://www.databricks.com/', '19201', '2231', None,
+     'https://www.databricks.com/#mlflow/experiments/19201/runs/2231'),
+    ('https://www.databricks.com/', '19201', '2231', '0',
+     'https://www.databricks.com/#mlflow/experiments/19201/runs/2231'),
+    ('https://www.databricks.com/', '19201', '2231', '0',
+     'https://www.databricks.com/#mlflow/experiments/19201/runs/2231'),
+    (None, '19201', '2231', '0', 'Exception'),
+    ('https://www.databricks.com/', None, '2231', '0', 'Exception'),
+    ('https://www.databricks.com/', '19201', None, '0', 'Exception'),
+])
+def test_construct_run_url(hostname, experiment_id, run_id, workspace_id, result):
+    if result == 'Exception':
+        with pytest.raises(MlflowException):
+            construct_run_url(hostname, experiment_id, run_id, workspace_id)
+    else:
+        assert(construct_run_url(hostname, experiment_id, run_id, workspace_id) == result)
 
 
 def test_uri_types():

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -45,17 +45,18 @@ def test_get_db_info_from_uri(server_uri, result):
     ('https://www.databricks.com/', '19201', '2231', '0',
      'https://www.databricks.com/#mlflow/experiments/19201/runs/2231'),
     ('https://www.databricks.com/', '19201', '2231', '0',
-     'https://www.databricks.com/#mlflow/experiments/19201/runs/2231'),
-    (None, '19201', '2231', '0', 'Exception'),
-    ('https://www.databricks.com/', None, '2231', '0', 'Exception'),
-    ('https://www.databricks.com/', '19201', None, '0', 'Exception'),
-])
+     'https://www.databricks.com/#mlflow/experiments/19201/runs/2231')])
 def test_construct_run_url(hostname, experiment_id, run_id, workspace_id, result):
-    if result == 'Exception':
-        with pytest.raises(MlflowException):
-            construct_run_url(hostname, experiment_id, run_id, workspace_id)
-    else:
-        assert(construct_run_url(hostname, experiment_id, run_id, workspace_id) == result)
+    assert(construct_run_url(hostname, experiment_id, run_id, workspace_id) == result)
+
+
+@pytest.mark.parametrize("hostname, experiment_id, run_id, workspace_id", [
+    (None, '19201', '2231', '0'),
+    ('https://www.databricks.com/', None, '2231', '0'),
+    ('https://www.databricks.com/', '19201', None, '0')])
+def test_construct_run_url_errors(hostname, experiment_id, run_id, workspace_id):
+    with pytest.raises(MlflowException):
+        construct_run_url(hostname, experiment_id, run_id, workspace_id)
 
 
 def test_uri_types():


### PR DESCRIPTION
## What changes are proposed in this pull request?

In this PR, we introduce `run_link` as a parameter that can be passed into `create_model_version`. This will allow users to track the exact lineage of their model versions in settings where the Model Registry is hosted on a different MLflow instance than the tracking server. 

If using MLflow in a Databricks notebook where the tracking server is in the workspace of the notebook, the run link is automatically populated. Otherwise, we expect a profile for the tracking URI of the form: databricks://profile/prefix, where the host name, token, and workspace ID are stored as secrets in the Databricks Secret Manager with the scope=<profile> and the key being <prefix>-host, <prefix>-token, and <prefix>-workspace-id,

## How is this patch tested?

Unit testing and manual testing (please contact for instructions on how to manual test)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introduces run_link to create_model_version to allow for lineage tracking in scenarios where the model registry is hosted in a different MLflow instance.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
