### PR TITLE
PyTorch Autolog Example Readme files 

### DIFF
--- a/examples/pytorch/BertNewsClassification/MLproject
+++ b/examples/pytorch/BertNewsClassification/MLproject
@@ -5,7 +5,7 @@ conda_env: conda.yaml
 entry_points:
   main:
     parameters:
-      epochs: {type: int, default: 5}
+      max_epochs: {type: int, default: 5}
       gpus: {type: int, default: 0}
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
@@ -13,7 +13,7 @@ entry_points:
 
     command: |
           python bert_classification.py \
-            --max-epochs {epochs} \
+            --max_epochs {max_epochs} \
             --gpus {gpus} \
             --batch-size {batch_size} \
             --num-workers {num_workers} \

--- a/examples/pytorch/BertNewsClassification/README.md
+++ b/examples/pytorch/BertNewsClassification/README.md
@@ -1,5 +1,6 @@
 ## BERT news classification example
-In this example, we train a Pytorch Lightning model to classify news articles into "World", "Sports", "Business" and "Sci/Tech" categories. The code, adapted from [this repository](https://github.com/ricardorei/lightning-text-classification/blob/a92f753e22527bbc0648c3ff3544981562f69c22/classifier.py), is almost entirely dedicated to model training, with the addition of a single ``mlflow.pytorch.autolog()`` call to enable automatic logging of params, metrics, and models.
+In this example, we train a Pytorch Lightning model to classify news articles into "World", "Sports", "Business" and "Sci/Tech" categories. The code, adapted from this [repository](https://github.com/ricardorei/lightning-text-classification/blob/master/classifier.py), is almost entirely dedicated to model training, with the addition of a single mlflow.pytorch.autolog() call to enable automatic logging of params, metrics, and models.
+ 
 
 ### Running the code
 To run the example via MLflow, navigate to the `mlflow/examples/pytorch/BertNewsClassification` directory and run the command
@@ -13,18 +14,20 @@ This will run `bert_classification.py` with the default set of parameters such a
 In order to run the file with custom parameters, run the command
 
 ```
-mlflow run . -P epochs=X
+mlflow run . -P max_epochs=X
 ```
 
-where `X` is your desired value for `epochs`.
+where `X` is your desired value for `max_epochs`.
 
 If you have the required modules for the file and would like to skip the creation of a conda environment, add the argument `--no-conda`.
 
 ```
 mlflow run . --no-conda
+
 ```
 
 ### Viewing results in the MLflow UI
+
 Once the code is finished executing, you can view the run's metrics, parameters, and details by running the command
 
 ```
@@ -37,32 +40,31 @@ For more details on MLflow tracking, see [the docs](https://www.mlflow.org/docs/
 
 ### Passing custom training parameters
 
-The parameters below can be overridden via the command line:
+The parameters can be overridden via the command line:
 
-1. ``max_epochs`` - Number of epochs to train model. Training can be interrupted early via Ctrl+C
-2. ``gpus`` - Number of GPUs
-3. ``accelerator`` - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags)
-   (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used.
-4. ``batch-size`` - Input batch size for training
-5. ``num-workers`` - Number of worker threads to load training data
-6. ``lr`` - Learning rate
-
+1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
+2. gpus - Number of GPUs
+3. accelrator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used. 
+4. batch-size - Input batch size for training
+5. num-workers - Number of worker threads to load training data
+6. lr - Learning rate
 
 For example:
 ```
-mlflow run . -P epochs=5 -P gpus=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P accelerator="ddp"
+mlflow run . -P max_epochs=5 -P gpus=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P accelerator="ddp"
 ```
-
 Or to run the training script directly with custom parameters:
+
 ```
 python bert_classification.py \
-    --max-epochs 5 \
+    --max_epochs 5 \
     --gpus 1 \
     --accelerator "ddp" \
-    --batch-size 32 \
+    --batch-size 64 \
     --num-workers 2 \
-    --lr 0.01
+    --lr 0.001
 ```
 
+
 ## Logging to a custom tracking server
-To configure MLflow to log to a custom (non-default) tracking location, set the ``MLFLOW_TRACKING_URI`` environment variable, e.g. via  ``export MLFLOW_TRACKING_URI=http://localhost:5000/``.  For more details, see [the docs](https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded).
+To configure MLflow to log to a custom (non-default) tracking location, set the MLFLOW_TRACKING_URI environment variable, e.g. via export MLFLOW_TRACKING_URI=http://localhost:5000/. For more details, see [the docs](https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded).

--- a/examples/pytorch/BertNewsClassification/README.md
+++ b/examples/pytorch/BertNewsClassification/README.md
@@ -1,22 +1,11 @@
 ## Bert news classification example with MLFlow
-
-In this example, we have used a pretrained Bert model to classify the news reports into any one of the 4 different categories("world", "Sports", "Business", "Sci/Tech").
-The autolog code uses Pytorch Lightning's MLFlowLogger to log metrics.
-The code is trained using pytorch lightning loop and the autolog function call in the main - `mlflow.pytorch.autolog()`
-is responsible for logging the params, metrics, model summary and the model.
+In this example, we train a Pytorch Lightning model adapted from [github](https://github.com/ricardorei/lightning-text-classification/blob/master/classifier.py) to classify news into 4 different categories namely "world", "Sports", "Business" and "Sci/Tech". The code is almost entirely dedicated to model training in a ``DDP (Distributed Data Parallel)`` environment, with the addition of a single ``mlflow.pytorch.autolog()`` call to enable automatic logging of params, metrics, models and its summary from training.
  
 
 ### Code related to MLflow:
 * [`mlflow.pytorch.autolog`]
 This is an experimental api that logs ML model artifacts and metrics.
 The metrics are logged during training of the model.
-
-## Setting tracking URI
-MLflow tracking URI can be set using the environment variable MLFLOW_TRACKING_URI
-
-Example: `export MLFLOW_TRACKING_URI=http://localhost:5000/`
-
-For more details - https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded
 
 ### Running the code
 To run the example via MLflow, navigate to the `mlflow/examples/pytorch/BertNewsClassification` directory and run the command
@@ -71,5 +60,7 @@ mlflow ui
 
 and navigating to [http://localhost:5000](http://localhost:5000).
 
-For more information on MLflow tracking, click [here](https://www.mlflow.org/docs/latest/tracking.html#mlflow-tracking) to view documentation.
+For more details on MLflow tracking, see [the docs](https://www.mlflow.org/docs/latest/tracking.html#mlflow-tracking).
 
+## Logging to a custom tracking server
+To configure MLflow to log to a custom (non-default) tracking location, set the ``MLFLOW_TRACKING_URI`` environment variable, e.g. via  ``export MLFLOW_TRACKING_URI=http://localhost:5000/``.  For more details, see [the docs](https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded).

--- a/examples/pytorch/BertNewsClassification/README.md
+++ b/examples/pytorch/BertNewsClassification/README.md
@@ -47,15 +47,21 @@ The parameters below can be overridden via the command line:
 5. ``num-workers`` - Number of worker threads to load training data
 6. ``lr`` - Learning rate
 
+
 For example:
+```
+mlflow run . -P epochs=5 -P gpus=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P accelerator="ddp"
+```
+
+Or to run the training script directly with custom parameters:
 ```
 python bert_classification.py \
     --max-epochs 5 \
     --gpus 1 \
     --accelerator "ddp" \
-    --batch-size 64 \
+    --batch-size 32 \
     --num-workers 2 \
-    --lr 0.001
+    --lr 0.01
 ```
 
 ## Logging to a custom tracking server

--- a/examples/pytorch/BertNewsClassification/README.md
+++ b/examples/pytorch/BertNewsClassification/README.md
@@ -1,5 +1,5 @@
 ## BERT news classification example
-In this example, we train a Pytorch Lightning model to classify news articles into "World", "Sports", "Business" and "Sci/Tech" categories. The code, adapted from this [repository](https://github.com/ricardorei/lightning-text-classification/blob/master/classifier.py), is almost entirely dedicated to model training, with the addition of a single mlflow.pytorch.autolog() call to enable automatic logging of params, metrics, and models.
+In this example, we train a Pytorch Lightning model to classify news articles into "World", "Sports", "Business" and "Sci/Tech" categories. The code, adapted from this [repository](https://github.com/ricardorei/lightning-text-classification/blob/master/classifier.py), is almost entirely dedicated to model training, with the addition of a single ``mlflow.pytorch.autolog()`` call to enable automatic logging of params, metrics, and models.
  
 
 ### Running the code
@@ -44,7 +44,7 @@ The parameters can be overridden via the command line:
 
 1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
 2. gpus - Number of GPUs
-3. accelrator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used. 
+3. accelerator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used. 
 4. batch-size - Input batch size for training
 5. num-workers - Number of worker threads to load training data
 6. lr - Learning rate

--- a/examples/pytorch/BertNewsClassification/README.md
+++ b/examples/pytorch/BertNewsClassification/README.md
@@ -1,11 +1,5 @@
-## Bert news classification example with MLFlow
-In this example, we train a Pytorch Lightning model adapted from [github](https://github.com/ricardorei/lightning-text-classification/blob/master/classifier.py) to classify news into 4 different categories namely "world", "Sports", "Business" and "Sci/Tech". The code is almost entirely dedicated to model training in a ``DDP (Distributed Data Parallel)`` environment, with the addition of a single ``mlflow.pytorch.autolog()`` call to enable automatic logging of params, metrics, models and its summary from training.
- 
-
-### Code related to MLflow:
-* [`mlflow.pytorch.autolog`]
-This is an experimental api that logs ML model artifacts and metrics.
-The metrics are logged during training of the model.
+## BERT news classification example
+In this example, we train a Pytorch Lightning model to classify news articles into "World", "Sports", "Business" and "Sci/Tech" categories. The code, adapted from [this repository](https://github.com/ricardorei/lightning-text-classification/blob/a92f753e22527bbc0648c3ff3544981562f69c22/classifier.py), is almost entirely dedicated to model training, with the addition of a single ``mlflow.pytorch.autolog()`` call to enable automatic logging of params, metrics, and models.
 
 ### Running the code
 To run the example via MLflow, navigate to the `mlflow/examples/pytorch/BertNewsClassification` directory and run the command
@@ -14,7 +8,7 @@ To run the example via MLflow, navigate to the `mlflow/examples/pytorch/BertNews
 mlflow run .
 ```
 
-This will run `bert_classification..py` with the default set of parameters such as  `--max_epochs=5`. You can see the default value in the `MLproject` file.
+This will run `bert_classification.py` with the default set of parameters such as  `--max_epochs=5`. You can see the default value in the `MLproject` file.
 
 In order to run the file with custom parameters, run the command
 
@@ -30,16 +24,28 @@ If you have the required modules for the file and would like to skip the creatio
 mlflow run . --no-conda
 ```
 
-### Example with custom input
+### Viewing results in the MLflow UI
+Once the code is finished executing, you can view the run's metrics, parameters, and details by running the command
 
-Following are the parameters which can be overridden by passing values in command line argument.
+```
+mlflow ui
+```
 
-1. Number of epochs - max_epochs
-2. Number of gpus - gpus
-3. Backend in case of gpus environment - accelerator
-4. Batch size to process - batch-size
-5. Number of workers to process input - num-workers
-6. Learning rate - lr
+and navigating to [http://localhost:5000](http://localhost:5000).
+
+For more details on MLflow tracking, see [the docs](https://www.mlflow.org/docs/latest/tracking.html#mlflow-tracking).
+
+### Passing custom training parameters
+
+The parameters below can be overridden via the command line:
+
+1. ``max_epochs`` - Number of epochs to train model. Training can be interrupted early via Ctrl+C
+2. ``gpus`` - Number of GPUs
+3. ``accelerator`` - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags)
+   (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used.
+4. ``batch-size`` - Input batch size for training
+5. ``num-workers`` - Number of worker threads to load training data
+6. ``lr`` - Learning rate
 
 For example:
 ```
@@ -51,16 +57,6 @@ python bert_classification.py \
     --num-workers 2 \
     --lr 0.001
 ```
-
-Once the code is finished executing, you can view the run's metrics, parameters, and details by running the command
-
-```
-mlflow ui
-```
-
-and navigating to [http://localhost:5000](http://localhost:5000).
-
-For more details on MLflow tracking, see [the docs](https://www.mlflow.org/docs/latest/tracking.html#mlflow-tracking).
 
 ## Logging to a custom tracking server
 To configure MLflow to log to a custom (non-default) tracking location, set the ``MLFLOW_TRACKING_URI`` environment variable, e.g. via  ``export MLFLOW_TRACKING_URI=http://localhost:5000/``.  For more details, see [the docs](https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded).

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -169,7 +169,7 @@ class BertDataModule(pl.LightningDataModule):
             type=int,
             default=3,
             metavar="N",
-            help="number of workers (default: 0)",
+            help="number of workers (default: 3)",
         )
         return parser
 

--- a/examples/pytorch/MNIST/example1/MLproject
+++ b/examples/pytorch/MNIST/example1/MLproject
@@ -5,7 +5,7 @@ conda_env: conda.yaml
 entry_points:
   main:
     parameters:
-      epochs: {type: int, default: 5}
+      max_epochs: {type: int, default: 5}
       gpus: {type: int, default: 0}
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
@@ -17,7 +17,7 @@ entry_points:
 
     command: |
           python mnist_autolog_example1.py \
-            --max-epochs {epochs} \
+            --max_epochs {max_epochs} \
             --gpus {gpus} \
             --batch-size {batch_size} \
             --num-workers {num_workers} \

--- a/examples/pytorch/MNIST/example1/README.md
+++ b/examples/pytorch/MNIST/example1/README.md
@@ -1,61 +1,31 @@
 ## MNIST example with MLFlow
-In this example, we train a Pytorch Lightning model adapted from [this repository](https://github.com/PyTorchLightning/pytorch-lightning/blob/e81707ba0242f12f47d742e86a982f529a7ae65b/pl_examples/basic_examples/mnist.py) to predict handwritten digits. The code is almost entirely dedicated to model training, with the addition of ``mlflow.pytorch.autolog()`` call to enable automatic logging of params, metrics, and models from training.
-
+In this example, we train a Pytorch Lightning model to preidct handwritten digits. The code, adapted from this [repository](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/basic_examples/mnist.py), is almost entirely dedicated to model training, with the addition of a single mlflow.pytorch.autolog() call to enable automatic logging of params, metrics, and models.Additionally the call would also enable saving of parameters and metrics related to ``early stopping callback`` and the best model check point.
 
 ### Running the code
-To run the example via MLflow, navigate to the `mlflow/examples/pytorch/MNIST/example1` directory and run the command
+To run the example via MLflow, navigate to the `mlflow/examples/pytorch/BertNewsClassification` directory and run the command
 
 ```
 mlflow run .
 ```
 
-This will run `mnist_autolog_example1.py` with the default set of parameters such as  `--max-epochs=5`. You can see the default value in the `MLproject` file.
+This will run `bert_classification.py` with the default set of parameters such as  `--max_epochs=5`. You can see the default value in the `MLproject` file.
 
 In order to run the file with custom parameters, run the command
 
 ```
-mlflow run . -P epochs=X
+mlflow run . -P max_epochs=X
 ```
 
-where `X` is your desired value for `epochs`.
+where `X` is your desired value for `max_epochs`.
 
 If you have the required modules for the file and would like to skip the creation of a conda environment, add the argument `--no-conda`.
 
 ```
 mlflow run . --no-conda
+
 ```
 
-### Example with custom input
-
-Following are the parameters which can be overridden by passing values in command line argument.
-
-1. Number of epochs - max_epochs
-2. Number of gpus - gpus
-3. Backend in case of gpus environment - accelerator
-4. Batch size to process - batch-size
-5. Number of workers to process input - num-workers
-6. Learning rate - lr
-
-For example:
-```
-python mnist_autolog_example1.py \
-    --max-epochs 5 \
-    --gpus 1 \
-    --accelerator "ddp" \
-    --batch-size 64 \
-    --num-workers 3 \
-    --lr 0.001 \
-    --es-patience 5
-```
-
-Apart from model specific arguments, this example demonstrates early stopping behaviour.
-Following are the early stopping parameter which can be set using command line argument
-
-1. monitor is set to `val_loss` (--es-monitor)
-2. mode is set to `min` (--es-mode)
-3. patience is set to default value `3` (--es-patience)
-4. verbose is set to `True` (--es-verbose)
-
+### Viewing results in the MLflow UI
 
 Once the code is finished executing, you can view the run's metrics, parameters, and details by running the command
 
@@ -67,6 +37,44 @@ and navigating to [http://localhost:5000](http://localhost:5000).
 
 For more details on MLflow tracking, see [the docs](https://www.mlflow.org/docs/latest/tracking.html#mlflow-tracking).
 
+
+
+
+### Passing custom training parameters
+
+The parameters can be overridden via the command line:
+
+1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
+2. gpus - Number of GPUs
+3. accelrator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used. 
+4. batch-size - Input batch size for training
+5. num-workers - Number of worker threads to load training data
+6. lr - Learning rate
+7. patience -parameter of early stopping
+8. mode - parameter of early stopping
+9. monitor - parameter of early stopping
+10.verbose - parameter of early stopping
+
+For example:
+```
+mlflow run . -P max_epochs=5 -P gpus=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P accelerator="ddp" -P patience=5 -P mode="min" -P monitor="val_loss" -P verbose=True
+```
+
+Or to run the training script directly with custom parameters:
+```
+python mnist_autolog_example1.py \
+    --max_epochs 5 \
+    --gpus 1 \
+    --accelerator "ddp" \
+    --batch-size 64 \
+    --num-workers 3 \
+    --lr 0.001 \
+    --es-patience 5
+    --es-mode "min"
+    --es-monitor "val_loss"
+    --es-verbose True
+```
+
 ## Logging to a custom tracking server
-To configure MLflow to log to a custom (non-default) tracking location, set the ``MLFLOW_TRACKING_URI`` environment variable, e.g. via  ``export MLFLOW_TRACKING_URI=http://localhost:5000/``.  For more details, see [the docs](https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded)
+To configure MLflow to log to a custom (non-default) tracking location, set the MLFLOW_TRACKING_URI environment variable, e.g. via export MLFLOW_TRACKING_URI=http://localhost:5000/. For more details, see [the docs](https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded).
 

--- a/examples/pytorch/MNIST/example1/README.md
+++ b/examples/pytorch/MNIST/example1/README.md
@@ -1,11 +1,6 @@
 ## MNIST example with MLFlow
-In this example, we train a Pytorch Lightning model adapted from [github](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/basic_examples/mnist.py) to predict handwritten digits. The code is almost entirely dedicated to model training, with the addition of a single line of code ``mlflow.pytorch.autolog()``. Apart from automatic logging of params, metrics, model and its summary from training, the call would also enable saving of parameters and metrics related to ``early stopping callback`` and the best model check point. 
+In this example, we train a Pytorch Lightning model adapted from [this repository](https://github.com/PyTorchLightning/pytorch-lightning/blob/e81707ba0242f12f47d742e86a982f529a7ae65b/pl_examples/basic_examples/mnist.py) to predict handwritten digits. The code is almost entirely dedicated to model training, with the addition of ``mlflow.pytorch.autolog()`` call to enable automatic logging of params, metrics, and models from training.
 
-
-### Code related to MLflow:
-* [`mlflow.pytorch.autolog`]
-This is an experimental api that logs ML model artifacts and metrics.
-The metrics are logged during training of the model.
 
 ### Running the code
 To run the example via MLflow, navigate to the `mlflow/examples/pytorch/MNIST/example1` directory and run the command

--- a/examples/pytorch/MNIST/example1/README.md
+++ b/examples/pytorch/MNIST/example1/README.md
@@ -1,21 +1,11 @@
 ## MNIST example with MLFlow
+In this example, we train a Pytorch Lightning model adapted from [github](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/basic_examples/mnist.py) to predict handwritten digits. The code is almost entirely dedicated to model training, with the addition of a single line of code ``mlflow.pytorch.autolog()``. Apart from automatic logging of params, metrics, model and its summary from training, the call would also enable saving of parameters and metrics related to ``early stopping callback`` and the best model check point. 
 
-In this example, we train a model to predict handwritten digits.The autolog code uses Pytorch Lightning's MLFlowLogger to log metrics. 
-The code is trained using pytorch lightning loop and the autolog function call in the main - `mlflow.pytorch.autolog()`
-is responsible for logging the params, metrics, model summary and the model.
-Early stopping condition and Model Checkpoint are added in this example.
 
 ### Code related to MLflow:
 * [`mlflow.pytorch.autolog`]
 This is an experimental api that logs ML model artifacts and metrics.
 The metrics are logged during training of the model.
-
-## Setting tracking URI
-MLflow tracking URI can be set using the environment variable MLFLOW_TRACKING_URI
-
-Example: `export MLFLOW_TRACKING_URI=http://localhost:5000/`
-
-For more details - https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded
 
 ### Running the code
 To run the example via MLflow, navigate to the `mlflow/examples/pytorch/MNIST/example1` directory and run the command
@@ -80,4 +70,8 @@ mlflow ui
 
 and navigating to [http://localhost:5000](http://localhost:5000).
 
-For more information on MLflow tracking, click [here](https://www.mlflow.org/docs/latest/tracking.html#mlflow-tracking) to view documentation.
+For more details on MLflow tracking, see [the docs](https://www.mlflow.org/docs/latest/tracking.html#mlflow-tracking).
+
+## Logging to a custom tracking server
+To configure MLflow to log to a custom (non-default) tracking location, set the ``MLFLOW_TRACKING_URI`` environment variable, e.g. via  ``export MLFLOW_TRACKING_URI=http://localhost:5000/``.  For more details, see [the docs](https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded)
+

--- a/examples/pytorch/MNIST/example1/README.md
+++ b/examples/pytorch/MNIST/example1/README.md
@@ -1,14 +1,16 @@
 ## MNIST example with MLFlow
-In this example, we train a Pytorch Lightning model to preidct handwritten digits. The code, adapted from this [repository](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/basic_examples/mnist.py), is almost entirely dedicated to model training, with the addition of a single mlflow.pytorch.autolog() call to enable automatic logging of params, metrics, and models.Additionally the call would also enable saving of parameters and metrics related to ``early stopping callback`` and the best model check point.
+In this example, we train a Pytorch Lightning model to predict handwritten digits, leveraging early stopping.
+The code, adapted from this [repository](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/basic_examples/mnist.py), is almost entirely dedicated to model training, with the addition of a single ``mlflow.pytorch.autolog()`` call to enable automatic logging of params, metrics, and models,
+including the best model from early stopping.
 
 ### Running the code
-To run the example via MLflow, navigate to the `mlflow/examples/pytorch/BertNewsClassification` directory and run the command
+To run the example via MLflow, navigate to the `mlflow/examples/pytorch/MNIST/example1` directory and run the command
 
 ```
 mlflow run .
 ```
 
-This will run `bert_classification.py` with the default set of parameters such as  `--max_epochs=5`. You can see the default value in the `MLproject` file.
+This will run `mnist_autolog_example1.py` with the default set of parameters such as  `--max_epochs=5`. You can see the default value in the `MLproject` file.
 
 In order to run the file with custom parameters, run the command
 
@@ -46,7 +48,7 @@ The parameters can be overridden via the command line:
 
 1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
 2. gpus - Number of GPUs
-3. accelrator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used. 
+3. accelerator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used. 
 4. batch-size - Input batch size for training
 5. num-workers - Number of worker threads to load training data
 6. lr - Learning rate

--- a/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
+++ b/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
@@ -78,7 +78,7 @@ class MNISTDataModule(pl.LightningDataModule):
             type=int,
             default=3,
             metavar="N",
-            help="number of workers (default: 0)",
+            help="number of workers (default: 3)",
         )
         return parser
 

--- a/examples/pytorch/MNIST/example2/MLproject
+++ b/examples/pytorch/MNIST/example2/MLproject
@@ -5,7 +5,7 @@ conda_env: conda.yaml
 entry_points:
   main:
     parameters:
-      epochs: {type: int, default: 5}
+      max_epochs: {type: int, default: 5}
       gpus: {type: int, default: 0}
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
@@ -13,7 +13,7 @@ entry_points:
 
     command: |
           python mnist_autolog_example2.py \
-            --max-epochs {epochs} \
+            --max_epochs {max_epochs} \
             --gpus {gpus} \
             --batch-size {batch_size} \
             --num-workers {num_workers} \

--- a/examples/pytorch/MNIST/example2/README.md
+++ b/examples/pytorch/MNIST/example2/README.md
@@ -1,14 +1,20 @@
 ## MNIST example with MLFlow
-In this example, we train a Pytorch Lightning model to preidct handwritten digits. The code, adapted from this [repository](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/basic_examples/mnist.py), is almost entirely dedicated to model training, with the addition of a single mlflow.pytorch.autolog() call to enable automatic logging of params, metrics, and models every nth epoch.
+In this example, we train a Pytorch Lightning model to predict handwritten digits.
+The code, adapted from this
+[repository](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/basic_examples/mnist.py),
+is almost entirely dedicated to model training, with the addition of a single ``mlflow.pytorch.autolog()`` call to enable automatic logging of params, metrics, and models.
+In this example, we also demonstrate customizing the frequency of metric logging by passing the
+``log_every_n_epoch`` parameter to ``mlflow.pytorch.autolog``.
+
 
 ### Running the code
-To run the example via MLflow, navigate to the `mlflow/examples/pytorch/BertNewsClassification` directory and run the command
+To run the example via MLflow, navigate to the `mlflow/examples/pytorch/MNIST/example2` directory and run the command
 
 ```
 mlflow run .
 ```
 
-This will run `bert_classification.py` with the default set of parameters such as  `--max_epochs=5`. You can see the default value in the `MLproject` file.
+This will run `mnist_autolog_example2.py` with the default set of parameters such as  `--max_epochs=5`. You can see the default value in the `MLproject` file.
 
 In order to run the file with custom parameters, run the command
 
@@ -43,7 +49,7 @@ The parameters can be overridden via the command line:
 
 1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
 2. gpus - Number of GPUs
-3. accelrator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used. 
+3. accelerator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used. 
 4. batch-size - Input batch size for training
 5. num-workers - Number of worker threads to load training data
 6. lr - Learning rate

--- a/examples/pytorch/MNIST/example2/README.md
+++ b/examples/pytorch/MNIST/example2/README.md
@@ -1,22 +1,13 @@
 ## MNIST example with MLFlow
+In this example, we train a Pytorch Lightning model adapted from [github](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/basic_examples/mnist.py) to predict handwritten digits. The code is almost entirely dedicated to model training, with the addition of a single line of code ``mlflow.pytorch.autolog()``. This call would enable automatic logging of params, metrics, model and its summary from training. The example would log metrics every nth epoch. It must be noted that the ``log_every_n_epoch parameter`` is user defined and an example of the same is shown below.
 
-In this example, we train a model to predict handwritten digits.The autolog code uses Pytorch Lightning's MLFlowLogger to log metrics. 
-The code is trained using pytorch lightning loop and the autolog function call in the main - `mlflow.pytorch.autolog()`
-is responsible for logging the params, metrics, model summary and the model.
-This example logs metrics only after n epoch iterations. The iteration limit can be set in the autolog method using the parameter `log_every_n_iter=NUMBER-OF-EPOCH`.
 For ex: `mlflow.pytorch.autolog(log_every_n_epoch=5)`
+
 
 ### Code related to MLflow:
 * [`mlflow.pytorch.autolog`]
 This is an experimental api that logs ML model artifacts and metrics.
 The metrics are logged during training of the model.
-
-## Setting tracking URI
-MLflow tracking URI can be set using the environment variable MLFLOW_TRACKING_URI
-
-Example: `export MLFLOW_TRACKING_URI=http://localhost:5000/`
-
-For more details - https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded
 
 ### Running the code
 To run the example via MLflow, navigate to the `mlflow/examples/pytorch/MNIST/example2` directory and run the command
@@ -71,6 +62,8 @@ mlflow ui
 
 and navigating to [http://localhost:5000](http://localhost:5000).
 
-For more information on MLflow tracking, click [here](https://www.mlflow.org/docs/latest/tracking.html#mlflow-tracking) to view documentation.
+For more details on MLflow tracking, see [the docs](https://www.mlflow.org/docs/latest/tracking.html#mlflow-tracking).
 
+## Logging to a custom tracking server
+To configure MLflow to log to a custom (non-default) tracking location, set the ``MLFLOW_TRACKING_URI`` environment variable, e.g. via  ``export MLFLOW_TRACKING_URI=http://localhost:5000/``.  For more details, see [the docs](https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded)
 

--- a/examples/pytorch/MNIST/example2/README.md
+++ b/examples/pytorch/MNIST/example2/README.md
@@ -1,58 +1,31 @@
 ## MNIST example with MLFlow
-In this example, we train a Pytorch Lightning model adapted from [github](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/basic_examples/mnist.py) to predict handwritten digits. The code is almost entirely dedicated to model training, with the addition of a single line of code ``mlflow.pytorch.autolog()``. This call would enable automatic logging of params, metrics, model and its summary from training. The example would log metrics every nth epoch. It must be noted that the ``log_every_n_epoch parameter`` is user defined and an example of the same is shown below.
-
-For ex: `mlflow.pytorch.autolog(log_every_n_epoch=5)`
-
-
-### Code related to MLflow:
-* [`mlflow.pytorch.autolog`]
-This is an experimental api that logs ML model artifacts and metrics.
-The metrics are logged during training of the model.
+In this example, we train a Pytorch Lightning model to preidct handwritten digits. The code, adapted from this [repository](https://github.com/PyTorchLightning/pytorch-lightning/blob/master/pl_examples/basic_examples/mnist.py), is almost entirely dedicated to model training, with the addition of a single mlflow.pytorch.autolog() call to enable automatic logging of params, metrics, and models every nth epoch.
 
 ### Running the code
-To run the example via MLflow, navigate to the `mlflow/examples/pytorch/MNIST/example2` directory and run the command
+To run the example via MLflow, navigate to the `mlflow/examples/pytorch/BertNewsClassification` directory and run the command
 
 ```
 mlflow run .
 ```
 
-This will run `mnist_autolog_example2.py` with the default set of parameters such as  `--max-epochs=5`. You can see the default value in the `MLproject` file.
+This will run `bert_classification.py` with the default set of parameters such as  `--max_epochs=5`. You can see the default value in the `MLproject` file.
 
 In order to run the file with custom parameters, run the command
 
 ```
-mlflow run . -P epochs=X
+mlflow run . -P max_epochs=X
 ```
 
-where `X` is your desired value for `epochs`.
+where `X` is your desired value for `max_epochs`.
 
 If you have the required modules for the file and would like to skip the creation of a conda environment, add the argument `--no-conda`.
 
 ```
 mlflow run . --no-conda
+
 ```
 
-### Example with custom input
-
-Following are the parameters which can be overridden by passing values in command line argument.
-
-1. Number of epochs - max_epochs
-2. Number of gpus - gpus
-3. Backend in case of gpus environment - accelerator
-4. Batch size to process - batch-size
-5. Number of workers to process input - num-workers
-6. Learning rate - lr
-
-For example:
-```
-python mnist_autolog_example2.py \
-    --max-epochs 5 \
-    --gpus 1 \
-    --accelerator "ddp" \
-    --batch-size 64 \
-    --num-workers 3 \
-    --lr 0.001
-```
+### Viewing results in the MLflow UI
 
 Once the code is finished executing, you can view the run's metrics, parameters, and details by running the command
 
@@ -64,6 +37,37 @@ and navigating to [http://localhost:5000](http://localhost:5000).
 
 For more details on MLflow tracking, see [the docs](https://www.mlflow.org/docs/latest/tracking.html#mlflow-tracking).
 
+### Passing custom training parameters
+
+The parameters can be overridden via the command line:
+
+1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
+2. gpus - Number of GPUs
+3. accelrator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used. 
+4. batch-size - Input batch size for training
+5. num-workers - Number of worker threads to load training data
+6. lr - Learning rate
+
+For example:
+
+```
+mlflow run . -P max_epochs=5 -P gpus=1 -P batch_size=32 -P num_workers=2 -P learning_rate=0.01 -P accelerator="ddp"
+```
+Or to run the training script directly with custom parameters:
+
+```
+python mnist_autolog_example2.py \
+    --max_epochs 5 \
+    --gpus 1 \
+    --accelerator "ddp" \
+    --batch-size 64 \
+    --num-workers 3 \
+    --lr 0.001 \
+```
+
 ## Logging to a custom tracking server
-To configure MLflow to log to a custom (non-default) tracking location, set the ``MLFLOW_TRACKING_URI`` environment variable, e.g. via  ``export MLFLOW_TRACKING_URI=http://localhost:5000/``.  For more details, see [the docs](https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded)
+To configure MLflow to log to a custom (non-default) tracking location, set the MLFLOW_TRACKING_URI environment variable, e.g. via export MLFLOW_TRACKING_URI=http://localhost:5000/. For more details, see [the docs](https://mlflow.org/docs/latest/tracking.html#where-runs-are-recorded).
+
+
+
 

--- a/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
+++ b/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
@@ -80,7 +80,7 @@ class MNISTDataModule(pl.LightningDataModule):
             type=int,
             default=3,
             metavar="N",
-            help="number of workers (default: 0)",
+            help="number of workers (default: 3)",
         )
         return parser
 


### PR DESCRIPTION
…cation and Mnist example file

Signed-off-by: karthik-77 <karthiks@ideas2it.com>

## What changes are proposed in this pull request?

Updated readme files for the pytorch autolog examples :bert-news-classification,mnist -example1,example2

## How is this patch tested?

Documentation - NA

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
