### PR TITLE
Fix a bug of `FTPArtifactRepository.log_artifacts` with `artifact_path` keyword argument (issue #3388)

### DIFF
--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -80,10 +80,11 @@ class FTPArtifactRepository(ArtifactRepository):
             upload_path = dest_path
             if root != local_dir:
                 rel_path = os.path.relpath(root, local_dir)
-                upload_path = relative_path_to_artifact_path(rel_path)
+                rel_upload_path = relative_path_to_artifact_path(rel_path)
+                upload_path = posixpath.join(dest_path, rel_upload_path)
             if not filenames:
                 with self.get_ftp_client() as ftp:
-                    self._mkdir(ftp, posixpath.join(self.path, upload_path))
+                    self._mkdir(ftp, upload_path)
             for f in filenames:
                 if os.path.isfile(os.path.join(root, f)):
                     self.log_artifact(os.path.join(root, f), upload_path)

--- a/tests/store/artifact/test_ftp_artifact_repo.py
+++ b/tests/store/artifact/test_ftp_artifact_repo.py
@@ -209,14 +209,14 @@ def test_log_artifact_multiple_calls(ftp_mock, tmpdir):
     ftp_mock.cwd.assert_called_with("/some/path")
     ftp_mock.storbinary.assert_called()
     assert ftp_mock.storbinary.call_args_list[0][0][0] == "STOR test2.txt"
-    
+
 
 def __posixpath_parents(pathname, root):
     parents = []
     parent, _ = posixpath.split(pathname)
     root = posixpath.normpath(root)
     parents.append(parent)
-    while parent != '/' and parent != root:
+    while parent != "/" and parent != root:
         parent, _ = posixpath.split(parent)
         parents.append(parent)
     return parents
@@ -231,34 +231,34 @@ def test_log_artifacts(artifact_path, ftp_mock, tmpdir):
     repo.get_ftp_client = MagicMock()
     call_mock = MagicMock(return_value=ftp_mock)
     repo.get_ftp_client.return_value = MagicMock(__enter__=call_mock)
-    
+
     dir_created = set([dest_path_root])
     file_created = set()
     cwd_history = []
-    
+
     def mkd_mock(pathname):
-        assert pathname == posixpath.abspath(pathname), 'mock not implemented'
+        assert pathname == posixpath.abspath(pathname), "mock not implemented"
         parent, _ = posixpath.split(pathname)
         if parent not in dir_created:
             raise ftplib.error_perm
-        assert pathname not in dir_created, 'mock not implemented'
+        assert pathname not in dir_created, "mock not implemented"
         dir_created.add(pathname)
-        
+
     ftp_mock.mkd = MagicMock(side_effect=mkd_mock)
-    
+
     def cwd_mock(pathname):
-        assert pathname == posixpath.abspath(pathname), 'mock not implemented'
+        assert pathname == posixpath.abspath(pathname), "mock not implemented"
         if pathname not in dir_created:
             raise ftplib.error_perm
         cwd_history.append(pathname)
-        
+
     ftp_mock.cwd = MagicMock(side_effect=cwd_mock)
-    
+
     def storbinary_mock(cmd, _):
         head, basename = cmd.split(" ", 1)
         assert head == "STOR"
         assert "/" not in basename
-        assert len(cwd_history) > 0, 'mock not implemented'
+        assert len(cwd_history) > 0, "mock not implemented"
         file_created.add(posixpath.join(cwd_history[-1], basename))
 
     ftp_mock.storbinary = MagicMock(side_effect=storbinary_mock)
@@ -268,21 +268,39 @@ def test_log_artifacts(artifact_path, ftp_mock, tmpdir):
     subd.join("a.txt").write("A")
     subd.join("b.txt").write("B")
     subd.join("c.txt").write("C")
-    
-    dest_path = dest_path_root if artifact_path is None else posixpath.join(dest_path_root, artifact_path)
-    dir_expected = set([
-        dest_path,
-    ])
-    file_expected = set([
-        posixpath.join(dest_path, 'a.txt'),
-        posixpath.join(dest_path, 'b.txt'),
-        posixpath.join(dest_path, 'c.txt'),
-    ])
-    
+    subd.mkdir("empty1")
+    subsubd = subd.mkdir("subsubdir")
+    subsubd.join("aa.txt").write("AA")
+    subsubd.join("bb.txt").write("BB")
+    subsubd.join("cc.txt").write("CC")
+    subsubd.mkdir("empty2")
+
+    dest_path = (
+        dest_path_root if artifact_path is None else posixpath.join(dest_path_root, artifact_path)
+    )
+    dir_expected = set(
+        [
+            dest_path,
+            posixpath.join(dest_path, "empty1"),
+            posixpath.join(dest_path, "subsubdir"),
+            posixpath.join(dest_path, "subsubdir", "empty2"),
+        ]
+    )
+    file_expected = set(
+        [
+            posixpath.join(dest_path, "a.txt"),
+            posixpath.join(dest_path, "b.txt"),
+            posixpath.join(dest_path, "c.txt"),
+            posixpath.join(dest_path, "subsubdir/aa.txt"),
+            posixpath.join(dest_path, "subsubdir/bb.txt"),
+            posixpath.join(dest_path, "subsubdir/cc.txt"),
+        ]
+    )
+
     for dir_expected_i in set(dir_expected):
         if dir_expected_i != dest_path_root:
             dir_expected |= set(__posixpath_parents(dir_expected_i, root=dest_path_root))
-    
+
     repo.log_artifacts(subd.strpath, artifact_path)
     assert dir_created == dir_expected
     assert file_created == file_expected

--- a/tests/store/artifact/test_ftp_artifact_repo.py
+++ b/tests/store/artifact/test_ftp_artifact_repo.py
@@ -209,34 +209,83 @@ def test_log_artifact_multiple_calls(ftp_mock, tmpdir):
     ftp_mock.cwd.assert_called_with("/some/path")
     ftp_mock.storbinary.assert_called()
     assert ftp_mock.storbinary.call_args_list[0][0][0] == "STOR test2.txt"
+    
+
+def __posixpath_parents(pathname, root):
+    parents = []
+    parent, _ = posixpath.split(pathname)
+    root = posixpath.normpath(root)
+    parents.append(parent)
+    while parent != '/' and parent != root:
+        parent, _ = posixpath.split(parent)
+        parents.append(parent)
+    return parents
 
 
 @pytest.mark.parametrize("artifact_path", [None, "dir", "dir1/dir2"])
 def test_log_artifacts(artifact_path, ftp_mock, tmpdir):
-    repo = FTPArtifactRepository("ftp://test_ftp/some/path")
+    # Setup FTP mock.
+    dest_path_root = "/some/path"
+    repo = FTPArtifactRepository("ftp://test_ftp" + dest_path_root)
 
     repo.get_ftp_client = MagicMock()
     call_mock = MagicMock(return_value=ftp_mock)
     repo.get_ftp_client.return_value = MagicMock(__enter__=call_mock)
+    
+    dir_created = set([dest_path_root])
+    file_created = set()
+    cwd_history = []
+    
+    def mkd_mock(pathname):
+        assert pathname == posixpath.abspath(pathname), 'mock not implemented'
+        parent, _ = posixpath.split(pathname)
+        if parent not in dir_created:
+            raise ftplib.error_perm
+        assert pathname not in dir_created, 'mock not implemented'
+        dir_created.add(pathname)
+        
+    ftp_mock.mkd = MagicMock(side_effect=mkd_mock)
+    
+    def cwd_mock(pathname):
+        assert pathname == posixpath.abspath(pathname), 'mock not implemented'
+        if pathname not in dir_created:
+            raise ftplib.error_perm
+        cwd_history.append(pathname)
+        
+    ftp_mock.cwd = MagicMock(side_effect=cwd_mock)
+    
+    def storbinary_mock(cmd, _):
+        head, basename = cmd.split(" ", 1)
+        assert head == "STOR"
+        assert "/" not in basename
+        assert len(cwd_history) > 0, 'mock not implemented'
+        file_created.add(posixpath.join(cwd_history[-1], basename))
 
+    ftp_mock.storbinary = MagicMock(side_effect=storbinary_mock)
+
+    # Test
     subd = tmpdir.mkdir("data").mkdir("subdir")
     subd.join("a.txt").write("A")
     subd.join("b.txt").write("B")
     subd.join("c.txt").write("C")
-
-    ftp_mock.cwd = MagicMock(side_effect=[ftplib.error_perm, None, None, None, None, None])
-
+    
+    dest_path = dest_path_root if artifact_path is None else posixpath.join(dest_path_root, artifact_path)
+    dir_expected = set([
+        dest_path,
+    ])
+    file_expected = set([
+        posixpath.join(dest_path, 'a.txt'),
+        posixpath.join(dest_path, 'b.txt'),
+        posixpath.join(dest_path, 'c.txt'),
+    ])
+    
+    for dir_expected_i in set(dir_expected):
+        if dir_expected_i != dest_path_root:
+            dir_expected |= set(__posixpath_parents(dir_expected_i, root=dest_path_root))
+    
     repo.log_artifacts(subd.strpath, artifact_path)
-
-    arg_expected = (
-        "/some/path" if artifact_path is None else posixpath.join("/some/path", artifact_path)
-    )
-    ftp_mock.mkd.assert_any_call(arg_expected)
-    ftp_mock.cwd.assert_any_call(arg_expected)
-
-    assert ftp_mock.storbinary.call_count == 3
-    storbinary_call_args = sorted([ftp_mock.storbinary.call_args_list[i][0][0] for i in range(3)])
-    assert storbinary_call_args == ["STOR a.txt", "STOR b.txt", "STOR c.txt"]
+    assert dir_created == dir_expected
+    assert file_created == file_expected
 
 
 def test_download_artifacts_single(ftp_mock):


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fixes #3388
- Adds a test case for `FTPArtifactRepository.log_artifacts`.

## How is this patch tested?

Verify no exisiting tests in `tests/store/artifact/test_ftp_artifact_repo.py` are broken.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
