### PR TITLE
Fix Azure Blob storage import issue with 12.4.0

### DIFF
--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -90,7 +90,14 @@ class AzureBlobArtifactRepository(ArtifactRepository):
                     container_client.upload_blob(remote_file_path, file)
 
     def list_artifacts(self, path=None):
-        from azure.storage.blob._models import BlobPrefix
+        # Newer versions of `azure-storage-blob` (>= 12.4.0) provide a public
+        # `azure.storage.blob.BlobPrefix` object to signify that a blob is a directory,
+        # while older versions only expose this API internally as
+        # `azure.storage.blob._models.BlobPrefix`
+        try:
+            from azure.storage.blob import BlobPrefix
+        except ImportError:
+            from azure.storage.blob._models import BlobPrefix
 
         (container, _, artifact_path) = self.parse_wasbs_uri(self.artifact_uri)
         container_client = self.client.get_container_client(container)


### PR DESCRIPTION
Signed-off-by: Corey Zumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

This PR addresses #3321  by updating the import logic for the `BlobPrefix` class for compatibility with Azure Blob Storage 12.4.0, where it has become part of the public API. `BlobPrefix` is used to verify that a blob list result is a directory; in versions prior to 12.4.0, it must be imported from the internal `azure.storage.blob._models` module. While this practice may seem strange, it is documented in the set of Azure Blob Storage examples; these examples were updated in 12.4.0 to account for `BlobPrefix`'s move into the public `azure.storage.blob` top-level module:

Relevant example (prior to 12.4.0): https://github.com/xiafu-msft/azure-sdk-for-python/blob/22846efbca7ecb3334346809aa97c2dffb018b09/sdk/storage/azure-storage-blob/samples/blob_samples_walk_blob_hierarchy.py#L46

Relevant example (12.4.0): https://github.com/xiafu-msft/azure-sdk-for-python/blob/2f9fb75599838a7d9788f397d97560daed8bd399/sdk/storage/azure-storage-blob/samples/blob_samples_walk_blob_hierarchy.py#L46

## How is this patch tested?

I've manually verified that artifacts containing a mixture of directories and files can be listed from a WASBS storage container on Azure Storage Blob 12.4.0, 12.3.2, and 12.0.0

## Release Notes

Fix a bug preventing listing of WASBS artifacts on the latest version of Azure Blob Storage (12.4.0)

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
