### PR TITLE
Updating torch version to latest stable release - 1.6.0

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -35,6 +35,7 @@ jobs:
     - name: Run example tests
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}
       env:
+        INSTALL_SMALL_PYTHON_DEPS: true
         INSTALL_LARGE_PYTHON_DEPS: true
       run: |
         source ./dev/install-common-deps.sh

--- a/dev/large-requirements.txt
+++ b/dev/large-requirements.txt
@@ -29,7 +29,7 @@ pysftp==0.2.9
 keras==2.3.1
 attrdict==2.0.0
 azureml-sdk==1.2.0; python_version >= "3.0"
-cloudpickle==0.8.0
+cloudpickle==1.6.0
 pytest-localserver==0.5.0
 sqlalchemy==1.3.0
 kubernetes==9.0.0

--- a/dev/large-requirements.txt
+++ b/dev/large-requirements.txt
@@ -19,7 +19,7 @@ scipy==1.2.1
 spacy==2.2.3
 tensorflow==1.15.2
 tf2onnx==1.5.4;
-torch==1.4.0
+torch==1.6.0
 torchvision==0.5.0
 xgboost>=0.82
 lightgbm==2.3.0

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -11,7 +11,7 @@ scipy==1.2.1
 pyarrow==0.17.0
 pysftp==0.2.9
 attrdict==2.0.0
-cloudpickle==0.8.0
+cloudpickle==1.6.0
 pytest==3.2.1
 pytest-cov==2.6.0
 pytest-localserver==0.5.0

--- a/examples/pytorch/conda.yaml
+++ b/examples/pytorch/conda.yaml
@@ -8,7 +8,7 @@ dependencies:
   - python=3.6
   - pip
   - pip:
-    - torch==1.4.0
+    - torch==1.6.0
     - torchvision==0.5.0
     - mlflow>=1.0
     - tensorboardX

--- a/mlflow/pytorch/pickle_module.py
+++ b/mlflow/pytorch/pickle_module.py
@@ -27,6 +27,7 @@ from cloudpickle import *
 # but this import renaming is necessary until either the requested change has been incorporated
 # into a CloudPickle release or the ``torch.save`` API has been updated to be compatible with
 # the existing CloudPickle API.
+# pylint: disable=unused-import
 from cloudpickle import CloudPickler as Pickler
 
 # CloudPickle does not include `Unpickler` in its namespace, which is required by PyTorch for

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -737,7 +737,8 @@ def test_load_model_allows_user_to_override_pickle_module_via_keyword_argument(
         pickle_module=pickle,
     )
 
-    mlflow_torch_pickle_load = mlflow_pytorch_pickle_module.load
+    mlflow_torch_pickle_load = mlflow_pytorch_pickle_module.Unpickler
+
     pickle_call_results = {
         "mlflow_torch_pickle_load_called": False,
     }
@@ -752,7 +753,7 @@ def test_load_model_allows_user_to_override_pickle_module_via_keyword_argument(
         log_messages.append(message_text % args % kwargs)
 
     with mock.patch(
-        "mlflow.pytorch.pickle_module.load"
+        "mlflow.pytorch.pickle_module.Unpickler"
     ) as mlflow_torch_pickle_load_mock, mock.patch("mlflow.pytorch._logger.warning") as warn_mock:
         mlflow_torch_pickle_load_mock.side_effect = validate_mlflow_torch_pickle_load_called
         warn_mock.side_effect = custom_warn


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updating torch version to recent stable release - 1.6.0.  

## How is this patch tested?

Verified `mlflow/tests/pytorch/test_pytorch_model_export.py` and `mlflow/examples/pytorch/mnist_tensorboard_artifact.py` with pytorch 1.6.0. 

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
