### PR TITLE
Add utility functions for SHAP integration

### DIFF
--- a/mlflow/shap.py
+++ b/mlflow/shap.py
@@ -1,0 +1,34 @@
+from contextlib import contextmanager
+import os
+import tempfile
+
+import numpy as np
+
+import mlflow
+
+
+@contextmanager
+def _log_artifact_contextmanager(out_file, artifact_path=None):
+    """
+    A context manager to make it easier to log an artifact.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = os.path.join(tmp_dir, out_file)
+        yield tmp_path
+        mlflow.log_artifact(tmp_path, artifact_path)
+
+
+def _log_numpy(numpy_obj, out_file, artifact_path=None):
+    """
+    Log a numpy object.
+    """
+    with _log_artifact_contextmanager(out_file, artifact_path) as tmp_path:
+        np.save(tmp_path, numpy_obj)
+
+
+def _log_matplotlib_figure(fig, out_file, artifact_path=None):
+    """
+    Log a matplotlib figure.
+    """
+    with _log_artifact_contextmanager(out_file, artifact_path) as tmp_path:
+        fig.savefig(tmp_path)

--- a/tests/shap/test_shap.py
+++ b/tests/shap/test_shap.py
@@ -1,0 +1,42 @@
+import pytest
+import numpy as np
+import matplotlib.pyplot as plt
+import mlflow.shap
+
+
+def yield_artifacts(run_id, path=None):
+    """
+    Yields all artifacts in the specified run.
+    """
+    client = mlflow.tracking.MlflowClient()
+    for item in client.list_artifacts(run_id, path):
+        if item.is_dir:
+            yield from yield_artifacts(run_id, item.path)
+        else:
+            yield item.path
+
+
+@pytest.mark.large
+@pytest.mark.parametrize("np_obj", [np.float(0.0), np.array([0.0])])
+def test_log_numpy(np_obj):
+
+    with mlflow.start_run() as run:
+        mlflow.shap._log_numpy(np_obj, "test.npy")
+        mlflow.shap._log_numpy(np_obj, "test.npy", artifact_path="dir")
+
+    artifacts = set(yield_artifacts(run.info.run_id))
+    assert artifacts == {"test.npy", "dir/test.npy"}
+
+
+@pytest.mark.large
+def test_log_matplotlib_figure():
+
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [2, 3])
+
+    with mlflow.start_run() as run:
+        mlflow.shap._log_matplotlib_figure(fig, "test.png")
+        mlflow.shap._log_matplotlib_figure(fig, "test.png", artifact_path="dir")
+
+    artifacts = set(yield_artifacts(run.info.run_id))
+    assert artifacts == {"test.png", "dir/test.png"}


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
