### PR TITLE
Update urllib imports from six.moves

### DIFF
--- a/mlflow/data.py
+++ b/mlflow/data.py
@@ -1,7 +1,6 @@
 import os
 import re
-
-from six.moves import urllib
+import urllib.parse
 
 from mlflow.utils import process
 from mlflow.utils.annotations import deprecated

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -2,8 +2,9 @@ import logging
 import os
 import posixpath
 import shutil
-from six.moves import urllib
 import tempfile
+import urllib.parse
+import urllib.request
 
 import docker
 

--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -2,10 +2,10 @@ import logging
 import os
 import re
 import tempfile
+import urllib.parse
 
 
 from distutils import dir_util
-from six.moves import urllib
 
 import mlflow.utils
 from mlflow.utils import databricks_utils

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -3,7 +3,7 @@ The ``mlflow.sagemaker`` module provides an API for deploying MLflow models to A
 """
 import os
 from subprocess import Popen
-from six.moves import urllib
+import urllib.parse
 import sys
 import tarfile
 import logging

--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -1,8 +1,7 @@
 import os
 import posixpath
 import re
-
-from six.moves import urllib
+import urllib.parse
 
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException

--- a/mlflow/store/artifact/ftp_artifact_repo.py
+++ b/mlflow/store/artifact/ftp_artifact_repo.py
@@ -4,7 +4,7 @@ from ftplib import FTP
 from contextlib import contextmanager
 
 import posixpath
-from six.moves import urllib
+import urllib.parse
 
 from mlflow.entities.file_info import FileInfo
 from mlflow.store.artifact.artifact_repo import ArtifactRepository

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -1,7 +1,7 @@
 import os
 
 import posixpath
-from six.moves import urllib
+import urllib.parse
 
 from mlflow.entities import FileInfo
 from mlflow.store.artifact.artifact_repo import ArtifactRepository

--- a/mlflow/store/artifact/hdfs_artifact_repo.py
+++ b/mlflow/store/artifact/hdfs_artifact_repo.py
@@ -2,8 +2,7 @@ import os
 import posixpath
 import tempfile
 from contextlib import contextmanager
-
-from six.moves import urllib
+import urllib.parse
 
 from mlflow.entities import FileInfo
 from mlflow.exceptions import MlflowException

--- a/mlflow/store/artifact/models_artifact_repo.py
+++ b/mlflow/store/artifact/models_artifact_repo.py
@@ -1,4 +1,4 @@
-from six.moves import urllib
+import urllib.parse
 
 import mlflow
 from mlflow.exceptions import MlflowException

--- a/mlflow/store/artifact/runs_artifact_repo.py
+++ b/mlflow/store/artifact/runs_artifact_repo.py
@@ -1,4 +1,4 @@
-from six.moves import urllib
+import urllib.parse
 
 from mlflow.exceptions import MlflowException
 from mlflow.store.artifact.artifact_repo import ArtifactRepository

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -2,7 +2,7 @@ import os
 from mimetypes import guess_type
 
 import posixpath
-from six.moves import urllib
+import urllib.parse
 
 from mlflow import data
 from mlflow.entities import FileInfo

--- a/mlflow/store/artifact/sftp_artifact_repo.py
+++ b/mlflow/store/artifact/sftp_artifact_repo.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 import posixpath
-from six.moves import urllib
+import urllib.parse
 
 from mlflow.entities import FileInfo
 from mlflow.store.artifact.artifact_repo import ArtifactRepository

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -5,8 +5,7 @@ import pathlib
 import posixpath
 import shutil
 import tempfile
-
-from six.moves import urllib
+import urllib.parse
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -8,9 +8,10 @@ import sys
 import tarfile
 import tempfile
 
-from six.moves.urllib.request import pathname2url
-from six.moves.urllib.parse import unquote
-from six.moves import urllib
+import urllib.parse
+import urllib.request
+from urllib.parse import unquote
+from urllib.request import pathname2url
 
 import yaml
 

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -1,5 +1,5 @@
 import posixpath
-from six.moves import urllib
+import urllib.parse
 
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/file_store.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/file_store.py
@@ -1,4 +1,4 @@
-from six.moves import urllib
+import urllib.parse
 
 from mlflow.store.tracking.file_store import FileStore
 

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/sql_store_alchemy.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/sql_store_alchemy.py
@@ -1,4 +1,4 @@
-from six.moves import urllib
+import urllib.parse
 
 from mlflow.store.model_registry.sqlalchemy_store import SqlAlchemyStore
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,8 +10,8 @@ import textwrap
 import time
 import subprocess
 
-from six.moves.urllib.request import url2pathname
-from six.moves.urllib.parse import urlparse, unquote
+from urllib.request import url2pathname
+from urllib.parse import urlparse, unquote
 
 from mlflow.cli import run, server, ui
 from mlflow.server import handlers

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -7,11 +7,11 @@ import os
 import sys
 import posixpath
 import pytest
-from six.moves import urllib
 import shutil
 import time
 import tempfile
 from unittest import mock
+import urllib.parse
 
 import mlflow.experiments
 from mlflow.exceptions import MlflowException


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the `urllib` imports from `six.moves.*` - specifically the `urllib.parse` and `urllib.request` imports. This gets us one step closer to removing `six` as a dependency of the package, now that Python 2 is no longer supported.

## How is this patch tested?

The tests are trivial and not tested locally.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
