### PR TITLE
[Model Version Schema] Add model-versions/get-artifact API

### DIFF
--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -46,7 +46,7 @@ def serve_artifacts():
 
 
 # Serve the "get-model-version-artifact" route.
-@app.route(_add_static_prefix('/get-model-version-artifact'))
+@app.route(_add_static_prefix('/model-versions/get-artifact'))
 def serve_model_version_artifact():
     return get_model_version_artifact_handler()
 

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -6,7 +6,8 @@ import textwrap
 from flask import Flask, send_from_directory, Response
 
 from mlflow.server import handlers
-from mlflow.server.handlers import get_artifact_handler, STATIC_PREFIX_ENV_VAR, _add_static_prefix
+from mlflow.server.handlers import get_artifact_handler, STATIC_PREFIX_ENV_VAR, \
+    _add_static_prefix, get_model_version_artifact_handler
 from mlflow.utils.process import exec_cmd
 
 # NB: These are intenrnal environment variables used for communication between
@@ -42,6 +43,12 @@ def health():
 @app.route(_add_static_prefix('/get-artifact'))
 def serve_artifacts():
     return get_artifact_handler()
+
+
+# Serve the "get-model-version-artifact" route.
+@app.route(_add_static_prefix('/get-model-version-artifact'))
+def serve_model_version_artifact():
+    return get_model_version_artifact_handler()
 
 
 # We expect the react app to be built assuming it is hosted at /static-files, so that requests for

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -45,7 +45,7 @@ def serve_artifacts():
     return get_artifact_handler()
 
 
-# Serve the "get-model-version-artifact" route.
+# Serve the "model-versions/get-artifact" route.
 @app.route(_add_static_prefix('/model-versions/get-artifact'))
 def serve_model_version_artifact():
     return get_model_version_artifact_handler()

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -622,7 +622,8 @@ def get_model_version_artifact_handler():
     name = request_dict.get('name')
     version = request_dict.get('version')
     artifact_uri = _get_model_registry_store().get_model_version_download_uri(name, version)
-    filename = os.path.abspath(get_artifact_repository(artifact_uri).download_artifacts(request_dict['path']))
+    artifact_repository = get_artifact_repository(artifact_uri)
+    filename = os.path.abspath(artifact_repository.download_artifacts(request_dict['path']))
     extension = os.path.splitext(filename)[-1].replace(".", "")
     # Always send artifacts as attachments to prevent the browser from displaying them on our web
     # server's domain, which might enable XSS.

--- a/mlflow/server/js/src/setupProxy.js
+++ b/mlflow/server/js/src/setupProxy.js
@@ -20,4 +20,11 @@ module.exports = function (app) {
       changeOrigin: true,
     }),
   );
+  app.use(
+    createProxyMiddleware('/get-model-version-artifact', {
+      target: proxyTarget,
+      ws: true,
+      changeOrigin: true,
+    }),
+  );
 };

--- a/mlflow/server/js/src/setupProxy.js
+++ b/mlflow/server/js/src/setupProxy.js
@@ -21,7 +21,7 @@ module.exports = function (app) {
     }),
   );
   app.use(
-    createProxyMiddleware('/get-model-version-artifact', {
+    createProxyMiddleware('/model-versions/get-artifact', {
       target: proxyTarget,
       ws: true,
       changeOrigin: true,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add get model version artifact API to support compare model version schema in the following PR

## How is this patch tested?

Manual Test

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
