### PR TITLE
Expose model flavors under `mlflow` so users don't have to import them

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -183,7 +183,7 @@ jobs:
           source activate test-environment
           ./dev/run-python-flavor-tests.sh;
 
-  mlflow:
+  import:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -183,6 +183,20 @@ jobs:
           source activate test-environment
           ./dev/run-python-flavor-tests.sh;
 
+  mlflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - name: Install mlflow
+        run: |
+          pip install -e .
+      - name: Verify mlflow can be imported without errors
+        run: |
+          python -c "import mlflow"
+
   tensorflow:
     runs-on: ubuntu-latest
     steps:

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -1,3 +1,4 @@
+# pylint: disable=wrong-import-position
 """
 The ``mlflow`` module provides a high-level "fluent" API for starting and managing MLflow runs.
 For example:
@@ -41,9 +42,25 @@ warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E
 # log a deprecated warning only once per function per module
 warnings.filterwarnings("module", category=DeprecationWarning)
 
-# pylint: disable=wrong-import-position
-import mlflow.projects as projects  # noqa
-import mlflow.tracking as tracking  # noqa
+import mlflow.projects as projects  # noqa: E402
+import mlflow.tracking as tracking  # noqa: E402
+
+# model flavors
+import mlflow.fastai as fastai  # noqa: E402
+import mlflow.gluon as gluon  # noqa: E402
+import mlflow.h2o as h2o  # noqa: E402
+import mlflow.keras as keras  # noqa: E402
+import mlflow.lightgbm as lightgbm  # noqa: E402
+import mlflow.mleap as mleap  # noqa: E402
+import mlflow.onnx as onnx  # noqa: E402
+import mlflow.pyfunc as pyfunc  # noqa: E402
+import mlflow.pytorch as pytorch  # noqa: E402
+import mlflow.sklearn as sklearn  # noqa: E402
+import mlflow.spacy as spacy  # noqa: E402
+import mlflow.spark as spark  # noqa: E402
+import mlflow.tensorflow as tensorflow  # noqa: E402
+import mlflow.xgboost as xgboost  # noqa: E402
+
 
 _configure_mlflow_loggers(root_module_name=__name__)
 
@@ -120,4 +137,19 @@ __all__ = [
     "get_registry_uri",
     "set_registry_uri",
     "list_run_infos",
+    # model flavors
+    "fastai",
+    "gluon",
+    "h2o",
+    "keras",
+    "lightgbm",
+    "mleap",
+    "onnx",
+    "pyfunc",
+    "pytorch",
+    "sklearn",
+    "spacy",
+    "spark",
+    "tensorflow",
+    "xgboost",
 ]

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -32,9 +32,6 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import try_mlflow_log, log_fn_args_as_params
 
-from fastai.tabular import TabularList
-from fastai.basic_data import DatasetType
-
 
 FLAVOR_NAME = "fastai"
 
@@ -230,6 +227,9 @@ class _FastaiModelWrapper:
         self.learner = learner
 
     def predict(self, dataframe):
+        from fastai.tabular import TabularList
+        from fastai.basic_data import DatasetType
+
         test_data = TabularList.from_df(dataframe, cont_names=self.learner.data.cont_names)
         self.learner.data.add_test(test_data)
         preds, target = self.learner.get_preds(DatasetType.Test)

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -1,7 +1,6 @@
 import os
 
 import gorilla
-import mxnet as mx
 import pandas as pd
 import yaml
 
@@ -74,6 +73,8 @@ class _GluonModelWrapper:
         :return: A Pandas DataFrame containing output array values. The underlying MXNet array
                  can be extracted from the output DataFrame as `ndarray = mx.nd.array(df.values)`.
         """
+        import mxnet as mx
+
         ndarray = mx.nd.array(df.values)
         return pd.DataFrame(self.gluon_model(ndarray).asnumpy())
 
@@ -84,6 +85,8 @@ def _load_pyfunc(path):
 
     :param path: Local filesystem path to the MLflow Model with the ``gluon`` flavor.
     """
+    import mxnet as mx
+
     m = load_model(path, mx.current_context())
     return _GluonModelWrapper(m)
 
@@ -200,6 +203,8 @@ def get_default_conda_env():
     :return: The default Conda environment for MLflow Models produced by calls to
              :func:`save_model()` and :func:`log_model()`.
     """
+    import mxnet as mx
+
     pip_deps = ["mxnet=={}".format(mx.__version__)]
 
     return _mlflow_conda_env(additional_pip_deps=pip_deps)

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -4,10 +4,6 @@ import gorilla
 import mxnet as mx
 import pandas as pd
 import yaml
-from mxnet import gluon
-from mxnet import sym
-from mxnet.gluon.contrib.estimator import Estimator, EpochEnd, TrainBegin, TrainEnd
-from mxnet.gluon.nn import HybridSequential
 
 import mlflow
 from mlflow import pyfunc
@@ -53,6 +49,9 @@ def load_model(model_uri, ctx):
         model = mlflow.gluon.load_model("runs:/" + gluon_random_data_run.info.run_id + "/model")
         model(nd.array(np.random.rand(1000, 1, 32)))
     """
+    from mxnet import gluon
+    from mxnet import sym
+
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
 
     model_arch_path = os.path.join(local_model_path, "data", _MODEL_SAVE_PATH) + "-symbol.json"
@@ -304,6 +303,9 @@ def autolog():
     function, and optimizer data as parameters. Model checkpoints
     are logged as artifacts to a 'models' directory.
     """
+
+    from mxnet.gluon.contrib.estimator import Estimator, EpochEnd, TrainBegin, TrainEnd
+    from mxnet.gluon.nn import HybridSequential
 
     class __MLflowGluonCallback(EpochEnd, TrainEnd, TrainBegin):
         def __init__(self):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -647,8 +647,8 @@ def _setup_callbacks(lst):
 
     class __MLflowTfKerasCallback(Callback):
         """
-            Callback for auto-logging parameters (we rely on TensorBoard for metrics) in TensorFlow < 2.
-            Records model structural information as params after training finishes.
+        Callback for auto-logging parameters (we rely on TensorBoard for metrics) in TensorFlow < 2.
+        Records model structural information as params after training finishes.
         """
 
         def __init__(self):
@@ -713,8 +713,8 @@ def _setup_callbacks(lst):
 
     class __MLflowTfKeras2Callback(Callback):
         """
-            Callback for auto-logging parameters and metrics in TensorFlow >= 2.0.0.
-            Records model structural information as params when training starts.
+        Callback for auto-logging parameters and metrics in TensorFlow >= 2.0.0.
+        Records model structural information as params when training starts.
         """
 
         def __init__(self):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -22,11 +22,11 @@ from collections import namedtuple
 import pandas
 
 import mlflow
-import tensorflow
+
 import mlflow.keras
 from distutils.version import LooseVersion
 from contextlib import contextmanager
-from tensorflow.keras.callbacks import Callback, TensorBoard  # pylint: disable=import-error
+
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
@@ -64,6 +64,8 @@ def get_default_conda_env():
     :return: The default Conda environment for MLflow Models produced by calls to
              :func:`save_model()` and :func:`log_model()`.
     """
+    import tensorflow
+
     return _mlflow_conda_env(
         additional_conda_deps=["tensorflow={}".format(tensorflow.__version__)],
         additional_pip_deps=None,
@@ -276,6 +278,8 @@ def _validate_saved_model(tf_saved_model_dir, tf_meta_graph_tags, tf_signature_d
     Validate the TensorFlow SavedModel by attempting to load it in a new TensorFlow graph.
     If the loading process fails, any exceptions thrown by TensorFlow are propagated.
     """
+    import tensorflow
+
     if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
         validation_tf_graph = tensorflow.Graph()
         validation_tf_sess = tensorflow.Session(graph=validation_tf_graph)
@@ -340,6 +344,7 @@ def load_model(model_uri, tf_sess=None):
             output_tensors = [tf_graph.get_tensor_by_name(output_signature.name)
                                 for _, output_signature in signature_definition.outputs.items()]
     """
+    import tensorflow
 
     if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
         if not tf_sess:
@@ -402,6 +407,8 @@ def _load_tensorflow_saved_model(
              For TensorFlow versions >= 2.0.0:
              A callable graph (tensorflow.function) that takes inputs and returns inferences.
     """
+    import tensorflow
+
     if LooseVersion(tensorflow.__version__) < LooseVersion("2.0.0"):
         loaded = tensorflow.saved_model.loader.load(
             sess=tf_sess, tags=tf_meta_graph_tags, export_dir=tf_saved_model_dir
@@ -448,6 +455,8 @@ def _load_pyfunc(path):
 
     :param path: Local filesystem path to the MLflow Model with the ``tensorflow`` flavor.
     """
+    import tensorflow
+
     (
         tf_saved_model_dir,
         tf_meta_graph_tags,
@@ -525,6 +534,8 @@ class _TF2Wrapper(object):
         self.infer = infer
 
     def predict(self, df):
+        import tensorflow
+
         feed_dict = {}
         for df_col_name in list(df):
             # If there are multiple columns with the same name, selecting the shared name
@@ -544,111 +555,6 @@ class _TF2Wrapper(object):
                 pred_dict[col] = pred_dict[col].tolist()
 
         return pandas.DataFrame.from_dict(data=pred_dict)
-
-
-class __MLflowTfKerasCallback(Callback):
-    """
-        Callback for auto-logging parameters (we rely on TensorBoard for metrics) in TensorFlow < 2.
-        Records model structural information as params after training finishes.
-    """
-
-    def __init__(self):
-        pass
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
-
-    def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
-        opt = self.model.optimizer
-        if hasattr(opt, "_name"):
-            try_mlflow_log(mlflow.log_param, "optimizer_name", opt._name)
-        # Elif checks are if the optimizer is a TensorFlow optimizer rather than a Keras one.
-        elif hasattr(opt, "optimizer"):
-            # TensorFlow optimizer parameters are associated with the inner optimizer variable.
-            # Therefore, we assign opt to be opt.optimizer for logging parameters.
-            opt = opt.optimizer
-            try_mlflow_log(mlflow.log_param, "optimizer_name", type(opt).__name__)
-        if hasattr(opt, "lr"):
-            lr = opt.lr if type(opt.lr) is float else tensorflow.keras.backend.eval(opt.lr)
-            try_mlflow_log(mlflow.log_param, "learning_rate", lr)
-        elif hasattr(opt, "_lr"):
-            lr = opt._lr if type(opt._lr) is float else tensorflow.keras.backend.eval(opt._lr)
-            try_mlflow_log(mlflow.log_param, "learning_rate", lr)
-        if hasattr(opt, "epsilon"):
-            epsilon = (
-                opt.epsilon
-                if type(opt.epsilon) is float
-                else tensorflow.keras.backend.eval(opt.epsilon)
-            )
-            try_mlflow_log(mlflow.log_param, "epsilon", epsilon)
-        elif hasattr(opt, "_epsilon"):
-            epsilon = (
-                opt._epsilon
-                if type(opt._epsilon) is float
-                else tensorflow.keras.backend.eval(opt._epsilon)
-            )
-            try_mlflow_log(mlflow.log_param, "epsilon", epsilon)
-
-        sum_list = []
-        self.model.summary(print_fn=sum_list.append)
-        summary = "\n".join(sum_list)
-        tempdir = tempfile.mkdtemp()
-        try:
-            summary_file = os.path.join(tempdir, "model_summary.txt")
-            with open(summary_file, "w") as f:
-                f.write(summary)
-            try_mlflow_log(mlflow.log_artifact, local_path=summary_file)
-        finally:
-            shutil.rmtree(tempdir)
-
-    def on_epoch_end(self, epoch, logs=None):
-        pass
-
-    def on_train_end(self, logs=None):  # pylint: disable=unused-argument
-        try_mlflow_log(mlflow.keras.log_model, self.model, artifact_path="model")
-
-
-class __MLflowTfKeras2Callback(Callback):
-    """
-        Callback for auto-logging parameters and metrics in TensorFlow >= 2.0.0.
-        Records model structural information as params when training starts.
-    """
-
-    def __init__(self):
-        pass
-
-    def __enter__(self):
-        pass
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
-
-    def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
-        config = self.model.optimizer.get_config()
-        for attribute in config:
-            try_mlflow_log(mlflow.log_param, "opt_" + attribute, config[attribute])
-
-        sum_list = []
-        self.model.summary(print_fn=sum_list.append)
-        summary = "\n".join(sum_list)
-        tempdir = tempfile.mkdtemp()
-        try:
-            summary_file = os.path.join(tempdir, "model_summary.txt")
-            with open(summary_file, "w") as f:
-                f.write(summary)
-            try_mlflow_log(mlflow.log_artifact, local_path=summary_file)
-        finally:
-            shutil.rmtree(tempdir)
-
-    def on_epoch_end(self, epoch, logs=None):
-        if (epoch - 1) % _LOG_EVERY_N_STEPS == 0:
-            try_mlflow_log(mlflow.log_metrics, logs, step=epoch)
-
-    def on_train_end(self, logs=None):  # pylint: disable=unused-argument
-        try_mlflow_log(mlflow.keras.log_model, self.model, artifact_path="model")
 
 
 def _log_artifacts_with_warning(**kwargs):
@@ -716,6 +622,8 @@ def _log_event(event):
 
 
 def _get_tensorboard_callback(lst):
+    import tensorflow
+
     for x in lst:
         if isinstance(x, tensorflow.keras.callbacks.TensorBoard):
             return x
@@ -734,6 +642,114 @@ def _setup_callbacks(lst):
     Adds TensorBoard and MlfLowTfKeras callbacks to the
     input list, and returns the new list and appropriate log directory.
     """
+    import tensorflow
+    from tensorflow.keras.callbacks import Callback, TensorBoard
+
+    class __MLflowTfKerasCallback(Callback):
+        """
+            Callback for auto-logging parameters (we rely on TensorBoard for metrics) in TensorFlow < 2.
+            Records model structural information as params after training finishes.
+        """
+
+        def __init__(self):
+            pass
+
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+        def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
+            import tensorflow
+
+            opt = self.model.optimizer
+            if hasattr(opt, "_name"):
+                try_mlflow_log(mlflow.log_param, "optimizer_name", opt._name)
+            # Elif checks are if the optimizer is a TensorFlow optimizer rather than a Keras one.
+            elif hasattr(opt, "optimizer"):
+                # TensorFlow optimizer parameters are associated with the inner optimizer variable.
+                # Therefore, we assign opt to be opt.optimizer for logging parameters.
+                opt = opt.optimizer
+                try_mlflow_log(mlflow.log_param, "optimizer_name", type(opt).__name__)
+            if hasattr(opt, "lr"):
+                lr = opt.lr if type(opt.lr) is float else tensorflow.keras.backend.eval(opt.lr)
+                try_mlflow_log(mlflow.log_param, "learning_rate", lr)
+            elif hasattr(opt, "_lr"):
+                lr = opt._lr if type(opt._lr) is float else tensorflow.keras.backend.eval(opt._lr)
+                try_mlflow_log(mlflow.log_param, "learning_rate", lr)
+            if hasattr(opt, "epsilon"):
+                epsilon = (
+                    opt.epsilon
+                    if type(opt.epsilon) is float
+                    else tensorflow.keras.backend.eval(opt.epsilon)
+                )
+                try_mlflow_log(mlflow.log_param, "epsilon", epsilon)
+            elif hasattr(opt, "_epsilon"):
+                epsilon = (
+                    opt._epsilon
+                    if type(opt._epsilon) is float
+                    else tensorflow.keras.backend.eval(opt._epsilon)
+                )
+                try_mlflow_log(mlflow.log_param, "epsilon", epsilon)
+
+            sum_list = []
+            self.model.summary(print_fn=sum_list.append)
+            summary = "\n".join(sum_list)
+            tempdir = tempfile.mkdtemp()
+            try:
+                summary_file = os.path.join(tempdir, "model_summary.txt")
+                with open(summary_file, "w") as f:
+                    f.write(summary)
+                try_mlflow_log(mlflow.log_artifact, local_path=summary_file)
+            finally:
+                shutil.rmtree(tempdir)
+
+        def on_epoch_end(self, epoch, logs=None):
+            pass
+
+        def on_train_end(self, logs=None):  # pylint: disable=unused-argument
+            try_mlflow_log(mlflow.keras.log_model, self.model, artifact_path="model")
+
+    class __MLflowTfKeras2Callback(Callback):
+        """
+            Callback for auto-logging parameters and metrics in TensorFlow >= 2.0.0.
+            Records model structural information as params when training starts.
+        """
+
+        def __init__(self):
+            pass
+
+        def __enter__(self):
+            pass
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            pass
+
+        def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
+            config = self.model.optimizer.get_config()
+            for attribute in config:
+                try_mlflow_log(mlflow.log_param, "opt_" + attribute, config[attribute])
+
+            sum_list = []
+            self.model.summary(print_fn=sum_list.append)
+            summary = "\n".join(sum_list)
+            tempdir = tempfile.mkdtemp()
+            try:
+                summary_file = os.path.join(tempdir, "model_summary.txt")
+                with open(summary_file, "w") as f:
+                    f.write(summary)
+                try_mlflow_log(mlflow.log_artifact, local_path=summary_file)
+            finally:
+                shutil.rmtree(tempdir)
+
+        def on_epoch_end(self, epoch, logs=None):
+            if (epoch - 1) % _LOG_EVERY_N_STEPS == 0:
+                try_mlflow_log(mlflow.log_metrics, logs, step=epoch)
+
+        def on_train_end(self, logs=None):  # pylint: disable=unused-argument
+            try_mlflow_log(mlflow.keras.log_model, self.model, artifact_path="model")
+
     tb = _get_tensorboard_callback(lst)
     if tb is None:
         log_dir = _TensorBoardLogDir(location=tempfile.mkdtemp(), is_temp=True)
@@ -804,6 +820,8 @@ def autolog(every_n_iter=100):
                                   Defaults to 100. Ex: a value of 100 will log metrics
                                   at step 0, 100, 200, etc.
     """
+    import tensorflow
+
     global _LOG_EVERY_N_STEPS
     _LOG_EVERY_N_STEPS = every_n_iter
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -18,15 +18,12 @@ import atexit
 import time
 import tempfile
 from collections import namedtuple
-
 import pandas
-
-import mlflow
-
-import mlflow.keras
 from distutils.version import LooseVersion
 from contextlib import contextmanager
 
+import mlflow
+import mlflow.keras
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -38,8 +38,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import try_mlflow_log, log_fn_args_as_params
 
-import xgboost as xgb
-
 FLAVOR_NAME = "xgboost"
 
 _logger = logging.getLogger(__name__)

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -38,6 +38,8 @@ from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import try_mlflow_log, log_fn_args_as_params
 
+import xgboost as xgb
+
 FLAVOR_NAME = "xgboost"
 
 _logger = logging.getLogger(__name__)

--- a/tests/test_flavors.py
+++ b/tests/test_flavors.py
@@ -1,0 +1,39 @@
+import os
+import ast
+
+import mlflow
+
+
+def read_file(path):
+    with open(path) as f:
+        return f.read()
+
+
+def is_model_flavor(src):
+    for node in ast.iter_child_nodes(ast.parse(src)):
+        if (
+            isinstance(node, ast.Assign)
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == "FLAVOR_NAME"
+        ):
+            return True
+    return False
+
+
+def iter_flavor_names():
+    for root, dirs, files in os.walk("mlflow"):
+        for f in files:
+            if not f.endswith(".py"):
+                continue
+            path = os.path.join(root, f)
+            src = read_file(path)
+            if is_model_flavor(src):
+                basename = os.path.basename(root if (f == "__init__.py") else path)
+                yield os.path.splitext(basename)[0]
+
+
+def test_all_flavors_can_be_accessed_from_mlflow():
+    flavor_names = list(iter_flavor_names())
+    assert len(flavor_names) != 0
+    for flavor_name in flavor_names:
+        assert hasattr(mlflow, flavor_name)

--- a/tests/test_flavors.py
+++ b/tests/test_flavors.py
@@ -21,7 +21,7 @@ def is_model_flavor(src):
 
 
 def iter_flavor_names():
-    for root, dirs, files in os.walk("mlflow"):
+    for root, _, files in os.walk("mlflow"):
         for f in files:
             if not f.endswith(".py"):
                 continue

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -120,7 +120,7 @@ def test_all_fluent_apis_are_included_in_dunder_all():
         for a in dir(mlflow)
         if _is_function_or_class(getattr(mlflow, a)) and not a.startswith("_")
     ]
-    assert sorted(apis) == sorted(mlflow.__all__)
+    assert set(apis).issubset(set(mlflow.__all__))
 
 
 def test_get_experiment_id_from_env():


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Expose model flavors under `mlflow` so users don't have to import them.

Before:

```python
import mlflow

mlflow.sklearn.log_model(...)  # raises an error without `import mlflow.sklearn`
```

After:

```python
import mlflow

mlflow.sklearn.log_model(...)  # works
```

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

All model flavors are exposed under `mllfow`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
