### PR TITLE
Un-max-pin sqlparse

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -260,6 +260,10 @@ class SearchUtils(object):
             return False
         elif token.match(ttype=TokenType.Keyword, values=["AND", "IN"]):
             return False
+        elif token.match(ttype=TokenType.Comparison, values=["IN"]):
+            # `IN` is a comparison token in sqlparse >= 0.4.0:
+            # https://github.com/andialbrecht/sqlparse/pull/567/files
+            return False
         else:
             return True
 

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -260,7 +260,7 @@ class SearchUtils(object):
             return False
         elif token.match(ttype=TokenType.Keyword, values=["AND", "IN"]):
             return False
-        elif token.match(ttype=TokenType.Comparison, values=["IN"]):
+        elif token.match(ttype=TokenType.Operator.Comparison, values=["IN"]):
             # `IN` is a comparison token in sqlparse >= 0.4.0:
             # https://github.com/andialbrecht/sqlparse/pull/567
             return False

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -262,7 +262,7 @@ class SearchUtils(object):
             return False
         elif token.match(ttype=TokenType.Comparison, values=["IN"]):
             # `IN` is a comparison token in sqlparse >= 0.4.0:
-            # https://github.com/andialbrecht/sqlparse/pull/567/files
+            # https://github.com/andialbrecht/sqlparse/pull/567
             return False
         else:
             return True

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
         "docker>=4.0.0",
         "entrypoints",
         # Pin sqlparse for: https://github.com/mlflow/mlflow/issues/3433
-        "sqlparse==0.3.1",
+        "sqlparse>=0.3.1",
         "sqlalchemy<=1.3.13",
         "gorilla",
         "prometheus-flask-exporter",


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

A follow-up for #3502.

Unpin sqlparse by fixing `_invalid_statement_token_search_model_registry`.


## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
