### PR TITLE
Correct accidental omission of model registry tags feature from MLflow 1.10 changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ Features:
   URI (#3072, @sueann)
 - Added paginated ``MlflowClient.search_registered_models`` API (#2939, #3023, #3027 @ankitmathur-db; #2966, @mparkhe)
 - Added syntax highlighting when viewing text files (YAML etc) in the MLflow runs UI (#3041, @harupy)
+- Added REST API and Python client support for setting tags on model versions and registered models,
+  via the ``MlflowClient.create_registered_model``,  ``MlflowClient.create_model_version``,
+  ``MlflowClient.set_registered_model_tag`` and ``MlflowClient.set_model_version_tag`` methods (#3094, @zhidongqu-db)
 
 Bug fixes and documentation updates:
 
@@ -25,7 +28,7 @@ Bug fixes and documentation updates:
   within a notebook (#3035, @smurching)
 - Added docs explaining how to fetching an MLflow model from the model registry (#3000, @andychow-db)
 
-Small bug fixes and doc updates (#3112, #3102, #3089, #3103, #3096, #3090, #3049, #3080, #3070, #3078, #3083, #3051, #3050, #2875, #2982, #2949, #3121 @harupy; #3094, @zhidongqu-db; #3082, @ankitmathur-db; #3084, #3019, @smurching)
+Small bug fixes and doc updates (#3112, #3102, #3089, #3103, #3096, #3090, #3049, #3080, #3070, #3078, #3083, #3051, #3050, #2875, #2982, #2949, #3121 @harupy; #3082, @ankitmathur-db; #3084, #3019, @smurching)
 
 1.9.1 (2020-06-25)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Features:
 - Added syntax highlighting when viewing text files (YAML etc) in the MLflow runs UI (#3041, @harupy)
 - Added REST API and Python client support for setting tags on model versions and registered models,
   via the ``MlflowClient.create_registered_model``,  ``MlflowClient.create_model_version``,
-  ``MlflowClient.set_registered_model_tag`` and ``MlflowClient.set_model_version_tag`` methods (#3094, @zhidongqu-db)
+  ``MlflowClient.set_registered_model_tag`` and ``MlflowClient.set_model_version_tag`` APIs (#3094, @zhidongqu-db)
 
 Bug fixes and documentation updates:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,9 +15,10 @@ Features:
   URI (#3072, @sueann)
 - Added paginated ``MlflowClient.search_registered_models`` API (#2939, #3023, #3027 @ankitmathur-db; #2966, @mparkhe)
 - Added syntax highlighting when viewing text files (YAML etc) in the MLflow runs UI (#3041, @harupy)
-- Added REST API and Python client support for setting tags on model versions and registered models,
+- Added REST API and Python client support for setting and deleting tags on model versions and registered models,
   via the ``MlflowClient.create_registered_model``,  ``MlflowClient.create_model_version``,
-  ``MlflowClient.set_registered_model_tag`` and ``MlflowClient.set_model_version_tag`` APIs (#3094, @zhidongqu-db)
+  ``MlflowClient.set_registered_model_tag``, ``MlflowClient.set_model_version_tag``,
+  ``MlflowClient.delete_registered_model_tag``, and ``MlflowClient.delete_model_version_tag`` APIs (#3094, @zhidongqu-db)
 
 Bug fixes and documentation updates:
 


### PR DESCRIPTION
Signed-off-by: Sid Murching <sid.murching@databricks.com>

## What changes are proposed in this pull request?

Corrects accidental omission of model registry tags feature from MLflow 1.10 changelog - our changelog generation automation described #3094 as a "small change" because it had the `rn/none` label, but it's actually a noteworthy & significant feature!

## How is this patch tested?

N/A - only text changes

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
