### PR TITLE
Exclude `extra-ml-requirements.txt` from `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,7 @@ dev
 !dev/small-requirements.txt
 !dev/large-requirements.txt
 !dev/lint-requirements.txt
+!dev/extra-ml-requirements.txt
 
 tests
 # required for Docker build

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -19,7 +19,7 @@ jobs:
             git fetch origin master:master
           fi
 
-          REGEXP="tests/examples\|examples\|Dockerfile\$"
+          REGEXP="tests/examples\|examples\|Dockerfile\|\.dockerignore\$"
           CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
           EXAMPLES_CHANGED=$([[ "$CHANGED_FILES" == *"examples"* ]] && echo "true" || echo "false")
           DOCKER_CHANGED=$([[ ("$CHANGED_FILES" == *"Dockerfile"*) || ("$CHANGED_FILES" == *".dockerignore"*) ]] && echo "true" || echo "false")

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -2,7 +2,7 @@ name: Examples
 
 on:
   pull_request:
-    branches: [master]
+    branches: [ master ]
   schedule:
     # Run this action daily at 7:00 UTC
     - cron: "0 7 * * *"

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,7 +22,7 @@ jobs:
         REGEXP="tests/examples\|examples\|Dockerfile\$"
         CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
         EXAMPLES_CHANGED=$([[ "$CHANGED_FILES" == *"examples"* ]] && echo "true" || echo "false")
-        DOCKER_CHANGED=$([[ "$CHANGED_FILES" == *"Dockerfile"* ]] && echo "true" || echo "false")
+        DOCKER_CHANGED=$([[ ("$CHANGED_FILES" == *"Dockerfile"*) || ("$CHANGED_FILES" == *".dockeignore"*) ]] && echo "true" || echo "false")
 
         echo "CHANGED_FILES:"
         echo "$CHANGED_FILES"

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -11,42 +11,42 @@ jobs:
   examples:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Check diff
-        id: check-diff
-        run: |
-          if [ ! "$(git branch --show-current)" == "master" ]; then
-            git fetch origin master:master
-          fi
+    - uses: actions/checkout@v2
+    - name: Check diff
+      id: check-diff
+      run: |
+        if [ ! "$(git branch --show-current)" == "master" ]; then
+          git fetch origin master:master
+        fi
 
-          REGEXP="tests/examples\|examples\|Dockerfile\|\.dockerignore\$"
-          CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
-          EXAMPLES_CHANGED=$([[ "$CHANGED_FILES" == *"examples"* ]] && echo "true" || echo "false")
-          DOCKER_CHANGED=$([[ ("$CHANGED_FILES" == *"Dockerfile"*) || ("$CHANGED_FILES" == *".dockerignore"*) ]] && echo "true" || echo "false")
+        REGEXP="tests/examples\|examples\|Dockerfile\|\.dockerignore\$"
+        CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
+        EXAMPLES_CHANGED=$([[ "$CHANGED_FILES" == *"examples"* ]] && echo "true" || echo "false")
+        DOCKER_CHANGED=$([[ ("$CHANGED_FILES" == *"Dockerfile"*) || ("$CHANGED_FILES" == *".dockerignore"*) ]] && echo "true" || echo "false")
 
-          echo "CHANGED_FILES:"
-          echo "$CHANGED_FILES"
-          echo "EXAMPLES_CHANGED: $EXAMPLES_CHANGED"
-          echo "DOCKER_CHANGED: $DOCKER_CHANGED"
+        echo "CHANGED_FILES:"
+        echo "$CHANGED_FILES"
+        echo "EXAMPLES_CHANGED: $EXAMPLES_CHANGED"
+        echo "DOCKER_CHANGED: $DOCKER_CHANGED"
 
-          echo "::set-output name=examples_changed::$EXAMPLES_CHANGED"
-          echo "::set-output name=docker_changed::$DOCKER_CHANGED"
+        echo "::set-output name=examples_changed::$EXAMPLES_CHANGED"
+        echo "::set-output name=docker_changed::$DOCKER_CHANGED"
 
-      - name: Run example tests
-        if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}
-        env:
-          INSTALL_SMALL_PYTHON_DEPS: true
-          INSTALL_LARGE_PYTHON_DEPS: true
-        run: |
-          source ./dev/install-common-deps.sh
-          source activate test-environment
-          pytest --verbose tests/examples --durations=0 --large
+    - name: Run example tests
+      if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}
+      env:
+        INSTALL_SMALL_PYTHON_DEPS: true
+        INSTALL_LARGE_PYTHON_DEPS: true
+      run: |
+        source ./dev/install-common-deps.sh
+        source activate test-environment
+        pytest --verbose tests/examples --durations=0 --large
 
-      - name: Remove conda environments
-        run: |
-          ./dev/remove-conda-envs.sh
+    - name: Remove conda environments
+      run: |
+        ./dev/remove-conda-envs.sh
 
-      - name: Run docker tests
-        if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.docker_changed == 'true' }}
-        run: |
-          docker build -t mlflow_test_build . && docker images | grep mlflow_test_build
+    - name: Run docker tests
+      if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.docker_changed == 'true' }}
+      run: |
+        docker build -t mlflow_test_build . && docker images | grep mlflow_test_build

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -2,7 +2,7 @@ name: Examples
 
 on:
   pull_request:
-    branches: [ master ]
+    branches: [master]
   schedule:
     # Run this action daily at 7:00 UTC
     - cron: "0 7 * * *"
@@ -11,42 +11,42 @@ jobs:
   examples:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Check diff
-      id: check-diff
-      run: |
-        if [ ! "$(git branch --show-current)" == "master" ]; then
-          git fetch origin master:master
-        fi
+      - uses: actions/checkout@v2
+      - name: Check diff
+        id: check-diff
+        run: |
+          if [ ! "$(git branch --show-current)" == "master" ]; then
+            git fetch origin master:master
+          fi
 
-        REGEXP="tests/examples\|examples\|Dockerfile\$"
-        CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
-        EXAMPLES_CHANGED=$([[ "$CHANGED_FILES" == *"examples"* ]] && echo "true" || echo "false")
-        DOCKER_CHANGED=$([[ ("$CHANGED_FILES" == *"Dockerfile"*) || ("$CHANGED_FILES" == *".dockeignore"*) ]] && echo "true" || echo "false")
+          REGEXP="tests/examples\|examples\|Dockerfile\$"
+          CHANGED_FILES=$(git diff --name-only master..HEAD | grep "$REGEXP") || true;
+          EXAMPLES_CHANGED=$([[ "$CHANGED_FILES" == *"examples"* ]] && echo "true" || echo "false")
+          DOCKER_CHANGED=$([[ ("$CHANGED_FILES" == *"Dockerfile"*) || ("$CHANGED_FILES" == *".dockerignore"*) ]] && echo "true" || echo "false")
 
-        echo "CHANGED_FILES:"
-        echo "$CHANGED_FILES"
-        echo "EXAMPLES_CHANGED: $EXAMPLES_CHANGED"
-        echo "DOCKER_CHANGED: $DOCKER_CHANGED"
+          echo "CHANGED_FILES:"
+          echo "$CHANGED_FILES"
+          echo "EXAMPLES_CHANGED: $EXAMPLES_CHANGED"
+          echo "DOCKER_CHANGED: $DOCKER_CHANGED"
 
-        echo "::set-output name=examples_changed::$EXAMPLES_CHANGED"
-        echo "::set-output name=docker_changed::$DOCKER_CHANGED"
+          echo "::set-output name=examples_changed::$EXAMPLES_CHANGED"
+          echo "::set-output name=docker_changed::$DOCKER_CHANGED"
 
-    - name: Run example tests
-      if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}
-      env:
-        INSTALL_SMALL_PYTHON_DEPS: true
-        INSTALL_LARGE_PYTHON_DEPS: true
-      run: |
-        source ./dev/install-common-deps.sh
-        source activate test-environment
-        pytest --verbose tests/examples --durations=0 --large
+      - name: Run example tests
+        if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}
+        env:
+          INSTALL_SMALL_PYTHON_DEPS: true
+          INSTALL_LARGE_PYTHON_DEPS: true
+        run: |
+          source ./dev/install-common-deps.sh
+          source activate test-environment
+          pytest --verbose tests/examples --durations=0 --large
 
-    - name: Remove conda environments
-      run: |
-        ./dev/remove-conda-envs.sh
+      - name: Remove conda environments
+        run: |
+          ./dev/remove-conda-envs.sh
 
-    - name: Run docker tests
-      if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.docker_changed == 'true' }}
-      run: |
-        docker build -t mlflow_test_build . && docker images | grep mlflow_test_build
+      - name: Run docker tests
+        if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.docker_changed == 'true' }}
+        run: |
+          docker build -t mlflow_test_build . && docker images | grep mlflow_test_build

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,3 @@ RUN apt-get update && \
     cd mlflow/server/js && \
     npm install && \
     npm run build
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,4 @@ RUN apt-get update && \
     cd mlflow/server/js && \
     npm install && \
     npm run build
+


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

The `examples.yml` check fails with:

```
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'dev/extra-ml-requirements.txt'
```

https://github.com/mlflow/mlflow/runs/1251985852?check_suite_focus=true#step:6:770

This PR fixes this error by excluding `extra-ml-requirements.txt` from `.dockerignore`.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
