### PR TITLE
[ML-12172] Prettify JSON artifact outputs

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.js
@@ -51,16 +51,29 @@ class ShowArtifactTextView extends Component {
       );
     } else {
       const language = getLanguage(this.props.path);
+      const renderedContent = ShowArtifactTextView.prettifyText(language, this.state.text);
       return (
         <div className='ShowArtifactPage'>
           <div className='text-area-border-box'>
             <SyntaxHighlighter language={language} style={style}>
-              {this.state.text}
+              {renderedContent}
             </SyntaxHighlighter>
           </div>
         </div>
       );
     }
+  }
+
+  static prettifyText(language, rawText) {
+    if (language === 'json') {
+      try {
+        const parsedJson = JSON.parse(rawText);
+        return JSON.stringify(parsedJson, null, 2);
+      } catch (e) {
+        return rawText;
+      }
+    }
+    return rawText;
   }
 
   /** Fetches artifacts and updates component state with the result */

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.test.js
@@ -125,4 +125,25 @@ describe('ShowArtifactTextView', () => {
     expect(instance.fetchArtifacts).toBeCalled();
     expect(instance.props.getArtifact).toBeCalled();
   });
+
+  test('should render prettified valid json', (done) => {
+    const getArtifact = jest.fn((artifactLocation) => {
+      return Promise.resolve('{"key1": "val1", "key2": "val2"}');
+    });
+    const props = { path: 'fake.json', runUuid: 'fakeUuid', getArtifact };
+    wrapper = mount(<ShowArtifactTextView {...props} />);
+    setImmediate(() => {
+      wrapper.update();
+      expect(wrapper.find('.ShowArtifactPage').length).toBe(1);
+      expect(wrapper.find('code').length).toBe(1);
+      expect(wrapper.find('code').text()).toContain('\n');
+      expect(wrapper.find('code').text()).toContain('key1');
+      done();
+    });
+  });
+
+  test('should leave invalid json untouched', () => {
+    const outputText = ShowArtifactTextView.prettifyText('json', '{"hello');
+    expect(outputText).toBe('{"hello');
+  });
 });


### PR DESCRIPTION
## What changes are proposed in this pull request?

Format json artifact content in the artifact preview.

Valid JSON is formatted with existing syntax highlighting:
<img width="1062" alt="Screen Shot 2020-10-02 at 12 15 37 PM" src="https://user-images.githubusercontent.com/2577963/94950991-7eeb3b80-04b1-11eb-9cba-b59e100deffe.png">
Invalid JSON is passed through transparently
<img width="1050" alt="Screen Shot 2020-10-02 at 12 15 50 PM" src="https://user-images.githubusercontent.com/2577963/94951002-8579b300-04b1-11eb-8642-129753388ef7.png">
Other files passed through
<img width="1106" alt="Screen Shot 2020-10-05 at 2 06 47 PM" src="https://user-images.githubusercontent.com/2577963/95115789-0b953400-0714-11eb-9941-e47a456101c5.png">

## How is this patch tested?

npm test -- src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.test.js

## Release Notes

- [ ] No. You can skip the rest of this section.
- [x ] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLFlow will now automatically format valid json artifacts in the artifact preview pane to improve readability. To examine the raw file with original formatting you can download the json file.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ x ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ x ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
