### PR TITLE
Some additional model handling to azureml.deploy

### DIFF
--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -402,7 +402,7 @@ def deploy(
                     registered_model.name,
                     registered_model.version,
                 )
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             _logger.info(
                 "Unable to find model in AzureML with ID '%s', will register the model.", m_id
             )

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -386,8 +386,8 @@ def deploy(
 
         try:
             if model_uri.startswith("models:/"):
-                m_name = model_uri.split('/')[-2]
-                m_version = int(model_uri.split('/')[-1])
+                m_name = model_uri.split("/")[-2]
+                m_version = int(model_uri.split("/")[-1])
                 m_id = "{}:{}".format(m_name, m_version)
                 registered_model = AzureModel(workspace, id=m_id)
 
@@ -397,19 +397,28 @@ def deploy(
                 m_id = "{}:{}".format(m.name, m.version)
                 registered_model = AzureModel(workspace, id=m_id)
 
-                _logger.info("Registered an Azure Model with name: `%s` and version: `%s`",
-                             registered_model.name, registered_model.version)
+                _logger.info(
+                    "Registered an Azure Model with name: `%s` and version: `%s`",
+                    registered_model.name,
+                    registered_model.version,
+                )
         except:
-            _logger.info("Unable to find model in AzureML with ID '{}', will register the "
-                         "model.".format(m_id))
+            _logger.info(
+                "Unable to find model in AzureML with ID '{}', will register the "
+                "model.".format(m_id)
+            )
 
         if not registered_model:
-            registered_model = AzureModel.register(workspace=workspace, model_path=tmp_model_path,
-                                                   model_name=model_name, tags=tags)
+            registered_model = AzureModel.register(
+                workspace=workspace, model_path=tmp_model_path, model_name=model_name, tags=tags
+            )
 
-            _logger.info("Registered an Azure Model with name: `%s` and version: `%s`",
-                         registered_model.name, registered_model.version)
-        
+            _logger.info(
+                "Registered an Azure Model with name: `%s` and version: `%s`",
+                registered_model.name,
+                registered_model.version,
+            )
+
         # Create an execution script (entry point) for the image's model server. Azure ML requires
         # the container's execution script to be located in the current working directory during
         # image creation, so we create the execution script as a temporary file in the current

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -391,7 +391,7 @@ def deploy(
                 m_id = "{}:{}".format(m_name, m_version)
                 registered_model = AzureModel(workspace, id=m_id)
 
-                _logger.info("Found registered model in AzureML with ID '{}'".format(m_id))
+                _logger.info("Found registered model in AzureML with ID '%s'", m_id)
             elif model_uri.startswith("runs:/") and get_tracking_uri().startswith("azureml"):
                 m = mlflow_register_model(model_uri, model_name)
                 m_id = "{}:{}".format(m.name, m.version)
@@ -402,10 +402,9 @@ def deploy(
                     registered_model.name,
                     registered_model.version,
                 )
-        except:
+        except Exception:
             _logger.info(
-                "Unable to find model in AzureML with ID '{}', will register the "
-                "model.".format(m_id)
+                "Unable to find model in AzureML with ID '%s', will register the model.", m_id
             )
 
         if not registered_model:

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -389,8 +389,11 @@ def deploy(
             m_name = model_uri.split("/")[-2]
             m_version = int(model_uri.split("/")[-1])
             azure_model_id = "{}:{}".format(m_name, m_version)
-        elif model_uri.startswith("runs:/") and get_tracking_uri().startswith("azureml") and \
-                get_registry_uri().startswith("azureml"):
+        elif (
+            model_uri.startswith("runs:/")
+            and get_tracking_uri().startswith("azureml")
+            and get_registry_uri().startswith("azureml")
+        ):
             m = mlflow_register_model(model_uri, model_name)
             azure_model_id = "{}:{}".format(m.name, m.version)
 

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -2,7 +2,6 @@
 The ``mlflow.azureml`` module provides an API for deploying MLflow models to Azure
 Machine Learning.
 """
-import mlflow
 import sys
 import os
 import subprocess
@@ -11,7 +10,9 @@ import uuid
 
 from distutils.version import StrictVersion
 
+from mlflow import get_tracking_uri
 from mlflow import pyfunc
+from mlflow import register_model as mlflow_register_model
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME
@@ -391,9 +392,8 @@ def deploy(
                 registered_model = AzureModel(workspace, id=m_id)
 
                 _logger.info("Found registered model in AzureML with ID '{}'".format(m_id))
-            elif model_uri.startswith("runs:/") and \
-                    mlflow.get_tracking_uri().startswith("azureml:/"):
-                m = mlflow.register_model(model_uri, model_name)
+            elif model_uri.startswith("runs:/") and get_tracking_uri().startswith("azureml:/"):
+                m = mlflow_register_model(model_uri, model_name)
                 m_id = "{}:{}".format(m.name, m.version)
                 registered_model = AzureModel(workspace, id=m_id)
 

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -392,7 +392,7 @@ def deploy(
                 registered_model = AzureModel(workspace, id=m_id)
 
                 _logger.info("Found registered model in AzureML with ID '{}'".format(m_id))
-            elif model_uri.startswith("runs:/") and get_tracking_uri().startswith("azureml:/"):
+            elif model_uri.startswith("runs:/") and get_tracking_uri().startswith("azureml"):
                 m = mlflow_register_model(model_uri, model_name)
                 m_id = "{}:{}".format(m.name, m.version)
                 registered_model = AzureModel(workspace, id=m_id)

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -406,7 +406,9 @@ def deploy(
             except Exception as e:  # pylint: disable=broad-except
                 _logger.info(
                     "Unable to find model in AzureML with ID '%s', will register the model.\n"
-                    "Exception was: %s", m_id, e
+                    "Exception was: %s",
+                    m_id,
+                    e,
                 )
 
         if not registered_model:

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -386,18 +386,16 @@ def deploy(
         registered_model = None
         azure_model_id = None
 
-        """
-            If we are passed a 'models' uri, we will attempt to extract a name and version which
-            can be used to retreive an AzureML Model. This will ignore stage based model uris,
-            which is alright until we have full deployment plugin support.
-            
-            If instead we are passed a 'runs' uri while the user is using the AzureML tracking
-            and registry stores, we will be able to register the model on their behalf using
-            the AzureML plugin, which will maintain lineage between the model and the run that
-            produced it. This returns an MLFlow Model object however, so we'll still need the 
-            name and ID in order to retrieve the AzureML Model object which is currently 
-            needed to deploy.
-        """
+        # If we are passed a 'models' uri, we will attempt to extract a name and version which
+        # can be used to retreive an AzureML Model. This will ignore stage based model uris,
+        # which is alright until we have full deployment plugin support.
+        #
+        # If instead we are passed a 'runs' uri while the user is using the AzureML tracking
+        # and registry stores, we will be able to register the model on their behalf using
+        # the AzureML plugin, which will maintain lineage between the model and the run that
+        # produced it. This returns an MLFlow Model object however, so we'll still need the
+        # name and ID in order to retrieve the AzureML Model object which is currently
+        # needed to deploy.
         if model_uri.startswith("models:/"):
             m_name = model_uri.split("/")[-2]
             m_version = int(model_uri.split("/")[-1])


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding some handling to mlflow.azureml.deploy to better align with handling within our tracking/registry plugins.

## How is this patch tested?

There are automated tests in `tests\azureml\test_deploy.py`, as well as more manual testing focused around the AML specific handling.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Deploying a model using `mlflow.azureml.deploy` now integrates better with the AzureML tracking/registry plugins if the user has been using them before calling deploy. Previously registered models will be reused instead of being registered again, and models provided from a run via a 'run://' model_uri will have proper run ID lineage.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [x] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
