### PR TITLE
Use `wrap_patch` in autologging integrations to preserve original function attributes

### DIFF
--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -30,7 +30,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.utils.annotations import experimental
-from mlflow.utils.autologging_utils import try_mlflow_log, log_fn_args_as_params
+from mlflow.utils.autologging_utils import try_mlflow_log, log_fn_args_as_params, wrap_patch
 
 
 FLAVOR_NAME = "fastai"
@@ -414,11 +414,9 @@ def autolog():
 
         return result
 
-    @gorilla.patch(Learner)
     def fit(self, *args, **kwargs):
         original = gorilla.get_original_attribute(Learner, "fit")
         unlogged_params = ["self", "callbacks", "learner"]
         return _run_and_log_function(self, original, args, kwargs, unlogged_params, 3)
 
-    settings = gorilla.Settings(allow_hit=True, store_hit=True)
-    gorilla.apply(gorilla.Patch(Learner, "fit", fit, settings=settings))
+    wrap_patch(Learner, "fit", fit)

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -13,7 +13,7 @@ from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.annotations import experimental
-from mlflow.utils.autologging_utils import try_mlflow_log
+from mlflow.utils.autologging_utils import try_mlflow_log, wrap_patch
 from mlflow.utils.environment import _mlflow_conda_env
 
 FLAVOR_NAME = "gluon"
@@ -345,7 +345,6 @@ def autolog():
             if isinstance(estimator.net, HybridSequential):
                 try_mlflow_log(log_model, estimator.net, artifact_path="model")
 
-    @gorilla.patch(Estimator)
     def fit(self, *args, **kwargs):
         if not mlflow.active_run():
             auto_end_run = True
@@ -366,5 +365,4 @@ def autolog():
             mlflow.end_run()
         return result
 
-    settings = gorilla.Settings(allow_hit=True, store_hit=True)
-    gorilla.apply(gorilla.Patch(Estimator, "fit", fit, settings=settings))
+    wrap_patch(Estimator, "fit", fit)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -28,7 +28,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.utils.annotations import experimental
-from mlflow.utils.autologging_utils import try_mlflow_log, log_fn_args_as_params
+from mlflow.utils.autologging_utils import try_mlflow_log, log_fn_args_as_params, wrap_patch
 
 
 FLAVOR_NAME = "keras"
@@ -684,18 +684,15 @@ def autolog():
 
         return history
 
-    @gorilla.patch(keras.Model)
     def fit(self, *args, **kwargs):
         original = gorilla.get_original_attribute(keras.Model, "fit")
         unlogged_params = ["self", "x", "y", "callbacks", "validation_data", "verbose"]
         return _run_and_log_function(self, original, args, kwargs, unlogged_params, 5)
 
-    @gorilla.patch(keras.Model)
     def fit_generator(self, *args, **kwargs):
         original = gorilla.get_original_attribute(keras.Model, "fit_generator")
         unlogged_params = ["self", "generator", "callbacks", "validation_data", "verbose"]
         return _run_and_log_function(self, original, args, kwargs, unlogged_params, 4)
 
-    settings = gorilla.Settings(allow_hit=True, store_hit=True)
-    gorilla.apply(gorilla.Patch(keras.Model, "fit", fit, settings=settings))
-    gorilla.apply(gorilla.Patch(keras.Model, "fit_generator", fit_generator, settings=settings))
+    wrap_patch(keras.Model, "fit", fit)
+    wrap_patch(keras.Model, "fit_generator", fit_generator)

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -37,7 +37,7 @@ from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
-from mlflow.utils.autologging_utils import try_mlflow_log, log_fn_args_as_params
+from mlflow.utils.autologging_utils import try_mlflow_log, log_fn_args_as_params, wrap_patch
 
 
 FLAVOR_NAME = "lightgbm"
@@ -283,7 +283,6 @@ def autolog():
     import lightgbm
     import numpy as np
 
-    @gorilla.patch(lightgbm)
     def train(*args, **kwargs):
         def record_eval_results(eval_results):
             """
@@ -430,5 +429,4 @@ def autolog():
             try_mlflow_log(mlflow.end_run)
         return model
 
-    settings = gorilla.Settings(allow_hit=True, store_hit=True)
-    gorilla.apply(gorilla.Patch(lightgbm, "train", train, settings=settings))
+    wrap_patch(lightgbm, "train", train)

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -30,7 +30,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.annotations import experimental
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
-from mlflow.utils.autologging_utils import try_mlflow_log
+from mlflow.utils.autologging_utils import try_mlflow_log, wrap_patch
 
 FLAVOR_NAME = "sklearn"
 
@@ -913,9 +913,4 @@ def autolog():
                     continue
 
                 patch_func = create_patch_func(func_name)
-                # TODO(harupy): Package this wrap & patch routine into a utility function so we can
-                # reuse it in other autologging integrations.
-                # preserve original function attributes
-                patch_func = functools.wraps(original)(patch_func)
-                patch = gorilla.Patch(class_def, func_name, patch_func, settings=patch_settings)
-                gorilla.apply(patch)
+                wrap_patch(class_def, func_name, patch_func)

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -8,7 +8,6 @@ Python (native) `pickle <https://scikit-learn.org/stable/modules/model_persisten
 :py:mod:`mlflow.pyfunc`
     Produced for use by generic pyfunc-based deployment tools and batch inference.
 """
-import functools
 import gorilla
 import os
 import logging

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -881,7 +881,6 @@ def autolog():
 
         return f
 
-    patch_settings = gorilla.Settings(allow_hit=True, store_hit=True)
     _, estimators_to_patch = zip(*_all_estimators())
     # Ensure that relevant meta estimators (e.g. GridSearchCV, Pipeline) are selected
     # for patching if they are not already included in the output of `all_estimators()`

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1056,8 +1056,8 @@ def autolog(every_n_iter=100):
         (tensorflow.estimator.Estimator, "train", train),
         (tensorflow.keras.Model, "fit", fit),
         (tensorflow.keras.Model, "fit_generator", fit_generator),
-        (tensorflow.estimator.Estimator, "export_saved_model", export_saved_model,),
-        (tensorflow.estimator.Estimator, "export_savedmodel", export_savedmodel,),
+        (tensorflow.estimator.Estimator, "export_saved_model", export_saved_model),
+        (tensorflow.estimator.Estimator, "export_savedmodel", export_savedmodel),
         (FileWriter, "add_summary", add_summary),
     ]
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -286,7 +286,6 @@ def autolog(importance_types=["weight"]):  # pylint: disable=W0102
     import xgboost
     import numpy as np
 
-    @gorilla.patch(xgboost)
     def train(*args, **kwargs):
         def record_eval_results(eval_results):
             """

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -36,7 +36,7 @@ from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
-from mlflow.utils.autologging_utils import try_mlflow_log, log_fn_args_as_params
+from mlflow.utils.autologging_utils import try_mlflow_log, log_fn_args_as_params, wrap_patch
 
 FLAVOR_NAME = "xgboost"
 
@@ -423,5 +423,4 @@ def autolog(importance_types=["weight"]):  # pylint: disable=W0102
             try_mlflow_log(mlflow.end_run)
         return model
 
-    settings = gorilla.Settings(allow_hit=True, store_hit=True)
-    gorilla.apply(gorilla.Patch(xgboost, "train", train, settings=settings))
+    wrap_patch(xgboost, "train", train)


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- A follow-up for #3294 
- Use `wrap_patch` in autologging integrations.

## How is this patch tested?

Verify no exisiting tests are broken.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
