### PR TITLE
Reduce execution time of pyfunc tests

### DIFF
--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -11,7 +11,7 @@ export MLFLOW_HOME=$(pwd)
 pytest --verbose tests/pytorch --large
 pytest --verbose tests/h2o --large
 pytest --verbose tests/onnx --large
-pytest --verbose tests/pyfunc --large
+pytest --verbose tests/pyfunc --durations=0 --large
 pytest --verbose tests/sklearn --large
 pytest --verbose tests/azureml --large
 pytest --verbose tests/models --large

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -127,6 +127,7 @@ def pyfunc_serve_and_score_model(
     activity_polling_timeout_seconds=500,
     extra_args=None,
     stdout=sys.stdout,
+    install_mlflow=True,
 ):
     """
     :param model_uri: URI to the model to be served.
@@ -154,8 +155,9 @@ def pyfunc_serve_and_score_model(
         model_uri,
         "-p",
         str(port),
-        "--install-mlflow",
     ]
+    if install_mlflow:
+        scoring_cmd += ["--install-mlflow"]
     if extra_args is not None:
         scoring_cmd += extra_args
     proc = _start_scoring_proc(cmd=scoring_cmd, env=env, stdout=stdout, stderr=stdout)

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -414,6 +414,7 @@ def test_pyfunc_model_serving_with_conda_env_activation_succeeds_with_main_scope
         model_uri=pyfunc_model_path,
         data=sample_input,
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+        install_mlflow=False,
     )
     assert scoring_response.status_code == 200
     np.testing.assert_array_equal(


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
