### PR TITLE
Almost remove dependence on six

### DIFF
--- a/examples/multistep_workflow/main.py
+++ b/examples/multistep_workflow/main.py
@@ -13,7 +13,6 @@ import mlflow
 from mlflow.utils import mlflow_tags
 from mlflow.entities import RunStatus
 from mlflow.utils.logging_utils import eprint
-import six
 
 from mlflow.tracking.fluent import _get_experiment_id
 
@@ -32,7 +31,7 @@ def _already_ran(entry_point_name, parameters, git_commit, experiment_id=None):
         if tags.get(mlflow_tags.MLFLOW_PROJECT_ENTRY_POINT, None) != entry_point_name:
             continue
         match_failed = False
-        for param_key, param_value in six.iteritems(parameters):
+        for param_key, param_value in parameters.items():
             run_value = full_run.data.params.get(param_key)
             if run_value != param_value:
                 match_failed = True

--- a/mlflow/projects/_project_spec.py
+++ b/mlflow/projects/_project_spec.py
@@ -1,9 +1,8 @@
 """Internal utilities for parsing MLproject YAML files."""
 
 import os
+from shlex import quote
 import yaml
-
-from six.moves import shlex_quote
 
 from mlflow import data
 from mlflow.exceptions import ExecutionException
@@ -123,12 +122,12 @@ class Project(object):
         _, file_extension = os.path.splitext(entry_point)
         ext_to_cmd = {".py": "python", ".sh": os.environ.get("SHELL", "bash")}
         if file_extension in ext_to_cmd:
-            command = "%s %s" % (ext_to_cmd[file_extension], shlex_quote(entry_point))
+            command = "%s %s" % (ext_to_cmd[file_extension], quote(entry_point))
             if not is_string_type(command):
                 command = command.encode("utf-8")
             return EntryPoint(name=entry_point, parameters={}, command=command)
         elif file_extension == ".R":
-            command = "Rscript -e \"mlflow::mlflow_source('%s')\" --args" % shlex_quote(entry_point)
+            command = "Rscript -e \"mlflow::mlflow_source('%s')\" --args" % quote(entry_point)
             return EntryPoint(name=entry_point, parameters={}, command=command)
         raise ExecutionException(
             "Could not find {0} among entry points {1} or interpret {0} as a "
@@ -197,7 +196,7 @@ class EntryPoint(object):
 
     @staticmethod
     def _sanitize_param_dict(param_dict):
-        return {str(key): shlex_quote(str(value)) for key, value in param_dict.items()}
+        return {str(key): quote(str(value)) for key, value in param_dict.items()}
 
 
 class Parameter(object):

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -8,7 +8,7 @@ import time
 import logging
 import posixpath
 
-from six.moves import shlex_quote
+from shlex import quote as shlex_quote
 
 from mlflow import tracking
 from mlflow.entities import RunStatus

--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -13,7 +13,7 @@ from mlflow.projects.submitted_run import SubmittedRun
 from mlflow.entities import RunStatus
 
 from shlex import split
-from shlex quote
+from shlex import quote
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -13,7 +13,7 @@ from mlflow.projects.submitted_run import SubmittedRun
 from mlflow.entities import RunStatus
 
 from shlex import split
-from six.moves import shlex_quote as quote
+from shlex quote
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/rfunc/backend.py
+++ b/mlflow/rfunc/backend.py
@@ -1,8 +1,8 @@
 import logging
 import os
 import re
+from shlex import quote
 import subprocess
-from six.moves import shlex_quote
 
 from mlflow.models import FlavorBackend
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
@@ -29,7 +29,7 @@ class RFuncBackend(FlavorBackend):
             "output_path = {2}, content_type = {3}, json_format = {4})"
         )
         command = str_cmd.format(
-            shlex_quote(model_path),
+            quote(model_path),
             _str_optional(input_path),
             _str_optional(output_path),
             _str_optional(content_type),
@@ -43,7 +43,7 @@ class RFuncBackend(FlavorBackend):
         """
         model_path = _download_artifact_from_uri(model_uri)
         command = "mlflow::mlflow_rfunc_serve('{0}', port = {1}, host = '{2}')".format(
-            shlex_quote(model_path), port, host
+            quote(model_path), port, host
         )
         _execute(command)
 
@@ -79,4 +79,4 @@ def _execute(command):
 
 
 def _str_optional(s):
-    return "NULL" if s is None else "'{}'".format(shlex_quote(str(s)))
+    return "NULL" if s is None else "'{}'".format(quote(str(s)))

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -6,7 +6,6 @@ exposed in the :py:mod:`mlflow.tracking` module.
 
 import time
 import os
-from six import iteritems
 
 from mlflow.models import Model
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
@@ -92,7 +91,7 @@ class TrackingServiceClient(object):
             experiment_id=experiment_id,
             user_id=user_id,
             start_time=start_time or int(time.time() * 1000),
-            tags=[RunTag(key, value) for (key, value) in iteritems(tags)],
+            tags=[RunTag(key, value) for (key, value) in tags.items()],
         )
 
     def list_run_infos(

--- a/mlflow/utils/string_utils.py
+++ b/mlflow/utils/string_utils.py
@@ -11,6 +11,4 @@ def strip_suffix(original, suffix):
 
 
 def is_string_type(item):
-    import six
-
-    return isinstance(item, six.string_types)
+    return isinstance(item, str)

--- a/tests/projects/test_entry_point.py
+++ b/tests/projects/test_entry_point.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from six.moves import shlex_quote
+from shlex import quote
 from unittest import mock
 
 from mlflow.exceptions import ExecutionException
@@ -49,7 +49,7 @@ def test_entry_point_compute_command():
         # Test shell escaping
         name_value = "friend; echo 'hi'"
         command = entry_point.compute_command({"name": name_value}, storage_dir)
-        assert command == "python greeter.py %s %s" % (shlex_quote("hi"), shlex_quote(name_value))
+        assert command == "python greeter.py %s %s" % (quote("hi"), quote(name_value))
 
 
 def test_path_parameter():

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -5,7 +5,6 @@ import yaml
 import numpy as np
 import pandas as pd
 import pytest
-import six
 import sklearn.datasets
 import sklearn.linear_model
 import sklearn.neighbors
@@ -27,10 +26,7 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 
 def _load_pyfunc(path):
     with open(path, "rb") as f:
-        if six.PY2:
-            return pickle.load(f)
-        else:
-            return pickle.load(f, encoding="latin1")  # pylint: disable=unexpected-keyword-arg
+        return pickle.load(f, encoding="latin1")  # pylint: disable=unexpected-keyword-arg
 
 
 @pytest.fixture

--- a/tests/sagemaker/test_deployment.py
+++ b/tests/sagemaker/test_deployment.py
@@ -56,10 +56,7 @@ def get_sagemaker_backend(region_name):
 
 
 def mock_sagemaker_aws_services(fn):
-    # Import `wraps` from `six` instead of `functools` to properly set the
-    # wrapped function's `__wrapped__` attribute to the required value
-    # in Python 2
-    from six import wraps
+    from functools import wraps
     from moto import mock_s3, mock_ecr, mock_sts, mock_iam
 
     @mock_ecr

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -4,7 +4,6 @@ from collections import namedtuple
 
 import pandas as pd
 import pytest
-import six
 import spacy
 import yaml
 from spacy.util import compounding, minibatch
@@ -297,7 +296,7 @@ def _get_train_test_dataset(cats_to_fetch, limit=100):
     X = newsgroups.data[:limit]
     y = newsgroups.target[:limit]
 
-    X = [six.text_type(x) for x in X]  # Ensure all strings to unicode for python 2.7 compatibility
+    X = [str(x) for x in X]  # Ensure all strings to unicode for python 2.7 compatibility
 
     # Category 0 comp-graphic, 1 rec.sport baseball. We can threat it as a binary class.
     cats = [{"comp.graphics": not bool(el), "rec.sport.baseball": bool(el)} for el in y]

--- a/tests/store/artifact/test_artifact_repository_registry.py
+++ b/tests/store/artifact/test_artifact_repository_registry.py
@@ -1,5 +1,5 @@
+from importlib import reload
 import pytest
-from six.moves import reload_module as reload
 from unittest import mock
 
 import mlflow

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -3,7 +3,6 @@ import unittest
 
 from unittest import mock
 import pytest
-import six
 
 import mlflow
 from mlflow.entities import (
@@ -62,7 +61,7 @@ class TestRestStore(object):
     def test_successful_http_request(self, request):
         def mock_request(**kwargs):
             # Filter out None arguments
-            kwargs = dict((k, v) for k, v in six.iteritems(kwargs) if v is not None)
+            kwargs = dict((k, v) for k, v in kwargs.items() if v is not None)
             assert kwargs == {
                 "method": "GET",
                 "params": {"view_type": "ACTIVE_ONLY"},

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -1,7 +1,7 @@
+from importlib import reload
 from unittest import mock
 import os
 import pytest
-from six.moves import reload_module as reload
 
 import mlflow
 from mlflow.store.db.db_types import DATABASE_ENGINES

--- a/tests/tracking/context/test_registry.py
+++ b/tests/tracking/context/test_registry.py
@@ -1,6 +1,6 @@
+from importlib import reload
 from unittest import mock
 import pytest
-from six.moves import reload_module as reload
 
 import mlflow.tracking.context.registry
 from mlflow.tracking.context.default_context import DefaultRunContext

--- a/tests/tracking/test_fluent.py
+++ b/tests/tracking/test_fluent.py
@@ -1,3 +1,4 @@
+from importlib import reload
 import os
 import random
 import uuid
@@ -6,7 +7,6 @@ import inspect
 import numpy as np
 import pandas as pd
 import pytest
-from six.moves import reload_module as reload
 from unittest import mock
 
 import mlflow

--- a/tests/utils/test_file_utils.py
+++ b/tests/utils/test_file_utils.py
@@ -5,7 +5,6 @@ import hashlib
 import os
 import shutil
 import pytest
-import six
 import tarfile
 
 from mlflow.utils import file_utils
@@ -18,7 +17,7 @@ from tests.helper_functions import random_int, random_file, safe_edit_yaml
 def test_yaml_read_and_write(tmpdir):
     temp_dir = str(tmpdir)
     yaml_file = random_file("yaml")
-    long_value = long(1) if six.PY2 else 1  # pylint: disable=undefined-variable
+    long_value = 1  # pylint: disable=undefined-variable
     data = {
         "a": random_int(),
         "B": random_int(),


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR removes almost all of the dependence on six - except for the use of `six.reraise`, which will be handled in a separate PR.

Note to reviewer : Except for one commit, each commit in this PR is self-contained and makes only one type of change. In all, the changes made in this PR are 

- replace `six.iteritems(dict)` with `dict.items()`
- replace `six.moves.shlex_quote` with `shlex.quote`
- replace `six.string_types` with `str`
- replace `six.moves.reload_module` with `importlib.reload`
- remove conditionals that relied on `six.PY2`
- replace `six.wraps` with `functools.wraps`
- replace use of `six.text_type` with `str`

## How is this patch tested?

This patch has not been tested locally. I am relying on the CI.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
