### PR TITLE
Add addition metrics for sklearn auto logging

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -531,6 +531,56 @@ def autolog():
       **Metrics**
         - A training score obtained by ``estimator.score``. Note that the training score is
           computed using parameters given to ``fit()``.
+        - Common metrics for classifier:
+
+          - `precision score`_
+
+          .. _precision score:
+              https://scikit-learn.org/stable/modules/generated/sklearn.metrics.precision_score.html
+
+          - `recall score`_
+
+          .. _recall score:
+              https://scikit-learn.org/stable/modules/generated/sklearn.metrics.recall_score.html
+
+          - `f1 score`_
+
+          .. _f1 score:
+              https://scikit-learn.org/stable/modules/generated/sklearn.metrics.f1_score.html
+
+          - `accuracy score`_
+
+          .. _accuracy score:
+              https://scikit-learn.org/stable/modules/generated/sklearn.metrics.accuracy_score.html
+
+          If the classifier has method ``predict_proba``, we additionally log:
+
+          - `log loss`_
+
+          .. _log loss:
+              https://scikit-learn.org/stable/modules/generated/sklearn.metrics.log_loss.html
+
+          - `roc auc score`_
+
+          .. _roc auc score:
+              https://scikit-learn.org/stable/modules/generated/sklearn.metrics.roc_auc_score.html
+
+        - Common metrics for regressor:
+
+          - `(root) mean squared error`_
+
+          .. _(root) mean squared error:
+              https://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_squared_error.html
+
+          - `mean absolute error`_
+
+          .. _mean absolute error:
+              https://scikit-learn.org/stable/modules/generated/sklearn.metrics.mean_absolute_error.html
+
+          - `r2 score`_
+
+          .. _r2 score:
+              https://scikit-learn.org/stable/modules/generated/sklearn.metrics.r2_score.html
 
       **Tags**
         - An estimator class name (e.g. "LinearRegression").
@@ -626,6 +676,7 @@ def autolog():
         _is_supported_version,
         _chunk_dict,
         _get_args_for_score,
+        _log_specialized_estimator_content,
         _get_Xy,
         _all_estimators,
         _truncate_dict,
@@ -730,6 +781,9 @@ def autolog():
             else:
                 try_mlflow_log(mlflow.log_metric, "training_score", training_score)
 
+        # log common metrics and artifacts for estimators (classifier, regressor)
+        _log_specialized_estimator_content(estimator, mlflow.active_run().info.run_id, args, kwargs)
+
         input_example = None
         signature = None
         if hasattr(estimator, "predict"):
@@ -829,6 +883,7 @@ def autolog():
     estimators_to_patch = set(estimators_to_patch).union(
         set(_get_meta_estimators_for_autologging())
     )
+
     for class_def in estimators_to_patch:
         for func_name in ["fit", "fit_transform", "fit_predict"]:
             if hasattr(class_def, func_name):


### PR DESCRIPTION
## What changes are proposed in this pull request?

auto-log common metrics for classifiers & regressors

For classifier:
(1) accuracy_score
(2) log_loss (for classifier with **predict_proba** method)
(3) f1_score
(4) precision_score
(5) recall_score
(6) roc_auc_score (for classifier with **predict_proba** method, and with Sklearn version above **0.22.2**)

For regressor:
(1) mean_squared_error
(2) root_mean_squared_error
(3) r2_score
(4) mean_absolute_error

## How is this patch tested?

Through full coverage of unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
