### PR TITLE
fix issue #1997 with sparkling water and s3

### DIFF
--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -108,7 +108,10 @@ def save_model(
         _save_example(mlflow_model, input_example, path)
 
     # Save h2o-model
-    h2o_save_location = h2o.save_model(model=h2o_model, path=model_data_path, force=True)
+    if "download_model" in dir(h2o):
+        h2o_save_location = h2o.download_model(model=h2o_model, path=model_data_path)
+    else:
+        h2o_save_location = h2o.save_model(model=h2o_model, path=model_data_path, force=True)
     model_file = os.path.basename(h2o_save_location)
 
     # Save h2o-settings


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixes stale issue #1997

As per comments on my previous attempt to fix the problem in #2882, I have added a line of code to test for the existence of the download_model method. This obviates the check on the version of h2o.

## How is this patch tested?

- sparkling-water-3.30.0.3-1-2.4
- pysparkling

## Release Notes

### Is this a user-facing change?

- No.

### What component(s), interfaces, languages, and integrations does this PR affect?

integrations/h2o

### How should the PR be classified in the release notes? Choose one:

Bug fix.