### PR TITLE
Add additional artifacts for auto logging

### DIFF
--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -6,6 +6,7 @@ boto3==1.9.84      # pinned for moto
 moto==1.3.7
 mxnet==1.5.0
 scikit-learn==0.23.2
+matplotlib==3.2.1
 scipy==1.2.1
 pyarrow==0.17.0
 pysftp==0.2.9

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -280,9 +280,9 @@ def _get_classifier_artifacts(fitted_estimator, fit_args, fit_kwargs):
     https://scikit-learn.org/stable/modules/generated/sklearn.metrics.plot_confusion_matrix.html
 
     For only binary classifiers, we will log:
-    (3) precision recall curve:
-    https://scikit-learn.org/stable/modules/generated/sklearn.metrics.plot_precision_recall_curve.html#sklearn.metrics.plot_precision_recall_curve
-    (2) roc curve:
+    (2) precision recall curve:
+    https://scikit-learn.org/stable/modules/generated/sklearn.metrics.plot_precision_recall_curve.html
+    (3) roc curve:
     https://scikit-learn.org/stable/auto_examples/model_selection/plot_roc.html
 
     Steps:

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -250,7 +250,7 @@ def _get_classifier_metrics(fitted_estimator, fit_args, fit_kwargs):
             # For binary case, the parameter `y_score` expect scores must be
             # the scores of the class with the greater label.
             if len(y_pred_proba[0]) == 2:
-                y_pred_proba = [prob[1] for prob in y_pred_proba]
+                y_pred_proba = y_pred_proba[:, 1]
 
             classifier_metrics.extend(
                 [

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -459,7 +459,6 @@ def _log_warning_for_artifacts(func_name, func_call, err):
         + " Artifact error: "
         + str(err)
     )
-    print("2: ", msg)
     _logger.warning(msg)
 
 
@@ -481,7 +480,6 @@ def _log_specialized_estimator_content(fitted_estimator, run_id, fit_args, fit_k
             + ". Logging error: "
             + str(err)
         )
-        print("3: ", msg)
         _logger.warning(msg)
     else:
         # batch log all metrics
@@ -505,7 +503,6 @@ def _log_specialized_estimator_content(fitted_estimator, run_id, fit_args, fit_k
             + ". Logging error: "
             + str(err)
         )
-        print("4: ", msg)
         _logger.warning(msg)
     else:
         if bool(name_artifact_dict):

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -4,8 +4,8 @@ from itertools import islice
 import inspect
 import logging
 from numbers import Number
+import matplotlib.pyplot as plt
 import numpy as np
-import os
 import time
 
 from mlflow.entities import Metric, Param
@@ -513,6 +513,7 @@ def _log_specialized_estimator_content(fitted_estimator, run_id, fit_args, fit_k
                 for name, display in name_artifact_dict.items():
                     filepath = tmp.path("{}.png".format(name))
                     display.figure_.savefig(filepath)
+                    plt.close(display.figure_)
                 try_mlflow_log(mlflow_client.log_artifacts, run_id, tmp.path())
 
 

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -680,7 +680,7 @@ def test_autolog_emits_warning_message_when_model_prediction_fails():
         )
         cv_model.fit(*get_iris())
         # Will be called twice, once for metrics, once for artifacts
-        assert(mock_warning.call_count == 2)
+        assert mock_warning.call_count == 2
 
 
 def test_fit_xxx_performs_logging_only_once(fit_func_name):

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -3,7 +3,6 @@ import inspect
 from unittest import mock
 import os
 import warnings
-
 import numpy as np
 import pandas as pd
 import pytest
@@ -18,9 +17,9 @@ from mlflow.models.utils import _read_example
 import mlflow.sklearn
 from mlflow.entities import RunStatus
 from mlflow.sklearn.utils import (
-    _METRICS_PREFIX,
     _is_supported_version,
     _is_metric_supported,
+    _is_plotting_supported,
     _get_arg_names,
     _truncate_dict,
 )
@@ -201,11 +200,73 @@ def test_estimator(fit_func_name):
     assert_predict_equal(loaded_model, model, X)
 
 
-def test_classifier():
+def test_classifier_binary():
     mlflow.sklearn.autolog()
     # use RandomForestClassifier that has method [predict_proba], so that we can test
     # logging of (1) log_loss and (2) roc_auc_score.
     model = sklearn.ensemble.RandomForestClassifier(max_depth=2, random_state=0, n_estimators=10)
+
+    # use binary datasets to cover the test for roc curve & precision recall curve
+    X, y_true = sklearn.datasets.load_breast_cancer(return_X_y=True)
+
+    with mlflow.start_run() as run:
+        model = fit_model(model, X, y_true, "fit")
+
+    y_pred = model.predict(X)
+    y_pred_prob = model.predict_proba(X)
+    # For binary classification, y_score only accepts the probability of greater label
+    y_pred_prob_roc = y_pred_prob[:, 1]
+
+    run_id = run.info.run_id
+    params, metrics, tags, artifacts = get_run_data(run_id)
+    assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
+
+    expected_metrics = {
+        TRAINING_SCORE: model.score(X, y_true),
+        "training_accuracy_score": sklearn.metrics.accuracy_score(y_true, y_pred),
+        "training_precision_score": sklearn.metrics.precision_score(
+            y_true, y_pred, average="weighted"
+        ),
+        "training_recall_score": sklearn.metrics.recall_score(y_true, y_pred, average="weighted"),
+        "training_f1_score": sklearn.metrics.f1_score(y_true, y_pred, average="weighted"),
+        "training_log_loss": sklearn.metrics.log_loss(y_true, y_pred_prob),
+    }
+    if _is_metric_supported("roc_auc_score"):
+        expected_metrics["training_roc_auc_score"] = sklearn.metrics.roc_auc_score(
+            y_true, y_score=y_pred_prob_roc, average="weighted", multi_class="ovo",
+        )
+
+    assert metrics == expected_metrics
+
+    assert tags == get_expected_class_tags(model)
+    assert MODEL_DIR in artifacts
+
+    client = mlflow.tracking.MlflowClient()
+    artifacts = [x.path for x in client.list_artifacts(run_id)]
+
+    plot_names = []
+    if _is_plotting_supported():
+        plot_names.extend(
+            [
+                "{}.png".format("training_confusion_matrix"),
+                "{}.png".format("training_roc_curve"),
+                "{}.png".format("training_precision_recall_curve"),
+            ]
+        )
+
+    assert all(x in artifacts for x in plot_names)
+
+    loaded_model = load_model_by_run_id(run_id)
+    assert_predict_equal(loaded_model, model, X)
+
+
+def test_classifier_multi_class():
+    mlflow.sklearn.autolog()
+    # use RandomForestClassifier that has method [predict_proba], so that we can test
+    # logging of (1) log_loss and (2) roc_auc_score.
+    model = sklearn.ensemble.RandomForestClassifier(max_depth=2, random_state=0, n_estimators=10)
+
+    # use multi-class datasets to verify that roc curve & precision recall curve care not recorded
     X, y_true = get_iris()
 
     with mlflow.start_run() as run:
@@ -213,29 +274,39 @@ def test_classifier():
 
     y_pred = model.predict(X)
     y_pred_prob = model.predict_proba(X)
+
     run_id = run.info.run_id
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
 
     expected_metrics = {
         TRAINING_SCORE: model.score(X, y_true),
-        _METRICS_PREFIX + "accuracy_score": sklearn.metrics.accuracy_score(y_true, y_pred),
-        _METRICS_PREFIX
-        + "precision_score": sklearn.metrics.precision_score(y_true, y_pred, average="weighted"),
-        _METRICS_PREFIX
-        + "recall_score": sklearn.metrics.recall_score(y_true, y_pred, average="weighted"),
-        _METRICS_PREFIX + "f1_score": sklearn.metrics.f1_score(y_true, y_pred, average="weighted"),
-        _METRICS_PREFIX + "log_loss": sklearn.metrics.log_loss(y_true, y_pred_prob),
+        "training_accuracy_score": sklearn.metrics.accuracy_score(y_true, y_pred),
+        "training_precision_score": sklearn.metrics.precision_score(
+            y_true, y_pred, average="weighted"
+        ),
+        "training_recall_score": sklearn.metrics.recall_score(y_true, y_pred, average="weighted"),
+        "training_f1_score": sklearn.metrics.f1_score(y_true, y_pred, average="weighted"),
+        "training_log_loss": sklearn.metrics.log_loss(y_true, y_pred_prob),
     }
     if _is_metric_supported("roc_auc_score"):
-        expected_metrics[_METRICS_PREFIX + "roc_auc_score"] = sklearn.metrics.roc_auc_score(
-            y_true, y_score=y_pred_prob, average="weighted", multi_class="ovo"
+        expected_metrics["training_roc_auc_score"] = sklearn.metrics.roc_auc_score(
+            y_true, y_score=y_pred_prob, average="weighted", multi_class="ovo",
         )
 
     assert metrics == expected_metrics
 
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
+
+    client = mlflow.tracking.MlflowClient()
+    artifacts = [x.path for x in client.list_artifacts(run_id)]
+
+    plot_names = []
+    if _is_plotting_supported():
+        plot_names = ["{}.png".format("training_confusion_matrix")]
+
+    assert all(x in artifacts for x in plot_names)
 
     loaded_model = load_model_by_run_id(run_id)
     assert_predict_equal(loaded_model, model, X)
@@ -257,10 +328,10 @@ def test_regressor():
 
     assert metrics == {
         TRAINING_SCORE: model.score(X, y_true),
-        _METRICS_PREFIX + "mse": sklearn.metrics.mean_squared_error(y_true, y_pred),
-        _METRICS_PREFIX + "rmse": np.sqrt(sklearn.metrics.mean_squared_error(y_true, y_pred)),
-        _METRICS_PREFIX + "mae": sklearn.metrics.mean_absolute_error(y_true, y_pred),
-        _METRICS_PREFIX + "r2_score": sklearn.metrics.r2_score(y_true, y_pred),
+        "training_mse": sklearn.metrics.mean_squared_error(y_true, y_pred),
+        "training_rmse": np.sqrt(sklearn.metrics.mean_squared_error(y_true, y_pred)),
+        "training_mae": sklearn.metrics.mean_absolute_error(y_true, y_pred),
+        "training_r2_score": sklearn.metrics.r2_score(y_true, y_pred),
     }
     assert tags == get_expected_class_tags(model)
     assert MODEL_DIR in artifacts
@@ -567,9 +638,9 @@ def test_autolog_emits_warning_message_when_metric_fails():
     def throwing_metrics(y_true, y_pred):  # pylint: disable=unused-argument
         raise Exception("EXCEPTION")
 
-    sklearn.metrics.precision_score = throwing_metrics
-
-    with mlflow.start_run(), mock.patch("mlflow.sklearn.utils._logger.warning") as mock_warning:
+    with mlflow.start_run(), mock.patch(
+        "mlflow.sklearn.utils._logger.warning"
+    ) as mock_warning, mock.patch("sklearn.metrics.precision_score", side_effect=throwing_metrics):
         model.fit(*get_iris())
         mock_warning.assert_called_once()
         mock_warning.called_once_with(
@@ -608,12 +679,8 @@ def test_autolog_emits_warning_message_when_model_prediction_fails():
             svc, {"C": [1]}, n_jobs=1, scoring=metrics_to_log, refit=False
         )
         cv_model.fit(*get_iris())
-        mock_warning.assert_called_once()
-        mock_warning.called_once_with(
-            "Failed to autolog metrics for "
-            + sklearn.model_selection.GridSearchCV.__class__.__name__
-            + ". Logging error: EXCEPTION"
-        )
+        # Will be called twice, once for metrics, once for artifacts
+        assert(mock_warning.call_count == 2)
 
 
 def test_fit_xxx_performs_logging_only_once(fit_func_name):

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -3,6 +3,7 @@ import inspect
 from unittest import mock
 import os
 import warnings
+import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
@@ -258,6 +259,8 @@ def test_classifier_binary():
 
     loaded_model = load_model_by_run_id(run_id)
     assert_predict_equal(loaded_model, model, X)
+    # verify no figure is open
+    assert len(plt.get_fignums()) == 0
 
 
 def test_classifier_multi_class():


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- Take over #3369 

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Autologging for scikit-learn logs metric plots (e.g confusion matrix).

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
