### PR TITLE
R test fix

### DIFF
--- a/mlflow/R/mlflow/R/model-h2o.R
+++ b/mlflow/R/mlflow/R/model-h2o.R
@@ -31,7 +31,7 @@ mlflow_save_model.H2OModel <- function(model,
   )
   yaml::write_yaml(settings, file.path(model_data_path, "h2o.yaml"))
 
-  needed because R and python packages may not have the same patch number
+  # needed because R and python packages may not have the same patch number
   version <- remove_patch_version(
     as.character(utils::packageVersion("h2o"))
   )

--- a/mlflow/R/mlflow/R/model-h2o.R
+++ b/mlflow/R/mlflow/R/model-h2o.R
@@ -37,7 +37,7 @@ mlflow_save_model.H2OModel <- function(model,
   )
 
   conda_env <- create_default_conda_env_if_absent(
-    path, conda_env, default_pip_deps = list("mlflow", paste0("h2o>=", as.character(utils::packageVersion("h2o"))))
+    path, conda_env, default_pip_deps = list("mlflow", paste0("h2o==", as.character(utils::packageVersion("h2o"))))
   )
 
   h2o_conf <- list(

--- a/mlflow/R/mlflow/R/model-h2o.R
+++ b/mlflow/R/mlflow/R/model-h2o.R
@@ -32,12 +32,12 @@ mlflow_save_model.H2OModel <- function(model,
   yaml::write_yaml(settings, file.path(model_data_path, "h2o.yaml"))
 
   # needed because R and python packages may not have the same patch number
-  version <- remove_patch_version(
-    as.character(utils::packageVersion("h2o"))
-  )
+  # version <- remove_patch_version(
+  #   as.character(utils::packageVersion("h2o"))
+  # )
 
   conda_env <- create_default_conda_env_if_absent(
-    path, conda_env, default_pip_deps = list("mlflow", paste0("h2o==", version))
+    path, conda_env, default_pip_deps = list("mlflow", paste0("h2o==", as.character(utils::packageVersion("h2o"))))
   )
 
   h2o_conf <- list(

--- a/mlflow/R/mlflow/R/model-h2o.R
+++ b/mlflow/R/mlflow/R/model-h2o.R
@@ -31,13 +31,13 @@ mlflow_save_model.H2OModel <- function(model,
   )
   yaml::write_yaml(settings, file.path(model_data_path, "h2o.yaml"))
 
-  # needed because R and python packages may not have the same patch number
-  # version <- remove_patch_version(
-  #   as.character(utils::packageVersion("h2o"))
-  # )
+  needed because R and python packages may not have the same patch number
+  version <- remove_patch_version(
+    as.character(utils::packageVersion("h2o"))
+  )
 
   conda_env <- create_default_conda_env_if_absent(
-    path, conda_env, default_pip_deps = list("mlflow", paste0("h2o==", as.character(utils::packageVersion("h2o"))))
+    path, conda_env, default_pip_deps = list("mlflow", paste0("h2o>=", as.character(utils::packageVersion("h2o"))))
   )
 
   h2o_conf <- list(

--- a/mlflow/R/mlflow/R/model-h2o.R
+++ b/mlflow/R/mlflow/R/model-h2o.R
@@ -31,11 +31,6 @@ mlflow_save_model.H2OModel <- function(model,
   )
   yaml::write_yaml(settings, file.path(model_data_path, "h2o.yaml"))
 
-  # needed because R and python packages may not have the same patch number
-  version <- remove_patch_version(
-    as.character(utils::packageVersion("h2o"))
-  )
-
   conda_env <- create_default_conda_env_if_absent(
     path, conda_env, default_pip_deps = list("mlflow", paste0("h2o==", as.character(utils::packageVersion("h2o"))))
   )

--- a/mlflow/R/mlflow/R/model-h2o.R
+++ b/mlflow/R/mlflow/R/model-h2o.R
@@ -37,7 +37,7 @@ mlflow_save_model.H2OModel <- function(model,
   )
 
   conda_env <- create_default_conda_env_if_absent(
-    path, conda_env, default_pip_deps = list("mlflow", paste0("h2o>=", version))
+    path, conda_env, default_pip_deps = list("mlflow", paste0("h2o==", version))
   )
 
   h2o_conf <- list(

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -7,7 +7,11 @@ predictors <- setdiff(colnames(iris), prediction)
 train <- iris[idx[1:100], ]
 test <- iris[idx[101:nrow(iris)], ]
 
-h2o::h2o.init()
+version <- remove_patch_version(
+  as.character(utils::packageVersion("h2o"))
+)
+
+h2o::h2o.init(paste0(mlflow_h2o_pyfunc_", version))
 
 model <- h2o::h2o.randomForest(
   x = predictors, y = prediction, training_frame = h2o::as.h2o(train)

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -7,6 +7,7 @@ predictors <- setdiff(colnames(iris), prediction)
 train <- iris[idx[1:100], ]
 test <- iris[idx[101:nrow(iris)], ]
 
+# Installing most recent h2o package, see https://docs.h2o.ai/h2o/latest-stable/h2o-docs/downloading.html#install-in-r
 if ("package:h2o" %in% search()) { detach("package:h2o", unload=TRUE) }
 if ("h2o" %in% rownames(installed.packages())) { remove.packages("h2o") }
 pkgs <- c("RCurl","jsonlite")

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -11,7 +11,7 @@ version <- remove_patch_version(
   as.character(utils::packageVersion("h2o"))
 )
 
-h2o::h2o.init(paste0(mlflow_h2o_pyfunc_", version))
+h2o::h2o.init(paste0("mlflow_h2o_pyfunc_", version))
 
 model <- h2o::h2o.randomForest(
   x = predictors, y = prediction, training_frame = h2o::as.h2o(train)

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -7,7 +7,14 @@ predictors <- setdiff(colnames(iris), prediction)
 train <- iris[idx[1:100], ]
 test <- iris[idx[101:nrow(iris)], ]
 
-h2o::h2o.shutdown()
+if ("package:h2o" %in% search()) { detach("package:h2o", unload=TRUE) }
+if ("h2o" %in% rownames(installed.packages())) { remove.packages("h2o") }
+pkgs <- c("RCurl","jsonlite")
+for (pkg in pkgs) {
+  if (! (pkg %in% rownames(installed.packages()))) { install.packages(pkg) }
+}
+install.packages("h2o", type="source", repos=(c("http://h2o-release.s3.amazonaws.com/h2o/latest_stable_R")))
+
 h2o::h2o.init()
 
 model <- h2o::h2o.randomForest(

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -7,6 +7,7 @@ predictors <- setdiff(colnames(iris), prediction)
 train <- iris[idx[1:100], ]
 test <- iris[idx[101:nrow(iris)], ]
 
+h2o::h2o.shutdown()
 h2o::h2o.init()
 
 model <- h2o::h2o.randomForest(

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -7,11 +7,7 @@ predictors <- setdiff(colnames(iris), prediction)
 train <- iris[idx[1:100], ]
 test <- iris[idx[101:nrow(iris)], ]
 
-version <- remove_patch_version(
-  as.character(utils::packageVersion("h2o"))
-)
-
-h2o::h2o.init(paste0("mlflow_h2o_pyfunc_", version))
+h2o::h2o.init()
 
 model <- h2o::h2o.randomForest(
   x = predictors, y = prediction, training_frame = h2o::as.h2o(train)


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes the R test failures. This was caused due to a mismatch between the h2o cluster persisted by the test (3.30.1.2) and the version being run client-side (3.30.1.3). This PR also sets the conda environment versioning of h2o to be equal instead of greater than equal to the version used to save the model in R.

In order to fix the cluster versioning mismatch, I followed the instructions at https://docs.h2o.ai/h2o/latest-stable/h2o-docs/downloading.html#install-in-r to reinstall h2o every time in the tests before calling `h2o.init()`. This creates a cluster with the latest versioning so old clusters don't get used for testing.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
