### PR TITLE
Fix `window.removeEventListener` error in `ExperimentRunsTableMultiColumnView2`

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -335,13 +335,11 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
     this.applyRowSelectionFromProps();
     this.handleColumnSizeRefit();
     this.handleLoadingOverlay();
+    this.fitOnWindowResize = _.debounce(() => {
+      this.gridApi.sizeColumnsToFit();
+    }, 100);
 
-    window.addEventListener(
-      'resize',
-      _.debounce(() => {
-        this.gridApi.sizeColumnsToFit();
-      }, 100),
-    );
+    window.addEventListener('resize', this.fitOnWindowResize);
   };
 
   // There is no way in ag-grid to declaratively specify row selections. Thus, we have to use grid
@@ -415,7 +413,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize');
+    window.removeEventListener('resize', this.fitOnWindowResize);
   }
 
   render() {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -413,7 +413,7 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('resize', this.fitOnWindowResize);
+    window.removeEventListener('resize', this.fitColumnsOnWindowResize);
   }
 
   render() {

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -335,11 +335,11 @@ export class ExperimentRunsTableMultiColumnView2 extends React.Component {
     this.applyRowSelectionFromProps();
     this.handleColumnSizeRefit();
     this.handleLoadingOverlay();
-    this.fitOnWindowResize = _.debounce(() => {
+    this.fitColumnsOnWindowResize = _.debounce(() => {
       this.gridApi.sizeColumnsToFit();
     }, 100);
 
-    window.addEventListener('resize', this.fitOnWindowResize);
+    window.addEventListener('resize', this.fitColumnsOnWindowResize);
   };
 
   // There is no way in ag-grid to declaratively specify row selections. Thus, we have to use grid


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix a `window.removeEventListener` error in `ExperimentRunsTableMultiColumnView2`

## How is this patch tested?

Manual testing

### Before:

![remove-event-listener](https://user-images.githubusercontent.com/17039389/88736475-a7824c80-d173-11ea-99ad-397bb44daede.gif)

### After:

![remove-event-listener-after](https://user-images.githubusercontent.com/17039389/88736616-b1a44b00-d173-11ea-8083-a9960daef88b.gif)



## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
