### PR TITLE
Use miniconda in windows tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -233,7 +233,7 @@ jobs:
     - name: Install dependencies
       run: |
         conda create -y -n test-environment python=3.7
-        call activate test-environment
+        call conda activate test-environment
         pip install -r dev-requirements.txt
         pip install -r travis/small-requirements.txt
         pip install .

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -229,7 +229,7 @@ jobs:
           echo "::add-path::C:\Miniconda\Scripts"
       - name: Install dependencies
         run: |
-          conda create -n test-environment python=3.7
+          conda create -y -n test-environment python=3.7
           conda activate test-environment
           pip install . -r dev-requirements.txt -r travis/small-requirements.txt
       - name: Run tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -228,10 +228,9 @@ jobs:
           echo "::add-path::C:\Miniconda"
           echo "::add-path::C:\Miniconda\Scripts"
       - name: Install dependencies
-        run:
+        run: |
           conda create -n test-environment python=3.7
           source activate test-environment
-          conda install pip
           pip install . -r dev-requirements.txt -r travis/small-requirements.txt
       - name: Run tests
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,9 +2,9 @@ name: MLflow tests
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    branches: [master]
+    branches: [ master ]
 
 env:
   CONDA_DIR: /usr/share/miniconda
@@ -13,127 +13,127 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        env:
-          INSTALL_LARGE_PYTHON_DEPS: true
-          INSTALL_SMALL_PYTHON_DEPS: true
-        run: |
-          source ./travis/install-common-deps.sh
-          pip install -r ./travis/lint-requirements.txt
-      - name: Run tests
-        run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
-          source activate test-environment
-          ./lint.sh
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      env:
+        INSTALL_LARGE_PYTHON_DEPS: true
+        INSTALL_SMALL_PYTHON_DEPS: true
+      run: |
+        source ./travis/install-common-deps.sh
+        pip install -r ./travis/lint-requirements.txt
+    - name: Run tests
+      run: |
+        export PATH="$CONDA_DIR/bin:$PATH"
+        source activate test-environment
+        ./lint.sh
   r:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: r-lib/actions/setup-r@v1
-      # This step dumps the current set of R dependencies and R version into files to be used
-      # as a cache key when caching/restoring R dependencies.
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps("mlflow/R/mlflow", dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
+    - uses: actions/checkout@master
+    - uses: r-lib/actions/setup-r@v1
+    # This step dumps the current set of R dependencies and R version into files to be used
+    # as a cache key when caching/restoring R dependencies.
+    - name: Query dependencies
+      run: |
+        install.packages('remotes')
+        saveRDS(remotes::dev_package_deps("mlflow/R/mlflow", dependencies = TRUE), ".github/depends.Rds", version = 2)
+        writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+      shell: Rscript {0}
 
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
-          # R dependencies
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get install -y libcurl4-openssl-dev
-      - name: Install dependencies
-        run: |
-          install.packages("devtools")
-          remotes::install_deps('mlflow/R/mlflow', dependencies = TRUE, upgrade = FALSE)
-        shell: Rscript {0}
-      - name: Run tests
-        run: |
-          source ./travis/install-common-deps.sh
-          source activate test-environment
-          cd mlflow/R/mlflow
-          R CMD build .
-          export LINTR_COMMENT_BOT=false
-          cd tests
-          Rscript ../.travis.R
-      - name: Calculate code coverage
-        if: ${{ success() }}
-        run: |
-          export MLFLOW_HOME=$(pwd)
-          cd mlflow/R/mlflow/tests
-          Rscript -e 'covr::codecov()' || :
-        env:
-          COVR_RUNNING: true
-      - name: Show 00check.log on failure
-        if: ${{ failure() }}
-        run: |
-          LOG_FILE="${HOME}/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
-          [ -r "${LOG_FILE}" ] && cat "${LOG_FILE}"
-          cp "${LOG_FILE}" /tmp
-      - uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: 00check.log
-          path: /tmp/00check.log
+    - name: Cache R packages
+      if: runner.os != 'Windows'
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.R_LIBS_USER }}
+        # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
+        # R dependencies
+        key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+        restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+    - name: Install system dependencies
+      run: |
+        sudo apt-get install -y libcurl4-openssl-dev
+    - name: Install dependencies
+      run: |
+        install.packages("devtools")
+        remotes::install_deps('mlflow/R/mlflow', dependencies = TRUE, upgrade = FALSE)
+      shell: Rscript {0}
+    - name: Run tests
+      run: |
+        source ./travis/install-common-deps.sh
+        source activate test-environment
+        cd mlflow/R/mlflow
+        R CMD build .
+        export LINTR_COMMENT_BOT=false
+        cd tests
+        Rscript ../.travis.R
+    - name: Calculate code coverage
+      if: ${{ success() }}
+      run: |
+        export MLFLOW_HOME=$(pwd)
+        cd mlflow/R/mlflow/tests
+        Rscript -e 'covr::codecov()' || :
+      env:
+        COVR_RUNNING: true
+    - name: Show 00check.log on failure
+      if: ${{ failure() }}
+      run: |
+        LOG_FILE="${HOME}/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
+        [ -r "${LOG_FILE}" ] && cat "${LOG_FILE}"
+        cp "${LOG_FILE}" /tmp
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: 00check.log
+        path: /tmp/00check.log
   python-small:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        env:
-          INSTALL_LARGE_PYTHON_DEPS: true
-        run: |
-          source ./travis/install-common-deps.sh
-      - name: Run tests
-        run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
-          source activate test-environment
-          ./travis/run-small-python-tests.sh
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      env:
+        INSTALL_LARGE_PYTHON_DEPS: true
+      run: |
+        source ./travis/install-common-deps.sh
+    - name: Run tests
+      run: |
+        export PATH="$CONDA_DIR/bin:$PATH"
+        source activate test-environment
+        ./travis/run-small-python-tests.sh
 
   python-large:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        env:
-          INSTALL_LARGE_PYTHON_DEPS: true
-        run: |
-          source ./travis/install-common-deps.sh
-      - name: Run tests
-        run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
-          source activate test-environment
-          ./travis/run-large-python-tests.sh
-          ./travis/test-anaconda-compatibility.sh "anaconda3:2020.02"
-          ./travis/test-anaconda-compatibility.sh "anaconda3:2019.03"
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      env:
+        INSTALL_LARGE_PYTHON_DEPS: true
+      run: |
+        source ./travis/install-common-deps.sh
+    - name: Run tests
+      run: |
+        export PATH="$CONDA_DIR/bin:$PATH"
+        source activate test-environment
+        ./travis/run-large-python-tests.sh
+        ./travis/test-anaconda-compatibility.sh "anaconda3:2020.02"
+        ./travis/test-anaconda-compatibility.sh "anaconda3:2019.03"
 
   java:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Java
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - name: Install dependencies
-        run: |
-          source ./travis/install-common-deps.sh
-      - name: Run tests
-        run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
-          source activate test-environment
-          cd mlflow/java
-          mvn clean package -q
+    - uses: actions/checkout@v2
+    - name: Set up Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Install dependencies
+      run: |
+        source ./travis/install-common-deps.sh
+    - name: Run tests
+      run: |
+        export PATH="$CONDA_DIR/bin:$PATH"
+        source activate test-environment
+        cd mlflow/java
+        mvn clean package -q
 
   js:
     runs-on: ubuntu-latest
@@ -141,32 +141,32 @@ jobs:
       run:
         working-directory: mlflow/server/js
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 10.x
-      - name: Install dependencies
-        run: |
-          npm i
-      - name: Run lint
-        run: |
-          npm run lint
-      - name: Run tests
-        run: |
-          npm run test
+    - uses: actions/checkout@v2
+    - name: Set up Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - name: Install dependencies
+      run: |
+        npm i
+    - name: Run lint
+      run: |
+        npm run lint
+    - name: Run tests
+      run: |
+        npm run test
 
   protos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: |
-          wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O $HOME/protoc.zip
-          sudo unzip $HOME/protoc.zip -d /usr
-      - name: Run tests
-        run: |
-          ./test-generate-protos.sh
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O $HOME/protoc.zip
+        sudo unzip $HOME/protoc.zip -d /usr
+    - name: Run tests
+      run: |
+        ./test-generate-protos.sh
 
   flavors:
     runs-on: ubuntu-latest
@@ -219,23 +219,23 @@ jobs:
   windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-      - name: Add miniconda to PATH
-        run: |
-          echo "::add-path::C:\Miniconda"
-          echo "::add-path::C:\Miniconda\Scripts"
-      - name: Initialize conda
-        run: |
-          conda init powershell
-      - name: Install dependencies
-        run: |
-          conda create -y -n test-environment python=3.7
-          conda activate test-environment
-          pip install . -r dev-requirements.txt -r travis/small-requirements.txt
-      - name: Run tests
-        run: |
-          conda activate test-environment
-          pytest --verbose --ignore-flavors --ignore=tests/projects tests
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Add miniconda to PATH
+      run: |
+        echo "::add-path::C:\Miniconda"
+        echo "::add-path::C:\Miniconda\Scripts"
+    - name: Initialize conda
+      run: |
+        conda init powershell
+    - name: Install dependencies
+      run: |
+        conda create -y -n test-environment python=3.7
+        conda activate test-environment
+        pip install . -r dev-requirements.txt -r travis/small-requirements.txt
+    - name: Run tests
+      run: |
+        conda activate test-environment
+        pytest --verbose --ignore-flavors --ignore=tests/projects tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -231,6 +231,7 @@ jobs:
         run:
           conda create -n test-environment python=3.7
           source activate test-environment
+          conda install pip
           pip install . -r dev-requirements.txt -r travis/small-requirements.txt
       - name: Run tests
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Install dependencies
         run: |
           conda create -n test-environment python=3.7
-          source activate test-environment
+          conda activate test-environment
           pip install . -r dev-requirements.txt -r travis/small-requirements.txt
       - name: Run tests
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -223,6 +223,10 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
+      - name: Add miniconda path to PATH
+        run: |
+          echo "::add-path::C:\Miniconda"
+      - run: conda --version
       - name: Install dependecies
         run: |
           pip install -r dev-requirements.txt

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -223,16 +223,16 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.7
-      - name: Add miniconda path to PATH
+      - name: Add miniconda to PATH
         run: |
           echo "::add-path::C:\Miniconda"
           echo "::add-path::C:\Miniconda\Scripts"
-      - run: conda --version
       - name: Install dependencies
-        run: |
-          pip install -r dev-requirements.txt
-          pip install -r travis/small-requirements.txt
-          pip install -e .
+        run:
+          conda create -n test-environment python=3.7
+          source activate test-environment
+          pip install -e . -r dev-requirements.txt -r travis/small-requirements.txt
       - name: Run tests
         run: |
+          conda activate test-environment
           pytest --verbose --ignore-flavors --ignore=tests/projects tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -226,8 +226,9 @@ jobs:
       - name: Add miniconda path to PATH
         run: |
           echo "::add-path::C:\Miniconda"
+          echo "::add-path::C:\Miniconda\Scripts"
       - run: conda --version
-      - name: Install dependecies
+      - name: Install dependencies
         run: |
           pip install -r dev-requirements.txt
           pip install -r travis/small-requirements.txt

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -231,7 +231,7 @@ jobs:
         run:
           conda create -n test-environment python=3.7
           source activate test-environment
-          pip install -e . -r dev-requirements.txt -r travis/small-requirements.txt
+          pip install . -r dev-requirements.txt -r travis/small-requirements.txt
       - name: Run tests
         run: |
           conda activate test-environment

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -233,9 +233,11 @@ jobs:
     - name: Install dependencies
       run: |
         conda create -y -n test-environment python=3.7
-        conda activate test-environment
-        pip install . -r dev-requirements.txt -r travis/small-requirements.txt
+        call activate test-environment
+        pip install -r dev-requirements.txt
+        pip install -r travis/small-requirements.txt
+        pip install .
     - name: Run tests
       run: |
-        conda activate test-environment
+        call activate test-environment
         pytest --verbose --ignore-flavors --ignore=tests/projects tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,9 +2,9 @@ name: MLflow tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CONDA_DIR: /usr/share/miniconda
@@ -13,127 +13,127 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      env:
-        INSTALL_LARGE_PYTHON_DEPS: true
-        INSTALL_SMALL_PYTHON_DEPS: true
-      run: |
-        source ./travis/install-common-deps.sh
-        pip install -r ./travis/lint-requirements.txt
-    - name: Run tests
-      run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        ./lint.sh
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        env:
+          INSTALL_LARGE_PYTHON_DEPS: true
+          INSTALL_SMALL_PYTHON_DEPS: true
+        run: |
+          source ./travis/install-common-deps.sh
+          pip install -r ./travis/lint-requirements.txt
+      - name: Run tests
+        run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          ./lint.sh
   r:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: r-lib/actions/setup-r@v1
-    # This step dumps the current set of R dependencies and R version into files to be used
-    # as a cache key when caching/restoring R dependencies.
-    - name: Query dependencies
-      run: |
-        install.packages('remotes')
-        saveRDS(remotes::dev_package_deps("mlflow/R/mlflow", dependencies = TRUE), ".github/depends.Rds", version = 2)
-        writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-      shell: Rscript {0}
+      - uses: actions/checkout@master
+      - uses: r-lib/actions/setup-r@v1
+      # This step dumps the current set of R dependencies and R version into files to be used
+      # as a cache key when caching/restoring R dependencies.
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps("mlflow/R/mlflow", dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
 
-    - name: Cache R packages
-      if: runner.os != 'Windows'
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.R_LIBS_USER }}
-        # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
-        # R dependencies
-        key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-        restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-    - name: Install system dependencies
-      run: |
-        sudo apt-get install -y libcurl4-openssl-dev
-    - name: Install dependencies
-      run: |
-        install.packages("devtools")
-        remotes::install_deps('mlflow/R/mlflow', dependencies = TRUE, upgrade = FALSE)
-      shell: Rscript {0}
-    - name: Run tests
-      run: |
-        source ./travis/install-common-deps.sh
-        source activate test-environment
-        cd mlflow/R/mlflow
-        R CMD build .
-        export LINTR_COMMENT_BOT=false
-        cd tests
-        Rscript ../.travis.R
-    - name: Calculate code coverage
-      if: ${{ success() }}
-      run: |
-        export MLFLOW_HOME=$(pwd)
-        cd mlflow/R/mlflow/tests
-        Rscript -e 'covr::codecov()' || :
-      env:
-        COVR_RUNNING: true
-    - name: Show 00check.log on failure
-      if: ${{ failure() }}
-      run: |
-        LOG_FILE="${HOME}/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
-        [ -r "${LOG_FILE}" ] && cat "${LOG_FILE}"
-        cp "${LOG_FILE}" /tmp
-    - uses: actions/upload-artifact@v1
-      if: failure()
-      with:
-        name: 00check.log
-        path: /tmp/00check.log
+      - name: Cache R packages
+        if: runner.os != 'Windows'
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
+          # R dependencies
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+      - name: Install system dependencies
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev
+      - name: Install dependencies
+        run: |
+          install.packages("devtools")
+          remotes::install_deps('mlflow/R/mlflow', dependencies = TRUE, upgrade = FALSE)
+        shell: Rscript {0}
+      - name: Run tests
+        run: |
+          source ./travis/install-common-deps.sh
+          source activate test-environment
+          cd mlflow/R/mlflow
+          R CMD build .
+          export LINTR_COMMENT_BOT=false
+          cd tests
+          Rscript ../.travis.R
+      - name: Calculate code coverage
+        if: ${{ success() }}
+        run: |
+          export MLFLOW_HOME=$(pwd)
+          cd mlflow/R/mlflow/tests
+          Rscript -e 'covr::codecov()' || :
+        env:
+          COVR_RUNNING: true
+      - name: Show 00check.log on failure
+        if: ${{ failure() }}
+        run: |
+          LOG_FILE="${HOME}/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
+          [ -r "${LOG_FILE}" ] && cat "${LOG_FILE}"
+          cp "${LOG_FILE}" /tmp
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: 00check.log
+          path: /tmp/00check.log
   python-small:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      env:
-        INSTALL_LARGE_PYTHON_DEPS: true
-      run: |
-        source ./travis/install-common-deps.sh
-    - name: Run tests
-      run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        ./travis/run-small-python-tests.sh
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        env:
+          INSTALL_LARGE_PYTHON_DEPS: true
+        run: |
+          source ./travis/install-common-deps.sh
+      - name: Run tests
+        run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          ./travis/run-small-python-tests.sh
 
   python-large:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      env:
-        INSTALL_LARGE_PYTHON_DEPS: true
-      run: |
-        source ./travis/install-common-deps.sh
-    - name: Run tests
-      run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        ./travis/run-large-python-tests.sh
-        ./travis/test-anaconda-compatibility.sh "anaconda3:2020.02"
-        ./travis/test-anaconda-compatibility.sh "anaconda3:2019.03"
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        env:
+          INSTALL_LARGE_PYTHON_DEPS: true
+        run: |
+          source ./travis/install-common-deps.sh
+      - name: Run tests
+        run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          ./travis/run-large-python-tests.sh
+          ./travis/test-anaconda-compatibility.sh "anaconda3:2020.02"
+          ./travis/test-anaconda-compatibility.sh "anaconda3:2019.03"
 
   java:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Java
-      uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - name: Install dependencies
-      run: |
-        source ./travis/install-common-deps.sh
-    - name: Run tests
-      run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        cd mlflow/java
-        mvn clean package -q
+      - uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Install dependencies
+        run: |
+          source ./travis/install-common-deps.sh
+      - name: Run tests
+        run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          cd mlflow/java
+          mvn clean package -q
 
   js:
     runs-on: ubuntu-latest
@@ -141,32 +141,32 @@ jobs:
       run:
         working-directory: mlflow/server/js
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: 10.x
-    - name: Install dependencies
-      run: |
-        npm i
-    - name: Run lint
-      run: |
-        npm run lint
-    - name: Run tests
-      run: |
-        npm run test
+      - uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Install dependencies
+        run: |
+          npm i
+      - name: Run lint
+        run: |
+          npm run lint
+      - name: Run tests
+        run: |
+          npm run test
 
   protos:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: |
-        wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O $HOME/protoc.zip
-        sudo unzip $HOME/protoc.zip -d /usr
-    - name: Run tests
-      run: |
-        ./test-generate-protos.sh
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O $HOME/protoc.zip
+          sudo unzip $HOME/protoc.zip -d /usr
+      - name: Run tests
+        run: |
+          ./test-generate-protos.sh
 
   flavors:
     runs-on: ubuntu-latest
@@ -227,6 +227,9 @@ jobs:
         run: |
           echo "::add-path::C:\Miniconda"
           echo "::add-path::C:\Miniconda\Scripts"
+      - name: Initialize conda
+        run: |
+          conda init powershell
       - name: Install dependencies
         run: |
           conda create -y -n test-environment python=3.7

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -227,17 +227,17 @@ jobs:
       run: |
         echo "::add-path::C:\Miniconda"
         echo "::add-path::C:\Miniconda\Scripts"
-    - name: Initialize conda
+    - name: Run conda init
       run: |
         conda init powershell
     - name: Install dependencies
       run: |
         conda create -y -n test-environment python=3.7
-        call conda activate test-environment
+        conda activate test-environment
         pip install -r dev-requirements.txt
         pip install -r travis/small-requirements.txt
         pip install .
     - name: Run tests
       run: |
-        call activate test-environment
+        conda activate test-environment
         pytest --verbose --ignore-flavors --ignore=tests/projects tests


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Use miniconda in the windows tests. This change allows us to run tests for mlflow models or projects in windows.

## How is this patch tested?

GitHub Actions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [x] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
