### PR TITLE
Enable `no-console` rule for ESLint to avoid using `console.log`

### DIFF
--- a/mlflow/server/js/.eslintrc.js
+++ b/mlflow/server/js/.eslintrc.js
@@ -149,7 +149,7 @@ module.exports = {
     'no-class-assign': 2,
     'no-cond-assign': 2,
     'no-confusing-arrow': 0,
-    'no-console': 0,
+    'no-console': [2, { allow: ['warn', 'error'] }],
     'no-const-assign': 2,
     'no-constant-condition': 2,
     'no-continue': 0,

--- a/mlflow/server/js/src/experiment-tracking/components/RunsTableColumnSelectionDropdown.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunsTableColumnSelectionDropdown.js
@@ -26,7 +26,6 @@ export class RunsTableColumnSelectionDropdown extends React.Component {
   };
 
   handleCheck = (checkedKeys, allKeys) => {
-    console.log('checkedKeys', checkedKeys);
     const { onCheck } = this.props;
     if (onCheck) {
       onCheck(getCategorizedUncheckedKeys(checkedKeys, allKeys));


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Enable `no-console` rule for ESLint to avoid using `console.log`

## How is this patch tested?

- Verify the js lint check fails if `console.log` found

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
