### PR TITLE
Add signature and input example to parameter search best estimator

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -754,7 +754,7 @@ def autolog():
 
         if _is_parameter_search_estimator(estimator):
             if hasattr(estimator, "best_estimator_"):
-                try_mlflow_log(log_model, estimator.best_estimator_, artifact_path="best_estimator")
+                try_mlflow_log(log_model, estimator.best_estimator_, artifact_path="best_estimator", signature=signature, input_example=input_example)
 
             if hasattr(estimator, "best_params_"):
                 best_params = {

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -754,7 +754,13 @@ def autolog():
 
         if _is_parameter_search_estimator(estimator):
             if hasattr(estimator, "best_estimator_"):
-                try_mlflow_log(log_model, estimator.best_estimator_, artifact_path="best_estimator", signature=signature, input_example=input_example)
+                try_mlflow_log(
+                    log_model,
+                    estimator.best_estimator_,
+                    artifact_path="best_estimator",
+                    signature=signature,
+                    input_example=input_example,
+                )
 
             if hasattr(estimator, "best_params_"):
                 best_params = {

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -593,7 +593,7 @@ def test_parameter_search_estimators_produce_expected_outputs(cv_class, search_s
 
     best_estimator_path = os.path.join(run.info.artifact_uri, "best_estimator")
     input_example = _read_example(best_estimator_conf, best_estimator_path)
-    best_estimator.predict(input_example) # Ensure that input example evaluation succeeds
+    best_estimator.predict(input_example)  # Ensure that input example evaluation succeeds
 
     client = mlflow.tracking.MlflowClient()
     child_runs = client.search_runs(

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -76,8 +76,8 @@ def load_model_by_run_id(run_id):
     return mlflow.sklearn.load_model("runs:/{}/{}".format(run_id, MODEL_DIR))
 
 
-def get_model_conf(artifact_uri):
-    model_conf_path = os.path.join(artifact_uri, MODEL_DIR, "MLmodel")
+def get_model_conf(artifact_uri, model_subpath=MODEL_DIR):
+    model_conf_path = os.path.join(artifact_uri, model_subpath, "MLmodel")
     return Model.load(model_conf_path)
 
 
@@ -586,6 +586,14 @@ def test_parameter_search_estimators_produce_expected_outputs(cv_class, search_s
     assert isinstance(best_estimator, sklearn.svm.SVC)
     cv_model = mlflow.sklearn.load_model("runs:/{}/{}".format(run_id, MODEL_DIR))
     assert isinstance(cv_model, cv_class)
+
+    # Ensure that a signature and input example are produced for the best estimator 
+    best_estimator_conf = get_model_conf(run.info.artifact_uri, "best_estimator")
+    assert best_estimator_conf.signature == infer_signature(X, best_estimator.predict(X[:5]))
+    
+    best_estimator_path = os.path.join(run.info.artifact_uri, "best_estimator")
+    input_example = _read_example(best_estimator_conf, best_estimator_path)
+    best_estimator.predict(input_example) # Ensure that input example evaluation succeeds
 
     client = mlflow.tracking.MlflowClient()
     child_runs = client.search_runs(

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -587,10 +587,10 @@ def test_parameter_search_estimators_produce_expected_outputs(cv_class, search_s
     cv_model = mlflow.sklearn.load_model("runs:/{}/{}".format(run_id, MODEL_DIR))
     assert isinstance(cv_model, cv_class)
 
-    # Ensure that a signature and input example are produced for the best estimator 
+    # Ensure that a signature and input example are produced for the best estimator
     best_estimator_conf = get_model_conf(run.info.artifact_uri, "best_estimator")
     assert best_estimator_conf.signature == infer_signature(X, best_estimator.predict(X[:5]))
-    
+
     best_estimator_path = os.path.join(run.info.artifact_uri, "best_estimator")
     input_example = _read_example(best_estimator_conf, best_estimator_path)
     best_estimator.predict(input_example) # Ensure that input example evaluation succeeds


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add signature and input example to parameter search best estimator

## How is this patch tested?

Included unit tests + manual verification w/ `GridSearchCV`

## Release Notes

Autologging for scikit-learn

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
