### PR TITLE
Fixing pylint issues in mlflow pytorch

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -15,6 +15,7 @@ import yaml
 import cloudpickle
 import numpy as np
 import pandas as pd
+import shutil
 
 import mlflow
 import mlflow.pyfunc.utils as pyfunc_utils
@@ -27,7 +28,7 @@ from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.pytorch import pickle_module as mlflow_pytorch_pickle_module
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
-from mlflow.utils.file_utils import _copy_file_or_tree
+from mlflow.utils.file_utils import _copy_file_or_tree, TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 
 FLAVOR_NAME = "pytorch"
@@ -70,6 +71,7 @@ def log_model(
     registered_model_name=None,
     signature: ModelSignature = None,
     input_example: ModelInputExample = None,
+    artifacts=None,
     **kwargs
 ):
     """
@@ -131,6 +133,24 @@ def log_model(
                           serialized to json using the Pandas split-oriented format. Bytes are
                           base64-encoded.
 
+    :param artifacts: A dictionary containing ``<name, artifact_uri>`` entries. Remote artifact URIs
+                      are resolved to absolute filesystem paths, producing a dictionary of
+                      ``<name, absolute_path>`` entries. ``python_model`` can reference these
+                      resolved entries as the ``artifacts`` property of the ``context`` parameter
+                      in :func:`PythonModel.load_context() <mlflow.pyfunc.PythonModel.load_context>`
+                      and :func:`PythonModel.predict() <mlflow.pyfunc.PythonModel.predict>`.
+                      For example, consider the following ``artifacts`` dictionary::
+
+                        {
+                            "my_file": "s3://my-bucket/path/to/my/file"
+                        }
+
+                      In this case, the ``"my_file"`` artifact is downloaded from S3. The
+                      ``python_model`` can then refer to ``"my_file"`` as an absolute filesystem
+                      path via ``context.artifacts["my_file"]``.
+
+                      If ``None``, no artifacts are added to the model.
+
 
     :param kwargs: kwargs to pass to ``torch.save`` method.
 
@@ -190,6 +210,7 @@ def log_model(
         registered_model_name=registered_model_name,
         signature=signature,
         input_example=input_example,
+        artifacts=artifacts,
         **kwargs
     )
 
@@ -203,6 +224,7 @@ def save_model(
     pickle_module=None,
     signature: ModelSignature = None,
     input_example: ModelInputExample = None,
+    artifacts=None,
     **kwargs
 ):
     """
@@ -263,6 +285,24 @@ def save_model(
                           serialized to json using the Pandas split-oriented format. Bytes are
                           base64-encoded.
 
+    :param artifacts: A dictionary containing ``<name, artifact_uri>`` entries. Remote artifact URIs
+                      are resolved to absolute filesystem paths, producing a dictionary of
+                      ``<name, absolute_path>`` entries. ``python_model`` can reference these
+                      resolved entries as the ``artifacts`` property of the ``context`` parameter
+                      in :func:`PythonModel.load_context() <mlflow.pyfunc.PythonModel.load_context>`
+                      and :func:`PythonModel.predict() <mlflow.pyfunc.PythonModel.predict>`.
+                      For example, consider the following ``artifacts`` dictionary::
+
+                        {
+                            "my_file": "s3://my-bucket/path/to/my/file"
+                        }
+
+                      In this case, the ``"my_file"`` artifact is downloaded from S3. The
+                      ``python_model`` can then refer to ``"my_file"`` as an absolute filesystem
+                      path via ``context.artifacts["my_file"]``.
+
+                      If ``None``, no artifacts are added to the model.
+
     :param kwargs: kwargs to pass to ``torch.save`` method.
 
     .. code-block:: python
@@ -291,7 +331,9 @@ def save_model(
         raise TypeError("Argument 'pytorch_model' should be a torch.nn.Module")
     if code_paths is not None:
         if not isinstance(code_paths, list):
-            raise TypeError("Argument code_paths should be a list, not {}".format(type(code_paths)))
+            raise TypeError(
+                "Argument code_paths should be a list, not {}".format(type(code_paths))
+            )
     path = os.path.abspath(path)
     if os.path.exists(path):
         raise RuntimeError("Path '{}' already exists".format(path))
@@ -318,6 +360,25 @@ def save_model(
     pickle_module_path = os.path.join(model_data_path, _PICKLE_MODULE_INFO_FILE_NAME)
     with open(pickle_module_path, "w") as f:
         f.write(pickle_module.__name__)
+
+    if artifacts:
+        if not isinstance(artifacts, dict):
+            raise TypeError("Argument artifacts should be a list")
+
+        with TempDir() as tmp_artifacts_dir:
+            tmp_artifacts_config = {}
+            saved_artifacts_dir_subpath = "artifacts"
+            for artifact_name, artifact_uri in artifacts.items():
+                tmp_artifact_path = _download_artifact_from_uri(
+                    artifact_uri=artifact_uri, output_path=tmp_artifacts_dir.path()
+                )
+                tmp_artifacts_config[artifact_name] = tmp_artifact_path
+
+            shutil.move(
+                tmp_artifacts_dir.path(),
+                os.path.join(path, saved_artifacts_dir_subpath),
+            )
+
     # Save pytorch model
     model_path = os.path.join(model_data_path, _SERIALIZED_TORCH_MODEL_FILE_NAME)
     torch.save(pytorch_model, model_path, pickle_module=pickle_module, **kwargs)
@@ -366,7 +427,10 @@ def _load_model(path, **kwargs):
         pickle_module_path = os.path.join(path, _PICKLE_MODULE_INFO_FILE_NAME)
         with open(pickle_module_path, "r") as f:
             pickle_module_name = f.read()
-        if "pickle_module" in kwargs and kwargs["pickle_module"].__name__ != pickle_module_name:
+        if (
+            "pickle_module" in kwargs
+            and kwargs["pickle_module"].__name__ != pickle_module_name
+        ):
             _logger.warning(
                 "Attempting to load the PyTorch model with a pickle module, '%s', that does not"
                 " match the pickle module that was used to save the model: '%s'.",
@@ -440,14 +504,18 @@ def load_model(model_uri, **kwargs):
             code_path=os.path.join(local_model_path, code_subpath)
         )
 
-    pytorch_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    pytorch_conf = _get_flavor_configuration(
+        model_path=local_model_path, flavor_name=FLAVOR_NAME
+    )
     if torch.__version__ != pytorch_conf["pytorch_version"]:
         _logger.warning(
             "Stored model version '%s' does not match installed PyTorch version '%s'",
             pytorch_conf["pytorch_version"],
             torch.__version__,
         )
-    torch_model_artifacts_path = os.path.join(local_model_path, pytorch_conf["model_data"])
+    torch_model_artifacts_path = os.path.join(
+        local_model_path, pytorch_conf["model_data"]
+    )
     return _load_model(path=torch_model_artifacts_path, **kwargs)
 
 

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -376,7 +376,7 @@ def _load_model(path, **kwargs):
         else:
             try:
                 kwargs["pickle_module"] = importlib.import_module(pickle_module_name)
-            except ImportError:
+            except ImportError as exc:
                 raise MlflowException(
                     message=(
                         "Failed to import the pickle module that was used to save the PyTorch"
@@ -385,7 +385,7 @@ def _load_model(path, **kwargs):
                         )
                     ),
                     error_code=RESOURCE_DOES_NOT_EXIST,
-                )
+                ) from exc
 
     else:
         model_path = path

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -12,6 +12,7 @@ import pytest
 import numpy as np
 import pandas as pd
 import sklearn.datasets as datasets
+import shutil
 import yaml
 
 import mlflow.pyfunc as pyfunc
@@ -37,7 +38,9 @@ _logger = logging.getLogger(__name__)
 try:
     from tests.helper_functions import pyfunc_serve_and_score_model
     from tests.helper_functions import score_model_in_sagemaker_docker_container
-    from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
+    from tests.helper_functions import (
+        set_boto_credentials,
+    )  # pylint: disable=unused-import
     from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 except ImportError:
     _logger.warning(
@@ -49,7 +52,8 @@ except ImportError:
 def data():
     iris = datasets.load_iris()
     data = pd.DataFrame(
-        data=np.c_[iris["data"], iris["target"]], columns=iris["feature_names"] + ["target"]
+        data=np.c_[iris["data"], iris["target"]],
+        columns=iris["feature_names"] + ["target"],
     )
     y = data["target"]
     x = data.drop("target", axis=1)
@@ -58,7 +62,10 @@ def data():
 
 def get_dataset(data):
     x, y = data
-    dataset = [(xi.astype(np.float32), yi.astype(np.float32)) for xi, yi in zip(x.values, y.values)]
+    dataset = [
+        (xi.astype(np.float32), yi.astype(np.float32))
+        for xi, yi in zip(x.values, y.values)
+    ]
     return dataset
 
 
@@ -69,7 +76,11 @@ def train_model(model, data):
     batch_size = 16
     num_workers = 4
     dataloader = DataLoader(
-        dataset, batch_size=batch_size, num_workers=num_workers, shuffle=True, drop_last=False
+        dataset,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        shuffle=True,
+        drop_last=False,
     )
 
     model.train()
@@ -162,7 +173,11 @@ def _predict(model, data):
     batch_size = 16
     num_workers = 4
     dataloader = DataLoader(
-        dataset, batch_size=batch_size, num_workers=num_workers, shuffle=False, drop_last=False
+        dataset,
+        batch_size=batch_size,
+        num_workers=num_workers,
+        shuffle=False,
+        drop_last=False,
     )
     predictions = np.zeros((len(dataloader.sampler),))
     model.eval()
@@ -290,7 +305,9 @@ def test_save_and_load_model(sequential_model, model_path, data, sequential_pred
 
     # Loading pytorch model
     sequential_model_loaded = mlflow.pytorch.load_model(model_path)
-    np.testing.assert_array_equal(_predict(sequential_model_loaded, data), sequential_predicted)
+    np.testing.assert_array_equal(
+        _predict(sequential_model_loaded, data), sequential_predicted
+    )
 
     # Loading pyfunc model
     pyfunc_loaded = mlflow.pyfunc.load_pyfunc(model_path)
@@ -312,7 +329,9 @@ def test_load_model_from_remote_uri_succeeds(
 
     model_uri = artifact_root + "/" + artifact_path
     sequential_model_loaded = mlflow.pytorch.load_model(model_uri=model_uri)
-    np.testing.assert_array_equal(_predict(sequential_model_loaded, data), sequential_predicted)
+    np.testing.assert_array_equal(
+        _predict(sequential_model_loaded, data), sequential_predicted
+    )
 
 
 @pytest.mark.large
@@ -323,7 +342,9 @@ def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
         pytorch_model=sequential_model, path=model_path, conda_env=pytorch_custom_env
     )
 
-    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    pyfunc_conf = _get_flavor_configuration(
+        model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME
+    )
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
     assert os.path.exists(saved_conda_env_path)
     assert saved_conda_env_path != pytorch_custom_env
@@ -339,9 +360,13 @@ def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
 def test_model_save_accepts_conda_env_as_dict(sequential_model, model_path):
     conda_env = dict(mlflow.pytorch.get_default_conda_env())
     conda_env["dependencies"].append("pytest")
-    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path, conda_env=conda_env)
+    mlflow.pytorch.save_model(
+        pytorch_model=sequential_model, path=model_path, conda_env=conda_env
+    )
 
-    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    pyfunc_conf = _get_flavor_configuration(
+        model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME
+    )
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
     assert os.path.exists(saved_conda_env_path)
 
@@ -367,7 +392,9 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
             )
         )
 
-    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    pyfunc_conf = _get_flavor_configuration(
+        model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME
+    )
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
     assert os.path.exists(saved_conda_env_path)
     assert saved_conda_env_path != pytorch_custom_env
@@ -383,9 +410,13 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
     sequential_model, model_path
 ):
-    mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path, conda_env=None)
+    mlflow.pytorch.save_model(
+        pytorch_model=sequential_model, path=model_path, conda_env=None
+    )
 
-    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    pyfunc_conf = _get_flavor_configuration(
+        model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME
+    )
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
     with open(conda_env_path, "r") as f:
         conda_env = yaml.safe_load(f)
@@ -408,7 +439,9 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
             )
         )
 
-    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    pyfunc_conf = _get_flavor_configuration(
+        model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME
+    )
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
     with open(conda_env_path, "r") as f:
         conda_env = yaml.safe_load(f)
@@ -417,12 +450,16 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 
 
 @pytest.mark.large
-def test_load_model_with_differing_pytorch_version_logs_warning(sequential_model, model_path):
+def test_load_model_with_differing_pytorch_version_logs_warning(
+    sequential_model, model_path
+):
     mlflow.pytorch.save_model(pytorch_model=sequential_model, path=model_path)
     saver_pytorch_version = "1.0"
     model_config_path = os.path.join(model_path, "MLmodel")
     model_config = Model.load(model_config_path)
-    model_config.flavors[mlflow.pytorch.FLAVOR_NAME]["pytorch_version"] = saver_pytorch_version
+    model_config.flavors[mlflow.pytorch.FLAVOR_NAME][
+        "pytorch_version"
+    ] = saver_pytorch_version
     model_config.save(model_config_path)
 
     log_messages = []
@@ -486,9 +523,9 @@ def test_save_model_with_wrong_codepaths_fails_corrrectly(
             conda_env=None,
             code_paths="some string",
         )
-    assert "TypeError: Argument code_paths should be a list, not {}".format(type("")) in str(
-        exc_info
-    )
+    assert "TypeError: Argument code_paths should be a list, not {}".format(
+        type("")
+    ) in str(exc_info)
     assert not os.path.exists(model_path)
 
 
@@ -538,7 +575,9 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
     class TorchValidatorModel(pyfunc.PythonModel):
         def load_context(self, context):
             # pylint: disable=attribute-defined-outside-init
-            self.pytorch_model = mlflow.pytorch.load_model(context.artifacts["pytorch_model"])
+            self.pytorch_model = mlflow.pytorch.load_model(
+                context.artifacts["pytorch_model"]
+            )
 
         def predict(self, context, model_input):
             with torch.no_grad():
@@ -555,7 +594,8 @@ def test_load_model_succeeds_with_dependencies_specified_via_code_paths(
         )
         pyfunc_model_path = _download_artifact_from_uri(
             "runs:/{run_id}/{artifact_path}".format(
-                run_id=mlflow.active_run().info.run_id, artifact_path=pyfunc_artifact_path
+                run_id=mlflow.active_run().info.run_id,
+                artifact_path=pyfunc_artifact_path,
             )
         )
 
@@ -662,7 +702,9 @@ def test_load_pyfunc_succeeds_when_data_is_model_file_instead_of_directory(
     assert pyfunc_conf is not None
     model_data_path = os.path.join(model_path, pyfunc_conf[pyfunc.DATA])
     assert os.path.exists(model_data_path)
-    assert mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME in os.listdir(model_data_path)
+    assert mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME in os.listdir(
+        model_data_path
+    )
     pyfunc_conf[pyfunc.DATA] = os.path.join(
         model_data_path, mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME
     )
@@ -706,7 +748,9 @@ def test_load_model_succeeds_when_data_is_model_file_instead_of_directory(
     assert pyfunc_conf is not None
     model_data_path = os.path.join(model_path, pyfunc_conf[pyfunc.DATA])
     assert os.path.exists(model_data_path)
-    assert mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME in os.listdir(model_data_path)
+    assert mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME in os.listdir(
+        model_data_path
+    )
     pyfunc_conf[pyfunc.DATA] = os.path.join(
         model_data_path, mlflow.pytorch._SERIALIZED_TORCH_MODEL_FILE_NAME
     )
@@ -748,15 +792,22 @@ def test_load_model_allows_user_to_override_pickle_module_via_keyword_argument(
 
     with mock.patch(
         "mlflow.pytorch.pickle_module.load"
-    ) as mlflow_torch_pickle_load_mock, mock.patch("mlflow.pytorch._logger.warning") as warn_mock:
-        mlflow_torch_pickle_load_mock.side_effect = validate_mlflow_torch_pickle_load_called
+    ) as mlflow_torch_pickle_load_mock, mock.patch(
+        "mlflow.pytorch._logger.warning"
+    ) as warn_mock:
+        mlflow_torch_pickle_load_mock.side_effect = (
+            validate_mlflow_torch_pickle_load_called
+        )
         warn_mock.side_effect = custom_warn
-        mlflow.pytorch.load_model(model_uri=model_path, pickle_module=mlflow_pytorch_pickle_module)
+        mlflow.pytorch.load_model(
+            model_uri=model_path, pickle_module=mlflow_pytorch_pickle_module
+        )
 
     assert all(pickle_call_results.values())
     assert any(
         [
-            "does not match the pickle module that was used to save the model" in log_message
+            "does not match the pickle module that was used to save the model"
+            in log_message
             and pickle.__name__ in log_message
             and mlflow_pytorch_pickle_module.__name__ in log_message
             for log_message in log_messages
@@ -774,7 +825,9 @@ def test_load_model_raises_exception_when_pickle_module_cannot_be_imported(
 
     bad_pickle_module_name = "not.a.real.module"
 
-    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    pyfunc_conf = _get_flavor_configuration(
+        model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME
+    )
     model_data_path = os.path.join(model_path, pyfunc_conf[pyfunc.DATA])
     assert os.path.exists(model_data_path)
     assert mlflow.pytorch._PICKLE_MODULE_INFO_FILE_NAME in os.listdir(model_data_path)
@@ -808,3 +861,86 @@ def test_sagemaker_docker_model_scoring_with_sequential_model_and_default_conda_
     np.testing.assert_array_almost_equal(
         deployed_model_preds.values[:, 0], sequential_predicted, decimal=4
     )
+
+
+@pytest.fixture
+def create_artifact(tmpdir):
+    artifact_file_name = "requirements.txt"
+    fp = tmpdir.mkdir("artifacts").join(artifact_file_name)
+    test_string = "pytest"
+    fp.write(test_string)
+    yield fp
+    shutil.rmtree(str(tmpdir))
+
+
+def test_artifacts_log_model(create_artifact, sequential_model):
+    artifact_file_path = create_artifact
+    with mlflow.start_run():
+        mlflow.pytorch.log_model(
+            pytorch_model=sequential_model,
+            artifact_path="models",
+            conda_env=None,
+            artifacts={"requirements.txt": str(artifact_file_path)},
+        )
+
+        model_uri = "runs:/{run_id}/{model_path}".format(
+            run_id=mlflow.active_run().info.run_id, model_path="models"
+        )
+        with TempDir(remove_on_exit=True) as tmp:
+            model_path = _download_artifact_from_uri(model_uri, tmp.path())
+            assert os.path.isdir(os.path.join(model_path, "artifacts")) is True
+            requirements_file = os.path.join(
+                model_path, "artifacts", "requirements.txt"
+            )
+            assert os.path.isfile(requirements_file) is True
+            with open(requirements_file) as fp:
+                content = fp.read()
+            assert "pytest" in content
+
+
+def test_artifacts_save_model(create_artifact, sequential_model):
+    artifact_path = create_artifact
+    with mlflow.start_run(), TempDir(remove_on_exit=True) as tmp:
+        model_path = os.path.join(tmp.path(), "models")
+        mlflow.pytorch.save_model(
+            pytorch_model=sequential_model,
+            path=model_path,
+            artifacts={"requirements.txt": str(artifact_path)},
+        )
+
+        assert os.path.isdir(os.path.join(model_path, "artifacts")) is True
+        requirements_file = os.path.join(model_path, "artifacts", "requirements.txt")
+        assert os.path.isfile(requirements_file) is True
+        with open(requirements_file) as fp:
+            content = fp.read()
+
+        assert "pytest" in content
+
+
+def test_log_model_invalid_path(create_artifact, sequential_model):
+    artifact_file_path = create_artifact
+    print("Artifact Path {}".format(artifact_file_path))
+    with mlflow.start_run(), pytest.raises(FileNotFoundError):
+        mlflow.pytorch.log_model(
+            pytorch_model=sequential_model,
+            artifact_path="models",
+            conda_env=None,
+            artifacts={
+                "requirements.txt": str(artifact_file_path).replace(
+                    "requirements", "requirements1"
+                )
+            },
+        )
+
+
+def test_log_model_invalid_type(create_artifact, sequential_model):
+    artifact_file_path = create_artifact
+    print("Artifact Path {}".format(artifact_file_path))
+    with mlflow.start_run(), pytest.raises(TypeError) as exc_info:
+        mlflow.pytorch.log_model(
+            pytorch_model=sequential_model,
+            artifact_path="models",
+            conda_env=None,
+            artifacts=str(artifact_file_path).replace("requirements", "requirements1"),
+        )
+        assert "Argument artifacts should be a list" in str(exc_info)

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -98,6 +98,7 @@ def get_subclassed_model_definition():
     can be invoked within a module to define the class in the module's scope.
     """
 
+    # pylint: disable=W0223
     class SubclassedModel(torch.nn.Module):
         def __init__(self):
             super(SubclassedModel, self).__init__()
@@ -123,6 +124,7 @@ def main_scoped_subclassed_model(data):
     return model
 
 
+# pylint: disable=W0223
 class ModuleScopedSubclassedModel(get_subclassed_model_definition()):
     """
     A custom PyTorch model class defined in the test module scope. This is a subclass of


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixing pylint issues in mlflow pytorch library, Looks like an existing issue in repository and the fix is needed to unblock - https://github.com/mlflow/mlflow/pull/3382 . 

## How is this patch tested?

Tested by loading pytorch model with incorrect pickle file - MLFLowException is getting raised as expected. 

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
