### PR TITLE
Update AzureML model deploy 

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -798,6 +798,7 @@ accepts the following data formats as input:
 
     import requests
     import json
+    
     # `sample_input` is a JSON-serialized pandas DataFrame with the `split` orientation
     sample_input = {
         "columns": [

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -748,14 +748,13 @@ For more info, see:
 Deploy a ``python_function`` model on Microsoft Azure ML
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The :py:mod:`mlflow.azureml` module can package ``python_function`` models into Azure ML container images.
-These images can be deployed to Azure Kubernetes Service (AKS) and the Azure Container Instances (ACI)
+The :py:mod:`mlflow.azureml` module can package ``python_function`` models into Azure ML container images and deploy them as a webservice. Models can be deployed to Azure Kubernetes Service (AKS) and the Azure Container Instances (ACI)
 platform for real-time serving. The resulting Azure ML ContainerImage contains a web server that
 accepts the following data formats as input:
 
 * JSON-serialized pandas DataFrames in the ``split`` orientation. For example, ``data = pandas_df.to_json(orient='split')``. This format is specified using a ``Content-Type`` request header value of ``application/json``.
 
-* :py:func:`build_image <mlflow.azureml.build_image>` registers an MLflow Model with an existing Azure ML workspace and builds an Azure ML container image for deployment to AKS and ACI. The `Azure ML SDK`_ is required in order to use this function. *The Azure ML SDK requires Python 3. It cannot be installed with earlier versions of Python.*
+* :py:func:`mlflow.azureml.deploy` registers an MLflow Model with an existing Azure ML workspace, builds an Azure ML container image and deploys the model to AKS and ACI. The `Azure ML SDK`_ is required in order to use this function. *The Azure ML SDK requires Python 3. It cannot be installed with earlier versions of Python.*
 
 .. _Azure ML SDK: https://docs.microsoft.com/python/api/overview/azure/ml/intro?view=azure-ml-py
 
@@ -781,22 +780,16 @@ accepts the following data formats as input:
                                        location=location,
                                        create_resource_group=True,
                                        exist_okay=True)
+    # Create a deployment config
+    aci_config = AciWebservice.deploy_configuration(cpu_cores=1, memory_gb=1)                                       
 
-    # Build an Azure ML container image for deployment
-    azure_image, azure_model = mlflow.azureml.build_image(model_uri="<path-to-model>",
-                                                          workspace=azure_workspace,
-                                                          description="Wine regression model 1",
-                                                          synchronous=True)
-    # If your image build failed, you can access build logs at the following URI:
-    print("Access the following URI for build logs: {}".format(azure_image.image_build_log_uri))
-
-    # Deploy the container image to ACI
-    webservice_deployment_config = AciWebservice.deploy_configuration()
-    webservice = Webservice.deploy_from_image(
-                        image=azure_image, workspace=azure_workspace, name="<deployment-name>")
-    webservice.wait_for_deployment()
-
-    # After the image deployment completes, requests can be posted via HTTP to the new ACI
+    # Register and deploy model to Azure Container Instance (ACI)
+    (webservice, model) = mlflow.azureml.deploy(model_uri='<your-model-uri>',
+                                                workspace=azure_workspace,
+                                                model_name='mymodelname', 
+                                                service_name='myservice', 
+                                                deployment_config=aci_config)
+    # After the model deployment completes, requests can be posted via HTTP to the new ACI
     # webservice's scoring URI. The following example posts a sample input from the wine dataset
     # used in the MLflow ElasticNet example:
     # https://github.com/mlflow/mlflow/tree/master/examples/sklearn_elasticnet_wine
@@ -804,7 +797,7 @@ accepts the following data formats as input:
 
     import requests
     import json
-
+    
     # `sample_input` is a JSON-serialized pandas DataFrame with the `split` orientation
     sample_input = {
         "columns": [
@@ -829,23 +822,26 @@ accepts the following data formats as input:
                   headers={"Content-type": "application/json"})
     response_json = json.loads(response.text)
     print(response_json)
-
+    
 .. rubric:: Example workflow using the MLflow CLI
-
+    
 .. code-block:: bash
 
+    # note: mlflow azureml build-image is being deprecated, it will be replaced with a new command for model deployment soon
+    
     mlflow azureml build-image -w <workspace-name> -m <model-path> -d "Wine regression model 1"
-
+    
     az ml service create aci -n <deployment-name> --image-id <image-name>:<image-version>
-
+    
     # After the image deployment completes, requests can be posted via HTTP to the new ACI
     # webservice's scoring URI. The following example posts a sample input from the wine dataset
     # used in the MLflow ElasticNet example:
     # https://github.com/mlflow/mlflow/tree/master/examples/sklearn_elasticnet_wine
-
+    
     scoring_uri=$(az ml service show --name <deployment-name> -v | jq -r ".scoringUri")
 
-    # `sample_input` is a JSON-serialized pandas DataFrame with the `split` orientation
+    
+        # `sample_input` is a JSON-serialized pandas DataFrame with the `split` orientation
     sample_input='
     {
         "columns": [
@@ -865,12 +861,12 @@ accepts the following data formats as input:
             [8.8, 0.045, 0.36, 1.001, 7, 45, 3, 20.7, 0.45, 170, 0.27]
         ]
     }'
-
+    
     echo $sample_input | curl -s -X POST $scoring_uri\
     -H 'Cache-Control: no-cache'\
     -H 'Content-Type: application/json'\
     -d @-
-
+    
 For more info, see:
 
 .. code-block:: bash

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -798,7 +798,6 @@ accepts the following data formats as input:
 
     import requests
     import json
-    
     # `sample_input` is a JSON-serialized pandas DataFrame with the `split` orientation
     sample_input = {
         "columns": [

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -789,6 +789,7 @@ accepts the following data formats as input:
                                                 model_name='mymodelname', 
                                                 service_name='myservice', 
                                                 deployment_config=aci_config)
+                                                
     # After the model deployment completes, requests can be posted via HTTP to the new ACI
     # webservice's scoring URI. The following example posts a sample input from the wine dataset
     # used in the MLflow ElasticNet example:
@@ -797,7 +798,6 @@ accepts the following data formats as input:
 
     import requests
     import json
-    
     # `sample_input` is a JSON-serialized pandas DataFrame with the `split` orientation
     sample_input = {
         "columns": [
@@ -827,8 +827,7 @@ accepts the following data formats as input:
     
 .. code-block:: bash
 
-    # note: mlflow azureml build-image is being deprecated, it will be replaced with a new command for model deployment soon
-    
+    # note mlflow azureml build-image is being deprecated, it will be replaced with a new command for model deployment soon
     mlflow azureml build-image -w <workspace-name> -m <model-path> -d "Wine regression model 1"
     
     az ml service create aci -n <deployment-name> --image-id <image-name>:<image-version>
@@ -839,9 +838,8 @@ accepts the following data formats as input:
     # https://github.com/mlflow/mlflow/tree/master/examples/sklearn_elasticnet_wine
     
     scoring_uri=$(az ml service show --name <deployment-name> -v | jq -r ".scoringUri")
-
     
-        # `sample_input` is a JSON-serialized pandas DataFrame with the `split` orientation
+    # `sample_input` is a JSON-serialized pandas DataFrame with the `split` orientation
     sample_input='
     {
         "columns": [

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -781,15 +781,15 @@ accepts the following data formats as input:
                                        create_resource_group=True,
                                        exist_okay=True)
     # Create a deployment config
-    aci_config = AciWebservice.deploy_configuration(cpu_cores=1, memory_gb=1)                                       
+    aci_config = AciWebservice.deploy_configuration(cpu_cores=1, memory_gb=1)
 
     # Register and deploy model to Azure Container Instance (ACI)
     (webservice, model) = mlflow.azureml.deploy(model_uri='<your-model-uri>',
                                                 workspace=azure_workspace,
-                                                model_name='mymodelname', 
-                                                service_name='myservice', 
+                                                model_name='mymodelname',
+                                                service_name='myservice',
                                                 deployment_config=aci_config)
-                                                
+
     # After the model deployment completes, requests can be posted via HTTP to the new ACI
     # webservice's scoring URI. The following example posts a sample input from the wine dataset
     # used in the MLflow ElasticNet example:
@@ -822,23 +822,23 @@ accepts the following data formats as input:
                   headers={"Content-type": "application/json"})
     response_json = json.loads(response.text)
     print(response_json)
-    
+
 .. rubric:: Example workflow using the MLflow CLI
-    
+
 .. code-block:: bash
 
     # note mlflow azureml build-image is being deprecated, it will be replaced with a new command for model deployment soon
     mlflow azureml build-image -w <workspace-name> -m <model-path> -d "Wine regression model 1"
-    
+
     az ml service create aci -n <deployment-name> --image-id <image-name>:<image-version>
-    
+
     # After the image deployment completes, requests can be posted via HTTP to the new ACI
     # webservice's scoring URI. The following example posts a sample input from the wine dataset
     # used in the MLflow ElasticNet example:
     # https://github.com/mlflow/mlflow/tree/master/examples/sklearn_elasticnet_wine
-    
+
     scoring_uri=$(az ml service show --name <deployment-name> -v | jq -r ".scoringUri")
-    
+
     # `sample_input` is a JSON-serialized pandas DataFrame with the `split` orientation
     sample_input='
     {
@@ -859,12 +859,12 @@ accepts the following data formats as input:
             [8.8, 0.045, 0.36, 1.001, 7, 45, 3, 20.7, 0.45, 170, 0.27]
         ]
     }'
-    
+
     echo $sample_input | curl -s -X POST $scoring_uri\
     -H 'Cache-Control: no-cache'\
     -H 'Content-Type: application/json'\
     -d @-
-    
+
 For more info, see:
 
 .. code-block:: bash


### PR DESCRIPTION
Signed-off-by: Shivani Patel 41974238+shivp950@users.noreply.github.com

## What changes are proposed in this pull request?

Removed the build image method for deploying an MLflow model to AzureML since it is deprecated. I added the new azureml.mlflow.deploy method.

## How is this patch tested?
Azure ML team developed and validated this method with internal tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Model Deployments to Azure Machine Learning do not require an image build step anymore, there's a new azureml.mlflow.deploy method. With the new method, users can package and deploy a model in one step. 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [x] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
