### PR TITLE
Autologging: Pluralize configuration arguments

### DIFF
--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -494,8 +494,8 @@ def autolog(log_input_examples=False, log_model_signatures=True):
         input_example, signature = resolve_input_example_and_signature(
             get_input_example,
             infer_model_signature,
-            log_input_example,
-            log_model_signature,
+            log_input_examples,
+            log_model_signatures,
             _logger,
         )
 

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -281,7 +281,7 @@ class _LGBModelWrapper:
 
 
 @experimental
-def autolog(log_input_example=False, log_model_signature=True):
+def autolog(log_input_examples=False, log_model_signatures=True):
     """
     Enables automatic logging from LightGBM to MLflow. Logs the following.
 
@@ -295,11 +295,14 @@ def autolog(log_input_example=False, log_model_signature=True):
 
     Note that the `scikit-learn API`_ is not supported.
 
-    :param log_input_example: if True, logs a sample of the training data as part of the model
-                              as an example for future reference. If False, no sample is logged.
-    :param log_model_signature: if True, records the type signature of the inputs and outputs as
-                                part of the model. If False, the signature is not recorded to the
-                                model.
+    :param log_input_examples: If ``True``, input examples from training datasets are collected and
+                               logged along with LightGBM model artifacts during training. If
+                               ``False``, input examples are not logged.
+    :param log_model_signatures: If ``True``,
+                                 :py:class:`ModelSignatures <mlflow.models.ModelSignature>`
+                                 describing model inputs and outputs are collected and logged along
+                                 with LightGBM model artifacts during training. If ``False``,
+                                 signatures are not logged.
     """
     import lightgbm
     import numpy as np

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -849,8 +849,8 @@ def autolog(log_input_examples=False, log_model_signatures=True):
         input_example, signature = resolve_input_example_and_signature(
             get_input_example,
             infer_model_signature,
-            log_input_example,
-            log_model_signature,
+            log_input_examples,
+            log_model_signatures,
             _logger,
         )
 

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -532,7 +532,7 @@ class _SklearnTrainingSession(object):
 
 
 @experimental
-def autolog(log_input_example=False, log_model_signature=True):
+def autolog(log_input_examples=False, log_model_signatures=True):
     """
     Enables autologging for scikit-learn estimators.
 
@@ -696,11 +696,14 @@ def autolog(log_input_example=False, log_model_signature=True):
         pprint(artifacts)
         # ['model/MLmodel', 'model/conda.yaml', 'model/model.pkl']
 
-    :param log_input_example: if True, logs a sample of the training data as part of the model
-                              as an example for future reference. If False, no sample is logged.
-    :param log_model_signature: if True, records the type signature of the inputs and outputs as
-                                part of the model. If False, the signature is not recorded to the
-                                model.
+    :param log_input_examples: If ``True``, input examples from training datasets are collected and
+                               logged along with scikit-learn model artifacts during training. If
+                               ``False``, input examples are not logged.
+    :param log_model_signatures: If ``True``,
+                                 :py:class:`ModelSignatures <mlflow.models.ModelSignature>`
+                                 describing model inputs and outputs are collected and logged along
+                                 with scikit-learn model artifacts during training. If ``False``,
+                                 signatures are not logged.
     """
     import pandas as pd
     import sklearn

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1027,7 +1027,7 @@ def _get_experiment_id():
     ) or deprecated_default_exp_id
 
 
-def autolog(log_input_example=False, log_model_signature=True):  # pylint: disable=unused-argument
+def autolog(log_input_examples=False, log_model_signatures=True):  # pylint: disable=unused-argument
     """
     Enable autologging for all supported integrations.
 
@@ -1036,12 +1036,14 @@ def autolog(log_input_example=False, log_model_signature=True):  # pylint: disab
     See the :ref:`tracking docs <automatic-logging>` for a list of supported autologging
     integrations.
 
-    :param log_input_example: if True, input examples from training datasets will be collected and
-                              logged along with model artifacts during training. If False, no
-                              sample is logged.
-    :param log_model_signature: if True, the type signature of the inputs and outputs to each model
-                                are recorded as part of the model. If False, the signature is not
-                                recorded to the model.
+    :param log_input_examples: If ``True``, input examples from training datasets are collected and
+                               logged along with model artifacts during training. If ``False``, 
+                               input examples are not logged.
+    :param log_model_signatures: If ``True``,
+                                 :py:class:`ModelSignatures <mlflow.models.ModelSignature>`
+                                 describing model inputs and outputs are collected and logged along
+                                 with model artifacts during training. If ``False``, signatures are
+                                 not logged.
     """
     locals_copy = locals().items()
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1037,7 +1037,7 @@ def autolog(log_input_examples=False, log_model_signatures=True):  # pylint: dis
     integrations.
 
     :param log_input_examples: If ``True``, input examples from training datasets are collected and
-                               logged along with model artifacts during training. If ``False``, 
+                               logged along with model artifacts during training. If ``False``,
                                input examples are not logged.
     :param log_model_signatures: If ``True``,
                                  :py:class:`ModelSignatures <mlflow.models.ModelSignature>`

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -283,7 +283,7 @@ class _XGBModelWrapper:
 
 @experimental
 def autolog(
-    importance_types=["weight"], log_input_example=False, log_model_signature=True
+    importance_types=["weight"], log_input_examples=False, log_model_signatures=True
 ):  # pylint: disable=W0102
     """
     Enables automatic logging from XGBoost to MLflow. Logs the following.
@@ -299,11 +299,14 @@ def autolog(
     Note that the `scikit-learn API`_ is not supported.
 
     :param importance_types: importance types to log.
-    :param log_input_example: if True, logs a sample of the training data as part of the model
-                              as an example for future reference. If False, no sample is logged.
-    :param log_model_signature: if True, records the type signature of the inputs and outputs as
-                                part of the model. If False, the signature is not recorded to the
-                                model.
+    :param log_input_examples: If ``True``, input examples from training datasets are collected and
+                               logged along with XGBoost model artifacts during training. If
+                               ``False``, input examples are not logged.
+    :param log_model_signatures: If ``True``,
+                                 :py:class:`ModelSignatures <mlflow.models.ModelSignature>`
+                                 describing model inputs and outputs are collected and logged along
+                                 with XGBoost model artifacts during training. If ``False``,
+                                 signatures are not logged.
     """
     import xgboost
     import numpy as np

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -490,8 +490,8 @@ def autolog(
         input_example, signature = resolve_input_example_and_signature(
             get_input_example,
             infer_model_signature,
-            log_input_example,
-            log_model_signature,
+            log_input_examples,
+            log_model_signatures,
             _logger,
         )
 

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -332,7 +332,7 @@ def test_lgb_autolog_gets_input_example(bst_params):
     y = iris.target
     dataset = lgb.Dataset(X, y, free_raw_data=True)
 
-    mlflow.lightgbm.autolog(log_input_example=True)
+    mlflow.lightgbm.autolog(log_input_examples=True)
     lgb.train(bst_params, dataset)
     run = get_latest_run()
 
@@ -356,7 +356,7 @@ def test_lgb_autolog_infers_model_signature_correctly(bst_params):
     y = iris.target
     dataset = lgb.Dataset(X, y, free_raw_data=True)
 
-    mlflow.lightgbm.autolog(log_model_signature=True)
+    mlflow.lightgbm.autolog(log_model_signatures=True)
     lgb.train(bst_params, dataset)
     run = get_latest_run()
     run_id = run.info.run_id
@@ -409,7 +409,7 @@ def test_lgb_autolog_continues_logging_even_if_signature_inference_fails(tmpdir)
         "num_class": 3,
     }
 
-    mlflow.lightgbm.autolog(log_model_signature=True)
+    mlflow.lightgbm.autolog(log_model_signatures=True)
     lgb.train(bst_params, dataset)
     run = get_latest_run()
     run_id = run.info.run_id
@@ -431,22 +431,22 @@ def test_lgb_autolog_continues_logging_even_if_signature_inference_fails(tmpdir)
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("log_input_example", [True, False])
-@pytest.mark.parametrize("log_model_signature", [True, False])
-def test_lgb_autolog_configuration_options(bst_params, log_input_example, log_model_signature):
+@pytest.mark.parametrize("log_input_examples", [True, False])
+@pytest.mark.parametrize("log_model_signatures", [True, False])
+def test_lgb_autolog_configuration_options(bst_params, log_input_examples, log_model_signatures):
     iris = datasets.load_iris()
     X = pd.DataFrame(iris.data[:, :2], columns=iris.feature_names[:2])
     y = iris.target
 
     with mlflow.start_run() as run:
         mlflow.lightgbm.autolog(
-            log_input_example=log_input_example, log_model_signature=log_model_signature
+            log_input_examples=log_input_examples, log_model_signatures=log_model_signatures
         )
         dataset = lgb.Dataset(X, y)
         lgb.train(bst_params, dataset)
     model_conf = get_model_conf(run.info.artifact_uri)
-    assert ("saved_input_example_info" in model_conf.to_dict()) == log_input_example
-    assert ("signature" in model_conf.to_dict()) == log_model_signature
+    assert ("saved_input_example_info" in model_conf.to_dict()) == log_input_examples
+    assert ("signature" in model_conf.to_dict()) == log_model_signatures
 
 
 def test_lgb_autolog_does_not_break_dataset_instantiation_with_data_none():

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -746,7 +746,7 @@ def test_meta_estimator_fit_performs_logging_only_once():
 )
 @pytest.mark.parametrize("backend", [None, "threading", "loky"])
 def test_parameter_search_estimators_produce_expected_outputs(cv_class, search_space, backend):
-    mlflow.sklearn.autolog(log_input_example=True, log_model_signature=True)
+    mlflow.sklearn.autolog(log_input_examples=True, log_model_signatures=True)
 
     svc = sklearn.svm.SVC()
     cv_model = cv_class(svc, search_space, n_jobs=5, return_train_score=True)
@@ -891,7 +891,7 @@ def test_autolog_does_not_throw_when_mlflow_logging_fails(func_to_fail):
 
 @pytest.mark.parametrize("data_type", [pd.DataFrame, np.array])
 def test_autolog_logs_signature_and_input_example(data_type):
-    mlflow.sklearn.autolog(log_input_example=True, log_model_signature=True)
+    mlflow.sklearn.autolog(log_input_examples=True, log_model_signatures=True)
 
     X, y = get_iris()
     X = data_type(X)
@@ -944,7 +944,7 @@ def test_autolog_does_not_throw_when_failing_to_sample_X():
 def test_autolog_logs_signature_only_when_estimator_defines_predict():
     from sklearn.cluster import AgglomerativeClustering
 
-    mlflow.sklearn.autolog(log_model_signature=True)
+    mlflow.sklearn.autolog(log_model_signatures=True)
 
     X, y = get_iris()
     model = AgglomerativeClustering()
@@ -964,7 +964,7 @@ def test_autolog_does_not_throw_when_predict_fails():
     with mlflow.start_run() as run, mock.patch(
         "sklearn.linear_model.LinearRegression.predict", side_effect=Exception("Failed")
     ), mock.patch("mlflow.sklearn._logger.warning") as mock_warning:
-        mlflow.sklearn.autolog(log_input_example=True, log_model_signature=True)
+        mlflow.sklearn.autolog(log_input_examples=True, log_model_signatures=True)
         model = sklearn.linear_model.LinearRegression()
         model.fit(X, y)
 
@@ -979,7 +979,7 @@ def test_autolog_does_not_throw_when_infer_signature_fails():
     with mlflow.start_run() as run, mock.patch(
         "mlflow.models.infer_signature", side_effect=Exception("Failed")
     ), mock.patch("mlflow.sklearn._logger.warning") as mock_warning:
-        mlflow.sklearn.autolog(log_input_example=True, log_model_signature=True)
+        mlflow.sklearn.autolog(log_input_examples=True, log_model_signatures=True)
         model = sklearn.linear_model.LinearRegression()
         model.fit(X, y)
 
@@ -989,20 +989,20 @@ def test_autolog_does_not_throw_when_infer_signature_fails():
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("log_input_example", [True, False])
-@pytest.mark.parametrize("log_model_signature", [True, False])
-def test_autolog_configuration_options(log_input_example, log_model_signature):
+@pytest.mark.parametrize("log_input_examples", [True, False])
+@pytest.mark.parametrize("log_model_signatures", [True, False])
+def test_autolog_configuration_options(log_input_examples, log_model_signatures):
     X, y = get_iris()
 
     with mlflow.start_run() as run:
         mlflow.sklearn.autolog(
-            log_input_example=log_input_example, log_model_signature=log_model_signature
+            log_input_examples=log_input_examples, log_model_signatures=log_model_signatures
         )
         model = sklearn.linear_model.LinearRegression()
         model.fit(X, y)
     model_conf = get_model_conf(run.info.artifact_uri)
-    assert ("saved_input_example_info" in model_conf.to_dict()) == log_input_example
-    assert ("signature" in model_conf.to_dict()) == log_model_signature
+    assert ("saved_input_example_info" in model_conf.to_dict()) == log_input_examples
+    assert ("signature" in model_conf.to_dict()) == log_model_signatures
 
 
 @pytest.mark.large

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -80,7 +80,7 @@ def test_universal_autolog_calls_specific_autologs_correctly(library, mlflow_mod
 
     # modify the __signature__ of the mock to contain the needed parameters
     args = (
-        {"log_input_example": bool, "log_model_signature": bool}
+        {"log_input_examples": bool, "log_model_signatures": bool}
         if library in integrations_with_config
         else {}
     )
@@ -96,7 +96,7 @@ def test_universal_autolog_calls_specific_autologs_correctly(library, mlflow_mod
         autolog_mock.assert_not_called()
 
         # this should attach import hooks to each library
-        mlflow.autolog(log_input_example=True, log_model_signature=True)
+        mlflow.autolog(log_input_examples=True, log_model_signatures=True)
 
         autolog_mock.assert_not_called()
 
@@ -104,7 +104,7 @@ def test_universal_autolog_calls_specific_autologs_correctly(library, mlflow_mod
 
         # after each library is imported, its corresponding autolog function should have been called
         if library in integrations_with_config:
-            autolog_mock.assert_called_once_with(log_input_example=True, log_model_signature=True)
+            autolog_mock.assert_called_once_with(log_input_examples=True, log_model_signatures=True)
         else:
             autolog_mock.assert_called_once_with()
 

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -323,7 +323,7 @@ def test_xgb_autolog_does_not_throw_if_importance_values_not_supported(dtrain):
 
 @pytest.mark.large
 def test_xgb_autolog_gets_input_example(bst_params):
-    mlflow.xgboost.autolog(log_input_example=True)
+    mlflow.xgboost.autolog(log_input_examples=True)
 
     # we cannot use dtrain fixture, as the dataset must be constructed
     #   after the call to autolog() in order to get the input example
@@ -350,7 +350,7 @@ def test_xgb_autolog_gets_input_example(bst_params):
 
 @pytest.mark.large
 def test_xgb_autolog_infers_model_signature_correctly(bst_params):
-    mlflow.xgboost.autolog(log_model_signature=True)
+    mlflow.xgboost.autolog(log_model_signatures=True)
 
     # we cannot use dtrain fixture, as the dataset must be constructed
     #   after the call to autolog() in order to get the input example
@@ -418,7 +418,7 @@ def test_xgb_autolog_continues_logging_even_if_signature_inference_fails(bst_par
     tmp_csv.write("0,2.4,5.2\n")
     tmp_csv.write("1,0.3,-1.2\n")
 
-    mlflow.xgboost.autolog(importance_types=[], log_model_signature=True)
+    mlflow.xgboost.autolog(importance_types=[], log_model_signatures=True)
 
     # signature and input example inference should fail here since the dataset is given
     #   as a file path
@@ -462,22 +462,22 @@ def test_xgb_autolog_does_not_break_dmatrix_serialization(bst_params, tmpdir):
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("log_input_example", [True, False])
-@pytest.mark.parametrize("log_model_signature", [True, False])
-def test_xgb_autolog_configuration_options(bst_params, log_input_example, log_model_signature):
+@pytest.mark.parametrize("log_input_examples", [True, False])
+@pytest.mark.parametrize("log_model_signatures", [True, False])
+def test_xgb_autolog_configuration_options(bst_params, log_input_examples, log_model_signatures):
     iris = datasets.load_iris()
     X = pd.DataFrame(iris.data[:, :2], columns=iris.feature_names[:2])
     y = iris.target
 
     with mlflow.start_run() as run:
         mlflow.xgboost.autolog(
-            log_input_example=log_input_example, log_model_signature=log_model_signature
+            log_input_examples=log_input_examples, log_model_signatures=log_model_signatures
         )
         dataset = xgb.DMatrix(X, y)
         xgb.train(bst_params, dataset)
     model_conf = get_model_conf(run.info.artifact_uri)
-    assert ("saved_input_example_info" in model_conf.to_dict()) == log_input_example
-    assert ("signature" in model_conf.to_dict()) == log_model_signature
+    assert ("saved_input_example_info" in model_conf.to_dict()) == log_input_examples
+    assert ("signature" in model_conf.to_dict()) == log_model_signatures
 
 
 def test_xgb_autolog_does_not_break_dmatrix_instantiation_with_data_none():


### PR DESCRIPTION
## What changes are proposed in this pull request?

For clarity / accuracy, this PR pluralizes the preexisting `log_input_example` and `log_model_signature` configuration arguments across MLflow's autologging integrations (which have yet to be released), renaming them to `log_input_examples` and `log_model_signatures`, respectively. This PR also improves the documentation for these parameters.

## How is this patch tested?

Docs unit tests, manual verification that generated parameter descriptions look as expected & that docs links work

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
