### PR TITLE
[FR] Add optional models serve prometheus exporter

### DIFF
--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -34,8 +34,8 @@ def commands():
 @cli_args.INSTALL_MLFLOW
 @cli_args.EXPOSE_PROMETHEUS
 @cli_args.APP_NAME
-def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False, expose_prometheus=None,
-          app_name="default"):
+def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False,
+          expose_prometheus=None, app_name="default"):
     """
     Serve a model saved with MLflow by launching a webserver on the specified host and port.
     The command supports models with the ``python_function`` or ``crate`` (R Function) flavor.
@@ -57,7 +57,8 @@ def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False, 
     """
     return _get_flavor_backend(
         model_uri, no_conda=no_conda, workers=workers, install_mlflow=install_mlflow
-    ).serve(model_uri=model_uri, port=port, host=host, expose_prometheus=expose_prometheus, app_name=app_name)
+    ).serve(model_uri=model_uri, port=port, host=host,
+            expose_prometheus=expose_prometheus, app_name=app_name)
 
 
 @commands.command("predict")

--- a/mlflow/models/cli.py
+++ b/mlflow/models/cli.py
@@ -32,7 +32,10 @@ def commands():
 @cli_args.WORKERS
 @cli_args.NO_CONDA
 @cli_args.INSTALL_MLFLOW
-def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False):
+@cli_args.EXPOSE_PROMETHEUS
+@cli_args.APP_NAME
+def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False, expose_prometheus=None,
+          app_name="default"):
     """
     Serve a model saved with MLflow by launching a webserver on the specified host and port.
     The command supports models with the ``python_function`` or ``crate`` (R Function) flavor.
@@ -54,7 +57,7 @@ def serve(model_uri, port, host, workers, no_conda=False, install_mlflow=False):
     """
     return _get_flavor_backend(
         model_uri, no_conda=no_conda, workers=workers, install_mlflow=install_mlflow
-    ).serve(model_uri=model_uri, port=port, host=host)
+    ).serve(model_uri=model_uri, port=port, host=host, expose_prometheus=expose_prometheus, app_name=app_name)
 
 
 @commands.command("predict")

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -65,7 +65,7 @@ class PyFuncBackend(FlavorBackend):
         else:
             scoring_server._predict(local_uri, input_path, output_path, content_type, json_format)
 
-    def serve(self, model_uri, port, host, expose_prometheus, app_name):
+    def serve(self, model_uri, port, host):
         """
         Serve pyfunc model locally.
         """
@@ -86,9 +86,6 @@ class PyFuncBackend(FlavorBackend):
 
         command_env = os.environ.copy()
         command_env[scoring_server._SERVER_MODEL_PATH] = local_uri
-        if expose_prometheus:
-            command_env[scoring_server.PROMETHEUS_EXPORTER_ENV_VAR] = expose_prometheus
-            command_env[scoring_server.APP_ENV_VAR] = app_name
         if not self._no_conda and ENV in self._config:
             conda_env_path = os.path.join(local_path, self._config[ENV])
             return _execute_in_conda_env(

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -65,7 +65,7 @@ class PyFuncBackend(FlavorBackend):
         else:
             scoring_server._predict(local_uri, input_path, output_path, content_type, json_format)
 
-    def serve(self, model_uri, port, host):
+    def serve(self, model_uri, port, host, expose_prometheus, app_name):
         """
         Serve pyfunc model locally.
         """
@@ -86,6 +86,9 @@ class PyFuncBackend(FlavorBackend):
 
         command_env = os.environ.copy()
         command_env[scoring_server._SERVER_MODEL_PATH] = local_uri
+        if expose_prometheus:
+            command_env[scoring_server.PROMETHEUS_EXPORTER_ENV_VAR] = expose_prometheus
+            command_env[scoring_server.APP_ENV_VAR] = app_name
         if not self._no_conda and ENV in self._config:
             conda_env_path = os.path.join(local_path, self._config[ENV])
             return _execute_in_conda_env(

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -21,7 +21,7 @@ import sys
 import traceback
 from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 import os
-from flask import Flask, request
+from flask import request
 
 # NB: We need to be careful what we import form mlflow here. Scoring server is used from within
 # model's conda environment. The version of mlflow doing the serving (outside) and the version of
@@ -173,8 +173,8 @@ def init(model: PyFuncModel):
     if os.getenv(PROMETHEUS_EXPORTER_ENV_VAR):
         prometheus_metrics_path = os.getenv(PROMETHEUS_EXPORTER_ENV_VAR)
 
-    if not os.path.exists(prometheus_metrics_path):
-        os.makedirs(prometheus_metrics_path)
+        if not os.path.exists(prometheus_metrics_path):
+            os.makedirs(prometheus_metrics_path)
     metrics = GunicornInternalPrometheusMetrics(app, export_defaults=False)
     _logger.info("start flask prometheus exporter")
 

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -10,6 +10,7 @@ Defines two endpoints:
     /ping used for health check
     /invocations used for scoring
 """
+
 from collections import OrderedDict
 import flask
 import json
@@ -22,6 +23,7 @@ import traceback
 from prometheus_flask_exporter.multiprocess import GunicornInternalPrometheusMetrics
 import os
 from flask import request
+
 
 # NB: We need to be careful what we import form mlflow here. Scoring server is used from within
 # model's conda environment. The version of mlflow doing the serving (outside) and the version of
@@ -173,8 +175,8 @@ def init(model: PyFuncModel):
     if os.getenv(PROMETHEUS_EXPORTER_ENV_VAR):
         prometheus_metrics_path = os.getenv(PROMETHEUS_EXPORTER_ENV_VAR)
 
-        if not os.path.exists(prometheus_metrics_path):
-            os.makedirs(prometheus_metrics_path)
+    if not os.path.exists(prometheus_metrics_path):
+        os.makedirs(prometheus_metrics_path)
     metrics = GunicornInternalPrometheusMetrics(app, export_defaults=False)
     _logger.info("start flask prometheus exporter")
 

--- a/mlflow/utils/cli_args.py
+++ b/mlflow/utils/cli_args.py
@@ -80,3 +80,16 @@ WORKERS = click.option(
     default=None,
     help="Number of gunicorn worker processes to handle requests (default: 4).",
 )
+
+EXPOSE_PROMETHEUS = click.option(
+    "--expose-prometheus",
+    default=None,
+    help="Path to the directory where metrics will be stored. If the directory"
+         "doesn't exist, it will be created."
+         "Activate prometheus exporter to expose metrics on /metrics endpoint.")
+
+APP_NAME = click.option(
+    "--app-name",
+    default="default",
+    help="the name of the application, which is used for the models serve prometheus export,"
+         "to distinguish application name in the prometheus metrics")


### PR DESCRIPTION
## What changes are proposed in this pull request?

A new parameter to the mlflow models serve  cli allowing to activate a prometheus exporter which expose metrics on the /metrics endpoint.  and  new paramter to distinguish application from promethues metrics

the following metrics will be expose 
 - http request total 
 - http request delay

## How is this patch tested?

Locally, by trying to launch the models serve with or without the argument --activate-prometheus and --app-name, and by checking that metrics are indeed available on /metrics endpoint.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
A prometheus exporter exposing metrics on /metrics can be activated using --activate-parameter and --app-name arguments of the mlflow models serve cli.
### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
