### PR TITLE
Fix h2o issue

### DIFF
--- a/mlflow/R/mlflow/.run-tests.R
+++ b/mlflow/R/mlflow/.run-tests.R
@@ -9,8 +9,8 @@ use_condaenv(mlflow:::mlflow_conda_env_name())
 keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
-reticulate::conda_install("h2o", envname = mlflow:::mlflow_conda_env_name())
-reticulate::conda_install("h2o-py", envname = mlflow:::mlflow_conda_env_name())
+reticulate::conda_install("h2o==3.30.1.3", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
+# reticulate::conda_install("h2o-py", envname = mlflow:::mlflow_conda_env_name())
 
 # TODO(harupy): Add `error_on = "note"` once the issue below has been fixed:
 # https://stackoverflow.com/questions/63613301/r-cmd-check-note-unable-to-verify-current-time/63616156#63616156

--- a/mlflow/R/mlflow/.run-tests.R
+++ b/mlflow/R/mlflow/.run-tests.R
@@ -9,6 +9,7 @@ use_condaenv(mlflow:::mlflow_conda_env_name())
 keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
+# Pin h2o to prevent version-mismatch between python and R
 reticulate::conda_install("h2o==3.30.1.3", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 
 # TODO(harupy): Add `error_on = "note"` once the issue below has been fixed:

--- a/mlflow/R/mlflow/.run-tests.R
+++ b/mlflow/R/mlflow/.run-tests.R
@@ -10,7 +10,6 @@ keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
 reticulate::conda_install("h2o==3.30.1.3", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
-# reticulate::conda_install("h2o-py", envname = mlflow:::mlflow_conda_env_name())
 
 # TODO(harupy): Add `error_on = "note"` once the issue below has been fixed:
 # https://stackoverflow.com/questions/63613301/r-cmd-check-note-unable-to-verify-current-time/63616156#63616156

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -17,7 +17,7 @@ pkgs <- c("RCurl","jsonlite")
 for (pkg in pkgs) {
   if (! (pkg %in% rownames(installed.packages()))) { install.packages(pkg) }
 }
-install.packages("h2o")
+install.packages("https://cran.r-project.org/src/contrib/h2o_3.30.1.3.tar.gz", repos=NULL, type="source")
 
 h2o::h2o.init()
 

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -17,7 +17,7 @@ pkgs <- c("RCurl","jsonlite")
 for (pkg in pkgs) {
   if (! (pkg %in% rownames(installed.packages()))) { install.packages(pkg) }
 }
-install.packages("h2o", type="source", repos=(c("http://h2o-release.s3.amazonaws.com/h2o/latest_stable_R")))
+install.packages("h2o")
 
 h2o::h2o.init()
 

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -17,6 +17,7 @@ pkgs <- c("RCurl","jsonlite")
 for (pkg in pkgs) {
   if (! (pkg %in% rownames(installed.packages()))) { install.packages(pkg) }
 }
+# Use the same version of h2o as .run-tests.R
 install.packages("https://cran.r-project.org/src/contrib/h2o_3.30.1.3.tar.gz", repos=NULL, type="source")
 
 h2o::h2o.init()

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -17,7 +17,7 @@ pkgs <- c("RCurl","jsonlite")
 for (pkg in pkgs) {
   if (! (pkg %in% rownames(installed.packages()))) { install.packages(pkg) }
 }
-# Use the same version of h2o as .run-tests.R
+# Pin h2o to prevent version-mismatch between python and R
 install.packages("https://cran.r-project.org/src/contrib/h2o_3.30.1.3.tar.gz", repos=NULL, type="source")
 
 h2o::h2o.init()


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Pin `h2o` to prevent version-mismatch between python and R.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
