### PR TITLE
Fix model version run_link URL for some Databricks regions

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -157,7 +157,7 @@ def get_workspace_info_from_dbutils():
         context = json.loads(
             dbutils.notebook.entry_point.getDbutils().notebook().getContext().toJson()
         )
-        workspace_host = 'https://' + context["extraContext"]["browserHostName"]
+        workspace_host = "https://" + context["extraContext"]["browserHostName"]
         workspace_id = context["tags"]["orgId"]
         return workspace_host, workspace_id
     return None, None

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -157,7 +157,7 @@ def get_workspace_info_from_dbutils():
         context = json.loads(
             dbutils.notebook.entry_point.getDbutils().notebook().getContext().toJson()
         )
-        workspace_host = "https://" + context["extraContext"]["browserHostName"]
+        workspace_host = "https://" + context["tags"]["browserHostName"]
         workspace_id = context["tags"]["orgId"]
         return workspace_host, workspace_id
     return None, None

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -157,7 +157,7 @@ def get_workspace_info_from_dbutils():
         context = json.loads(
             dbutils.notebook.entry_point.getDbutils().notebook().getContext().toJson()
         )
-        workspace_host = context["extraContext"]["api_url"]
+        workspace_host = 'https://' + context["extraContext"]["browserHostName"]
         workspace_id = context["tags"]["orgId"]
         return workspace_host, workspace_id
     return None, None

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -104,7 +104,7 @@ def test_get_workspace_info_from_databricks_secrets():
 def test_get_workspace_info_from_dbutils():
     mock_dbutils = mock.MagicMock()
     mock_dbutils.notebook.entry_point.getDbutils.return_value.notebook.return_value.getContext.return_value.toJson.return_value = (  # noqa
-        '"tags": {"orgId" : "1111", "browserHostName": "mlflow.databricks.com"}}'
+        '{"tags": {"orgId" : "1111", "browserHostName": "mlflow.databricks.com"}}'
     )
     with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
         workspace_host, workspace_id = get_workspace_info_from_dbutils()

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -104,9 +104,7 @@ def test_get_workspace_info_from_databricks_secrets():
 def test_get_workspace_info_from_dbutils():
     mock_dbutils = mock.MagicMock()
     mock_dbutils.notebook.entry_point.getDbutils.return_value.notebook.return_value.getContext.return_value.toJson.return_value = (  # noqa
-        '{"extraContext":'
-        '{"browserHostName": "mlflow.databricks.com"},'
-        '"tags": {"orgId" : "1111"}}'
+        '"tags": {"orgId" : "1111", "browserHostName": "mlflow.databricks.com"}}'
     )
     with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
         workspace_host, workspace_id = get_workspace_info_from_dbutils()

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -105,7 +105,7 @@ def test_get_workspace_info_from_dbutils():
     mock_dbutils = mock.MagicMock()
     mock_dbutils.notebook.entry_point.getDbutils.return_value.notebook.return_value.getContext.return_value.toJson.return_value = (  # noqa
         '{"extraContext":'
-        '{"api_url": "https://mlflow.databricks.com"},'
+        '{"browserHostName": "mlflow.databricks.com"},'
         '"tags": {"orgId" : "1111"}}'
     )
     with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes the bug where the ``run_link`` field for model versions created from a remote Databricks workspace was incorrect for certain regions. 

## How is this patch tested?

- Unit tests
- Manual tests
```
from mlflow.tracking.client import MlflowClient
client = MlflowClient()
client._get_run_link('databricks', 'abcde')
```

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes the bug where the ``run_link`` field for model versions created from a remote Databricks workspace was incorrect for certain regions. 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
