### PR TITLE
docs: indicate that input example artifacts will be included for xgboost and lightgbm autologging

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -292,11 +292,11 @@ Call :py:func:`mlflow.xgboost.autolog` before your training code to enable autom
 
 Autologging captures the following information:
 
-+-----------+------------------------+-----------------------------+---------------+------------------------------------------------------------------------------------+
-| Framework | Metrics                | Parameters                  | Tags          | Artifacts                                                                          |
-+-----------+------------------------+-----------------------------+---------------+------------------------------------------------------------------------------------+
-| XGBoost   | user-specified metrics | `xgboost.train`_ parameters | --            | `MLflow Model`_ (XGBoost model) on training end; feature importance; input example |
-+-----------+------------------------+-----------------------------+---------------+------------------------------------------------------------------------------------+
++-----------+------------------------+-----------------------------+---------------+---------------------------------------------------------------------------------------------------------+
+| Framework | Metrics                | Parameters                  | Tags          | Artifacts                                                                                               |
++-----------+------------------------+-----------------------------+---------------+---------------------------------------------------------------------------------------------------------+
+| XGBoost   | user-specified metrics | `xgboost.train`_ parameters | --            | `MLflow Model`_ (XGBoost model) with model signature on training end; feature importance; input example |
++-----------+------------------------+-----------------------------+---------------+---------------------------------------------------------------------------------------------------------+
 
 If early stopping is activated, metrics at the best iteration will be logged as an extra step/iteration.
 
@@ -314,11 +314,11 @@ Call :py:func:`mlflow.lightgbm.autolog` before your training code to enable auto
 
 Autologging captures the following information:
 
-+-----------+------------------------+------------------------------+---------------+--------------------------------------------------------------------------------------+
-| Framework | Metrics                | Parameters                   | Tags          | Artifacts                                                                            |
-+-----------+------------------------+------------------------------+---------------+--------------------------------------------------------------------------------------+
-| LightGBM  | user-specified metrics | `lightgbm.train`_ parameters | --            | `MLflow Model`_ (LightGBM model) on training end; feature importance; input example  |
-+-----------+------------------------+------------------------------+---------------+--------------------------------------------------------------------------------------+
++-----------+------------------------+------------------------------+---------------+-----------------------------------------------------------------------------------------------------------+
+| Framework | Metrics                | Parameters                   | Tags          | Artifacts                                                                                                 |
++-----------+------------------------+------------------------------+---------------+-----------------------------------------------------------------------------------------------------------+
+| LightGBM  | user-specified metrics | `lightgbm.train`_ parameters | --            | `MLflow Model`_ (LightGBM model) with model signature on training end; feature importance; input example  |
++-----------+------------------------+------------------------------+---------------+-----------------------------------------------------------------------------------------------------------+
 
 If early stopping is activated, metrics at the best iteration will be logged as an extra step/iteration.
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -292,11 +292,11 @@ Call :py:func:`mlflow.xgboost.autolog` before your training code to enable autom
 
 Autologging captures the following information:
 
-+-----------+------------------------+-----------------------------+---------------+---------------------------------------------------------------------+
-| Framework | Metrics                | Parameters                  | Tags          | Artifacts                                                           |
-+-----------+------------------------+-----------------------------+---------------+---------------------------------------------------------------------+
-| XGBoost   | user-specified metrics | `xgboost.train`_ parameters | --            | `MLflow Model`_ (XGBoost model) on training end; feature importance |
-+-----------+------------------------+-----------------------------+---------------+---------------------------------------------------------------------+
++-----------+------------------------+-----------------------------+---------------+------------------------------------------------------------------------------------+
+| Framework | Metrics                | Parameters                  | Tags          | Artifacts                                                                          |
++-----------+------------------------+-----------------------------+---------------+------------------------------------------------------------------------------------+
+| XGBoost   | user-specified metrics | `xgboost.train`_ parameters | --            | `MLflow Model`_ (XGBoost model) on training end; feature importance; input example |
++-----------+------------------------+-----------------------------+---------------+------------------------------------------------------------------------------------+
 
 If early stopping is activated, metrics at the best iteration will be logged as an extra step/iteration.
 
@@ -314,11 +314,11 @@ Call :py:func:`mlflow.lightgbm.autolog` before your training code to enable auto
 
 Autologging captures the following information:
 
-+-----------+------------------------+------------------------------+---------------+----------------------------------------------------------------------+
-| Framework | Metrics                | Parameters                   | Tags          | Artifacts                                                            |
-+-----------+------------------------+------------------------------+---------------+----------------------------------------------------------------------+
-| LightGBM  | user-specified metrics | `lightgbm.train`_ parameters | --            | `MLflow Model`_ (LightGBM model) on training end; feature importance |
-+-----------+------------------------+------------------------------+---------------+----------------------------------------------------------------------+
++-----------+------------------------+------------------------------+---------------+--------------------------------------------------------------------------------------+
+| Framework | Metrics                | Parameters                   | Tags          | Artifacts                                                                            |
++-----------+------------------------+------------------------------+---------------+--------------------------------------------------------------------------------------+
+| LightGBM  | user-specified metrics | `lightgbm.train`_ parameters | --            | `MLflow Model`_ (LightGBM model) on training end; feature importance; input example  |
++-----------+------------------------+------------------------------+---------------+--------------------------------------------------------------------------------------+
 
 If early stopping is activated, metrics at the best iteration will be logged as an extra step/iteration.
 


### PR DESCRIPTION
Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

## What changes are proposed in this pull request?

title :)

## How is this patch tested?

Checked that docs render correctly

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
