### PR TITLE
Handle spaces in Databricks profile URIs

### DIFF
--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -54,7 +54,7 @@ def validate_db_scope_prefix_info(scope, prefix):
     if prefix is not None and prefix.strip() == "":
         raise MlflowException(
             "Unsupported Databricks profile key prefix: '%s'." % prefix
-            + " Key prefixes cannot be empty'%s'." % c
+            + " Key prefixes cannot be empty."
         )
 
 

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -40,7 +40,7 @@ def construct_db_uri_from_profile(profile):
 # Both scope and key_prefix should not contain special chars for URIs, like '/'
 # and ':'.
 def validate_db_scope_prefix_info(scope, prefix):
-    for c in ["/", ":"]:
+    for c in ["/", ":", " "]:
         if c in scope:
             raise MlflowException(
                 "Unsupported Databricks profile name: %s." % scope
@@ -51,6 +51,11 @@ def validate_db_scope_prefix_info(scope, prefix):
                 "Unsupported Databricks profile key prefix: %s." % prefix
                 + " Key prefixes cannot contain '%s'." % c
             )
+    if prefix is not None and prefix.strip() == "":
+        raise MlflowException(
+            "Unsupported Databricks profile key prefix: '%s'." % prefix
+            + " Key prefixes cannot be empty'%s'." % c
+        )
 
 
 def get_db_info_from_uri(uri):

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -43,6 +43,7 @@ def test_extract_db_type_from_uri():
         ("databricks://aAbB/", ("aAbB", None)),
         ("databricks://aAbB/path", ("aAbB", None)),
         ("databricks://profile:prefix", ("profile", "prefix")),
+        ("databricks://profile:prefix/extra", ("profile", "prefix")),
         ("nondatabricks://profile:prefix", (None, None)),
         ("databricks://profile", ("profile", None)),
         ("databricks://profile/", ("profile", None)),
@@ -51,6 +52,23 @@ def test_extract_db_type_from_uri():
 )
 def test_get_db_info_from_uri(server_uri, result):
     assert get_db_info_from_uri(server_uri) == result
+
+
+@pytest.mark.parametrize(
+    "server_uri",
+    [
+        "databricks://profile:prefix:extra",
+        "databricks://profile:prefix:extra  ",
+        "databricks://profile:prefix extra",
+        "databricks://profile:prefix  ",
+        "databricks://profile ",
+        "databricks://profile:",
+        "databricks://profile: ",
+    ],
+)
+def test_get_db_info_from_uri_errors(server_uri):
+    with pytest.raises(MlflowException):
+        get_db_info_from_uri(server_uri)
 
 
 @pytest.mark.parametrize(
@@ -491,6 +509,7 @@ def test_add_databricks_profile_info_to_artifact_uri(artifact_uri, profile_uri, 
         ("dbfs:/path/a/b", "databricks://not:legit:auth"),
         ("dbfs:/path/a/b/", "databricks://scope::key"),
         ("dbfs:/path/a/b/", "databricks://scope:key:/"),
+        ("dbfs:/path/a/b/", "databricks://scope:key "),
     ],
 )
 def test_add_databricks_profile_info_to_artifact_uri_errors(artifact_uri, profile_uri):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Do not allow spaces in the key prefix of Databricks profile URIs. We could strip the tokens ourselves, but since there are multiple branches in the parsing code, it's prone to error. It seems reasonable to expect the user to send in a clean version of the URI (without leading or trailing spaces).

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.


### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
