### PR TITLE
improve isolation among mlflow/R/mlflow test cases

### DIFF
--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -45,7 +45,7 @@ Suggests:
   carrier,
   keras,
   lintr,
-  testthat,
+  testthat (>= 2.0.0),
   stringi (< 1.4.4),
   xgboost,
   h2o

--- a/mlflow/R/mlflow/tests/testthat/test-client.R
+++ b/mlflow/R/mlflow/tests/testthat/test-client.R
@@ -1,5 +1,9 @@
 context("client")
 
+teardown({
+  mlflow_clear_test_dir("mlruns")
+})
+
 test_that("http(s) clients work as expected", {
   mlflow_clear_test_dir("mlruns")
   with_mock(.env = "mlflow", mlflow_rest = function(..., client) {

--- a/mlflow/R/mlflow/tests/testthat/test-keras-model.R
+++ b/mlflow/R/mlflow/tests/testthat/test-keras-model.R
@@ -2,9 +2,15 @@ context("Model")
 
 library("keras")
 
+testthat_model_dir <- tempfile("model_")
+
+teardown({
+  mlflow_clear_test_dir(testthat_model_dir)
+})
+
 test_that("mlflow can save keras model ", {
   PATH <- Sys.getenv("PATH", "") # keras package modifies PATH which breaks other tests
-  mlflow_clear_test_dir("model")
+  mlflow_clear_test_dir(testthat_model_dir)
   model <- keras_model_sequential() %>%
   layer_dense(units = 8, activation = "relu", input_shape = dim(iris)[2] - 1) %>%
   layer_dense(units = 3, activation = "softmax")
@@ -16,10 +22,10 @@ test_that("mlflow can save keras model ", {
   train_x <- as.matrix(iris[, 1:4])
   train_y <- to_categorical(as.numeric(iris[, 5]) - 1, 3)
   model %>% fit(train_x, train_y, epochs = 1)
-  model %>% mlflow_save_model("model")
-  expect_true(dir.exists("model"))
+  model %>% mlflow_save_model(testthat_model_dir)
+  expect_true(dir.exists(testthat_model_dir))
   detach("package:keras", unload = TRUE)
-  model_reloaded <- mlflow_load_model("model")
+  model_reloaded <- mlflow_load_model(testthat_model_dir)
   expect_equal(
     predict(model, train_x),
     predict(model_reloaded, train_x),

--- a/mlflow/R/mlflow/tests/testthat/test-run.R
+++ b/mlflow/R/mlflow/tests/testthat/test-run.R
@@ -1,5 +1,9 @@
 context("Run")
 
+teardown({
+  mlflow_clear_test_dir("mlruns")
+})
+
 test_that("mlflow can run and save model", {
   mlflow_clear_test_dir("mlruns")
 

--- a/mlflow/R/mlflow/tests/testthat/test-serve.R
+++ b/mlflow/R/mlflow/tests/testthat/test-serve.R
@@ -5,11 +5,14 @@ library("carrier")
 wait_for_server_to_start <- function(server_process, port) {
   status_code <- 500
   for (i in 1:5) {
-    tryCatch({
-      status_code <- httr::status_code(httr::GET(sprintf("http://127.0.0.1:%d/ping/", port)))
-    }, error = function(...) {
-      status_code <- 500
-    })
+    tryCatch(
+      {
+        status_code <- httr::status_code(httr::GET(sprintf("http://127.0.0.1:%d/ping/", port)))
+      },
+      error = function(...) {
+        status_code <- 500
+      }
+    )
     if (status_code != 200) {
       Sys.sleep(5)
     } else {
@@ -45,7 +48,7 @@ test_that("mlflow can serve a model function", {
       "-e",
       sprintf(
         "mlflow::mlflow_rfunc_serve('model', port = %d, browse = FALSE)",
-	port
+        port
       )
     ),
     supervise = TRUE,
@@ -53,14 +56,17 @@ test_that("mlflow can serve a model function", {
     stderr = "|"
   )
   Sys.sleep(10)
-  tryCatch({
-    status_code <- httr::status_code(httr::GET(sprintf("http://127.0.0.1:%d/ping/", port)))
-  }, error = function(e) {
-    write("FAILED!", stderr())
-    error_text <- testthat_model_server$read_error()
-    testthat_model_server$kill()
-    stop(e$message, ": ", error_text)
-  })
+  tryCatch(
+    {
+      status_code <- httr::status_code(httr::GET(sprintf("http://127.0.0.1:%d/ping/", port)))
+    },
+    error = function(e) {
+      write("FAILED!", stderr())
+      error_text <- testthat_model_server$read_error()
+      testthat_model_server$kill()
+      stop(e$message, ": ", error_text)
+    }
+  )
 
   expect_equal(status_code, 200)
 
@@ -90,7 +96,8 @@ test_that("mlflow models server api works with R model function", {
   expect_true(dir.exists("model"))
   port <- httpuv::randomPort()
   testthat_model_server <<- mlflow:::mlflow_cli("models", "serve", "-m", "model", "-p", as.character(port),
-                                      background = TRUE)
+    background = TRUE
+  )
   wait_for_server_to_start(testthat_model_server, port)
   newdata <- iris[1:2, c("Sepal.Length", "Petal.Width")]
   check_prediction <- function(http_prediction) {
@@ -113,12 +120,16 @@ test_that("mlflow models server api works with R model function", {
       )
     )
   )
-  newdata_split <- list(columns = names(newdata), index = row.names(newdata),
-                        data = as.matrix(newdata))
+  newdata_split <- list(
+    columns = names(newdata), index = row.names(newdata),
+    data = as.matrix(newdata)
+  )
   # json split
-  for (content_type in c("application/json",
-                         "application/json; format=pandas-split",
-                         "application/json-numpy-split")) {
+  for (content_type in c(
+    "application/json",
+    "application/json; format=pandas-split",
+    "application/json-numpy-split"
+  )) {
     check_prediction(
       httr::content(
         httr::POST(

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -1,5 +1,9 @@
 context("Tracking - Experiments")
 
+teardown({
+  mlflow_clear_test_dir("mlruns")
+})
+
 test_that("mlflow_create/get_experiment() basic functionality (fluent)", {
   mlflow_clear_test_dir("mlruns")
 

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -1,5 +1,9 @@
 context("Tracking")
 
+teardown({
+  mlflow_clear_test_dir("mlruns")
+})
+
 test_that("mlflow_start_run()/mlflow_get_run() work properly", {
   mlflow_clear_test_dir("mlruns")
   client <- mlflow_client()


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>

## What changes are proposed in this pull request?

Ensure side effects from one test case does not interfere with subsequent test runs:

- all port numbers are selected using `httpuv::randomPort()` to avoid collision of port numbers
- model directory names are randomized
- mlruns directory clean-up, server shutdown, and any other necessary tear down steps are implemented as part of `testthat::teardown(...)` 

## How is this patch tested?

running all test cases in mlflow/R/mlflow/tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
