### PR TITLE
Add `SklearnTrainigSession` for sklearn autologging

### DIFF
--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -440,6 +440,33 @@ class _SklearnTrainingSession(object):
         :param clazz: A class object that this session originates from.
         :param allow_children: If True, allows autologging in child sessions.
                                If False, disallows autologging in all descendant sessions.
+
+        Example:
+
+        >>> class Parent: pass
+        >>> class Child: pass
+        >>> class Grandchild: pass
+
+        >>> with _SklearnTrainingSession(Parent, False) as p:
+        ...     with _SklearnTrainingSession(Child, True) as c:
+        ...         with _SklearnTrainingSession(Grandchild, True) as g:
+        ...             print(p.should_log())
+        ...             print(c.should_log())
+        ...             print(g.should_log())
+        True
+        False
+        False
+
+        >>> with _SklearnTrainingSession(Parent, True) as p:
+        ...     with _SklearnTrainingSession(Child, False) as c:
+        ...         with _SklearnTrainingSession(Grandchild, True) as g:
+        ...             print(p.should_log())
+        ...             print(c.should_log())
+        ...             print(g.should_log())
+        True
+        True
+        False
+
         """
         self.allow_children = allow_children
         self.clazz = clazz

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -25,7 +25,6 @@ from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
-from mlflow.utils.autologging_utils import try_mlflow_log
 
 FLAVOR_NAME = "sklearn"
 

--- a/mlflow/sklearn.py
+++ b/mlflow/sklearn.py
@@ -467,6 +467,12 @@ class _SklearnTrainingSession(object):
         True
         False
 
+        >>> with _SklearnTrainingSession(Child, True) as c1:
+        ...     with _SklearnTrainingSession(Child, True) as c2:
+        ...             print(c1.should_log())
+        ...             print(c2.should_log())
+        True
+        False
         """
         self.allow_children = allow_children
         self.clazz = clazz

--- a/tests/sklearn/test_sklearn_training_session.py
+++ b/tests/sklearn/test_sklearn_training_session.py
@@ -1,0 +1,50 @@
+import pytest
+
+from mlflow.sklearn import _SklearnTrainingSession
+
+
+class Parent:
+    pass
+
+
+class Child:
+    pass
+
+
+def assert_session_stack(classes):
+    assert len(_SklearnTrainingSession._session_stack) == len(classes)
+
+    for idx, (sess, (clazz, parent_clazz)) in enumerate(
+        zip(_SklearnTrainingSession._session_stack, classes)
+    ):
+        assert sess.clazz == clazz
+        if idx == 0:
+            assert sess._parent is None
+        else:
+            assert sess._parent.clazz == parent_clazz
+
+
+@pytest.fixture(params=[True, False])
+def allow_children(request):
+    return request.param
+
+
+def test_only_root_session(allow_children):
+    with _SklearnTrainingSession(Parent, allow_children=allow_children) as p:
+        assert p.should_log()
+
+        assert_session_stack([(Parent, None)])
+    assert_session_stack([])
+
+
+def test_nested_once(allow_children):
+    with _SklearnTrainingSession(Parent, allow_children=allow_children) as p:
+        assert_session_stack([(Parent, None)])
+
+        with _SklearnTrainingSession(Child) as c:
+            assert p.should_log()
+            assert c.should_log() == allow_children
+
+            assert_session_stack([(Parent, None), (Child, Parent)])
+        assert_session_stack([(Parent, None)])
+    assert_session_stack([])

--- a/tests/sklearn/test_sklearn_training_session.py
+++ b/tests/sklearn/test_sklearn_training_session.py
@@ -45,7 +45,7 @@ def test_nested_once(allow_children):
     with _SklearnTrainingSession(Parent, allow_children=allow_children) as p:
         assert_session_stack([(None, Parent)])
 
-        with _SklearnTrainingSession(Child) as c:
+        with _SklearnTrainingSession(Child, allow_children=True) as c:
             assert_session_stack([(None, Parent), (Parent, Child)])
             assert p.should_log()
             assert c.should_log() == allow_children
@@ -61,7 +61,7 @@ def test_parent_session_overrides_child_sessions_allow_children():
         with _SklearnTrainingSession(Child, allow_children=True) as c:
             assert_session_stack([(None, Parent), (Parent, Child)])
 
-            with _SklearnTrainingSession(Grandchild) as g:
+            with _SklearnTrainingSession(Grandchild, allow_children=True) as g:
                 assert_session_stack([(None, Parent), (Parent, Child), (Child, Grandchild)])
 
                 assert p.should_log()

--- a/tests/sklearn/test_sklearn_training_session.py
+++ b/tests/sklearn/test_sklearn_training_session.py
@@ -54,7 +54,7 @@ def test_nested_once(allow_children):
     assert_session_stack([])
 
 
-def test_parent_session_overrides_second_level_sessions_allow_children():
+def test_parent_session_overrides_child_sessions_allow_children():
     with _SklearnTrainingSession(Parent, allow_children=False) as p:
         assert_session_stack([(None, Parent)])
 

--- a/tests/sklearn/test_sklearn_training_session.py
+++ b/tests/sklearn/test_sklearn_training_session.py
@@ -11,10 +11,14 @@ class Child:
     pass
 
 
+class Grandchild:
+    pass
+
+
 def assert_session_stack(classes):
     assert len(_SklearnTrainingSession._session_stack) == len(classes)
 
-    for idx, (sess, (clazz, parent_clazz)) in enumerate(
+    for idx, (sess, (parent_clazz, clazz)) in enumerate(
         zip(_SklearnTrainingSession._session_stack, classes)
     ):
         assert sess.clazz == clazz
@@ -31,20 +35,39 @@ def allow_children(request):
 
 def test_only_root_session(allow_children):
     with _SklearnTrainingSession(Parent, allow_children=allow_children) as p:
+        assert_session_stack([(None, Parent)])
         assert p.should_log()
 
-        assert_session_stack([(Parent, None)])
     assert_session_stack([])
 
 
 def test_nested_once(allow_children):
     with _SklearnTrainingSession(Parent, allow_children=allow_children) as p:
-        assert_session_stack([(Parent, None)])
+        assert_session_stack([(None, Parent)])
 
         with _SklearnTrainingSession(Child) as c:
+            assert_session_stack([(None, Parent), (Parent, Child)])
             assert p.should_log()
             assert c.should_log() == allow_children
 
-            assert_session_stack([(Parent, None), (Child, Parent)])
-        assert_session_stack([(Parent, None)])
+        assert_session_stack([(None, Parent)])
+    assert_session_stack([])
+
+
+def test_parent_session_overrides_second_level_sessions_allow_children():
+    with _SklearnTrainingSession(Parent, allow_children=False) as p:
+        assert_session_stack([(None, Parent)])
+
+        with _SklearnTrainingSession(Child, allow_children=True) as c:
+            assert_session_stack([(None, Parent), (Parent, Child)])
+
+            with _SklearnTrainingSession(Grandchild) as g:
+                assert_session_stack([(None, Parent), (Parent, Child), (Child, Grandchild)])
+
+                assert p.should_log()
+                assert not c.should_log()
+                assert not g.should_log()
+
+            assert_session_stack([(None, Parent), (Parent, Child)])
+        assert_session_stack([(None, Parent)])
     assert_session_stack([])

--- a/tests/sklearn/test_sklearn_training_session.py
+++ b/tests/sklearn/test_sklearn_training_session.py
@@ -33,7 +33,7 @@ def allow_children(request):
     return request.param
 
 
-def test_only_root_session(allow_children):
+def test_should_log_always_returns_true_in_root_session(allow_children):
     with _SklearnTrainingSession(Parent, allow_children=allow_children) as p:
         assert_session_stack([(None, Parent)])
         assert p.should_log()
@@ -41,7 +41,7 @@ def test_only_root_session(allow_children):
     assert_session_stack([])
 
 
-def test_nested_once(allow_children):
+def test_nested_sessions(allow_children):
     with _SklearnTrainingSession(Parent, allow_children=allow_children) as p:
         assert_session_stack([(None, Parent)])
 
@@ -54,7 +54,7 @@ def test_nested_once(allow_children):
     assert_session_stack([])
 
 
-def test_parent_session_overrides_child_sessions_allow_children():
+def test_parent_session_overrides_child_session():
     with _SklearnTrainingSession(Parent, allow_children=False) as p:
         assert_session_stack([(None, Parent)])
 
@@ -73,28 +73,8 @@ def test_parent_session_overrides_child_sessions_allow_children():
     assert_session_stack([])
 
 
-def test_parent_session_does_not_override_child_sessions_allow_children():
-    # The opposite case of `test_parent_session_overrides_child_sessions_allow_children`
-    with _SklearnTrainingSession(Parent, allow_children=True) as p:
-        assert_session_stack([(None, Parent)])
-
-        with _SklearnTrainingSession(Child, allow_children=False) as c:
-            assert_session_stack([(None, Parent), (Parent, Child)])
-
-            with _SklearnTrainingSession(Grandchild, allow_children=True) as g:
-                assert_session_stack([(None, Parent), (Parent, Child), (Child, Grandchild)])
-
-                assert p.should_log()
-                assert c.should_log()
-                assert not g.should_log()
-
-            assert_session_stack([(None, Parent), (Parent, Child)])
-        assert_session_stack([(None, Parent)])
-    assert_session_stack([])
-
-
-def test_should_not_log_when_parent_session_has_the_same_class():
-    # This test case corresponds to Pipeline.fit() calls Transformer.fit_transform()
+def test_should_log_returns_false_when_parrent_session_has_the_same_class():
+    # This test case corresponds to when Pipeline.fit() calls Transformer.fit_transform()
     # which calls Transformer.fit()
     with _SklearnTrainingSession(Parent, allow_children=True) as p:
         assert_session_stack([(None, Parent)])

--- a/tests/sklearn/test_sklearn_training_session.py
+++ b/tests/sklearn/test_sklearn_training_session.py
@@ -71,3 +71,23 @@ def test_parent_session_overrides_child_sessions_allow_children():
             assert_session_stack([(None, Parent), (Parent, Child)])
         assert_session_stack([(None, Parent)])
     assert_session_stack([])
+
+
+def test_parent_session_does_not_override_child_sessions_allow_children():
+    # The opposite case of `test_parent_session_overrides_child_sessions_allow_children`
+    with _SklearnTrainingSession(Parent, allow_children=True) as p:
+        assert_session_stack([(None, Parent)])
+
+        with _SklearnTrainingSession(Child, allow_children=False) as c:
+            assert_session_stack([(None, Parent), (Parent, Child)])
+
+            with _SklearnTrainingSession(Grandchild, allow_children=True) as g:
+                assert_session_stack([(None, Parent), (Parent, Child), (Child, Grandchild)])
+
+                assert p.should_log()
+                assert c.should_log()
+                assert not g.should_log()
+
+            assert_session_stack([(None, Parent), (Parent, Child)])
+        assert_session_stack([(None, Parent)])
+    assert_session_stack([])


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Add `SklearnTrainigSession` for sklearn autologging. 

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
