### PR TITLE
Trigger auto-labeling action when new issue or PR has been opened

### DIFF
--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -4,9 +4,11 @@ on:
   issues:
     types:
       - opened
+      - edited
   pull_request_target:
     types:
       - opened
+      - edited
 
 jobs:
   labeling:

--- a/.github/workflows/labeling.yml
+++ b/.github/workflows/labeling.yml
@@ -1,9 +1,12 @@
 name: Labeling
 
 on:
-  schedule:
-    # Run this action daily at 7:00 UTC
-    - cron: "0 7 * * *"
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
 
 jobs:
   labeling:
@@ -14,5 +17,3 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           label-pattern: '- \[(.*?)\] ?`(.+?)`'
-          # Label issues from last week
-          offset: '7d'


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

GitHub has introduced a new workflow event `pull_request_target` ([link](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/)) where we can run actions with read/write permission. This PR udpates the auto-labeling action to get triggered when a new issue or PR has been opened.

## How is this patch tested?

Verified on my auto-labeling repo: https://github.com/harupy/auto-labeling

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
