### PR TITLE
Fix a bug where artifact locations become malformed when using an SFTP file store in Windows

### DIFF
--- a/mlflow/store/artifact/sftp_artifact_repo.py
+++ b/mlflow/store/artifact/sftp_artifact_repo.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import posixpath
 from six.moves import urllib
@@ -6,6 +7,18 @@ from six.moves import urllib
 from mlflow.entities import FileInfo
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.exceptions import MlflowException
+
+
+# Based on: https://stackoverflow.com/a/58466685
+def _put_r_for_windows(sftp, local_dir, remote_dir, preserve_mtime=False):
+    for entry in os.listdir(local_dir):
+        local_path = os.path.join(local_dir, entry)
+        remote_path = posixpath.join(remote_dir, entry)
+        if os.path.isdir(local_path):
+            sftp.mkdir(remote_path)
+            _put_r_for_windows(sftp, local_path, remote_path, preserve_mtime)
+        else:
+            sftp.put(local_path, remote_path, preserve_mtime=preserve_mtime)
 
 
 class SFTPArtifactRepository(ArtifactRepository):
@@ -70,7 +83,10 @@ class SFTPArtifactRepository(ArtifactRepository):
         artifact_dir = posixpath.join(self.path, artifact_path) \
             if artifact_path else self.path
         self.sftp.makedirs(artifact_dir)
-        self.sftp.put_r(local_dir, artifact_dir)
+        if sys.platform == "win32":
+            _put_r_for_windows(self.sftp, local_dir, artifact_dir)
+        else:
+            self.sftp.put_r(local_dir, artifact_dir)
 
     def _is_directory(self, artifact_path):
         artifact_dir = self.path


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- Fix a bug where artifact locations become malformed when using an SFTP file store in Windows
- Fixes #2844

## How is this patch tested?

Manually verified that the issue has been fixed.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [x] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
