### PR TITLE
Enable `import-init` option for pylint

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -26,7 +26,7 @@ For a lower level API, see the :py:mod:`mlflow.tracking` module.
 """
 import sys
 
-from mlflow.version import VERSION as __version__
+from mlflow.version import VERSION as __version__  # pylint: disable=unused-import
 from mlflow.utils.logging_utils import _configure_mlflow_loggers
 import mlflow.tracking._model_registry.fluent
 import mlflow.tracking.fluent

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -4,22 +4,20 @@ Machine Learning.
 """
 import sys
 import os
-import shutil
 import subprocess
-import tempfile
 import logging
 import uuid
 
 from distutils.version import StrictVersion
 
-import mlflow
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils import PYTHON_VERSION, experimental, get_unique_resource_id
+from mlflow.utils import get_unique_resource_id
+from mlflow.utils.annotations import experimental
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree, _copy_project
 from mlflow.version import VERSION as mlflow_version
 from pathlib import Path

--- a/mlflow/azureml/cli.py
+++ b/mlflow/azureml/cli.py
@@ -6,7 +6,8 @@ import json
 import click
 
 import mlflow.azureml
-from mlflow.utils import cli_args, experimental
+from mlflow.utils import cli_args
+from mlflow.utils.annotations import experimental
 
 
 @click.group("azureml")

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -22,7 +22,8 @@ from mlflow.server.handlers import initialize_backend_stores
 from mlflow.store.tracking import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.tracking import _get_store
-from mlflow.utils import cli_args, experimental
+from mlflow.utils import cli_args
+from mlflow.utils.annotations import experimental
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.process import ShellCommandException
 from mlflow.utils.uri import is_local_uri

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -4,7 +4,7 @@ import re
 from six.moves import urllib
 
 from mlflow.utils import process
-from mlflow.utils import deprecated
+from mlflow.utils.annotations import deprecated
 
 DBFS_PREFIX = "dbfs:/"
 S3_PREFIX = "s3://"

--- a/mlflow/deployments/base.py
+++ b/mlflow/deployments/base.py
@@ -11,7 +11,7 @@ In particular, a valid deployment plugin module must implement:
 
 import abc
 
-from mlflow.utils import experimental
+from mlflow.utils.annotations import experimental
 
 
 @experimental

--- a/mlflow/deployments/interface.py
+++ b/mlflow/deployments/interface.py
@@ -1,7 +1,7 @@
 import inspect
 from mlflow.deployments.plugin_manager import DeploymentPlugins
 from mlflow.deployments.base import BaseDeploymentClient
-from mlflow.utils import experimental
+from mlflow.utils.annotations import experimental
 from mlflow.deployments.utils import parse_target_uri
 
 plugin_store = DeploymentPlugins()

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -17,7 +17,7 @@ from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils import experimental
+from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import try_mlflow_log
 from mlflow.utils.environment import _mlflow_conda_env
 

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -20,7 +20,7 @@ from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.exceptions import MlflowException
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
-from mlflow.utils import keyword_only
+from mlflow.utils.annotations import keyword_only
 
 FLAVOR_NAME = "mleap"
 

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -23,4 +23,4 @@ from .flavor_backend import FlavorBackend
 from .signature import ModelSignature, infer_signature
 from .utils import ModelInputExample
 
-__all__ = ["Model", "ModelSignature", "infer_signature", "FlavorBackend"]
+__all__ = ["Model", "ModelSignature", "ModelInputExample", "infer_signature", "FlavorBackend"]

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -22,7 +22,7 @@ from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils import experimental
+from mlflow.utils.annotations import experimental
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -215,7 +215,11 @@ import mlflow.pyfunc.utils
 from mlflow.models import Model, ModelSignature, ModelInputExample
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.utils import _save_example
-from mlflow.pyfunc.model import PythonModel, get_default_conda_env  # pylint: disable=unused-import
+from mlflow.pyfunc.model import (
+    PythonModel,
+    PythonModelContext,
+    get_default_conda_env,
+)  # pylint: disable=unused-import
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType, Schema
 from mlflow.utils import PYTHON_VERSION, get_major_minor_py_version

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -215,10 +215,11 @@ import mlflow.pyfunc.utils
 from mlflow.models import Model, ModelSignature, ModelInputExample
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.utils import _save_example
-from mlflow.pyfunc.model import PythonModel, PythonModelContext, get_default_conda_env
+from mlflow.pyfunc.model import PythonModel, get_default_conda_env  # pylint: disable=unused-import
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType, Schema
-from mlflow.utils import PYTHON_VERSION, deprecated, get_major_minor_py_version
+from mlflow.utils import PYTHON_VERSION, get_major_minor_py_version
+from mlflow.utils.annotations import deprecated
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -215,11 +215,8 @@ import mlflow.pyfunc.utils
 from mlflow.models import Model, ModelSignature, ModelInputExample
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.utils import _save_example
-from mlflow.pyfunc.model import (
-    PythonModel,
-    PythonModelContext,
-    get_default_conda_env,
-)  # pylint: disable=unused-import
+from mlflow.pyfunc.model import PythonModel, PythonModelContext  # pylint: disable=unused-import
+from mlflow.pyfunc.model import get_default_conda_env
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType, Schema
 from mlflow.utils import PYTHON_VERSION, get_major_minor_py_version

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -5,8 +5,7 @@ import subprocess
 import posixpath
 from mlflow.models import FlavorBackend
 from mlflow.models.docker_utils import _build_image, DISABLE_ENV_CREATION
-from mlflow.pyfunc import ENV
-from mlflow.pyfunc import scoring_server
+from mlflow.pyfunc import ENV, scoring_server
 
 from mlflow.utils.conda import get_or_create_conda_env, get_conda_bin_executable, get_conda_command
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -13,7 +13,6 @@ Defines two endpoints:
 from collections import OrderedDict
 import flask
 import json
-from json import JSONEncoder
 import logging
 import numpy as np
 import pandas as pd

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -2,7 +2,7 @@
 The ``mlflow.sagemaker`` module provides an API for deploying MLflow models to Amazon SageMaker.
 """
 import os
-from subprocess import Popen, PIPE, STDOUT
+from subprocess import Popen
 from six.moves import urllib
 import sys
 import tarfile
@@ -20,7 +20,6 @@ from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, INVALID_PARAME
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils import get_unique_resource_id
 from mlflow.utils.file_utils import TempDir
-from mlflow.utils.logging_utils import eprint
 from mlflow.models.container import SUPPORTED_FLAVORS as SUPPORTED_DEPLOYMENT_FLAVORS
 from mlflow.models.container import DEPLOYMENT_CONFIG_KEY_FLAVOR_NAME
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -39,7 +39,7 @@ from mlflow.store.artifact.models_artifact_repo import ModelsArtifactRepository
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.uri import is_local_uri, append_to_uri_path
 from mlflow.utils.model_utils import _get_flavor_configuration_from_uri
-from mlflow.utils import experimental
+from mlflow.utils.annotations import experimental
 
 
 FLAVOR_NAME = "spark"

--- a/mlflow/store/artifact/artifact_repo.py
+++ b/mlflow/store/artifact/artifact_repo.py
@@ -4,7 +4,7 @@ import tempfile
 from abc import abstractmethod, ABCMeta
 
 from mlflow.utils.validation import path_not_unique, bad_path_message
-from mlflow.utils import experimental
+from mlflow.utils.annotations import experimental
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_DOES_NOT_EXIST

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -3,7 +3,7 @@ from abc import abstractmethod, ABCMeta
 from mlflow.entities import ViewType
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
-from mlflow.utils import experimental
+from mlflow.utils.annotations import experimental
 
 
 class AbstractStore:

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -35,7 +35,7 @@ from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.protos.databricks_pb2 import DIRECTORY_NOT_EMPTY
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils import keyword_only, experimental
+from mlflow.utils.annotations import keyword_only, experimental
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import _copy_file_or_tree
 from mlflow.utils.model_utils import _get_flavor_configuration

--- a/mlflow/tracking/__init__.py
+++ b/mlflow/tracking/__init__.py
@@ -28,6 +28,7 @@ __all__ = [
     "get_registry_uri",
     "set_registry_uri",
     "_EXPERIMENT_ID_ENV_VAR",
+    "_EXPERIMENT_NAME_ENV_VAR",
     "_RUN_ID_ENV_VAR",
     "_TRACKING_URI_ENV_VAR",
 ]

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -2,7 +2,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, ErrorCode
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.tracking import MlflowClient
-from mlflow.utils import experimental
+from mlflow.utils.annotations import experimental
 from mlflow.utils.logging_utils import eprint
 
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -17,7 +17,7 @@ from mlflow.tracking._tracking_service import utils
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
 from mlflow.tracking.artifact_utils import _upload_artifacts_to_databricks
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
-from mlflow.utils import experimental
+from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import (
     is_databricks_default_tracking_uri,
     is_in_databricks_job,

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -1,6 +1,5 @@
 from sys import version_info
 
-from mlflow.utils.annotations import deprecated, experimental, keyword_only
 
 PYTHON_VERSION = "{major}.{minor}.{micro}".format(
     major=version_info.major, minor=version_info.minor, micro=version_info.micro

--- a/pylintrc
+++ b/pylintrc
@@ -457,7 +457,7 @@ dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
 ignored-argument-names=_.*|^ignored_|^unused_
 
 # Tells whether we should check for unused import in __init__ files.
-init-import=no
+init-import=yes
 
 # List of qualified module names which can have objects that can redefine
 # builtins.

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -8,7 +8,7 @@ from moto.core.responses import BaseResponse
 from moto.ec2 import ec2_backends
 
 from moto.iam.models import ACCOUNT_ID
-from moto.core.models import base_decorator, deprecated_base_decorator
+from moto.core.models import base_decorator
 
 SageMakerResourceWithArn = namedtuple("SageMakerResourceWithArn", ["resource", "arn"])
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

A follow-up for #3260. Enable `import-init` option to disallow unused imports in `__init__.py`

## How is this patch tested?

lint check

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
