### PR TITLE
Enable `prefer-destructuring` rule for ESLint to force destructuring assignment 

### DIFF
--- a/mlflow/server/js/.eslintrc.js
+++ b/mlflow/server/js/.eslintrc.js
@@ -369,7 +369,7 @@ module.exports = {
     'complexity': ['error', 20],
     'no-multi-assign': 'off',
     'no-useless-return': 'off',
-    'prefer-destructuring': 'off',
+    'prefer-destructuring': 2,
     'no-restricted-globals': [
       2,
       'addEventListener',

--- a/mlflow/server/js/src/common/utils/ActionUtils.js
+++ b/mlflow/server/js/src/common/utils/ActionUtils.js
@@ -85,7 +85,7 @@ export class ErrorWrapper {
   }
 
   getErrorCode() {
-    const responseText = this.xhr.responseText;
+    const { responseText } = this.xhr;
     if (responseText) {
       try {
         const parsed = JSON.parse(responseText);
@@ -102,7 +102,7 @@ export class ErrorWrapper {
   // Return the responseText if it is in the
   // { error_code: ..., message: ...} format. Otherwise return "INTERNAL_SERVER_ERROR".
   getUserVisibleError() {
-    const responseText = this.xhr.responseText;
+    const { responseText } = this.xhr;
     if (responseText) {
       try {
         const parsed = JSON.parse(responseText);
@@ -117,7 +117,7 @@ export class ErrorWrapper {
   }
 
   getMessageField() {
-    const responseText = this.xhr.responseText;
+    const { responseText } = this.xhr;
     if (responseText) {
       try {
         const parsed = JSON.parse(responseText);
@@ -134,7 +134,7 @@ export class ErrorWrapper {
   // Does a best-effort at rendering an arbitrary HTTP error. If it's a DatabricksServiceException,
   // will render the error code and message. If it's HTML, we'll strip the tags.
   renderHttpError() {
-    const responseText = this.xhr.responseText;
+    const { responseText } = this.xhr;
     if (responseText) {
       try {
         const parsed = JSON.parse(responseText);

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
@@ -136,7 +136,7 @@ export class ArtifactViewImpl extends Component {
   };
 
   getTreebeardData = (artifactNode) => {
-    const isRoot = artifactNode.isRoot;
+    const { isRoot } = artifactNode;
     if (isRoot) {
       if (artifactNode.children) {
         return Object.values(artifactNode.children).map((c) => this.getTreebeardData(c));
@@ -152,7 +152,7 @@ export class ArtifactViewImpl extends Component {
     let active;
 
     if (artifactNode.fileInfo) {
-      const path = artifactNode.fileInfo.path;
+      const { path } = artifactNode.fileInfo;
       id = path;
       name = getBasename(path);
     }

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.js
@@ -15,7 +15,7 @@ import Utils from '../../common/utils/Utils';
 import { Tabs } from 'antd';
 import ParallelCoordinatesPlotPanel from './ParallelCoordinatesPlotPanel';
 
-const TabPane = Tabs.TabPane;
+const { TabPane } = Tabs;
 
 export class CompareRunView extends Component {
   static propTypes = {
@@ -40,7 +40,7 @@ export class CompareRunView extends Component {
   }
 
   render() {
-    const experiment = this.props.experiment;
+    const { experiment } = this.props;
     const experimentId = experiment.getExperimentId();
     const { runInfos, runNames } = this.props;
     return (

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.test.js
@@ -94,7 +94,7 @@ test('URL can encode order_by', () => {
 
 test('Loading state without any URL params', () => {
   const wrapper = getExperimentPageMock();
-  const state = wrapper.instance().state;
+  const { state } = wrapper.instance();
   expect(state.persistedState.paramKeyFilterString).toEqual('');
   expect(state.persistedState.metricKeyFilterString).toEqual('');
   expect(state.persistedState.searchInput).toEqual('');
@@ -105,7 +105,7 @@ test('Loading state without any URL params', () => {
 test('Loading state with all URL params', () => {
   location.search = 'params=a&metrics=b&search=c&orderByKey=d&orderByAsc=false';
   const wrapper = getExperimentPageMock();
-  const state = wrapper.instance().state;
+  const { state } = wrapper.instance();
   expect(state.persistedState.paramKeyFilterString).toEqual('a');
   expect(state.persistedState.metricKeyFilterString).toEqual('b');
   expect(state.persistedState.searchInput).toEqual('c');

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentViewUtil.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentViewUtil.js
@@ -67,8 +67,7 @@ export default class ExperimentViewUtil {
     const user = Utils.getUser(runInfo, tags);
     const queryParams = window.location && window.location.search ? window.location.search : '';
     const sourceType = Utils.renderSource(tags, queryParams);
-    const startTime = runInfo.start_time;
-    const status = runInfo.status;
+    const { status, start_time: startTime } = runInfo;
     const runName = Utils.getRunName(tags);
     const childLeftMargin = isParent ? {} : { paddingLeft: 16 };
     const columnProps = [
@@ -439,7 +438,7 @@ export default class ExperimentViewUtil {
     });
     const mergedRows = [];
     parentRows.forEach((r) => {
-      const runId = r.runId;
+      const { runId } = r;
       mergedRows.push(r);
       const childrenIdxs = parentIdToChildren[runId];
       if (childrenIdxs) {

--- a/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ParallelCoordinatesPlotView.js
@@ -151,7 +151,7 @@ export const generateAttributesForCategoricalDimension = (labels) => {
  */
 export const inferType = (key, runUuids, entryByRunUuid) => {
   for (let i = 0; i < runUuids.length; i++) {
-    const value = entryByRunUuid[runUuids[i]][key].value;
+    const { value } = entryByRunUuid[runUuids[i]][key];
     if (typeof value === 'string' && isNaN(Number(value)) && value !== 'NaN') {
       return 'string';
     }

--- a/mlflow/server/js/src/experiment-tracking/components/RunPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunPage.js
@@ -77,8 +77,7 @@ export class RunPageImpl extends Component {
 
 const mapStateToProps = (state, ownProps) => {
   const { match } = ownProps;
-  const runUuid = match.params.runUuid;
-  const experimentId = match.params.experimentId;
+  const { runUuid, experimentId } = match.params;
   return {
     runUuid,
     experimentId,

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -275,13 +275,13 @@ const getMetricValues = (latestMetrics, getMetricPagePath) => {
   return Object.values(latestMetrics)
     .sort()
     .map((m) => {
-      const key = m.key;
+      const { key, value } = m;
       return [
         <Link to={getMetricPagePath(key)} title='Plot chart'>
           {key}
           <i className='fas fa-chart-line' style={{ paddingLeft: '6px' }} />
         </Link>,
-        <span title={m.value}>{Utils.formatMetric(m.value)}</span>,
+        <span title={value}>{Utils.formatMetric(value)}</span>,
       ];
     });
 };

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -274,8 +274,7 @@ const getParamValues = (params) => {
 const getMetricValues = (latestMetrics, getMetricPagePath) => {
   return Object.values(latestMetrics)
     .sort()
-    .map((m) => {
-      const { key, value } = m;
+    .map(({ key, value }) => {
       return [
         <Link to={getMetricPagePath(key)} title='Plot chart'>
           {key}

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMapView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMapView.js
@@ -11,7 +11,7 @@ import iconShadow from 'leaflet/dist/images/marker-shadow.png';
 
 function onEachFeature(feature, layer) {
   if (feature.properties && feature.properties.popupContent) {
-    const popupContent = feature.properties.popupContent;
+    const { popupContent } = feature.properties;
     layer.bindPopup(popupContent);
   }
 }

--- a/mlflow/server/js/src/experiment-tracking/reducers/MetricReducer.js
+++ b/mlflow/server/js/src/experiment-tracking/reducers/MetricReducer.js
@@ -55,9 +55,8 @@ export const latestMetricsByRunUuid = (state = {}, action) => {
     }
     case fulfilled(GET_METRIC_HISTORY_API): {
       const newState = { ...state };
-      const runUuid = action.meta.runUuid;
-      const key = action.meta.key;
-      const metrics = action.payload.metrics;
+      const { runUuid, key } = action.meta.runUuid;
+      const { metrics } = action.payload;
       if (metrics && metrics.length > 0) {
         const lastMetric = Metric.fromJs(metrics[metrics.length - 1]);
         if (newState[runUuid]) {
@@ -76,7 +75,7 @@ export const latestMetricsByRunUuid = (state = {}, action) => {
 export const metricsByRunUuid = (state = {}, action) => {
   switch (action.type) {
     case fulfilled(GET_METRIC_HISTORY_API): {
-      const runUuid = action.meta.runUuid;
+      const { runUuid } = action.meta;
       const metrics = action.payload.metrics || [];
       return {
         ...state,
@@ -92,7 +91,7 @@ export const metricsByKey = (state = {}, action, metrics) => {
   const newState = { ...state };
   switch (action.type) {
     case fulfilled(GET_METRIC_HISTORY_API): {
-      const key = action.meta.key;
+      const { key } = action.meta;
       newState[key] = metrics.map((m) => Metric.fromJs(m));
       return newState;
     }

--- a/mlflow/server/js/src/experiment-tracking/reducers/Reducers.js
+++ b/mlflow/server/js/src/experiment-tracking/reducers/Reducers.js
@@ -124,7 +124,7 @@ export const paramsByRunUuid = (state = {}, action) => {
   };
   switch (action.type) {
     case fulfilled(GET_RUN_API): {
-      const run = action.payload.run;
+      const { run } = action.payload;
       const runUuid = run.info.run_uuid;
       const params = run.data.params || [];
       const newState = { ...state };
@@ -133,7 +133,7 @@ export const paramsByRunUuid = (state = {}, action) => {
     }
     case fulfilled(SEARCH_RUNS_API):
     case fulfilled(LOAD_MORE_RUNS_API): {
-      const runs = action.payload.runs;
+      const { runs } = action.payload;
       const newState = { ...state };
       if (runs) {
         runs.forEach((rJson) => {
@@ -173,7 +173,7 @@ export const tagsByRunUuid = (state = {}, action) => {
     }
     case fulfilled(SEARCH_RUNS_API):
     case fulfilled(LOAD_MORE_RUNS_API): {
-      const runs = action.payload.runs;
+      const { runs } = action.payload;
       const newState = { ...state };
       if (runs) {
         runs.forEach((rJson) => {
@@ -189,7 +189,7 @@ export const tagsByRunUuid = (state = {}, action) => {
       return amendTagsByRunUuid(state, [tag], action.meta.runUuid);
     }
     case fulfilled(DELETE_TAG_API): {
-      const runUuid = action.meta.runUuid;
+      const { runUuid } = action.meta;
       const oldTags = state[runUuid] ? state[runUuid] : {};
       const newTags = _.omit(oldTags, action.meta.key);
       if (Object.keys(newTags).length === 0) {
@@ -270,7 +270,7 @@ export const artifactsByRunUuid = (state = {}, action) => {
   switch (action.type) {
     case fulfilled(LIST_ARTIFACTS_API): {
       const queryPath = action.meta.path;
-      const runUuid = action.meta.runUuid;
+      const { runUuid } = action.meta;
       let artifactNode = state[runUuid] || new ArtifactNode(true);
       // Make deep copy.
       artifactNode = artifactNode.deepCopy();

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsPage.js
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsPage.js
@@ -56,7 +56,7 @@ class CompareModelVersionsPage extends Component {
         } else {
           this.removeRunRequestId();
         }
-        const modelName = this.props.modelName;
+        const { modelName } = this.props;
         this.props.getModelVersionApi(modelName, modelVersion, this.versionRequestId);
       }
     }

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.js
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.js
@@ -17,7 +17,7 @@ import { modelListPageRoute, getModelPageRoute, getModelVersionPageRoute } from 
 import { css } from 'emotion';
 import _ from 'lodash';
 
-const TabPane = Tabs.TabPane;
+const { TabPane } = Tabs;
 
 export class CompareModelVersionsView extends Component {
   static propTypes = {

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.js
@@ -43,7 +43,7 @@ export class ModelVersionView extends React.Component {
 
   handleDeleteConfirm = () => {
     const { modelName, modelVersion, history } = this.props;
-    const version = modelVersion.version;
+    const { version } = modelVersion;
     this.showConfirmLoading();
     this.props
       .deleteModelVersionApi(modelName, version)

--- a/mlflow/server/js/src/model-registry/components/SchemaTable.js
+++ b/mlflow/server/js/src/model-registry/components/SchemaTable.js
@@ -5,7 +5,7 @@ import { css } from 'emotion';
 import { gray800 } from '../../common/styles/color';
 import { spacingMedium } from '../../common/styles/spacing';
 
-const Column = Table.Column;
+const { Column } = Table;
 
 export class SchemaTable extends React.PureComponent {
   static propTypes = {


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Enable `prefer-destructuring` rule for ESLint to force destructuring assignment

## How is this patch tested?

`npm run lint`

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
