### PR TITLE
Support remote Databricks model registries in `mlflow.<flavor>.load_model`

### DIFF
--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -1,5 +1,6 @@
 from six.moves import urllib
 
+import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository
 from mlflow.utils.uri import (
@@ -66,7 +67,9 @@ class ModelsArtifactRepository(ArtifactRepository):
         # we'll need to add setting of registry URIs via environment variables.
         from mlflow.tracking import MlflowClient
 
-        databricks_profile_uri = get_databricks_profile_uri_from_artifact_uri(uri)
+        databricks_profile_uri = (
+            get_databricks_profile_uri_from_artifact_uri(uri) or mlflow.get_registry_uri()
+        )
         client = MlflowClient(registry_uri=databricks_profile_uri)
         (name, version, stage) = ModelsArtifactRepository._parse_uri(uri)
         if stage is not None:

--- a/tests/store/artifact/test_models_artifact_repo.py
+++ b/tests/store/artifact/test_models_artifact_repo.py
@@ -67,8 +67,9 @@ def test_parse_models_uri_invalid_input(uri):
         ModelsArtifactRepository._parse_uri(uri)
 
 
-@pytest.mark.parametrize('artifact_location',
-                         ["dbfs:/databricks/mlflow-registry/12345/models/keras-model"])
+@pytest.mark.parametrize(
+    "artifact_location", ["dbfs:/databricks/mlflow-registry/12345/models/keras-model"]
+)
 def test_models_artifact_repo_init_with_version_uri(
     host_creds_mock, mock_get_model_version_download_uri, artifact_location
 ):  # pylint: disable=unused-argument
@@ -90,10 +91,12 @@ def test_models_artifact_repo_init_with_version_uri(
             "dbfs:/databricks/mlflow-registry/12345/models/keras-model"
         )
 
-@pytest.mark.parametrize('artifact_location',
-                         ["dbfs:/databricks/mlflow-registry/12345/models/keras-model"])
+
+@pytest.mark.parametrize(
+    "artifact_location", ["dbfs:/databricks/mlflow-registry/12345/models/keras-model"]
+)
 def test_models_artifact_repo_init_with_version_uri_and_db_profile(
-    mock_get_model_version_download_uri
+    mock_get_model_version_download_uri,
 ):  # pylint: disable=unused-argument
     model_uri = "models://profile@databricks/MyModel/12"
     final_uri = "dbfs://profile@databricks/databricks/mlflow-registry/12345/models/keras-model"
@@ -106,10 +109,11 @@ def test_models_artifact_repo_init_with_version_uri_and_db_profile(
         mock_repo.assert_called_once_with(final_uri)
 
 
-@pytest.mark.parametrize('artifact_location',
-                         ["dbfs:/databricks/mlflow-registry/12345/models/keras-model"])
+@pytest.mark.parametrize(
+    "artifact_location", ["dbfs:/databricks/mlflow-registry/12345/models/keras-model"]
+)
 def test_models_artifact_repo_init_with_version_uri_and_db_profile_from_context(
-        mock_get_model_version_download_uri
+    mock_get_model_version_download_uri,
 ):  # pylint: disable=unused-argument
     model_uri = "models:/MyModel/12"
     with mock.patch(
@@ -123,10 +127,11 @@ def test_models_artifact_repo_init_with_version_uri_and_db_profile_from_context(
         )
 
 
-@pytest.mark.parametrize('artifact_location',
-                         ["dbfs:/databricks/mlflow-registry/12345/models/keras-model"])
+@pytest.mark.parametrize(
+    "artifact_location", ["dbfs:/databricks/mlflow-registry/12345/models/keras-model"]
+)
 def test_models_artifact_repo_init_with_version_uri_and_bad_db_profile_from_context(
-    mock_get_model_version_download_uri
+    mock_get_model_version_download_uri,
 ):  # pylint: disable=unused-argument
     model_uri = "models:/MyModel/12"
     with mock.patch("mlflow.get_registry_uri", return_value="databricks://scope:key:invalid"):
@@ -135,8 +140,9 @@ def test_models_artifact_repo_init_with_version_uri_and_bad_db_profile_from_cont
         assert "Key prefixes cannot contain" in ex.value.message
 
 
-@pytest.mark.parametrize('artifact_location',
-                         ["dbfs:/databricks/mlflow-registry/12345/models/keras-model"])
+@pytest.mark.parametrize(
+    "artifact_location", ["dbfs:/databricks/mlflow-registry/12345/models/keras-model"]
+)
 def test_models_artifact_repo_init_with_stage_uri(
     host_creds_mock, mock_get_model_version_download_uri, artifact_location
 ):  # pylint: disable=unused-argument
@@ -162,10 +168,11 @@ def test_models_artifact_repo_init_with_stage_uri(
         assert models_repo.repo.artifact_uri == artifact_location
 
 
-@pytest.mark.parametrize('artifact_location',
-                         ["dbfs:/databricks/mlflow-registry/12345/models/keras-model"])
+@pytest.mark.parametrize(
+    "artifact_location", ["dbfs:/databricks/mlflow-registry/12345/models/keras-model"]
+)
 def test_models_artifact_repo_init_with_stage_uri_and_db_profile(
-    mock_get_model_version_download_uri
+    mock_get_model_version_download_uri,
 ):  # pylint: disable=unused-argument
     model_uri = "models://profile@databricks/MyModel/Staging"
     final_uri = "dbfs://profile@databricks/databricks/mlflow-registry/12345/models/keras-model"
@@ -192,9 +199,9 @@ def test_models_artifact_repo_init_with_stage_uri_and_db_profile(
         mock_repo.assert_called_once_with(final_uri)
 
 
-@pytest.mark.parametrize('artifact_location', ["s3://blah_bucket/"])
+@pytest.mark.parametrize("artifact_location", ["s3://blah_bucket/"])
 def test_models_artifact_repo_uses_repo_download_artifacts(
-    mock_get_model_version_download_uri
+    mock_get_model_version_download_uri,
 ):  # pylint: disable=unused-argument
     """
     ``ModelsArtifactRepository`` should delegate `download_artifacts` to its


### PR DESCRIPTION
Signed-off-by: Sue Ann Hong <sueann@databricks.com>

## What changes are proposed in this pull request?

Support remote Databricks model registries in `mlflow.<flavor>.load_model` when called with a `models:/` URI.

Currently, the following two ways to call mlflow.<flavor>.load_model from a remote Databricks model registry work:
```
mlflow.pyfunc.load_model('models://profile@databricks/model_name/Staging')
```
```
mlflow.set_tracking_uri(registry_uri)
mlflow.pyfunc.load_model('models:/model_name/Staging')
```

But the following, more natural, way does not:
```
mlflow.set_registry_uri(registry_uri)
mlflow.pyfunc.load_model('models:/model_name/Staging')
```

This is because each flavor’s `load_model` 
calls `_download_artifact_from_uri`
which calls `get_artifact_repository(artifact_uri=root_uri).download_artifacts`
and no registry server information is passed into the eventual DBFS artifact repository instance. So then the DBFS artifact repository uses the tracking URI from the context (i.e. set via the global variable or the environment variable).

To fix this, here we have `ModelsArtifactRepository` automatically use the Databricks model registry server information if specified in the context.

## How is this patch tested?

- [x] Unit tests
- [x] Manual tests

```
mlflow.set_registry_uri('databricks://blah')  # invalid but ignored
mlflow.set_tracking_uri('databricks://blurgh')  # invalid but ignored
model = mlflow.pyfunc.load_model(f'models://{profile}@databricks/{model_name}/Staging')
model.predict(1)
```
```
mlflow.set_registry_uri(f'databricks://{profile}')  # valid registry URI
mlflow.set_tracking_uri('databricks://blurgh')  # invalid but ignored
model = mlflow.pyfunc.load_model(f'models:/{model_name}/Staging')
model.predict(1)
```
```
mlflow.set_registry_uri(None)
mlflow.set_tracking_uri(f'databricks://{profile}')  # valid registry URI
model = mlflow.pyfunc.load_model(f'models:/{model_name}/Staging')
model.predict(1)
```

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

``mlflow.<flavor>.load_model`` methods will fetch the model from the Databricks model registry specified by ``mlflow.set_registry_uri`` if it is set to one.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
