### PR TITLE
Fix validation error in pandas.read_csv

### DIFF
--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -134,7 +134,7 @@ def saved_tf_categorical_model(tmpdir):
     ])
     types = collections.OrderedDict((key, type(value[0]))
                                     for key, value in defaults.items())
-    df = pd.read_csv(path, names=types.keys(), dtype=types, na_values="?")
+    df = pd.read_csv(path, names=list(types.keys()), dtype=types, na_values="?")
     df = df.dropna()
 
     # Extract the label from the features dataframe

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -91,7 +91,7 @@ def saved_tf_categorical_model(tmpdir):
     ])
     types = collections.OrderedDict((key, type(value[0]))
                                     for key, value in defaults.items())
-    df = pd.read_csv(path, names=types.keys(), dtype=types, na_values="?")
+    df = pd.read_csv(path, names=list(types.keys()), dtype=types, na_values="?")
     df = df.dropna()
 
     # Extract the label from the features dataframe


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

In pandas 1.1.0 (released today), `pd.read_csv` checks that the `names` argument is an ordered collection or not. If not, an error is thrown ([related PR in pandas repo](https://github.com/pandas-dev/pandas/pull/34956)). This PR makes the change to avoid this validation error.

https://github.com/mlflow/mlflow/pull/3188/checks?check_run_id=921103329#step:4:709

![Screen Shot 2020-07-29 at 9 12 31](https://user-images.githubusercontent.com/17039389/88741901-be2ca180-d17b-11ea-88f0-cd32d40a631d.png)


## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
