### PR TITLE
Update super usage

### DIFF
--- a/examples/prophet/train.ipynb
+++ b/examples/prophet/train.ipynb
@@ -30,7 +30,7 @@
     "\n",
     "    def __init__(self, model):\n",
     "        self.model = model\n",
-    "        super(FbProphetWrapper, self).__init__()\n",
+    "        super().__init__()\n",
     "\n",
     "\n",
     "    def load_context(self, context):\n",

--- a/examples/prophet/train.py
+++ b/examples/prophet/train.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 class FbProphetWrapper(mlflow.pyfunc.PythonModel):
     def __init__(self, model):
         self.model = model
-        super(FbProphetWrapper, self).__init__()
+        super().__init__()
 
     def load_context(self, context):
         from fbprophet import Prophet

--- a/examples/pytorch/mnist_tensorboard_artifact.py
+++ b/examples/pytorch/mnist_tensorboard_artifact.py
@@ -102,7 +102,7 @@ test_loader = torch.utils.data.DataLoader(
 
 class Net(nn.Module):
     def __init__(self):
-        super(Net, self).__init__()
+        super().__init__()
         self.conv1 = nn.Conv2d(1, 10, kernel_size=5)
         self.conv2 = nn.Conv2d(10, 20, kernel_size=5)
         self.conv2_drop = nn.Dropout2d()

--- a/mlflow/entities/_mlflow_object.py
+++ b/mlflow/entities/_mlflow_object.py
@@ -40,7 +40,7 @@ def get_classname(obj):
 
 class _MLflowObjectPrinter(object):
     def __init__(self):
-        super(_MLflowObjectPrinter, self).__init__()
+        super().__init__()
         self.printer = pprint.PrettyPrinter()
 
     def to_string(self, obj):

--- a/mlflow/entities/experiment.py
+++ b/mlflow/entities/experiment.py
@@ -14,7 +14,7 @@ class Experiment(_MLflowObject):
     DEFAULT_EXPERIMENT_NAME = "Default"
 
     def __init__(self, experiment_id, name, artifact_location, lifecycle_stage, tags=None):
-        super(Experiment, self).__init__()
+        super().__init__()
         self._experiment_id = experiment_id
         self._name = name
         self._artifact_location = artifact_location

--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -31,7 +31,7 @@ class ModelVersion(_ModelRegistryEntity):
         tags=None,
         run_link=None,
     ):
-        super(ModelVersion, self).__init__()
+        super().__init__()
         self._name = name
         self._version = version
         self._creation_time = creation_timestamp

--- a/mlflow/entities/model_registry/registered_model.py
+++ b/mlflow/entities/model_registry/registered_model.py
@@ -25,7 +25,7 @@ class RegisteredModel(_ModelRegistryEntity):
         tags=None,
     ):
         # Constructor is called only from within the system by various backend stores.
-        super(RegisteredModel, self).__init__()
+        super().__init__()
         self._name = name
         self._creation_time = creation_timestamp
         self._last_updated_timestamp = last_updated_timestamp

--- a/mlflow/exceptions.py
+++ b/mlflow/exceptions.py
@@ -52,7 +52,7 @@ class MlflowException(Exception):
             self.error_code = ErrorCode.Name(INTERNAL_ERROR)
         self.message = message
         self.json_kwargs = kwargs
-        super(MlflowException, self).__init__(message)
+        super().__init__(message)
 
     def serialize_as_json(self):
         exception_dict = {"error_code": self.error_code, "message": self.message}
@@ -72,7 +72,7 @@ class RestException(MlflowException):
             error_code,
             json["message"] if "message" in json else "Response: " + str(json),
         )
-        super(RestException, self).__init__(message, error_code=ErrorCode.Value(error_code))
+        super().__init__(message, error_code=ErrorCode.Value(error_code))
         self.json = json
 
 

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -356,7 +356,7 @@ class DatabricksSubmittedRun(SubmittedRun):
     POLL_STATUS_INTERVAL = 30
 
     def __init__(self, databricks_run_id, mlflow_run_id, databricks_job_runner):
-        super(DatabricksSubmittedRun, self).__init__()
+        super().__init__()
         self._databricks_run_id = databricks_run_id
         self._mlflow_run_id = mlflow_run_id
         self._job_runner = databricks_job_runner

--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -101,7 +101,7 @@ class KubernetesSubmittedRun(SubmittedRun):
     POLL_STATUS_INTERVAL = 5
 
     def __init__(self, mlflow_run_id, job_name, job_namespace):
-        super(KubernetesSubmittedRun, self).__init__()
+        super().__init__()
         self._mlflow_run_id = mlflow_run_id
         self._job_name = job_name
         self._job_namespace = job_namespace

--- a/mlflow/projects/submitted_run.py
+++ b/mlflow/projects/submitted_run.py
@@ -64,7 +64,7 @@ class LocalSubmittedRun(SubmittedRun):
     """
 
     def __init__(self, run_id, command_proc):
-        super(LocalSubmittedRun, self).__init__()
+        super().__init__()
         self._run_id = run_id
         self.command_proc = command_proc
 

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -21,7 +21,7 @@ class PyFuncBackend(FlavorBackend):
     """
 
     def __init__(self, config, workers=1, no_conda=False, install_mlflow=False, **kwargs):
-        super(PyFuncBackend, self).__init__(config=config, **kwargs)
+        super().__init__(config=config, **kwargs)
         self._nworkers = workers or 1
         self._no_conda = no_conda
         self._install_mlflow = install_mlflow

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -152,7 +152,7 @@ def log_model(
         # https://github.com/hunkim/PyTorchZeroToAll
         class Model(torch.nn.Module):
             def __init__(self):
-               super(Model, self).__init__()
+               super().__init__()
                self.linear = torch.nn.Linear(1, 1)  # One in and one out
             def forward(self, x):
                 y_pred = self.linear(x)

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -82,7 +82,7 @@ STATIC_PREFIX_ENV_VAR = "_MLFLOW_STATIC_PREFIX"
 
 class TrackingStoreRegistryWrapper(TrackingStoreRegistry):
     def __init__(self):
-        super(TrackingStoreRegistryWrapper, self).__init__()
+        super().__init__()
         self.register("", self._get_file_store)
         self.register("file", self._get_file_store)
         for scheme in DATABASE_ENGINES:
@@ -104,7 +104,7 @@ class TrackingStoreRegistryWrapper(TrackingStoreRegistry):
 
 class ModelRegistryStoreRegistryWrapper(ModelRegistryStoreRegistry):
     def __init__(self):
-        super(ModelRegistryStoreRegistryWrapper, self).__init__()
+        super().__init__()
         # NB: Model Registry does not support file based stores
         for scheme in DATABASE_ENGINES:
             self.register(scheme, self._get_sqlalchemy_store)

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -20,7 +20,7 @@ class AzureBlobArtifactRepository(ArtifactRepository):
     """
 
     def __init__(self, artifact_uri, client=None):
-        super(AzureBlobArtifactRepository, self).__init__(artifact_uri)
+        super().__init__(artifact_uri)
 
         # Allow override for testing
         if client:

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -74,9 +74,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
             )
         # The dbfs:/ path ultimately used for artifact operations should not contain the
         # Databricks profile info, so strip it before setting ``artifact_uri``.
-        super().__init__(
-            remove_databricks_profile_info_from_artifact_uri(artifact_uri)
-        )
+        super().__init__(remove_databricks_profile_info_from_artifact_uri(artifact_uri))
 
         self.databricks_profile_uri = (
             get_databricks_profile_uri_from_artifact_uri(artifact_uri)

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -74,7 +74,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
             )
         # The dbfs:/ path ultimately used for artifact operations should not contain the
         # Databricks profile info, so strip it before setting ``artifact_uri``.
-        super(DatabricksArtifactRepository, self).__init__(
+        super().__init__(
             remove_databricks_profile_info_from_artifact_uri(artifact_uri)
         )
 

--- a/mlflow/store/artifact/dbfs_artifact_repo.py
+++ b/mlflow/store/artifact/dbfs_artifact_repo.py
@@ -47,7 +47,7 @@ class DbfsRestArtifactRepository(ArtifactRepository):
 
         # The dbfs:/ path ultimately used for artifact operations should not contain the
         # Databricks profile info, so strip it before setting ``artifact_uri``.
-        super(DbfsRestArtifactRepository, self).__init__(
+        super().__init__(
             remove_databricks_profile_info_from_artifact_uri(artifact_uri)
         )
 

--- a/mlflow/store/artifact/dbfs_artifact_repo.py
+++ b/mlflow/store/artifact/dbfs_artifact_repo.py
@@ -47,9 +47,7 @@ class DbfsRestArtifactRepository(ArtifactRepository):
 
         # The dbfs:/ path ultimately used for artifact operations should not contain the
         # Databricks profile info, so strip it before setting ``artifact_uri``.
-        super().__init__(
-            remove_databricks_profile_info_from_artifact_uri(artifact_uri)
-        )
+        super().__init__(remove_databricks_profile_info_from_artifact_uri(artifact_uri))
 
         databricks_profile_uri = get_databricks_profile_uri_from_artifact_uri(artifact_uri)
         if databricks_profile_uri:

--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -29,7 +29,7 @@ class FTPArtifactRepository(ArtifactRepository):
         if self.config["host"] is None:
             self.config["host"] = "localhost"
 
-        super(FTPArtifactRepository, self).__init__(artifact_uri)
+        super().__init__(artifact_uri)
 
     @contextmanager
     def get_ftp_client(self):

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -24,7 +24,7 @@ class GCSArtifactRepository(ArtifactRepository):
             from google.cloud import storage as gcs_storage
 
             self.gcs = gcs_storage
-        super(GCSArtifactRepository, self).__init__(artifact_uri)
+        super().__init__(artifact_uri)
 
     @staticmethod
     def parse_gcs_uri(uri):

--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -21,7 +21,7 @@ class HdfsArtifactRepository(ArtifactRepository):
 
     def __init__(self, artifact_uri):
         self.scheme, self.host, self.port, self.path = _resolve_connection_params(artifact_uri)
-        super(HdfsArtifactRepository, self).__init__(artifact_uri)
+        super().__init__(artifact_uri)
 
     def log_artifact(self, local_file, artifact_path=None):
         """

--- a/mlflow/store/artifact/local_artifact_repo.py
+++ b/mlflow/store/artifact/local_artifact_repo.py
@@ -16,7 +16,7 @@ class LocalArtifactRepository(ArtifactRepository):
     """Stores artifacts as files in a local directory."""
 
     def __init__(self, *args, **kwargs):
-        super(LocalArtifactRepository, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._artifact_dir = local_file_uri_to_path(self.artifact_uri)
 
     @property
@@ -71,7 +71,7 @@ class LocalArtifactRepository(ArtifactRepository):
         :return: Absolute path of the local filesystem location containing the desired artifacts.
         """
         if dst_path:
-            return super(LocalArtifactRepository, self).download_artifacts(artifact_path, dst_path)
+            return super().download_artifacts(artifact_path, dst_path)
         # NOTE: The artifact_path is expected to be in posix format.
         # Posix paths work fine on windows but just in case we normalize it here.
         local_artifact_path = os.path.join(self.artifact_dir, os.path.normpath(artifact_path))

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -21,7 +21,7 @@ class ModelsArtifactRepository(ArtifactRepository):
     def __init__(self, artifact_uri):
         from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 
-        super(ModelsArtifactRepository, self).__init__(artifact_uri)
+        super().__init__(artifact_uri)
         uri = ModelsArtifactRepository.get_underlying_uri(artifact_uri)
         # TODO: it may be nice to fall back to the source URI explicitly here if for some reason
         #  we don't get a download URI here, or fail during the download itself.

--- a/mlflow/store/artifact/runs_artifact_repo.py
+++ b/mlflow/store/artifact/runs_artifact_repo.py
@@ -22,7 +22,7 @@ class RunsArtifactRepository(ArtifactRepository):
     def __init__(self, artifact_uri):
         from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 
-        super(RunsArtifactRepository, self).__init__(artifact_uri)
+        super().__init__(artifact_uri)
         uri = RunsArtifactRepository.get_underlying_uri(artifact_uri)
         self.repo = get_artifact_repository(uri)
 

--- a/mlflow/store/artifact/sftp_artifact_repo.py
+++ b/mlflow/store/artifact/sftp_artifact_repo.py
@@ -69,7 +69,7 @@ class SFTPArtifactRepository(ArtifactRepository):
 
             self.sftp = pysftp.Connection(**self.config)
 
-        super(SFTPArtifactRepository, self).__init__(artifact_uri)
+        super().__init__(artifact_uri)
 
     def log_artifact(self, local_file, artifact_path=None):
         artifact_dir = posixpath.join(self.path, artifact_path) if artifact_path else self.path

--- a/mlflow/store/entities/paged_list.py
+++ b/mlflow/store/entities/paged_list.py
@@ -1,4 +1,4 @@
 class PagedList(list):
     def __init__(self, items, token):
-        super(PagedList, self).__init__(items)
+        super().__init__(items)
         self.token = token

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -49,7 +49,7 @@ class RestStore(AbstractStore):
     """
 
     def __init__(self, get_host_creds):
-        super(RestStore, self).__init__()
+        super().__init__()
         self.get_host_creds = get_host_creds
 
     def _call_endpoint(self, api, json_body):

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -85,7 +85,7 @@ class SqlAlchemyStore(AbstractStore):
         :param default_artifact_root: Path/URI to location suitable for large data (such as a blob
                                       store object, DBFS path, or shared NFS file system).
         """
-        super(SqlAlchemyStore, self).__init__()
+        super().__init__()
         self.db_uri = db_uri
         self.db_type = extract_db_type_from_uri(db_uri)
         self.engine = mlflow.store.db.utils.create_sqlalchemy_engine(db_uri)

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -128,7 +128,7 @@ class FileStore(AbstractStore):
         """
         Create a new FileStore with the given root directory and a given default artifact root URI.
         """
-        super(FileStore, self).__init__()
+        super().__init__()
         self.root_directory = local_file_uri_to_path(root_directory or _default_root_dir())
         self.artifact_root_uri = artifact_root_uri or path_to_local_file_uri(self.root_directory)
         self.trash_folder = os.path.join(self.root_directory, FileStore.TRASH_FOLDER_NAME)

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -46,7 +46,7 @@ class RestStore(AbstractStore):
     """
 
     def __init__(self, get_host_creds):
-        super(RestStore, self).__init__()
+        super().__init__()
         self.get_host_creds = get_host_creds
 
     def _call_endpoint(self, api, json_body):

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -96,7 +96,7 @@ class SqlAlchemyStore(AbstractStore):
         :param default_artifact_root: Path/URI to location suitable for large data (such as a blob
                                       store object, DBFS path, or shared NFS file system).
         """
-        super(SqlAlchemyStore, self).__init__()
+        super().__init__()
         self.db_uri = db_uri
         self.db_type = extract_db_type_from_uri(db_uri)
         self.artifact_root_uri = default_artifact_root

--- a/mlflow/tracking/_model_registry/registry.py
+++ b/mlflow/tracking/_model_registry/registry.py
@@ -17,7 +17,7 @@ class ModelRegistryStoreRegistry(StoreRegistry):
     """
 
     def __init__(self):
-        super(ModelRegistryStoreRegistry, self).__init__("mlflow.model_registry_store")
+        super().__init__("mlflow.model_registry_store")
 
     def get_store(self, store_uri=None):
         """Get a store from the registry based on the scheme of store_uri

--- a/mlflow/tracking/_tracking_service/registry.py
+++ b/mlflow/tracking/_tracking_service/registry.py
@@ -17,7 +17,7 @@ class TrackingStoreRegistry(StoreRegistry):
     """
 
     def __init__(self):
-        super(TrackingStoreRegistry, self).__init__("mlflow.tracking_store")
+        super().__init__("mlflow.tracking_store")
 
     def get_store(self, store_uri=None, artifact_uri=None):
         """Get a store from the registry based on the scheme of store_uri

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -18,7 +18,7 @@ class UnsupportedModelRegistryStoreURIException(MlflowException):
             " how to run an MLflow server against one of the supported backend storage"
             " locations."
         ).format(unsupported_uri, supported_uri_schemes)
-        super(UnsupportedModelRegistryStoreURIException, self).__init__(
+        super().__init__(
             message, error_code=INVALID_PARAMETER_VALUE
         )
         self.supported_uri_schemes = supported_uri_schemes

--- a/mlflow/tracking/registry.py
+++ b/mlflow/tracking/registry.py
@@ -18,9 +18,7 @@ class UnsupportedModelRegistryStoreURIException(MlflowException):
             " how to run an MLflow server against one of the supported backend storage"
             " locations."
         ).format(unsupported_uri, supported_uri_schemes)
-        super().__init__(
-            message, error_code=INVALID_PARAMETER_VALUE
-        )
+        super().__init__(message, error_code=INVALID_PARAMETER_VALUE)
         self.supported_uri_schemes = supported_uri_schemes
 
 

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -101,7 +101,7 @@ def custom_layer():
     class MyDense(Layer):
         def __init__(self, output_dim, **kwargs):
             self.output_dim = output_dim
-            super(MyDense, self).__init__(**kwargs)
+            super().__init__(**kwargs)
 
         def build(self, input_shape):
             # pylint: disable=attribute-defined-outside-init
@@ -111,7 +111,7 @@ def custom_layer():
                 initializer="uniform",
                 trainable=True,
             )
-            super(MyDense, self).build(input_shape)
+            super().build(input_shape)
 
         def call(self, x):
             # pylint: disable=arguments-differ

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -50,7 +50,7 @@ def get_model_class():
             self.predict_fn = predict_fn
 
         def load_context(self, context):
-            super(CustomSklearnModel, self).load_context(context)
+            super().load_context(context)
             # pylint: disable=attribute-defined-outside-init
             self.model = mlflow.sklearn.load_model(model_uri=context.artifacts["sk_model"])
 

--- a/tests/pytorch/test_pytorch_model_export.py
+++ b/tests/pytorch/test_pytorch_model_export.py
@@ -102,7 +102,7 @@ def get_subclassed_model_definition():
     # pylint: disable=W0223
     class SubclassedModel(torch.nn.Module):
         def __init__(self):
-            super(SubclassedModel, self).__init__()
+            super().__init__()
             self.linear = torch.nn.Linear(4, 1)
 
         def forward(self, x):

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/file_store.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/file_store.py
@@ -9,4 +9,4 @@ class PluginFileStore(FileStore):
     def __init__(self, store_uri=None, artifact_uri=None):
         path = urllib.parse.urlparse(store_uri).path if store_uri else None
         self.is_plugin = True
-        super(PluginFileStore, self).__init__(path, artifact_uri)
+        super().__init__(path, artifact_uri)

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/sql_store_alchemy.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/sql_store_alchemy.py
@@ -7,4 +7,4 @@ class PluginRegistrySqlAlchemyStore(SqlAlchemyStore):
     def __init__(self, store_uri=None):
         path = urllib.parse.urlparse(store_uri).path if store_uri else None
         self.is_plugin = True
-        super(PluginRegistrySqlAlchemyStore, self).__init__(path)
+        super().__init__(path)

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -505,7 +505,7 @@ class Endpoint(TimestampedResource):
         :param latest_operation: The most recent operation that was invoked on the endpoint,
                                  represented as an EndpointOperation object.
         """
-        super(Endpoint, self).__init__()
+        super().__init__()
         self.endpoint_name = endpoint_name
         self.config_name = config_name
         self.tags = tags
@@ -637,7 +637,7 @@ class EndpointConfig(TimestampedResource):
     """
 
     def __init__(self, config_name, production_variants, tags):
-        super(EndpointConfig, self).__init__()
+        super().__init__()
         self.config_name = config_name
         self.production_variants = production_variants
         self.tags = tags
@@ -696,7 +696,7 @@ class Model(TimestampedResource):
     """
 
     def __init__(self, model_name, primary_container, execution_role_arn, tags, vpc_config):
-        super(Model, self).__init__()
+        super().__init__()
         self.model_name = model_name
         self.primary_container = primary_container
         self.execution_role_arn = execution_role_arn

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -917,7 +917,7 @@ def test_autolog_does_not_throw_when_failing_to_sample_X():
         def __getitem__(self, key):
             if isinstance(key, slice):
                 raise IndexError("DO NOT SLICE ME")
-            return super(ArrayThatThrowsWhenSliced, self).__getitem__(key)
+            return super().__getitem__(key)
 
     X, y = get_iris()
     throwing_X = ArrayThatThrowsWhenSliced(X)


### PR DESCRIPTION
## What changes are proposed in this pull request?

The usage of the builtin super function has changed between Python 2 and Python 3 - on Python 3, super does not need to be called with any arguments in the normal cases where super is used.

This PR updates the super usage in the codebase.

Note that the changes were made using regex-based automated search and replace. The regex used is `(super)+\(+(\w+)(,)+\s(self)+\)+` - which matched e.g. `super(Store, self)` - which was replaced with `super()`. The changes were then verified one after another before being staged. All of the uses of `super` are trivial uses of the nature `super(ClassName, self)` called within the `class ClassName` so these changes should cause no behavioral changes in the codebase.

## How is this patch tested?

The changes are trivial and were not tested locally. I am reling on CI.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
