### PR TITLE
Updating pytorch autolog to log only the first optimizer params

### DIFF
--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -92,10 +92,7 @@ def _autolog(log_every_n_epoch=1):
                 try_mlflow_log(mlflow.log_param, "optimizer_name", type(optimizer).__name__)
 
                 if hasattr(optimizer, "defaults"):
-                    optim_dict = optimizer.defaults
-
-                    for key, value in optim_dict.items():
-                        try_mlflow_log(mlflow.log_param, key, value)
+                    try_mlflow_log(mlflow.log_params, optimizer.defaults)
 
             summary = str(ModelSummary(pl_module, mode="full"))
             tempdir = tempfile.mkdtemp()

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -87,6 +87,14 @@ def _autolog(log_every_n_epoch=1):
                     self.early_stopping = True
                     self._log_early_stop_params(callback)
 
+            # TODO For logging optimizer params - Following scenarios are to revisited.
+            # 1. In the current scenario, only the first optimizer details are logged.
+            #    Code to be enhanced to log params when multiple optimizers are used.
+            # 2. mlflow.log_params is used to store optimizer default values into mlflow.
+            #    The keys in default dictionary are too short, Ex: (lr - learning_rate).
+            #    Efficient mapping technique needs to be introduced
+            #    to rename the optimizer parameters based on keys in default dictionary.
+
             if hasattr(trainer, "optimizers"):
                 optimizer = trainer.optimizers[0]
                 try_mlflow_log(mlflow.log_param, "optimizer_name", type(optimizer).__name__)

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -88,36 +88,14 @@ def _autolog(log_every_n_epoch=1):
                     self._log_early_stop_params(callback)
 
             if hasattr(trainer, "optimizers"):
-                for optimizer in trainer.optimizers:
-                    try_mlflow_log(mlflow.log_param, "optimizer_name", type(optimizer).__name__)
-                    optimizer_name = type(optimizer).__name__.lower() + "_optimizer"
+                optimizer = trainer.optimizers[0]
+                try_mlflow_log(mlflow.log_param, "optimizer_name", type(optimizer).__name__)
 
-                    if hasattr(optimizer, "defaults"):
-                        optim_dict = optimizer.defaults
+                if hasattr(optimizer, "defaults"):
+                    optim_dict = optimizer.defaults
 
-                        if "lr" in optim_dict:
-                            try_mlflow_log(
-                                mlflow.log_param,
-                                "learning_rate_" + optimizer_name,
-                                optim_dict["lr"],
-                            )
-
-                        if "eps" in optim_dict:
-                            try_mlflow_log(
-                                mlflow.log_param, "epsilon_" + optimizer_name, optim_dict["eps"]
-                            )
-
-                        if "betas" in optim_dict:
-                            try_mlflow_log(
-                                mlflow.log_param, "betas_" + optimizer_name, optim_dict["betas"]
-                            )
-
-                        if "weight_decay" in optim_dict:
-                            try_mlflow_log(
-                                mlflow.log_param,
-                                "weight_decay_" + optimizer_name,
-                                optim_dict["weight_decay"],
-                            )
+                    for key, value in optim_dict.items():
+                        try_mlflow_log(mlflow.log_param, key, value)
 
             summary = str(ModelSummary(pl_module, mode="full"))
             tempdir = tempfile.mkdtemp()

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -17,24 +17,23 @@ def pytorch_model():
     model = IrisClassification()
     trainer = pl.Trainer(max_epochs=NUM_EPOCHS)
     trainer.fit(model)
-    optimizer_name = type(trainer.optimizers[0]).__name__.lower() + "_optimizer"
     client = mlflow.tracking.MlflowClient()
     run = client.get_run(client.list_run_infos(experiment_id="0")[0].run_id)
-    return trainer, run, optimizer_name
+    return trainer, run
 
 
 def test_pytorch_autolog_logs_default_params(pytorch_model):
-    _, run, optimizer_name = pytorch_model
+    _, run = pytorch_model
     data = run.data
-    assert "learning_rate_" + optimizer_name in data.params
-    assert "epsilon_" + optimizer_name in data.params
+    assert "lr" in data.params
+    assert "eps" in data.params
     assert "optimizer_name" in data.params
-    assert "weight_decay_" + optimizer_name in data.params
-    assert "betas_" + optimizer_name in data.params
+    assert "weight_decay" in data.params
+    assert "betas" in data.params
 
 
 def test_pytorch_autolog_logs_expected_data(pytorch_model):
-    _, run, _ = pytorch_model
+    _, run = pytorch_model
     data = run.data
 
     # Checking if metrics are logged
@@ -134,7 +133,7 @@ def test_pytorch_early_stop_metrics_logged(pytorch_model_with_callback):
 
 
 def test_pytorch_autolog_non_early_stop_callback_does_not_log(pytorch_model):
-    trainer, run, _ = pytorch_model
+    trainer, run = pytorch_model
     client = mlflow.tracking.MlflowClient()
     metric_history = client.get_metric_history(run.info.run_id, "loss")
     assert trainer.max_epochs == NUM_EPOCHS


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

As per the discussion, suffixing the optimizer name in every parameter creates confusion. Hence, removing the logic of suffixing the optimizer name and logging only the first optimizer parameters. 

## How is this patch tested?

Fixed corresponding Unit test cases.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
