### PR TITLE
Universal mlflow.autolog() documentation

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -218,6 +218,8 @@ Here is an example plot of the :ref:`quick start tutorial <quickstart>` with the
   X-axis relative time - graphs the time relative to the first metric logged, for each run
 
 
+.. _automatic-logging:
+
 Automatic Logging
 =================
 

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -227,7 +227,7 @@ Automatic logging allows you to log metrics, parameters, and models without the 
 
 There are two ways to use autologging:
 
-#. Call :py:func:`mlflow.autolog` before your training code. This will enable autologging for every supported library you have installed as soon as you import it.
+#. Call :py:func:`mlflow.autolog` before your training code. This will enable autologging for each supported library you have installed as soon as you import it.
 #. Use library-specific autolog calls for each library you use in your code. See below for examples.
 
 The following libraries support autologging:

--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -221,8 +221,14 @@ Here is an example plot of the :ref:`quick start tutorial <quickstart>` with the
 Automatic Logging
 =================
 
-Automatic logging allows you to log metrics, parameters, and models without the need for explicit
-log statements, and is currently supported for:
+Automatic logging allows you to log metrics, parameters, and models without the need for explicit log statements.
+
+There are two ways to use autologging:
+
+#. Call :py:func:`mlflow.autolog` before your training code. This will enable autologging for every supported library you have installed as soon as you import it.
+#. Use library-specific autolog calls for each library you use in your code. See below for examples.
+
+The following libraries support autologging:
 
 .. contents::
   :local:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1036,11 +1036,12 @@ def autolog(log_input_example=False, log_model_signature=True):  # pylint: disab
     See the :ref:`tracking docs <automatic-logging>` for a list of supported autologging
     integrations.
 
-    :param log_input_example: if True, logs a sample of the training data as part of the model
-                              as an example for future reference. If False, no sample is logged.
-    :param log_model_signature: if True, records the type signature of the inputs and outputs as
-                                part of the model. If False, the signature is not recorded to the
-                                model.
+    :param log_input_example: if True, input examples from training datasets will be collected and
+                              logged along with model artifacts during training. If False, no
+                              sample is logged.
+    :param log_model_signature: if True, the type signature of the inputs and outputs to each model
+                                are recorded as part of the model. If False, the signature is not
+                                recorded to the model.
     """
     locals_copy = locals().items()
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1033,7 +1033,8 @@ def autolog(log_input_example=False, log_model_signature=True):  # pylint: disab
 
     The parameters are passed to any autologging integrations that support them.
 
-    See the :ref:`tracking docs <automatic-logging>` for a list of supported autologging integrations.
+    See the :ref:`tracking docs <automatic-logging>` for a list of supported autologging
+    integrations.
 
     :param log_input_example: if True, logs a sample of the training data as part of the model
                               as an example for future reference. If False, no sample is logged.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1033,7 +1033,7 @@ def autolog(log_input_example=False, log_model_signature=True):  # pylint: disab
 
     The parameters are passed to any autologging integrations that support them.
 
-    See the individual autolog function docs for more info.
+    See the :ref:`tracking docs <automatic-logging>` for a list of supported autologging integrations.
 
     :param log_input_example: if True, logs a sample of the training data as part of the model
                               as an example for future reference. If False, no sample is logged.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1031,11 +1031,15 @@ def autolog(log_input_example=False, log_model_signature=True):  # pylint: disab
     """
     Enable autologging for all supported integrations.
 
-    Takes any parameters, and passes whichever parameters are relevant to the specific autolog functions.
+    The parameters are passed to any autologging integrations that support them.
 
-    For example, the parameter `importance_types=['weight']` will only be passed to xgboost autologging.
+    See the individual autolog function docs for more info.
 
-    All the other integrations where no given parameters apply will be enabled with the default parameters.
+    :param log_input_example: if True, logs a sample of the training data as part of the model
+                              as an example for future reference. If False, no sample is logged.
+    :param log_model_signature: if True, records the type signature of the inputs and outputs as
+                                part of the model. If False, the signature is not recorded to the
+                                model.
     """
     locals_copy = locals().items()
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1028,6 +1028,15 @@ def _get_experiment_id():
 
 
 def autolog(log_input_example=False, log_model_signature=True):  # pylint: disable=unused-argument
+    """
+    Enable autologging for all supported integrations.
+
+    Takes any parameters, and passes whichever parameters are relevant to the specific autolog functions.
+
+    For example, the parameter `importance_types=['weight']` will only be passed to xgboost autologging.
+
+    All the other integrations where no given parameters apply will be enabled with the default parameters.
+    """
     locals_copy = locals().items()
 
     # Mapping of library module name to specific autolog function


### PR DESCRIPTION
Signed-off-by: Andrew Nitu <andrewnitu@gmail.com>

## What changes are proposed in this pull request?

Add docs to explain mlflow.autolog() both to the Tracking section and the Python API section

## How is this patch tested?

Verified through the GitHub docs build 

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added docs to explain mlflow.autolog function

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
