### PR TITLE
Remove `attrdict` from dependencies by using `collections.namedtuple` instead

### DIFF
--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -16,7 +16,6 @@ sqlalchemy==1.3.0
 # a remote Kubernetes cluster
 kubernetes==9.0.0
 ## Test-only dependencies
-attrdict==2.0.0
 pytest==3.2.1
 pytest-cov==2.6.0
 pytest-localserver==0.5.0

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -1,10 +1,10 @@
+from collections import namedtuple
 import filecmp
 import os
 import random
 import tempfile
 import time
 
-import attrdict
 import pytest
 from unittest import mock
 
@@ -24,6 +24,8 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_SOURCE_TYPE,
 )
 from mlflow.tracking.fluent import _RUN_ID_ENV_VAR
+
+MockExperiment = namedtuple("MockExperiment", ["experiment_id", "lifecycle_stage"])
 
 
 def test_create_experiment():
@@ -135,7 +137,7 @@ def test_set_experiment_with_zero_id(reset_mock):
         MlflowClient,
         "get_experiment_by_name",
         mock.Mock(
-            return_value=attrdict.AttrDict(experiment_id=0, lifecycle_stage=LifecycleStage.ACTIVE)
+            return_value=MockExperiment(experiment_id=0, lifecycle_stage=LifecycleStage.ACTIVE)
         ),
     )
     reset_mock(MlflowClient, "create_experiment", mock.Mock())


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Remove `attrdict` from dependencies by using `collections.namedtuple` instead.

## How is this patch tested?

Exisiting tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
