### PR TITLE
Allow to skip TLS verification of S3 endpoint

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -622,7 +622,7 @@ For example, if you have a MinIO server at 1.2.3.4 on port 9000:
 
   export MLFLOW_S3_ENDPOINT_URL=http://1.2.3.4:9000
 
-If MinIO server is configured with using SSL self-signed or signed using some internal-only CA certificate, you could set ``MLFLOW_S3_IGNORE_TLS`` or ``AWS_CA_BUNDLE`` variables (not both at the same time!) to disable certificate signature check or add use some custom CA bundle to perform this check, respectively:
+If the MinIO server is configured with using SSL self-signed or signed using some internal-only CA certificate, you could set ``MLFLOW_S3_IGNORE_TLS`` or ``AWS_CA_BUNDLE`` variables (not both at the same time!) to disable certificate signature check, or add a custom CA bundle to perform this check, respectively:
 
 .. code-block:: bash
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -622,11 +622,20 @@ For example, if you have a MinIO server at 1.2.3.4 on port 9000:
 
   export MLFLOW_S3_ENDPOINT_URL=http://1.2.3.4:9000
 
+If MinIO server is configured with using SSL self-signed or signed using some internal-only CA certificate, you could set ``MLFLOW_S3_IGNORE_TLS`` or ``AWS_CA_BUNDLE`` variables (not both at the same time!) to disable certificate signature check or add use some custom CA bundle to perform this check, respectively:
+
+.. code-block:: bash
+
+  export MLFLOW_S3_IGNORE_TLS=true
+  #or
+  export AWS_CA_BUNDLE=/some/ca/bundle.pem
+
 Additionally, if MinIO server is configured with non-default region, you should set ``AWS_DEFAULT_REGION`` variable:
 
 .. code-block:: bash
 
   export AWS_DEFAULT_REGION=my_region
+
 
 Complete list of configurable values for an S3 client is available in `boto3 documentation <https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#configuration>`_.
 

--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -30,9 +30,13 @@ def _fetch_s3(uri, local_path):
 
     client_kwargs = {}
     endpoint_url = os.environ.get("MLFLOW_S3_ENDPOINT_URL")
+    ignore_tls = os.environ.get("MLFLOW_S3_IGNORE_TLS")
 
     if endpoint_url:
         client_kwargs["endpoint_url"] = endpoint_url
+
+    if ignore_tls:
+        client_kwargs["verify"] = ignore_tls.lower() not in ["true", "yes", "1"]
 
     (bucket, s3_path) = parse_s3_uri(uri)
     boto3.client("s3", **client_kwargs).download_file(bucket, s3_path, local_path)

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -273,6 +273,7 @@ def _get_s3_artifact_cmd_and_envs(artifact_repo):
         "AWS_SECRET_ACCESS_KEY": os.environ.get("AWS_SECRET_ACCESS_KEY"),
         "AWS_ACCESS_KEY_ID": os.environ.get("AWS_ACCESS_KEY_ID"),
         "MLFLOW_S3_ENDPOINT_URL": os.environ.get("MLFLOW_S3_ENDPOINT_URL"),
+        "MLFLOW_S3_IGNORE_TLS": os.environ.get("MLFLOW_S3_IGNORE_TLS"),
     }
     envs = dict((k, v) for k, v in envs.items() if v is not None)
     return volumes, envs

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -40,11 +40,20 @@ class S3ArtifactRepository(ArtifactRepository):
         from botocore.client import Config
 
         s3_endpoint_url = os.environ.get("MLFLOW_S3_ENDPOINT_URL")
+        ignore_tls = os.environ.get("MLFLOW_S3_IGNORE_TLS")
+
+        verify = True
+        if ignore_tls:
+            verify = ignore_tls.lower() not in ["true", "yes", "1"]
+
         # NOTE: If you need to specify this env variable, please file an issue at
         # https://github.com/mlflow/mlflow/issues so we know your use-case!
         signature_version = os.environ.get("MLFLOW_EXPERIMENTAL_S3_SIGNATURE_VERSION", "s3v4")
         return boto3.client(
-            "s3", config=Config(signature_version=signature_version), endpoint_url=s3_endpoint_url
+            "s3",
+            config=Config(signature_version=signature_version),
+            endpoint_url=s3_endpoint_url,
+            verify=verify,
         )
 
     def _upload_file(self, s3_client, local_file, bucket, key):

--- a/tests/projects/backend/test_local.py
+++ b/tests/projects/backend/test_local.py
@@ -9,6 +9,7 @@ def test_docker_s3_artifact_cmd_and_envs_from_env():
         "AWS_SECRET_ACCESS_KEY": "mock_secret",
         "AWS_ACCESS_KEY_ID": "mock_access_key",
         "MLFLOW_S3_ENDPOINT_URL": "mock_endpoint",
+        "MLFLOW_S3_IGNORE_TLS": "false",
     }
     with mock.patch.dict("os.environ", mock_env), mock.patch(
         "posixpath.exists", return_value=False


### PR DESCRIPTION
## What changes are proposed in this pull request?
There is a `MLFLOW_TRACKING_INSECURE_TLS` and `MLFLOW_TRACKING_SERVER_CERT_PATH` for skipping TLS verification or passing custom ca bundle for certificates checking. This allows users to access their local MLflow instances with self-signed SSL certificates, and that's quite useful feature.

Underlying AWS client library boto3 already have option of getting value of env variable `AWS_CA_BUNDLE` (of corresponding config option) which can be used for passing custom ca bundle.

But there is no env variables for disabling SSL certificate check completely, like `MLFLOW_TRACKING_INSECURE_TLS`, but for artifact storage.

This pull request adds new env variable `MLFLOW_S3_IGNORE_TLS` with just the same meaning.

## How is this patch tested?

Added few mock items to existing test.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Allow to skip TLS verification of S3 endpoint.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
