### PR TITLE
Fix metrics sorting error on UI

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -490,13 +490,22 @@ class SearchUtils(object):
                 "Invalid order_by entity type '%s'" % key_type, error_code=INVALID_PARAMETER_VALUE
             )
 
-        # Return a key such that None values are always at the end.
-        is_null_or_nan = sort_value is None or (
-            isinstance(sort_value, float) and math.isnan(sort_value)
-        )
+        # Return a key such that runs are always sorted in the order: [ valid_value, nan, None ]
+        is_none = sort_value is None
+        is_nan = isinstance(sort_value, float) and math.isnan(sort_value)
+
+        def get_inf():
+            return math.inf if ascending else -math.inf
+
+        if is_none:
+            sort_value = get_inf()
+
+        if is_nan:
+            sort_value = -get_inf()
+
         if ascending:
-            return (is_null_or_nan, sort_value)
-        return (not is_null_or_nan, sort_value)
+            return (is_none or is_nan, sort_value)
+        return (not (is_none or is_nan), sort_value)
 
     @classmethod
     def sort(cls, runs, order_by_list):

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -490,22 +490,19 @@ class SearchUtils(object):
                 "Invalid order_by entity type '%s'" % key_type, error_code=INVALID_PARAMETER_VALUE
             )
 
-        # Return a key such that runs are always sorted in the order: [ valid_value, nan, None ]
+        # Return a key such that None values are always at the end.
         is_none = sort_value is None
         is_nan = isinstance(sort_value, float) and math.isnan(sort_value)
-
-        def get_inf():
-            return math.inf if ascending else -math.inf
+        fill_value = (1 if ascending else -1) * math.inf
 
         if is_none:
-            sort_value = get_inf()
+            sort_value = fill_value
+        elif is_nan:
+            sort_value = -fill_value
 
-        if is_nan:
-            sort_value = -get_inf()
+        is_none_or_nan = is_none or is_nan
 
-        if ascending:
-            return (is_none or is_nan, sort_value)
-        return (not (is_none or is_nan), sort_value)
+        return (is_none_or_nan, sort_value) if ascending else (not is_none_or_nan, sort_value)
 
     @classmethod
     def sort(cls, runs, order_by_list):

--- a/tests/utils/test_search_utils.py
+++ b/tests/utils/test_search_utils.py
@@ -382,8 +382,8 @@ def test_correct_sorting(order_bys, matching_runs):
     assert sorted_run_indices == matching_runs
 
 
-def test_order_by_metric_with_nans_and_infs():
-    metric_vals_str = ["nan", "inf", "-inf", "-1000", "0", "1000"]
+def test_order_by_metric_with_nans_infs_nones():
+    metric_vals_str = ["nan", "inf", "-inf", "-1000", "0", "1000", "None"]
     runs = [
         Run(
             run_info=RunInfo(
@@ -396,16 +396,16 @@ def test_order_by_metric_with_nans_and_infs():
                 end_time=1,
                 lifecycle_stage=LifecycleStage.ACTIVE,
             ),
-            run_data=RunData(metrics=[Metric("x", float(x), 1, 0)]),
+            run_data=RunData(metrics=[Metric("x", None if x == "None" else float(x), 1, 0)]),
         )
         for x in metric_vals_str
     ]
     sorted_runs_asc = [x.info.run_id for x in SearchUtils.sort(runs, ["metrics.x asc"])]
     sorted_runs_desc = [x.info.run_id for x in SearchUtils.sort(runs, ["metrics.x desc"])]
     # asc
-    assert ["-inf", "-1000", "0", "1000", "inf", "nan"] == sorted_runs_asc
+    assert ["-inf", "-1000", "0", "1000", "inf", "nan", "None"] == sorted_runs_asc
     # desc
-    assert ["inf", "1000", "0", "-1000", "-inf", "nan"] == sorted_runs_desc
+    assert ["inf", "1000", "0", "-1000", "-inf", "nan", "None"] == sorted_runs_desc
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fixes #3406

## How is this patch tested?

- Unit test
- Manually verify that runs are sorted as expetecd on the MLflow UI

![sort-runs](https://user-images.githubusercontent.com/17039389/92863283-b462b300-f436-11ea-87ce-74f0cbeed243.gif)


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
