### PR TITLE
Fix directory doubling issue for `FTPArtifactRepository.log_artifacts`

### DIFF
--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -77,20 +77,12 @@ class FTPArtifactRepository(ArtifactRepository):
         dest_path = posixpath.join(self.path, artifact_path) \
             if artifact_path else self.path
 
-        dest_path = posixpath.join(
-            dest_path, os.path.split(local_dir)[1])
-        dest_path_re = os.path.split(local_dir)[1]
-        if artifact_path:
-            dest_path_re = posixpath.join(
-                artifact_path, os.path.split(local_dir)[1])
-
         local_dir = os.path.abspath(local_dir)
         for (root, _, filenames) in os.walk(local_dir):
             upload_path = dest_path
             if root != local_dir:
                 rel_path = os.path.relpath(root, local_dir)
-                rel_path = relative_path_to_artifact_path(rel_path)
-                upload_path = posixpath.join(dest_path_re, rel_path)
+                upload_path = relative_path_to_artifact_path(rel_path)
             if not filenames:
                 with self.get_ftp_client() as ftp:
                     self._mkdir(ftp, posixpath.join(self.path, upload_path))

--- a/tests/store/artifact/test_ftp_artifact_repo.py
+++ b/tests/store/artifact/test_ftp_artifact_repo.py
@@ -1,6 +1,4 @@
 # pylint: disable=redefined-outer-name
-import posixpath
-
 from mock import MagicMock
 import pytest
 import posixpath

--- a/tests/store/artifact/test_ftp_artifact_repo.py
+++ b/tests/store/artifact/test_ftp_artifact_repo.py
@@ -195,12 +195,11 @@ def test_log_artifacts(artifact_path, ftp_mock, tmpdir):
 
     repo.log_artifacts(subd.strpath, artifact_path)
 
-    if artifact_path is None:
-        ftp_mock.mkd.assert_any_call('/some/path')
-        ftp_mock.cwd.assert_any_call('/some/path')
-    else:
-        ftp_mock.mkd.assert_any_call(os.path.join('/some/path', artifact_path))
-        ftp_mock.cwd.assert_any_call(os.path.join('/some/path', artifact_path))
+    arg_expected = (
+        '/some/path' if artifact_path is None else os.path.join('/some/path', artifact_path)
+    )
+    ftp_mock.mkd.assert_any_call(arg_expected)
+    ftp_mock.cwd.assert_any_call(arg_expected)
 
     assert ftp_mock.storbinary.call_count == 3
     storbinary_call_args = sorted([ftp_mock.storbinary.call_args_list[i][0][0] for i in range(3)])

--- a/tests/store/artifact/test_ftp_artifact_repo.py
+++ b/tests/store/artifact/test_ftp_artifact_repo.py
@@ -1,4 +1,6 @@
 # pylint: disable=redefined-outer-name
+import os
+
 from mock import MagicMock
 import pytest
 import posixpath
@@ -176,7 +178,8 @@ def test_log_artifact_multiple_calls(ftp_mock, tmpdir):
     assert ftp_mock.storbinary.call_args_list[0][0][0] == 'STOR test2.txt'
 
 
-def test_log_artifacts(ftp_mock, tmpdir):
+@pytest.mark.parametrize("artifact_path", [None, 'dir', 'dir1/dir2'])
+def test_log_artifacts(artifact_path, ftp_mock, tmpdir):
     repo = FTPArtifactRepository("ftp://test_ftp/some/path")
 
     repo.get_ftp_client = MagicMock()
@@ -190,10 +193,15 @@ def test_log_artifacts(ftp_mock, tmpdir):
 
     ftp_mock.cwd = MagicMock(side_effect=[ftplib.error_perm, None, None, None, None, None])
 
-    repo.log_artifacts(subd.strpath)
+    repo.log_artifacts(subd.strpath, artifact_path)
 
-    ftp_mock.mkd.assert_any_call('/some/path/subdir')
-    ftp_mock.cwd.assert_any_call('/some/path/subdir')
+    if artifact_path is None:
+        ftp_mock.mkd.assert_any_call('/some/path')
+        ftp_mock.cwd.assert_any_call('/some/path')
+    else:
+        ftp_mock.mkd.assert_any_call(os.path.join('/some/path', artifact_path))
+        ftp_mock.cwd.assert_any_call(os.path.join('/some/path', artifact_path))
+
     assert ftp_mock.storbinary.call_count == 3
     storbinary_call_args = sorted([ftp_mock.storbinary.call_args_list[i][0][0] for i in range(3)])
     assert storbinary_call_args == ['STOR a.txt', 'STOR b.txt', 'STOR c.txt']

--- a/tests/store/artifact/test_ftp_artifact_repo.py
+++ b/tests/store/artifact/test_ftp_artifact_repo.py
@@ -1,5 +1,5 @@
 # pylint: disable=redefined-outer-name
-import os
+import posixpath
 
 from mock import MagicMock
 import pytest
@@ -196,7 +196,7 @@ def test_log_artifacts(artifact_path, ftp_mock, tmpdir):
     repo.log_artifacts(subd.strpath, artifact_path)
 
     arg_expected = (
-        '/some/path' if artifact_path is None else os.path.join('/some/path', artifact_path)
+        '/some/path' if artifact_path is None else posixpath.join('/some/path', artifact_path)
     )
     ftp_mock.mkd.assert_any_call(arg_expected)
     ftp_mock.cwd.assert_any_call(arg_expected)


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fixes #2641 
Fixes #2688 (which is a dup of this PR)

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
