### PR TITLE
fix issue #1997 with sparkling water and s3

### DIFF
--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -221,11 +221,12 @@ def _load_model(path, init=False):
 
     model_path = os.path.join(path, params["model_file"])
     if "upload_model" in dir(h2o):
-       model = h2o.upload_model(model_path)
+        model = h2o.upload_model(model_path)
     else:
-       model = h2o.load_model(model_path)
+        model = h2o.load_model(model_path)
 
     return model
+
 
 class _H2OModelWrapper:
     def __init__(self, h2o_model):

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -108,7 +108,7 @@ def save_model(
         _save_example(mlflow_model, input_example, path)
 
     # Save h2o-model
-    if "download_model" in dir(h2o):
+    if hasattr(h2o,"download_model"):
         h2o_save_location = h2o.download_model(model=h2o_model, path=model_data_path)
     else:
         h2o_save_location = h2o.save_model(model=h2o_model, path=model_data_path, force=True)
@@ -220,7 +220,7 @@ def _load_model(path, init=False):
         h2o.no_progress()
 
     model_path = os.path.join(path, params["model_file"])
-    if "upload_model" in dir(h2o):
+    if hasattr(h2o,"upload_model"):
         model = h2o.upload_model(model_path)
     else:
         model = h2o.load_model(model_path)

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -108,7 +108,10 @@ def save_model(
         _save_example(mlflow_model, input_example, path)
 
     # Save h2o-model
-    h2o_save_location = h2o.save_model(model=h2o_model, path=model_data_path, force=True)
+    if "download_model" in dir(h2o):
+        h2o_save_location = h2o.download_model(model=h2o_model, path=model_data_path)
+    else:
+        h2o_save_location = h2o.save_model(model=h2o_model, path=model_data_path, force=True)
     model_file = os.path.basename(h2o_save_location)
 
     # Save h2o-settings

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -218,8 +218,14 @@ def _load_model(path, init=False):
     if init:
         h2o.init(**(params["init"] if "init" in params else {}))
         h2o.no_progress()
-    return h2o.load_model(os.path.join(path, params["model_file"]))
 
+    model_path = os.path.join(path, params["model_file"])
+    if "upload_model" in dir(h2o):
+       model = h2o.upload_model(model_path)
+    else:
+       model = h2o.load_model(model_path)
+
+    return model
 
 class _H2OModelWrapper:
     def __init__(self, h2o_model):

--- a/mlflow/h2o.py
+++ b/mlflow/h2o.py
@@ -8,6 +8,7 @@ H20 (native) format
     Produced for use by generic pyfunc-based deployment tools and batch inference.
 """
 import os
+import warnings
 import yaml
 
 import mlflow
@@ -19,7 +20,6 @@ from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
-from mlflow.exceptions import MlflowException
 
 FLAVOR_NAME = "h2o"
 
@@ -112,11 +112,10 @@ def save_model(
     if hasattr(h2o, "download_model"):
         h2o_save_location = h2o.download_model(model=h2o_model, path=model_data_path)
     else:
-        if "pysparkling" in dir():
-            raise MlflowException(
-                "Mlflow not compatible with Sparkling water over this H2O version. "
-                "Please upgrade H2O"
-            )
+        warnings.warn(
+            "If your cluster is remote, H2O may not store the model correctly. "
+            "Please upgrade H2O version to a newer version"
+        )
         h2o_save_location = h2o.save_model(model=h2o_model, path=model_data_path, force=True)
     model_file = os.path.basename(h2o_save_location)
 
@@ -229,11 +228,10 @@ def _load_model(path, init=False):
     if hasattr(h2o, "upload_model"):
         model = h2o.upload_model(model_path)
     else:
-        if "pysparkling" in dir():
-            raise MlflowException(
-                "Mlflow not compatible with Sparkling water over this H2O version. "
-                "Please upgrade H2O"
-            )
+        warnings.warn(
+            "If your cluster is remote, H2O may not load the model correctly. "
+            "Please upgrade H2O version to a newer version"
+        )
         model = h2o.load_model(model_path)
 
     return model


### PR DESCRIPTION
Signed-off-by: Carlos Del Cacho Vicente <delcacho@gmail.com>

## What changes are proposed in this pull request?

Issue #1997 with the fix identified in pull request #2882, whereby H2O models are not correctly saved to S3 when using Sparkling Water. Basically download_model should be used instead of save_model, if available. I added a check to ensure the function exists before invoking it, irrespective of H2O version.

## How is this patch tested?

sparkling-water-3.30.0.3-1-2.4
pysparkling

## Release Notes

### Is this a user-facing change?

No

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?

integrations/h2o

### How should the PR be classified in the release notes? Choose one:

Bug fix.