### PR TITLE
Ensure Databricks model registry DBFS paths are always read-from using the REST API

### DIFF
--- a/mlflow/store/artifact/dbfs_artifact_repo.py
+++ b/mlflow/store/artifact/dbfs_artifact_repo.py
@@ -17,6 +17,7 @@ from mlflow.utils.string_utils import strip_prefix
 from mlflow.utils.uri import (
     get_databricks_profile_uri_from_artifact_uri,
     is_databricks_acled_artifacts_uri,
+    is_databricks_model_registry_artifacts_uri,
     is_valid_dbfs_uri,
     remove_databricks_profile_info_from_artifact_uri,
 )
@@ -214,7 +215,7 @@ def dbfs_artifact_repo_factory(artifact_uri):
     elif (
         mlflow.utils.databricks_utils.is_dbfs_fuse_available()
         and os.environ.get(USE_FUSE_ENV_VAR, "").lower() != "false"
-        and not artifact_uri.startswith("dbfs:/databricks/mlflow-registry")
+        and not is_databricks_model_registry_artifacts_uri(artifact_uri)
         and (db_profile_uri is None or db_profile_uri == "databricks")
     ):
         # If the DBFS FUSE mount is available, write artifacts directly to

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -237,6 +237,12 @@ def is_databricks_acled_artifacts_uri(artifact_uri):
     return artifact_uri_path.startswith(_ACLED_ARTIFACT_URI)
 
 
+def is_databricks_model_registry_artifacts_uri(artifact_uri):
+    _MODEL_REGISTRY_ARTIFACT_URI = "databricks/mlflow-registry/"
+    artifact_uri_path = extract_and_normalize_path(artifact_uri)
+    return artifact_uri_path.startswith(_MODEL_REGISTRY_ARTIFACT_URI)
+
+
 def construct_run_url(hostname, experiment_id, run_id, workspace_id=None):
     if not hostname or not experiment_id or not run_id:
         raise MlflowException(

--- a/tests/store/artifact/test_dbfs_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_artifact_repo.py
@@ -37,6 +37,7 @@ def test_dbfs_artifact_repo_factory_local_repo(artifact_uri, uri_at_init):
         "dbfs://databricks/databricks/mlflow-registry/abcdefg123/path",
         "dbfs://someProfile@databricks/mlflow-registry/abcdefg123/path",
         "dbfs://somewhere:else@databricks/mlflow-registry/abcdefg123/path",
+        "dbfs:/databricks/mlflow-registry/abcdefg123/path",
     ],
 )
 def test_dbfs_artifact_repo_factory_dbfs_rest_repo(artifact_uri):

--- a/tests/store/artifact/test_dbfs_artifact_repo.py
+++ b/tests/store/artifact/test_dbfs_artifact_repo.py
@@ -27,7 +27,17 @@ def test_dbfs_artifact_repo_factory_local_repo(artifact_uri, uri_at_init):
 
 @pytest.mark.parametrize(
     "artifact_uri",
-    [("dbfs://someProfile@databricks/path"), ("dbfs://somewhere:else@databricks/path")],
+    [
+        "dbfs://someProfile@databricks/path",
+        "dbfs://somewhere:else@databricks/path",
+        # Model registry paths should use the REST artifact repo, both when communicating
+        # with the current workspace (authority component = "databricks") and other workspaces
+        # (authority component = "someProfile@databricks"), as model registry paths cannot
+        # be accessed via the local filesystem (via FUSE)
+        "dbfs://databricks/databricks/mlflow-registry/abcdefg123/path",
+        "dbfs://someProfile@databricks/mlflow-registry/abcdefg123/path",
+        "dbfs://somewhere:else@databricks/mlflow-registry/abcdefg123/path",
+    ],
 )
 def test_dbfs_artifact_repo_factory_dbfs_rest_repo(artifact_uri):
     with mock.patch(


### PR DESCRIPTION
Signed-off-by: Sid Murching <sid.murching@databricks.com>

## What changes are proposed in this pull request?

Ensure Databricks model registry paths in DBFS are always read using the REST API, as these paths cannot be accessed via DBFS FUSE.

## How is this patch tested?

Added unit test & tested manually

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
