### PR TITLE
Remove Python 2 conditionals that rely on sys.version_info

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -27,8 +27,6 @@ implement mutual exclusion manually.
 
 For a lower level API, see the :py:mod:`mlflow.tracking` module.
 """
-import sys
-
 from mlflow.version import VERSION as __version__  # pylint: disable=unused-import
 from mlflow.utils.logging_utils import _configure_mlflow_loggers
 import mlflow.tracking._model_registry.fluent

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -66,17 +66,6 @@ import mlflow.xgboost as xgboost  # noqa: E402
 
 _configure_mlflow_loggers(root_module_name=__name__)
 
-if sys.version_info.major == 2:
-    warnings.warn(
-        "MLflow support for Python 2 is deprecated and will be dropped in a future "
-        "release. At that point, existing Python 2 workflows that use MLflow will "
-        "continue to work without modification, but Python 2 users will no longer "
-        "get access to the latest MLflow features and bugfixes. We recommend that "
-        "you upgrade to Python 3 - see https://docs.python.org/3/howto/pyporting.html "
-        "for a migration guide.",
-        DeprecationWarning,
-    )
-
 ActiveRun = mlflow.tracking.fluent.ActiveRun
 log_param = mlflow.tracking.fluent.log_param
 log_metric = mlflow.tracking.fluent.log_metric

--- a/tests/azureml/test_deploy.py
+++ b/tests/azureml/test_deploy.py
@@ -27,10 +27,6 @@ from mlflow.utils.file_utils import TempDir
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 
-pytestmark = pytest.mark.skipif(
-    (sys.version_info < (3, 0)), reason="Tests require Python 3 to run!"
-)
-
 
 class AzureMLMocks:
     def __init__(self):

--- a/tests/azureml/test_deploy.py
+++ b/tests/azureml/test_deploy.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import pytest
 import numpy as np

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -31,10 +31,6 @@ from mlflow.utils.file_utils import TempDir
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 
-pytestmark = pytest.mark.skipif(
-    (sys.version_info < (3, 0)), reason="Tests require Python 3 to run!"
-)
-
 
 class AzureMLMocks:
     def __init__(self):

--- a/tests/azureml/test_image_creation.py
+++ b/tests/azureml/test_image_creation.py
@@ -1,4 +1,3 @@
-import sys
 import os
 import json
 import pytest

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -1,4 +1,3 @@
-import sys
 from unittest import mock
 import os
 import pickle

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -1,6 +1,5 @@
 from unittest import mock
 import os
-import pickle
 import pytest
 import yaml
 import json

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -223,10 +223,7 @@ def test_custom_transformer_can_be_saved_and_loaded_with_cloudpickle_format(
     # current test module, we expect pickle to fail when attempting to serialize it. In contrast,
     # we expect cloudpickle to successfully locate the transformer definition and serialize the
     # model successfully.
-    if sys.version_info >= (3, 0):
-        expect_exception_context = pytest.raises(AttributeError)
-    else:
-        expect_exception_context = pytest.raises(pickle.PicklingError)
+    expect_exception_context = pytest.raises(AttributeError)
     with expect_exception_context:
         pickle_format_model_path = os.path.join(str(tmpdir), "pickle_model")
         mlflow.sklearn.save_model(

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -89,10 +89,7 @@ def saved_tf_iris_model(tmpdir):
     )
 
     # Building a dictionary of the predictions by the estimator.
-    if sys.version_info < (3, 0):
-        estimator_preds_dict = estimator_preds.next()
-    else:
-        estimator_preds_dict = next(estimator_preds)
+    estimator_preds_dict = next(estimator_preds)
     for row in estimator_preds:
         for key in row.keys():
             estimator_preds_dict[key] = np.vstack((estimator_preds_dict[key], row[key]))

--- a/tests/tensorflow/test_tensorflow2_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_model_export.py
@@ -3,7 +3,6 @@
 import collections
 import os
 import shutil
-import sys
 import pytest
 import yaml
 import json


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR removes Python 2 conditional statements which rely on `sys.version_info` information, specifically comparing version info to check that it is not python 3.

Because python 3 is no longer supported, these branches can be removed

## How is this patch tested?

This patch has not been tested locally. I am relying on CI. The changes themselves are trivial so I am not expecting any surprises.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
