### PR TITLE
Fix small bugs in XGBoost autologging

### DIFF
--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -397,6 +397,7 @@ def autolog(importance_types=["weight"]):  # pylint: disable=W0102
 
         # logging feature importance as artifacts.
         for imp_type in importance_types:
+            imp = None
             try:
                 imp = model.get_score(importance_type=imp_type)
                 features, importance = zip(*imp.items())
@@ -407,14 +408,15 @@ def autolog(importance_types=["weight"]):  # pylint: disable=W0102
                     "will ignore the failure and continue. Exception: "
                 )
 
-            tmpdir = tempfile.mkdtemp()
-            try:
-                filepath = os.path.join(tmpdir, "feature_importance_{}.json".format(imp_type))
-                with open(filepath, "w") as f:
-                    json.dump(imp, f)
-                try_mlflow_log(mlflow.log_artifact, filepath)
-            finally:
-                shutil.rmtree(tmpdir)
+            if imp is not None:
+                tmpdir = tempfile.mkdtemp()
+                try:
+                    filepath = os.path.join(tmpdir, "feature_importance_{}.json".format(imp_type))
+                    with open(filepath, "w") as f:
+                        json.dump(imp, f)
+                    try_mlflow_log(mlflow.log_artifact, filepath)
+                finally:
+                    shutil.rmtree(tmpdir)
 
         try_mlflow_log(log_model, model, artifact_path="model")
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -397,8 +397,8 @@ def autolog(importance_types=["weight"]):  # pylint: disable=W0102
 
         # logging feature importance as artifacts.
         for imp_type in importance_types:
-            imp = model.get_score(importance_type=imp_type)
             try:
+                imp = model.get_score(importance_type=imp_type)
                 features, importance = zip(*imp.items())
                 log_feature_importance_plot(features, importance, imp_type)
             except Exception:  # pylint: disable=broad-except

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -398,12 +398,12 @@ def autolog(importance_types=["weight"]):  # pylint: disable=W0102
         # logging feature importance as artifacts.
         for imp_type in importance_types:
             imp = model.get_score(importance_type=imp_type)
-            features, importance = zip(*imp.items())
             try:
+                features, importance = zip(*imp.items())
                 log_feature_importance_plot(features, importance, imp_type)
             except Exception:  # pylint: disable=broad-except
                 _logger.exception(
-                    "Failed to log feature importance plot. LightGBM autologging "
+                    "Failed to log feature importance plot. XGBoost autologging "
                     "will ignore the failure and continue. Exception: "
                 )
 

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -311,7 +311,10 @@ def test_xgb_autolog_does_not_throw_if_importance_values_not_supported(dtrain):
 
     # we make sure here that we do not throw while attempting to plot
     #   importance values on a model with a linear booster.
-    xgb.train(bst_params, dtrain)
+    model = xgb.train(bst_params, dtrain)
+
+    with pytest.raises(Exception):
+        model.get_score(importance_type='weight')
 
 
 @pytest.mark.large
@@ -327,4 +330,6 @@ def test_xgb_autolog_does_not_throw_if_importance_values_are_empty(bst_params, t
 
     # we make sure here that we do not throw while attempting to plot
     #   importance values on a dataset that returns no importance values.
-    xgb.train(bst_params, dataset)
+    model = xgb.train(bst_params, dataset)
+
+    assert model.get_score(importance_type='weight') == {}

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -1,7 +1,6 @@
 import os
 import json
 import pytest
-import mock
 import numpy as np
 import pandas as pd
 from sklearn import datasets

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -297,15 +297,12 @@ def test_xgb_autolog_loads_model_from_artifact(bst_params, dtrain):
     loaded_model = mlflow.xgboost.load_model("runs:/{}/model".format(run_id))
     np.testing.assert_array_almost_equal(model.predict(dtrain), loaded_model.predict(dtrain))
 
+
 @pytest.mark.large
 def test_xgb_autolog_does_not_throw_if_importance_values_not_supported(dtrain):
     # the gblinear booster does not support calling get_score on it,
     #   where get_score is used to create the importance values plot.
-    bst_params = {
-        "objective": "multi:softprob",
-        "num_class": 3,
-        "booster": "gblinear"
-    }
+    bst_params = {"objective": "multi:softprob", "num_class": 3, "booster": "gblinear"}
 
     mlflow.xgboost.autolog()
 
@@ -314,7 +311,7 @@ def test_xgb_autolog_does_not_throw_if_importance_values_not_supported(dtrain):
     model = xgb.train(bst_params, dtrain)
 
     with pytest.raises(Exception):
-        model.get_score(importance_type='weight')
+        model.get_score(importance_type="weight")
 
 
 @pytest.mark.large
@@ -332,4 +329,4 @@ def test_xgb_autolog_does_not_throw_if_importance_values_are_empty(bst_params, t
     #   importance values on a dataset that returns no importance values.
     model = xgb.train(bst_params, dataset)
 
-    assert model.get_score(importance_type='weight') == {}
+    assert model.get_score(importance_type="weight") == {}

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -315,7 +315,7 @@ def test_xgb_autolog_does_not_throw_if_importance_values_not_supported(dtrain):
 
 @pytest.mark.large
 def test_xgb_autolog_does_not_throw_if_importance_values_are_empty(bst_params, tmpdir):
-    tmp_csv = tmpdir.join("data2.csv")
+    tmp_csv = tmpdir.join("data.csv")
     tmp_csv.write("1,0.3,1.2\n")
     tmp_csv.write("0,2.4,5.2\n")
     tmp_csv.write("1,0.3,-1.2\n")


### PR DESCRIPTION
Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

## What changes are proposed in this pull request?

- Rename "LightGBM" to "XGBoost" in the error message when saving importance value plot
- Catch possible exception when the importance value array returned by XGBoost is empty

## How is this patch tested?

Manual testing to confirm it catches the exception I previously faced with a certain dataset

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
