### PR TITLE
Exclude preprocessing & imputation steps from scikit-learn autologging

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -921,11 +921,13 @@ def autolog(log_input_example=False, log_model_signature=True):
     # for these routines, unless they are captured as part of an ML pipeline
     # (via `sklearn.pipeline.Pipeline`)
     import sklearn.preprocessing
+
     excluded_modules = [sklearn.preprocessing]
     # The `sklearn.impute` module was introduced in scikit-learn 0.20.0; in an attempt
     # to preserve compatibility with version 0.19.x, we conditionally import this module
     try:
         import sklearn.impute
+
         excluded_modules.append(sklearn.impute)
     except ImportError:
         pass
@@ -933,7 +935,12 @@ def autolog(log_input_example=False, log_model_signature=True):
     estimators_to_patch = [
         estimator
         for estimator in estimators_to_patch
-        if not any([estimator.__module__.startswith(excluded_module.__name__) for excluded_module in excluded_modules])
+        if not any(
+            [
+                estimator.__module__.startswith(excluded_module.__name__)
+                for excluded_module in excluded_modules
+            ]
+        )
     ]
 
     for class_def in estimators_to_patch:

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -921,8 +921,10 @@ def autolog(log_input_example=False, log_model_signature=True):
     # for these preprocessing routines, unless they are captured as part of an ML pipeline
     # (via `sklearn.pipeline.Pipeline`)
     import sklearn.preprocessing
+
     estimators_to_patch = [
-        estimator for estimator in estimators_to_patch
+        estimator
+        for estimator in estimators_to_patch
         if not estimator.__module__.startswith(sklearn.preprocessing.__name__)
     ]
 

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -915,6 +915,16 @@ def autolog(log_input_example=False, log_model_signature=True):
     estimators_to_patch = set(estimators_to_patch).union(
         set(_get_meta_estimators_for_autologging())
     )
+    # Exclude preprocessing estimators from patching. These estimators represent
+    # data manipulation routines (e.g., normalization, label encoding) rather than ML
+    # algorithms. Accordingly, we should not create MLflow runs and log parameters / metrics
+    # for these preprocessing routines, unless they are captured as part of an ML pipeline
+    # (via `sklearn.pipeline.Pipeline`)
+    import sklearn.preprocessing
+    estimators_to_patch = [
+        estimator for estimator in estimators_to_patch
+        if not estimator.__module__.startswith(sklearn.preprocessing.__name__)
+    ]
 
     for class_def in estimators_to_patch:
         for func_name in ["fit", "fit_transform", "fit_predict"]:

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1011,6 +1011,11 @@ def test_autolog_does_not_capture_runs_for_preprocessing_estimators():
     (e.g., normalization, label encoding) rather than ML models, do not produce
     runs when their fit_* operations are invoked independently of an ML pipeline
     """
+    mlflow.sklearn.autolog()
+
+    # Create a run using the MLflow client, which will be resumed via the fluent API,
+    # in order to avoid setting fluent-level tags (e.g., source and user). Suppressing these
+    # tags simplifies test validation logic
     client = mlflow.tracking.MlflowClient()
     run_id = client.create_run(experiment_id=0).info.run_id
 

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1015,10 +1015,11 @@ def test_autolog_does_not_capture_runs_for_preprocessing_estimators():
     run_id = client.create_run(experiment_id=0).info.run_id
 
     from sklearn.preprocessing import Normalizer, LabelEncoder, MinMaxScaler
+
     with mlflow.start_run(run_id=run_id):
-        Normalizer().fit_transform(np.random.random((5,5)))
+        Normalizer().fit_transform(np.random.random((5, 5)))
         LabelEncoder().fit([1, 2, 2, 6])
-        MinMaxScaler().fit_transform(50 * np.random.random((10,10)))
+        MinMaxScaler().fit_transform(50 * np.random.random((10, 10)))
 
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert len(params) == 0

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1002,3 +1002,26 @@ def test_autolog_configuration_options(log_input_example, log_model_signature):
     model_conf = get_model_conf(run.info.artifact_uri)
     assert ("saved_input_example_info" in model_conf.to_dict()) == log_input_example
     assert ("signature" in model_conf.to_dict()) == log_model_signature
+
+
+@pytest.mark.large
+def test_autolog_does_not_capture_runs_for_preprocessing_estimators():
+    """
+    Verifies that preprocessing estimators, which represent data manipulation steps
+    (e.g., normalization, label encoding) rather than ML models, do not produce
+    runs when their fit_* operations are invoked independently of an ML pipeline
+    """
+    client = mlflow.tracking.MlflowClient()
+    run_id = client.create_run(experiment_id=0).info.run_id
+
+    from sklearn.preprocessing import Normalizer, LabelEncoder, MinMaxScaler
+    with mlflow.start_run(run_id=run_id):
+        Normalizer().fit_transform(np.random.random((5,5)))
+        LabelEncoder().fit([1, 2, 2, 6])
+        MinMaxScaler().fit_transform(50 * np.random.random((10,10)))
+
+    params, metrics, tags, artifacts = get_run_data(run_id)
+    assert len(params) == 0
+    assert len(metrics) == 0
+    assert len(tags) == 0
+    assert len(artifacts) == 0

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1005,11 +1005,11 @@ def test_autolog_configuration_options(log_input_example, log_model_signature):
 
 
 @pytest.mark.large
-def test_autolog_does_not_capture_runs_for_preprocessing_estimators():
+def test_autolog_does_not_capture_runs_for_preprocessing_or_imputation_estimators():
     """
-    Verifies that preprocessing estimators, which represent data manipulation steps
-    (e.g., normalization, label encoding) rather than ML models, do not produce
-    runs when their fit_* operations are invoked independently of an ML pipeline
+    Verifies that preprocessing and imputation estimators, which represent data manipulation steps
+    (e.g., normalization, label encoding) rather than ML models, do not produce runs when their
+    fit_* operations are invoked independently of an ML pipeline
     """
     mlflow.sklearn.autolog()
 
@@ -1020,11 +1020,13 @@ def test_autolog_does_not_capture_runs_for_preprocessing_estimators():
     run_id = client.create_run(experiment_id=0).info.run_id
 
     from sklearn.preprocessing import Normalizer, LabelEncoder, MinMaxScaler
+    from sklearn.impute import SimpleImputer
 
     with mlflow.start_run(run_id=run_id):
         Normalizer().fit_transform(np.random.random((5, 5)))
         LabelEncoder().fit([1, 2, 2, 6])
         MinMaxScaler().fit_transform(50 * np.random.random((10, 10)))
+        SimpleImputer().fit_transform([[1, 2], [np.nan, 3], [7, 6]])
 
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert len(params) == 0


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adjusts the scope of scikit-learn autologging estimators to exclude preprocessing and imputation routines used for data manipulation, label encoding, etc. These routines are not ML models and are often leveraged independently of ML training routines. Accordingly, we should not be capturing MLflow runs for preprocessing & imputation steps. 

We note that preprocessing routines will still be reflected as part of ML pipelines trained via `sklearn.pipeline.Pipeline`.

For reference, the following preprocessing / imputation estimators will no longer capture MLflow runs during autologging:

```
 sklearn.preprocessing._data.Binarizer,
 sklearn.preprocessing._function_transformer.FunctionTransformer,
 sklearn.preprocessing._discretization.KBinsDiscretizer,
 sklearn.preprocessing._data.KernelCenterer,
 sklearn.preprocessing._label.LabelBinarizer,
 sklearn.preprocessing._label.LabelEncoder,
 sklearn.preprocessing._data.MaxAbsScaler,
 sklearn.preprocessing._data.MinMaxScaler,
 sklearn.preprocessing._label.MultiLabelBinarizer,
 sklearn.preprocessing._data.Normalizer,
 sklearn.preprocessing._encoders.OneHotEncoder,
 sklearn.preprocessing._encoders.OrdinalEncoder,
 sklearn.preprocessing._data.PolynomialFeatures,
 sklearn.preprocessing._data.PowerTransformer,
 sklearn.preprocessing._data.QuantileTransformer,
 sklearn.preprocessing._data.RobustScaler,
 sklearn.preprocessing._data.StandardScaler
 sklearn.impute._iterative.IterativeImputer,
 sklearn.impute._knn.KNNImputer,
 sklearn.impute._base.MissingIndicator,
 sklearn.impute._base.SimpleImputer
```

## How is this patch tested?

Included unit tests

## Release Notes

Scikit-learn autologging no longer records MLflow runs for preprocessing steps (e.g., normalization and label encoding)

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
