### PR TITLE
Adding logging and scoring

### DIFF
--- a/examples/pytorch/mnist_tensorboard_artifact.py
+++ b/examples/pytorch/mnist_tensorboard_artifact.py
@@ -232,7 +232,7 @@ with mlflow.start_run():
     loaded_model = mlflow.pytorch.load_model(mlflow.get_artifact_uri("pytorch-model"))
 
     # Extract a few examples from the test dataset to evaulate on
-    _, (eval_data, eval_labels) = next(enumerate(test_loader))
+    eval_data, eval_labels = next(iter(test_loader))
 
     # Make a few predictions
     predictions = loaded_model(eval_data).data.max(1)[1]

--- a/examples/pytorch/mnist_tensorboard_artifact.py
+++ b/examples/pytorch/mnist_tensorboard_artifact.py
@@ -225,15 +225,14 @@ with mlflow.start_run():
     print("\nLogging the trained model as a run artifact...")
     mlflow.pytorch.log_model(model, artifact_path="pytorch-model", pickle_module=pickle)
     print(
-            "\nThe model is logged at:\n%s"
-            % os.path.join(mlflow.get_artifact_uri(), "pytorch-model")
+        "\nThe model is logged at:\n%s" % os.path.join(mlflow.get_artifact_uri(), "pytorch-model")
     )
 
     # Since the model was logged as an artifact, it can be loaded to make predictions
     loaded_model = mlflow.pytorch.load_model(mlflow.get_artifact_uri("pytorch-model"))
 
     # Extract a few examples from the test dataset to evaulate on
-    _ , (eval_data, eval_labels) = next(enumerate(test_loader))
+    _, (eval_data, eval_labels) = next(enumerate(test_loader))
 
     # Make a few predictions
     predictions = loaded_model(eval_data).data.max(1)[1]

--- a/examples/pytorch/mnist_tensorboard_artifact.py
+++ b/examples/pytorch/mnist_tensorboard_artifact.py
@@ -11,6 +11,8 @@
 import argparse
 import os
 import mlflow
+import mlflow.pytorch
+import pickle
 import tempfile
 import torch
 import torch.nn as nn
@@ -218,3 +220,24 @@ with mlflow.start_run():
         "\nLaunch TensorBoard with:\n\ntensorboard --logdir=%s"
         % os.path.join(mlflow.get_artifact_uri(), "events")
     )
+
+    # Log the model as an artifact of the MLflow run.
+    print("\nLogging the trained model as a run artifact...")
+    mlflow.pytorch.log_model(model, artifact_path="pytorch-model", pickle_module=pickle)
+    print(
+            "\nThe model is logged at:\n%s"
+            % os.path.join(mlflow.get_artifact_uri(), "pytorch-model")
+    )
+
+    # Since the model was logged as an artifact, it can be loaded to make predictions
+    loaded_model = mlflow.pytorch.load_model(mlflow.get_artifact_uri("pytorch-model"))
+
+    # Extract a few examples from the test dataset to evaulate on
+    _ , (eval_data, eval_labels) = next(enumerate(test_loader))
+
+    # Make a few predictions
+    predictions = loaded_model(eval_data).data.max(1)[1]
+    template = 'Sample {} : Ground truth is "{}", model prediction is "{}"'
+    print("\nSample predictions")
+    for index in range(5):
+        print(template.format(index, eval_labels[index], predictions[index]))


### PR DESCRIPTION
Signed-off-by: Arjun DCunha <arjun.dcunha@databricks.com>

## What changes are proposed in this pull request?

Adding logging and scoring to the pytorch example.

## How is this patch tested?

Manually using mlflow run .

## Release Notes

### Is this a user-facing change?

- [ x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
