### PR TITLE
[Issue #3170] PDF viewer doesn't render PDFs in MLflow 1.10

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPdfView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPdfView.js
@@ -2,11 +2,10 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import './ShowArtifactImageView.css';
 import { getSrc } from './ShowArtifactPage';
-import { Document, Page } from 'react-pdf';
+import { Document, Page, pdfjs } from 'react-pdf';
 import { Pagination, Spin } from 'antd';
 import { getArtifactBytesContent } from './ShowArtifactUtils';
 import './ShowArtifactPdfView.css';
-import { pdfjs } from 'react-pdf';
 
 pdfjs.GlobalWorkerOptions.workerSrc = `${process.env.PUBLIC_URL}/pdf.worker.js`;
 

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPdfView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPdfView.js
@@ -7,6 +7,8 @@ import { Pagination, Spin } from 'antd';
 import { getArtifactBytesContent } from './ShowArtifactUtils';
 import './ShowArtifactPdfView.css';
 
+// See: https://github.com/wojtekmaj/react-pdf/blob/master/README.md#enable-pdfjs-worker for how
+// workerSrc is supposed to be specified.
 pdfjs.GlobalWorkerOptions.workerSrc = `${process.env.PUBLIC_URL}/pdf.worker.js`;
 
 class ShowArtifactPdfView extends Component {

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPdfView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPdfView.js
@@ -8,7 +8,7 @@ import { getArtifactBytesContent } from './ShowArtifactUtils';
 import './ShowArtifactPdfView.css';
 import { pdfjs } from 'react-pdf';
 
-pdfjs.GlobalWorkerOptions.workerSrc = 'static-files/pdf.worker.js';
+pdfjs.GlobalWorkerOptions.workerSrc = `${process.env.PUBLIC_URL}/pdf.worker.js`;
 
 class ShowArtifactPdfView extends Component {
   state = {

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPdfView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPdfView.js
@@ -6,6 +6,9 @@ import { Document, Page } from 'react-pdf';
 import { Pagination, Spin } from 'antd';
 import { getArtifactBytesContent } from './ShowArtifactUtils';
 import './ShowArtifactPdfView.css';
+import { pdfjs } from 'react-pdf';
+
+pdfjs.GlobalWorkerOptions.workerSrc = 'static-files/pdf.worker.js';
 
 class ShowArtifactPdfView extends Component {
   state = {


### PR DESCRIPTION
Signed-off-by: Ankit Mathur <ankit.mathur@databricks.com>

In the built version of MLflow, we serve static files from `static-files/`, and so, for those OSS users who use the pip package (basically all of them), viewing PDFs won't work, since the request is sent to: `localhost:5000/pdf.worker.js`, which works when running MLflow from source.

This PR changes this to use the public URL which is used in [other parts of the code](https://github.com/mlflow/mlflow/blob/HEAD/mlflow/server/js/public/index.html#L6).

## How is this patch tested?

Manual with both bdist and dev setup

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
