### PR TITLE
pass custom environment variables to sagemaker docker

### DIFF
--- a/mlflow/sagemaker/cli.py
+++ b/mlflow/sagemaker/cli.py
@@ -9,6 +9,20 @@ from mlflow.sagemaker import DEFAULT_IMAGE_NAME as IMAGE
 from mlflow.utils import cli_args
 import mlflow.models.docker_utils
 
+_OPTION_ENV = click.option(
+    "--env",
+    default=None,
+    nargs=2,
+    type=click.Tuple([str, str]),
+    callback=lambda ctx, opt, value: {k: v for (k, v) in value},
+    multiple=True,
+    help=(
+        "Enviroment variable to be added to the docker container. "
+        "Can be repeated to set multiple variables. "
+        "Syntax is `--env key1 value1 --env key2 value2 ...`"
+    ),
+)
+
 
 @click.group("sagemaker")
 def commands():
@@ -109,6 +123,7 @@ def commands():
         " asynchronously using the `--async` flag, this value is ignored."
     ),
 )
+@_OPTION_ENV
 def deploy(
     app_name,
     model_uri,
@@ -124,6 +139,7 @@ def deploy(
     flavor,
     asynchronous,
     timeout,
+    env,
 ):
     """
     Deploy model on Sagemaker as a REST API endpoint. Current active AWS account needs to have
@@ -156,6 +172,7 @@ def deploy(
         flavor=flavor,
         synchronous=(not asynchronous),
         timeout_seconds=timeout,
+        env=env,
     )
 
 
@@ -236,11 +253,12 @@ def delete(app_name, region_name, archive, asynchronous, timeout):
         )
     ),
 )
-def run_local(model_uri, port, image, flavor):
+@_OPTION_ENV
+def run_local(model_uri, port, image, flavor, env):
     """
     Serve model locally running in a Sagemaker-compatible Docker container.
     """
-    mlflow.sagemaker.run_local(model_uri=model_uri, port=port, image=image, flavor=flavor)
+    mlflow.sagemaker.run_local(model_uri=model_uri, port=port, image=image, flavor=flavor, env=env)
 
 
 @commands.command("build-and-push-container")

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -208,6 +208,7 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_from_
     pretrained_model, sagemaker_client
 ):
     app_name = "test-app"
+    env = {"KEY1": "VALUE1", "KEY2": "VALUE2"}
     result = CliRunner(env={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}).invoke(
         mfscli.commands,
         [
@@ -218,6 +219,12 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_from_
             pretrained_model.model_uri,
             "--mode",
             mfs.DEPLOYMENT_MODE_CREATE,
+            "--env",
+            "KEY1",
+            env["KEY1"],
+            "--env",
+            "KEY2",
+            env["KEY2"],
         ],
     )
     assert result.exit_code == 0
@@ -230,6 +237,9 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_from_
     assert len(endpoint_production_variants) == 1
     model_name = endpoint_production_variants[0]["VariantName"]
     assert model_name in [model["ModelName"] for model in sagemaker_client.list_models()["Models"]]
+    model = sagemaker_client.describe_model(ModelName=model_name)
+    assert model["PrimaryContainer"]["Environment"]["KEY1"] == env["KEY1"]
+    assert model["PrimaryContainer"]["Environment"]["KEY2"] == env["KEY2"]
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]
@@ -301,9 +311,24 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_from_
     )
 
     app_name = "test-app"
+    env = {"KEY1": "VALUE1", "KEY2": "VALUE2"}
     result = CliRunner(env={"LC_ALL": "en_US.UTF-8", "LANG": "en_US.UTF-8"}).invoke(
         mfscli.commands,
-        ["deploy", "-a", app_name, "-m", model_s3_uri, "--mode", mfs.DEPLOYMENT_MODE_CREATE],
+        [
+            "deploy",
+            "-a",
+            app_name,
+            "-m",
+            model_s3_uri,
+            "--mode",
+            mfs.DEPLOYMENT_MODE_CREATE,
+            "--env",
+            "KEY1",
+            env["KEY1"],
+            "--env",
+            "KEY2",
+            env["KEY2"],
+        ],
     )
     assert result.exit_code == 0
 
@@ -315,6 +340,9 @@ def test_deploy_cli_creates_sagemaker_and_s3_resources_with_expected_names_from_
     assert len(endpoint_production_variants) == 1
     model_name = endpoint_production_variants[0]["VariantName"]
     assert model_name in [model["ModelName"] for model in sagemaker_client.list_models()["Models"]]
+    model = sagemaker_client.describe_model(ModelName=model_name)
+    assert model["PrimaryContainer"]["Environment"]["KEY1"] == env["KEY1"]
+    assert model["PrimaryContainer"]["Environment"]["KEY2"] == env["KEY2"]
     object_names = [
         entry["Key"] for entry in s3_client.list_objects(Bucket=default_bucket)["Contents"]
     ]


### PR DESCRIPTION
Signed-off-by: Stefano Padovan <ste.bioparco@gmail.com>

## What changes are proposed in this pull request?

#3337
pass custom environment variables to sagemaker docker

## How is this patch tested?

unit test

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

It's a new CLI param is added to mlflow sagemaker run-local/deploy. It's self-documented with --help

### What component(s), interfaces, languages, and integrations does this PR affect?

Integrations
- [x] `integrations/sagemaker`: SageMaker integrations

### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
