### PR TITLE
Fix performance issue when loading Spark models from DBFS-backed model URIs 

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -272,3 +272,6 @@ def get_databricks_host_creds(server_uri=None):
     elif config.token:
         return MlflowHostCreds(config.host, token=config.token, ignore_tls_verification=insecure)
     _fail_malformed_databricks_auth(profile)
+
+def is_default_databricks_profile(profile):
+    return profile == "databricks"

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -119,13 +119,13 @@ def add_databricks_profile_info_to_artifact_uri(artifact_uri, databricks_profile
         return artifact_uri
 
     scheme = artifact_uri_parsed.scheme
-    if scheme == "dbfs" or scheme == "runs" or scheme == "models":
-        if databricks_profile_uri == "databricks":
-            netloc = "databricks"
-        else:
-            (profile, key_prefix) = get_db_info_from_uri(databricks_profile_uri)
-            prefix = ":" + key_prefix if key_prefix else ""
-            netloc = profile + prefix + "@databricks"
+    # Note: a databricks profile URI of 'databricks' indicates the current workspace, so in that
+    # case we simply return the underlying DBFS, runs, or models URI as the default treatment
+    # for such DBFS, runs, models URIs is to assume they reference the current workspace
+    if (scheme == "dbfs" or scheme == "runs" or scheme == "models") and databricks_profile_uri != "databricks":
+        (profile, key_prefix) = get_db_info_from_uri(databricks_profile_uri)
+        prefix = ":" + key_prefix if key_prefix else ""
+        netloc = profile + prefix + "@databricks"
         new_parsed = artifact_uri_parsed._replace(netloc=netloc)
         return urllib.parse.urlunparse(new_parsed)
     else:

--- a/tests/utils/test_uri.py
+++ b/tests/utils/test_uri.py
@@ -452,8 +452,8 @@ def test_remove_databricks_profile_info_from_artifact_uri(uri, result):
     "artifact_uri, profile_uri, result",
     [
         # test various profile URIs
-        ("dbfs:/path/a/b", "databricks", "dbfs://databricks/path/a/b"),
-        ("dbfs:/path/a/b/", "databricks", "dbfs://databricks/path/a/b/"),
+        ("dbfs:/path/a/b", "databricks", "dbfs:/path/a/b"),
+        ("dbfs:/path/a/b/", "databricks", "dbfs:/path/a/b/"),
         ("dbfs:/path/a/b/", "databricks://", "dbfs://@databricks/path/a/b/"),
         ("dbfs:/path/a/b/", "databricks://Profile", "dbfs://Profile@databricks/path/a/b/"),
         ("dbfs:/path/a/b/", "databricks://profile/", "dbfs://profile@databricks/path/a/b/"),


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates `mlflow.spark.load_model` to strip the authority component from DBFS URIs returned by ModelsArtifactRepoif said DBFS URIs are in the current workspace. This allows Spark to read directly from DBFS URIs corresponding to registered models when loading back models, instead of downloading the model locally from DBFS, reuploading to DBFS, and calling PipelineModel.load() against the reuploaded DBFS location.

## How is this patch tested?

Manually

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
