### PR TITLE
Update example code for Spark autologging

### DIFF
--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -675,9 +675,10 @@ def autolog():
         df.write.csv(os.path.join(tempdir, "my-data-path"), header=True)
         # Enable Spark datasource autologging.
         mlflow.spark.autolog()
-        loaded_df = spark.read.csv(os.path.join(tempdir, "my-data-path"), header=True, inferSchema=True)
+        loaded_df = spark.read.csv(os.path.join(tempdir, "my-data-path"),
+                        header=True, inferSchema=True)
         # Call toPandas() to trigger a read of the Spark datasource. Datasource info
-        # (path and format) is logged to the current active run, or the 
+        # (path and format) is logged to the current active run, or the
         # next-created MLflow run if no run is currently active
         with mlflow.start_run() as active_run:
             pandas_df = loaded_df.toPandas()

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -654,10 +654,16 @@ def autolog():
         :caption: Example
 
         import mlflow.spark
+        import os
+        import shutil
         from pyspark.sql import SparkSession
         # Create and persist some dummy data
+        # Note: On environments like Databricks with pre-created SparkSessions,
+        # ensure the org.mlflow:mlflow-spark:1.11.0 is attached as a library to
+        # your cluster
         spark = (SparkSession.builder
-                    .config("spark.jars.packages", "org.mlflow.mlflow-spark")
+                    .config("spark.jars.packages", "org.mlflow:mlflow-spark:1.11.0")
+                    .master("local[*]")
                     .getOrCreate())
         df = spark.createDataFrame([
                 (4, "spark i j k"),
@@ -666,14 +672,20 @@ def autolog():
                 (7, "apache hadoop")], ["id", "text"])
         import tempfile
         tempdir = tempfile.mkdtemp()
-        df.write.format("csv").save(tempdir)
+        df.write.csv(os.path.join(tempdir, "my-data-path"), header=True)
         # Enable Spark datasource autologging.
         mlflow.spark.autolog()
-        loaded_df = spark.read.format("csv").load(tempdir)
-        # Call collect() to trigger a read of the Spark datasource. Datasource info
-        # (path and format)is automatically logged to an MLflow run.
-        loaded_df.collect()
-        shutil.rmtree(tempdir) # clean up tempdir
+        loaded_df = spark.read.csv(os.path.join(tempdir, "my-data-path"), header=True, inferSchema=True)
+        # Call toPandas() to trigger a read of the Spark datasource. Datasource info
+        # (path and format) is logged to the current active run, or the 
+        # next-created MLflow run if no run is currently active
+        with mlflow.start_run() as active_run:
+            pandas_df = loaded_df.toPandas()
+            text = pandas_df["text"]
+            print("Logged dataframe info to run with ID %s" % active_run.info.run_id)
+            # Train a model etc
+            import time
+            time.sleep(3)
     """
     from mlflow import _spark_autologging
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -682,11 +682,6 @@ def autolog():
         # next-created MLflow run if no run is currently active
         with mlflow.start_run() as active_run:
             pandas_df = loaded_df.toPandas()
-            text = pandas_df["text"]
-            print("Logged dataframe info to run with ID %s" % active_run.info.run_id)
-            # Train a model etc
-            import time
-            time.sleep(3)
     """
     from mlflow import _spark_autologging
 


### PR DESCRIPTION
Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

## What changes are proposed in this pull request?

Currently the example given in the docs for Spark autologging is broken, it's missing an import, specifies a Maven artifact in the wrong format, and doesn't actually create a run in MLflow. @smurching updated the snippet to work correctly, I'm just updating it in the docs

## How is this patch tested?

n/a

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
