### PR TITLE
Fix a bug where `xgboost.DMatrix(None)` fails after running `mlflow.xgboost.autolog`

### DIFF
--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -314,10 +314,9 @@ def autolog(
     # We store it on the DMatrix object so the train function is able to read it.
     def __init__(self, *args, **kwargs):
         data = args[0] if len(args) > 0 else kwargs.get("data")
+        original = gorilla.get_original_attribute(xgboost.DMatrix, "__init__")
 
         if data is not None:
-            original = gorilla.get_original_attribute(xgboost.DMatrix, "__init__")
-
             try:
                 if isinstance(data, str):
                     raise Exception(

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -478,3 +478,13 @@ def test_xgb_autolog_configuration_options(bst_params, log_input_example, log_mo
     model_conf = get_model_conf(run.info.artifact_uri)
     assert ("saved_input_example_info" in model_conf.to_dict()) == log_input_example
     assert ("signature" in model_conf.to_dict()) == log_model_signature
+
+
+def test_xgb_autolog_does_not_break_dmatrix_instantiation_with_data_none():
+    """
+    This test verifies that `xgboost.DMatrix(None)` doesn't fail after patching.
+    XGBoost internally calls `xgboost.DMatrix(None)` to create a blank `DMatrix` object.
+    Example: https://github.com/dmlc/xgboost/blob/v1.2.1/python-package/xgboost/core.py#L701
+    """
+    mlflow.xgboost.autolog()
+    xgb.DMatrix(None)


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix a bug where `xgboost.DMatrix(None)` fails with the following error after running `mlflow.xgboost.autolog`.

```
UnboundLocalError: local variable 'original' referenced before assignment
```


I found this bug when running this code:

```python
# Create prediction samples using the first 5 rows.
pred_samples = booster.predict(train_dmatrix.slice([0, 1, 2, 3, 4]))  # -> internally calls `xgboost.DMatrix(None)` and throws. 
signature = infer_signature(..., pred_samples)
```

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
