### PR TITLE
[Model Version Schema] Add Schema Section in Model Version and Compare Model Version View

### DIFF
--- a/mlflow/server/js/src/common/utils/ArtifactUtils.js
+++ b/mlflow/server/js/src/common/utils/ArtifactUtils.js
@@ -1,4 +1,4 @@
-import { getRequestHeaders } from '../../../setupAjaxHeaders';
+import { getRequestHeaders } from '../../setupAjaxHeaders';
 
 /**
  * Fetches the specified artifact, returning a Promise that resolves with

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -232,6 +232,16 @@ class Utils {
     return urlObj.toString();
   }
 
+  static getNotebookId(tags) {
+    const notebookIdTag = 'mlflow.databricks.notebookID';
+    return tags && tags[notebookIdTag] && tags[notebookIdTag].value;
+  }
+
+  static getNotebookRevisionId(tags) {
+    const revisionIdTag = 'mlflow.databricks.notebookRevisionID';
+    return tags && tags[revisionIdTag] && tags[revisionIdTag].value;
+  }
+
   /**
    * Renders the source name and entry point into an HTML element. Used for display.
    * @param tags Object containing tag key value pairs.
@@ -252,10 +262,8 @@ class Utils {
       }
       return res;
     } else if (sourceType === 'NOTEBOOK') {
-      const revisionIdTag = 'mlflow.databricks.notebookRevisionID';
-      const notebookIdTag = 'mlflow.databricks.notebookID';
-      const revisionId = tags && tags[revisionIdTag] && tags[revisionIdTag].value;
-      const notebookId = tags && tags[notebookIdTag] && tags[notebookIdTag].value;
+      const revisionId = Utils.getNotebookRevisionId(tags);
+      const notebookId = Utils.getNotebookId(tags);
       if (notebookId) {
         let url = Utils.setQueryParams(window.location.origin, queryParams);
         url += `#notebook/${notebookId}`;

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.css
@@ -2,8 +2,15 @@
 .experiment-name {
   display: inline-block;
 }
+
 .header-container {
   display: flex;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.header-container h1 {
+  margin-bottom: 0;
 }
 
 .separator {
@@ -29,6 +36,7 @@
   margin-bottom: 8px;
   margin-right: 12px;
 }
+
 .metadata-header {
   font-size: 14px;
   color: #888;

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactHtmlView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactHtmlView.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { getSrc } from './ShowArtifactPage';
-import { getArtifactContent } from './ShowArtifactUtils';
+import { getArtifactContent } from '../../../common/utils/ArtifactUtils';
 import './ShowArtifactHtmlView.css';
 import Iframe from 'react-iframe';
 

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMapView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactMapView.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { getSrc } from './ShowArtifactPage';
-import { getArtifactContent } from './ShowArtifactUtils';
+import { getArtifactContent } from '../../../common/utils/ArtifactUtils';
 import './ShowArtifactMapView.css';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPdfView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPdfView.js
@@ -4,7 +4,7 @@ import './ShowArtifactImageView.css';
 import { getSrc } from './ShowArtifactPage';
 import { Document, Page, pdfjs } from 'react-pdf';
 import { Pagination, Spin } from 'antd';
-import { getArtifactBytesContent } from './ShowArtifactUtils';
+import { getArtifactBytesContent } from '../../../common/utils/ArtifactUtils';
 import './ShowArtifactPdfView.css';
 
 // See: https://github.com/wojtekmaj/react-pdf/blob/master/README.md#enable-pdfjs-worker for how

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.js
@@ -4,7 +4,7 @@ import { getSrc } from './ShowArtifactPage';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { coy as style } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { getLanguage } from '../../../common/utils/FileUtils';
-import { getArtifactContent } from './ShowArtifactUtils';
+import { getArtifactContent } from '../../../common/utils/ArtifactUtils';
 import './ShowArtifactTextView.css';
 
 class ShowArtifactTextView extends Component {

--- a/mlflow/server/js/src/model-registry/actions.js
+++ b/mlflow/server/js/src/model-registry/actions.js
@@ -1,6 +1,8 @@
 import { Services } from './services';
 import { getUUID, wrapDeferred } from '../common/utils/ActionUtils';
+import { getArtifactContent } from '../common/utils/ArtifactUtils';
 import { REGISTERED_MODELS_PER_PAGE } from './constants';
+import YAML from 'yamljs';
 
 export const CREATE_REGISTERED_MODEL = 'CREATE_REGISTERED_MODEL';
 export const createRegisteredModelApi = (name, id = getUUID()) => ({
@@ -77,6 +79,38 @@ export const createModelVersionApi = (name, source, runId, id = getUUID()) => ({
   type: CREATE_MODEL_VERSION,
   payload: wrapDeferred(Services.createModelVersion, { name, source, run_id: runId }),
   meta: { id, name, runId },
+});
+
+export const GET_MODEL_VERSION_ARTIFACT = 'GET_MODEL_VERSION_ARTIFACT';
+export const getModelVersionArtifactApi = (modelName, version, id = getUUID()) => {
+  const baseUri = 'model-versions/get-artifact?path=MLmodel';
+  const uriEncodedModelName = `name=${encodeURIComponent(modelName)}`;
+  const uriEncodedModelVersion = `version=${encodeURIComponent(version)}`;
+  const artifactLocation = `${baseUri}&${uriEncodedModelName}&${uriEncodedModelVersion}`;
+  return {
+    type: GET_MODEL_VERSION_ARTIFACT,
+    payload: getArtifactContent(artifactLocation),
+    meta: { id, modelName, version },
+  };
+};
+
+// pass `null` to the `parseMlModelFile` API when we failed to fetch the
+// file from DBFS. This will ensure requestId is registered in redux `apis` state
+export const PARSE_MLMODEL_FILE = 'PARSE_MLMODEL_FILE';
+export const parseMlModelFile = (modelName, version, mlModelFile, id = getUUID()) => ({
+  type: PARSE_MLMODEL_FILE,
+  payload: mlModelFile ? Promise.resolve(YAML.parse(mlModelFile)) : Promise.reject(),
+  meta: { id, modelName, version },
+});
+
+export const GET_MODEL_VERSION_ACTIVITIES = 'GET_MODEL_VERSION_ACTIVITIES';
+export const getModelVersionActivitiesApi = (modelName, version, id = getUUID()) => ({
+  type: GET_MODEL_VERSION_ACTIVITIES,
+  payload: wrapDeferred(Services.getModelVersionActivities, {
+    name: modelName,
+    version: version,
+  }),
+  meta: { id, modelName, version },
 });
 
 export const SEARCH_MODEL_VERSIONS = 'SEARCH_MODEL_VERSIONS';

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.js
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.js
@@ -42,10 +42,10 @@ export class CompareModelVersionsView extends Component {
     runDisplayNames: PropTypes.arrayOf(PropTypes.string).isRequired,
     modelName: PropTypes.string.isRequired,
     versionsToRuns: PropTypes.object.isRequired,
-    inputsListByName: PropTypes.arrayOf(Array).isRequired,
-    inputsListByIndex: PropTypes.arrayOf(Array).isRequired,
-    outputsListByName: PropTypes.arrayOf(Array).isRequired,
-    outputsListByIndex: PropTypes.arrayOf(Array).isRequired,
+    inputsListByName: PropTypes.arrayOf(PropTypes.array).isRequired,
+    inputsListByIndex: PropTypes.arrayOf(PropTypes.array).isRequired,
+    outputsListByName: PropTypes.arrayOf(PropTypes.array).isRequired,
+    outputsListByIndex: PropTypes.arrayOf(PropTypes.array).isRequired,
   };
 
   state = {

--- a/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.test.js
+++ b/mlflow/server/js/src/model-registry/components/CompareModelVersionsView.test.js
@@ -26,6 +26,10 @@ describe('unconnected tests', () => {
       paramLists: [],
       runNames: [],
       runDisplayNames: [],
+      inputsListByName: [],
+      inputsListByIndex: [],
+      outputsListByName: [],
+      outputsListByIndex: [],
     };
 
     commonProps = {
@@ -48,6 +52,34 @@ describe('unconnected tests', () => {
       runInfosValid: [true, false],
       metricLists: [[{ key: 'test_metric', value: 0.0 }]],
       paramLists: [[{ key: 'test_param', value: '0.0' }]],
+      inputsListByName: [
+        [
+          { key: 'column1', value: 'long' },
+          { key: 'column2', value: 'string' },
+        ],
+        [],
+      ],
+      inputsListByIndex: [
+        [
+          { key: '0', value: 'column1: long' },
+          { key: '1', value: 'column2: string' },
+        ],
+        [],
+      ],
+      outputsListByName: [
+        [
+          { key: 'score1', value: 'long' },
+          { key: 'score2', value: 'string' },
+        ],
+        [],
+      ],
+      outputsListByIndex: [
+        [
+          { key: '0', value: 'score1: long' },
+          { key: '1', value: 'score2: string' },
+        ],
+        [],
+      ],
     };
   });
 
@@ -91,6 +123,7 @@ describe('connected tests', () => {
         },
         paramsByRunUuid: { '123': [{ key: 'test_param', value: '0.0' }] },
         tagsByRunUuid: { '123': [{ key: 'test_tag', value: 'test.user' }] },
+        mlModelArtifactByModelVersion: { '123': 'dummy' },
       },
       apis: {},
     });
@@ -114,6 +147,15 @@ describe('connected tests', () => {
         },
         paramsByRunUuid: { '123': [{ key: 'test_param', value: '0.0' }] },
         tagsByRunUuid: { '123': [{ key: 'test_tag', value: 'test.user' }] },
+        mlModelArtifactByModelVersion: {
+          '123': {
+            signature: {
+              inputs:
+                "[{'name': 'column1', 'type': 'long'}, {'name': 'column2', 'type': 'string'}]",
+              outputs: "[{'name': 'score1', 'type': 'long'}, {'name': 'score2', 'type': 'long'}]",
+            },
+          },
+        },
       },
       apis: {},
     });

--- a/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionPage.js
@@ -5,10 +5,12 @@ import {
   updateModelVersionApi,
   deleteModelVersionApi,
   transitionModelVersionStageApi,
+  getModelVersionArtifactApi,
+  parseMlModelFile,
 } from '../actions';
 import { getRunApi } from '../../experiment-tracking/actions';
 import PropTypes from 'prop-types';
-import { getModelVersion } from '../reducers';
+import { getModelVersion, getModelVersionSchemas } from '../reducers';
 import { ModelVersionView } from './ModelVersionView';
 import { ActivityTypes, MODEL_VERSION_STATUS_POLL_INTERVAL as POLL_INTERVAL } from '../constants';
 import Utils from '../../common/utils/Utils';
@@ -19,6 +21,7 @@ import { Spinner } from '../../common/components/Spinner';
 import { getModelPageRoute, modelListPageRoute } from '../routes';
 import { getProtoField } from '../utils';
 import { getUUID } from '../../common/utils/ActionUtils';
+import _ from 'lodash';
 
 export class ModelVersionPageImpl extends React.Component {
   static propTypes = {
@@ -37,6 +40,9 @@ export class ModelVersionPageImpl extends React.Component {
     deleteModelVersionApi: PropTypes.func.isRequired,
     getRunApi: PropTypes.func.isRequired,
     apis: PropTypes.object.isRequired,
+    getModelVersionArtifactApi: PropTypes.func.isRequired,
+    parseMlModelFile: PropTypes.func.isRequired,
+    schema: PropTypes.object,
   };
 
   initGetModelVersionDetailsRequestId = getUUID();
@@ -44,8 +50,12 @@ export class ModelVersionPageImpl extends React.Component {
   updateModelVersionRequestId = getUUID();
   transitionModelVersionStageRequestId = getUUID();
   getModelVersionDetailsRequestId = getUUID();
+  initGetMlModelFileRequestId = getUUID();
   state = {
-    criticalInitialRequestIds: [this.initGetModelVersionDetailsRequestId],
+    criticalInitialRequestIds: [
+      this.initGetModelVersionDetailsRequestId,
+      this.initGetMlModelFileRequestId,
+    ],
   };
 
   pollingRelatedRequestIds = [this.getModelVersionDetailsRequestId, this.getRunRequestId];
@@ -78,6 +88,32 @@ export class ModelVersionPageImpl extends React.Component {
         if (value && !value[getProtoField('model_version')].run_link) {
           this.props.getRunApi(value[getProtoField('model_version')].run_id, this.getRunRequestId);
         }
+      });
+  }
+  // We need this for getting mlModel artifact file,
+  // this will be replaced with a single backend call in the future when supported
+  getModelVersionMlModelFile() {
+    const { modelName, version } = this.props;
+    this.props
+      .getModelVersionArtifactApi(modelName, version)
+      .then((content) =>
+        this.props.parseMlModelFile(
+          modelName,
+          version,
+          content.value,
+          this.initGetMlModelFileRequestId,
+        ),
+      )
+      .catch(() => {
+        // Failure of this call chain should not block the page. Here we remove
+        // `initGetMlModelFileRequestId` from `criticalInitialRequestIds`
+        // to unblock RequestStateWrapper from rendering its content
+        this.setState((prevState) => ({
+          criticalInitialRequestIds: _.without(
+            prevState.criticalInitialRequestIds,
+            this.initGetMlModelFileRequestId,
+          ),
+        }));
       });
   }
 
@@ -125,6 +161,7 @@ export class ModelVersionPageImpl extends React.Component {
   componentDidMount() {
     this.loadData(true).catch(console.error);
     this.pollIntervalId = setInterval(this.pollData, POLL_INTERVAL);
+    this.getModelVersionMlModelFile();
   }
 
   componentWillUnmount() {
@@ -132,7 +169,15 @@ export class ModelVersionPageImpl extends React.Component {
   }
 
   render() {
-    const { modelName, version, modelVersion, runInfo, runDisplayName, history } = this.props;
+    const {
+      modelName,
+      version,
+      modelVersion,
+      runInfo,
+      runDisplayName,
+      history,
+      schema,
+    } = this.props;
 
     return (
       <div className='App-content'>
@@ -164,6 +209,7 @@ export class ModelVersionPageImpl extends React.Component {
                   deleteModelVersionApi={this.props.deleteModelVersionApi}
                   history={history}
                   handleStageTransitionDropdownSelect={this.handleStageTransitionDropdownSelect}
+                  schema={schema}
                 />
               );
             }
@@ -178,6 +224,7 @@ export class ModelVersionPageImpl extends React.Component {
 const mapStateToProps = (state, ownProps) => {
   const { modelName, version } = ownProps.match.params;
   const modelVersion = getModelVersion(state, modelName, version);
+  const schema = getModelVersionSchemas(state, modelName, version);
   let runInfo = null;
   if (modelVersion && !modelVersion.run_link) {
     runInfo = getRunInfo(modelVersion && modelVersion.run_id, state);
@@ -189,6 +236,7 @@ const mapStateToProps = (state, ownProps) => {
     modelName,
     version,
     modelVersion,
+    schema,
     runInfo,
     runDisplayName,
     apis,
@@ -199,6 +247,8 @@ const mapDispatchToProps = {
   getModelVersionApi,
   updateModelVersionApi,
   transitionModelVersionStageApi,
+  getModelVersionArtifactApi,
+  parseMlModelFile,
   deleteModelVersionApi,
   getRunApi,
 };

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { modelListPageRoute, getModelPageRoute } from '../routes';
+import { SchemaTable } from './SchemaTable';
 import Utils from '../../common/utils/Utils';
 import { ModelStageTransitionDropdown } from './ModelStageTransitionDropdown';
 import { Dropdown, Icon, Menu, Modal, Alert, Descriptions, Tooltip, message } from 'antd';
@@ -26,6 +27,7 @@ export class ModelVersionViewImpl extends React.Component {
   static propTypes = {
     modelName: PropTypes.string,
     modelVersion: PropTypes.object,
+    schema: PropTypes.object,
     runInfo: PropTypes.object,
     runDisplayName: PropTypes.string,
     handleStageTransitionDropdownSelect: PropTypes.func.isRequired,
@@ -217,7 +219,13 @@ export class ModelVersionViewImpl extends React.Component {
   }
 
   render() {
-    const { modelName, modelVersion, handleStageTransitionDropdownSelect, tags } = this.props;
+    const {
+      modelName,
+      modelVersion,
+      handleStageTransitionDropdownSelect,
+      tags,
+      schema,
+    } = this.props;
     const { status, description } = modelVersion;
     const {
       isDeleteModalVisible,
@@ -294,6 +302,9 @@ export class ModelVersionViewImpl extends React.Component {
             tags={tags}
             isRequestPending={isTagsRequestPending}
           />
+        </CollapsibleSection>
+        <CollapsibleSection title='Schema'>
+          <SchemaTable schema={schema} />
         </CollapsibleSection>
         <Modal
           title='Delete Model Version'

--- a/mlflow/server/js/src/model-registry/components/ModelVersionView.test.js
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionView.test.js
@@ -39,6 +39,10 @@ describe('ModelVersionView', () => {
       deleteModelVersionTagApi: jest.fn(),
       history: { push: jest.fn() },
       tags: {},
+      schema: {
+        inputs: [],
+        outputs: [],
+      },
     };
     minimalStoreRaw = {
       entities: {


### PR DESCRIPTION
GitOrigin-RevId: 2e6a553807b8b9638b6ce4c254b78adbd25b0d90

## What changes are proposed in this pull request?

Add Schema Section in Model Version and Compare Model Version View

Compare Model Versions:
![82719866-3b5f0600-9c63-11ea-996b-312691af2682](https://user-images.githubusercontent.com/64800904/89082342-93d91080-d342-11ea-8de3-426c47058ee9.png)
![82719864-38fcac00-9c63-11ea-9be6-fc86ac6ad7fc](https://user-images.githubusercontent.com/64800904/89082352-9b98b500-d342-11ea-8fee-490a1ddaf7bf.png)

Model Version
![Screen Shot 2020-07-31 at 3 20 13 PM](https://user-images.githubusercontent.com/64800904/89082346-976c9780-d342-11ea-86ee-e996e5ffb0c4.png)


## How is this patch tested?

Unit Test, Manual Test

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Navigating to model version page, if a model is registered with a schema, the schema will be displayed and user can also compare different schemas for different model versions for schema validation

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
