### PR TITLE
fix mlflow version when creating conda env

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -28,8 +28,12 @@ def _mlflow_conda_env(path=None, additional_conda_deps=None, additional_pip_deps
     :return: ``None`` if ``path`` is specified. Otherwise, the a dictionary representation of the
              Conda environment.
     """
-    pip_deps = (["mlflow"] if install_mlflow else []) + (
-        additional_pip_deps if additional_pip_deps else [])
+    pip_deps = []
+    if install_mlflow:
+        import mlflow
+        pip_deps.append("mlflow=={}".format(mlflow.__version__))
+    pip_deps.extend(additional_pip_deps) if additional_pip_deps else []
+
     conda_deps = (additional_conda_deps if additional_conda_deps else []) + (
         ["pip"] if pip_deps else [])
 

--- a/tests/utils/test_environment.py
+++ b/tests/utils/test_environment.py
@@ -53,3 +53,14 @@ def test_mlflow_conda_env_includes_pip_dependencies_and_pip_is_specified(pip_spe
         assert conda_dep in env["dependencies"]
     assert pip_specification in env["dependencies"]
     assert env["dependencies"].count("pip") == (2 if pip_specification == "pip" else 1)
+
+
+def test_mlflow_conda_env_includes_a_fixed_mlflow_version_by_default():
+    import mlflow
+    env = _mlflow_conda_env()
+    for dep in env["dependencies"]:
+        if isinstance(dep, dict) and dep.get("pip") is not None:
+            assert "mlflow=={}".format(mlflow.__version__) in dep.get("pip")
+            return
+
+    assert False


### PR DESCRIPTION
## What changes are proposed in this pull request?

When loging any kind of supported model, mlflow is added as a pip dependency to the `conda.yaml`. The following change with fix the mlflow version to the one used to log the model.

Fixes: #2979 

## How is this patch tested?
```py
import numpy as np
from sklearn.linear_model import LinearRegression
import mlflow
import mlflow.sklearn

X = np.array([[1, 1], [1, 2], [2, 2], [2, 3]])
y = np.dot(X, np.array([1, 2])) + 3
reg = LinearRegression().fit(X, y)
reg.score(X, y)

with mlflow.start_run():
    mlflow.sklearn.log_model(sk_model=reg, artifact_path="model")
```

results in the following `conda.yaml`
```yaml
channels:
- defaults
- conda-forge
dependencies:
- python=3.6.10
- scikit-learn=0.20.2
- pip
- pip:
  - mlflow==1.9.2.dev0
  - cloudpickle==0.8.0
name: mlflow-env
```

unit test added

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

When logging a model the `conda.yaml` file will an `mlflow` pip dependency with the version used to log the model

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
