### PR TITLE
feat: adding dest directory in artifacts download

### DIFF
--- a/mlflow/store/artifact/cli.py
+++ b/mlflow/store/artifact/cli.py
@@ -107,7 +107,13 @@ def _file_infos_to_json(file_infos):
     help="URI pointing to the artifact file or artifacts directory; use as an "
     "alternative to specifying --run_id and --artifact-path",
 )
-def download_artifacts(run_id, artifact_path, artifact_uri):
+@click.option(
+    "--dest-path",
+    "-d",
+    help="Destination path where you want to store the artifacts,"
+    "default is in temporary directory: /tmp/XXXXX/"
+)
+def download_artifacts(run_id, artifact_path, artifact_uri, dest_path=None):
     """
     Download an artifact file or directory to a local directory.
     The output is the name of the file or directory on the local disk.
@@ -126,7 +132,7 @@ def download_artifacts(run_id, artifact_path, artifact_uri):
     store = _get_store()
     artifact_uri = store.get_run(run_id).info.artifact_uri
     artifact_repo = get_artifact_repository(artifact_uri)
-    artifact_location = artifact_repo.download_artifacts(artifact_path)
+    artifact_location = artifact_repo.download_artifacts(artifact_path, dest_path)
     print(artifact_location)
 
 

--- a/mlflow/store/artifact/cli.py
+++ b/mlflow/store/artifact/cli.py
@@ -111,7 +111,7 @@ def _file_infos_to_json(file_infos):
     "--dest-path",
     "-d",
     help="Destination path where you want to store the artifacts,"
-    "default is in temporary directory: /tmp/XXXXX/"
+    "default is in temporary directory: /tmp/XXXXX/",
 )
 def download_artifacts(run_id, artifact_path, artifact_uri, dest_path=None):
     """


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding destination directory option in `mlflow artifacts download --dest-path "./"`

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
