### PR TITLE
Fix bug where `infer_signature` throws when `np.object` type column contains `nan`

### DIFF
--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -131,6 +131,8 @@ def _infer_numpy_array(col: np.ndarray) -> DataType:
         def __call__(self, x):
             if x is None:
                 return True
+            elif isinstance(x, float) and np.isnan(x):
+                return True
             elif any(map(lambda c: isinstance(x, c), self.classes)):
                 self.seen_instances += 1
                 return True

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -131,6 +131,8 @@ def _infer_numpy_array(col: np.ndarray) -> DataType:
         def __call__(self, x):
             if x is None:
                 return True
+            elif isinstance(x, float) and np.isnan(x):
+                return True
             elif any(map(lambda c: isinstance(x, c), self.classes)):
                 self.seen_instances += 1
                 return True
@@ -157,7 +159,7 @@ def _infer_numpy_array(col: np.ndarray) -> DataType:
         else:
             raise MlflowException(
                 "Unable to map 'np.object' type to MLflow DataType. np.object can"
-                "be mapped iff all values have identical data type which is one "
+                "be mapped if all values have identical data type which is one "
                 "of (string, (bytes or byterray),  int, float)."
             )
     else:

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -131,8 +131,6 @@ def _infer_numpy_array(col: np.ndarray) -> DataType:
         def __call__(self, x):
             if x is None:
                 return True
-            elif isinstance(x, float) and np.isnan(x):
-                return True
             elif any(map(lambda c: isinstance(x, c), self.classes)):
                 self.seen_instances += 1
                 return True
@@ -159,7 +157,7 @@ def _infer_numpy_array(col: np.ndarray) -> DataType:
         else:
             raise MlflowException(
                 "Unable to map 'np.object' type to MLflow DataType. np.object can"
-                "be mapped if all values have identical data type which is one "
+                "be mapped iff all values have identical data type which is one "
                 "of (string, (bytes or byterray),  int, float)."
             )
     else:

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -1,5 +1,6 @@
 import json
 import numpy as np
+import pandas as pd
 
 from mlflow.models.signature import ModelSignature, infer_signature
 from mlflow.types import DataType
@@ -45,3 +46,9 @@ def test_signature_inference_infers_input_and_output_as_expected():
     sig1 = infer_signature(np.array([1]), np.array([1]))
     assert sig1.inputs == sig0.inputs
     assert sig1.outputs == sig0.inputs
+
+
+def test_infer_signature_does_not_throw_when_np_object_type_column_contains_nan():
+    df = pd.DataFrame({"a": ["x", np.nan, float("nan")]})
+    sig = infer_signature(df)
+    assert sig.inputs == Schema([ColSpec(DataType.string, name="a")])


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- Fix a bug where `infer_signature` throws when `np.object` type column contains `nan`.
- Fix #3362

code to reproduce the bug:

```python
import numpy as np
import pandas as pd

from mlflow.models.signature import infer_signature

data = pd.DataFrame({"a": ["foo", np.nan]})
infer_signature(data)
```

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
