### PR TITLE
Performance improvement in Spark UDFs that return an array

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -690,7 +690,7 @@ def spark_udf(spark, model_uri, result_type="double"):
             result = result.applymap(str)
 
         if type(result_type) == ArrayType:
-            return pandas.Series([row[1].values for row in result.iterrows()])
+            return pandas.Series(result.values.tolist())
         else:
             return result[result.columns[0]]
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -690,7 +690,7 @@ def spark_udf(spark, model_uri, result_type="double"):
             result = result.applymap(str)
 
         if type(result_type) == ArrayType:
-            return pandas.Series(result.values.tolist())
+            return pandas.Series(result.to_numpy().tolist())
         else:
             return result[result.columns[0]]
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR improves performance in Spark UDFs that return an array. Pandas `.iterrows()` is notoriously slow and this fix brings quite a big improvement, especially on big datasets.

## How is this patch tested?

Existing spark unit tests are passing.

Performance comparison on a regular Pandas DataFrame with 100,000 rows and 2 columns:
![image](https://user-images.githubusercontent.com/669142/94021613-34b3dd00-fd82-11ea-9c54-8b8add880b61.png)


Performance comparison of `mlflow.pyfunc.spark_udf` with a simple model that returns two columns on a local Spark 2.4.0 instance on the same data:

| Number of rows           | Time Original   | Time Modified  |
|----------------|------------|-----------|
| 10,000 | 0.333 sec  | 0.166 sec |
| 100,000 | 1.945 sec  | 0.205 sec |
| 1,000,000 | 18.018 sec | 0.652 sec |

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
