### PR TITLE
Added support for high dimensional onnx models

### DIFF
--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -206,7 +206,8 @@ class _OnnxModelWrapper:
             feed_dict = {inp.name: column_data[inp.name] for inp in self.inputs}
         elif number_inputs > 1 and number_inputs != number_columns:
             raise MlflowException(
-                "Invalid input to model: The number of columns in the dataframe is not equal to  the number of model inputs."
+                "Invalid input to model: The number of columns in the dataframe is not"
+                + " equal to  the number of model inputs."
             )
         elif number_inputs == 1:
             cols = dataframe.columns if self.inputs[0].type == "tensor(float)" else []

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -150,8 +150,7 @@ def high_dim_model():
         t_in1 = tf.placeholder(tf.int32, (1, 2, 2), name="first_input")
         t_in2 = tf.placeholder(tf.int32, (1, 2, 2), name="second_input")
         t_out = tf.add(t_in1, t_in2)
-        t_out_named = tf.identity(t_out, name="output")
-
+        tf.identity(t_out, name="output")
     import tf2onnx
 
     sess = tf.Session(graph=graph)
@@ -255,10 +254,9 @@ def test_signature_and_examples_are_saved_correctly(onnx_model, data, onnx_custo
 # TODO: Mark this as large once MLflow's Travis build supports the onnxruntime library
 @pytest.mark.release
 def test_model_save_load_evaluate_pyfunc_format(onnx_model, model_path, data, predicted):
-    import onnx
     import mlflow.onnx
 
-    x, y = data
+    x, _ = data
     mlflow.onnx.save_model(onnx_model, model_path)
 
     # Loading pyfunc model
@@ -349,7 +347,6 @@ def test_pyfunc_representation_of_float32_model_casts_and_evalutes_float64_input
     precision (e.g., 32-bit floats may be converted to 64-bit floats when persisting a
     DataFrame as JSON).
     """
-    import onnx
     import mlflow.onnx
 
     mlflow.onnx.save_model(onnx_model_multiple_inputs_float32, model_path)
@@ -369,7 +366,6 @@ def test_pyfunc_representation_of_float32_model_casts_and_evalutes_float64_input
 def test_pyfunc_high_dim_models(
     high_dim_model, model_path, data_high_dim_inputs, predicted_high_dim_inputs,
 ):
-    import onnx
     import mlflow.onnx
 
     mlflow.onnx.save_model(high_dim_model, model_path)
@@ -386,7 +382,6 @@ def test_pyfunc_high_dim_models(
 def test_pyfunc_incorrect_input(
     high_dim_model, model_path,
 ):
-    import onnx
     import mlflow.onnx
 
     mlflow.onnx.save_model(high_dim_model, model_path)
@@ -460,10 +455,9 @@ def test_log_model_no_registered_model_name(onnx_model, onnx_custom_env):
 # TODO: Mark this as large once MLflow's Travis build supports the onnxruntime library
 @pytest.mark.release
 def test_model_log_evaluate_pyfunc_format(onnx_model, data, predicted):
-    import onnx
     import mlflow.onnx
 
-    x, y = data
+    x, _ = data
     # should_start_run tests whether or not calling log_model() automatically starts a run.
     for should_start_run in [False, True]:
         try:

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -157,7 +157,7 @@ def high_dim_model():
     sess = tf.Session(graph=graph)
 
     onnx_graph = tf2onnx.tfonnx.process_tf_graph(
-        sess.graph, input_names=["first_input:0", "second_input:0",], output_names=["output:0"],
+        sess.graph, input_names=["first_input:0", "second_input:0"], output_names=["output:0"]
     )
     model_proto = onnx_graph.make_model("test")
     return model_proto


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #3229 

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
