### PR TITLE
MlflowClient should pass in the tracking uri info to ArtifactRepository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ venv.bak/
 *.idea
 *.vscode
 *.iml
+*~
 
 # mkdocs documentation
 /site

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -17,6 +17,7 @@ from mlflow.entities import Param, Metric, RunStatus, RunTag, ViewType, Experime
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.utils.mlflow_tags import MLFLOW_USER
 from mlflow.utils.string_utils import is_string_type
+from mlflow.utils.uri import add_databricks_profile_info_to_artifact_uri
 
 
 class TrackingServiceClient(object):
@@ -239,6 +240,12 @@ class TrackingServiceClient(object):
                             "{}".format(type(mlflow_model)))
         self.store.record_logged_model(run_id, mlflow_model)
 
+    def _get_artifact_repo(self, run_id):
+        run = self.get_run(run_id)
+        artifact_uri = add_databricks_profile_info_to_artifact_uri(run.info.artifact_uri,
+                                                                   self.tracking_uri)
+        return get_artifact_repository(artifact_uri)
+
     def log_artifact(self, run_id, local_path, artifact_path=None):
         """
         Write a local file or directory to the remote ``artifact_uri``.
@@ -246,10 +253,7 @@ class TrackingServiceClient(object):
         :param local_path: Path to the file or directory to write.
         :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
         """
-        run = self.get_run(run_id)
-        # TODO: use add_databricks_profile_info_to_artifact_uri(artifact_root, self.tracking_uri)
-        #   for DBFS artifact repositories to use the correct tracking URI.
-        artifact_repo = get_artifact_repository(run.info.artifact_uri)
+        artifact_repo = self._get_artifact_repo(run_id)
         if os.path.isdir(local_path):
             dir_name = os.path.basename(os.path.normpath(local_path))
             path_name = os.path.join(artifact_path, dir_name) \
@@ -265,11 +269,7 @@ class TrackingServiceClient(object):
         :param local_dir: Path to the directory of files to write.
         :param artifact_path: If provided, the directory in ``artifact_uri`` to write to.
         """
-        run = self.get_run(run_id)
-        # TODO: use add_databricks_profile_info_to_artifact_uri(artifact_root, self.tracking_uri)
-        #   for DBFS artifact repositories to use the correct tracking URI.
-        artifact_repo = get_artifact_repository(run.info.artifact_uri)
-        artifact_repo.log_artifacts(local_dir, artifact_path)
+        self._get_artifact_repo(run_id).log_artifacts(local_dir, artifact_path)
 
     def list_artifacts(self, run_id, path=None):
         """
@@ -280,12 +280,7 @@ class TrackingServiceClient(object):
                      or the root artifact path.
         :return: List of :py:class:`mlflow.entities.FileInfo`
         """
-        run = self.get_run(run_id)
-        artifact_root = run.info.artifact_uri
-        # TODO: use add_databricks_profile_info_to_artifact_uri(artifact_root, self.tracking_uri)
-        #   for DBFS artifact repositories to use the correct tracking URI.
-        artifact_repo = get_artifact_repository(artifact_root)
-        return artifact_repo.list_artifacts(path)
+        return self._get_artifact_repo(run_id).list_artifacts(path)
 
     def download_artifacts(self, run_id, path, dst_path=None):
         """
@@ -301,12 +296,7 @@ class TrackingServiceClient(object):
                          directly in the case of the LocalArtifactRepository.
         :return: Local path of desired artifact.
         """
-        run = self.get_run(run_id)
-        artifact_root = run.info.artifact_uri
-        # TODO: use add_databricks_profile_info_to_artifact_uri(artifact_root, self.tracking_uri)
-        #   for DBFS artifact repositories to use the correct tracking URI.
-        artifact_repo = get_artifact_repository(artifact_root)
-        return artifact_repo.download_artifacts(path, dst_path)
+        return self._get_artifact_repo(run_id).download_artifacts(path, dst_path)
 
     def set_terminated(self, run_id, status=None, end_time=None):
         """Set a run's status to terminated.

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -104,6 +104,9 @@ def _upload_artifacts_to_databricks(source, run_id, source_host_uri=None,
             dest_root, target_databricks_profile_uri)
         dest_repo = DbfsRestArtifactRepository(dest_root_with_profile)
         dest_artifact_path = run_id if run_id else uuid4().hex
+        # Allow uploading from the same run id multiple times by randomizing a suffix
+        if len(dest_repo.list_artifacts(dest_artifact_path)) > 0:
+            dest_artifact_path = dest_artifact_path + '-' + uuid4().hex[0:4]
         dest_repo.log_artifacts(local_dir, artifact_path=dest_artifact_path)
         dirname = pathlib.PurePath(source).name  # innermost directory name
         return posixpath.join(dest_root, dest_artifact_path, dirname)  # new source

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -19,8 +19,9 @@ from mlflow.tracking.artifact_utils import _upload_artifacts_to_databricks
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
 from mlflow.utils import experimental
 from mlflow.utils.databricks_utils import is_databricks_default_tracking_uri, \
-    is_in_databricks_notebook, get_workspace_info_from_dbutils, \
+    is_in_databricks_job, is_in_databricks_notebook, get_workspace_info_from_dbutils, \
     get_workspace_info_from_databricks_secrets
+from mlflow.utils.logging_utils import eprint
 from mlflow.utils.uri import is_databricks_uri, construct_run_url
 
 _logger = logging.getLogger(__name__)
@@ -512,20 +513,16 @@ class MlflowClient(object):
         new_source = source
         if is_databricks_uri(self._registry_uri) and tracking_uri != self._registry_uri:
             # Print out some info for user since the copy may take a while for large models.
-            _logger.info("=== Copying model files from the source location to the model " +
-                         " registry workspace ===")
+            eprint("=== Copying model files from the source location to the model" +
+                   " registry workspace ===")
             new_source = _upload_artifacts_to_databricks(source, run_id, tracking_uri,
                                                          self._registry_uri)
             # NOTE: we can't easily delete the target temp location due to the async nature
             # of the model version creation - printing to let the user know.
-            _logger.info(
-                """
-                === Source model files were copied to %s
-                    in the model registry workspace. You may want to delete the files once the
-                    model version is in 'READY' status. You can also find this location in the
-                    `source` field of the created model version. ===
-                """,
-                new_source)
+            eprint("=== Source model files were copied to %s" % new_source +
+                   " in the model registry workspace. You may want to delete the files once the" +
+                   " model version is in 'READY' status. You can also find this location in the" +
+                   " `source` field of the created model version. ===")
         return self._get_registry_client().create_model_version(
             name=name,
             source=new_source,
@@ -536,7 +533,8 @@ class MlflowClient(object):
     def _get_run_link(self, tracking_uri, run_id):
         # if using the default Databricks tracking URI and in a notebook, we can automatically
         # figure out the run-link.
-        if is_databricks_default_tracking_uri(tracking_uri) and is_in_databricks_notebook():
+        if is_databricks_default_tracking_uri(tracking_uri) and \
+                (is_in_databricks_notebook() or is_in_databricks_job()):
             # use DBUtils to determine workspace information.
             workspace_host, workspace_id = get_workspace_info_from_dbutils()
         else:

--- a/tests/tracking/_tracking_service/test_tracking_service_client.py
+++ b/tests/tracking/_tracking_service/test_tracking_service_client.py
@@ -3,7 +3,7 @@ import mock
 
 from mlflow.entities import Run, RunInfo
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
-from mlflow.store.artifact.dbfs_artifact_repo import DbfsRestArtifactRepository
+
 
 @pytest.fixture
 def mock_store():
@@ -27,7 +27,7 @@ def newTrackingServiceClient():
     ('ftp://user:pass@host/path', 'databricks://profile', 'ftp://user:pass@host/path'),
 ])
 def test_get_artifact_repo(artifact_uri, databricks_uri, uri_for_repo):
-    with mock.patch('mlflow.tracking._tracking_service.client.TrackingServiceClient.get_run',  # or can mock the store
+    with mock.patch('mlflow.tracking._tracking_service.client.TrackingServiceClient.get_run',
                     return_value=Run(RunInfo('uuid', 'expr_id', 'userid', 'status', 0, 10,
                                              'active', artifact_uri=artifact_uri), None)), \
             mock.patch('mlflow.tracking._tracking_service.client.get_artifact_repository',

--- a/tests/tracking/_tracking_service/test_tracking_service_client.py
+++ b/tests/tracking/_tracking_service/test_tracking_service_client.py
@@ -1,0 +1,37 @@
+import pytest
+import mock
+
+from mlflow.entities import Run, RunInfo
+from mlflow.tracking._tracking_service.client import TrackingServiceClient
+from mlflow.store.artifact.dbfs_artifact_repo import DbfsRestArtifactRepository
+
+@pytest.fixture
+def mock_store():
+    with mock.patch("mlflow.tracking._trackingZ_service.utils._get_store") as mock_get_store:
+        yield mock_get_store.return_value
+
+
+def newTrackingServiceClient():
+    return TrackingServiceClient("databricks://scope:key")
+
+
+@pytest.mark.parametrize("artifact_uri, databricks_uri, uri_for_repo", [
+    ('dbfs:/path', 'databricks://profile', 'dbfs://profile@databricks/path'),
+    ('dbfs:/path', 'databricks://scope/key', 'dbfs://scope:key@databricks/path'),
+    ('runs:/path', 'databricks://scope/key', 'runs://scope:key@databricks/path'),
+    ('models:/path', 'databricks://scope/key', 'models://scope:key@databricks/path'),
+    # unaffected uri cases
+    ('dbfs://profile@databricks/path', 'databricks://scope/key', 'dbfs://profile@databricks/path'),
+    ('dbfs://profile@databricks/path', 'databricks://profile2', 'dbfs://profile@databricks/path'),
+    ('s3:/path', 'databricks://profile', 's3:/path'),
+    ('ftp://user:pass@host/path', 'databricks://profile', 'ftp://user:pass@host/path'),
+])
+def test_get_artifact_repo(artifact_uri, databricks_uri, uri_for_repo):
+    with mock.patch('mlflow.tracking._tracking_service.client.TrackingServiceClient.get_run',  # or can mock the store
+                    return_value=Run(RunInfo('uuid', 'expr_id', 'userid', 'status', 0, 10,
+                                             'active', artifact_uri=artifact_uri), None)), \
+            mock.patch('mlflow.tracking._tracking_service.client.get_artifact_repository',
+                       return_value=None) as get_repo_mock:
+        client = TrackingServiceClient(databricks_uri)
+        client._get_artifact_repo('some-run-id')
+        get_repo_mock.assert_called_once_with(uri_for_repo)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Previously, even if you specified the `tracking_uri` explicitly in initializing `MlflowClient`, its artifact methods (`log_artifact`, `log_artifacts`, `list_artifacts`, `download_artifacts`) did not talk to the correct tracking server if the artifacts were in DBFS. Now those methods instantiate an `ArtifactRepository` with the tracking URI to ensure that we talk to the correct Databricks workspace the DBFS location belongs to.

Also includes a few small fixes around dealing with different tracking and registry URIs:
* Allow uploading the files from the same run to a Databricks DBFS location multiple times in `artifact_utils._upload_artifacts_to_databricks`.
* In `MlflowClient.create_model_version`:
  * Change the messaging about model artifact copy to `eprint` (which seems to show up better in more contexts).
  * Support Databricks job context when constructing the `run_link`.

## How is this patch tested?

Manual tests - tried the artifact method with `tracking_uri` pointing to both local and remote contexts.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Writing and reading artifacts via ``MlflowClient`` to a DBFS location in a Databricks tracking server specified through the ``tracking_uri`` parameter during the initialization of ``MlflowClient`` now works properly.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
