### PR TITLE
Fix flaky test_search_attrs

### DIFF
--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1276,10 +1276,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase, AbstractStoreTest):
         filter_string = "attribute.artifact_uri LIKE '%{}%'".format(r1)
         six.assertCountEqual(self, [r1], self._search([e1, e2], filter_string))
 
-        filter_string = "attribute.artifact_uri LIKE '%{}%'".format(r1[:4])
+        filter_string = "attribute.artifact_uri LIKE '%{}%'".format(r1[:16])
         six.assertCountEqual(self, [r1], self._search([e1, e2], filter_string))
 
-        filter_string = "attribute.artifact_uri LIKE '%{}%'".format(r1[-4:])
+        filter_string = "attribute.artifact_uri LIKE '%{}%'".format(r1[-16:])
         six.assertCountEqual(self, [r1], self._search([e1, e2], filter_string))
 
         filter_string = "attribute.artifact_uri LIKE '%{}%'".format(r1.upper())
@@ -1288,10 +1288,10 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase, AbstractStoreTest):
         filter_string = "attribute.artifact_uri ILIKE '%{}%'".format(r1.upper())
         six.assertCountEqual(self, [r1], self._search([e1, e2], filter_string))
 
-        filter_string = "attribute.artifact_uri ILIKE '%{}%'".format(r1[:4].upper())
+        filter_string = "attribute.artifact_uri ILIKE '%{}%'".format(r1[:16].upper())
         six.assertCountEqual(self, [r1], self._search([e1, e2], filter_string))
 
-        filter_string = "attribute.artifact_uri ILIKE '%{}%'".format(r1[-4:].upper())
+        filter_string = "attribute.artifact_uri ILIKE '%{}%'".format(r1[-16:].upper())
         six.assertCountEqual(self, [r1], self._search([e1, e2], filter_string))
 
         for (k, v) in {"experiment_id": e1,


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

`test_search_attrs` contains the following assertion:

```python
# setup
e1 = self._experiment_factory('search_attributes_1')
r1 = self._run_factory(self._get_run_configs(experiment_id=e1)).info.run_id

e2 = self._experiment_factory('search_attrs_2')
r2 = self._run_factory(self._get_run_configs(experiment_id=e2)).info.run_id

...

# test that LIKE operator works properly
filter_string = "attribute.artifact_uri LIKE '%{}%'".format(r1[:4])
six.assertCountEqual(self, [r1], self._search([e1, e2], filter_string))
```

This asserion fails when `r2` conatins the first 4 characters of `r1` ([failure example](https://github.com/mlflow/mlflow/runs/959811889#step:4:173)):

- r1 = **abcd**xxxxxxxxxxxxxxxxxxxxxxxxxxxx
- r2 = xxxxxxxx**abcd**xxxxxxxxxxxxxxxxxxxx

It's NOT rare `r1` and `r2` have values like above.

This PR makes a query generated from `r1` less likely to match `r2` by increasing the slice length (from 4 to 16).

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
