### PR TITLE
Set experiment on start run

### DIFF
--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -566,6 +566,7 @@ mlflow_start_run <- function(run_id = NULL, experiment_id = NULL, start_time = N
     do.call(mlflow_create_run, args)
   }
   mlflow_set_active_run_id(mlflow_id(run))
+  mlflow_set_experiment(experiment_id = args$experiment_id)
   run
 }
 

--- a/mlflow/R/mlflow/tests/testthat/test-run.R
+++ b/mlflow/R/mlflow/tests/testthat/test-run.R
@@ -61,3 +61,13 @@ test_that("mlflow_run passes all numbers as non-scientific", {
     mlflow_run("project", parameters = c(scientific = 10e4, non_scientific = 30000))
   })
 })
+
+test_that("active experiment is set when starting a run", {
+  mlflow_clear_test_dir("mlruns")
+  mlflow_start_run(experiment_id = "0")
+  expect_equal(
+    mlflow_get_experiment()$experiment_id,
+    "0"
+  )
+  mlflow_end_run()
+})

--- a/mlflow/R/mlflow/tests/testthat/test-run.R
+++ b/mlflow/R/mlflow/tests/testthat/test-run.R
@@ -62,9 +62,21 @@ test_that("mlflow_run passes all numbers as non-scientific", {
   })
 })
 
-test_that("active experiment is set when starting a run", {
+test_that("active experiment is set when starting a run with experiemnt specified", {
   mlflow_clear_test_dir("mlruns")
-  mlflow_start_run(experiment_id = "0")
+  id <- mlflow_create_experiment("one-more")
+  mlflow_start_run(experiment_id = id)
+  expect_equal(
+    mlflow_get_experiment()$experiment_id,
+    id
+  )
+  mlflow_end_run()
+})
+
+test_that("active experiment is set when starting a run without experiemnt specified", {
+  mlflow_clear_test_dir("mlruns")
+  id <- mlflow_create_experiment("second-exp")
+  mlflow_start_run()
   expect_equal(
     mlflow_get_experiment()$experiment_id,
     "0"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Set the active experiment on `mlflow::mlflow_start_run(...)` so calling `mlflow::mlflow_get_experiment()` afterwards does return it (instead of an error). Fixes #3234. 

## How is this patch tested?

Added a test that fails to demonstrate behavior and then fixed it to make tests pass.


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.


### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
