### PR TITLE
fix instructions on installing mlflow-spark (issue #3460)

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -392,7 +392,8 @@ Spark (experimental)
 --------------------
 
 Initialize a SparkSession with the mlflow-spark JAR attached (e.g.
-``SparkSession.builder.config("spark.jars.packages", "org.mlflow.mlflow-spark")``) and then
+``SparkSession.builder.config("spark.jars.packages", "org.mlflow:mlflow-spark:1.12.0")``
+or start `pyspark` with `--packages org.mlflow:mlflow-spark:1.12.0`) and then
 call :py:func:`mlflow.spark.autolog` to enable automatic logging of Spark datasource
 information at read-time, without the need for explicit
 log statements. Note that autologging of Spark ML (MLlib) models is not yet supported.


### PR DESCRIPTION
## What changes are proposed in this pull request?

This fixes #3460 by describing correct maven coordinates for installing of `mlflow-spark`

## How is this patch tested?

No need to test

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
