### PR TITLE
Run sklearn autologging check against dev version for forwards compatibility

### DIFF
--- a/.github/workflows/sklearn.yml
+++ b/.github/workflows/sklearn.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
     paths:
+      - .github/workflows/sklearn.yml
       - mlflow/sklearn/**
 
 jobs:

--- a/.github/workflows/sklearn.yml
+++ b/.github/workflows/sklearn.yml
@@ -27,6 +27,8 @@ jobs:
           - "0.20.3"
           - "0.21.2"
           - "0.22.2"
+          # For forwards compatibility
+          - "dev"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -38,7 +40,14 @@ jobs:
           pip install -r dev/small-requirements.txt
       - name: Update scikit-learn
         run: |
-          pip install scikit-learn==${{ matrix.version }}
+          if [ "${{ matrix.version }}" = "dev" ]; then
+            pip install git+https://github.com/scikit-learn/scikit-learn.git@master
+          else
+            pip install scikit-learn==${{ matrix.version }}
+          fi
+      - name: Check scikit-learn version
+        run: |
+          python -c "import sklearn; print(sklearn.__version__)"
       - name: Run tests
         run: |
           pytest --verbose --large tests/sklearn/test_sklearn_autolog.py

--- a/.github/workflows/sklearn.yml
+++ b/.github/workflows/sklearn.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           ver="${{ matrix.version }}"
           op=$([[ "$ver" =~ https?://.+ ]] && echo "@" || echo "==")
-          pip install "scikit-learn $op $ver"
+          pip install -U "scikit-learn $op $ver"
       - name: Check scikit-learn version
         run: |
           python -c "import sklearn; print(sklearn.__version__)"

--- a/.github/workflows/sklearn.yml
+++ b/.github/workflows/sklearn.yml
@@ -41,7 +41,7 @@ jobs:
           pip install -r dev/small-requirements.txt
       - name: Update scikit-learn
         run: |
-          ver="$${{ matrix.version }}"
+          ver="${{ matrix.version }}"
           op=$([[ "$ver" =~ ^git ]] && echo "@" || echo "==")
           pip install -U "scikit-learn $op $ver"
       - name: Check scikit-learn version

--- a/.github/workflows/sklearn.yml
+++ b/.github/workflows/sklearn.yml
@@ -29,7 +29,7 @@ jobs:
           - "0.21.2"
           - "0.22.2"
           # To ensure forwards compatibility
-          - "dev"
+          - "https://github.com/scikit-learn/scikit-learn.git@master"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -41,11 +41,9 @@ jobs:
           pip install -r dev/small-requirements.txt
       - name: Update scikit-learn
         run: |
-          if [ "${{ matrix.version }}" = "dev" ]; then
-            pip install git+https://github.com/scikit-learn/scikit-learn.git@master
-          else
-            pip install scikit-learn==${{ matrix.version }}
-          fi
+          ver="${{ matrix.version }}"
+          op=$([[ "$ver" =~ https?://.+ ]] && echo "@" || echo "==")
+          pip install "scikit-learn $op $ver"
       - name: Check scikit-learn version
         run: |
           python -c "import sklearn; print(sklearn.__version__)"

--- a/.github/workflows/sklearn.yml
+++ b/.github/workflows/sklearn.yml
@@ -27,7 +27,7 @@ jobs:
           - "0.20.3"
           - "0.21.2"
           - "0.22.2"
-          # For forwards compatibility
+          # To ensure forwards compatibility
           - "dev"
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/sklearn.yml
+++ b/.github/workflows/sklearn.yml
@@ -29,7 +29,7 @@ jobs:
           - "0.21.2"
           - "0.22.2"
           # To ensure forwards compatibility
-          - "https://github.com/scikit-learn/scikit-learn.git@master"
+          - "git+https://github.com/scikit-learn/scikit-learn.git@master"
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -43,7 +43,7 @@ jobs:
         run: |
           ver="${{ matrix.version }}"
           op=$([[ "$ver" =~ https?://.+ ]] && echo "@" || echo "==")
-          pip install -U "scikit-learn $op $ver"
+          pip install "scikit-learn $op $ver"
       - name: Check scikit-learn version
         run: |
           python -c "import sklearn; print(sklearn.__version__)"

--- a/.github/workflows/sklearn.yml
+++ b/.github/workflows/sklearn.yml
@@ -41,9 +41,8 @@ jobs:
           pip install -r dev/small-requirements.txt
       - name: Update scikit-learn
         run: |
-          ver="${{ matrix.version }}"
-          op=$([[ "$ver" =~ https?://.+ ]] && echo "@" || echo "==")
-          pip install "scikit-learn $op $ver"
+          op=$([[ "$ver" =~ ^git ]] && echo "@" || echo "==")
+          pip install -U "scikit-learn $op $ver"
       - name: Check scikit-learn version
         run: |
           python -c "import sklearn; print(sklearn.__version__)"

--- a/.github/workflows/sklearn.yml
+++ b/.github/workflows/sklearn.yml
@@ -41,6 +41,7 @@ jobs:
           pip install -r dev/small-requirements.txt
       - name: Update scikit-learn
         run: |
+          ver="$${{ matrix.version }}"
           op=$([[ "$ver" =~ ^git ]] && echo "@" || echo "==")
           pip install -U "scikit-learn $op $ver"
       - name: Check scikit-learn version


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Run the sklearn autologging check (`.github/workflows/sklearn.yml`) against the dev version for forwards compatibility.

## How is this patch tested?

GitHub Action

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
