### PR TITLE
[R] Create a test conda env in a separate step

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Run tests
       run: |
         export LINTR_COMMENT_BOT=false
-        cd tests
+        cd mlflow/R/mlflow/tests
         Rscript ../.run-tests.R
     - name: Calculate code coverage
       if: ${{ success() }}

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -62,6 +62,7 @@ jobs:
         source ./dev/install-common-deps.sh
         cd mlflow/R/mlflow
         R CMD build .
+        cd tests
         Rscript ../.create-test-env.R
     - name: Run tests
       run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -57,11 +57,14 @@ jobs:
         install.packages("devtools")
         remotes::install_deps('mlflow/R/mlflow', dependencies = TRUE, upgrade = FALSE)
       shell: Rscript {0}
-    - name: Run tests
+    - name: Create test environment
       run: |
         source ./dev/install-common-deps.sh
         cd mlflow/R/mlflow
         R CMD build .
+        Rscript ../.create-test-env.R
+    - name: Run tests
+      run: |
         export LINTR_COMMENT_BOT=false
         cd tests
         Rscript ../.run-tests.R

--- a/mlflow/R/mlflow/.Rbuildignore
+++ b/mlflow/R/mlflow/.Rbuildignore
@@ -4,6 +4,7 @@ mlruns
 ^mlflow-model$
 packrat
 ^\.run-tests\.R$
+^\.create-test-env\.R
 ^README.Rmd$
 ^docs$
 ^model$

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -1,0 +1,13 @@
+parent_dir <- dir("../", full.names = TRUE)
+package <- parent_dir[grepl("mlflow_", parent_dir)]
+install.packages(package)
+
+mlflow:::mlflow_maybe_create_conda_env(python_version = "3.6")
+library(reticulate)
+use_condaenv(mlflow:::mlflow_conda_env_name())
+# pinning tensorflow version to 1.14 until test_keras_model.R is fixed
+keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
+reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
+reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
+# Pin h2o to prevent version-mismatch between python and R
+reticulate::conda_install("h2o==3.30.1.3", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)

--- a/mlflow/R/mlflow/.run-tests.R
+++ b/mlflow/R/mlflow/.run-tests.R
@@ -1,16 +1,8 @@
 parent_dir <- dir("../", full.names = TRUE)
 package <- parent_dir[grepl("mlflow_", parent_dir)]
-install.packages(package)
 
-mlflow:::mlflow_maybe_create_conda_env(python_version = "3.6")
 library(reticulate)
 use_condaenv(mlflow:::mlflow_conda_env_name())
-# pinning tensorflow version to 1.14 until test_keras_model.R is fixed
-keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
-reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
-reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
-# Pin h2o to prevent version-mismatch between python and R
-reticulate::conda_install("h2o==3.30.1.3", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 
 # TODO(harupy): Add `error_on = "note"` once the issue below has been fixed:
 # https://stackoverflow.com/questions/63613301/r-cmd-check-note-unable-to-verify-current-time/63616156#63616156


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Currently, we create a test conda env and run tests in the same step, and we need to scroll a lot to reach test error logs. This PR fixes it.

## How is this patch tested?

GitHub Actions

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
