### PR TITLE
update R API documentation for `mlflow_register_external_observer()`

### DIFF
--- a/docs/source/R-api.rst
+++ b/docs/source/R-api.rst
@@ -1007,6 +1007,52 @@ Arguments
 |                                   | methods.                          |
 +-----------------------------------+-----------------------------------+
 
+``mlflow_register_external_observer``
+=====================================
+
+Register an external MLflow observer
+
+Registers an external MLflow observer that will receive a
+``register_tracking_event(event_name, data)`` callback on any model
+tracking event such as “create_run”, “delete_run”, or “log_metric”. Each
+observer should have a ``register_tracking_event(event_name, data)``
+callback accepting a character vector ``event_name`` specifying the name
+of the tracking event, and ``data`` containing a list of attributes of
+the event. The callback should be non-blocking, and ideally should
+complete instantaneously. Any exception thrown from the callback will be
+ignored.
+
+.. code:: r
+
+   mlflow_register_external_observer(observer)
+
+.. _arguments-25:
+
+Arguments
+---------
+
++--------------+-----------------------------------+
+| Argument     | Description                       |
++==============+===================================+
+| ``observer`` | The observer object (see example) |
++--------------+-----------------------------------+
+
+.. _examples-2:
+
+Examples
+--------
+
+.. code:: r
+
+   library(mlflow)
+
+   observer <- structure(list())
+   observer$register_tracking_event <- function(event_name, data) {
+   print(event_name)
+   print(data)
+   }
+   mlflow_register_external_observer(observer)
+
 ``mlflow_rename_experiment``
 ============================
 
@@ -1018,7 +1064,7 @@ Renames an experiment.
 
    mlflow_rename_experiment(new_name, experiment_id = NULL, client = NULL)
 
-.. _arguments-25:
+.. _arguments-26:
 
 Arguments
 ---------
@@ -1058,7 +1104,7 @@ restored.
 
    mlflow_restore_experiment(experiment_id, client = NULL)
 
-.. _arguments-26:
+.. _arguments-27:
 
 Arguments
 ---------
@@ -1099,7 +1145,7 @@ Restores the run with the specified ID.
 
    mlflow_restore_run(run_id, client = NULL)
 
-.. _arguments-27:
+.. _arguments-28:
 
 Arguments
 ---------
@@ -1144,7 +1190,7 @@ endpoint will be removed in a future version of mlflow.
      ...
    )
 
-.. _arguments-28:
+.. _arguments-29:
 
 Arguments
 ---------
@@ -1197,7 +1243,7 @@ For more information about supported URI schemes, see the Artifacts
 Documentation at
 https://www.mlflow.org/docs/latest/tracking.html#artifact-stores.
 
-.. _examples-2:
+.. _examples-3:
 
 Examples
 --------
@@ -1238,7 +1284,7 @@ https://www.mlflow.org/docs/latest/cli.html#mlflow-run for more info.
      storage_dir = NULL
    )
 
-.. _arguments-29:
+.. _arguments-30:
 
 Arguments
 ---------
@@ -1293,7 +1339,7 @@ Value
 
 The run associated with this run.
 
-.. _examples-3:
+.. _examples-4:
 
 Examples
 --------
@@ -1331,7 +1377,7 @@ model types.
    list(list("mlflow_save_model"), list("xgb.Booster"))(model, path, model_spec = list(), conda_env = NULL, ...)
    mlflow_save_model(model, path, model_spec = list(), ...)
 
-.. _arguments-30:
+.. _arguments-31:
 
 Arguments
 ---------
@@ -1372,7 +1418,7 @@ Metric and Param keys.
      client = NULL
    )
 
-.. _arguments-31:
+.. _arguments-32:
 
 Arguments
 ---------
@@ -1427,7 +1473,7 @@ Wrapper for ``mlflow server``.
      static_prefix = NULL
    )
 
-.. _arguments-32:
+.. _arguments-33:
 
 Arguments
 ---------
@@ -1466,7 +1512,7 @@ metadata that can be updated.
 
    mlflow_set_experiment_tag(key, value, experiment_id = NULL, client = NULL)
 
-.. _arguments-33:
+.. _arguments-34:
 
 Arguments
 ---------
@@ -1516,7 +1562,7 @@ provided name. Returns the ID of the active experiment.
      artifact_location = NULL
    )
 
-.. _arguments-34:
+.. _arguments-35:
 
 Arguments
 ---------
@@ -1546,7 +1592,7 @@ run and after a run completes.
 
    mlflow_set_tag(key, value, run_id = NULL, client = NULL)
 
-.. _arguments-35:
+.. _arguments-36:
 
 Arguments
 ---------
@@ -1586,7 +1632,7 @@ experiments.
 
    mlflow_set_tracking_uri(uri)
 
-.. _arguments-36:
+.. _arguments-37:
 
 Arguments
 ---------
@@ -1609,7 +1655,7 @@ called via ``Rscript`` from the terminal or through the MLflow CLI.
 
    mlflow_source(uri)
 
-.. _arguments-37:
+.. _arguments-38:
 
 Arguments
 ---------
@@ -1641,7 +1687,7 @@ can be provided.
      client = NULL
    )
 
-.. _arguments-38:
+.. _arguments-39:
 
 Arguments
 ---------
@@ -1682,7 +1728,7 @@ Arguments
 |                               | the current tracking URI.            |
 +-------------------------------+--------------------------------------+
 
-.. _examples-4:
+.. _examples-5:
 
 Examples
 --------
@@ -1704,7 +1750,7 @@ Launches the MLflow user interface.
 
    mlflow_ui(client, ...)
 
-.. _arguments-39:
+.. _arguments-40:
 
 Arguments
 ---------
@@ -1727,7 +1773,7 @@ Arguments
 |                               | path to a file store.                |
 +-------------------------------+--------------------------------------+
 
-.. _examples-5:
+.. _examples-6:
 
 Examples
 --------


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>

## What changes are proposed in this pull request?

Fixing the missing update to R API documentation from https://github.com/mlflow/mlflow/pull/3501

## How is this patch tested?

- Checking changes in the docs/source/R-api.rst file make sense
- Waiting for all existing GitHub CI workflows for `mlflow` to complete successfully

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
