### PR TITLE
Pin sqlparse

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,8 @@ setup(
         "querystring_parser",
         "docker>=4.0.0",
         "entrypoints",
-        "sqlparse",
+        # Pin sqlparse for: https://github.com/mlflow/mlflow/issues/3433
+        "sqlparse>=0.3.1",
         "sqlalchemy<=1.3.13",
         "gorilla",
         "prometheus-flask-exporter",


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fixes https://github.com/mlflow/mlflow/issues/3433

# Why the error occurs?

`sqlparse.parse` works differently in `0.3.0` and `0.3.1`.

```python
import sqlparse

filter_string = "name ilike '%%'"
parsed = sqlparse.parse(filter_string)
print(parsed[0].tokens)
```

In `0.3.0`:

```
[<Identifier 'name' at 0x7FEC7001A8B8>, <Whitespace ' ' at 0x7FEC70076468>, <Keyword 'ilike' at 0x7FEC700764C8>, <Whitespace ' ' at 0x7FEC70076528>, <Single "'%%'" at 0x7FEC70076588>]
```

In `0.3.1`:

```
[<Comparison 'name i...' at 0x7FE5200BAA98>]
```

## How is this patch tested?

Manually verify the fix works (see: https://github.com/mlflow/mlflow/issues/3433#issuecomment-694606606)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
