### PR TITLE
Add temporary workaround for error in R check

### DIFF
--- a/mlflow/R/mlflow/.run-tests.R
+++ b/mlflow/R/mlflow/.run-tests.R
@@ -10,7 +10,7 @@ keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
 
-# TODO(harupy): Remove `error_on` once the issue below has been fixed:
+# TODO(harupy): Add `error_on = "note"` once the issue below has been fixed:
 # https://stackoverflow.com/questions/63613301/r-cmd-check-note-unable-to-verify-current-time/63616156#63616156
 devtools::check_built(path = package, args = "--no-tests")
 source("testthat.R")

--- a/mlflow/R/mlflow/.run-tests.R
+++ b/mlflow/R/mlflow/.run-tests.R
@@ -12,5 +12,5 @@ reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
 
 # TODO(harupy): Remove `error_on` once the issue below has been fixed:
 # https://stackoverflow.com/questions/63613301/r-cmd-check-note-unable-to-verify-current-time/63616156#63616156
-devtools::check_built(path = package, error_on = "note", args = "--no-tests", error_on = c("never", "error", "warning"))
+devtools::check_built(path = package, args = "--no-tests")
 source("testthat.R")

--- a/mlflow/R/mlflow/.run-tests.R
+++ b/mlflow/R/mlflow/.run-tests.R
@@ -10,5 +10,7 @@ keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
 
-devtools::check_built(path = package, error_on = "note", args = "--no-tests")
+# TODO(harupy): Remove `error_on` once the issue below has been fixed:
+# https://stackoverflow.com/questions/63613301/r-cmd-check-note-unable-to-verify-current-time/63616156#63616156
+devtools::check_built(path = package, error_on = "note", args = "--no-tests", error_on = c("never", "error", "warning"))
 source("testthat.R")


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

The R check fails due to the issue:

https://stackoverflow.com/questions/63613301/r-cmd-check-note-unable-to-verify-current-time/63616156#63616156

As a temporary workaround, remove `error_on = "note"` in `devtools::check_built` so note check failures are not treated as an error.

## How is this patch tested?

GitHub Actions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
