### PR TITLE
pass `docker_args` in non-synchronous mlflow project runs

### DIFF
--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -104,13 +104,14 @@ class LocalBackend(AbstractBackend):
             parameters=params,
             experiment_id=experiment_id,
             use_conda=use_conda,
+            docker_args=docker_args,
             storage_dir=storage_dir,
             run_id=active_run.info.run_id,
         )
 
 
 def _invoke_mlflow_run_subprocess(
-    work_dir, entry_point, parameters, experiment_id, use_conda, storage_dir, run_id
+    work_dir, entry_point, parameters, experiment_id, use_conda, docker_args, storage_dir, run_id
 ):
     """
     Run an MLflow project asynchronously by invoking ``mlflow run`` in a subprocess, returning
@@ -120,6 +121,7 @@ def _invoke_mlflow_run_subprocess(
     mlflow_run_arr = _build_mlflow_run_cmd(
         uri=work_dir,
         entry_point=entry_point,
+        docker_args=docker_args,
         storage_dir=storage_dir,
         use_conda=use_conda,
         run_id=run_id,
@@ -131,12 +133,17 @@ def _invoke_mlflow_run_subprocess(
     return LocalSubmittedRun(run_id, mlflow_run_subprocess)
 
 
-def _build_mlflow_run_cmd(uri, entry_point, storage_dir, use_conda, run_id, parameters):
+def _build_mlflow_run_cmd(
+    uri, entry_point, docker_args, storage_dir, use_conda, run_id, parameters
+):
     """
     Build and return an array containing an ``mlflow run`` command that can be invoked to locally
     run the project at the specified URI.
     """
     mlflow_run_arr = ["mlflow", "run", uri, "-e", entry_point, "--run-id", run_id]
+    if docker_args is not None:
+        for key, value in docker_args.items():
+            mlflow_run_arr.extend(["--docker-args", "%s=%s" % (key, value)])
     if storage_dir is not None:
         mlflow_run_arr.extend(["--storage-dir", storage_dir])
     if not use_conda:

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -143,7 +143,8 @@ def _build_mlflow_run_cmd(
     mlflow_run_arr = ["mlflow", "run", uri, "-e", entry_point, "--run-id", run_id]
     if docker_args is not None:
         for key, value in docker_args.items():
-            mlflow_run_arr.extend(["--docker-args", "%s=%s" % (key, value)])
+            args = key if isinstance(value, bool) else "%s=%s" % (key, value)
+            mlflow_run_arr.extend(["--docker-args", args])
     if storage_dir is not None:
         mlflow_run_arr.extend(["--storage-dir", storage_dir])
     if not use_conda:


### PR DESCRIPTION
fix issue described in #3562

closes #3562

## What changes are proposed in this pull request?
pass `docker_args` all the way to `_build_mlflow_run_cmd()` when `synchronous` is `False` so the behavior is the same as when `synchronous` is `True` (default)

## How is this patch tested?
unit-tests and repro in #3562

```python
import mlflow

mlflow.projects.run(
    uri='examples/docker',
    parameters={"alpha": 0.5},
    synchronous=False,
    docker_args={"name": "mlflow-container-run"},
)
```

Behavior:
```
$ docker container ls

CONTAINER ID        IMAGE                   COMMAND                  CREATED             STATUS              PORTS                    NAMES
d4ccfb3ec5dc        docker-example:latest   "/usr/bin/tini -- py…"   2 seconds ago       Up 1 second                                  mlflow-container-run
```
Container name is set as passed in `docker_args` as expected


Before fix, the internally generated mlrun run cmd is
```
['mlflow', 'run', '/home/alfozan/mlflow/examples/docker', '-e', 'main', '--run-id', 'ce179496f2ff47c5b010900928f55401', '-P', 'alpha=0.5']
```
after fix:
```
['mlflow', 'run', '/home/alfozan/mlflow/examples/docker', '-e', 'main', '--run-id', 'ce179496f2ff47c5b010900928f55401', '--docker-args', 'name=mlflow-container-run', '-P', 'alpha=0.5']
```
notice that ` '--docker-args', 'name=mlflow-container-run'` args are added.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
