### PR TITLE
Verify valid JSON format in REST output

### DIFF
--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -111,7 +111,7 @@ def http_request_safe(host_creds, endpoint, **kwargs):
 
 
 def verify_rest_response(response, endpoint):
-    """Verify the return code and raise exception if the request was not successful."""
+    """Verify the return code and format, raise exception if the request was not successful."""
     if response.status_code != 200:
         if _can_parse_as_json(response.text):
             raise RestException(json.loads(response.text))
@@ -121,6 +121,13 @@ def verify_rest_response(response, endpoint):
                 response.status_code,
             )
             raise MlflowException("%s. Response body: '%s'" % (base_msg, response.text))
+
+    if not _can_parse_as_json(response.text):
+        base_msg = (
+            "API request to endpoint was successful but the response body was not in JSON format"
+        )
+        raise MlflowException("%s. Response body: '%s'" % (base_msg, response.text))
+
     return response
 
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -124,7 +124,8 @@ def verify_rest_response(response, endpoint):
 
     if not _can_parse_as_json(response.text):
         base_msg = (
-            "API request to endpoint was successful but the response body was not in JSON format"
+            "API request to endpoint was successful but the response body was not "
+            "in a valid JSON format"
         )
         raise MlflowException("%s. Response body: '%s'" % (base_msg, response.text))
 

--- a/tests/store/artifact/test_dbfs_rest_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_rest_artifact_repo.py
@@ -172,11 +172,7 @@ class TestDbfsArtifactRepository(object):
                 "/dbfs/test/test.txt",
                 "/dbfs/test/empty-file",
             }
-            assert set(data) == {
-                TEST_FILE_2_CONTENT,
-                TEST_FILE_3_CONTENT,
-                "",
-            }
+            assert set(data) == {TEST_FILE_2_CONTENT, TEST_FILE_3_CONTENT, ""}
 
     def test_log_artifacts_error(self, dbfs_artifact_repo, test_dir):
         with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
@@ -240,11 +236,7 @@ class TestDbfsArtifactRepository(object):
         with mock.patch(DBFS_ARTIFACT_REPOSITORY + "._dbfs_is_dir") as is_dir_mock, mock.patch(
             DBFS_ARTIFACT_REPOSITORY + "._dbfs_list_api"
         ) as list_mock, mock.patch(DBFS_ARTIFACT_REPOSITORY + "._dbfs_download") as download_mock:
-            is_dir_mock.side_effect = [
-                True,
-                False,
-                True,
-            ]
+            is_dir_mock.side_effect = [True, False, True]
             list_mock.side_effect = [
                 Mock(text=json.dumps(LIST_ARTIFACTS_RESPONSE)),
                 Mock(text="{}"),  # this call is for listing `/dir`.

--- a/tests/store/artifact/test_dbfs_rest_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_rest_artifact_repo.py
@@ -109,7 +109,7 @@ class TestDbfsArtifactRepository(object):
             def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
                 endpoints.append(kwargs["endpoint"])
                 data.append(kwargs["data"].read())
-                return Mock(status_code=200)
+                return Mock(status_code=200, text="{}")
 
             http_request_mock.side_effect = my_http_request
             dbfs_artifact_repo.log_artifact(test_file.strpath, artifact_path)
@@ -122,7 +122,7 @@ class TestDbfsArtifactRepository(object):
             def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
                 assert kwargs["endpoint"] == "/dbfs/test/empty-file"
                 assert kwargs["data"] == ""
-                return Mock(status_code=200)
+                return Mock(status_code=200, text="{}")
 
             http_request_mock.side_effect = my_http_request
             dbfs_artifact_repo.log_artifact(os.path.join(test_dir.strpath, "empty-file"))
@@ -133,7 +133,7 @@ class TestDbfsArtifactRepository(object):
             def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
                 assert kwargs["endpoint"] == "/dbfs/test/test.txt"
                 assert kwargs["data"].read() == TEST_FILE_1_CONTENT
-                return Mock(status_code=200)
+                return Mock(status_code=200, text="{}")
 
             http_request_mock.side_effect = my_http_request
             dbfs_artifact_repo.log_artifact(test_file.strpath, "")
@@ -163,7 +163,7 @@ class TestDbfsArtifactRepository(object):
                     data.append(kwargs["data"])
                 else:
                     data.append(kwargs["data"].read())
-                return Mock(status_code=200)
+                return Mock(status_code=200, text="{}")
 
             http_request_mock.side_effect = my_http_request
             dbfs_artifact_repo.log_artifacts(test_dir.strpath, artifact_path)
@@ -214,7 +214,7 @@ class TestDbfsArtifactRepository(object):
 
             def my_http_request(host_creds, **kwargs):  # pylint: disable=unused-argument
                 endpoints.append(kwargs["endpoint"])
-                return Mock(status_code=200)
+                return Mock(status_code=200, text="{}")
 
             http_request_mock.side_effect = my_http_request
             dbfs_artifact_repo.log_artifacts(test_dir.strpath, artifact_path)

--- a/tests/store/artifact/test_dbfs_rest_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_rest_artifact_repo.py
@@ -172,7 +172,11 @@ class TestDbfsArtifactRepository(object):
                 "/dbfs/test/test.txt",
                 "/dbfs/test/empty-file",
             }
-            assert set(data) == {TEST_FILE_2_CONTENT, TEST_FILE_3_CONTENT, ""}
+            assert set(data) == {
+                TEST_FILE_2_CONTENT,
+                TEST_FILE_3_CONTENT,
+                "",
+            }
 
     def test_log_artifacts_error(self, dbfs_artifact_repo, test_dir):
         with mock.patch("mlflow.utils.rest_utils.http_request") as http_request_mock:
@@ -236,7 +240,11 @@ class TestDbfsArtifactRepository(object):
         with mock.patch(DBFS_ARTIFACT_REPOSITORY + "._dbfs_is_dir") as is_dir_mock, mock.patch(
             DBFS_ARTIFACT_REPOSITORY + "._dbfs_list_api"
         ) as list_mock, mock.patch(DBFS_ARTIFACT_REPOSITORY + "._dbfs_download") as download_mock:
-            is_dir_mock.side_effect = [True, False, True]
+            is_dir_mock.side_effect = [
+                True,
+                False,
+                True,
+            ]
             list_mock.side_effect = [
                 Mock(text=json.dumps(LIST_ARTIFACTS_RESPONSE)),
                 Mock(text="{}"),  # this call is for listing `/dir`.

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -191,7 +191,7 @@ def test_http_request_wrapper(request):
     host_only = MlflowHostCreds("http://my-host", ignore_tls_verification=True)
     response = mock.MagicMock()
     response.status_code = 200
-    response.text = '{}'
+    response.text = "{}"
     request.return_value = response
     http_request_safe(host_only, "/my/endpoint")
     request.assert_called_with(
@@ -202,11 +202,11 @@ def test_http_request_wrapper(request):
     request.return_value = response
     with pytest.raises(MlflowException, match="Response body"):
         http_request_safe(host_only, "/my/endpoint")
-    response.text = (
-        '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "Node type not supported"}'
-    )
+    response.text = '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "Node type not supported"}'
     request.return_value = response
-    with pytest.raises(RestException, match="RESOURCE_DOES_NOT_EXIST: Node type not supported"):
+    with pytest.raises(
+        RestException, match="RESOURCE_DOES_NOT_EXIST: Node type not supported"
+    ):
         http_request_safe(host_only, "/my/endpoint")
 
 

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -39,7 +39,11 @@ def test_non_json_ok_response():
         request_mock.return_value = response_mock
 
         response_proto = GetRun.Response()
-        with pytest.raises(MlflowException):
+        with pytest.raises(
+            MlflowException,
+            match="API request to endpoint was successful but the response body was not "
+            "in a valid JSON format",
+        ):
             call_endpoint(host_only, "/my/endpoint", "GET", "", response_proto)
 
 

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -29,6 +29,18 @@ def test_well_formed_json_error_response():
         with pytest.raises(RestException):
             call_endpoint(host_only, "/my/endpoint", "GET", "", response_proto)
 
+def test_non_json_ok_response():
+    with mock.patch("requests.request") as request_mock:
+        host_only = MlflowHostCreds("http://my-host")
+        response_mock = mock.MagicMock()
+        response_mock.status_code = 200
+        response_mock.text = "<html></html>"
+        request_mock.return_value = response_mock
+
+        response_proto = GetRun.Response()
+        with pytest.raises(MlflowException):
+            call_endpoint(host_only, "/my/endpoint", "GET", "", response_proto)
+
 
 @pytest.mark.parametrize(
     "response_mock",
@@ -179,6 +191,7 @@ def test_http_request_wrapper(request):
     host_only = MlflowHostCreds("http://my-host", ignore_tls_verification=True)
     response = mock.MagicMock()
     response.status_code = 200
+    response.text = '{}'
     request.return_value = response
     http_request_safe(host_only, "/my/endpoint")
     request.assert_called_with(

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -73,7 +73,7 @@ def test_http_request_hostonly(request):
     request.return_value = response
     http_request(host_only, "/my/endpoint")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS
+        url="http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS,
     )
 
 
@@ -86,7 +86,7 @@ def test_http_request_cleans_hostname(request):
     request.return_value = response
     http_request(host_only, "/my/endpoint")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS
+        url="http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS,
     )
 
 
@@ -99,7 +99,9 @@ def test_http_request_with_basic_auth(request):
     http_request(host_only, "/my/endpoint")
     headers = dict(_DEFAULT_HEADERS)
     headers["Authorization"] = "Basic dXNlcjpwYXNz"
-    request.assert_called_with(url="http://my-host/my/endpoint", verify=True, headers=headers)
+    request.assert_called_with(
+        url="http://my-host/my/endpoint", verify=True, headers=headers,
+    )
 
 
 @mock.patch("requests.request")
@@ -111,7 +113,9 @@ def test_http_request_with_token(request):
     http_request(host_only, "/my/endpoint")
     headers = dict(_DEFAULT_HEADERS)
     headers["Authorization"] = "Bearer my-token"
-    request.assert_called_with(url="http://my-host/my/endpoint", verify=True, headers=headers)
+    request.assert_called_with(
+        url="http://my-host/my/endpoint", verify=True, headers=headers,
+    )
 
 
 @mock.patch("requests.request")
@@ -122,7 +126,7 @@ def test_http_request_with_insecure(request):
     request.return_value = response
     http_request(host_only, "/my/endpoint")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS
+        url="http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS,
     )
 
 
@@ -134,7 +138,7 @@ def test_http_request_client_cert_path(request):
     request.return_value = response
     http_request(host_only, "/my/endpoint")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=True, cert="/some/path", headers=_DEFAULT_HEADERS
+        url="http://my-host/my/endpoint", verify=True, cert="/some/path", headers=_DEFAULT_HEADERS,
     )
 
 
@@ -146,14 +150,14 @@ def test_http_request_server_cert_path(request):
     request.return_value = response
     http_request(host_only, "/my/endpoint")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify="/some/path", headers=_DEFAULT_HEADERS
+        url="http://my-host/my/endpoint", verify="/some/path", headers=_DEFAULT_HEADERS,
     )
 
 
 def test_ignore_tls_verification_not_server_cert_path():
     with pytest.raises(MlflowException):
         MlflowHostCreds(
-            "http://my-host", ignore_tls_verification=True, server_cert_path="/some/path"
+            "http://my-host", ignore_tls_verification=True, server_cert_path="/some/path",
         )
 
 
@@ -196,7 +200,7 @@ def test_http_request_wrapper(request):
     request.return_value = response
     http_request_safe(host_only, "/my/endpoint")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS
+        url="http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS,
     )
     response.status_code = 400
     response.text = ""

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -29,6 +29,7 @@ def test_well_formed_json_error_response():
         with pytest.raises(RestException):
             call_endpoint(host_only, "/my/endpoint", "GET", "", response_proto)
 
+
 def test_non_json_ok_response():
     with mock.patch("requests.request") as request_mock:
         host_only = MlflowHostCreds("http://my-host")
@@ -68,7 +69,7 @@ def test_http_request_hostonly(request):
     request.return_value = response
     http_request(host_only, "/my/endpoint")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS,
+        url="http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS
     )
 
 
@@ -81,7 +82,7 @@ def test_http_request_cleans_hostname(request):
     request.return_value = response
     http_request(host_only, "/my/endpoint")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS,
+        url="http://my-host/my/endpoint", verify=True, headers=_DEFAULT_HEADERS
     )
 
 
@@ -94,9 +95,7 @@ def test_http_request_with_basic_auth(request):
     http_request(host_only, "/my/endpoint")
     headers = dict(_DEFAULT_HEADERS)
     headers["Authorization"] = "Basic dXNlcjpwYXNz"
-    request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=True, headers=headers,
-    )
+    request.assert_called_with(url="http://my-host/my/endpoint", verify=True, headers=headers)
 
 
 @mock.patch("requests.request")
@@ -108,9 +107,7 @@ def test_http_request_with_token(request):
     http_request(host_only, "/my/endpoint")
     headers = dict(_DEFAULT_HEADERS)
     headers["Authorization"] = "Bearer my-token"
-    request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=True, headers=headers,
-    )
+    request.assert_called_with(url="http://my-host/my/endpoint", verify=True, headers=headers)
 
 
 @mock.patch("requests.request")
@@ -121,7 +118,7 @@ def test_http_request_with_insecure(request):
     request.return_value = response
     http_request(host_only, "/my/endpoint")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS,
+        url="http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS
     )
 
 
@@ -133,7 +130,7 @@ def test_http_request_client_cert_path(request):
     request.return_value = response
     http_request(host_only, "/my/endpoint")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=True, cert="/some/path", headers=_DEFAULT_HEADERS,
+        url="http://my-host/my/endpoint", verify=True, cert="/some/path", headers=_DEFAULT_HEADERS
     )
 
 
@@ -145,14 +142,14 @@ def test_http_request_server_cert_path(request):
     request.return_value = response
     http_request(host_only, "/my/endpoint")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify="/some/path", headers=_DEFAULT_HEADERS,
+        url="http://my-host/my/endpoint", verify="/some/path", headers=_DEFAULT_HEADERS
     )
 
 
 def test_ignore_tls_verification_not_server_cert_path():
     with pytest.raises(MlflowException):
         MlflowHostCreds(
-            "http://my-host", ignore_tls_verification=True, server_cert_path="/some/path",
+            "http://my-host", ignore_tls_verification=True, server_cert_path="/some/path"
         )
 
 
@@ -195,18 +192,18 @@ def test_http_request_wrapper(request):
     request.return_value = response
     http_request_safe(host_only, "/my/endpoint")
     request.assert_called_with(
-        url="http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS,
+        url="http://my-host/my/endpoint", verify=False, headers=_DEFAULT_HEADERS
     )
     response.status_code = 400
     response.text = ""
     request.return_value = response
     with pytest.raises(MlflowException, match="Response body"):
         http_request_safe(host_only, "/my/endpoint")
-    response.text = '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "Node type not supported"}'
+    response.text = (
+        '{"error_code": "RESOURCE_DOES_NOT_EXIST", "message": "Node type not supported"}'
+    )
     request.return_value = response
-    with pytest.raises(
-        RestException, match="RESOURCE_DOES_NOT_EXIST: Node type not supported"
-    ):
+    with pytest.raises(RestException, match="RESOURCE_DOES_NOT_EXIST: Node type not supported"):
         http_request_safe(host_only, "/my/endpoint")
 
 


### PR DESCRIPTION
Signed-off-by: Bram Rodenburg <bramrodenburg@live.nl>

## What changes are proposed in this pull request?

- Added a check for verifying that the REST response is in valid JSON. (Related to issue https://github.com/mlflow/mlflow/issues/3301)

## How is this patch tested?

- Added unit test

## Release Notes

### Is this a user-facing change?

- [] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Show a proper error message when the the returned REST response is not in valid JSON.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [X] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
