### PR TITLE
Do not overwrite local Spark cache when loading SparkML models as spark_udf.

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -517,6 +517,10 @@ def _load_pyfunc(path):
 
     spark = pyspark.sql.SparkSession._instantiatedSession
     if spark is None:
+        # NB: If there is no existing Spark context, create a new local one.
+        # NB: We're disabling caching on the new context since we do not need it and we want to
+        # avoid overwriting cache of underlying Spark cluster when executed on a Spark Worker
+        # (e.g. as part of spark_udf).
         spark = pyspark.sql.SparkSession.builder\
             .config("spark.python.worker.reuse", True) \
             .config("spark.databricks.io.cache.enabled", False) \

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -517,7 +517,9 @@ def _load_pyfunc(path):
 
     spark = pyspark.sql.SparkSession._instantiatedSession
     if spark is None:
-        spark = pyspark.sql.SparkSession.builder.config("spark.python.worker.reuse", True) \
+        spark = pyspark.sql.SparkSession.builder\
+            .config("spark.python.worker.reuse", True) \
+            .config("spark.databricks.io.cache.enabled", False) \
             .master("local[1]").getOrCreate()
     return _PyFuncModelWrapper(spark, _load_model(model_uri=path))
 


### PR DESCRIPTION

## What changes are proposed in this pull request?
Add config to disable caching in spark context created when loading spark ml models as pyfunc. This is to avoid corrupting cache of the underlying spark cluster when loaded on spark executor (e.g. when loaded as mlflow.pyfunc.spark_udf). 

### Context
SparkML models loaded as pyfunc create their own spark context, unless there is already one available. If this happens on a Spark executor (e.g. when loaded as spark_udf) the local fs cache location of the newly created context may overlap with the cache for the underlying (main) Spark cluster and the main clusters cache gets corrupted causing problems when reading files on the cluster.. 

## How is this patch tested?
Manually.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for
Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
