### PR TITLE
Retry small requirements installation when it fails

### DIFF
--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -35,7 +35,7 @@ pip install --upgrade pip==19.3.1
 if [[ "$INSTALL_SMALL_PYTHON_DEPS" == "true" ]]; then
   # When downloading large packages from PyPI, the connection is sometimes aborted by the
   # remote host. See https://github.com/pypa/pip/issues/8510.
-  # As a workaround, we retry installation of packages.
+  # As a workaround, we retry installation of large packages.
   retry-with-backoff pip install --quiet -r ./travis/small-requirements.txt
 fi
 if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -33,7 +33,7 @@ pip install --upgrade pip==19.3.1
 
 # Install Python test dependencies only if we're running Python tests
 if [[ "$INSTALL_SMALL_PYTHON_DEPS" == "true" ]]; then
-  pip install --quiet -r ./travis/small-requirements.txt
+  retry-with-backoff pip install --quiet -r ./travis/small-requirements.txt
 fi
 if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   # When downloading large packages from PyPI, the connection is sometimes aborted by the

--- a/travis/install-common-deps.sh
+++ b/travis/install-common-deps.sh
@@ -33,12 +33,12 @@ pip install --upgrade pip==19.3.1
 
 # Install Python test dependencies only if we're running Python tests
 if [[ "$INSTALL_SMALL_PYTHON_DEPS" == "true" ]]; then
+  # When downloading large packages from PyPI, the connection is sometimes aborted by the
+  # remote host. See https://github.com/pypa/pip/issues/8510.
+  # As a workaround, we retry installation of packages.
   retry-with-backoff pip install --quiet -r ./travis/small-requirements.txt
 fi
 if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
-  # When downloading large packages from PyPI, the connection is sometimes aborted by the
-  # remote host. See https://github.com/pypa/pip/issues/8510.
-  # As a workaround, we retry installation of large packages.
   retry-with-backoff pip install --quiet -r ./travis/large-requirements.txt
   # Hack: make sure all spark-* scripts are executable. 
   # Conda installs 2 version spark-* scripts and makes the ones spark


### PR DESCRIPTION
## What changes are proposed in this pull request?

A follow-up for #3236. Apply `retry-with-backoff` to the small requirments installation.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
