### PR TITLE
"Call `atexit.register(_flush_queue)` in `tensorflow.autolog`

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -197,7 +197,7 @@ jobs:
         run: |
           python -c "import mlflow"
       - name: Verify `mlruns` directory doesn't exist
-        # This step prevents an issue like: https://github.com/mlflow/mlflow/issues/3400
+        # This step prevents issues like: https://github.com/mlflow/mlflow/issues/3400
         run: |
           if [ -d "./mlruns" ]; then
             exit 1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -196,9 +196,9 @@ jobs:
       - name: Verify mlflow can be imported without errors
         run: |
           python -c "import mlflow"
-      - name: Verify `mlruns` directory doesn't exist
-        # This step prevents issues like: https://github.com/mlflow/mlflow/issues/3400
-        run: |
+
+          # Just importing mlflow should not create `mlruns` directory
+          # See: https://github.com/mlflow/mlflow/issues/3400
           if [ -d "./mlruns" ]; then
             exit 1
           fi

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,9 +2,9 @@ name: MLflow tests
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
-    branches: [master]
+    branches: [ master ]
 
 env:
   CONDA_DIR: /usr/share/miniconda
@@ -13,126 +13,126 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        env:
-          INSTALL_LARGE_PYTHON_DEPS: true
-          INSTALL_SMALL_PYTHON_DEPS: true
-        run: |
-          source ./dev/install-common-deps.sh
-          pip install -r ./dev/lint-requirements.txt
-      - name: Run tests
-        run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
-          source activate test-environment
-          ./lint.sh
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      env:
+        INSTALL_LARGE_PYTHON_DEPS: true
+        INSTALL_SMALL_PYTHON_DEPS: true
+      run: |
+        source ./dev/install-common-deps.sh
+        pip install -r ./dev/lint-requirements.txt
+    - name: Run tests
+      run: |
+        export PATH="$CONDA_DIR/bin:$PATH"
+        source activate test-environment
+        ./lint.sh
   r:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
-      - uses: r-lib/actions/setup-r@v1
-      # This step dumps the current set of R dependencies and R version into files to be used
-      # as a cache key when caching/restoring R dependencies.
-      - name: Query dependencies
-        run: |
-          install.packages('remotes')
-          saveRDS(remotes::dev_package_deps("mlflow/R/mlflow", dependencies = TRUE), ".github/depends.Rds", version = 2)
-          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-        shell: Rscript {0}
+    - uses: actions/checkout@master
+    - uses: r-lib/actions/setup-r@v1
+    # This step dumps the current set of R dependencies and R version into files to be used
+    # as a cache key when caching/restoring R dependencies.
+    - name: Query dependencies
+      run: |
+        install.packages('remotes')
+        saveRDS(remotes::dev_package_deps("mlflow/R/mlflow", dependencies = TRUE), ".github/depends.Rds", version = 2)
+        writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+      shell: Rscript {0}
 
-      - name: Cache R packages
-        if: runner.os != 'Windows'
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.R_LIBS_USER }}
-          # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
-          # R dependencies
-          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get install -y libcurl4-openssl-dev
-      - name: Install dependencies
-        run: |
-          install.packages("devtools")
-          remotes::install_deps('mlflow/R/mlflow', dependencies = TRUE, upgrade = FALSE)
-        shell: Rscript {0}
-      - name: Run tests
-        run: |
-          source ./dev/install-common-deps.sh
-          cd mlflow/R/mlflow
-          R CMD build .
-          export LINTR_COMMENT_BOT=false
-          cd tests
-          Rscript ../.run-tests.R
-      - name: Calculate code coverage
-        if: ${{ success() }}
-        run: |
-          export MLFLOW_HOME=$(pwd)
-          cd mlflow/R/mlflow/tests
-          Rscript -e 'covr::codecov()' || :
-        env:
-          COVR_RUNNING: true
-      - name: Show 00check.log on failure
-        if: ${{ failure() }}
-        run: |
-          LOG_FILE="${HOME}/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
-          [ -r "${LOG_FILE}" ] && cat "${LOG_FILE}"
-          cp "${LOG_FILE}" /tmp
-      - uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: 00check.log
-          path: /tmp/00check.log
+    - name: Cache R packages
+      if: runner.os != 'Windows'
+      uses: actions/cache@v2
+      with:
+        path: ${{ env.R_LIBS_USER }}
+        # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
+        # R dependencies
+        key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+        restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+    - name: Install system dependencies
+      run: |
+        sudo apt-get install -y libcurl4-openssl-dev
+    - name: Install dependencies
+      run: |
+        install.packages("devtools")
+        remotes::install_deps('mlflow/R/mlflow', dependencies = TRUE, upgrade = FALSE)
+      shell: Rscript {0}
+    - name: Run tests
+      run: |
+        source ./dev/install-common-deps.sh
+        cd mlflow/R/mlflow
+        R CMD build .
+        export LINTR_COMMENT_BOT=false
+        cd tests
+        Rscript ../.run-tests.R
+    - name: Calculate code coverage
+      if: ${{ success() }}
+      run: |
+        export MLFLOW_HOME=$(pwd)
+        cd mlflow/R/mlflow/tests
+        Rscript -e 'covr::codecov()' || :
+      env:
+        COVR_RUNNING: true
+    - name: Show 00check.log on failure
+      if: ${{ failure() }}
+      run: |
+        LOG_FILE="${HOME}/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
+        [ -r "${LOG_FILE}" ] && cat "${LOG_FILE}"
+        cp "${LOG_FILE}" /tmp
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: 00check.log
+        path: /tmp/00check.log
   python-small:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        env:
-          INSTALL_LARGE_PYTHON_DEPS: true
-        run: |
-          source ./dev/install-common-deps.sh
-      - name: Run tests
-        run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
-          source activate test-environment
-          ./dev/run-small-python-tests.sh
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      env:
+        INSTALL_LARGE_PYTHON_DEPS: true
+      run: |
+        source ./dev/install-common-deps.sh
+    - name: Run tests
+      run: |
+        export PATH="$CONDA_DIR/bin:$PATH"
+        source activate test-environment
+        ./dev/run-small-python-tests.sh
 
   python-large:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        env:
-          INSTALL_LARGE_PYTHON_DEPS: true
-        run: |
-          source ./dev/install-common-deps.sh
-      - name: Run tests
-        run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
-          source activate test-environment
-          ./dev/run-large-python-tests.sh
-          ./dev/test-anaconda-compatibility.sh "anaconda3:2020.02"
-          ./dev/test-anaconda-compatibility.sh "anaconda3:2019.03"
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      env:
+        INSTALL_LARGE_PYTHON_DEPS: true
+      run: |
+        source ./dev/install-common-deps.sh
+    - name: Run tests
+      run: |
+        export PATH="$CONDA_DIR/bin:$PATH"
+        source activate test-environment
+        ./dev/run-large-python-tests.sh
+        ./dev/test-anaconda-compatibility.sh "anaconda3:2020.02"
+        ./dev/test-anaconda-compatibility.sh "anaconda3:2019.03"
 
   java:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Java
-        uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - name: Install dependencies
-        run: |
-          source ./dev/install-common-deps.sh
-      - name: Run tests
-        run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
-          source activate test-environment
-          cd mlflow/java
-          mvn clean package -q
+    - uses: actions/checkout@v2
+    - name: Set up Java
+      uses: actions/setup-java@v1
+      with:
+        java-version: 8
+    - name: Install dependencies
+      run: |
+        source ./dev/install-common-deps.sh
+    - name: Run tests
+      run: |
+        export PATH="$CONDA_DIR/bin:$PATH"
+        source activate test-environment
+        cd mlflow/java
+        mvn clean package -q
 
   js:
     runs-on: ubuntu-latest
@@ -140,32 +140,32 @@ jobs:
       run:
         working-directory: mlflow/server/js
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Node
-        uses: actions/setup-node@v1
-        with:
-          node-version: 10.x
-      - name: Install dependencies
-        run: |
-          npm i
-      - name: Run lint
-        run: |
-          npm run lint
-      - name: Run tests
-        run: |
-          npm run test
+    - uses: actions/checkout@v2
+    - name: Set up Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 10.x
+    - name: Install dependencies
+      run: |
+        npm i
+    - name: Run lint
+      run: |
+        npm run lint
+    - name: Run tests
+      run: |
+        npm run test
 
   protos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Install dependencies
-        run: |
-          wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O $HOME/protoc.zip
-          sudo unzip $HOME/protoc.zip -d /usr
-      - name: Run tests
-        run: |
-          ./test-generate-protos.sh
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O $HOME/protoc.zip
+        sudo unzip $HOME/protoc.zip -d /usr
+    - name: Run tests
+      run: |
+        ./test-generate-protos.sh
 
   flavors:
     runs-on: ubuntu-latest
@@ -189,14 +189,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.6"
+          python-version: '3.6'
       - name: Install mlflow
         run: |
           pip install -e .
       - name: Verify mlflow can be imported without errors
         run: |
           python -c "import mlflow"
-
       - name: Verify `mlruns` directory doesn't exist
         # This step prevents an issue like: https://github.com/mlflow/mlflow/issues/3400
         run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,9 +2,9 @@ name: MLflow tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 env:
   CONDA_DIR: /usr/share/miniconda
@@ -13,126 +13,126 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      env:
-        INSTALL_LARGE_PYTHON_DEPS: true
-        INSTALL_SMALL_PYTHON_DEPS: true
-      run: |
-        source ./dev/install-common-deps.sh
-        pip install -r ./dev/lint-requirements.txt
-    - name: Run tests
-      run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        ./lint.sh
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        env:
+          INSTALL_LARGE_PYTHON_DEPS: true
+          INSTALL_SMALL_PYTHON_DEPS: true
+        run: |
+          source ./dev/install-common-deps.sh
+          pip install -r ./dev/lint-requirements.txt
+      - name: Run tests
+        run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          ./lint.sh
   r:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: r-lib/actions/setup-r@v1
-    # This step dumps the current set of R dependencies and R version into files to be used
-    # as a cache key when caching/restoring R dependencies.
-    - name: Query dependencies
-      run: |
-        install.packages('remotes')
-        saveRDS(remotes::dev_package_deps("mlflow/R/mlflow", dependencies = TRUE), ".github/depends.Rds", version = 2)
-        writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-      shell: Rscript {0}
+      - uses: actions/checkout@master
+      - uses: r-lib/actions/setup-r@v1
+      # This step dumps the current set of R dependencies and R version into files to be used
+      # as a cache key when caching/restoring R dependencies.
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps("mlflow/R/mlflow", dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
 
-    - name: Cache R packages
-      if: runner.os != 'Windows'
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.R_LIBS_USER }}
-        # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
-        # R dependencies
-        key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-        restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
-    - name: Install system dependencies
-      run: |
-        sudo apt-get install -y libcurl4-openssl-dev
-    - name: Install dependencies
-      run: |
-        install.packages("devtools")
-        remotes::install_deps('mlflow/R/mlflow', dependencies = TRUE, upgrade = FALSE)
-      shell: Rscript {0}
-    - name: Run tests
-      run: |
-        source ./dev/install-common-deps.sh
-        cd mlflow/R/mlflow
-        R CMD build .
-        export LINTR_COMMENT_BOT=false
-        cd tests
-        Rscript ../.run-tests.R
-    - name: Calculate code coverage
-      if: ${{ success() }}
-      run: |
-        export MLFLOW_HOME=$(pwd)
-        cd mlflow/R/mlflow/tests
-        Rscript -e 'covr::codecov()' || :
-      env:
-        COVR_RUNNING: true
-    - name: Show 00check.log on failure
-      if: ${{ failure() }}
-      run: |
-        LOG_FILE="${HOME}/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
-        [ -r "${LOG_FILE}" ] && cat "${LOG_FILE}"
-        cp "${LOG_FILE}" /tmp
-    - uses: actions/upload-artifact@v1
-      if: failure()
-      with:
-        name: 00check.log
-        path: /tmp/00check.log
+      - name: Cache R packages
+        if: runner.os != 'Windows'
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
+          # R dependencies
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+      - name: Install system dependencies
+        run: |
+          sudo apt-get install -y libcurl4-openssl-dev
+      - name: Install dependencies
+        run: |
+          install.packages("devtools")
+          remotes::install_deps('mlflow/R/mlflow', dependencies = TRUE, upgrade = FALSE)
+        shell: Rscript {0}
+      - name: Run tests
+        run: |
+          source ./dev/install-common-deps.sh
+          cd mlflow/R/mlflow
+          R CMD build .
+          export LINTR_COMMENT_BOT=false
+          cd tests
+          Rscript ../.run-tests.R
+      - name: Calculate code coverage
+        if: ${{ success() }}
+        run: |
+          export MLFLOW_HOME=$(pwd)
+          cd mlflow/R/mlflow/tests
+          Rscript -e 'covr::codecov()' || :
+        env:
+          COVR_RUNNING: true
+      - name: Show 00check.log on failure
+        if: ${{ failure() }}
+        run: |
+          LOG_FILE="${HOME}/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
+          [ -r "${LOG_FILE}" ] && cat "${LOG_FILE}"
+          cp "${LOG_FILE}" /tmp
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: 00check.log
+          path: /tmp/00check.log
   python-small:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      env:
-        INSTALL_LARGE_PYTHON_DEPS: true
-      run: |
-        source ./dev/install-common-deps.sh
-    - name: Run tests
-      run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        ./dev/run-small-python-tests.sh
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        env:
+          INSTALL_LARGE_PYTHON_DEPS: true
+        run: |
+          source ./dev/install-common-deps.sh
+      - name: Run tests
+        run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          ./dev/run-small-python-tests.sh
 
   python-large:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      env:
-        INSTALL_LARGE_PYTHON_DEPS: true
-      run: |
-        source ./dev/install-common-deps.sh
-    - name: Run tests
-      run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        ./dev/run-large-python-tests.sh
-        ./dev/test-anaconda-compatibility.sh "anaconda3:2020.02"
-        ./dev/test-anaconda-compatibility.sh "anaconda3:2019.03"
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        env:
+          INSTALL_LARGE_PYTHON_DEPS: true
+        run: |
+          source ./dev/install-common-deps.sh
+      - name: Run tests
+        run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          ./dev/run-large-python-tests.sh
+          ./dev/test-anaconda-compatibility.sh "anaconda3:2020.02"
+          ./dev/test-anaconda-compatibility.sh "anaconda3:2019.03"
 
   java:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Java
-      uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - name: Install dependencies
-      run: |
-        source ./dev/install-common-deps.sh
-    - name: Run tests
-      run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        cd mlflow/java
-        mvn clean package -q
+      - uses: actions/checkout@v2
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Install dependencies
+        run: |
+          source ./dev/install-common-deps.sh
+      - name: Run tests
+        run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          cd mlflow/java
+          mvn clean package -q
 
   js:
     runs-on: ubuntu-latest
@@ -140,32 +140,32 @@ jobs:
       run:
         working-directory: mlflow/server/js
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: 10.x
-    - name: Install dependencies
-      run: |
-        npm i
-    - name: Run lint
-      run: |
-        npm run lint
-    - name: Run tests
-      run: |
-        npm run test
+      - uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - name: Install dependencies
+        run: |
+          npm i
+      - name: Run lint
+        run: |
+          npm run lint
+      - name: Run tests
+        run: |
+          npm run test
 
   protos:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: |
-        wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O $HOME/protoc.zip
-        sudo unzip $HOME/protoc.zip -d /usr
-    - name: Run tests
-      run: |
-        ./test-generate-protos.sh
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O $HOME/protoc.zip
+          sudo unzip $HOME/protoc.zip -d /usr
+      - name: Run tests
+        run: |
+          ./test-generate-protos.sh
 
   flavors:
     runs-on: ubuntu-latest
@@ -189,13 +189,20 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.6'
+          python-version: "3.6"
       - name: Install mlflow
         run: |
           pip install -e .
       - name: Verify mlflow can be imported without errors
         run: |
           python -c "import mlflow"
+
+      - name: Verify `mlruns` directory doesn't exist
+        # This step prevents an issue like: https://github.com/mlflow/mlflow/issues/3400
+        run: |
+          if [ -d "./mlruns" ]; then
+            exit 1
+          fi
 
   tensorflow:
     runs-on: ubuntu-latest

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -587,9 +587,6 @@ def _flush_queue():
     _metric_queue = []
 
 
-atexit.register(_flush_queue)
-
-
 def _add_to_queue(key, value, step, time, run_id):
     """
     Add a metric to the metric queue. Flush the queue if it exceeds
@@ -827,6 +824,8 @@ def autolog(every_n_iter=100):
 
     global _LOG_EVERY_N_STEPS
     _LOG_EVERY_N_STEPS = every_n_iter
+
+    atexit.register(_flush_queue)
 
     if LooseVersion(tensorflow.__version__) < LooseVersion("1.12"):
         warnings.warn(

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -587,6 +587,9 @@ def _flush_queue():
     _metric_queue = []
 
 
+atexit.register(_flush_queue)
+
+
 def _add_to_queue(key, value, step, time, run_id):
     """
     Add a metric to the metric queue. Flush the queue if it exceeds
@@ -824,8 +827,6 @@ def autolog(every_n_iter=100):
 
     global _LOG_EVERY_N_STEPS
     _LOG_EVERY_N_STEPS = every_n_iter
-
-    atexit.register(_flush_queue)
 
     if LooseVersion(tensorflow.__version__) < LooseVersion("1.12"):
         warnings.warn(


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fixes #3400 

When importing the tensorflow flavor, `mlruns` folder is created by `_flush_queue` registered by `atexit.register`. 

https://github.com/mlflow/mlflow/blob/e34dbf236f7c19e9774365d03c87bc1b746d932f/mlflow/tensorflow.py#L577-L591

We currently import the tensorflow flavor in `mlflow.__init__.py`. This means executing `import mlflow` creates `mlruns` folder. To fix this issue, call `atexit.register(_flush_queue)` in the `tensorflow.autolog` function.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
