### PR TITLE
Fix for parameter parsing when parameter contains '='

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -194,14 +194,14 @@ def run(
 def _user_args_to_dict(arguments, argument_type="P"):
     user_dict = {}
     for arg in arguments:
-        split = arg.split("=")
+        split_index = arg.find("=")
         # Docker arguments such as `t` don't require a value -> set to True if specified
-        if len(split) == 1 and argument_type == "A":
-            name = split[0]
+        if split_index == -1 and argument_type == "A":
+            name = arg[:split_index]
             value = True
-        elif len(split) == 2:
-            name = split[0]
-            value = split[1]
+        elif split_index >= 0:
+            name = arg[:split_index]
+            value = arg[split_index + 1:]
         else:
             eprint(
                 "Invalid format for -%s parameter: '%s'. "

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -201,7 +201,7 @@ def _user_args_to_dict(arguments, argument_type="P"):
             value = True
         elif split_index >= 0:
             name = arg[:split_index]
-            value = arg[split_index + 1:]
+            value = arg[split_index + 1 :]
         else:
             eprint(
                 "Invalid format for -%s parameter: '%s'. "

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -194,14 +194,14 @@ def run(
 def _user_args_to_dict(arguments, argument_type="P"):
     user_dict = {}
     for arg in arguments:
-        split_index = arg.find("=")
+        split = arg.split("=", maxsplit=1)
         # Docker arguments such as `t` don't require a value -> set to True if specified
-        if split_index == -1 and argument_type == "A":
-            name = arg[:split_index]
+        if len(split) == 1 and argument_type == "A":
+            name = split[0]
             value = True
-        elif split_index >= 0:
-            name = arg[:split_index]
-            value = arg[split_index + 1 :]
+        elif len(split) == 2:
+            name = split[0]
+            value = split[1]
         else:
             eprint(
                 "Invalid format for -%s parameter: '%s'. "

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -45,18 +45,11 @@ def test_run_local_params(name):
 
 
 @pytest.mark.large
-def test_run_local_with_docker_args(docker_example_base_image): # pylint: disable=unused-argument
+def test_run_local_with_docker_args(docker_example_base_image):  # pylint: disable=unused-argument
     # Verify that Docker project execution is successful when Docker flag and string
     # commandline arguments are supplied (`tty` and `name`, respectively)
     result = invoke_cli_runner(
-        cli.run,
-        [
-            TEST_DOCKER_PROJECT_DIR,
-            "-A",
-            "tty",
-            "-A",
-            "name=mycontainer",
-        ],
+        cli.run, [TEST_DOCKER_PROJECT_DIR, "-A", "tty", "-A", "name=mycontainer"]
     )
 
 

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -46,7 +46,7 @@ def test_run_local_params(name):
 
 @pytest.mark.large
 def test_run_local_with_docker_args(docker_example_base_image): # pylint: disable=unused-argument
-    # Verify that Docker project execution is successful when Docker flag and string 
+    # Verify that Docker project execution is successful when Docker flag and string
     # commandline arguments are supplied (`tty` and `name`, respectively)
     result = invoke_cli_runner(
         cli.run,

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -48,9 +48,7 @@ def test_run_local_params(name):
 def test_run_local_with_docker_args(docker_example_base_image):  # pylint: disable=unused-argument
     # Verify that Docker project execution is successful when Docker flag and string
     # commandline arguments are supplied (`tty` and `name`, respectively)
-    result = invoke_cli_runner(
-        cli.run, [TEST_DOCKER_PROJECT_DIR, "-A", "tty", "-A", "name=mycontainer"]
-    )
+    invoke_cli_runner(cli.run, [TEST_DOCKER_PROJECT_DIR, "-A", "tty", "-A", "name=mycontainer"])
 
 
 @pytest.mark.large

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -21,7 +21,6 @@ from tests.projects.utils import (
 
 _logger = logging.getLogger(__name__)
 
-TEST_PROJECT_DIR = "/Users/czumar/mlflow/tests/resources/example_project"
 
 @pytest.mark.large
 @pytest.mark.parametrize("name", ["friend", "friend=you", "='friend'"])

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -21,11 +21,12 @@ from tests.projects.utils import (
 
 _logger = logging.getLogger(__name__)
 
+TEST_PROJECT_DIR = "/Users/czumar/mlflow/tests/resources/example_project"
 
 @pytest.mark.large
-def test_run_local_params():
+@pytest.mark.parametrize("name", ["friend", "friend=you", "='friend'"])
+def test_run_local_params(name):
     excitement_arg = 2
-    name = "friend"
     invoke_cli_runner(
         cli.run,
         [

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -12,11 +12,13 @@ from mlflow import cli
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils import process
 from tests.integration.utils import invoke_cli_runner
+from tests.projects.utils import docker_example_base_image  # pylint: disable=unused-import
 from tests.projects.utils import (
     TEST_PROJECT_DIR,
     GIT_PROJECT_URI,
     SSH_PROJECT_URI,
     TEST_NO_SPEC_PROJECT_DIR,
+    TEST_DOCKER_PROJECT_DIR,
 )
 
 _logger = logging.getLogger(__name__)
@@ -38,6 +40,22 @@ def test_run_local_params(name):
             "name=%s" % name,
             "-P",
             "excitement=%s" % excitement_arg,
+        ],
+    )
+
+
+@pytest.mark.large
+def test_run_local_with_docker_args(docker_example_base_image): # pylint: disable=unused-argument
+    # Verify that Docker project execution is successful when Docker flag and string 
+    # commandline arguments are supplied (`tty` and `name`, respectively)
+    result = invoke_cli_runner(
+        cli.run,
+        [
+            TEST_DOCKER_PROJECT_DIR,
+            "-A",
+            "tty",
+            "-A",
+            "name=mycontainer",
         ],
     )
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes #3346 (a regression introduced by #3061) where project parameters whose values contain the `=` character were not being parsed properly.

## How is this patch tested?

Added unit test coverage to `test_projects_cli`

## Release Notes

Fixed a regression causing parameter values containing `=` to be parsed improperly.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [X] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
