### PR TITLE
Added the option to use AAD for auth for store

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -699,12 +699,25 @@ Azure Blob Storage
 
 To store artifacts in Azure Blob Storage, specify a URI of the form
 ``wasbs://<container>@<storage-account>.blob.core.windows.net/<path>``.
-MLflow expects Azure Storage access credentials in the
-``AZURE_STORAGE_CONNECTION_STRING`` or ``AZURE_STORAGE_ACCESS_KEY`` environment variables (preferring
-a connection string if one is set), so you must set one of these variables on both your client
-application and your MLflow tracking server. Finally, you must run ``pip install azure-storage-blob``
-separately (on both your client and the server) to access Azure Blob Storage; MLflow does not declare
-a dependency on this package by default.
+MLflow can access Azure Storage by using an access key or by using Azure Active Directory (AAD).
+
+When using an access key MLflow expects ``AZURE_STORAGE_CONNECTION_STRING`` or ``AZURE_STORAGE_ACCESS_KEY``
+environment variables, so you must set one of these variables on both your client application and your MLflow
+tracking server.
+
+If you use a blob container with AAD enabled you have two options when authenticating. The first is using a service
+principal where MLflow expects the environment variables ``AZURE_TENANT_ID``, ``AZURE_CLIENT_ID`` and
+``AZURE_CLIENT_SECRET``. The second option is to use the Azure CLI with the command ``az login``. To enable this option
+you must set the environment variable ``AZURE_STORAGE_CLI_LOGIN`` equal to ``true``. Finally, you must run
+``pip install azure-identity`` separately (on both your client and the server) to access Azure Blob Storage; MLflow
+does not declare a dependency on this package by default.
+
+The access priority is:
+
+1. Connection string given as ``AZURE_STORAGE_CONNECTION_STRING``
+2. Access key given as ``AZURE_STORAGE_ACCESS_KEY``
+3. Using AAD with ``AZURE_TENANT_ID``, ``AZURE_CLIENT_ID`` and ``AZURE_CLIENT_SECRET``
+4. Using AAD by logging in to Azure CLI
 
 Google Cloud Storage
 ^^^^^^^^^^^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
             # Required by the mlflow.projects module, when running projects against
             # a remote Kubernetes cluster
             "kubernetes",
+            "azure-identity>=1.4.0",
         ],
         "sqlserver": ["mlflow-dbstore",],
         "aliyun-oss": ["aliyunstoreplugin",],

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -9,7 +9,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.artifact.azure_blob_artifact_repo import AzureBlobArtifactRepository
 
-
 TEST_ROOT_PATH = "some/path"
 TEST_BLOB_CONTAINER_ROOT = "wasbs://container@account.blob.core.windows.net/"
 TEST_URI = os.path.join(TEST_BLOB_CONTAINER_ROOT, TEST_ROOT_PATH)
@@ -33,6 +32,18 @@ def mock_client():
     old_conn_string = os.environ.get("AZURE_STORAGE_CONNECTION_STRING")
     if old_conn_string is not None:
         del os.environ["AZURE_STORAGE_CONNECTION_STRING"]
+    old_conn_tenant = os.environ.get("AZURE_TENANT_ID")
+    if old_conn_tenant is not None:
+        del os.environ["AZURE_TENANT_ID"]
+    old_conn_id = os.environ.get("AZURE_CLIENT_ID")
+    if old_conn_id is not None:
+        del os.environ["AZURE_CLIENT_ID"]
+    old_conn_secret = os.environ.get("AZURE_CLIENT_SECRET")
+    if old_conn_secret is not None:
+        del os.environ["AZURE_CLIENT_SECRET"]
+    old_conn_cli = os.environ.get("AZURE_STORAGE_CLI_LOGIN")
+    if old_conn_cli is not None:
+        del os.environ["AZURE_STORAGE_CLI_LOGIN"]
 
     yield mock.MagicMock(autospec=BlobServiceClient)
 
@@ -40,6 +51,14 @@ def mock_client():
         os.environ["AZURE_STORAGE_ACCESS_KEY"] = old_access_key
     if old_conn_string is not None:
         os.environ["AZURE_STORAGE_CONNECTION_STRING"] = old_conn_string
+    if old_conn_tenant is not None:
+        os.environ["AZURE_TENANT_ID"] = old_conn_tenant
+    if old_conn_id is not None:
+        os.environ["AZURE_CLIENT_ID"] = old_conn_id
+    if old_conn_secret is not None:
+        os.environ["AZURE_CLIENT_SECRET"] = old_conn_secret
+    if old_conn_cli is not None:
+        os.environ["AZURE_STORAGE_CLI_LOGIN"] = old_conn_cli
 
 
 def test_artifact_uri_factory(mock_client):


### PR DESCRIPTION
## What changes are proposed in this pull request?

This change allows for using a Azure blob storage where AAD is used as authentication as described in #3483 

The main idea is that it allows for using a service principal that only has access to the blob container. It futhermore
allows for controlling access to the Artifact Store through AAD as user/developers/model-builders can login with Azure CLI locally through the Azure Activate Directory login flow. This means that the normal Azure login flow can be used for model-builders to get access to the Artifact store.

## How is this patch tested?

The current unit-test has been extended, and I have tried connecting to a AAD enabled blob container.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Azure Activate Directory authentication when using Azure blob as storage for artifact store.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [x] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
