### PR TITLE
Scikit-learn autologging specializations for parameter search

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -516,9 +516,9 @@ def autolog():
     **When is autologging performed?**
       Autologging is performed when you call:
 
-      - ``estimator.fit``
-      - ``estimator.fit_predict``
-      - ``estimator.fit_transform``
+      - ``estimator.fit()``
+      - ``estimator.fit_predict()``
+      - ``estimator.fit_transform()``
 
     **Logged information**
       **Parameters**
@@ -528,7 +528,7 @@ def autolog():
 
       **Metrics**
         - A training score obtained by ``estimator.score``. Note that the training score is
-          computed using parameters given to ``fit``.
+          computed using parameters given to ``fit()``.
 
       **Tags**
         - An estimator class name (e.g. "LinearRegression").
@@ -539,12 +539,20 @@ def autolog():
         - A fitted estimator (logged by :py:func:`mlflow.sklearn.log_model()`).
 
     **How does autologging work for meta estimators?**
-      When a meta estimator (e.g. `Pipeline`_, `GridSearchCV`_) calls ``fit``, it internally calls
-      ``fit`` on its child estimators. Autologging does NOT perform logging on these constituent
-      ``fit``.
+      When a meta estimator (e.g. `Pipeline`_, `GridSearchCV`_) calls ``fit()``, it internally calls
+      ``fit()`` on its child estimators. Autologging does NOT perform logging on these constituent
+      ``fit()`` calls.
+
+      **Parameter search**
+          In addition to recording the information discussed above, autologging for parameter
+          search meta estimators (`GridSearchCV`_ and `RandomizedSearchCV`_) records child runs
+          with metrics for each set of explored parameters, as well as artifacts and parameters
+          for the best model (if available).
 
     **Supported estimators**
-      All estimators obtained by `sklearn.utils.all_estimators`_ (including meta estimators).
+      - All estimators obtained by `sklearn.utils.all_estimators`_ (including meta estimators).
+      - `Pipeline`_
+      - Parameter search estimators (`GridSearchCV`_ and `RandomizedSearchCV`_)
 
     .. _sklearn.utils.all_estimators:
         https://scikit-learn.org/stable/modules/generated/sklearn.utils.all_estimators.html
@@ -554,6 +562,9 @@ def autolog():
 
     .. _GridSearchCV:
         https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html
+
+    .. _RandomizedSearchCV:
+        https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.RandomizedSearchCV.html
 
     **Example**
 
@@ -601,6 +612,7 @@ def autolog():
         # ['model/MLmodel', 'model/conda.yaml', 'model/model.pkl']
     """
     import sklearn
+    import pandas as pd
     from mlflow.sklearn.utils import (
         _MIN_SKLEARN_VERSION,
         _is_supported_version,
@@ -608,7 +620,13 @@ def autolog():
         _get_args_for_score,
         _all_estimators,
         _truncate_dict,
+        _get_estimator_info_tags,
+        _get_meta_estimators_for_autologging,
+        _is_parameter_search_estimator,
+        _log_parameter_search_results_as_artifact,
+        _create_child_runs_for_parameter_search,
     )
+    from mlflow.tracking.context import registry as context_registry
     from mlflow.utils.validation import (
         MAX_PARAMS_TAGS_PER_BATCH,
         MAX_PARAM_VAL_LENGTH,
@@ -629,21 +647,7 @@ def autolog():
         if should_start_run:
             try_mlflow_log(mlflow.start_run)
 
-        # TODO: We should not log nested estimator parameters for
-        # parameter search estimators (GridSearchCV, RandomizedSearchCV)
-
-        # Chunk and truncate model parameters to avoid hitting the log_batch API limit
-        for chunk in _chunk_dict(self.get_params(deep=True), chunk_size=MAX_PARAMS_TAGS_PER_BATCH):
-            truncated = _truncate_dict(chunk, MAX_ENTITY_KEY_LENGTH, MAX_PARAM_VAL_LENGTH)
-            try_mlflow_log(mlflow.log_params, truncated)
-
-        try_mlflow_log(
-            mlflow.set_tags,
-            {
-                "estimator_name": self.__class__.__name__,
-                "estimator_class": self.__class__.__module__ + "." + self.__class__.__name__,
-            },
-        )
+        _log_pretraining_metadata(self, *args, **kwargs)
 
         original_fit = gorilla.get_original_attribute(self, func_name)
         try:
@@ -654,13 +658,61 @@ def autolog():
 
             raise e
 
-        if hasattr(self, "score"):
+        _log_posttraining_metadata(self, *args, **kwargs)
+
+        if should_start_run:
+            try_mlflow_log(mlflow.end_run)
+
+        return fit_output
+
+    def _log_pretraining_metadata(estimator, *args, **kwargs):  # pylint: disable=unused-argument
+        """
+        Records metadata (e.g., params and tags) for a scikit-learn estimator prior to training.
+        This is intended to be invoked within a patched scikit-learn training routine
+        (e.g., `fit()`, `fit_transform()`, ...) and assumes the existence of an active
+        MLflow run that can be referenced via the fluent Tracking API.
+
+        :param estimator: The scikit-learn estimator for which to log metadata.
+        :param args: The arguments passed to the scikit-learn training routine (e.g.,
+                     `fit()`, `fit_transform()`, ...).
+        :param kwargs: The keyword arguments passed to the scikit-learn training routine.
+        """
+        # Deep parameter logging includes parameters from children of a given
+        # estimator. For some meta estimators (e.g., pipelines), recording
+        # these parameters is desirable. For parameter search estimators,
+        # however, child estimators act as seeds for the parameter search
+        # process; accordingly, we avoid logging initial, untuned parameters
+        # for these seed estimators.
+        should_log_params_deeply = not _is_parameter_search_estimator(estimator)
+        # Chunk model parameters to avoid hitting the log_batch API limit
+        for chunk in _chunk_dict(
+            estimator.get_params(deep=should_log_params_deeply),
+            chunk_size=MAX_PARAMS_TAGS_PER_BATCH,
+        ):
+            truncated = _truncate_dict(chunk, MAX_ENTITY_KEY_LENGTH, MAX_PARAM_VAL_LENGTH)
+            try_mlflow_log(mlflow.log_params, truncated)
+
+        try_mlflow_log(mlflow.set_tags, _get_estimator_info_tags(estimator))
+
+    def _log_posttraining_metadata(estimator, *args, **kwargs):
+        """
+        Records metadata for a scikit-learn estimator after training has completed.
+        This is intended to be invoked within a patched scikit-learn training routine
+        (e.g., `fit()`, `fit_transform()`, ...) and assumes the existence of an active
+        MLflow run that can be referenced via the fluent Tracking API.
+
+        :param estimator: The scikit-learn estimator for which to log metadata.
+        :param args: The arguments passed to the scikit-learn training routine (e.g.,
+                     `fit()`, `fit_transform()`, ...).
+        :param kwargs: The keyword arguments passed to the scikit-learn training routine.
+        """
+        if hasattr(estimator, "score"):
             try:
-                score_args = _get_args_for_score(self.score, self.fit, args, kwargs)
-                training_score = self.score(*score_args)
+                score_args = _get_args_for_score(estimator.score, estimator.fit, args, kwargs)
+                training_score = estimator.score(*score_args)
             except Exception as e:  # pylint: disable=broad-except
                 msg = (
-                    self.score.__qualname__
+                    estimator.score.__qualname__
                     + " failed. The 'training_score' metric will not be recorded. Scoring error: "
                     + str(e)
                 )
@@ -668,12 +720,49 @@ def autolog():
             else:
                 try_mlflow_log(mlflow.log_metric, "training_score", training_score)
 
-        try_mlflow_log(log_model, self, artifact_path="model")
+        try_mlflow_log(log_model, estimator, artifact_path="model")
 
-        if should_start_run:
-            try_mlflow_log(mlflow.end_run)
+        if _is_parameter_search_estimator(estimator):
+            if hasattr(estimator, "best_estimator_"):
+                try_mlflow_log(log_model, estimator.best_estimator_, artifact_path="best_estimator")
 
-        return fit_output
+            if hasattr(estimator, "best_params_"):
+                best_params = {
+                    "best_{param_name}".format(param_name=param_name): param_value
+                    for param_name, param_value in estimator.best_params_.items()
+                }
+                try_mlflow_log(mlflow.log_params, best_params)
+
+            if hasattr(estimator, "cv_results_"):
+                try:
+                    # Fetch environment-specific tags (e.g., user and source) to ensure that lineage
+                    # information is consistent with the parent run
+                    environment_tags = context_registry.resolve_tags()
+                    _create_child_runs_for_parameter_search(
+                        cv_estimator=estimator,
+                        parent_run=mlflow.active_run(),
+                        child_tags=environment_tags,
+                    )
+                except Exception as e:  # pylint: disable=broad-except
+
+                    msg = (
+                        "Encountered exception during creation of child runs for parameter search."
+                        " Child runs may be missing. Exception: {}".format(str(e))
+                    )
+                    _logger.warning(msg)
+
+                try:
+                    cv_results_df = pd.DataFrame.from_dict(estimator.cv_results_)
+                    _log_parameter_search_results_as_artifact(
+                        cv_results_df, mlflow.active_run().info.run_id
+                    )
+                except Exception as e:  # pylint: disable=broad-except
+
+                    msg = (
+                        "Failed to log parameter search results as an artifact."
+                        " Exception: {}".format(str(e))
+                    )
+                    _logger.warning(msg)
 
     def patched_fit(self, func_name, *args, **kwargs):
         """
@@ -694,7 +783,13 @@ def autolog():
         return f
 
     patch_settings = gorilla.Settings(allow_hit=True, store_hit=True)
-    for _, class_def in _all_estimators():
+    _, estimators_to_patch = zip(*_all_estimators())
+    # Ensure that relevant meta estimators (e.g. GridSearchCV, Pipeline) are selected
+    # for patching if they are not already included in the output of `all_estimators()`
+    estimators_to_patch = set(estimators_to_patch).union(
+        set(_get_meta_estimators_for_autologging())
+    )
+    for class_def in estimators_to_patch:
         for func_name in ["fit", "fit_transform", "fit_predict"]:
             if hasattr(class_def, func_name):
                 original = getattr(class_def, func_name)

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -2,6 +2,21 @@ from distutils.version import LooseVersion
 import inspect
 from itertools import islice
 import logging
+from numbers import Number
+import time
+
+from mlflow.entities import Metric, Param
+from mlflow.tracking.client import MlflowClient
+from mlflow.utils.autologging_utils import try_mlflow_log
+from mlflow.utils.file_utils import TempDir
+from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID
+from mlflow.utils.validation import (
+    MAX_PARAMS_TAGS_PER_BATCH,
+    MAX_METRICS_PER_BATCH,
+    MAX_ENTITIES_PER_BATCH,
+    MAX_ENTITY_KEY_LENGTH,
+    MAX_PARAM_VAL_LENGTH,
+)
 
 _logger = logging.getLogger(__name__)
 
@@ -10,6 +25,17 @@ _logger = logging.getLogger(__name__)
 _MIN_SKLEARN_VERSION = "0.20.3"
 
 _SAMPLE_WEIGHT = "sample_weight"
+
+
+def _get_estimator_info_tags(estimator):
+    """
+    :return: A dictionary of MLflow run tag keys and values
+             describing the specified estimator.
+    """
+    return {
+        "estimator_name": estimator.__class__.__name__,
+        "estimator_class": (estimator.__class__.__module__ + "." + estimator.__class__.__name__),
+    }
 
 
 def _get_Xy(args, kwargs, X_var_name, y_var_name):
@@ -66,7 +92,7 @@ def _get_args_for_score(score_func, fit_func, fit_args, fit_kwargs):
 
     # In most cases, X_var_name and y_var_name become "X" and "y", respectively.
     # However, certain sklearn models use different variable names for X and y.
-    # See: https://scikit-learn.org/stable/modules/generated/sklearn.covariance.GraphicalLasso.html#sklearn.covariance.GraphicalLasso.score # noqa: E501
+    # E.g., see: https://scikit-learn.org/stable/modules/generated/sklearn.multioutput.MultiOutputClassifier.html#sklearn.multioutput.MultiOutputClassifier.fit # noqa: E501
     X_var_name, y_var_name = fit_arg_names[:2]
     Xy = _get_Xy(fit_args, fit_kwargs, X_var_name, y_var_name)
 
@@ -86,6 +112,9 @@ def _chunk_dict(d, chunk_size):
 
 
 def _truncate_dict(d, max_key_length=None, max_value_length=None):
+    def _truncate_and_ellipsize(value, max_length):
+        return str(value)[: (max_length - 3)] + "..."
+
     key_is_none = max_key_length is None
     val_is_none = max_value_length is None
 
@@ -97,19 +126,174 @@ def _truncate_dict(d, max_key_length=None, max_value_length=None):
         should_truncate_key = (not key_is_none) and (len(str(k)) > max_key_length)
         should_truncate_val = (not val_is_none) and (len(str(v)) > max_value_length)
 
-        new_k = str(k)[:max_key_length] if should_truncate_key else k
+        new_k = _truncate_and_ellipsize(k, max_key_length) if should_truncate_key else k
         if should_truncate_key:
-            msg = "Truncated the key `{}`".format(k)
+            # Use the truncated key for warning logs to avoid noisy printing to stdout
+            msg = "Truncated the key `{}`".format(new_k)
             _logger.warning(msg)
 
-        new_v = str(v)[:max_value_length] if should_truncate_val else v
+        new_v = _truncate_and_ellipsize(v, max_value_length) if should_truncate_val else v
         if should_truncate_val:
-            msg = "Truncated the value `{}` (in the key `{}`)".format(v, k)
+            # Use the truncated key and value for warning logs to avoid noisy printing to stdout
+            msg = "Truncated the value of the key `{}`. Truncated value: `{}`".format(new_k, new_v)
             _logger.warning(msg)
 
         truncated[new_k] = new_v
 
     return truncated
+
+
+def _get_meta_estimators_for_autologging():
+    """
+    :return: A list of meta estimator class definitions
+             (e.g., `sklearn.model_selection.GridSearchCV`) that should be included
+             when patching training functions for autologging
+    """
+    from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
+    from sklearn.pipeline import Pipeline
+
+    return [
+        GridSearchCV,
+        RandomizedSearchCV,
+        Pipeline,
+    ]
+
+
+def _is_parameter_search_estimator(estimator):
+    """
+    :return: `True` if the specified scikit-learn estimator is a parameter search estimator,
+             such as `GridSearchCV`. `False` otherwise.
+    """
+    from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
+
+    parameter_search_estimators = [
+        GridSearchCV,
+        RandomizedSearchCV,
+    ]
+
+    return any(
+        [
+            isinstance(estimator, param_search_estimator)
+            for param_search_estimator in parameter_search_estimators
+        ]
+    )
+
+
+def _log_parameter_search_results_as_artifact(cv_results_df, run_id):
+    """
+    Records a collection of parameter search results as an MLflow artifact
+    for the specified run.
+
+    :param cv_results_df: A Pandas DataFrame containing the results of a parameter search
+                          training session, which may be obtained by parsing the `cv_results_`
+                          attribute of a trained parameter search estimator such as
+                          `GridSearchCV`.
+    :param run_id: The ID of the MLflow Run to which the artifact should be recorded.
+    """
+    with TempDir() as t:
+        results_path = t.path("cv_results.csv")
+        cv_results_df.to_csv(results_path, index=False)
+        try_mlflow_log(MlflowClient().log_artifact, run_id, results_path)
+
+
+def _create_child_runs_for_parameter_search(cv_estimator, parent_run, child_tags=None):
+    """
+    Creates a collection of child runs for a parameter search training session.
+    Runs are reconstructed from the `cv_results_` attribute of the specified trained
+    parameter search estimator - `cv_estimator`, which provides relevant performance
+    metrics for each point in the parameter search space. One child run is created
+    for each point in the parameter search space. For additional information, see
+    `https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html`_. # noqa: E501
+
+    :param cv_estimator: The trained parameter search estimator for which to create
+                         child runs.
+    :param parent_run: A py:class:`mlflow.entities.Run` object referring to the parent
+                       parameter search run for which child runs should be created.
+    :param child_tags: An optional dictionary of MLflow tag keys and values to log
+                       for each child run.
+    """
+    import pandas as pd
+
+    client = MlflowClient()
+    # Use the start time of the parent parameter search run as a rough estimate for the
+    # start time of child runs, since we cannot precisely determine when each point
+    # in the parameter search space was explored
+    child_run_start_time = parent_run.info.start_time
+    child_run_end_time = int(time.time() * 1000)
+
+    seed_estimator = cv_estimator.estimator
+    # In the unlikely case that a seed of a parameter search estimator is,
+    # itself, a parameter search estimator, we should avoid logging the untuned
+    # parameters of the seeds's seed estimator
+    should_log_params_deeply = not _is_parameter_search_estimator(seed_estimator)
+    # Each row of `cv_results_` only provides parameters that vary across
+    # the user-specified parameter grid. In order to log the complete set
+    # of parameters for each child run, we fetch the parameters defined by
+    # the seed estimator and update them with parameter subset specified
+    # in the result row
+    base_params = seed_estimator.get_params(deep=should_log_params_deeply)
+
+    cv_results_df = pd.DataFrame.from_dict(cv_estimator.cv_results_)
+    for _, result_row in cv_results_df.iterrows():
+        tags_to_log = dict(child_tags) if child_tags else {}
+        tags_to_log.update({MLFLOW_PARENT_RUN_ID: parent_run.info.run_id})
+        tags_to_log.update(_get_estimator_info_tags(seed_estimator))
+        child_run = client.create_run(
+            experiment_id=parent_run.info.experiment_id,
+            start_time=child_run_start_time,
+            tags=tags_to_log,
+        )
+
+        from itertools import zip_longest
+
+        params_to_log = dict(base_params)
+        params_to_log.update(result_row.get("params", {}))
+        param_batches_to_log = _chunk_dict(params_to_log, chunk_size=MAX_PARAMS_TAGS_PER_BATCH)
+
+        # Parameters values are recorded twice in the set of search `cv_results_`:
+        # once within a `params` column with dictionary values and once within
+        # a separate dataframe column that is created for each parameter. To prevent
+        # duplication of parameters, we log the consolidated values from the parameter
+        # dictionary column and filter out the other parameter-specific columns with
+        # names of the form `param_{param_name}`. Additionally, `cv_results_` produces
+        # metrics for each training split, which is fairly verbose; accordingly, we filter
+        # out per-split metrics in favor of aggregate metrics (mean, std, etc.)
+        excluded_metric_prefixes = ["param", "split"]
+        metric_batches_to_log = _chunk_dict(
+            {
+                key: value
+                for key, value in result_row.iteritems()
+                if not any([key.startswith(prefix) for prefix in excluded_metric_prefixes])
+                and isinstance(value, Number)
+            },
+            chunk_size=min(
+                MAX_ENTITIES_PER_BATCH - MAX_PARAMS_TAGS_PER_BATCH, MAX_METRICS_PER_BATCH
+            ),
+        )
+
+        for params_batch, metrics_batch in zip_longest(
+            param_batches_to_log, metric_batches_to_log, fillvalue={}
+        ):
+            # Trim any parameter keys / values and metric keys that exceed the limits
+            # imposed by corresponding MLflow Tracking APIs (e.g., LogParam, LogMetric)
+            truncated_params_batch = _truncate_dict(
+                params_batch, MAX_ENTITY_KEY_LENGTH, MAX_PARAM_VAL_LENGTH
+            )
+            truncated_metrics_batch = _truncate_dict(
+                metrics_batch, max_key_length=MAX_ENTITY_KEY_LENGTH
+            )
+            client.log_batch(
+                run_id=child_run.info.run_id,
+                params=[
+                    Param(str(key), str(value)) for key, value in truncated_params_batch.items()
+                ],
+                metrics=[
+                    Metric(key=str(key), value=value, timestamp=child_run_end_time, step=0)
+                    for key, value in truncated_metrics_batch.items()
+                ],
+            )
+
+        client.set_terminated(run_id=child_run.info.run_id, end_time=child_run_end_time)
 
 
 def _is_supported_version():


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR introduces specialized autologging behavior for parameter search:

- Child runs are reconstructed based on search results (`estimator.cv_results_`)
- Search results (`estimator.cv_results_`) are logged as an artifact
- The best estimator is logged as an artifact (when `refit=True`)
- The set of best parameters is logged (when `refit=True`)

## How is this patch tested?

Included unit tests + manual testing of GridSearchCV and RandomizedSearchCV with varying inputs

## Release Notes

Introduce autologging for scikit-learn (along with #3287)

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
