### PR TITLE
Pin h5py < 3 to fix incompatibility with TensorFlow model serialization

### DIFF
--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -5,6 +5,8 @@
 azureml-sdk==1.2.0
 # Required by mlflow.keras
 keras==2.3.1
+# See: https://github.com/h5py/h5py/issues/1732
+h5py<3
 # Required by mlflow.sklearn
 scikit-learn
 # Required by mlflow.gluon

--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -5,8 +5,8 @@
 azureml-sdk==1.2.0
 # Required by mlflow.keras
 keras==2.3.1
-# Pin h5py < 3 to avoid this issue: https://github.com/h5py/h5py/issues/1732
-h5py<3
+# Pin h5py < 3.0.0 to avoid this issue: https://github.com/h5py/h5py/issues/1732
+h5py<3.0.0
 # Required by mlflow.sklearn
 scikit-learn
 # Required by mlflow.gluon

--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -5,7 +5,7 @@
 azureml-sdk==1.2.0
 # Required by mlflow.keras
 keras==2.3.1
-# See: https://github.com/h5py/h5py/issues/1732
+# Pin h5py < 3 to avoid this issue: https://github.com/h5py/h5py/issues/1732
 h5py<3
 # Required by mlflow.sklearn
 scikit-learn

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -6,7 +6,9 @@ mlflow:::mlflow_maybe_create_conda_env(python_version = "3.6")
 library(reticulate)
 use_condaenv(mlflow:::mlflow_conda_env_name())
 # pinning tensorflow version to 1.14 until test_keras_model.R is fixed
-keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
+# Pin h5py < 3 to avoid this issue: https://github.com/h5py/h5py/issues/1732
+keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(),
+                     tensorflow="1.15.2", extra_packages=c("h5py<3"))
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
 # Pin h2o to prevent version-mismatch between python and R

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -7,7 +7,7 @@ library(reticulate)
 use_condaenv(mlflow:::mlflow_conda_env_name())
 # pinning tensorflow version to 1.14 until test_keras_model.R is fixed
 keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
-# pinning h5py < 3 to avoid this issue: https://github.com/h5py/h5py/issues/1732
+# pinning h5py < 3.0.0 to avoid this issue: https://github.com/h5py/h5py/issues/1732
 reticulate::conda_install("'h5py<3.0.0'", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -6,9 +6,9 @@ mlflow:::mlflow_maybe_create_conda_env(python_version = "3.6")
 library(reticulate)
 use_condaenv(mlflow:::mlflow_conda_env_name())
 # pinning tensorflow version to 1.14 until test_keras_model.R is fixed
-# Pin h5py < 3 to avoid this issue: https://github.com/h5py/h5py/issues/1732
-keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(),
-                     tensorflow="1.15.2", extra_packages=c("h5py<3"))
+keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
+# pinning h5py < 3 to avoid this issue: https://github.com/h5py/h5py/issues/1732
+reticulate::conda_install("h5py<3", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
 # Pin h2o to prevent version-mismatch between python and R

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -8,7 +8,7 @@ use_condaenv(mlflow:::mlflow_conda_env_name())
 # pinning tensorflow version to 1.14 until test_keras_model.R is fixed
 keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
 # pinning h5py < 3 to avoid this issue: https://github.com/h5py/h5py/issues/1732
-reticulate::conda_install("h5py==2.10.0", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
+reticulate::conda_install("'h5py<3.0.0'", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
 # Pin h2o to prevent version-mismatch between python and R

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -8,7 +8,7 @@ use_condaenv(mlflow:::mlflow_conda_env_name())
 # pinning tensorflow version to 1.14 until test_keras_model.R is fixed
 keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
 # pinning h5py < 3 to avoid this issue: https://github.com/h5py/h5py/issues/1732
-reticulate::conda_install("h5py<3.0.0", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
+reticulate::conda_install("h5py==2.10.0", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
 # Pin h2o to prevent version-mismatch between python and R

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -8,7 +8,7 @@ use_condaenv(mlflow:::mlflow_conda_env_name())
 # pinning tensorflow version to 1.14 until test_keras_model.R is fixed
 keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
 # pinning h5py < 3 to avoid this issue: https://github.com/h5py/h5py/issues/1732
-reticulate::conda_install("h5py<3", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
+reticulate::conda_install("h5py<3.0.0", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
 # Pin h2o to prevent version-mismatch between python and R

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def reset_mock():
     cache[:] = []
 
 
-@pytest.fixture(autouse=False)
+@pytest.fixture(autouse=True)
 def tracking_uri_mock(tmpdir, request):
     try:
         if "notrackingurimock" not in request.keywords:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def reset_mock():
     cache[:] = []
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=False)
 def tracking_uri_mock(tmpdir, request):
     try:
         if "notrackingurimock" not in request.keywords:

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -250,7 +250,6 @@ def test_model_save_load(build_model, model_path, data):
     np.allclose(np.array(spark_udf_preds), expected.reshape(len(spark_udf_preds)))
 
 
-@pytest.mark.skip("Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
 @pytest.mark.large
 def test_signature_and_examples_are_saved_correctly(model, data):
     signature_ = infer_signature(*data)
@@ -270,6 +269,7 @@ def test_signature_and_examples_are_saved_correctly(model, data):
                     assert all((_read_example(mlflow_model, path) == example).all())
 
 
+@pytest.mark.skip("Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
 @pytest.mark.large
 def test_custom_model_save_load(custom_model, custom_layer, data, custom_predicted, model_path):
     x, _ = data

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -210,6 +210,7 @@ def test_that_keras_module_arg_works(model_path):
             assert x == b
 
 
+@pytest.skip("Disable this test until https://github.com/h5py/h5py/issues/1732 is fixed")
 @pytest.mark.parametrize("build_model", [model, tf_keras_model])
 @pytest.mark.large
 def test_model_save_load(build_model, model_path, data):
@@ -249,6 +250,7 @@ def test_model_save_load(build_model, model_path, data):
     np.allclose(np.array(spark_udf_preds), expected.reshape(len(spark_udf_preds)))
 
 
+@pytest.skip("Disable this test until https://github.com/h5py/h5py/issues/1732 is fixed")
 @pytest.mark.large
 def test_signature_and_examples_are_saved_correctly(model, data):
     signature_ = infer_signature(*data)

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -210,7 +210,7 @@ def test_that_keras_module_arg_works(model_path):
             assert x == b
 
 
-@pytest.skip("Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
+@pytest.mark.skip("Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
 @pytest.mark.parametrize("build_model", [model, tf_keras_model])
 @pytest.mark.large
 def test_model_save_load(build_model, model_path, data):
@@ -250,7 +250,7 @@ def test_model_save_load(build_model, model_path, data):
     np.allclose(np.array(spark_udf_preds), expected.reshape(len(spark_udf_preds)))
 
 
-@pytest.skip("Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
+@pytest.mark.skip("Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
 @pytest.mark.large
 def test_signature_and_examples_are_saved_correctly(model, data):
     signature_ = infer_signature(*data)

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -210,7 +210,7 @@ def test_that_keras_module_arg_works(model_path):
             assert x == b
 
 
-@pytest.skip(reason="Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
+@pytest.skip("Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
 @pytest.mark.parametrize("build_model", [model, tf_keras_model])
 @pytest.mark.large
 def test_model_save_load(build_model, model_path, data):
@@ -250,7 +250,7 @@ def test_model_save_load(build_model, model_path, data):
     np.allclose(np.array(spark_udf_preds), expected.reshape(len(spark_udf_preds)))
 
 
-@pytest.skip(reason="Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
+@pytest.skip("Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
 @pytest.mark.large
 def test_signature_and_examples_are_saved_correctly(model, data):
     signature_ = infer_signature(*data)

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -210,7 +210,7 @@ def test_that_keras_module_arg_works(model_path):
             assert x == b
 
 
-@pytest.skip("Disable this test until https://github.com/h5py/h5py/issues/1732 is fixed")
+@pytest.skip(reason="Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
 @pytest.mark.parametrize("build_model", [model, tf_keras_model])
 @pytest.mark.large
 def test_model_save_load(build_model, model_path, data):
@@ -250,7 +250,7 @@ def test_model_save_load(build_model, model_path, data):
     np.allclose(np.array(spark_udf_preds), expected.reshape(len(spark_udf_preds)))
 
 
-@pytest.skip("Disable this test until https://github.com/h5py/h5py/issues/1732 is fixed")
+@pytest.skip(reason="Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
 @pytest.mark.large
 def test_signature_and_examples_are_saved_correctly(model, data):
     signature_ = infer_signature(*data)


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Pin `h5py` to avoid: https://github.com/h5py/h5py/issues/1732

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
