### PR TITLE
Scikit-learn autologging: Exclude feature extraction / selection estimator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
         "sqlparse>=0.3.1",
         # Required to run the MLflow server against SQL-backed storage
         "sqlalchemy",
-        "gorilla",
         "prometheus-flask-exporter",
     ],
     extras_require={

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1005,11 +1005,11 @@ def test_autolog_configuration_options(log_input_example, log_model_signature):
 
 
 @pytest.mark.large
-def test_autolog_does_not_capture_runs_for_preprocessing_or_imputation_estimators():
+def test_autolog_does_not_capture_runs_for_preprocessing_or_feature_manipulation_estimators():
     """
-    Verifies that preprocessing and imputation estimators, which represent data manipulation steps
-    (e.g., normalization, label encoding) rather than ML models, do not produce runs when their
-    fit_* operations are invoked independently of an ML pipeline
+    Verifies that preprocessing and feature manipulation estimators, which represent data
+    manipulation steps (e.g., normalization, label encoding) rather than ML models, do not
+    produce runs when their fit_* operations are invoked independently of an ML pipeline
     """
     mlflow.sklearn.autolog()
 
@@ -1021,12 +1021,20 @@ def test_autolog_does_not_capture_runs_for_preprocessing_or_imputation_estimator
 
     from sklearn.preprocessing import Normalizer, LabelEncoder, MinMaxScaler
     from sklearn.impute import SimpleImputer
+    from sklearn.feature_extraction.text import TfidfVectorizer
+    from sklearn.feature_selection import VarianceThreshold
 
     with mlflow.start_run(run_id=run_id):
         Normalizer().fit_transform(np.random.random((5, 5)))
         LabelEncoder().fit([1, 2, 2, 6])
         MinMaxScaler().fit_transform(50 * np.random.random((10, 10)))
         SimpleImputer().fit_transform([[1, 2], [np.nan, 3], [7, 6]])
+        TfidfVectorizer().fit_transform([
+            "MLflow is an end-to-end machine learning platform.",
+            "MLflow enables me to systematize my ML experimentation",
+        ])
+        VarianceThreshold().fit_transform([[0, 2, 0, 3], [0, 1, 4, 3], [0, 1, 1, 3]])
+
 
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert len(params) == 0

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1029,12 +1029,13 @@ def test_autolog_does_not_capture_runs_for_preprocessing_or_feature_manipulation
         LabelEncoder().fit([1, 2, 2, 6])
         MinMaxScaler().fit_transform(50 * np.random.random((10, 10)))
         SimpleImputer().fit_transform([[1, 2], [np.nan, 3], [7, 6]])
-        TfidfVectorizer().fit_transform([
-            "MLflow is an end-to-end machine learning platform.",
-            "MLflow enables me to systematize my ML experimentation",
-        ])
+        TfidfVectorizer().fit_transform(
+            [
+                "MLflow is an end-to-end machine learning platform.",
+                "MLflow enables me to systematize my ML experimentation",
+            ]
+        )
         VarianceThreshold().fit_transform([[0, 2, 0, 3], [0, 1, 4, 3], [0, 1, 1, 3]])
-
 
     params, metrics, tags, artifacts = get_run_data(run_id)
     assert len(params) == 0


### PR DESCRIPTION
Signed-off-by: Corey Zumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

As a follow-up for #3574, this PR excludes feature extraction / selection estimators from the set of estimators that capture MLflow runs during training. These estimators, which come from the https://scikit-learn.org/stable/modules/classes.html#module-sklearn.feature_selection and https://scikit-learn.org/stable/modules/classes.html#module-sklearn.feature_extraction modules, don't really represent ML models.

## How is this patch tested?

Unit tests

## Release Notes

Scikit-learn autologging will no longer record MLflow Runs for non-ML operations in scikit-learn, such as preprocessing, imputation, and feature extraction/selection.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.


### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
