### PR TITLE
Use debug log for generally less relevant piece of info

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -308,7 +308,7 @@ class _HadoopFileSystem:
         try:
             return cls._fs().exists(dfs_path)
         except Exception as ex:  # pylint: disable=broad-except
-            _logger.warning(
+            _logger.debug(
                 "Unexpected exception while checking if model uri is visible on " "DFS: %s", ex
             )
         return False

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -308,6 +308,8 @@ class _HadoopFileSystem:
         try:
             return cls._fs().exists(dfs_path)
         except Exception as ex:  # pylint: disable=broad-except
+            # Log a debug-level message, since existence checks may raise exceptions
+            # in normal operating circumstances that do not warrant warnings
             _logger.debug(
                 "Unexpected exception while checking if model uri is visible on " "DFS: %s", ex
             )


### PR DESCRIPTION
Signed-off-by: Corey Zumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Change file existence check failure logging level from `warning` to `debug`, recognizing that this warning is accounted for by surrounding/related logic that explores alternative file resolution mechanisms when an existence check fails. In the event that such alternatives fail, we raise clear error messages independently of this particular statement.

## How is this patch tested?

Manual testing on Databricks

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
