### PR TITLE
Fix runs table to resize with browser resize

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -335,6 +335,10 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
     this.applyRowSelectionFromProps();
     this.handleColumnSizeRefit();
     this.handleLoadingOverlay();
+
+    window.addEventListener('resize', () => {
+      this.gridApi.sizeColumnsToFit();
+    });
   };
 
   // There is no way in ag-grid to declaratively specify row selections. Thus, we have to use grid
@@ -405,6 +409,10 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
     this.handleColumnSizeRefit();
     this.handleLoadingOverlay();
     this.restoreGridState();
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize');
   }
 
   render() {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -336,9 +336,12 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
     this.handleColumnSizeRefit();
     this.handleLoadingOverlay();
 
-    window.addEventListener('resize', () => {
-      _.debounce(this.gridApi.sizeColumnsToFit, 100);
-    });
+    window.addEventListener(
+      'resize',
+      _.debounce(() => {
+        this.gridApi.sizeColumnsToFit();
+      }, 100),
+    );
   };
 
   // There is no way in ag-grid to declaratively specify row selections. Thus, we have to use grid

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -337,7 +337,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
     this.handleLoadingOverlay();
 
     window.addEventListener('resize', () => {
-      this.gridApi.sizeColumnsToFit();
+      _.debounce(this.gridApi.sizeColumnsToFit, 100);
     });
   };
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fixes #2405 

![autofit2](https://user-images.githubusercontent.com/17039389/88566386-e4194f80-d070-11ea-80ef-234441bbbdf6.gif)



## How is this patch tested?

I got [this error](https://stackoverflow.com/questions/58665089/ag-grid-jest-testing-this-btfirst-insertadjacentelement-is-not-a-function) when I tried to run the following unit test:

```
test('should call sizeColumnsToFit on window resize', () => {
    wrapper = mount(<ExperimentRunsTableMultiColumnView2 {...minimalProps} />);
    instance = wrapper.instance();
    instance.columnApi = {
      getColumnGroupState: jest.fn(() => [{ open: true }]),
    };
    instance.gridApi = {
      sizeColumnsToFit: jest.fn(),
    };
    window.dispatchEvent(new Event('resize'));
    expect(instance.gridApi.sizeColumnsToFit).toBeCalled();
  });
```


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
