### PR TITLE
Remove pycodestyle & improve 'black' error message

### DIFF
--- a/dev/run-black-linter.sh
+++ b/dev/run-black-linter.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Exclude proto files because they are auto-generated
+black --check --line-length=100 --exclude=mlflow/protos .
+exit_code="$?"
+if [[ "$exit_code" != "0" ]]; then
+  echo "Python lint failed. Run 'black --line-length=100 --exclude=mlflow/protos .' from your"\
+    "checkout of MLflow (note the trailing '.' at the end of the command, corresponding to the"\
+    "current directory) to autoformat Python code"
+  exit $exit_code
+fi;

--- a/lint.sh
+++ b/lint.sh
@@ -26,12 +26,8 @@ exclude_dirs=(
   "mlflow/temporary_db_migrations_for_pre_1_users"
 )
 
-# Exclude proto files because they are auto-generated
-black --check --line-length=100 --exclude=mlflow/protos .
-
-exclude=$(join "," "${exclude_dirs[@]}")
-include=$(join " " "${include_dirs[@]}")
-pycodestyle --max-line-length=100 --ignore=E203,W503 --exclude=$exclude -- $include
+# Check Python code for style issues using black
+./dev/run-black-linter.sh
 
 # pylint's `--ignore` option filters files based on their base names, not paths.
 # see: http://pylint.pycqa.org/en/latest/user_guide/run.html#command-line-options


### PR DESCRIPTION
Signed-off-by: Sid Murching <sid.murching@databricks.com>

## What changes are proposed in this pull request?

Removes `pycodestyle` lint check (superseded by `black`) and improves the error message when `black` lint fails to explain how to rerun `black` to autoformat Python code

## How is this patch tested?
Tested manually by messing up formatting of `mlflow/version.py` and running `./lint.sh`, which now produces:

```
(mlflow-python3) ➜  mlflow git:(fix-black-error-msg) ✗ ./lint.sh   
would reformat /Users/sid.murching/code/mlflow/setup.py
Oh no! 💥 💔 💥
1 file would be reformatted, 416 files would be left unchanged.
Python lint failed. Run 'black --line-length=100 --exclude=mlflow/protos .' from your checkout of MLflow (note the trailing '.' at the end of the command, corresponding to the current directory) to autoformat Python code
```

In the case where there are no linter errors, the behavior is the same as before (this should also be validated by this PR passing lint in Github actions, hopefully :P)



## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
