### PR TITLE
Fix ArtifactView styles

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.css
@@ -2,13 +2,14 @@ div.artifact-view {
   height: 558px;
   border: solid 1px #ccc;
   display: flex;
-  overflow-x: scroll;
+  overflow: hidden;
 }
 
 .artifact-left {
   min-width: 200px;
   max-width: 400px;
   flex: 1;
+  border-right: solid 1px #ccc;
 }
 
 .artifact-left li {
@@ -27,6 +28,7 @@ div.artifact-view {
   padding: 8px 16px;
   white-space: nowrap;
   display: flex;
+  border-bottom: solid 1px #ccc;
 }
 
 .artifact-info-left {

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
@@ -370,7 +370,7 @@ const TREEBEARD_STYLE = {
       fontSize: '14px',
       maxWidth: '500px',
       height: '556px',
-      overflow: 'scroll',
+      overflow: 'auto',
     },
     node: {
       base: {

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.css
@@ -7,5 +7,13 @@
 
 .ShowArtifactPage .text-area-border-box {
   width: 100%;
-  height: 500px;
+}
+
+.ShowArtifactPage .text-area-border-box pre {
+  padding-left: 1em!important;
+  padding-top: 0.5em!important;
+  margin: 0!important;
+  border: none!important;
+  height: 500px!important;
+  overflow: auto!important;
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Currently Artifacts view on Run page does not tool like a best viewer for .py and other text files content:
- There is no enough space between a left border of content area and the content itself. That leads to difficulties with file content reading.
- Instead of scrolling file content the entire artifact view panel is scrolling, and that does not look OK. Due to that you need to scroll down the file content panel to see the horizontal scrollbar, and this is not convenient.
- Scrollbars are always on the screen even if there is no need to show them. In some cases these scrollbars are attached to each other, and that's is really ugly.
- The file content goes off the panel border. You can open file with long lines and try horizontal scroll to see that.
- This panel has a rounded border. Sometimes the background of selected file in the left panel is overlapping with this border. This causes the strange sharp angles appearance in the right angles-based interface.

Examples:
![scroll_files_old](https://user-images.githubusercontent.com/4661021/92036879-94b5f580-ed79-11ea-8535-1e46cd1e1df0.gif)
![scroll_content_old](https://user-images.githubusercontent.com/4661021/92036868-8ff14180-ed79-11ea-8a37-c3e875a7bae0.gif)

This pull request fixes all these cases:
- The file list panel and the content panel now have separated scrollbars
- They are hidden if nothing is going off the drawing area
- The left padding of file content panel increased
- The horizontal scroll of file content panel does not cause strange appearance effects
- The file list panel, the file info panel and the file content panel have their own borders now
- No rounded borders anymore, just right angles

Examples:
![scroll_files_new](https://user-images.githubusercontent.com/4661021/92036904-9da6c700-ed79-11ea-92e2-9597de968b65.gif)

![scroll_content_new](https://user-images.githubusercontent.com/4661021/92036892-9a134000-ed79-11ea-9710-08d87b2e003d.gif)

## How is this patch tested?

MLflow UI was browsed using Firefox 80.0b8 and Chrome 86.0.4240.22.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed some small artifacts panel UI issues.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [X] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
