### PR TITLE
Pytorch autolog Examples - Fixing argument parser & Adding `accelerator` to MLProject

### DIFF
--- a/examples/pytorch/BertNewsClassification/MLproject
+++ b/examples/pytorch/BertNewsClassification/MLproject
@@ -7,14 +7,18 @@ entry_points:
     parameters:
       max_epochs: {type: int, default: 5}
       gpus: {type: int, default: 0}
+      accelerator: {type str, default: "None"}
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
+      num_samples: {type: int, default: 15000}
 
     command: |
           python bert_classification.py \
             --max_epochs {max_epochs} \
             --gpus {gpus} \
+            --accelerator {accelerator} \
             --batch-size {batch_size} \
             --num-workers {num_workers} \
+            --num-samples {num_samples} \
             --lr {learning_rate}

--- a/examples/pytorch/BertNewsClassification/MLproject
+++ b/examples/pytorch/BertNewsClassification/MLproject
@@ -18,7 +18,7 @@ entry_points:
             --max_epochs {max_epochs} \
             --gpus {gpus} \
             --accelerator {accelerator} \
-            --batch-size {batch_size} \
-            --num-workers {num_workers} \
-            --num-samples {num_samples} \
+            --batch_size {batch_size} \
+            --num_workers {num_workers} \
+            --num_samples {num_samples} \
             --lr {learning_rate}

--- a/examples/pytorch/BertNewsClassification/README.md
+++ b/examples/pytorch/BertNewsClassification/README.md
@@ -45,8 +45,8 @@ The parameters can be overridden via the command line:
 1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
 2. gpus - Number of GPUs
 3. accelerator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used. 
-4. batch-size - Input batch size for training
-5. num-workers - Number of worker threads to load training data
+4. batch_size - Input batch size for training
+5. num_workers - Number of worker threads to load training data
 6. lr - Learning rate
 
 For example:

--- a/examples/pytorch/BertNewsClassification/README.md
+++ b/examples/pytorch/BertNewsClassification/README.md
@@ -60,8 +60,8 @@ python bert_classification.py \
     --max_epochs 5 \
     --gpus 1 \
     --accelerator "ddp" \
-    --batch-size 64 \
-    --num-workers 2 \
+    --batch_size 64 \
+    --num_workers 2 \
     --lr 0.001
 ```
 

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -365,20 +365,6 @@ class BertNewsClassifier(pl.LightningModule):
 if __name__ == "__main__":
     parser = ArgumentParser(description="Bert-News Classifier Example")
 
-    # Add trainer specific arguments
-    parser.add_argument(
-        "--max_epochs", type=int, default=10, help="number of epochs to run (default: 10)"
-    )
-    parser.add_argument(
-        "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"
-    )
-    parser.add_argument(
-        "--accelerator",
-        type=lambda x: None if x == "None" else x,
-        default=None,
-        help="Accelerator - (default: None)",
-    )
-
     parser.add_argument(
         "--num-samples",
         type=int,
@@ -387,14 +373,18 @@ if __name__ == "__main__":
         help="Number of samples to be used for training and evaluation steps (default: 15000) Maximum:100000",
     )
 
+    parser = pl.Trainer.add_argparse_args(parent_parser=parser)
     parser = BertNewsClassifier.add_model_specific_args(parent_parser=parser)
-
     parser = BertDataModule.add_model_specific_args(parent_parser=parser)
 
     mlflow.pytorch.autolog()
 
     args = parser.parse_args()
     dict_args = vars(args)
+
+    if "accelerator" in dict_args:
+        if dict_args["accelerator"] == "None":
+            dict_args["accelerator"] = None
 
     dm = BertDataModule(**dict_args)
     dm.prepare_data()

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -269,7 +269,11 @@ class BertNewsClassifier(pl.LightningModule):
         """
         parser = ArgumentParser(parents=[parent_parser], add_help=False)
         parser.add_argument(
-            "--lr", type=float, default=0.001, metavar="LR", help="learning rate (default: 0.001)",
+            "--lr",
+            type=float,
+            default=0.001,
+            metavar="LR",
+            help="learning rate (default: 0.001)",
         )
         return parser
 
@@ -355,7 +359,12 @@ class BertNewsClassifier(pl.LightningModule):
         self.optimizer = AdamW(self.parameters(), lr=self.args["lr"])
         self.scheduler = {
             "scheduler": torch.optim.lr_scheduler.ReduceLROnPlateau(
-                self.optimizer, mode="min", factor=0.2, patience=2, min_lr=1e-6, verbose=True,
+                self.optimizer,
+                mode="min",
+                factor=0.2,
+                patience=2,
+                min_lr=1e-6,
+                verbose=True,
             ),
             "monitor": "val_loss",
         }
@@ -373,7 +382,10 @@ if __name__ == "__main__":
         "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"
     )
     parser.add_argument(
-        "--accelerator", type=lambda x: None if x == "None" else x, default=None, help="Accelerator - (default: None)",
+        "--accelerator",
+        type=lambda x: None if x == "None" else x,
+        default=None,
+        help="Accelerator - (default: None)",
     )
 
     parser.add_argument(
@@ -401,7 +413,12 @@ if __name__ == "__main__":
     early_stopping = EarlyStopping(monitor="val_loss", mode="min", verbose=True)
 
     checkpoint_callback = ModelCheckpoint(
-        filepath=os.getcwd(), save_top_k=1, verbose=True, monitor="val_loss", mode="min", prefix="",
+        filepath=os.getcwd(),
+        save_top_k=1,
+        verbose=True,
+        monitor="val_loss",
+        mode="min",
+        prefix="",
     )
     lr_logger = LearningRateMonitor()
 

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -373,7 +373,7 @@ if __name__ == "__main__":
         "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"
     )
     parser.add_argument(
-        "--accelerator", type=str, default=None, help="Distributed Backend - (default: None)",
+        "--accelerator", type=lambda x: None if x == "None" else x, default=None, help="Accelerator - (default: None)",
     )
 
     parser.add_argument(

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -367,7 +367,7 @@ if __name__ == "__main__":
 
     # Add trainer specific arguments
     parser.add_argument(
-        "--max-epochs", type=int, default=10, help="number of epochs to run (default: 10)"
+        "--max_epochs", type=int, default=10, help="number of epochs to run (default: 10)"
     )
     parser.add_argument(
         "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -269,11 +269,7 @@ class BertNewsClassifier(pl.LightningModule):
         """
         parser = ArgumentParser(parents=[parent_parser], add_help=False)
         parser.add_argument(
-            "--lr",
-            type=float,
-            default=0.001,
-            metavar="LR",
-            help="learning rate (default: 0.001)",
+            "--lr", type=float, default=0.001, metavar="LR", help="learning rate (default: 0.001)",
         )
         return parser
 
@@ -359,12 +355,7 @@ class BertNewsClassifier(pl.LightningModule):
         self.optimizer = AdamW(self.parameters(), lr=self.args["lr"])
         self.scheduler = {
             "scheduler": torch.optim.lr_scheduler.ReduceLROnPlateau(
-                self.optimizer,
-                mode="min",
-                factor=0.2,
-                patience=2,
-                min_lr=1e-6,
-                verbose=True,
+                self.optimizer, mode="min", factor=0.2, patience=2, min_lr=1e-6, verbose=True,
             ),
             "monitor": "val_loss",
         }
@@ -413,12 +404,7 @@ if __name__ == "__main__":
     early_stopping = EarlyStopping(monitor="val_loss", mode="min", verbose=True)
 
     checkpoint_callback = ModelCheckpoint(
-        filepath=os.getcwd(),
-        save_top_k=1,
-        verbose=True,
-        monitor="val_loss",
-        mode="min",
-        prefix="",
+        filepath=os.getcwd(), save_top_k=1, verbose=True, monitor="val_loss", mode="min", prefix="",
     )
     lr_logger = LearningRateMonitor()
 

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -158,14 +158,14 @@ class BertDataModule(pl.LightningDataModule):
         """
         parser = ArgumentParser(parents=[parent_parser], add_help=False)
         parser.add_argument(
-            "--batch-size",
+            "--batch_size",
             type=int,
             default=16,
             metavar="N",
             help="input batch size for training (default: 16)",
         )
         parser.add_argument(
-            "--num-workers",
+            "--num_workers",
             type=int,
             default=3,
             metavar="N",
@@ -366,7 +366,7 @@ if __name__ == "__main__":
     parser = ArgumentParser(description="Bert-News Classifier Example")
 
     parser.add_argument(
-        "--num-samples",
+        "--num_samples",
         type=int,
         default=15000,
         metavar="N",

--- a/examples/pytorch/BertNewsClassification/conda.yaml
+++ b/examples/pytorch/BertNewsClassification/conda.yaml
@@ -14,4 +14,5 @@ dependencies:
   - cloudpickle==1.6.0
   - boto3
   - transformers
-  - torchtext
+  - torchtext==0.7.0
+  - pandas

--- a/examples/pytorch/MNIST/example1/MLproject
+++ b/examples/pytorch/MNIST/example1/MLproject
@@ -21,10 +21,10 @@ entry_points:
             --max_epochs {max_epochs} \
             --gpus {gpus} \
             --accelerator {accelerator} \
-            --batch-size {batch_size} \
-            --num-workers {num_workers} \
+            --batch_size {batch_size} \
+            --num_workers {num_workers} \
             --lr {learning_rate} \
-            --es-patience {patience} \
-            --es-mode {mode} \
-            --es-verbose {verbose} \
-            --es-monitor {monitor}
+            --es_patience {patience} \
+            --es_mode {mode} \
+            --es_verbose {verbose} \
+            --es_monitor {monitor}

--- a/examples/pytorch/MNIST/example1/MLproject
+++ b/examples/pytorch/MNIST/example1/MLproject
@@ -7,6 +7,7 @@ entry_points:
     parameters:
       max_epochs: {type: int, default: 5}
       gpus: {type: int, default: 0}
+      accelerator: {type str, default: "None"}
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
@@ -19,6 +20,7 @@ entry_points:
           python mnist_autolog_example1.py \
             --max_epochs {max_epochs} \
             --gpus {gpus} \
+            --accelerator {accelerator} \
             --batch-size {batch_size} \
             --num-workers {num_workers} \
             --lr {learning_rate} \

--- a/examples/pytorch/MNIST/example1/README.md
+++ b/examples/pytorch/MNIST/example1/README.md
@@ -49,8 +49,8 @@ The parameters can be overridden via the command line:
 1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
 2. gpus - Number of GPUs
 3. accelerator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used. 
-4. batch-size - Input batch size for training
-5. num-workers - Number of worker threads to load training data
+4. batch_size - Input batch size for training
+5. num_workers - Number of worker threads to load training data
 6. lr - Learning rate
 7. patience -parameter of early stopping
 8. mode - parameter of early stopping
@@ -68,13 +68,13 @@ python mnist_autolog_example1.py \
     --max_epochs 5 \
     --gpus 1 \
     --accelerator "ddp" \
-    --batch-size 64 \
-    --num-workers 3 \
+    --batch_size 64 \
+    --num_workers 3 \
     --lr 0.001 \
-    --es-patience 5
-    --es-mode "min"
-    --es-monitor "val_loss"
-    --es-verbose True
+    --es_patience 5 \
+    --es_mode "min" \
+    --es_monitor "val_loss" \
+    --es_verbose True
 ```
 
 ## Logging to a custom tracking server

--- a/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
+++ b/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
@@ -91,9 +91,7 @@ class MNISTDataModule(pl.LightningDataModule):
         :return: Returns the constructed dataloader
         """
         return DataLoader(
-            df,
-            batch_size=self.args["batch_size"],
-            num_workers=self.args["num_workers"],
+            df, batch_size=self.args["batch_size"], num_workers=self.args["num_workers"],
         )
 
     def train_dataloader(self):
@@ -148,11 +146,7 @@ class LightningMNISTClassifier(pl.LightningModule):
             help="number of workers (default: 3)",
         )
         parser.add_argument(
-            "--lr",
-            type=float,
-            default=0.001,
-            metavar="LR",
-            help="learning rate (default: 0.001)",
+            "--lr", type=float, default=0.001, metavar="LR", help="learning rate (default: 0.001)",
         )
         return parser
 
@@ -271,12 +265,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         self.optimizer = torch.optim.Adam(self.parameters(), lr=self.args["lr"])
         self.scheduler = {
             "scheduler": torch.optim.lr_scheduler.ReduceLROnPlateau(
-                self.optimizer,
-                mode="min",
-                factor=0.2,
-                patience=2,
-                min_lr=1e-6,
-                verbose=True,
+                self.optimizer, mode="min", factor=0.2, patience=2, min_lr=1e-6, verbose=True,
             ),
             "monitor": "val_loss",
         }
@@ -338,12 +327,7 @@ if __name__ == "__main__":
     )
 
     checkpoint_callback = ModelCheckpoint(
-        filepath=os.getcwd(),
-        save_top_k=1,
-        verbose=True,
-        monitor="val_loss",
-        mode="min",
-        prefix="",
+        filepath=os.getcwd(), save_top_k=1, verbose=True, monitor="val_loss", mode="min", prefix="",
     )
     lr_logger = LearningRateMonitor()
 

--- a/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
+++ b/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
@@ -91,7 +91,9 @@ class MNISTDataModule(pl.LightningDataModule):
         :return: Returns the constructed dataloader
         """
         return DataLoader(
-            df, batch_size=self.args["batch_size"], num_workers=self.args["num_workers"],
+            df,
+            batch_size=self.args["batch_size"],
+            num_workers=self.args["num_workers"],
         )
 
     def train_dataloader(self):
@@ -146,7 +148,11 @@ class LightningMNISTClassifier(pl.LightningModule):
             help="number of workers (default: 3)",
         )
         parser.add_argument(
-            "--lr", type=float, default=0.001, metavar="LR", help="learning rate (default: 0.001)",
+            "--lr",
+            type=float,
+            default=0.001,
+            metavar="LR",
+            help="learning rate (default: 0.001)",
         )
         return parser
 
@@ -265,7 +271,12 @@ class LightningMNISTClassifier(pl.LightningModule):
         self.optimizer = torch.optim.Adam(self.parameters(), lr=self.args["lr"])
         self.scheduler = {
             "scheduler": torch.optim.lr_scheduler.ReduceLROnPlateau(
-                self.optimizer, mode="min", factor=0.2, patience=2, min_lr=1e-6, verbose=True,
+                self.optimizer,
+                mode="min",
+                factor=0.2,
+                patience=2,
+                min_lr=1e-6,
+                verbose=True,
             ),
             "monitor": "val_loss",
         }
@@ -284,7 +295,10 @@ if __name__ == "__main__":
         "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"
     )
     parser.add_argument(
-        "--accelerator", type=lambda x: None if x == "None" else x, default=None, help="Accelerator - (default: None)",
+        "--accelerator",
+        type=lambda x: None if x == "None" else x,
+        default=None,
+        help="Accelerator - (default: None)",
     )
 
     # Early stopping parameters
@@ -324,7 +338,12 @@ if __name__ == "__main__":
     )
 
     checkpoint_callback = ModelCheckpoint(
-        filepath=os.getcwd(), save_top_k=1, verbose=True, monitor="val_loss", mode="min", prefix="",
+        filepath=os.getcwd(),
+        save_top_k=1,
+        verbose=True,
+        monitor="val_loss",
+        mode="min",
+        prefix="",
     )
     lr_logger = LearningRateMonitor()
 

--- a/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
+++ b/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
@@ -275,23 +275,7 @@ class LightningMNISTClassifier(pl.LightningModule):
 if __name__ == "__main__":
     parser = ArgumentParser(description="PyTorch Autolog Mnist Example")
 
-    # Add trainer specific arguments
-
-    parser.add_argument(
-        "--max_epochs", type=int, default=20, help="number of epochs to run (default: 20)"
-    )
-    parser.add_argument(
-        "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"
-    )
-    parser.add_argument(
-        "--accelerator",
-        type=lambda x: None if x == "None" else x,
-        default=None,
-        help="Accelerator - (default: None)",
-    )
-
     # Early stopping parameters
-
     parser.add_argument(
         "--es-monitor", type=str, default="val_loss", help="Early stopping monitor parameter"
     )
@@ -306,12 +290,17 @@ if __name__ == "__main__":
         "--es-patience", type=int, default=3, help="Early stopping patience parameter"
     )
 
+    parser = pl.Trainer.add_argparse_args(parent_parser=parser)
     parser = LightningMNISTClassifier.add_model_specific_args(parent_parser=parser)
 
     mlflow.pytorch.autolog()
 
     args = parser.parse_args()
     dict_args = vars(args)
+
+    if "accelerator" in dict_args:
+        if dict_args["accelerator"] == "None":
+            dict_args["accelerator"] = None
 
     model = LightningMNISTClassifier(**dict_args)
 

--- a/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
+++ b/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
@@ -278,7 +278,7 @@ if __name__ == "__main__":
     # Add trainer specific arguments
 
     parser.add_argument(
-        "--max-epochs", type=int, default=20, help="number of epochs to run (default: 20)"
+        "--max_epochs", type=int, default=20, help="number of epochs to run (default: 20)"
     )
     parser.add_argument(
         "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"

--- a/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
+++ b/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
@@ -56,32 +56,6 @@ class MNISTDataModule(pl.LightningDataModule):
             "dataset", download=True, train=False, transform=self.transform
         )
 
-    @staticmethod
-    def add_model_specific_args(parent_parser):
-        """
-        Returns the review text and the targets of the specified item
-
-        :param parent_parser: Application specific parser
-
-        :return: Returns the augmented arugument parser
-        """
-        parser = ArgumentParser(parents=[parent_parser], add_help=False)
-        parser.add_argument(
-            "--batch-size",
-            type=int,
-            default=16,
-            metavar="N",
-            help="input batch size for training (default: 16)",
-        )
-        parser.add_argument(
-            "--num-workers",
-            type=int,
-            default=3,
-            metavar="N",
-            help="number of workers (default: 3)",
-        )
-        return parser
-
     def create_data_loader(self, df):
         """
         Generic data loader function
@@ -132,14 +106,14 @@ class LightningMNISTClassifier(pl.LightningModule):
     def add_model_specific_args(parent_parser):
         parser = ArgumentParser(parents=[parent_parser], add_help=False)
         parser.add_argument(
-            "--batch-size",
+            "--batch_size",
             type=int,
             default=64,
             metavar="N",
             help="input batch size for training (default: 64)",
         )
         parser.add_argument(
-            "--num-workers",
+            "--num_workers",
             type=int,
             default=3,
             metavar="N",
@@ -277,17 +251,17 @@ if __name__ == "__main__":
 
     # Early stopping parameters
     parser.add_argument(
-        "--es-monitor", type=str, default="val_loss", help="Early stopping monitor parameter"
+        "--es_monitor", type=str, default="val_loss", help="Early stopping monitor parameter"
     )
 
-    parser.add_argument("--es-mode", type=str, default="min", help="Early stopping mode parameter")
+    parser.add_argument("--es_mode", type=str, default="min", help="Early stopping mode parameter")
 
     parser.add_argument(
-        "--es-verbose", type=bool, default=True, help="Early stopping verbose parameter"
+        "--es_verbose", type=bool, default=True, help="Early stopping verbose parameter"
     )
 
     parser.add_argument(
-        "--es-patience", type=int, default=3, help="Early stopping patience parameter"
+        "--es_patience", type=int, default=3, help="Early stopping patience parameter"
     )
 
     parser = pl.Trainer.add_argparse_args(parent_parser=parser)

--- a/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
+++ b/examples/pytorch/MNIST/example1/mnist_autolog_example1.py
@@ -284,7 +284,7 @@ if __name__ == "__main__":
         "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"
     )
     parser.add_argument(
-        "--accelerator", type=str, default=None, help="Accelerator - (default: None)",
+        "--accelerator", type=lambda x: None if x == "None" else x, default=None, help="Accelerator - (default: None)",
     )
 
     # Early stopping parameters

--- a/examples/pytorch/MNIST/example2/MLproject
+++ b/examples/pytorch/MNIST/example2/MLproject
@@ -17,6 +17,6 @@ entry_points:
             --max_epochs {max_epochs} \
             --gpus {gpus} \
             --accelerator {accelerator} \
-            --batch-size {batch_size} \
-            --num-workers {num_workers} \
+            --batch_size {batch_size} \
+            --num_workers {num_workers} \
             --lr {learning_rate}

--- a/examples/pytorch/MNIST/example2/MLproject
+++ b/examples/pytorch/MNIST/example2/MLproject
@@ -7,6 +7,7 @@ entry_points:
     parameters:
       max_epochs: {type: int, default: 5}
       gpus: {type: int, default: 0}
+      accelerator: {type str, default: "None"}
       batch_size: {type: int, default: 64}
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
@@ -15,6 +16,7 @@ entry_points:
           python mnist_autolog_example2.py \
             --max_epochs {max_epochs} \
             --gpus {gpus} \
+            --accelerator {accelerator} \
             --batch-size {batch_size} \
             --num-workers {num_workers} \
             --lr {learning_rate}

--- a/examples/pytorch/MNIST/example2/README.md
+++ b/examples/pytorch/MNIST/example2/README.md
@@ -50,8 +50,8 @@ The parameters can be overridden via the command line:
 1. max_epochs - Number of epochs to train model. Training can be interrupted early via Ctrl+C
 2. gpus - Number of GPUs
 3. accelerator - [Accelerator backend](https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#trainer-flags) (e.g. "ddp" for the Distributed Data Parallel backend) to use for training. By default, no accelerator is used. 
-4. batch-size - Input batch size for training
-5. num-workers - Number of worker threads to load training data
+4. batch_size - Input batch size for training
+5. num_workers - Number of worker threads to load training data
 6. lr - Learning rate
 
 For example:
@@ -66,9 +66,9 @@ python mnist_autolog_example2.py \
     --max_epochs 5 \
     --gpus 1 \
     --accelerator "ddp" \
-    --batch-size 64 \
-    --num-workers 3 \
-    --lr 0.001 \
+    --batch_size 64 \
+    --num_workers 3 \
+    --lr 0.001
 ```
 
 ## Logging to a custom tracking server

--- a/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
+++ b/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
@@ -93,9 +93,7 @@ class MNISTDataModule(pl.LightningDataModule):
         :return: Returns the constructed dataloader
         """
         return DataLoader(
-            df,
-            batch_size=self.args["batch_size"],
-            num_workers=self.args["num_workers"],
+            df, batch_size=self.args["batch_size"], num_workers=self.args["num_workers"],
         )
 
     def train_dataloader(self):
@@ -150,11 +148,7 @@ class LightningMNISTClassifier(pl.LightningModule):
             help="number of workers (default: 3)",
         )
         parser.add_argument(
-            "--lr",
-            type=float,
-            default=0.001,
-            metavar="LR",
-            help="learning rate (default: 0.001)",
+            "--lr", type=float, default=0.001, metavar="LR", help="learning rate (default: 0.001)",
         )
         return parser
 
@@ -273,12 +267,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         self.optimizer = torch.optim.Adam(self.parameters(), lr=self.args["lr"])
         self.scheduler = {
             "scheduler": torch.optim.lr_scheduler.ReduceLROnPlateau(
-                self.optimizer,
-                mode="min",
-                factor=0.2,
-                patience=2,
-                min_lr=1e-6,
-                verbose=True,
+                self.optimizer, mode="min", factor=0.2, patience=2, min_lr=1e-6, verbose=True,
             ),
             "monitor": "val_loss",
         }

--- a/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
+++ b/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
@@ -285,7 +285,7 @@ if __name__ == "__main__":
         "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"
     )
     parser.add_argument(
-        "--accelerator", type=str, default=None, help="Accelerator - (default: None)",
+        "--accelerator", type=lambda x: None if x == "None" else x, default=None, help="Accelerator - (default: None)",
     )
     parser = LightningMNISTClassifier.add_model_specific_args(parent_parser=parser)
 

--- a/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
+++ b/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
@@ -93,7 +93,9 @@ class MNISTDataModule(pl.LightningDataModule):
         :return: Returns the constructed dataloader
         """
         return DataLoader(
-            df, batch_size=self.args["batch_size"], num_workers=self.args["num_workers"],
+            df,
+            batch_size=self.args["batch_size"],
+            num_workers=self.args["num_workers"],
         )
 
     def train_dataloader(self):
@@ -148,7 +150,11 @@ class LightningMNISTClassifier(pl.LightningModule):
             help="number of workers (default: 3)",
         )
         parser.add_argument(
-            "--lr", type=float, default=0.001, metavar="LR", help="learning rate (default: 0.001)",
+            "--lr",
+            type=float,
+            default=0.001,
+            metavar="LR",
+            help="learning rate (default: 0.001)",
         )
         return parser
 
@@ -267,7 +273,12 @@ class LightningMNISTClassifier(pl.LightningModule):
         self.optimizer = torch.optim.Adam(self.parameters(), lr=self.args["lr"])
         self.scheduler = {
             "scheduler": torch.optim.lr_scheduler.ReduceLROnPlateau(
-                self.optimizer, mode="min", factor=0.2, patience=2, min_lr=1e-6, verbose=True,
+                self.optimizer,
+                mode="min",
+                factor=0.2,
+                patience=2,
+                min_lr=1e-6,
+                verbose=True,
             ),
             "monitor": "val_loss",
         }
@@ -285,7 +296,10 @@ if __name__ == "__main__":
         "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"
     )
     parser.add_argument(
-        "--accelerator", type=lambda x: None if x == "None" else x, default=None, help="Accelerator - (default: None)",
+        "--accelerator",
+        type=lambda x: None if x == "None" else x,
+        default=None,
+        help="Accelerator - (default: None)",
     )
     parser = LightningMNISTClassifier.add_model_specific_args(parent_parser=parser)
 

--- a/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
+++ b/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
@@ -277,25 +277,17 @@ class LightningMNISTClassifier(pl.LightningModule):
 if __name__ == "__main__":
     parser = ArgumentParser(description="PyTorch autolog Mnist Example")
 
-    # Add trainer specific arguments
-    parser.add_argument(
-        "--max_epochs", type=int, default=5, help="number of epochs to run (default: 5)"
-    )
-    parser.add_argument(
-        "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"
-    )
-    parser.add_argument(
-        "--accelerator",
-        type=lambda x: None if x == "None" else x,
-        default=None,
-        help="Accelerator - (default: None)",
-    )
+    parser = pl.Trainer.add_argparse_args(parent_parser=parser)
     parser = LightningMNISTClassifier.add_model_specific_args(parent_parser=parser)
 
     mlflow.pytorch.autolog(log_every_n_epoch=2)
 
     args = parser.parse_args()
     dict_args = vars(args)
+
+    if "accelerator" in dict_args:
+        if dict_args["accelerator"] == "None":
+            dict_args["accelerator"] = None
 
     dm = MNISTDataModule(**dict_args)
     dm.prepare_data()

--- a/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
+++ b/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
@@ -58,32 +58,6 @@ class MNISTDataModule(pl.LightningDataModule):
             "dataset", download=True, train=False, transform=self.transform
         )
 
-    @staticmethod
-    def add_model_specific_args(parent_parser):
-        """
-        Returns the review text and the targets of the specified item
-
-        :param parent_parser: Application specific parser
-
-        :return: Returns the augmented arugument parser
-        """
-        parser = ArgumentParser(parents=[parent_parser], add_help=False)
-        parser.add_argument(
-            "--batch-size",
-            type=int,
-            default=16,
-            metavar="N",
-            help="input batch size for training (default: 16)",
-        )
-        parser.add_argument(
-            "--num-workers",
-            type=int,
-            default=3,
-            metavar="N",
-            help="number of workers (default: 3)",
-        )
-        return parser
-
     def create_data_loader(self, df):
         """
         Generic data loader function
@@ -134,14 +108,14 @@ class LightningMNISTClassifier(pl.LightningModule):
     def add_model_specific_args(parent_parser):
         parser = ArgumentParser(parents=[parent_parser], add_help=False)
         parser.add_argument(
-            "--batch-size",
+            "--batch_size",
             type=int,
             default=64,
             metavar="N",
             help="input batch size for training (default: 64)",
         )
         parser.add_argument(
-            "--num-workers",
+            "--num_workers",
             type=int,
             default=3,
             metavar="N",

--- a/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
+++ b/examples/pytorch/MNIST/example2/mnist_autolog_example2.py
@@ -279,7 +279,7 @@ if __name__ == "__main__":
 
     # Add trainer specific arguments
     parser.add_argument(
-        "--max-epochs", type=int, default=5, help="number of epochs to run (default: 5)"
+        "--max_epochs", type=int, default=5, help="number of epochs to run (default: 5)"
     )
     parser.add_argument(
         "--gpus", type=int, default=0, help="Number of gpus - by default runs on CPU"


### PR DESCRIPTION
Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

Breaking Change - Number of epochs to run argument has been set to `max_epochs` in [README.md](https://github.com/mlflow/mlflow/blob/master/examples/pytorch/MNIST/example1/README.md) and [MLProject](https://github.com/mlflow/mlflow/blob/master/examples/pytorch/MNIST/example1/MLproject). However, all the [examples](https://github.com/mlflow/mlflow/blob/c56d92002fc6dae387e54684b6a61f25896edc9f/examples/pytorch/MNIST/example1/mnist_autolog_example1.py#L281) are still set as `max-epochs` .

Hence, Changing it to `max_epochs` in all the scripts.

Adding `accelerator` parameter to MLProject. For CPU users accelerator parameter will be None by default.

## How is this patch tested?

Tested by running the examples

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
