### PR TITLE
Add ability to add description in model/version create APIs

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/ModelRegistry.java
@@ -5728,6 +5728,32 @@ public final class ModelRegistry {
      */
     org.mlflow.api.proto.ModelRegistry.RegisteredModelTagOrBuilder getTagsOrBuilder(
         int index);
+
+    /**
+     * <pre>
+     * Optional description for registered model.
+     * </pre>
+     *
+     * <code>optional string description = 3;</code>
+     */
+    boolean hasDescription();
+    /**
+     * <pre>
+     * Optional description for registered model.
+     * </pre>
+     *
+     * <code>optional string description = 3;</code>
+     */
+    java.lang.String getDescription();
+    /**
+     * <pre>
+     * Optional description for registered model.
+     * </pre>
+     *
+     * <code>optional string description = 3;</code>
+     */
+    com.google.protobuf.ByteString
+        getDescriptionBytes();
   }
   /**
    * Protobuf type {@code mlflow.CreateRegisteredModel}
@@ -5744,6 +5770,7 @@ public final class ModelRegistry {
     private CreateRegisteredModel() {
       name_ = "";
       tags_ = java.util.Collections.emptyList();
+      description_ = "";
     }
 
     @java.lang.Override
@@ -5783,6 +5810,12 @@ public final class ModelRegistry {
               }
               tags_.add(
                   input.readMessage(org.mlflow.api.proto.ModelRegistry.RegisteredModelTag.PARSER, extensionRegistry));
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              description_ = bs;
               break;
             }
             default: {
@@ -6547,6 +6580,60 @@ public final class ModelRegistry {
       return tags_.get(index);
     }
 
+    public static final int DESCRIPTION_FIELD_NUMBER = 3;
+    private volatile java.lang.Object description_;
+    /**
+     * <pre>
+     * Optional description for registered model.
+     * </pre>
+     *
+     * <code>optional string description = 3;</code>
+     */
+    public boolean hasDescription() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <pre>
+     * Optional description for registered model.
+     * </pre>
+     *
+     * <code>optional string description = 3;</code>
+     */
+    public java.lang.String getDescription() {
+      java.lang.Object ref = description_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          description_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Optional description for registered model.
+     * </pre>
+     *
+     * <code>optional string description = 3;</code>
+     */
+    public com.google.protobuf.ByteString
+        getDescriptionBytes() {
+      java.lang.Object ref = description_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        description_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -6567,6 +6654,9 @@ public final class ModelRegistry {
       for (int i = 0; i < tags_.size(); i++) {
         output.writeMessage(2, tags_.get(i));
       }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, description_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -6582,6 +6672,9 @@ public final class ModelRegistry {
       for (int i = 0; i < tags_.size(); i++) {
         size += com.google.protobuf.CodedOutputStream
           .computeMessageSize(2, tags_.get(i));
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, description_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -6606,6 +6699,11 @@ public final class ModelRegistry {
       }
       result = result && getTagsList()
           .equals(other.getTagsList());
+      result = result && (hasDescription() == other.hasDescription());
+      if (hasDescription()) {
+        result = result && getDescription()
+            .equals(other.getDescription());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -6624,6 +6722,10 @@ public final class ModelRegistry {
       if (getTagsCount() > 0) {
         hash = (37 * hash) + TAGS_FIELD_NUMBER;
         hash = (53 * hash) + getTagsList().hashCode();
+      }
+      if (hasDescription()) {
+        hash = (37 * hash) + DESCRIPTION_FIELD_NUMBER;
+        hash = (53 * hash) + getDescription().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -6767,6 +6869,8 @@ public final class ModelRegistry {
         } else {
           tagsBuilder_.clear();
         }
+        description_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -6808,6 +6912,10 @@ public final class ModelRegistry {
         } else {
           result.tags_ = tagsBuilder_.build();
         }
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.description_ = description_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -6887,6 +6995,11 @@ public final class ModelRegistry {
               tagsBuilder_.addAllMessages(other.tags_);
             }
           }
+        }
+        if (other.hasDescription()) {
+          bitField0_ |= 0x00000004;
+          description_ = other.description_;
+          onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
         onChanged();
@@ -7328,6 +7441,106 @@ public final class ModelRegistry {
           tags_ = null;
         }
         return tagsBuilder_;
+      }
+
+      private java.lang.Object description_ = "";
+      /**
+       * <pre>
+       * Optional description for registered model.
+       * </pre>
+       *
+       * <code>optional string description = 3;</code>
+       */
+      public boolean hasDescription() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <pre>
+       * Optional description for registered model.
+       * </pre>
+       *
+       * <code>optional string description = 3;</code>
+       */
+      public java.lang.String getDescription() {
+        java.lang.Object ref = description_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            description_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Optional description for registered model.
+       * </pre>
+       *
+       * <code>optional string description = 3;</code>
+       */
+      public com.google.protobuf.ByteString
+          getDescriptionBytes() {
+        java.lang.Object ref = description_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          description_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Optional description for registered model.
+       * </pre>
+       *
+       * <code>optional string description = 3;</code>
+       */
+      public Builder setDescription(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        description_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Optional description for registered model.
+       * </pre>
+       *
+       * <code>optional string description = 3;</code>
+       */
+      public Builder clearDescription() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        description_ = getDefaultInstance().getDescription();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Optional description for registered model.
+       * </pre>
+       *
+       * <code>optional string description = 3;</code>
+       */
+      public Builder setDescriptionBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        description_ = value;
+        onChanged();
+        return this;
       }
       @java.lang.Override
       public final Builder setUnknownFields(
@@ -18698,6 +18911,32 @@ public final class ModelRegistry {
      */
     com.google.protobuf.ByteString
         getRunLinkBytes();
+
+    /**
+     * <pre>
+     * Optional description for model version.
+     * </pre>
+     *
+     * <code>optional string description = 6;</code>
+     */
+    boolean hasDescription();
+    /**
+     * <pre>
+     * Optional description for model version.
+     * </pre>
+     *
+     * <code>optional string description = 6;</code>
+     */
+    java.lang.String getDescription();
+    /**
+     * <pre>
+     * Optional description for model version.
+     * </pre>
+     *
+     * <code>optional string description = 6;</code>
+     */
+    com.google.protobuf.ByteString
+        getDescriptionBytes();
   }
   /**
    * Protobuf type {@code mlflow.CreateModelVersion}
@@ -18717,6 +18956,7 @@ public final class ModelRegistry {
       runId_ = "";
       tags_ = java.util.Collections.emptyList();
       runLink_ = "";
+      description_ = "";
     }
 
     @java.lang.Override
@@ -18774,6 +19014,12 @@ public final class ModelRegistry {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000008;
               runLink_ = bs;
+              break;
+            }
+            case 50: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000010;
+              description_ = bs;
               break;
             }
             default: {
@@ -19766,6 +20012,60 @@ public final class ModelRegistry {
       }
     }
 
+    public static final int DESCRIPTION_FIELD_NUMBER = 6;
+    private volatile java.lang.Object description_;
+    /**
+     * <pre>
+     * Optional description for model version.
+     * </pre>
+     *
+     * <code>optional string description = 6;</code>
+     */
+    public boolean hasDescription() {
+      return ((bitField0_ & 0x00000010) == 0x00000010);
+    }
+    /**
+     * <pre>
+     * Optional description for model version.
+     * </pre>
+     *
+     * <code>optional string description = 6;</code>
+     */
+    public java.lang.String getDescription() {
+      java.lang.Object ref = description_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          description_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Optional description for model version.
+     * </pre>
+     *
+     * <code>optional string description = 6;</code>
+     */
+    public com.google.protobuf.ByteString
+        getDescriptionBytes() {
+      java.lang.Object ref = description_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        description_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -19795,6 +20095,9 @@ public final class ModelRegistry {
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 5, runLink_);
       }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 6, description_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -19819,6 +20122,9 @@ public final class ModelRegistry {
       }
       if (((bitField0_ & 0x00000008) == 0x00000008)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(5, runLink_);
+      }
+      if (((bitField0_ & 0x00000010) == 0x00000010)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(6, description_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -19858,6 +20164,11 @@ public final class ModelRegistry {
         result = result && getRunLink()
             .equals(other.getRunLink());
       }
+      result = result && (hasDescription() == other.hasDescription());
+      if (hasDescription()) {
+        result = result && getDescription()
+            .equals(other.getDescription());
+      }
       result = result && unknownFields.equals(other.unknownFields);
       return result;
     }
@@ -19888,6 +20199,10 @@ public final class ModelRegistry {
       if (hasRunLink()) {
         hash = (37 * hash) + RUN_LINK_FIELD_NUMBER;
         hash = (53 * hash) + getRunLink().hashCode();
+      }
+      if (hasDescription()) {
+        hash = (37 * hash) + DESCRIPTION_FIELD_NUMBER;
+        hash = (53 * hash) + getDescription().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -20037,6 +20352,8 @@ public final class ModelRegistry {
         }
         runLink_ = "";
         bitField0_ = (bitField0_ & ~0x00000010);
+        description_ = "";
+        bitField0_ = (bitField0_ & ~0x00000020);
         return this;
       }
 
@@ -20090,6 +20407,10 @@ public final class ModelRegistry {
           to_bitField0_ |= 0x00000008;
         }
         result.runLink_ = runLink_;
+        if (((from_bitField0_ & 0x00000020) == 0x00000020)) {
+          to_bitField0_ |= 0x00000010;
+        }
+        result.description_ = description_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -20183,6 +20504,11 @@ public final class ModelRegistry {
         if (other.hasRunLink()) {
           bitField0_ |= 0x00000010;
           runLink_ = other.runLink_;
+          onChanged();
+        }
+        if (other.hasDescription()) {
+          bitField0_ |= 0x00000020;
+          description_ = other.description_;
           onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -20935,6 +21261,106 @@ public final class ModelRegistry {
   }
   bitField0_ |= 0x00000010;
         runLink_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object description_ = "";
+      /**
+       * <pre>
+       * Optional description for model version.
+       * </pre>
+       *
+       * <code>optional string description = 6;</code>
+       */
+      public boolean hasDescription() {
+        return ((bitField0_ & 0x00000020) == 0x00000020);
+      }
+      /**
+       * <pre>
+       * Optional description for model version.
+       * </pre>
+       *
+       * <code>optional string description = 6;</code>
+       */
+      public java.lang.String getDescription() {
+        java.lang.Object ref = description_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            description_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Optional description for model version.
+       * </pre>
+       *
+       * <code>optional string description = 6;</code>
+       */
+      public com.google.protobuf.ByteString
+          getDescriptionBytes() {
+        java.lang.Object ref = description_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          description_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Optional description for model version.
+       * </pre>
+       *
+       * <code>optional string description = 6;</code>
+       */
+      public Builder setDescription(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
+        description_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Optional description for model version.
+       * </pre>
+       *
+       * <code>optional string description = 6;</code>
+       */
+      public Builder clearDescription() {
+        bitField0_ = (bitField0_ & ~0x00000020);
+        description_ = getDefaultInstance().getDescription();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Optional description for model version.
+       * </pre>
+       *
+       * <code>optional string description = 6;</code>
+       */
+      public Builder setDescriptionBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000020;
+        description_ = value;
         onChanged();
         return this;
       }
@@ -39074,184 +39500,185 @@ public final class ModelRegistry {
       "\006run_id\030\t \001(\t\022*\n\006status\030\n \001(\0162\032.mlflow.M" +
       "odelVersionStatus\022\026\n\016status_message\030\013 \001(" +
       "\t\022%\n\004tags\030\014 \003(\0132\027.mlflow.ModelVersionTag" +
-      "\022\020\n\010run_link\030\r \001(\t\"\301\001\n\025CreateRegisteredM" +
+      "\022\020\n\010run_link\030\r \001(\t\"\326\001\n\025CreateRegisteredM" +
       "odel\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022(\n\004tags\030\002 \003(\0132\032" +
-      ".mlflow.RegisteredModelTag\032=\n\010Response\0221" +
-      "\n\020registered_model\030\001 \001(\0132\027.mlflow.Regist" +
-      "eredModel:+\342?(\n&com.databricks.rpc.RPC[$" +
-      "this.Response]\"\251\001\n\025RenameRegisteredModel" +
-      "\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\020\n\010new_name\030\002 \001(\t\032=" +
-      "\n\010Response\0221\n\020registered_model\030\001 \001(\0132\027.m" +
-      "lflow.RegisteredModel:+\342?(\n&com.databric" +
-      "ks.rpc.RPC[$this.Response]\"\254\001\n\025UpdateReg" +
-      "isteredModel\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\023\n\013desc" +
-      "ription\030\002 \001(\t\032=\n\010Response\0221\n\020registered_" +
-      "model\030\001 \001(\0132\027.mlflow.RegisteredModel:+\342?" +
+      ".mlflow.RegisteredModelTag\022\023\n\013descriptio" +
+      "n\030\003 \001(\t\032=\n\010Response\0221\n\020registered_model\030" +
+      "\001 \001(\0132\027.mlflow.RegisteredModel:+\342?(\n&com" +
+      ".databricks.rpc.RPC[$this.Response]\"\251\001\n\025" +
+      "RenameRegisteredModel\022\022\n\004name\030\001 \001(\tB\004\370\206\031" +
+      "\001\022\020\n\010new_name\030\002 \001(\t\032=\n\010Response\0221\n\020regis" +
+      "tered_model\030\001 \001(\0132\027.mlflow.RegisteredMod" +
+      "el:+\342?(\n&com.databricks.rpc.RPC[$this.Re" +
+      "sponse]\"\254\001\n\025UpdateRegisteredModel\022\022\n\004nam" +
+      "e\030\001 \001(\tB\004\370\206\031\001\022\023\n\013description\030\002 \001(\t\032=\n\010Re" +
+      "sponse\0221\n\020registered_model\030\001 \001(\0132\027.mlflo" +
+      "w.RegisteredModel:+\342?(\n&com.databricks.r" +
+      "pc.RPC[$this.Response]\"d\n\025DeleteRegister" +
+      "edModel\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\032\n\n\010Response:" +
+      "+\342?(\n&com.databricks.rpc.RPC[$this.Respo" +
+      "nse]\"\224\001\n\022GetRegisteredModel\022\022\n\004name\030\001 \001(" +
+      "\tB\004\370\206\031\001\032=\n\010Response\0221\n\020registered_model\030" +
+      "\001 \001(\0132\027.mlflow.RegisteredModel:+\342?(\n&com" +
+      ".databricks.rpc.RPC[$this.Response]\"\312\001\n\024" +
+      "ListRegisteredModels\022\030\n\013max_results\030\001 \001(" +
+      "\003:\003100\022\022\n\npage_token\030\002 \001(\t\032W\n\010Response\0222" +
+      "\n\021registered_models\030\001 \003(\0132\027.mlflow.Regis" +
+      "teredModel\022\027\n\017next_page_token\030\002 \001(\t:+\342?(" +
+      "\n&com.databricks.rpc.RPC[$this.Response]" +
+      "\"\356\001\n\026SearchRegisteredModels\022\016\n\006filter\030\001 " +
+      "\001(\t\022\030\n\013max_results\030\002 \001(\003:\003100\022\020\n\010order_b" +
+      "y\030\003 \003(\t\022\022\n\npage_token\030\004 \001(\t\032W\n\010Response\022" +
+      "2\n\021registered_models\030\001 \003(\0132\027.mlflow.Regi" +
+      "steredModel\022\027\n\017next_page_token\030\002 \001(\t:+\342?" +
       "(\n&com.databricks.rpc.RPC[$this.Response" +
-      "]\"d\n\025DeleteRegisteredModel\022\022\n\004name\030\001 \001(\t" +
-      "B\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.databricks." +
-      "rpc.RPC[$this.Response]\"\224\001\n\022GetRegistere" +
-      "dModel\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\032=\n\010Response\0221" +
-      "\n\020registered_model\030\001 \001(\0132\027.mlflow.Regist" +
-      "eredModel:+\342?(\n&com.databricks.rpc.RPC[$" +
-      "this.Response]\"\312\001\n\024ListRegisteredModels\022" +
-      "\030\n\013max_results\030\001 \001(\003:\003100\022\022\n\npage_token\030" +
-      "\002 \001(\t\032W\n\010Response\0222\n\021registered_models\030\001" +
-      " \003(\0132\027.mlflow.RegisteredModel\022\027\n\017next_pa" +
-      "ge_token\030\002 \001(\t:+\342?(\n&com.databricks.rpc." +
-      "RPC[$this.Response]\"\356\001\n\026SearchRegistered" +
-      "Models\022\016\n\006filter\030\001 \001(\t\022\030\n\013max_results\030\002 " +
-      "\001(\003:\003100\022\020\n\010order_by\030\003 \003(\t\022\022\n\npage_token" +
-      "\030\004 \001(\t\032W\n\010Response\0222\n\021registered_models\030" +
-      "\001 \003(\0132\027.mlflow.RegisteredModel\022\027\n\017next_p" +
-      "age_token\030\002 \001(\t:+\342?(\n&com.databricks.rpc" +
-      ".RPC[$this.Response]\"\236\001\n\021GetLatestVersio" +
-      "ns\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\016\n\006stages\030\002 \003(\t\0328" +
-      "\n\010Response\022,\n\016model_versions\030\001 \003(\0132\024.mlf" +
-      "low.ModelVersion:+\342?(\n&com.databricks.rp" +
-      "c.RPC[$this.Response]\"\355\001\n\022CreateModelVer" +
-      "sion\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\024\n\006source\030\002 \001(\t" +
-      "B\004\370\206\031\001\022\016\n\006run_id\030\003 \001(\t\022%\n\004tags\030\004 \003(\0132\027.m" +
-      "lflow.ModelVersionTag\022\020\n\010run_link\030\005 \001(\t\032" +
-      "7\n\010Response\022+\n\rmodel_version\030\001 \001(\0132\024.mlf" +
-      "low.ModelVersion:+\342?(\n&com.databricks.rp" +
-      "c.RPC[$this.Response]\"\272\001\n\022UpdateModelVer" +
-      "sion\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(" +
-      "\tB\004\370\206\031\001\022\023\n\013description\030\003 \001(\t\0327\n\010Response" +
-      "\022+\n\rmodel_version\030\001 \001(\0132\024.mlflow.ModelVe" +
-      "rsion:+\342?(\n&com.databricks.rpc.RPC[$this" +
-      ".Response]\"\354\001\n\033TransitionModelVersionSta" +
-      "ge\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB" +
-      "\004\370\206\031\001\022\023\n\005stage\030\003 \001(\tB\004\370\206\031\001\022\'\n\031archive_ex" +
-      "isting_versions\030\004 \001(\010B\004\370\206\031\001\0327\n\010Response\022" +
-      "+\n\rmodel_version\030\001 \001(\0132\024.mlflow.ModelVer" +
-      "sion:+\342?(\n&com.databricks.rpc.RPC[$this." +
-      "Response]\"x\n\022DeleteModelVersion\022\022\n\004name\030" +
-      "\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\032\n\n\010Re" +
-      "sponse:+\342?(\n&com.databricks.rpc.RPC[$thi" +
-      "s.Response]\"\242\001\n\017GetModelVersion\022\022\n\004name\030" +
-      "\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\0327\n\010Re" +
-      "sponse\022+\n\rmodel_version\030\001 \001(\0132\024.mlflow.M" +
-      "odelVersion:+\342?(\n&com.databricks.rpc.RPC" +
-      "[$this.Response]\"\350\001\n\023SearchModelVersions" +
-      "\022\016\n\006filter\030\001 \001(\t\022\033\n\013max_results\030\002 \001(\003:\0062" +
-      "00000\022\020\n\010order_by\030\003 \003(\t\022\022\n\npage_token\030\004 " +
-      "\001(\t\032Q\n\010Response\022,\n\016model_versions\030\001 \003(\0132" +
-      "\024.mlflow.ModelVersion\022\027\n\017next_page_token" +
-      "\030\002 \001(\t:+\342?(\n&com.databricks.rpc.RPC[$thi" +
-      "s.Response]\"\226\001\n\032GetModelVersionDownloadU" +
-      "ri\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB" +
-      "\004\370\206\031\001\032 \n\010Response\022\024\n\014artifact_uri\030\001 \001(\t:" +
-      "+\342?(\n&com.databricks.rpc.RPC[$this.Respo" +
-      "nse]\"-\n\017ModelVersionTag\022\013\n\003key\030\001 \001(\t\022\r\n\005" +
-      "value\030\002 \001(\t\"0\n\022RegisteredModelTag\022\013\n\003key" +
-      "\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"\214\001\n\025SetRegisteredM" +
-      "odelTag\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\t" +
-      "B\004\370\206\031\001\022\023\n\005value\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Response:" +
-      "+\342?(\n&com.databricks.rpc.RPC[$this.Respo" +
-      "nse]\"\240\001\n\022SetModelVersionTag\022\022\n\004name\030\001 \001(" +
-      "\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\022\021\n\003key\030\003 " +
-      "\001(\tB\004\370\206\031\001\022\023\n\005value\030\004 \001(\tB\004\370\206\031\001\032\n\n\010Respon" +
-      "se:+\342?(\n&com.databricks.rpc.RPC[$this.Re" +
-      "sponse]\"z\n\030DeleteRegisteredModelTag\022\022\n\004n" +
-      "ame\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\032\n\n\010Re" +
-      "sponse:+\342?(\n&com.databricks.rpc.RPC[$thi" +
-      "s.Response]\"\216\001\n\025DeleteModelVersionTag\022\022\n" +
-      "\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001" +
-      "\022\021\n\003key\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&co" +
-      "m.databricks.rpc.RPC[$this.Response]*R\n\022" +
-      "ModelVersionStatus\022\030\n\024PENDING_REGISTRATI" +
-      "ON\020\001\022\027\n\023FAILED_REGISTRATION\020\002\022\t\n\005READY\020\003" +
-      "2\307\033\n\024ModelRegistryService\022\266\001\n\025createRegi" +
-      "steredModel\022\035.mlflow.CreateRegisteredMod" +
-      "el\032&.mlflow.CreateRegisteredModel.Respon" +
-      "se\"V\362\206\031R\n6\n\004POST\022(/preview/mlflow/regist" +
-      "ered-models/create\032\004\010\002\020\000\020\001*\026Create Regis" +
-      "teredModel\022\266\001\n\025renameRegisteredModel\022\035.m" +
-      "lflow.RenameRegisteredModel\032&.mlflow.Ren" +
-      "ameRegisteredModel.Response\"V\362\206\031R\n6\n\004POS" +
-      "T\022(/preview/mlflow/registered-models/ren" +
-      "ame\032\004\010\002\020\000\020\001*\026Rename RegisteredModel\022\267\001\n\025" +
-      "updateRegisteredModel\022\035.mlflow.UpdateReg" +
-      "isteredModel\032&.mlflow.UpdateRegisteredMo" +
-      "del.Response\"W\362\206\031S\n7\n\005PATCH\022(/preview/ml" +
-      "flow/registered-models/update\032\004\010\002\020\000\020\001*\026U" +
-      "pdate RegisteredModel\022\270\001\n\025deleteRegister" +
-      "edModel\022\035.mlflow.DeleteRegisteredModel\032&" +
-      ".mlflow.DeleteRegisteredModel.Response\"X" +
-      "\362\206\031T\n8\n\006DELETE\022(/preview/mlflow/register" +
-      "ed-models/delete\032\004\010\002\020\000\020\001*\026Delete Registe" +
-      "redModel\022\246\001\n\022getRegisteredModel\022\032.mlflow" +
-      ".GetRegisteredModel\032#.mlflow.GetRegister" +
-      "edModel.Response\"O\362\206\031K\n2\n\003GET\022%/preview/" +
-      "mlflow/registered-models/get\032\004\010\002\020\000\020\001*\023Ge" +
-      "t RegisteredModel\022\271\001\n\026searchRegisteredMo" +
-      "dels\022\036.mlflow.SearchRegisteredModels\032\'.m" +
-      "lflow.SearchRegisteredModels.Response\"V\362" +
-      "\206\031R\n5\n\003GET\022(/preview/mlflow/registered-m" +
-      "odels/search\032\004\010\002\020\000\020\001*\027Search RegisteredM" +
-      "odels\022\257\001\n\024listRegisteredModels\022\034.mlflow." +
-      "ListRegisteredModels\032%.mlflow.ListRegist" +
-      "eredModels.Response\"R\362\206\031N\n3\n\003GET\022&/previ" +
-      "ew/mlflow/registered-models/list\032\004\010\002\020\000\020\001" +
-      "*\025List RegisteredModels\022\270\001\n\021getLatestVer" +
-      "sions\022\031.mlflow.GetLatestVersions\032\".mlflo" +
-      "w.GetLatestVersions.Response\"d\362\206\031`\nB\n\003GE" +
-      "T\0225/preview/mlflow/registered-models/get" +
-      "-latest-versions\032\004\010\002\020\000\020\001*\030Get Latest Mod" +
-      "elVersions\022\247\001\n\022createModelVersion\022\032.mlfl" +
-      "ow.CreateModelVersion\032#.mlflow.CreateMod" +
-      "elVersion.Response\"P\362\206\031L\n3\n\004POST\022%/previ" +
-      "ew/mlflow/model-versions/create\032\004\010\002\020\000\020\001*" +
-      "\023Create ModelVersion\022\250\001\n\022updateModelVers" +
-      "ion\022\032.mlflow.UpdateModelVersion\032#.mlflow" +
-      ".UpdateModelVersion.Response\"Q\362\206\031M\n4\n\005PA" +
-      "TCH\022%/preview/mlflow/model-versions/upda" +
-      "te\032\004\010\002\020\000\020\001*\023Update ModelVersion\022\326\001\n\033tran" +
-      "sitionModelVersionStage\022#.mlflow.Transit" +
-      "ionModelVersionStage\032,.mlflow.Transition" +
-      "ModelVersionStage.Response\"d\362\206\031`\n=\n\004POST" +
-      "\022//preview/mlflow/model-versions/transit" +
-      "ion-stage\032\004\010\002\020\000\020\001*\035Transition ModelVersi" +
-      "on Stage\022\251\001\n\022deleteModelVersion\022\032.mlflow" +
-      ".DeleteModelVersion\032#.mlflow.DeleteModel" +
-      "Version.Response\"R\362\206\031N\n5\n\006DELETE\022%/previ" +
-      "ew/mlflow/model-versions/delete\032\004\010\002\020\000\020\001*" +
-      "\023Delete ModelVersion\022\227\001\n\017getModelVersion" +
-      "\022\027.mlflow.GetModelVersion\032 .mlflow.GetMo" +
-      "delVersion.Response\"I\362\206\031E\n/\n\003GET\022\"/previ" +
-      "ew/mlflow/model-versions/get\032\004\010\002\020\000\020\001*\020Ge" +
-      "t ModelVersion\022\252\001\n\023searchModelVersions\022\033" +
-      ".mlflow.SearchModelVersions\032$.mlflow.Sea" +
-      "rchModelVersions.Response\"P\362\206\031L\n2\n\003GET\022%" +
-      "/preview/mlflow/model-versions/search\032\004\010" +
-      "\002\020\000\020\001*\024Search ModelVersions\022\340\001\n\032getModel" +
-      "VersionDownloadUri\022\".mlflow.GetModelVers" +
-      "ionDownloadUri\032+.mlflow.GetModelVersionD" +
-      "ownloadUri.Response\"q\362\206\031m\n<\n\003GET\022//previ" +
-      "ew/mlflow/model-versions/get-download-ur" +
-      "i\032\004\010\002\020\000\020\001*+Get Download URI For ModelVer" +
-      "sion Artifacts\022\271\001\n\025setRegisteredModelTag" +
-      "\022\035.mlflow.SetRegisteredModelTag\032&.mlflow" +
-      ".SetRegisteredModelTag.Response\"Y\362\206\031U\n7\n" +
-      "\004POST\022)/preview/mlflow/registered-models" +
-      "/set-tag\032\004\010\002\020\000\020\001*\030Set Registered Model T" +
-      "ag\022\252\001\n\022setModelVersionTag\022\032.mlflow.SetMo" +
-      "delVersionTag\032#.mlflow.SetModelVersionTa" +
-      "g.Response\"S\362\206\031O\n4\n\004POST\022&/preview/mlflo" +
-      "w/model-versions/set-tag\032\004\010\002\020\000\020\001*\025Set Mo" +
-      "del Version Tag\022\312\001\n\030deleteRegisteredMode" +
-      "lTag\022 .mlflow.DeleteRegisteredModelTag\032)" +
-      ".mlflow.DeleteRegisteredModelTag.Respons" +
-      "e\"a\362\206\031]\n<\n\006DELETE\022,/preview/mlflow/regis" +
-      "tered-models/delete-tag\032\004\010\002\020\000\020\001*\033Delete " +
-      "Registered Model Tag\022\273\001\n\025deleteModelVers" +
-      "ionTag\022\035.mlflow.DeleteModelVersionTag\032&." +
-      "mlflow.DeleteModelVersionTag.Response\"[\362" +
-      "\206\031W\n9\n\006DELETE\022)/preview/mlflow/model-ver" +
-      "sions/delete-tag\032\004\010\002\020\000\020\001*\030Delete Model V" +
-      "ersion TagB!\n\024org.mlflow.api.proto\220\001\001\240\001\001" +
-      "\342?\002\020\001"
+      "]\"\236\001\n\021GetLatestVersions\022\022\n\004name\030\001 \001(\tB\004\370" +
+      "\206\031\001\022\016\n\006stages\030\002 \003(\t\0328\n\010Response\022,\n\016model" +
+      "_versions\030\001 \003(\0132\024.mlflow.ModelVersion:+\342" +
+      "?(\n&com.databricks.rpc.RPC[$this.Respons" +
+      "e]\"\202\002\n\022CreateModelVersion\022\022\n\004name\030\001 \001(\tB" +
+      "\004\370\206\031\001\022\024\n\006source\030\002 \001(\tB\004\370\206\031\001\022\016\n\006run_id\030\003 " +
+      "\001(\t\022%\n\004tags\030\004 \003(\0132\027.mlflow.ModelVersionT" +
+      "ag\022\020\n\010run_link\030\005 \001(\t\022\023\n\013description\030\006 \001(" +
+      "\t\0327\n\010Response\022+\n\rmodel_version\030\001 \001(\0132\024.m" +
+      "lflow.ModelVersion:+\342?(\n&com.databricks." +
+      "rpc.RPC[$this.Response]\"\272\001\n\022UpdateModelV" +
+      "ersion\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 " +
+      "\001(\tB\004\370\206\031\001\022\023\n\013description\030\003 \001(\t\0327\n\010Respon" +
+      "se\022+\n\rmodel_version\030\001 \001(\0132\024.mlflow.Model" +
+      "Version:+\342?(\n&com.databricks.rpc.RPC[$th" +
+      "is.Response]\"\354\001\n\033TransitionModelVersionS" +
+      "tage\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(" +
+      "\tB\004\370\206\031\001\022\023\n\005stage\030\003 \001(\tB\004\370\206\031\001\022\'\n\031archive_" +
+      "existing_versions\030\004 \001(\010B\004\370\206\031\001\0327\n\010Respons" +
+      "e\022+\n\rmodel_version\030\001 \001(\0132\024.mlflow.ModelV" +
+      "ersion:+\342?(\n&com.databricks.rpc.RPC[$thi" +
+      "s.Response]\"x\n\022DeleteModelVersion\022\022\n\004nam" +
+      "e\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\032\n\n\010" +
+      "Response:+\342?(\n&com.databricks.rpc.RPC[$t" +
+      "his.Response]\"\242\001\n\017GetModelVersion\022\022\n\004nam" +
+      "e\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\0327\n\010" +
+      "Response\022+\n\rmodel_version\030\001 \001(\0132\024.mlflow" +
+      ".ModelVersion:+\342?(\n&com.databricks.rpc.R" +
+      "PC[$this.Response]\"\350\001\n\023SearchModelVersio" +
+      "ns\022\016\n\006filter\030\001 \001(\t\022\033\n\013max_results\030\002 \001(\003:" +
+      "\006200000\022\020\n\010order_by\030\003 \003(\t\022\022\n\npage_token\030" +
+      "\004 \001(\t\032Q\n\010Response\022,\n\016model_versions\030\001 \003(" +
+      "\0132\024.mlflow.ModelVersion\022\027\n\017next_page_tok" +
+      "en\030\002 \001(\t:+\342?(\n&com.databricks.rpc.RPC[$t" +
+      "his.Response]\"\226\001\n\032GetModelVersionDownloa" +
+      "dUri\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(" +
+      "\tB\004\370\206\031\001\032 \n\010Response\022\024\n\014artifact_uri\030\001 \001(" +
+      "\t:+\342?(\n&com.databricks.rpc.RPC[$this.Res" +
+      "ponse]\"-\n\017ModelVersionTag\022\013\n\003key\030\001 \001(\t\022\r" +
+      "\n\005value\030\002 \001(\t\"0\n\022RegisteredModelTag\022\013\n\003k" +
+      "ey\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"\214\001\n\025SetRegistere" +
+      "dModelTag\022\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001" +
+      "(\tB\004\370\206\031\001\022\023\n\005value\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Respons" +
+      "e:+\342?(\n&com.databricks.rpc.RPC[$this.Res" +
+      "ponse]\"\240\001\n\022SetModelVersionTag\022\022\n\004name\030\001 " +
+      "\001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206\031\001\022\021\n\003key\030" +
+      "\003 \001(\tB\004\370\206\031\001\022\023\n\005value\030\004 \001(\tB\004\370\206\031\001\032\n\n\010Resp" +
+      "onse:+\342?(\n&com.databricks.rpc.RPC[$this." +
+      "Response]\"z\n\030DeleteRegisteredModelTag\022\022\n" +
+      "\004name\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\032\n\n\010" +
+      "Response:+\342?(\n&com.databricks.rpc.RPC[$t" +
+      "his.Response]\"\216\001\n\025DeleteModelVersionTag\022" +
+      "\022\n\004name\030\001 \001(\tB\004\370\206\031\001\022\025\n\007version\030\002 \001(\tB\004\370\206" +
+      "\031\001\022\021\n\003key\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&" +
+      "com.databricks.rpc.RPC[$this.Response]*R" +
+      "\n\022ModelVersionStatus\022\030\n\024PENDING_REGISTRA" +
+      "TION\020\001\022\027\n\023FAILED_REGISTRATION\020\002\022\t\n\005READY" +
+      "\020\0032\307\033\n\024ModelRegistryService\022\266\001\n\025createRe" +
+      "gisteredModel\022\035.mlflow.CreateRegisteredM" +
+      "odel\032&.mlflow.CreateRegisteredModel.Resp" +
+      "onse\"V\362\206\031R\n6\n\004POST\022(/preview/mlflow/regi" +
+      "stered-models/create\032\004\010\002\020\000\020\001*\026Create Reg" +
+      "isteredModel\022\266\001\n\025renameRegisteredModel\022\035" +
+      ".mlflow.RenameRegisteredModel\032&.mlflow.R" +
+      "enameRegisteredModel.Response\"V\362\206\031R\n6\n\004P" +
+      "OST\022(/preview/mlflow/registered-models/r" +
+      "ename\032\004\010\002\020\000\020\001*\026Rename RegisteredModel\022\267\001" +
+      "\n\025updateRegisteredModel\022\035.mlflow.UpdateR" +
+      "egisteredModel\032&.mlflow.UpdateRegistered" +
+      "Model.Response\"W\362\206\031S\n7\n\005PATCH\022(/preview/" +
+      "mlflow/registered-models/update\032\004\010\002\020\000\020\001*" +
+      "\026Update RegisteredModel\022\270\001\n\025deleteRegist" +
+      "eredModel\022\035.mlflow.DeleteRegisteredModel" +
+      "\032&.mlflow.DeleteRegisteredModel.Response" +
+      "\"X\362\206\031T\n8\n\006DELETE\022(/preview/mlflow/regist" +
+      "ered-models/delete\032\004\010\002\020\000\020\001*\026Delete Regis" +
+      "teredModel\022\246\001\n\022getRegisteredModel\022\032.mlfl" +
+      "ow.GetRegisteredModel\032#.mlflow.GetRegist" +
+      "eredModel.Response\"O\362\206\031K\n2\n\003GET\022%/previe" +
+      "w/mlflow/registered-models/get\032\004\010\002\020\000\020\001*\023" +
+      "Get RegisteredModel\022\271\001\n\026searchRegistered" +
+      "Models\022\036.mlflow.SearchRegisteredModels\032\'" +
+      ".mlflow.SearchRegisteredModels.Response\"" +
+      "V\362\206\031R\n5\n\003GET\022(/preview/mlflow/registered" +
+      "-models/search\032\004\010\002\020\000\020\001*\027Search Registere" +
+      "dModels\022\257\001\n\024listRegisteredModels\022\034.mlflo" +
+      "w.ListRegisteredModels\032%.mlflow.ListRegi" +
+      "steredModels.Response\"R\362\206\031N\n3\n\003GET\022&/pre" +
+      "view/mlflow/registered-models/list\032\004\010\002\020\000" +
+      "\020\001*\025List RegisteredModels\022\270\001\n\021getLatestV" +
+      "ersions\022\031.mlflow.GetLatestVersions\032\".mlf" +
+      "low.GetLatestVersions.Response\"d\362\206\031`\nB\n\003" +
+      "GET\0225/preview/mlflow/registered-models/g" +
+      "et-latest-versions\032\004\010\002\020\000\020\001*\030Get Latest M" +
+      "odelVersions\022\247\001\n\022createModelVersion\022\032.ml" +
+      "flow.CreateModelVersion\032#.mlflow.CreateM" +
+      "odelVersion.Response\"P\362\206\031L\n3\n\004POST\022%/pre" +
+      "view/mlflow/model-versions/create\032\004\010\002\020\000\020" +
+      "\001*\023Create ModelVersion\022\250\001\n\022updateModelVe" +
+      "rsion\022\032.mlflow.UpdateModelVersion\032#.mlfl" +
+      "ow.UpdateModelVersion.Response\"Q\362\206\031M\n4\n\005" +
+      "PATCH\022%/preview/mlflow/model-versions/up" +
+      "date\032\004\010\002\020\000\020\001*\023Update ModelVersion\022\326\001\n\033tr" +
+      "ansitionModelVersionStage\022#.mlflow.Trans" +
+      "itionModelVersionStage\032,.mlflow.Transiti" +
+      "onModelVersionStage.Response\"d\362\206\031`\n=\n\004PO" +
+      "ST\022//preview/mlflow/model-versions/trans" +
+      "ition-stage\032\004\010\002\020\000\020\001*\035Transition ModelVer" +
+      "sion Stage\022\251\001\n\022deleteModelVersion\022\032.mlfl" +
+      "ow.DeleteModelVersion\032#.mlflow.DeleteMod" +
+      "elVersion.Response\"R\362\206\031N\n5\n\006DELETE\022%/pre" +
+      "view/mlflow/model-versions/delete\032\004\010\002\020\000\020" +
+      "\001*\023Delete ModelVersion\022\227\001\n\017getModelVersi" +
+      "on\022\027.mlflow.GetModelVersion\032 .mlflow.Get" +
+      "ModelVersion.Response\"I\362\206\031E\n/\n\003GET\022\"/pre" +
+      "view/mlflow/model-versions/get\032\004\010\002\020\000\020\001*\020" +
+      "Get ModelVersion\022\252\001\n\023searchModelVersions" +
+      "\022\033.mlflow.SearchModelVersions\032$.mlflow.S" +
+      "earchModelVersions.Response\"P\362\206\031L\n2\n\003GET" +
+      "\022%/preview/mlflow/model-versions/search\032" +
+      "\004\010\002\020\000\020\001*\024Search ModelVersions\022\340\001\n\032getMod" +
+      "elVersionDownloadUri\022\".mlflow.GetModelVe" +
+      "rsionDownloadUri\032+.mlflow.GetModelVersio" +
+      "nDownloadUri.Response\"q\362\206\031m\n<\n\003GET\022//pre" +
+      "view/mlflow/model-versions/get-download-" +
+      "uri\032\004\010\002\020\000\020\001*+Get Download URI For ModelV" +
+      "ersion Artifacts\022\271\001\n\025setRegisteredModelT" +
+      "ag\022\035.mlflow.SetRegisteredModelTag\032&.mlfl" +
+      "ow.SetRegisteredModelTag.Response\"Y\362\206\031U\n" +
+      "7\n\004POST\022)/preview/mlflow/registered-mode" +
+      "ls/set-tag\032\004\010\002\020\000\020\001*\030Set Registered Model" +
+      " Tag\022\252\001\n\022setModelVersionTag\022\032.mlflow.Set" +
+      "ModelVersionTag\032#.mlflow.SetModelVersion" +
+      "Tag.Response\"S\362\206\031O\n4\n\004POST\022&/preview/mlf" +
+      "low/model-versions/set-tag\032\004\010\002\020\000\020\001*\025Set " +
+      "Model Version Tag\022\312\001\n\030deleteRegisteredMo" +
+      "delTag\022 .mlflow.DeleteRegisteredModelTag" +
+      "\032).mlflow.DeleteRegisteredModelTag.Respo" +
+      "nse\"a\362\206\031]\n<\n\006DELETE\022,/preview/mlflow/reg" +
+      "istered-models/delete-tag\032\004\010\002\020\000\020\001*\033Delet" +
+      "e Registered Model Tag\022\273\001\n\025deleteModelVe" +
+      "rsionTag\022\035.mlflow.DeleteModelVersionTag\032" +
+      "&.mlflow.DeleteModelVersionTag.Response\"" +
+      "[\362\206\031W\n9\n\006DELETE\022)/preview/mlflow/model-v" +
+      "ersions/delete-tag\032\004\010\002\020\000\020\001*\030Delete Model" +
+      " Version TagB!\n\024org.mlflow.api.proto\220\001\001\240" +
+      "\001\001\342?\002\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -39284,7 +39711,7 @@ public final class ModelRegistry {
     internal_static_mlflow_CreateRegisteredModel_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_CreateRegisteredModel_descriptor,
-        new java.lang.String[] { "Name", "Tags", });
+        new java.lang.String[] { "Name", "Tags", "Description", });
     internal_static_mlflow_CreateRegisteredModel_Response_descriptor =
       internal_static_mlflow_CreateRegisteredModel_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_CreateRegisteredModel_Response_fieldAccessorTable = new
@@ -39380,7 +39807,7 @@ public final class ModelRegistry {
     internal_static_mlflow_CreateModelVersion_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_CreateModelVersion_descriptor,
-        new java.lang.String[] { "Name", "Source", "RunId", "Tags", "RunLink", });
+        new java.lang.String[] { "Name", "Source", "RunId", "Tags", "RunLink", "Description", });
     internal_static_mlflow_CreateModelVersion_Response_descriptor =
       internal_static_mlflow_CreateModelVersion_descriptor.getNestedTypes().get(0);
     internal_static_mlflow_CreateModelVersion_Response_fieldAccessorTable = new

--- a/mlflow/protos/model_registry.proto
+++ b/mlflow/protos/model_registry.proto
@@ -375,6 +375,9 @@ message CreateRegisteredModel {
   // Additional metadata for registered model.
   repeated RegisteredModelTag tags = 2;
 
+  // Optional description for registered model.
+  optional string description = 3;
+
   message Response {
     optional RegisteredModel registered_model = 1;
   }
@@ -509,6 +512,9 @@ message CreateModelVersion {
   // MLflow run link - this is the exact link of the run that generated this model version,
   // potentially hosted at another instance of MLflow.
   optional string run_link = 5;
+
+  // Optional description for model version.
+  optional string description = 6;
 
   message Response {
     // Return new version number generated for this model in registry.

--- a/mlflow/protos/model_registry_pb2.py
+++ b/mlflow/protos/model_registry_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\024org.mlflow.api.proto\220\001\001\240\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\x14model_registry.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xda\x01\n\x0fRegisteredModel\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x02 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x03 \x01(\x03\x12\x0f\n\x07user_id\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12-\n\x0flatest_versions\x18\x06 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12(\n\x04tags\x18\x07 \x03(\x0b\x32\x1a.mlflow.RegisteredModelTag\"\xc3\x02\n\x0cModelVersion\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x03 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x04 \x01(\x03\x12\x0f\n\x07user_id\x18\x05 \x01(\t\x12\x15\n\rcurrent_stage\x18\x06 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x07 \x01(\t\x12\x0e\n\x06source\x18\x08 \x01(\t\x12\x0e\n\x06run_id\x18\t \x01(\t\x12*\n\x06status\x18\n \x01(\x0e\x32\x1a.mlflow.ModelVersionStatus\x12\x16\n\x0estatus_message\x18\x0b \x01(\t\x12%\n\x04tags\x18\x0c \x03(\x0b\x32\x17.mlflow.ModelVersionTag\x12\x10\n\x08run_link\x18\r \x01(\t\"\xc1\x01\n\x15\x43reateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12(\n\x04tags\x18\x02 \x03(\x0b\x32\x1a.mlflow.RegisteredModelTag\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa9\x01\n\x15RenameRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\x15UpdateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"d\n\x15\x44\x65leteRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x94\x01\n\x12GetRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xca\x01\n\x14ListRegisteredModels\x12\x18\n\x0bmax_results\x18\x01 \x01(\x03:\x03\x31\x30\x30\x12\x12\n\npage_token\x18\x02 \x01(\t\x1aW\n\x08Response\x12\x32\n\x11registered_models\x18\x01 \x03(\x0b\x32\x17.mlflow.RegisteredModel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xee\x01\n\x16SearchRegisteredModels\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x18\n\x0bmax_results\x18\x02 \x01(\x03:\x03\x31\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aW\n\x08Response\x12\x32\n\x11registered_models\x18\x01 \x03(\x0b\x32\x17.mlflow.RegisteredModel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9e\x01\n\x11GetLatestVersions\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06stages\x18\x02 \x03(\t\x1a\x38\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xed\x01\n\x12\x43reateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x14\n\x06source\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12%\n\x04tags\x18\x04 \x03(\x0b\x32\x17.mlflow.ModelVersionTag\x12\x10\n\x08run_link\x18\x05 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x01\n\x12UpdateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xec\x01\n\x1bTransitionModelVersionStage\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05stage\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\'\n\x19\x61rchive_existing_versions\x18\x04 \x01(\x08\x42\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"x\n\x12\x44\x65leteModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa2\x01\n\x0fGetModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe8\x01\n\x13SearchModelVersions\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x1b\n\x0bmax_results\x18\x02 \x01(\x03:\x06\x32\x30\x30\x30\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aQ\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\x1aGetModelVersionDownloadUri\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a \n\x08Response\x12\x14\n\x0c\x61rtifact_uri\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"-\n\x0fModelVersionTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x12RegisteredModelTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x8c\x01\n\x15SetRegisteredModelTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa0\x01\n\x12SetModelVersionTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x04 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x18\x44\x65leteRegisteredModelTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8e\x01\n\x15\x44\x65leteModelVersionTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*R\n\x12ModelVersionStatus\x12\x18\n\x14PENDING_REGISTRATION\x10\x01\x12\x17\n\x13\x46\x41ILED_REGISTRATION\x10\x02\x12\t\n\x05READY\x10\x03\x32\xc7\x1b\n\x14ModelRegistryService\x12\xb6\x01\n\x15\x63reateRegisteredModel\x12\x1d.mlflow.CreateRegisteredModel\x1a&.mlflow.CreateRegisteredModel.Response\"V\xf2\x86\x19R\n6\n\x04POST\x12(/preview/mlflow/registered-models/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x43reate RegisteredModel\x12\xb6\x01\n\x15renameRegisteredModel\x12\x1d.mlflow.RenameRegisteredModel\x1a&.mlflow.RenameRegisteredModel.Response\"V\xf2\x86\x19R\n6\n\x04POST\x12(/preview/mlflow/registered-models/rename\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Rename RegisteredModel\x12\xb7\x01\n\x15updateRegisteredModel\x12\x1d.mlflow.UpdateRegisteredModel\x1a&.mlflow.UpdateRegisteredModel.Response\"W\xf2\x86\x19S\n7\n\x05PATCH\x12(/preview/mlflow/registered-models/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Update RegisteredModel\x12\xb8\x01\n\x15\x64\x65leteRegisteredModel\x12\x1d.mlflow.DeleteRegisteredModel\x1a&.mlflow.DeleteRegisteredModel.Response\"X\xf2\x86\x19T\n8\n\x06\x44\x45LETE\x12(/preview/mlflow/registered-models/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x44\x65lete RegisteredModel\x12\xa6\x01\n\x12getRegisteredModel\x12\x1a.mlflow.GetRegisteredModel\x1a#.mlflow.GetRegisteredModel.Response\"O\xf2\x86\x19K\n2\n\x03GET\x12%/preview/mlflow/registered-models/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Get RegisteredModel\x12\xb9\x01\n\x16searchRegisteredModels\x12\x1e.mlflow.SearchRegisteredModels\x1a\'.mlflow.SearchRegisteredModels.Response\"V\xf2\x86\x19R\n5\n\x03GET\x12(/preview/mlflow/registered-models/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x17Search RegisteredModels\x12\xaf\x01\n\x14listRegisteredModels\x12\x1c.mlflow.ListRegisteredModels\x1a%.mlflow.ListRegisteredModels.Response\"R\xf2\x86\x19N\n3\n\x03GET\x12&/preview/mlflow/registered-models/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x15List RegisteredModels\x12\xb8\x01\n\x11getLatestVersions\x12\x19.mlflow.GetLatestVersions\x1a\".mlflow.GetLatestVersions.Response\"d\xf2\x86\x19`\nB\n\x03GET\x12\x35/preview/mlflow/registered-models/get-latest-versions\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Get Latest ModelVersions\x12\xa7\x01\n\x12\x63reateModelVersion\x12\x1a.mlflow.CreateModelVersion\x1a#.mlflow.CreateModelVersion.Response\"P\xf2\x86\x19L\n3\n\x04POST\x12%/preview/mlflow/model-versions/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x43reate ModelVersion\x12\xa8\x01\n\x12updateModelVersion\x12\x1a.mlflow.UpdateModelVersion\x1a#.mlflow.UpdateModelVersion.Response\"Q\xf2\x86\x19M\n4\n\x05PATCH\x12%/preview/mlflow/model-versions/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Update ModelVersion\x12\xd6\x01\n\x1btransitionModelVersionStage\x12#.mlflow.TransitionModelVersionStage\x1a,.mlflow.TransitionModelVersionStage.Response\"d\xf2\x86\x19`\n=\n\x04POST\x12//preview/mlflow/model-versions/transition-stage\x1a\x04\x08\x02\x10\x00\x10\x01*\x1dTransition ModelVersion Stage\x12\xa9\x01\n\x12\x64\x65leteModelVersion\x12\x1a.mlflow.DeleteModelVersion\x1a#.mlflow.DeleteModelVersion.Response\"R\xf2\x86\x19N\n5\n\x06\x44\x45LETE\x12%/preview/mlflow/model-versions/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x44\x65lete ModelVersion\x12\x97\x01\n\x0fgetModelVersion\x12\x17.mlflow.GetModelVersion\x1a .mlflow.GetModelVersion.Response\"I\xf2\x86\x19\x45\n/\n\x03GET\x12\"/preview/mlflow/model-versions/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x10Get ModelVersion\x12\xaa\x01\n\x13searchModelVersions\x12\x1b.mlflow.SearchModelVersions\x1a$.mlflow.SearchModelVersions.Response\"P\xf2\x86\x19L\n2\n\x03GET\x12%/preview/mlflow/model-versions/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x14Search ModelVersions\x12\xe0\x01\n\x1agetModelVersionDownloadUri\x12\".mlflow.GetModelVersionDownloadUri\x1a+.mlflow.GetModelVersionDownloadUri.Response\"q\xf2\x86\x19m\n<\n\x03GET\x12//preview/mlflow/model-versions/get-download-uri\x1a\x04\x08\x02\x10\x00\x10\x01*+Get Download URI For ModelVersion Artifacts\x12\xb9\x01\n\x15setRegisteredModelTag\x12\x1d.mlflow.SetRegisteredModelTag\x1a&.mlflow.SetRegisteredModelTag.Response\"Y\xf2\x86\x19U\n7\n\x04POST\x12)/preview/mlflow/registered-models/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Set Registered Model Tag\x12\xaa\x01\n\x12setModelVersionTag\x12\x1a.mlflow.SetModelVersionTag\x1a#.mlflow.SetModelVersionTag.Response\"S\xf2\x86\x19O\n4\n\x04POST\x12&/preview/mlflow/model-versions/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x15Set Model Version Tag\x12\xca\x01\n\x18\x64\x65leteRegisteredModelTag\x12 .mlflow.DeleteRegisteredModelTag\x1a).mlflow.DeleteRegisteredModelTag.Response\"a\xf2\x86\x19]\n<\n\x06\x44\x45LETE\x12,/preview/mlflow/registered-models/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x1b\x44\x65lete Registered Model Tag\x12\xbb\x01\n\x15\x64\x65leteModelVersionTag\x12\x1d.mlflow.DeleteModelVersionTag\x1a&.mlflow.DeleteModelVersionTag.Response\"[\xf2\x86\x19W\n9\n\x06\x44\x45LETE\x12)/preview/mlflow/model-versions/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x18\x44\x65lete Model Version TagB!\n\x14org.mlflow.api.proto\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\x14model_registry.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xda\x01\n\x0fRegisteredModel\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x02 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x03 \x01(\x03\x12\x0f\n\x07user_id\x18\x04 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x05 \x01(\t\x12-\n\x0flatest_versions\x18\x06 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12(\n\x04tags\x18\x07 \x03(\x0b\x32\x1a.mlflow.RegisteredModelTag\"\xc3\x02\n\x0cModelVersion\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x0f\n\x07version\x18\x02 \x01(\t\x12\x1a\n\x12\x63reation_timestamp\x18\x03 \x01(\x03\x12\x1e\n\x16last_updated_timestamp\x18\x04 \x01(\x03\x12\x0f\n\x07user_id\x18\x05 \x01(\t\x12\x15\n\rcurrent_stage\x18\x06 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x07 \x01(\t\x12\x0e\n\x06source\x18\x08 \x01(\t\x12\x0e\n\x06run_id\x18\t \x01(\t\x12*\n\x06status\x18\n \x01(\x0e\x32\x1a.mlflow.ModelVersionStatus\x12\x16\n\x0estatus_message\x18\x0b \x01(\t\x12%\n\x04tags\x18\x0c \x03(\x0b\x32\x17.mlflow.ModelVersionTag\x12\x10\n\x08run_link\x18\r \x01(\t\"\xd6\x01\n\x15\x43reateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12(\n\x04tags\x18\x02 \x03(\x0b\x32\x1a.mlflow.RegisteredModelTag\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa9\x01\n\x15RenameRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xac\x01\n\x15UpdateRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"d\n\x15\x44\x65leteRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x94\x01\n\x12GetRegisteredModel\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a=\n\x08Response\x12\x31\n\x10registered_model\x18\x01 \x01(\x0b\x32\x17.mlflow.RegisteredModel:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xca\x01\n\x14ListRegisteredModels\x12\x18\n\x0bmax_results\x18\x01 \x01(\x03:\x03\x31\x30\x30\x12\x12\n\npage_token\x18\x02 \x01(\t\x1aW\n\x08Response\x12\x32\n\x11registered_models\x18\x01 \x03(\x0b\x32\x17.mlflow.RegisteredModel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xee\x01\n\x16SearchRegisteredModels\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x18\n\x0bmax_results\x18\x02 \x01(\x03:\x03\x31\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aW\n\x08Response\x12\x32\n\x11registered_models\x18\x01 \x03(\x0b\x32\x17.mlflow.RegisteredModel\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x9e\x01\n\x11GetLatestVersions\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06stages\x18\x02 \x03(\t\x1a\x38\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x82\x02\n\x12\x43reateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x14\n\x06source\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12%\n\x04tags\x18\x04 \x03(\x0b\x32\x17.mlflow.ModelVersionTag\x12\x10\n\x08run_link\x18\x05 \x01(\t\x12\x13\n\x0b\x64\x65scription\x18\x06 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xba\x01\n\x12UpdateModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x0b\x64\x65scription\x18\x03 \x01(\t\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xec\x01\n\x1bTransitionModelVersionStage\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05stage\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\'\n\x19\x61rchive_existing_versions\x18\x04 \x01(\x08\x42\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"x\n\x12\x44\x65leteModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa2\x01\n\x0fGetModelVersion\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x37\n\x08Response\x12+\n\rmodel_version\x18\x01 \x01(\x0b\x32\x14.mlflow.ModelVersion:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xe8\x01\n\x13SearchModelVersions\x12\x0e\n\x06\x66ilter\x18\x01 \x01(\t\x12\x1b\n\x0bmax_results\x18\x02 \x01(\x03:\x06\x32\x30\x30\x30\x30\x30\x12\x10\n\x08order_by\x18\x03 \x03(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aQ\n\x08Response\x12,\n\x0emodel_versions\x18\x01 \x03(\x0b\x32\x14.mlflow.ModelVersion\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x96\x01\n\x1aGetModelVersionDownloadUri\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a \n\x08Response\x12\x14\n\x0c\x61rtifact_uri\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"-\n\x0fModelVersionTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"0\n\x12RegisteredModelTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\x8c\x01\n\x15SetRegisteredModelTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xa0\x01\n\x12SetModelVersionTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x04 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x18\x44\x65leteRegisteredModelTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8e\x01\n\x15\x44\x65leteModelVersionTag\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x15\n\x07version\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*R\n\x12ModelVersionStatus\x12\x18\n\x14PENDING_REGISTRATION\x10\x01\x12\x17\n\x13\x46\x41ILED_REGISTRATION\x10\x02\x12\t\n\x05READY\x10\x03\x32\xc7\x1b\n\x14ModelRegistryService\x12\xb6\x01\n\x15\x63reateRegisteredModel\x12\x1d.mlflow.CreateRegisteredModel\x1a&.mlflow.CreateRegisteredModel.Response\"V\xf2\x86\x19R\n6\n\x04POST\x12(/preview/mlflow/registered-models/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x43reate RegisteredModel\x12\xb6\x01\n\x15renameRegisteredModel\x12\x1d.mlflow.RenameRegisteredModel\x1a&.mlflow.RenameRegisteredModel.Response\"V\xf2\x86\x19R\n6\n\x04POST\x12(/preview/mlflow/registered-models/rename\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Rename RegisteredModel\x12\xb7\x01\n\x15updateRegisteredModel\x12\x1d.mlflow.UpdateRegisteredModel\x1a&.mlflow.UpdateRegisteredModel.Response\"W\xf2\x86\x19S\n7\n\x05PATCH\x12(/preview/mlflow/registered-models/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Update RegisteredModel\x12\xb8\x01\n\x15\x64\x65leteRegisteredModel\x12\x1d.mlflow.DeleteRegisteredModel\x1a&.mlflow.DeleteRegisteredModel.Response\"X\xf2\x86\x19T\n8\n\x06\x44\x45LETE\x12(/preview/mlflow/registered-models/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x16\x44\x65lete RegisteredModel\x12\xa6\x01\n\x12getRegisteredModel\x12\x1a.mlflow.GetRegisteredModel\x1a#.mlflow.GetRegisteredModel.Response\"O\xf2\x86\x19K\n2\n\x03GET\x12%/preview/mlflow/registered-models/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Get RegisteredModel\x12\xb9\x01\n\x16searchRegisteredModels\x12\x1e.mlflow.SearchRegisteredModels\x1a\'.mlflow.SearchRegisteredModels.Response\"V\xf2\x86\x19R\n5\n\x03GET\x12(/preview/mlflow/registered-models/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x17Search RegisteredModels\x12\xaf\x01\n\x14listRegisteredModels\x12\x1c.mlflow.ListRegisteredModels\x1a%.mlflow.ListRegisteredModels.Response\"R\xf2\x86\x19N\n3\n\x03GET\x12&/preview/mlflow/registered-models/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x15List RegisteredModels\x12\xb8\x01\n\x11getLatestVersions\x12\x19.mlflow.GetLatestVersions\x1a\".mlflow.GetLatestVersions.Response\"d\xf2\x86\x19`\nB\n\x03GET\x12\x35/preview/mlflow/registered-models/get-latest-versions\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Get Latest ModelVersions\x12\xa7\x01\n\x12\x63reateModelVersion\x12\x1a.mlflow.CreateModelVersion\x1a#.mlflow.CreateModelVersion.Response\"P\xf2\x86\x19L\n3\n\x04POST\x12%/preview/mlflow/model-versions/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x43reate ModelVersion\x12\xa8\x01\n\x12updateModelVersion\x12\x1a.mlflow.UpdateModelVersion\x1a#.mlflow.UpdateModelVersion.Response\"Q\xf2\x86\x19M\n4\n\x05PATCH\x12%/preview/mlflow/model-versions/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x13Update ModelVersion\x12\xd6\x01\n\x1btransitionModelVersionStage\x12#.mlflow.TransitionModelVersionStage\x1a,.mlflow.TransitionModelVersionStage.Response\"d\xf2\x86\x19`\n=\n\x04POST\x12//preview/mlflow/model-versions/transition-stage\x1a\x04\x08\x02\x10\x00\x10\x01*\x1dTransition ModelVersion Stage\x12\xa9\x01\n\x12\x64\x65leteModelVersion\x12\x1a.mlflow.DeleteModelVersion\x1a#.mlflow.DeleteModelVersion.Response\"R\xf2\x86\x19N\n5\n\x06\x44\x45LETE\x12%/preview/mlflow/model-versions/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x13\x44\x65lete ModelVersion\x12\x97\x01\n\x0fgetModelVersion\x12\x17.mlflow.GetModelVersion\x1a .mlflow.GetModelVersion.Response\"I\xf2\x86\x19\x45\n/\n\x03GET\x12\"/preview/mlflow/model-versions/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x10Get ModelVersion\x12\xaa\x01\n\x13searchModelVersions\x12\x1b.mlflow.SearchModelVersions\x1a$.mlflow.SearchModelVersions.Response\"P\xf2\x86\x19L\n2\n\x03GET\x12%/preview/mlflow/model-versions/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x14Search ModelVersions\x12\xe0\x01\n\x1agetModelVersionDownloadUri\x12\".mlflow.GetModelVersionDownloadUri\x1a+.mlflow.GetModelVersionDownloadUri.Response\"q\xf2\x86\x19m\n<\n\x03GET\x12//preview/mlflow/model-versions/get-download-uri\x1a\x04\x08\x02\x10\x00\x10\x01*+Get Download URI For ModelVersion Artifacts\x12\xb9\x01\n\x15setRegisteredModelTag\x12\x1d.mlflow.SetRegisteredModelTag\x1a&.mlflow.SetRegisteredModelTag.Response\"Y\xf2\x86\x19U\n7\n\x04POST\x12)/preview/mlflow/registered-models/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x18Set Registered Model Tag\x12\xaa\x01\n\x12setModelVersionTag\x12\x1a.mlflow.SetModelVersionTag\x1a#.mlflow.SetModelVersionTag.Response\"S\xf2\x86\x19O\n4\n\x04POST\x12&/preview/mlflow/model-versions/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x15Set Model Version Tag\x12\xca\x01\n\x18\x64\x65leteRegisteredModelTag\x12 .mlflow.DeleteRegisteredModelTag\x1a).mlflow.DeleteRegisteredModelTag.Response\"a\xf2\x86\x19]\n<\n\x06\x44\x45LETE\x12,/preview/mlflow/registered-models/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x1b\x44\x65lete Registered Model Tag\x12\xbb\x01\n\x15\x64\x65leteModelVersionTag\x12\x1d.mlflow.DeleteModelVersionTag\x1a&.mlflow.DeleteModelVersionTag.Response\"[\xf2\x86\x19W\n9\n\x06\x44\x45LETE\x12)/preview/mlflow/model-versions/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x18\x44\x65lete Model Version TagB!\n\x14org.mlflow.api.proto\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -49,8 +49,8 @@ _MODELVERSIONSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4038,
-  serialized_end=4120,
+  serialized_start=4080,
+  serialized_end=4162,
 )
 _sym_db.RegisterEnumDescriptor(_MODELVERSIONSTATUS)
 
@@ -275,8 +275,8 @@ _CREATEREGISTEREDMODEL_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=708,
-  serialized_end=769,
+  serialized_start=729,
+  serialized_end=790,
 )
 
 _CREATEREGISTEREDMODEL = _descriptor.Descriptor(
@@ -300,6 +300,13 @@ _CREATEREGISTEREDMODEL = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='description', full_name='mlflow.CreateRegisteredModel.description', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -313,7 +320,7 @@ _CREATEREGISTEREDMODEL = _descriptor.Descriptor(
   oneofs=[
   ],
   serialized_start=621,
-  serialized_end=814,
+  serialized_end=835,
 )
 
 
@@ -343,8 +350,8 @@ _RENAMEREGISTEREDMODEL_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=708,
-  serialized_end=769,
+  serialized_start=729,
+  serialized_end=790,
 )
 
 _RENAMEREGISTEREDMODEL = _descriptor.Descriptor(
@@ -380,8 +387,8 @@ _RENAMEREGISTEREDMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=817,
-  serialized_end=986,
+  serialized_start=838,
+  serialized_end=1007,
 )
 
 
@@ -411,8 +418,8 @@ _UPDATEREGISTEREDMODEL_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=708,
-  serialized_end=769,
+  serialized_start=729,
+  serialized_end=790,
 )
 
 _UPDATEREGISTEREDMODEL = _descriptor.Descriptor(
@@ -448,8 +455,8 @@ _UPDATEREGISTEREDMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=989,
-  serialized_end=1161,
+  serialized_start=1010,
+  serialized_end=1182,
 )
 
 
@@ -472,8 +479,8 @@ _DELETEREGISTEREDMODEL_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=708,
-  serialized_end=718,
+  serialized_start=729,
+  serialized_end=739,
 )
 
 _DELETEREGISTEREDMODEL = _descriptor.Descriptor(
@@ -502,8 +509,8 @@ _DELETEREGISTEREDMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1163,
-  serialized_end=1263,
+  serialized_start=1184,
+  serialized_end=1284,
 )
 
 
@@ -533,8 +540,8 @@ _GETREGISTEREDMODEL_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=708,
-  serialized_end=769,
+  serialized_start=729,
+  serialized_end=790,
 )
 
 _GETREGISTEREDMODEL = _descriptor.Descriptor(
@@ -563,8 +570,8 @@ _GETREGISTEREDMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1266,
-  serialized_end=1414,
+  serialized_start=1287,
+  serialized_end=1435,
 )
 
 
@@ -601,8 +608,8 @@ _LISTREGISTEREDMODELS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1487,
-  serialized_end=1574,
+  serialized_start=1508,
+  serialized_end=1595,
 )
 
 _LISTREGISTEREDMODELS = _descriptor.Descriptor(
@@ -638,8 +645,8 @@ _LISTREGISTEREDMODELS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1417,
-  serialized_end=1619,
+  serialized_start=1438,
+  serialized_end=1640,
 )
 
 
@@ -676,8 +683,8 @@ _SEARCHREGISTEREDMODELS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1487,
-  serialized_end=1574,
+  serialized_start=1508,
+  serialized_end=1595,
 )
 
 _SEARCHREGISTEREDMODELS = _descriptor.Descriptor(
@@ -727,8 +734,8 @@ _SEARCHREGISTEREDMODELS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1622,
-  serialized_end=1860,
+  serialized_start=1643,
+  serialized_end=1881,
 )
 
 
@@ -758,8 +765,8 @@ _GETLATESTVERSIONS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1920,
-  serialized_end=1976,
+  serialized_start=1941,
+  serialized_end=1997,
 )
 
 _GETLATESTVERSIONS = _descriptor.Descriptor(
@@ -795,8 +802,8 @@ _GETLATESTVERSIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1863,
-  serialized_end=2021,
+  serialized_start=1884,
+  serialized_end=2042,
 )
 
 
@@ -826,8 +833,8 @@ _CREATEMODELVERSION_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2161,
-  serialized_end=2216,
+  serialized_start=2203,
+  serialized_end=2258,
 )
 
 _CREATEMODELVERSION = _descriptor.Descriptor(
@@ -872,6 +879,13 @@ _CREATEMODELVERSION = _descriptor.Descriptor(
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='description', full_name='mlflow.CreateModelVersion.description', index=5,
+      number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
   ],
   extensions=[
   ],
@@ -884,8 +898,8 @@ _CREATEMODELVERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2024,
-  serialized_end=2261,
+  serialized_start=2045,
+  serialized_end=2303,
 )
 
 
@@ -915,8 +929,8 @@ _UPDATEMODELVERSION_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2161,
-  serialized_end=2216,
+  serialized_start=2203,
+  serialized_end=2258,
 )
 
 _UPDATEMODELVERSION = _descriptor.Descriptor(
@@ -959,8 +973,8 @@ _UPDATEMODELVERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2264,
-  serialized_end=2450,
+  serialized_start=2306,
+  serialized_end=2492,
 )
 
 
@@ -990,8 +1004,8 @@ _TRANSITIONMODELVERSIONSTAGE_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2161,
-  serialized_end=2216,
+  serialized_start=2203,
+  serialized_end=2258,
 )
 
 _TRANSITIONMODELVERSIONSTAGE = _descriptor.Descriptor(
@@ -1041,8 +1055,8 @@ _TRANSITIONMODELVERSIONSTAGE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2453,
-  serialized_end=2689,
+  serialized_start=2495,
+  serialized_end=2731,
 )
 
 
@@ -1065,8 +1079,8 @@ _DELETEMODELVERSION_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=708,
-  serialized_end=718,
+  serialized_start=729,
+  serialized_end=739,
 )
 
 _DELETEMODELVERSION = _descriptor.Descriptor(
@@ -1102,8 +1116,8 @@ _DELETEMODELVERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2691,
-  serialized_end=2811,
+  serialized_start=2733,
+  serialized_end=2853,
 )
 
 
@@ -1133,8 +1147,8 @@ _GETMODELVERSION_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2161,
-  serialized_end=2216,
+  serialized_start=2203,
+  serialized_end=2258,
 )
 
 _GETMODELVERSION = _descriptor.Descriptor(
@@ -1170,8 +1184,8 @@ _GETMODELVERSION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2814,
-  serialized_end=2976,
+  serialized_start=2856,
+  serialized_end=3018,
 )
 
 
@@ -1208,8 +1222,8 @@ _SEARCHMODELVERSIONS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3085,
-  serialized_end=3166,
+  serialized_start=3127,
+  serialized_end=3208,
 )
 
 _SEARCHMODELVERSIONS = _descriptor.Descriptor(
@@ -1259,8 +1273,8 @@ _SEARCHMODELVERSIONS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2979,
-  serialized_end=3211,
+  serialized_start=3021,
+  serialized_end=3253,
 )
 
 
@@ -1290,8 +1304,8 @@ _GETMODELVERSIONDOWNLOADURI_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3287,
-  serialized_end=3319,
+  serialized_start=3329,
+  serialized_end=3361,
 )
 
 _GETMODELVERSIONDOWNLOADURI = _descriptor.Descriptor(
@@ -1327,8 +1341,8 @@ _GETMODELVERSIONDOWNLOADURI = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3214,
-  serialized_end=3364,
+  serialized_start=3256,
+  serialized_end=3406,
 )
 
 
@@ -1365,8 +1379,8 @@ _MODELVERSIONTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3366,
-  serialized_end=3411,
+  serialized_start=3408,
+  serialized_end=3453,
 )
 
 
@@ -1403,8 +1417,8 @@ _REGISTEREDMODELTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3413,
-  serialized_end=3461,
+  serialized_start=3455,
+  serialized_end=3503,
 )
 
 
@@ -1427,8 +1441,8 @@ _SETREGISTEREDMODELTAG_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=708,
-  serialized_end=718,
+  serialized_start=729,
+  serialized_end=739,
 )
 
 _SETREGISTEREDMODELTAG = _descriptor.Descriptor(
@@ -1471,8 +1485,8 @@ _SETREGISTEREDMODELTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3464,
-  serialized_end=3604,
+  serialized_start=3506,
+  serialized_end=3646,
 )
 
 
@@ -1495,8 +1509,8 @@ _SETMODELVERSIONTAG_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=708,
-  serialized_end=718,
+  serialized_start=729,
+  serialized_end=739,
 )
 
 _SETMODELVERSIONTAG = _descriptor.Descriptor(
@@ -1546,8 +1560,8 @@ _SETMODELVERSIONTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3607,
-  serialized_end=3767,
+  serialized_start=3649,
+  serialized_end=3809,
 )
 
 
@@ -1570,8 +1584,8 @@ _DELETEREGISTEREDMODELTAG_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=708,
-  serialized_end=718,
+  serialized_start=729,
+  serialized_end=739,
 )
 
 _DELETEREGISTEREDMODELTAG = _descriptor.Descriptor(
@@ -1607,8 +1621,8 @@ _DELETEREGISTEREDMODELTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3769,
-  serialized_end=3891,
+  serialized_start=3811,
+  serialized_end=3933,
 )
 
 
@@ -1631,8 +1645,8 @@ _DELETEMODELVERSIONTAG_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=708,
-  serialized_end=718,
+  serialized_start=729,
+  serialized_end=739,
 )
 
 _DELETEMODELVERSIONTAG = _descriptor.Descriptor(
@@ -1675,8 +1689,8 @@ _DELETEMODELVERSIONTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3894,
-  serialized_end=4036,
+  serialized_start=3936,
+  serialized_end=4078,
 )
 
 _REGISTEREDMODEL.fields_by_name['latest_versions'].message_type = _MODELVERSION
@@ -2115,8 +2129,8 @@ _MODELREGISTRYSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=4123,
-  serialized_end=7650,
+  serialized_start=4165,
+  serialized_end=7692,
   methods=[
   _descriptor.MethodDescriptor(
     name='createRegisteredModel',

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -573,7 +573,9 @@ def _wrap_response(response_message):
 def _create_registered_model():
     request_message = _get_request_message(CreateRegisteredModel())
     registered_model = _get_model_registry_store().create_registered_model(
-        name=request_message.name, tags=request_message.tags
+        name=request_message.name,
+        tags=request_message.tags,
+        description=request_message.description,
     )
     response_message = CreateRegisteredModel.Response(registered_model=registered_model.to_proto())
     return _wrap_response(response_message)
@@ -685,6 +687,7 @@ def _create_model_version():
         run_id=request_message.run_id,
         run_link=request_message.run_link,
         tags=request_message.tags,
+        description=request_message.description,
     )
     response_message = CreateModelVersion.Response(model_version=model_version.to_proto())
     return _wrap_response(response_message)

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -146,7 +146,9 @@ class AbstractStore:
     # CRUD API for ModelVersion objects
 
     @abstractmethod
-    def create_model_version(self, name, source, run_id, tags=None, run_link=None, description=None):
+    def create_model_version(
+        self, name, source, run_id, tags=None, run_link=None, description=None
+    ):
         """
         Create a new model version from given source and run ID.
 

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -19,13 +19,14 @@ class AbstractStore:
     # CRUD API for RegisteredModel objects
 
     @abstractmethod
-    def create_registered_model(self, name, tags=None):
+    def create_registered_model(self, name, tags=None, description=None):
         """
         Create a new registered model in backend store.
 
         :param name: Name of the new model. This is expected to be unique in the backend store.
         :param tags: A list of :py:class:`mlflow.entities.model_registry.RegisteredModelTag`
                      instances associated with this registered model.
+        :param description: Description of the model.
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
                  created in the backend.
         """
@@ -145,7 +146,7 @@ class AbstractStore:
     # CRUD API for ModelVersion objects
 
     @abstractmethod
-    def create_model_version(self, name, source, run_id, tags=None, run_link=None):
+    def create_model_version(self, name, source, run_id, tags=None, run_link=None, description=None):
         """
         Create a new model version from given source and run ID.
 
@@ -155,6 +156,7 @@ class AbstractStore:
         :param tags: A list of :py:class:`mlflow.entities.model_registry.ModelVersionTag`
                      instances associated with this model version.
         :param run_link: Link to the run from an MLflow tracking server that generated this model.
+        :param description: Description of the version.
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
                  created in the backend.
         """

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -69,7 +69,8 @@ class RestStore(AbstractStore):
         """
         proto_tags = [tag.to_proto() for tag in tags or []]
         req_body = message_to_json(
-            CreateRegisteredModel(name=name, tags=proto_tags, description=description))
+            CreateRegisteredModel(name=name, tags=proto_tags, description=description)
+        )
         response_proto = self._call_endpoint(CreateRegisteredModel, req_body)
         return RegisteredModel.from_proto(response_proto.registered_model)
 
@@ -214,7 +215,9 @@ class RestStore(AbstractStore):
 
     # CRUD API for ModelVersion objects
 
-    def create_model_version(self, name, source, run_id, tags=None, run_link=None, description=None):
+    def create_model_version(
+        self, name, source, run_id, tags=None, run_link=None, description=None
+    ):
         """
         Create a new model version from given source and run ID.
 

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -56,18 +56,20 @@ class RestStore(AbstractStore):
 
     # CRUD API for RegisteredModel objects
 
-    def create_registered_model(self, name, tags=None):
+    def create_registered_model(self, name, tags=None, description=None):
         """
         Create a new registered model in backend store.
 
         :param name: Name of the new model. This is expected to be unique in the backend store.
         :param tags: A list of :py:class:`mlflow.entities.model_registry.RegisteredModelTag`
                      instances associated with this registered model.
+        :param description: Description of the model.
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
                  created in the backend.
         """
         proto_tags = [tag.to_proto() for tag in tags or []]
-        req_body = message_to_json(CreateRegisteredModel(name=name, tags=proto_tags))
+        req_body = message_to_json(
+            CreateRegisteredModel(name=name, tags=proto_tags, description=description))
         response_proto = self._call_endpoint(CreateRegisteredModel, req_body)
         return RegisteredModel.from_proto(response_proto.registered_model)
 
@@ -212,7 +214,7 @@ class RestStore(AbstractStore):
 
     # CRUD API for ModelVersion objects
 
-    def create_model_version(self, name, source, run_id, tags=None, run_link=None):
+    def create_model_version(self, name, source, run_id, tags=None, run_link=None, description=None):
         """
         Create a new model version from given source and run ID.
 
@@ -222,15 +224,14 @@ class RestStore(AbstractStore):
         :param tags: A list of :py:class:`mlflow.entities.model_registry.ModelVersionTag`
                      instances associated with this model version.
         :param run_link: Link to the run from an MLflow tracking server that generated this model.
+        :param description: Description of the version.
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
                  created in the backend.
         """
         proto_tags = [tag.to_proto() for tag in tags or []]
-        req_body = message_to_json(
-            CreateModelVersion(
-                name=name, source=source, run_id=run_id, run_link=run_link, tags=proto_tags
-            )
-        )
+        req_body = message_to_json(CreateModelVersion(name=name, source=source,
+                                                      run_id=run_id, run_link=run_link,
+                                                      tags=proto_tags, description=description))
         response_proto = self._call_endpoint(CreateModelVersion, req_body)
         return ModelVersion.from_proto(response_proto.model_version)
 

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -229,9 +229,16 @@ class RestStore(AbstractStore):
                  created in the backend.
         """
         proto_tags = [tag.to_proto() for tag in tags or []]
-        req_body = message_to_json(CreateModelVersion(name=name, source=source,
-                                                      run_id=run_id, run_link=run_link,
-                                                      tags=proto_tags, description=description))
+        req_body = message_to_json(
+            CreateModelVersion(
+                name=name,
+                source=source,
+                run_id=run_id,
+                run_link=run_link,
+                tags=proto_tags,
+                description=description,
+            )
+        )
         response_proto = self._call_endpoint(CreateModelVersion, req_body)
         return ModelVersion.from_proto(response_proto.model_version)
 

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -491,7 +491,9 @@ class SqlAlchemyStore(AbstractStore):
 
     # CRUD API for ModelVersion objects
 
-    def create_model_version(self, name, source, run_id, tags=None, run_link=None, description=None):
+    def create_model_version(
+        self, name, source, run_id, tags=None, run_link=None, description=None
+    ):
         """
         Create a new model version from given source and run ID.
 

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -168,9 +168,12 @@ class SqlAlchemyStore(AbstractStore):
         with self.ManagedSessionMaker() as session:
             try:
                 creation_time = now()
-                registered_model = SqlRegisteredModel(name=name, creation_time=creation_time,
-                                                      last_updated_time=creation_time,
-                                                      description=description)
+                registered_model = SqlRegisteredModel(
+                    name=name,
+                    creation_time=creation_time,
+                    last_updated_time=creation_time,
+                    description=description,
+                )
                 tags_dict = {}
                 for tag in tags or []:
                     tags_dict[tag.key] = tag.value

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -151,13 +151,14 @@ class SqlAlchemyStore(AbstractStore):
             # single object
             session.add(objs)
 
-    def create_registered_model(self, name, tags=None):
+    def create_registered_model(self, name, tags=None, description=None):
         """
         Create a new registered model in backend store.
 
         :param name: Name of the new model. This is expected to be unique in the backend store.
         :param tags: A list of :py:class:`mlflow.entities.model_registry.RegisteredModelTag`
                      instances associated with this registered model.
+        :param description: Description of the version.
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
                  created in the backend.
         """
@@ -167,9 +168,9 @@ class SqlAlchemyStore(AbstractStore):
         with self.ManagedSessionMaker() as session:
             try:
                 creation_time = now()
-                registered_model = SqlRegisteredModel(
-                    name=name, creation_time=creation_time, last_updated_time=creation_time
-                )
+                registered_model = SqlRegisteredModel(name=name, creation_time=creation_time,
+                                                      last_updated_time=creation_time,
+                                                      description=description)
                 tags_dict = {}
                 for tag in tags or []:
                     tags_dict[tag.key] = tag.value
@@ -487,7 +488,7 @@ class SqlAlchemyStore(AbstractStore):
 
     # CRUD API for ModelVersion objects
 
-    def create_model_version(self, name, source, run_id, tags=None, run_link=None):
+    def create_model_version(self, name, source, run_id, tags=None, run_link=None, description=None):
         """
         Create a new model version from given source and run ID.
 
@@ -497,6 +498,7 @@ class SqlAlchemyStore(AbstractStore):
         :param tags: A list of :py:class:`mlflow.entities.model_registry.ModelVersionTag`
                      instances associated with this model version.
         :param run_link: Link to the run from an MLflow tracking server that generated this model.
+        :param description: Description of the version.
         :return: A single object of :py:class:`mlflow.entities.model_registry.ModelVersion`
                  created in the backend.
         """
@@ -525,6 +527,7 @@ class SqlAlchemyStore(AbstractStore):
                         source=source,
                         run_id=run_id,
                         run_link=run_link,
+                        description=description,
                     )
                     tags_dict = {}
                     for tag in tags or []:

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -29,13 +29,14 @@ class ModelRegistryClient(object):
 
     # Registered Model Methods
 
-    def create_registered_model(self, name, tags=None):
+    def create_registered_model(self, name, tags=None, description=None):
         """
         Create a new registered model in backend store.
 
         :param name: Name of the new model. This is expected to be unique in the backend store.
         :param tags: A dictionary of key-value pairs that are converted into
                      :py:class:`mlflow.entities.model_registry.RegisteredModelTag` objects.
+       :param description: Description of the model.
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
                  created by backend.
         """
@@ -43,7 +44,7 @@ class ModelRegistryClient(object):
         #       Those are constraints applicable to any backend, given the model URI format.
         tags = tags if tags else {}
         tags = [RegisteredModelTag(key, str(value)) for key, value in tags.items()]
-        return self.store.create_registered_model(name, tags)
+        return self.store.create_registered_model(name, tags, description)
 
     def update_registered_model(self, name, description):
         """
@@ -158,7 +159,7 @@ class ModelRegistryClient(object):
 
     # Model Version Methods
 
-    def create_model_version(self, name, source, run_id, tags=None, run_link=None):
+    def create_model_version(self, name, source, run_id, tags=None, run_link=None, description=None):
         """
         Create a new model version from given source.
 
@@ -168,12 +169,13 @@ class ModelRegistryClient(object):
         :param tags: A dictionary of key-value pairs that are converted into
                      :py:class:`mlflow.entities.model_registry.ModelVersionTag` objects.
         :param run_link: Link to the run from an MLflow tracking server that generated this model.
+        :param description: Description of the version.
         :return: Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by
                  backend.
         """
         tags = tags if tags else {}
         tags = [ModelVersionTag(key, str(value)) for key, value in tags.items()]
-        return self.store.create_model_version(name, source, run_id, tags, run_link)
+        return self.store.create_model_version(name, source, run_id, tags, run_link, description)
 
     def update_model_version(self, name, version, description):
         """

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -159,7 +159,9 @@ class ModelRegistryClient(object):
 
     # Model Version Methods
 
-    def create_model_version(self, name, source, run_id, tags=None, run_link=None, description=None):
+    def create_model_version(
+        self, name, source, run_id, tags=None, run_link=None, description=None
+    ):
         """
         Create a new model version from given source.
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -381,17 +381,18 @@ class MlflowClient(object):
     # Registered Model Methods
 
     @experimental
-    def create_registered_model(self, name, tags=None):
+    def create_registered_model(self, name, tags=None, description=None):
         """
         Create a new registered model in backend store.
 
         :param name: Name of the new model. This is expected to be unique in the backend store.
         :param tags: A dictionary of key-value pairs that are converted into
                      :py:class:`mlflow.entities.model_registry.RegisteredModelTag` objects.
+        :param description: Description of the model.
         :return: A single object of :py:class:`mlflow.entities.model_registry.RegisteredModel`
                  created by backend.
         """
-        return self._get_registry_client().create_registered_model(name, tags)
+        return self._get_registry_client().create_registered_model(name, tags, description)
 
     @experimental
     def rename_registered_model(self, name, new_name):
@@ -520,7 +521,7 @@ class MlflowClient(object):
     # Model Version Methods
 
     @experimental
-    def create_model_version(self, name, source, run_id, tags=None, run_link=None):
+    def create_model_version(self, name, source, run_id, tags=None, run_link=None, description=None):
         """
         Create a new model version from given source (artifact URI).
 
@@ -530,6 +531,7 @@ class MlflowClient(object):
         :param tags: A dictionary of key-value pairs that are converted into
                      :py:class:`mlflow.entities.model_registry.ModelVersionTag` objects.
         :param run_link: Link to the run from an MLflow tracking server that generated this model.
+        :param description: Description of the version.
         :return: Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by
                  backend.
         """
@@ -555,7 +557,12 @@ class MlflowClient(object):
                 + " `source` field of the created model version. ==="
             )
         return self._get_registry_client().create_model_version(
-            name=name, source=new_source, run_id=run_id, tags=tags, run_link=run_link
+            name=name,
+            source=new_source,
+            run_id=run_id,
+            tags=tags,
+            run_link=run_link,
+            description=description,
         )
 
     def _get_run_link(self, tracking_uri, run_id):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -521,7 +521,9 @@ class MlflowClient(object):
     # Model Version Methods
 
     @experimental
-    def create_model_version(self, name, source, run_id, tags=None, run_link=None, description=None):
+    def create_model_version(
+        self, name, source, run_id, tags=None, run_link=None, description=None
+    ):
         """
         Create a new model version from given source (artifact URI).
 

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -75,12 +75,14 @@ class TestRestStore(unittest.TestCase):
             RegisteredModelTag(key="key", value="value"),
             RegisteredModelTag(key="anotherKey", value="some other value"),
         ]
-        self.store.create_registered_model("model_1", tags)
+        description = "best model ever"
+        self.store.create_registered_model("model_1", tags, description)
         self._verify_requests(
             mock_http,
             "registered-models/create",
             "POST",
-            CreateRegisteredModel(name="model_1", tags=[tag.to_proto() for tag in tags]),
+            CreateRegisteredModel(name="model_1", tags=[tag.to_proto() for tag in tags],
+                                  description),
         )
 
     @mock.patch("mlflow.utils.rest_utils.http_request")

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -81,8 +81,9 @@ class TestRestStore(unittest.TestCase):
             mock_http,
             "registered-models/create",
             "POST",
-            CreateRegisteredModel(name="model_1", tags=[tag.to_proto() for tag in tags],
-                                  description),
+            CreateRegisteredModel(
+                name="model_1", tags=[tag.to_proto() for tag in tags], description
+            ),
         )
 
     @mock.patch("mlflow.utils.rest_utils.http_request")
@@ -204,9 +205,12 @@ class TestRestStore(unittest.TestCase):
     def test_create_model_version(self, mock_http):
         run_id = uuid.uuid4().hex
         self.store.create_model_version("model_1", "path/to/source", run_id)
-        self._verify_requests(mock_http, "model-versions/create", "POST",
-                              CreateModelVersion(name="model_1", source="path/to/source",
-                                                 run_id=run_id))
+        self._verify_requests(
+            mock_http,
+            "model-versions/create",
+            "POST",
+            CreateModelVersion(name="model_1", source="path/to/source", run_id=run_id),
+        )
         # test optional fields
         tags = [
             ModelVersionTag(key="key", value="value"),
@@ -214,8 +218,14 @@ class TestRestStore(unittest.TestCase):
         ]
         run_link = "localhost:5000/path/to/run"
         description = "version description"
-        self.store.create_model_version("model_1", "path/to/source", run_id, tags,
-                                        run_link=run_link, description=description)
+        self.store.create_model_version(
+            "model_1",
+            "path/to/source",
+            run_id,
+            tags,
+            run_link=run_link,
+            description=description,
+        )
         self._verify_requests(
             mock_http,
             "model-versions/create",

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -200,15 +200,20 @@ class TestRestStore(unittest.TestCase):
 
     @mock.patch("mlflow.utils.rest_utils.http_request")
     def test_create_model_version(self, mock_http):
+        run_id = uuid.uuid4().hex
+        self.store.create_model_version("model_1", "path/to/source", run_id)
+        self._verify_requests(mock_http, "model-versions/create", "POST",
+                              CreateModelVersion(name="model_1", source="path/to/source",
+                                                 run_id=run_id))
+        # test optional fields
         tags = [
             ModelVersionTag(key="key", value="value"),
             ModelVersionTag(key="anotherKey", value="some other value"),
         ]
-        run_id = uuid.uuid4().hex
         run_link = "localhost:5000/path/to/run"
-        self.store.create_model_version(
-            "model_1", "path/to/source", run_id, tags, run_link=run_link
-        )
+        description = "version description"
+        self.store.create_model_version("model_1", "path/to/source", run_id, tags,
+                                        run_link=run_link, description=description)
         self._verify_requests(
             mock_http,
             "model-versions/create",
@@ -219,6 +224,7 @@ class TestRestStore(unittest.TestCase):
                 run_id=run_id,
                 run_link=run_link,
                 tags=[tag.to_proto() for tag in tags],
+                description=description,
             ),
         )
 

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -219,12 +219,7 @@ class TestRestStore(unittest.TestCase):
         run_link = "localhost:5000/path/to/run"
         description = "version description"
         self.store.create_model_version(
-            "model_1",
-            "path/to/source",
-            run_id,
-            tags,
-            run_link=run_link,
-            description=description,
+            "model_1", "path/to/source", run_id, tags, run_link=run_link, description=description,
         )
         self._verify_requests(
             mock_http,

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -82,7 +82,7 @@ class TestRestStore(unittest.TestCase):
             "registered-models/create",
             "POST",
             CreateRegisteredModel(
-                name="model_1", tags=[tag.to_proto() for tag in tags], description
+                name="model_1", tags=[tag.to_proto() for tag in tags], description=description
             ),
         )
 

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -43,13 +43,13 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         mlflow.store.db.base_sql_model.Base.metadata.drop_all(self.store.engine)
         os.remove(self.temp_dbfile)
 
-    def _rm_maker(self, name, tags=None):
-        return self.store.create_registered_model(name, tags)
+    def _rm_maker(self, name, tags=None, description=None):
+        return self.store.create_registered_model(name, tags, description)
 
-    def _mv_maker(
-        self, name, source="path/to/source", run_id=uuid.uuid4().hex, tags=None, run_link=None
-    ):
-        return self.store.create_model_version(name, source, run_id, tags, run_link=run_link)
+    def _mv_maker(self, name, source="path/to/source", run_id=uuid.uuid4().hex, tags=None,
+                  run_link=None, description=None):
+        return self.store.create_model_version(name, source, run_id, tags, run_link=run_link,
+                                               description=description)
 
     def _extract_latest_by_stage(self, latest_versions):
         return {mvd.current_stage: mvd.version for mvd in latest_versions}
@@ -58,6 +58,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         name = random_str() + "abCD"
         rm1 = self._rm_maker(name)
         self.assertEqual(rm1.name, name)
+        self.assertEqual(rm1.description, None)
 
         # error on duplicate
         with self.assertRaises(MlflowException) as exception_context:
@@ -81,6 +82,16 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(rm2.tags, {tag.key: tag.value for tag in tags})
         self.assertEqual(rmd2.name, name2)
         self.assertEqual(rmd2.tags, {tag.key: tag.value for tag in tags})
+
+        # create with description
+        name3 = random_str() + "-description"
+        description = 'the best model ever'
+        rm3 = self._rm_maker(name3, description=description)
+        rmd3 = self.store.get_registered_model(name3)
+        self.assertEqual(rm3.name, name3)
+        self.assertEqual(rm3.description, description)
+        self.assertEqual(rmd3.name, name3)
+        self.assertEqual(rmd3.description, description)
 
         # invalid model name will fail
         with self.assertRaises(MlflowException) as exception_context:

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -85,7 +85,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # create with description
         name3 = random_str() + "-description"
-        description = 'the best model ever'
+        description = "the best model ever"
         rm3 = self._rm_maker(name3, description=description)
         rmd3 = self.store.get_registered_model(name3)
         self.assertEqual(rm3.name, name3)
@@ -469,7 +469,17 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(mvd4.version, 4)
         self.assertEqual(mvd4.run_link, run_link)
 
-    def test_update_model_version(self):
+        # create model version with description
+        description = "the best model ever"
+        mv5 = self._mv_maker(name, run_link=run_link)
+        mvd5 = self.store.get_model_version(name, mv4.version)
+        self.assertEqual(mv5.version, 5)
+        self.assertEqual(mv5.description, description)
+        self.assertEqual(mvd5.version, 5)
+        self.assertEqual(mvd5.description, description)
+
+
+def test_update_model_version(self):
         name = "test_for_update_MV"
         self._rm_maker(name)
         mv1 = self._mv_maker(name)

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -47,8 +47,13 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         return self.store.create_registered_model(name, tags, description)
 
     def _mv_maker(
-        self, name, source="path/to/source", run_id=uuid.uuid4().hex, tags=None, run_link=None,
-        description=None
+        self,
+        name,
+        source="path/to/source",
+        run_id=uuid.uuid4().hex,
+        tags=None,
+        run_link=None,
+        description=None,
     ):
         return self.store.create_model_version(
             name, source, run_id, tags, run_link=run_link, description=description

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -474,8 +474,8 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
 
         # create model version with description
         description = "the best model ever"
-        mv5 = self._mv_maker(name, run_link=run_link)
-        mvd5 = self.store.get_model_version(name, mv4.version)
+        mv5 = self._mv_maker(name, description=description)
+        mvd5 = self.store.get_model_version(name, mv5.version)
         self.assertEqual(mv5.version, 5)
         self.assertEqual(mv5.description, description)
         self.assertEqual(mvd5.version, 5)

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -46,10 +46,13 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
     def _rm_maker(self, name, tags=None, description=None):
         return self.store.create_registered_model(name, tags, description)
 
-    def _mv_maker(self, name, source="path/to/source", run_id=uuid.uuid4().hex, tags=None,
-                  run_link=None, description=None):
-        return self.store.create_model_version(name, source, run_id, tags, run_link=run_link,
-                                               description=description)
+    def _mv_maker(
+        self, name, source="path/to/source", run_id=uuid.uuid4().hex, tags=None, run_link=None,
+        description=None
+    ):
+        return self.store.create_model_version(
+            name, source, run_id, tags, run_link=run_link, description=description
+        )
 
     def _extract_latest_by_stage(self, latest_versions):
         return {mvd.current_stage: mvd.version for mvd in latest_versions}
@@ -478,8 +481,7 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(mvd5.version, 5)
         self.assertEqual(mvd5.description, description)
 
-
-def test_update_model_version(self):
+    def test_update_model_version(self):
         name = "test_for_update_MV"
         self._rm_maker(name)
         mv1 = self._mv_maker(name)

--- a/tests/tracking/_model_registry/test_model_registry_client.py
+++ b/tests/tracking/_model_registry/test_model_registry_client.py
@@ -46,9 +46,11 @@ def _model_version(name, version, stage, source="some:/source", run_id="run13579
 def test_create_registered_model(mock_store):
     tags_dict = {"key": "value", "another key": "some other value"}
     tags = [RegisteredModelTag(key, value) for key, value in tags_dict.items()]
-    mock_store.create_registered_model.return_value = RegisteredModel("Model 1", tags=tags)
-    result = newModelRegistryClient().create_registered_model("Model 1", tags_dict)
-    mock_store.create_registered_model.assert_called_once_with("Model 1", tags)
+    description = 'such a great model'
+    mock_store.create_registered_model.return_value = RegisteredModel("Model 1", tags=tags,
+                                                                      description=description)
+    result = newModelRegistryClient().create_registered_model("Model 1", tags_dict, description)
+    mock_store.create_registered_model.assert_called_once_with("Model 1", tags, description)
     assert result.name == "Model 1"
     assert result.tags == tags_dict
 
@@ -197,15 +199,18 @@ def test_create_model_version(mock_store):
     version = "1"
     tags_dict = {"key": "value", "another key": "some other value"}
     tags = [ModelVersionTag(key, value) for key, value in tags_dict.items()]
+    description = "best model ever"
+
     mock_store.create_model_version.return_value = ModelVersion(
-        name=name, version=version, creation_timestamp=123, tags=tags, run_link=None
+        name=name, version=version, creation_timestamp=123, tags=tags, run_link=None, description
     )
     result = newModelRegistryClient().create_model_version(
-        name, "uri:/for/source", "run123", tags_dict
+        name, "uri:/for/source", "run123", tags_dict, None, description
     )
     mock_store.create_model_version.assert_called_once_with(
-        name, "uri:/for/source", "run123", tags, None
+        name, "uri:/for/source", "run123", tags, None, description
     )
+
     assert result.name == name
     assert result.version == version
     assert result.tags == tags_dict

--- a/tests/tracking/_model_registry/test_model_registry_client.py
+++ b/tests/tracking/_model_registry/test_model_registry_client.py
@@ -208,7 +208,7 @@ def test_create_model_version(mock_store):
         creation_timestamp=123,
         tags=tags,
         run_link=None,
-        description=description
+        description=description,
     )
     result = newModelRegistryClient().create_model_version(
         name, "uri:/for/source", "run123", tags_dict, None, description

--- a/tests/tracking/_model_registry/test_model_registry_client.py
+++ b/tests/tracking/_model_registry/test_model_registry_client.py
@@ -46,9 +46,10 @@ def _model_version(name, version, stage, source="some:/source", run_id="run13579
 def test_create_registered_model(mock_store):
     tags_dict = {"key": "value", "another key": "some other value"}
     tags = [RegisteredModelTag(key, value) for key, value in tags_dict.items()]
-    description = 'such a great model'
-    mock_store.create_registered_model.return_value = RegisteredModel("Model 1", tags=tags,
-                                                                      description=description)
+    description = "such a great model"
+    mock_store.create_registered_model.return_value = RegisteredModel(
+        "Model 1", tags=tags, description=description
+    )
     result = newModelRegistryClient().create_registered_model("Model 1", tags_dict, description)
     mock_store.create_registered_model.assert_called_once_with("Model 1", tags, description)
     assert result.name == "Model 1"

--- a/tests/tracking/_model_registry/test_model_registry_client.py
+++ b/tests/tracking/_model_registry/test_model_registry_client.py
@@ -203,7 +203,12 @@ def test_create_model_version(mock_store):
     description = "best model ever"
 
     mock_store.create_model_version.return_value = ModelVersion(
-        name=name, version=version, creation_timestamp=123, tags=tags, run_link=None, description
+        name=name,
+        version=version,
+        creation_timestamp=123,
+        tags=tags,
+        run_link=None,
+        description=description
     )
     result = newModelRegistryClient().create_model_version(
         name, "uri:/for/source", "run123", tags_dict, None, description

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -292,7 +292,7 @@ def test_create_model_version_nondatabricks_source_no_runlink(mock_registry_stor
     assert model_version.run_id == "runid"
     # verify that the store was not provided a run link
     mock_registry_store.create_model_version.assert_called_once_with(
-        "name", "source", "runid", [], None
+        "name", "source", "runid", [], None, None
     )
 
 
@@ -316,7 +316,7 @@ def test_create_model_version_explicitly_set_run_link(mock_registry_store):
         assert model_version.run_link == run_link
         # verify that the store was provided with the explicitly passed in run link
         mock_registry_store.create_model_version.assert_called_once_with(
-            "name", "source", "runid", [], run_link
+            "name", "source", "runid", [], run_link, None
         )
 
 
@@ -345,7 +345,7 @@ def test_create_model_version_run_link_in_notebook_with_default_profile(mock_reg
         assert model_version.run_link == workspace_url
         # verify that the client generated the right URL
         mock_registry_store.create_model_version.assert_called_once_with(
-            "name", "source", "runid", [], workspace_url
+            "name", "source", "runid", [], workspace_url, None
         )
 
 
@@ -374,7 +374,7 @@ def test_create_model_version_run_link_with_configured_profile(mock_registry_sto
         assert model_version.run_link == workspace_url
         # verify that the client generated the right URL
         mock_registry_store.create_model_version.assert_called_once_with(
-            "name", "source", "runid", [], workspace_url
+            "name", "source", "runid", [], workspace_url, None
         )
 
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2,7 +2,7 @@ import mock
 import pytest
 
 from mlflow.entities import SourceType, ViewType, RunTag, Run, RunInfo
-from mlflow.entities.model_registry import ModelVersion
+from mlflow.entities.model_registry import ModelVersion, ModelVersionTag
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import ErrorCode, FEATURE_DISABLED
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
@@ -213,6 +213,21 @@ def test_update_registered_model(mock_registry_store):
         name="orig name", description="new description"
     )
     mock_registry_store.rename_registered_model.assert_not_called()
+
+
+def test_create_model_version(mock_registry_store):
+    """
+    Basic test for create model version.
+    """
+    expected_return_value = "some faux expected return value."
+    mock_registry_store.create_model_version.return_value = expected_return_value
+    res = MlflowClient(registry_uri="sqlite:///somedb.db").create_model_version(
+        "orig name", "source", "run-id", tags={"key": "value"}, description="desc"
+    )
+    assert res == expected_return_value
+    mock_registry_store.create_model_version.assert_called_once_with(
+        "orig name", "source", "run-id", [ModelVersionTag(key="key", value="value")], None, "desc"
+    )
 
 
 def test_update_model_version(mock_registry_store):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Allow specifying a description for a registered model or a model version on create. (Addresses https://github.com/mlflow/mlflow/issues/3169)

## How is this patch tested?

- [x] Unit tests
- [x] Manual tests - ran a server locally with sqlite and tested the client methods (create + get)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Now you can specify a description for a model or a version when they are created via the model registry API.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
