### PR TITLE
Remove optimizer step override in PL examples

### DIFF
--- a/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
+++ b/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
@@ -271,27 +271,6 @@ class LightningMNISTClassifier(pl.LightningModule):
         }
         return [self.optimizer], [self.scheduler]
 
-    def optimizer_step(
-        self,
-        epoch,
-        batch_idx,
-        optimizer,
-        optimizer_idx,
-        second_order_closure=None,
-        on_tpu=False,
-        using_lbfgs=False,
-        using_native_amp=False,
-    ):
-        """
-        Training step function which runs for the given number of epochs
-
-        :param epoch: Number of epochs to train
-        :param batch_idx: batch indices
-        :param optimizer: Optimizer to be used in training step
-        """
-        self.optimizer.step()
-        self.optimizer.zero_grad()
-
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="PyTorch Autolog Mnist Example")

--- a/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
+++ b/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
@@ -273,27 +273,6 @@ class LightningMNISTClassifier(pl.LightningModule):
         }
         return [self.optimizer], [self.scheduler]
 
-    def optimizer_step(
-        self,
-        epoch,
-        batch_idx,
-        optimizer,
-        optimizer_idx,
-        second_order_closure=None,
-        on_tpu=False,
-        using_lbfgs=False,
-        using_native_amp=False,
-    ):
-        """
-        Training step function which runs for the given number of epochs
-
-        :param epoch: Number of epochs to train
-        :param batch_idx: batch indices
-        :param optimizer: Optimizer to be used in training step
-        """
-        self.optimizer.step()
-        self.optimizer.zero_grad()
-
 
 if __name__ == "__main__":
     parser = ArgumentParser(description="PyTorch autolog Mnist Example")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Ties to code review in #3608. We should not override the optimizer step as this breaks functionality across many accelerators. Let the base class handle it :)

## How is this patch tested?

Ran the mnist script

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
