### PR TITLE
Fix error due to names with absolute path returned by ftp.nlst

### DIFF
--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -112,6 +112,8 @@ class FTPArtifactRepository(ArtifactRepository):
                 return []
             artifact_files = ftp.nlst(list_dir)
             artifact_files = list(filter(lambda x: x != "." and x != "..", artifact_files))
+            # This is to make sure artifact_files is a list of the file names, because
+            # ftp.nlst may return them with an absolute path.
             artifact_files = list(map(lambda x: os.path.basename(x), artifact_files))
             infos = []
             for file_name in artifact_files:

--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -112,6 +112,7 @@ class FTPArtifactRepository(ArtifactRepository):
                 return []
             artifact_files = ftp.nlst(list_dir)
             artifact_files = list(filter(lambda x: x != "." and x != "..", artifact_files))
+            artifact_files = list(map(lambda x: os.path.basename(x), artifact_files))
             infos = []
             for file_name in artifact_files:
                 file_path = (file_name if path is None

--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -114,7 +114,7 @@ class FTPArtifactRepository(ArtifactRepository):
             artifact_files = list(filter(lambda x: x != "." and x != "..", artifact_files))
             # Make sure artifact_files is a list of file names because ftp.nlst
             # may return absolute paths.
-            artifact_files = list(map(lambda x: os.path.basename(x), artifact_files))
+            artifact_files = [os.path.basename(f) for f in artifact_files]
             infos = []
             for file_name in artifact_files:
                 file_path = (file_name if path is None

--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -112,8 +112,7 @@ class FTPArtifactRepository(ArtifactRepository):
                 return []
             artifact_files = ftp.nlst(list_dir)
             artifact_files = list(filter(lambda x: x != "." and x != "..", artifact_files))
-            # This is to make sure artifact_files is a list of the file names, because
-            # ftp.nlst may return them with an absolute path.
+            # Make sure artifact_files is a list of file names because ftp.nlst may return absolute paths.
             artifact_files = list(map(lambda x: os.path.basename(x), artifact_files))
             infos = []
             for file_name in artifact_files:

--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -112,7 +112,8 @@ class FTPArtifactRepository(ArtifactRepository):
                 return []
             artifact_files = ftp.nlst(list_dir)
             artifact_files = list(filter(lambda x: x != "." and x != "..", artifact_files))
-            # Make sure artifact_files is a list of file names because ftp.nlst may return absolute paths.
+            # Make sure artifact_files is a list of file names because ftp.nlst
+            # may return absolute paths.
             artifact_files = list(map(lambda x: os.path.basename(x), artifact_files))
             infos = []
             for file_name in artifact_files:

--- a/tests/store/artifact/test_ftp_artifact_repo.py
+++ b/tests/store/artifact/test_ftp_artifact_repo.py
@@ -1,6 +1,4 @@
 # pylint: disable=redefined-outer-name
-import os
-
 from mock import MagicMock
 import pytest
 import posixpath

--- a/tests/store/artifact/test_ftp_artifact_repo.py
+++ b/tests/store/artifact/test_ftp_artifact_repo.py
@@ -68,7 +68,7 @@ def test_list_artifacts(ftp_mock):
     assert artifacts[1].file_size is None
 
 
-def test_list_artifacts_with_absolute_path(ftp_mock):
+def test_list_artifacts_when_ftp_nlst_returns_absolute_paths(ftp_mock):
     artifact_root_path = "/experiment_id/run_id/"
     repo = FTPArtifactRepository("ftp://test_ftp"+artifact_root_path)
 

--- a/tests/store/artifact/test_ftp_artifact_repo.py
+++ b/tests/store/artifact/test_ftp_artifact_repo.py
@@ -81,26 +81,27 @@ def test_list_artifacts_with_absolute_path(ftp_mock):
     #  |- model
     #     |- model.pb
 
-    file_path = "/file"
-    file_name = os.path.basename(file_path)
-    dir_path = "/model"
-    dir_name = os.path.basename(dir_path)
+    file_path = "file"
+    dir_path = "model"
     file_size = 678
     ftp_mock.cwd = MagicMock(side_effect=[None, ftplib.error_perm, None])
-    ftp_mock.nlst = MagicMock(return_value=[file_path, dir_path])
+    ftp_mock.nlst = MagicMock(return_value=[
+       posixpath.join(artifact_root_path, file_path),
+       posixpath.join(artifact_root_path, dir_path)
+    ])
 
     ftp_mock.size = MagicMock(return_value=file_size)
 
     artifacts = repo.list_artifacts(path=None)
 
     ftp_mock.nlst.assert_called_once_with(artifact_root_path)
-    ftp_mock.size.assert_called_once_with(artifact_root_path + file_name)
+    ftp_mock.size.assert_called_once_with(artifact_root_path + file_path)
 
     assert len(artifacts) == 2
-    assert artifacts[0].path == file_name
+    assert artifacts[0].path == file_path
     assert artifacts[0].is_dir is False
     assert artifacts[0].file_size == file_size
-    assert artifacts[1].path == dir_name
+    assert artifacts[1].path == dir_path
     assert artifacts[1].is_dir is True
     assert artifacts[1].file_size is None
 


### PR DESCRIPTION
In vsftpd, `ftp.nlst` returns a list of file names with absolute path.
And, it will cause an error. To solve it, the path need to be removed
with basename.

Fixes https://github.com/mlflow/mlflow/issues/3197

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
