### PR TITLE
Add docs clarifications for pyfunc flavor in mlflow.sklearn

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -77,7 +77,12 @@ def save_model(
     input_example: ModelInputExample = None,
 ):
     """
-    Save a scikit-learn model to a path on the local file system.
+    Save a scikit-learn model to a path on the local file system. Produces an MLflow Model
+    containing the following flavors:
+
+        - :py:mod:`mlflow.sklearn`
+        - :py:mod:`mlflow.pyfunc`. NOTE: This flavor is only included for scikit-learn models
+          that define `predict()`, since `predict()` is required for pyfunc model inference
 
     :param sk_model: scikit-learn model to be saved.
     :param path: Local path where the model is to be saved.
@@ -222,7 +227,12 @@ def log_model(
     await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
 ):
     """
-    Log a scikit-learn model as an MLflow artifact for the current run.
+    Log a scikit-learn model as an MLflow artifact for the current run. Produces an MLflow Model
+    containing the following flavors:
+
+        - :py:mod:`mlflow.sklearn`
+        - :py:mod:`mlflow.pyfunc`. NOTE: This flavor is only included for scikit-learn models
+          that define `predict()`, since `predict()` is required for pyfunc model inference
 
     :param sk_model: scikit-learn model to be saved.
     :param artifact_path: Run-relative artifact path.

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -611,9 +611,9 @@ def autolog(log_input_example=False, log_model_signature=True):
           (e.g. "sklearn.linear_model._base.LinearRegression").
 
       **Artifacts**
-        - An MLflow Model with the `mlflow.sklearn` flavor containing a fitted estimator
+        - An MLflow Model with the :py:mod:`mlflow.sklearn` flavor containing a fitted estimator
           (logged by :py:func:`mlflow.sklearn.log_model()`). The Model also contains the
-          `mlflow.pyfunc` flavor when the scikit-learn estimator defines `predict()`.
+          :py:mod:`mlflow.pyfunc` flavor when the scikit-learn estimator defines `predict()`.
 
     **How does autologging work for meta estimators?**
       When a meta estimator (e.g. `Pipeline`_, `GridSearchCV`_) calls ``fit()``, it internally calls

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -7,7 +7,8 @@ Python (native) `pickle <https://scikit-learn.org/stable/modules/model_persisten
 
 :py:mod:`mlflow.pyfunc`
     Produced for use by generic pyfunc-based deployment tools and batch inference.
-    NOTE: The `mlflow.pyfunc` flavor is only added for scikit-learn models that define `predict()`.
+    NOTE: The `mlflow.pyfunc` flavor is only added for scikit-learn models that define `predict()`,
+    since `predict()` is required for pyfunc model inference.
 """
 import os
 import logging

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -611,7 +611,9 @@ def autolog(log_input_example=False, log_model_signature=True):
           (e.g. "sklearn.linear_model._base.LinearRegression").
 
       **Artifacts**
-        - A fitted estimator (logged by :py:func:`mlflow.sklearn.log_model()`).
+        - An MLflow Model with the `mlflow.sklearn` flavor containing a fitted estimator
+          (logged by :py:func:`mlflow.sklearn.log_model()`). The Model also contains the
+          `mlflow.pyfunc` flavor when the scikit-learn estimator defines `predict()`.
 
     **How does autologging work for meta estimators?**
       When a meta estimator (e.g. `Pipeline`_, `GridSearchCV`_) calls ``fit()``, it internally calls

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -7,6 +7,7 @@ Python (native) `pickle <https://scikit-learn.org/stable/modules/model_persisten
 
 :py:mod:`mlflow.pyfunc`
     Produced for use by generic pyfunc-based deployment tools and batch inference.
+    NOTE: The `mlflow.pyfunc` flavor is only added for scikit-learn models that define `predict()`.
 """
 import os
 import logging

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -83,7 +83,7 @@ def save_model(
 
         - :py:mod:`mlflow.sklearn`
         - :py:mod:`mlflow.pyfunc`. NOTE: This flavor is only included for scikit-learn models
-          that define `predict()`, since `predict()` is required for pyfunc model inference
+          that define `predict()`, since `predict()` is required for pyfunc model inference.
 
     :param sk_model: scikit-learn model to be saved.
     :param path: Local path where the model is to be saved.
@@ -233,7 +233,7 @@ def log_model(
 
         - :py:mod:`mlflow.sklearn`
         - :py:mod:`mlflow.pyfunc`. NOTE: This flavor is only included for scikit-learn models
-          that define `predict()`, since `predict()` is required for pyfunc model inference
+          that define `predict()`, since `predict()` is required for pyfunc model inference.
 
     :param sk_model: scikit-learn model to be saved.
     :param artifact_path: Run-relative artifact path.


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR updates the docs for `mlflow.sklearn.log/load_model` and `mlflow.sklearn.autolog()` to indicate that the `mlflow.pyfunc` flavor is only produced when the input scikit-learn model defines a `predict()` method (which is required for pyfunc inference).

## How is this patch tested?

Docs tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
