### PR TITLE
Replace use of six.reraise

### DIFF
--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -12,7 +12,6 @@ import logging
 import os
 import sys
 import traceback
-from six import reraise
 
 import mlflow
 from mlflow.models import Model
@@ -265,6 +264,17 @@ def _handle_py4j_error(reraised_error_type, reraised_error_text):
     Logs information about an exception that is currently being handled
     and reraises it with the specified error text as a message.
     """
+    def reraise(tp, value, tb=None):
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
+
     traceback.print_exc()
     tb = sys.exc_info()[2]
     reraise(reraised_error_type, reraised_error_type(reraised_error_text), tb)

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -264,18 +264,17 @@ def _handle_py4j_error(reraised_error_type, reraised_error_text):
     Logs information about an exception that is currently being handled
     and reraises it with the specified error text as a message.
     """
-    def reraise(tp, value, tb=None):
-        try:
-            if value.__traceback__ is not tb:
-                raise value.with_traceback(tb)
-            raise value
-        finally:
-            value = None
-            tb = None
-
     traceback.print_exc()
     tb = sys.exc_info()[2]
-    reraise(reraised_error_type, reraised_error_type(reraised_error_text), tb)
+    exception = reraised_error_type(reraised_error_text)
+
+    try:
+        if exception.__traceback__ is not tb:
+            raise exception.with_traceback(tb)
+        raise exception
+    finally:
+        exception = None
+        tb = None
 
 
 class MLeapSerializationException(MlflowException):

--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -266,8 +266,6 @@ def _handle_py4j_error(reraised_error_type, reraised_error_text):
     """
     def reraise(tp, value, tb=None):
         try:
-            if value is None:
-                value = tp()
             if value.__traceback__ is not tb:
                 raise value.with_traceback(tb)
             raise value

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -16,7 +16,6 @@ import json
 import logging
 import numpy as np
 import pandas as pd
-from six import reraise
 import sys
 import traceback
 
@@ -143,6 +142,17 @@ def _handle_serving_error(error_message, error_code, include_traceback=True):
                        the codes listed in the `mlflow.protos.databricks_pb2` proto.
     :param include_traceback: Whether to include the current traceback in the returned error.
     """
+    def reraise(tp, value, tb=None):
+        try:
+            if value is None:
+                value = tp()
+            if value.__traceback__ is not tb:
+                raise value.with_traceback(tb)
+            raise value
+        finally:
+            value = None
+            tb = None
+
     if include_traceback:
         traceback_buf = StringIO()
         traceback.print_exc(file=traceback_buf)

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -156,7 +156,6 @@ def _handle_serving_error(error_message, error_code, include_traceback=True):
         raise e
     finally:
         e = None
-        tb = None
 
 
 def init(model: PyFuncModel):

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -144,8 +144,6 @@ def _handle_serving_error(error_message, error_code, include_traceback=True):
     """
     def reraise(tp, value, tb=None):
         try:
-            if value is None:
-                value = tp()
             if value.__traceback__ is not tb:
                 raise value.with_traceback(tb)
             raise value


### PR DESCRIPTION
## What changes are proposed in this pull request?

Along with #3538 , this PR removes the dependence on six.

This PR specifially handles removing the dependence on `six.reraise`. This was slightly tricky so I chose to simply replace the use of `six.reraise` with the actual implementation of `six.reraise`, removing the unnecessary pieces.

The code used comes from - https://github.com/benjaminp/six/blob/c0be8815d13df45b6ae471c4c436cce8c192245d/six.py#L697-L706

## How is this patch tested?

The changes are slightly non-trivial so this patch was not tested locally. I hope the testsuite will catch any potential issues with this patch.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
