### PR TITLE
Unpin and deduplicate test requirements where possible

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -247,7 +247,7 @@ jobs:
         run: |
           pip install -r dev-requirements.txt
           pip install -r dev/small-requirements.txt
-          pip install -e .
+          pip install -e .[extras]
       - name: Run tests
         run: |
           pytest --verbose --ignore-flavors --ignore=tests/projects tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -84,6 +84,7 @@ jobs:
       with:
         name: 00check.log
         path: /tmp/00check.log
+
   python-small:
     runs-on: ubuntu-latest
     steps:

--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -3,8 +3,6 @@
 ##
 # Required by mlflow.azureml
 azureml-sdk==1.2.0; python_version >= "3.0"
-# Required by mlflow.pyfunc
-cloudpickle
 # Required by mlflow.keras
 keras==2.3.1
 # Required by mlflow.sklearn

--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -6,31 +6,31 @@ azureml-sdk==1.2.0; python_version >= "3.0"
 # Required by mlflow.keras
 keras==2.3.1
 # Required by mlflow.sklearn
-scikit-learn
+scikit-learn==0.23.2
 # Required by mlflow.gluon
-mxnet
+mxnet==1.5.0
 # Required by mlflow.fastai
-fastai
+fastai==1.0.60
 # Required by mlflow.spacy
-spacy
+spacy==2.2.3
 # Required by mlflow.tensorflow
-tensorflow
+tensorflow==1.15.2
 # Required by mlflow.pytorch
-torch
-torchvision
+torch==1.4.0
+torchvision==0.5.0
 # Required by mlflow.xgboost
-xgboost
+xgboost>=0.82
 # Required by mlflow.lightgbm
-lightgbm
+lightgbm==2.3.0
 # Required by mlflow.h2o
-h2o
+h2o==3.22.1.4
 # Required by mlflow.onnx
-onnx
-onnxmltools
-onnxruntime
+onnx==1.4.1;
+onnxmltools==1.4.0;
+onnxruntime==0.3.0;
 # Required by mlflow.mleap, and in order to save SparkML models in
 # mleap format via ``mlflow.spark.log_model``, ``mlflow.spark.save_model``
-mleap
+mleap==0.16.0
 # Required by mlflow.spark
-pyspark
+pyspark==2.4.0
 

--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -16,7 +16,7 @@ spacy==2.2.3
 # Required by mlflow.tensorflow
 tensorflow==1.15.2
 # Required by mlflow.pytorch
-torch==1.4.0
+torch==1.6.0
 torchvision==0.5.0
 # Required by mlflow.xgboost
 xgboost>=0.82

--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -4,35 +4,35 @@
 # Required by mlflow.azureml
 azureml-sdk==1.2.0; python_version >= "3.0"
 # Required by mlflow.pyfunc
-cloudpickle==0.8.0
+cloudpickle
 # Required by mlflow.keras
 keras==2.3.1
 # Required by mlflow.sklearn
-scikit-learn==0.23.2
+scikit-learn
 # Required by mlflow.gluon
-mxnet==1.5.0
+mxnet
 # Required by mlflow.fastai
-fastai==1.0.60
+fastai
 # Required by mlflow.spacy
-spacy==2.2.3
+spacy
 # Required by mlflow.tensorflow
-tensorflow==1.15.2
+tensorflow
 # Required by mlflow.pytorch
-torch==1.4.0
-torchvision==0.5.0
+torch
+torchvision
 # Required by mlflow.xgboost
-xgboost>=0.82
+xgboost
 # Required by mlflow.lightgbm
-lightgbm==2.3.0
+lightgbm
 # Required by mlflow.h2o
-h2o==3.22.1.4
+h2o
 # Required by mlflow.onnx
-onnx==1.4.1;
-onnxmltools==1.4.0;
-onnxruntime==0.3.0;
+onnx
+onnxmltools
+onnxruntime
 # Required by mlflow.mleap, and in order to save SparkML models in
 # mleap format via ``mlflow.spark.log_model``, ``mlflow.spark.save_model``
-mleap==0.16.0
+mleap
 # Required by mlflow.spark
-pyspark==2.4.0
+pyspark
 

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -48,7 +48,7 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   ls -lha $(find $CONDA_DIR/envs/test-environment/ -path "*bin/spark-*")
 fi
 
-pip install .
+pip install .[extras]
 export MLFLOW_HOME=$(pwd)
 
 # Print current environment info

--- a/dev/large-requirements.txt
+++ b/dev/large-requirements.txt
@@ -2,4 +2,3 @@
 ## Test-only dependencies
 matplotlib
 tf2onnx
-pyarrow

--- a/dev/large-requirements.txt
+++ b/dev/large-requirements.txt
@@ -1,5 +1,5 @@
 ## Large test reqs
 ## Test-only dependencies
-matplotlib==3.2.1
-tf2onnx==1.5.4
-pyarrow==0.17.0
+matplotlib
+tf2onnx
+pyarrow

--- a/dev/large-requirements.txt
+++ b/dev/large-requirements.txt
@@ -1,4 +1,3 @@
 ## Large test reqs
-## Test-only dependencies
 matplotlib
 tf2onnx

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -1,6 +1,4 @@
 ## Small test reqs
-# Required to log artifacts and models to HDFS artifact locations
-pyarrow==0.17.0
 # Required to log artifacts to SFTP artifact locations
 pysftp==0.2.9
 # Required to run the MLflow server against SQL-backed storage

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -1,7 +1,4 @@
 ## Small test reqs
-# Required to log artifacts and models to AWS S3 artifact locations
-botocore==1.12.84  # pinned for moto
-boto3==1.9.84      # pinned for moto
 # Required to log artifacts and models to HDFS artifact locations
 pyarrow==0.17.0
 # Required to log artifacts to SFTP artifact locations

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -1,11 +1,4 @@
 ## Small test reqs
-# Required to log artifacts to SFTP artifact locations
-pysftp
-# Required to run the MLflow server against SQL-backed storage
-sqlalchemy
-# Required by the mlflow.projects module, when running projects against
-# a remote Kubernetes cluster
-kubernetes
 ## Test-only dependencies
 attrdict
 pytest==3.2.1

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -1,17 +1,17 @@
 ## Small test reqs
 # Required to log artifacts to SFTP artifact locations
-pysftp==0.2.9
+pysftp
 # Required to run the MLflow server against SQL-backed storage
-sqlalchemy==1.3.0
+sqlalchemy
 # Required by the mlflow.projects module, when running projects against
 # a remote Kubernetes cluster
-kubernetes==9.0.0
+kubernetes
 ## Test-only dependencies
-attrdict==2.0.0
+attrdict
 pytest==3.2.1
 pytest-cov==2.6.0
 pytest-localserver==0.5.0
-scipy==1.2.1
-moto==1.3.7
+scipy
+moto
 # Test plugin, used to verify correctness of MLflow plugin APIs
 tests/resources/mlflow-test-plugin/

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -2,25 +2,25 @@
 # Required
 azure-storage-blob==12.3.0
 # Required to log artifacts and models to GCS artifact locations
-google-cloud-storage==1.14.0
+google-cloud-storage
 # Required to log artifacts and models to AWS S3 artifact locations
-botocore==1.12.84  # pinned for moto
-boto3==1.9.84      # pinned for moto
+botocore
+boto3
 # Required to log artifacts and models to HDFS artifact locations
-pyarrow==0.17.0
+pyarrow
 # Required to log artifacts to SFTP artifact locations
-pysftp==0.2.9
+pysftp
 # Required to run the MLflow server against SQL-backed storage
-sqlalchemy==1.3.0
+sqlalchemy
 # Required by the mlflow.projects module, when running projects against
 # a remote Kubernetes cluster
-kubernetes==9.0.0
+kubernetes
 ## Test-only dependencies
-attrdict==2.0.0
+attrdict
 pytest==3.2.1
 pytest-cov==2.6.0
 pytest-localserver==0.5.0
-scipy==1.2.1
-moto==1.3.7
+scipy
+moto
 # Test plugin, used to verify correctness of MLflow plugin APIs
 tests/resources/mlflow-test-plugin/

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -5,6 +5,6 @@ attrdict==2.0.0
 pytest==3.2.1
 pytest-cov==2.6.0
 pytest-localserver==0.5.0
-moto
+moto==1.3.16
 # Test plugin, used to verify correctness of MLflow plugin APIs
 tests/resources/mlflow-test-plugin/

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -1,26 +1,24 @@
 ## Small test reqs
 # Required
 azure-storage-blob==12.3.0
-# Required to log artifacts and models to GCS artifact locations
-google-cloud-storage
 # Required to log artifacts and models to AWS S3 artifact locations
-botocore
-boto3
+botocore==1.12.84  # pinned for moto
+boto3==1.9.84      # pinned for moto
 # Required to log artifacts and models to HDFS artifact locations
-pyarrow
+pyarrow==0.17.0
 # Required to log artifacts to SFTP artifact locations
-pysftp
+pysftp==0.2.9
 # Required to run the MLflow server against SQL-backed storage
-sqlalchemy
+sqlalchemy==1.3.0
 # Required by the mlflow.projects module, when running projects against
 # a remote Kubernetes cluster
-kubernetes
+kubernetes==9.0.0
 ## Test-only dependencies
-attrdict
+attrdict==2.0.0
 pytest==3.2.1
 pytest-cov==2.6.0
 pytest-localserver==0.5.0
-scipy
-moto
+scipy==1.2.1
+moto==1.3.7
 # Test plugin, used to verify correctness of MLflow plugin APIs
 tests/resources/mlflow-test-plugin/

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -5,6 +5,6 @@ attrdict==2.0.0
 pytest==3.2.1
 pytest-cov==2.6.0
 pytest-localserver==0.5.0
-moto==1.3.7
+moto
 # Test plugin, used to verify correctness of MLflow plugin APIs
 tests/resources/mlflow-test-plugin/

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -1,10 +1,10 @@
 ## Small test reqs
+scipy
 ## Test-only dependencies
-attrdict
+attrdict==2.0.0
 pytest==3.2.1
 pytest-cov==2.6.0
 pytest-localserver==0.5.0
-scipy
-moto
+moto==1.3.7
 # Test plugin, used to verify correctness of MLflow plugin APIs
 tests/resources/mlflow-test-plugin/

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -1,6 +1,4 @@
 ## Small test reqs
-# Required
-azure-storage-blob==12.3.0
 # Required to log artifacts and models to AWS S3 artifact locations
 botocore==1.12.84  # pinned for moto
 boto3==1.9.84      # pinned for moto

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     package_data={"mlflow": js_files + models_container_server_files + alembic_files},
     install_requires=[
         "alembic<=1.4.1",
+        # Required
         "azure-storage-blob",
         "click>=7.0",
         "cloudpickle",
@@ -47,12 +48,12 @@ setup(
         "protobuf>=3.6.0",
         "gitpython>=2.1.0",
         "pyyaml",
-        "pyarrow",
         "querystring_parser",
         "docker>=4.0.0",
         "entrypoints",
         # Pin sqlparse for: https://github.com/mlflow/mlflow/issues/3433
         "sqlparse>=0.3.1",
+        # Required to run the MLflow server against SQL-backed storage
         "sqlalchemy<=1.3.13",
         "gorilla",
         "prometheus-flask-exporter",
@@ -61,10 +62,19 @@ setup(
         "extras": [
             "scikit-learn; python_version >= '3.5'",
             "scikit-learn==0.20; python_version < '3.5'",
+            # Required to log artifacts and models to HDFS artifact locations
+            "pyarrow",
+            # Required to log artifacts and models to AWS S3 artifact locations
             "boto3",
             "mleap",
+            # Required to log artifacts and models to GCS artifact locations
             "google-cloud-storage",
             "azureml-core>=1.2.0",
+            # Required to log artifacts to SFTP artifact locations
+            "pysftp",
+            # Required by the mlflow.projects module, when running projects against
+            # a remote Kubernetes cluster
+            "kubernetes",
         ],
         "sqlserver": ["mlflow-dbstore",],
         "aliyun-oss": ["aliyunstoreplugin",],

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,7 @@ setup(
     ],
     extras_require={
         "extras": [
-            "scikit-learn; python_version >= '3.5'",
-            "scikit-learn==0.20; python_version < '3.5'",
+            "scikit-learn",
             # Required to log artifacts and models to HDFS artifact locations
             "pyarrow",
             # Required to log artifacts and models to AWS S3 artifact locations

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     package_data={"mlflow": js_files + models_container_server_files + alembic_files},
     install_requires=[
         "alembic<=1.4.1",
-        "azure-storage-blob>=12.0",
+        "azure-storage-blob",
         "click>=7.0",
         "cloudpickle",
         "databricks-cli>=0.8.7",
@@ -59,9 +59,9 @@ setup(
     extras_require={
         "extras": [
             "scikit-learn; python_version >= '3.5'",
-            "boto3>=1.7.12",
-            "mleap>=0.16.0",
-            "azure-storage-blob>=12.0",
+            "scikit-learn==0.20; python_version < '3.5'",
+            "boto3",
+            "mleap",
             "google-cloud-storage",
             "azureml-core>=1.2.0",
         ],

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "protobuf>=3.6.0",
         "gitpython>=2.1.0",
         "pyyaml",
+        "pyarrow",
         "querystring_parser",
         "docker>=4.0.0",
         "entrypoints",

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -4,10 +4,10 @@ import pytest
 from unittest import mock
 
 try:
-    from azure.storage.blob import BlobPrefix
+    from azure.storage.blob import BlobPrefix, BlobProperties
 except ImportError:
-    from azure.storage.blob._models import BlobPrefix
-from azure.storage.blob import BlobServiceClient, BlobProperties
+    from azure.storage.blob._models import BlobPrefix, BlobProperties
+from azure.storage.blob import BlobServiceClient
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -3,11 +3,7 @@ import posixpath
 import pytest
 from unittest import mock
 
-try:
-    from azure.storage.blob import BlobPrefix, BlobProperties
-except ImportError:
-    from azure.storage.blob._models import BlobPrefix, BlobProperties
-from azure.storage.blob import BlobServiceClient
+from azure.storage.blob import BlobServiceClient, BlobPrefix, BlobProperties
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -3,8 +3,7 @@ import posixpath
 import pytest
 from unittest import mock
 
-from azure.storage.blob import BlobServiceClient
-from azure.storage.blob._models import BlobPrefix, BlobProperties
+from azure.storage.blob import BlobServiceClient, BlobPrefix, BlobProperties
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository

--- a/tests/store/artifact/test_azure_blob_artifact_repo.py
+++ b/tests/store/artifact/test_azure_blob_artifact_repo.py
@@ -3,7 +3,11 @@ import posixpath
 import pytest
 from unittest import mock
 
-from azure.storage.blob import BlobServiceClient, BlobPrefix, BlobProperties
+try:
+    from azure.storage.blob import BlobPrefix
+except ImportError:
+    from azure.storage.blob._models import BlobPrefix
+from azure.storage.blob import BlobServiceClient, BlobProperties
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository


### PR DESCRIPTION
## What changes are proposed in this pull request?

We are hoping to test the latest version of MLflow's dependencies to identify regressions. This involves:
- Removing the version pins from `dev/small-requirements.txt` and `dev/large-requirements.txt`
- Removing dependencies in `dev/small-requirements.txt` and `dev/large-requirements.txt`, if those dependencies are already specified in `setup.py`. 

## How is this patch tested?

Re-run tests and ensure there is no behavior change.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
