### PR TITLE
(Issue #3224) Allow keras models to be saved with SavedModel format

### DIFF
--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -37,7 +37,7 @@ FLAVOR_NAME = "keras"
 _CUSTOM_OBJECTS_SAVE_PATH = "custom_objects.cloudpickle"
 _KERAS_MODULE_SPEC_PATH = "keras_module.txt"
 # File name to which keras model is saved
-_MODEL_SAVE_PATH = "model.h5"
+_MODEL_SAVE_PATH = "model"
 # Conda env subpath when saving/loading model
 _CONDA_ENV_SUBPATH = "conda.yaml"
 
@@ -390,6 +390,14 @@ def _load_model(model_path, keras_module, **kwargs):
             pickled_custom_objects = cloudpickle.load(in_f)
             pickled_custom_objects.update(custom_objects)
             custom_objects = pickled_custom_objects
+    
+    # TODO: consider removing this fallback when versions of mlflow which save models with h5 prefix are deprecated
+    # To ensure backwards compatibility, if the _MODEL_SAVE_PATH does not exist, we will look for a file with the
+    # "h5" file extension.
+    if not os.path.exists(model_path):
+        # TODO: log a warning?
+        model_path = f"{model_path}.h5"
+    
     from distutils.version import StrictVersion
 
     if StrictVersion(keras_module.__version__.split("-")[0]) >= StrictVersion("2.2.3"):

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -16,7 +16,6 @@ import shutil
 import pandas as pd
 
 from distutils.version import LooseVersion
-from distutils.version import StrictVersion
 from mlflow import pyfunc
 from mlflow.models import Model
 from mlflow.models.model import MLMODEL_FILE_NAME

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -456,7 +456,7 @@ def _load_pyfunc(path):
         import keras
 
         keras_module = keras
-    
+
     # By default, we assume the save_format is h5 for backwards compatibility
     save_format = "h5"
     save_format_path = os.path.join(path, _KERAS_SAVE_FORMAT_PATH)
@@ -475,7 +475,9 @@ def _load_pyfunc(path):
             with graph.as_default():
                 with sess.as_default():  # pylint:disable=not-context-manager
                     K.set_learning_phase(0)
-                    m = _load_model(path, keras_module=keras_module, save_format=save_format, compile=False)
+                    m = _load_model(
+                        path, keras_module=keras_module, save_format=save_format, compile=False
+                    )
                     return _KerasModelWrapper(m, graph, sess)
         else:
             K.set_learning_phase(0)

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -389,7 +389,7 @@ def _save_custom_objects(path, custom_objects):
         cloudpickle.dump(custom_objects, out_f)
 
 
-def _load_model(model_path, keras_module, save_format: str, **kwargs):
+def _load_model(model_path, keras_module, save_format, **kwargs):
     keras_models = importlib.import_module(keras_module.__name__ + ".models")
     custom_objects = kwargs.pop("custom_objects", {})
     custom_objects_path = None

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -90,7 +90,7 @@ def save_model(
     keras_module=None,
     signature: ModelSignature = None,
     input_example: ModelInputExample = None,
-    **kwargs
+    **kwargs,
 ):
     """
     Save a Keras model to a path on the local file system.
@@ -270,7 +270,7 @@ def log_model(
     signature: ModelSignature = None,
     input_example: ModelInputExample = None,
     await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
-    **kwargs
+    **kwargs,
 ):
     """
     Log a Keras model as an MLflow artifact for the current run.
@@ -356,7 +356,7 @@ def log_model(
         signature=signature,
         input_example=input_example,
         await_registration_for=await_registration_for,
-        **kwargs
+        **kwargs,
     )
 
 
@@ -394,14 +394,17 @@ def _load_model(model_path, keras_module, save_format: str, **kwargs):
             pickled_custom_objects = cloudpickle.load(in_f)
             pickled_custom_objects.update(custom_objects)
             custom_objects = pickled_custom_objects
-    
-    # TODO: remove this fallback after older versions of mlflow which save with h5 suffix are deprecated
+
+    # TODO: remove this fallback after older versions of mlflow which save with h5 suffix
+    # are deprecated
     if save_format == "h5" and not os.path.exists(model_path):
         # TODO: log warning?
         model_path = f"{model_path}.h5"
     from distutils.version import StrictVersion
 
-    if save_format == "h5" and StrictVersion(keras_module.__version__.split("-")[0]) >= StrictVersion("2.2.3"):
+    if save_format == "h5" and StrictVersion(
+        keras_module.__version__.split("-")[0]
+    ) >= StrictVersion("2.2.3"):
         # NOTE: Keras 2.2.3 does not work with unicode paths in python2. Pass in h5py.File instead
         # of string to avoid issues.
         import h5py
@@ -506,7 +509,12 @@ def load_model(model_uri, **kwargs):
     )
     # For backwards compatibility, we assume h5 when the save_format is absent
     save_format = flavor_conf.get("save_format", "h5")
-    return _load_model(model_path=keras_model_artifacts_path, keras_module=keras_module, save_format=save_format, **kwargs)
+    return _load_model(
+        model_path=keras_model_artifacts_path,
+        keras_module=keras_module,
+        save_format=save_format,
+        **kwargs,
+    )
 
 
 @experimental

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -468,6 +468,8 @@ def _load_pyfunc(path):
         with open(save_format_path, "r") as f:
             save_format = f.read()
 
+    # In SavedModel format, if we don't compile the model
+    should_compile = save_format == "tf"
     K = importlib.import_module(keras_module.__name__ + ".backend")
     if keras_module.__name__ == "tensorflow.keras" or K.backend() == "tensorflow":
         if LooseVersion(tf.__version__) < LooseVersion("2.0.0"):
@@ -480,12 +482,12 @@ def _load_pyfunc(path):
                 with sess.as_default():  # pylint:disable=not-context-manager
                     K.set_learning_phase(0)
                     m = _load_model(
-                        path, keras_module=keras_module, save_format=save_format, compile=False
+                        path, keras_module=keras_module, save_format=save_format, compile=should_compile
                     )
                     return _KerasModelWrapper(m, graph, sess)
         else:
             K.set_learning_phase(0)
-            m = _load_model(path, keras_module=keras_module, save_format=save_format, compile=False)
+            m = _load_model(path, keras_module=keras_module, save_format=save_format, compile=should_compile)
             return _KerasModelWrapper(m, None, None)
 
     else:

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -398,8 +398,8 @@ def _load_model(model_path, keras_module, save_format: str, **kwargs):
     # TODO: remove this fallback after older versions of mlflow which save with h5 suffix
     # are deprecated
     if save_format == "h5" and not os.path.exists(model_path):
-        # TODO: log warning?
-        model_path = f"{model_path}.h5"
+        model_path = model_path + ".h5"
+
     from distutils.version import StrictVersion
 
     if save_format == "h5" and StrictVersion(

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -482,12 +482,17 @@ def _load_pyfunc(path):
                 with sess.as_default():  # pylint:disable=not-context-manager
                     K.set_learning_phase(0)
                     m = _load_model(
-                        path, keras_module=keras_module, save_format=save_format, compile=should_compile
+                        path,
+                        keras_module=keras_module,
+                        save_format=save_format,
+                        compile=should_compile,
                     )
                     return _KerasModelWrapper(m, graph, sess)
         else:
             K.set_learning_phase(0)
-            m = _load_model(path, keras_module=keras_module, save_format=save_format, compile=should_compile)
+            m = _load_model(
+                path, keras_module=keras_module, save_format=save_format, compile=should_compile
+            )
             return _KerasModelWrapper(m, None, None)
 
     else:

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -234,10 +234,10 @@ def test_model_save_load(build_model, save_format, model_path, data):
     # exactly the same.
     if save_format != "tf":
         assert type(keras_model) == type(model_loaded)
-    assert all(expected == model_loaded.predict(x))
+    assert expected == pytest.approx(model_loaded.predict(x))
     # Loading pyfunc model
     pyfunc_loaded = mlflow.pyfunc.load_model(model_path)
-    assert all(pyfunc_loaded.predict(x).values == expected)
+    assert expected == pytest.approx(pyfunc_loaded.predict(x).values)
 
     # pyfunc serve
     scoring_response = pyfunc_serve_and_score_model(

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -547,7 +547,8 @@ def test_model_load_h5(
     Keras has standardized on the SavedModel format, but this requires a filepath without the "h5" file extension.
     However, models which were saved in earlier versions of mlflow were always saved with h5 file extension.
     """
-    mlflow.keras.save_model(keras_model=model, path=model_path, keras_module=tf.keras)
+    kwargs = {} if StrictVersion(tf.__version__) < StrictVersion('2.3.1') else {'save_format': "h5"}
+    mlflow.keras.save_model(keras_model=model, path=model_path, keras_module=tf.keras, **kwargs)
     # Here we add the h5 file extension to test backwards compatibility
     shutil.move(os.path.join(model_path, "data/model"), os.path.join(model_path, "data/model.h5"))
     model_conf_path = os.path.join(model_path, "MLmodel")

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -210,10 +210,11 @@ def test_that_keras_module_arg_works(model_path):
             assert x == b
 
 
-# @pytest.mark.skip("Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
 @pytest.mark.parametrize(
     "build_model,save_format",
-    [(model, None), (tf_keras_model, None), (tf_keras_model, "h5"), (tf_keras_model, "tf")],
+    # Unskip these parameters once https://github.com/h5py/h5py/issues/1732 is fixed
+    # [(model, None), (tf_keras_model, None), (tf_keras_model, "h5"),
+    (tf_keras_model, "tf")],
 )
 @pytest.mark.large
 def test_model_save_load(build_model, save_format, model_path, data):

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -555,7 +555,7 @@ def test_save_and_load_model_with_tf_save_format(tf_keras_model, model_path):
 
 @pytest.mark.large
 def test_load_without_save_format(tf_keras_model, model_path):
-    """Ensures that keras models with save_format can still be loaded."""
+    """Ensures that keras models without save_format can still be loaded."""
     mlflow.keras.save_model(tf_keras_model, model_path, save_format="h5")
     model_conf_path = os.path.join(model_path, "MLmodel")
     model_conf = Model.load(model_conf_path)

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -547,6 +547,7 @@ def test_model_load_h5(
     Keras has standardized on the SavedModel format, but this requires a filepath without the "h5" file extension.
     However, models which were saved in earlier versions of mlflow were always saved with h5 file extension.
     """
+    from distutils.version import StrictVersion
     kwargs = {} if StrictVersion(tf.__version__) < StrictVersion('2.3.1') else {'save_format': "h5"}
     mlflow.keras.save_model(keras_model=model, path=model_path, keras_module=tf.keras, **kwargs)
     # Here we add the h5 file extension to test backwards compatibility

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -212,7 +212,7 @@ def test_that_keras_module_arg_works(model_path):
 
 @pytest.mark.parametrize(
     "build_model,save_format",
-    # Unskip these parameters once https://github.com/h5py/h5py/issues/1732 is fixed
+    # TODO: Unskip these parameters once https://github.com/h5py/h5py/issues/1732 is fixed
     # [(model, None), (tf_keras_model, None), (tf_keras_model, "h5"),
     [(tf_keras_model, "tf")],
 )

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -10,7 +10,6 @@ import random
 from packaging import version
 
 import tensorflow as tf
-import keras
 from tensorflow.keras.models import Sequential as TfSequential
 from tensorflow.keras.layers import Dense as TfDense
 from tensorflow.keras.optimizers import SGD as TfSGD

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -211,8 +211,10 @@ def test_that_keras_module_arg_works(model_path):
 
 
 # @pytest.mark.skip("Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
-@pytest.mark.parametrize("build_model", [model, tf_keras_model])
-@pytest.mark.parametrize("build_model,save_format", [(model, None), (tf_keras_model, None), (tf_keras_model, "h5"), (tf_keras_model, "tf")])
+@pytest.mark.parametrize(
+    "build_model,save_format",
+    [(model, None), (tf_keras_model, None), (tf_keras_model, "h5"), (tf_keras_model, "tf")],
+)
 @pytest.mark.large
 def test_model_save_load(build_model, save_format, model_path, data):
     x, _ = data

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -232,7 +232,7 @@ def test_model_save_load(build_model, save_format, model_path, data):
     # When saving as SavedModel, we actually convert the model
     # to a slightly different format, so we cannot assume it is
     # exactly the same.
-    if save_format is not "tf":
+    if save_format != "tf":
         assert type(keras_model) == type(model_loaded)
     assert all(expected == model_loaded.predict(x))
     # Loading pyfunc model

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -526,7 +526,7 @@ def test_sagemaker_docker_model_scoring_with_default_conda_env(model, model_path
 
 def test_save_model_with_tf_save_format(model_path):
     """Ensures that Keras models can be saved with SavedModel format.
-    
+
     Using SavedModel format (save_format="tf") requires that the file extension
     is _not_ "h5".
     """
@@ -538,17 +538,18 @@ def test_save_model_with_tf_save_format(model_path):
     # Ensure that the saved model does not have h5 extension
     assert not args[0].endswith(".h5")
 
+
 @pytest.mark.large
-def test_model_load_h5(
-    model, model_path, data, predicted
-):
-    """Test that models previously saved with h5 format can still be loaded, for backwards compatibility.
-    
-    Keras has standardized on the SavedModel format, but this requires a filepath without the "h5" file extension.
-    However, models which were saved in earlier versions of mlflow were always saved with h5 file extension.
+def test_model_load_h5(model, model_path, data, predicted):
+    """Test that models previously saved with h5 format can still be loaded.
+
+    Keras has standardized on the SavedModel format, but this requires a filepath
+    without the "h5" file extension. However, models which were saved in earlier
+    versions of mlflow were always saved with h5 file extension.
     """
     from distutils.version import StrictVersion
-    kwargs = {} if StrictVersion(tf.__version__) < StrictVersion('2.3.1') else {'save_format': "h5"}
+
+    kwargs = {} if StrictVersion(tf.__version__) < StrictVersion("2.3.1") else {"save_format": "h5"}
     mlflow.keras.save_model(keras_model=model, path=model_path, keras_module=tf.keras, **kwargs)
     # Here we add the h5 file extension to test backwards compatibility
     shutil.move(os.path.join(model_path, "data/model"), os.path.join(model_path, "data/model.h5"))

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -10,7 +10,6 @@ import random
 from packaging import version
 
 import tensorflow as tf
-import keras
 from tensorflow.keras.models import Sequential as TfSequential
 from tensorflow.keras.layers import Dense as TfDense
 from tensorflow.keras.optimizers import SGD as TfSGD
@@ -528,7 +527,7 @@ def test_save_model_with_tf_save_format(model_path):
 
 
 @pytest.mark.large
-def test_save_and_load_model_with_tf_save_format(tf_keras_model, model_path, data, predicted):
+def test_save_and_load_model_with_tf_save_format(tf_keras_model, model_path):
     """Ensures that keras models saved with save_format="tf" can be loaded."""
     mlflow.keras.save_model(keras_model=tf_keras_model, path=model_path, save_format="tf")
     model_conf_path = os.path.join(model_path, "MLmodel")

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -214,7 +214,7 @@ def test_that_keras_module_arg_works(model_path):
     "build_model,save_format",
     # Unskip these parameters once https://github.com/h5py/h5py/issues/1732 is fixed
     # [(model, None), (tf_keras_model, None), (tf_keras_model, "h5"),
-    (tf_keras_model, "tf")],
+    [(tf_keras_model, "tf")],
 )
 @pytest.mark.large
 def test_model_save_load(build_model, save_format, model_path, data):

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -246,9 +246,9 @@ def test_model_save_load(build_model, save_format, model_path, data):
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
     )
     print(scoring_response.content)
-    actual_scoring_response = pd.read_json(scoring_response.content, orient="records", encoding="utf8").values.astype(
-            np.float32
-        )
+    actual_scoring_response = pd.read_json(
+        scoring_response.content, orient="records", encoding="utf8"
+    ).values.astype(np.float32)
     np.testing.assert_allclose(actual_scoring_response, expected, rtol=1e-5)
 
     # test spark udf

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -249,7 +249,7 @@ def test_model_save_load(build_model, save_format, model_path, data):
     actual_scoring_response = pd.read_json(
         scoring_response.content, orient="records", encoding="utf8"
     ).values.astype(np.float32)
-    np.testing.assert_allclose(actual_scoring_response, expected, rtol=3e-6)
+    np.testing.assert_allclose(actual_scoring_response, expected, rtol=1e-5)
 
     # test spark udf
     spark_udf_preds = score_model_as_udf(
@@ -555,7 +555,7 @@ def test_save_and_load_model_with_tf_save_format(tf_keras_model, model_path):
 
 @pytest.mark.large
 def test_load_without_save_format(tf_keras_model, model_path):
-    """Ensures that keras models saved in earlier versions (before save_format support) can still be loaded."""
+    """Ensures that keras models with save_format can still be loaded."""
     mlflow.keras.save_model(tf_keras_model, model_path, save_format="h5")
     model_conf_path = os.path.join(model_path, "MLmodel")
     model_conf = Model.load(model_conf_path)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Allow keras models to be saved in SavedModel format (via `save_format="tf"`).

fix issue described in #3224 

closes #3224 

## How is this patch tested?
Additional tests added. We also tested with an internal use case and verified this let us save keras models with preprocessing layers in SavedModel format.

## Release Notes
The default save format in keras is `SavedModel`, but mlflow has set the default to HDF5. If you would like to use `SavedModel`, you can pass `save_format="tf"` to `log_model` which will be propagated to keras.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

By default, mlflow.keras will save models in HDF5 format. Prior to this change HDF5 was the only supported format, but now users can use `save_format="tf"` to use `SavedModel` format.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
