### PR TITLE
[ML-12267] Search using the IN operator for `runId` in search model versions

### DIFF
--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -744,10 +744,10 @@ class SqlAlchemyStore(AbstractStore):
             conditions = []
         elif len(parsed_filter) == 1:
             filter_dict = parsed_filter[0]
-            if filter_dict["comparator"] != "=":
+            if filter_dict["comparator"] not in SearchUtils.VALID_MODEL_VERSIONS_SEARCH_COMPARATORS:
                 raise MlflowException(
-                    "Model Registry search filter only supports equality(=) "
-                    "comparator. Input filter string: %s" % filter_string,
+                    "Model Registry search filter only supports the equality(=) "
+                    "comparator and the IN operator for the run_id parameter. Input filter string: %s" % filter_string,
                     error_code=INVALID_PARAMETER_VALUE,
                 )
             if filter_dict["key"] == "name":
@@ -755,7 +755,10 @@ class SqlAlchemyStore(AbstractStore):
             elif filter_dict["key"] == "source_path":
                 conditions = [SqlModelVersion.source == filter_dict["value"]]
             elif filter_dict["key"] == "run_id":
-                conditions = [SqlModelVersion.run_id == filter_dict["value"]]
+                if filter_dict["comparator"] == "IN":
+                    conditions = [SqlModelVersion.run_id.in_(filter_dict["value"])]
+                else:
+                    conditions = [SqlModelVersion.run_id == filter_dict["value"]]
             else:
                 raise MlflowException(
                     "Invalid filter string: %s" % filter_string, error_code=INVALID_PARAMETER_VALUE
@@ -764,7 +767,7 @@ class SqlAlchemyStore(AbstractStore):
             raise MlflowException(
                 "Model Registry expects filter to be one of "
                 "\"name = '<model_name>'\" or "
-                "\"source_path = '<source_path>'\" or \"run_id = '<run_id>'."
+                "\"source_path = '<source_path>'\" or \"run_id = '<run_id>' or \"run_id IN (<run_ids>)\"."
                 "Input filter string: %s. " % filter_string,
                 error_code=INVALID_PARAMETER_VALUE,
             )

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -747,8 +747,8 @@ class SqlAlchemyStore(AbstractStore):
             if filter_dict["comparator"] not in SearchUtils.VALID_MODEL_VERSIONS_SEARCH_COMPARATORS:
                 raise MlflowException(
                     "Model Registry search filter only supports the equality(=) "
-                    "comparator and the IN operator for the run_id parameter. Input filter string: %s"
-                    % filter_string,
+                    "comparator and the IN operator "
+                    "for the run_id parameter. Input filter string: %s" % filter_string,
                     error_code=INVALID_PARAMETER_VALUE,
                 )
             if filter_dict["key"] == "name":
@@ -768,7 +768,8 @@ class SqlAlchemyStore(AbstractStore):
             raise MlflowException(
                 "Model Registry expects filter to be one of "
                 "\"name = '<model_name>'\" or "
-                '"source_path = \'<source_path>\'" or "run_id = \'<run_id>\' or "run_id IN (<run_ids>)".'
+                "\"source_path = '<source_path>'\" "
+                'or "run_id = \'<run_id>\' or "run_id IN (<run_ids>)".'
                 "Input filter string: %s. " % filter_string,
                 error_code=INVALID_PARAMETER_VALUE,
             )

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -747,7 +747,8 @@ class SqlAlchemyStore(AbstractStore):
             if filter_dict["comparator"] not in SearchUtils.VALID_MODEL_VERSIONS_SEARCH_COMPARATORS:
                 raise MlflowException(
                     "Model Registry search filter only supports the equality(=) "
-                    "comparator and the IN operator for the run_id parameter. Input filter string: %s" % filter_string,
+                    "comparator and the IN operator for the run_id parameter. Input filter string: %s"
+                    % filter_string,
                     error_code=INVALID_PARAMETER_VALUE,
                 )
             if filter_dict["key"] == "name":
@@ -767,7 +768,7 @@ class SqlAlchemyStore(AbstractStore):
             raise MlflowException(
                 "Model Registry expects filter to be one of "
                 "\"name = '<model_name>'\" or "
-                "\"source_path = '<source_path>'\" or \"run_id = '<run_id>' or \"run_id IN (<run_ids>)\"."
+                '"source_path = \'<source_path>\'" or "run_id = \'<run_id>\' or "run_id IN (<run_ids>)".'
                 "Input filter string: %s. " % filter_string,
                 error_code=INVALID_PARAMETER_VALUE,
             )

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -585,7 +585,7 @@ class SearchUtils(object):
     VALID_SEARCH_KEYS_FOR_REGISTERED_MODELS = set(["name"])
 
     @classmethod
-    def _is_valid_identifier_list(cls, value_token):
+    def _check_valid_identifier_list(cls, value_token):
         if len(value_token._groupable_tokens) == 0:
             raise MlflowException(
                 "While parsing a list in the query,"
@@ -612,19 +612,17 @@ class SearchUtils(object):
                 ),
                 error_code=INVALID_PARAMETER_VALUE,
             )
-        return value_token
 
     @classmethod
     def _parse_list_from_sql_token(cls, token):
         try:
-            value = ast.literal_eval(token.value)
+            return ast.literal_eval(token.value)
         except SyntaxError:
             raise MlflowException(
                 "While parsing a list in the query,"
                 " expected a non-empty list of string values, but got ill-formed list.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
-        return value
 
     @classmethod
     def _get_comparison_for_model_registry(cls, comparison, valid_search_keys):
@@ -650,7 +648,7 @@ class SearchUtils(object):
                 error_code=INVALID_PARAMETER_VALUE,
             )
         elif isinstance(value_token, Parenthesis):
-            cls._is_valid_identifier_list(value_token)
+            cls._check_valid_identifier_list(value_token)
             value = cls._parse_list_from_sql_token(value_token)
         else:
             value = cls._strip_quotes(value_token.value, expect_quoted_value=True)

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -588,17 +588,36 @@ class SearchUtils(object):
                 error_code=INVALID_PARAMETER_VALUE,
             )
         value_token = stripped_comparison[2]
-        if not isinstance(value_token, Parenthesis) and value_token.ttype not in cls.STRING_VALUE_TYPES:
+        if (
+            not isinstance(value_token, Parenthesis)
+            and value_token.ttype not in cls.STRING_VALUE_TYPES
+        ):
             raise MlflowException(
                 "Expected a quoted string value for attributes. "
-                "Got value {value} with type {type}".format(value=value_token.value, type=type(value_token)),
+                "Got value {value} with type {type}".format(
+                    value=value_token.value, type=type(value_token)
+                ),
                 error_code=INVALID_PARAMETER_VALUE,
             )
         elif isinstance(value_token, Parenthesis):
             if len(value_token._groupable_tokens) == 0:
-                raise MlflowException("While parsing a list in the query, expected a non-empty list of string values, but got empty list", error_code=INVALID_PARAMETER_VALUE)
-            elif not all(map(lambda token: token.ttype in cls.STRING_VALUE_TYPES.union(cls.DELIMITER_VALUE_TYPES), value_token._groupable_tokens[0].tokens)):
-                raise MlflowException("While parsing a list in the query, expected string value or punctuation, but got different type in list: {value_token}".format(value_token=value_token), error_code=INVALID_PARAMETER_VALUE)
+                raise MlflowException(
+                    "While parsing a list in the query, expected a non-empty list of string values, but got empty list",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+            elif not all(
+                map(
+                    lambda token: token.ttype
+                    in cls.STRING_VALUE_TYPES.union(cls.DELIMITER_VALUE_TYPES),
+                    value_token._groupable_tokens[0].tokens,
+                )
+            ):
+                raise MlflowException(
+                    "While parsing a list in the query, expected string value or punctuation, but got different type in list: {value_token}".format(
+                        value_token=value_token
+                    ),
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
             value = ast.literal_eval(value_token.value)
         else:
             value = cls._strip_quotes(value_token.value, expect_quoted_value=True)
@@ -634,7 +653,9 @@ class SearchUtils(object):
                 error_code=INVALID_PARAMETER_VALUE,
             )
         statement = parsed[0]
-        invalids = list(filter(cls._invalid_statement_token_search_model_registry, statement.tokens))
+        invalids = list(
+            filter(cls._invalid_statement_token_search_model_registry, statement.tokens)
+        )
         if len(invalids) > 0:
             invalid_clauses = ", ".join("'%s'" % token for token in invalids)
             raise MlflowException(
@@ -656,8 +677,12 @@ class SearchUtils(object):
                         "Search filter '%s' contains multiple expressions. "
                         "%s " % (filter_string, expected),
                         error_code=INVALID_PARAMETER_VALUE,
-                        )
-                if isinstance(statement.tokens[idx], Identifier) or statement.tokens[idx].match(ttype=TokenType.Keyword, values=["IN"]) or isinstance(statement.tokens[idx], Parenthesis):
+                    )
+                if (
+                    isinstance(statement.tokens[idx], Identifier)
+                    or statement.tokens[idx].match(ttype=TokenType.Keyword, values=["IN"])
+                    or isinstance(statement.tokens[idx], Parenthesis)
+                ):
                     comparison_subtokens.append(statement.tokens[idx])
                 else:
                     break

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -602,7 +602,8 @@ class SearchUtils(object):
         elif isinstance(value_token, Parenthesis):
             if len(value_token._groupable_tokens) == 0:
                 raise MlflowException(
-                    "While parsing a list in the query, expected a non-empty list of string values, but got empty list",
+                    "While parsing a list in the query,"
+                    " expected a non-empty list of string values, but got empty list",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
             elif not all(
@@ -613,7 +614,8 @@ class SearchUtils(object):
                 )
             ):
                 raise MlflowException(
-                    "While parsing a list in the query, expected string value or punctuation, but got different type in list: {value_token}".format(
+                    "While parsing a list in the query, expected string value "
+                    "or punctuation, but got different type in list: {value_token}".format(
                         value_token=value_token
                     ),
                     error_code=INVALID_PARAMETER_VALUE,

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -711,10 +711,14 @@ class SearchUtils(object):
                     comparison_subtokens.append(token)
                 elif not token.is_whitespace:
                     break
+            # if we have fewer than 3, that means we have an incomplete statement.
             if len(comparison_subtokens) == 3:
                 token_list = [Comparison(TokenList(comparison_subtokens))]
             else:
-                token_list = statement_tokens
+                raise MlflowException(
+                    "Invalid filter '%s'. Could not be parsed. %s" % (filter_string, expected),
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
         return token_list
 
     @classmethod

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -720,25 +720,38 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(set(search_versions("run_id='%s'" % run_id_2)), set([2, 3]))
 
         # search using the IN operator should return all versions
-        self.assertEqual(set(search_versions("run_id IN ('{run_id_1}','{run_id_2}')".format(run_id_1=run_id_1, run_id_2=run_id_2))), set([1,2,3]))
+        self.assertEqual(
+            set(
+                search_versions(
+                    "run_id IN ('{run_id_1}','{run_id_2}')".format(
+                        run_id_1=run_id_1, run_id_2=run_id_2
+                    )
+                )
+            ),
+            set([1, 2, 3]),
+        )
 
         # search using the IN operator with bad lists should return exceptions
         with self.assertRaises(MlflowException) as exception_context:
             search_versions("run_id IN (1,2,3)")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        assert 'expected string value or punctuation' in exception_context.exception.message
+        assert "expected string value or punctuation" in exception_context.exception.message
 
         # search using the IN operator with empty lists should return exceptions
         with self.assertRaises(MlflowException) as exception_context:
             search_versions("run_id IN ()")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        assert 'expected a non-empty list of string values' in exception_context.exception.message
+        assert "expected a non-empty list of string values" in exception_context.exception.message
 
         # search using the IN operator is not allowed with other additional filters
         with self.assertRaises(MlflowException) as exception_context:
-            search_versions("name='{name}]' AND run_id IN ('{run_id_1}','{run_id_2}')".format(name=name, run_id_1=run_id_1, run_id_2=run_id_2))
+            search_versions(
+                "name='{name}]' AND run_id IN ('{run_id_1}','{run_id_2}')".format(
+                    name=name, run_id_1=run_id_1, run_id_2=run_id_2
+                )
+            )
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
-        assert 'contains multiple expressions' in exception_context.exception.message
+        assert "contains multiple expressions" in exception_context.exception.message
 
         # search using source_path "A/D" should return version 3 and 4
         self.assertEqual(set(search_versions("source_path = 'A/D'")), set([3, 4]))

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -750,6 +750,11 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert "Invalid clause" in exception_context.exception.message
 
         with self.assertRaises(MlflowException) as exception_context:
+            search_versions("run_id IN")
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        assert "Invalid filter" in exception_context.exception.message
+
+        with self.assertRaises(MlflowException) as exception_context:
             search_versions("run_id IN (,)")
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         assert "ill-formed list" in exception_context.exception.message

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -749,6 +749,16 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         assert "Invalid clause" in exception_context.exception.message
 
+        with self.assertRaises(MlflowException) as exception_context:
+            search_versions("run_id IN (,)")
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        assert "ill-formed list" in exception_context.exception.message
+
+        with self.assertRaises(MlflowException) as exception_context:
+            search_versions("run_id IN ('runid1',,'runid2')")
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        assert "ill-formed list" in exception_context.exception.message
+
         # search using the IN operator is not allowed with other additional filters
         with self.assertRaises(MlflowException) as exception_context:
             search_versions(

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -743,6 +743,12 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
         assert "expected a non-empty list of string values" in exception_context.exception.message
 
+        # search using an ill-formed IN operator correctly throws exception
+        with self.assertRaises(MlflowException) as exception_context:
+            search_versions("run_id IN (")
+        assert exception_context.exception.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
+        assert "Invalid clause" in exception_context.exception.message
+
         # search using the IN operator is not allowed with other additional filters
         with self.assertRaises(MlflowException) as exception_context:
             search_versions(


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds support for the "IN" operator in a search query when querying the `run_id` parameter in search model versions. Community contribution for support for the other operators if desired would be awesome!

To accomplish this, we have to relax some of the current parsing rules we have, which assume that a `Comparison` is the only kind of valid operator to parse out of a statement. Unfortunately, sqlparse doesn't correctly parse `IN` as a `Comparison` so we have to manually construct the Comparison. Moreover, we currently don't support multiple search expressions at the same time.

## How is this patch tested?

Additional tests for the lists

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
