### PR TITLE
Create experiment set in MLFLOW_EXPERIMENT_NAME

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1193,10 +1193,17 @@ def _get_or_start_run():
 
 
 def _get_experiment_id_from_env():
+    client = MlflowClient()
     experiment_name = env.get_env(_EXPERIMENT_NAME_ENV_VAR)
     if experiment_name is not None:
-        exp = MlflowClient().get_experiment_by_name(experiment_name)
-        return exp.experiment_id if exp else None
+        experiment = client.get_experiment_by_name(experiment_name)
+        exp_id = experiment.experiment_id if experiment else None
+
+        if exp_id is None:  # id can be 0
+            print("INFO: '{}' does not exist. Creating a new experiment".format(experiment_name))
+            exp_id = client.create_experiment(experiment_name)
+
+        return exp_id
     return env.get_env(_EXPERIMENT_ID_ENV_VAR)
 
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -166,6 +166,11 @@ def test_get_experiment_id_with_no_active_experiments_returns_zero():
     assert _get_experiment_id() == "0"
 
 
+def test_get_experiment_id_when_with_new_experiment_returns_active_experiment_id():
+    HelperEnv.set_values(name="new_experiment")
+    assert _get_experiment_id() != "0"
+
+
 def test_get_experiment_id_in_databricks_detects_notebook_id_by_default():
     notebook_id = 768
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

If `MLFLOW_EXPERIMENT_NAME` is set, but the experiment referred to in the the env doesn't exist then MLflow uses the `default` experiment name. 
These changes change behaviour so that MLflow creates an experiment with the env var, and then sets that as the experiment name. 

## How is this patch tested?

There is an additional test for this function in 
`tests/tracking/fluent/test_fluent::test_get_experiment_id_when_with_new_experiment_returns_active_experiment_id`

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Setting `MLFLOW_EXPERIMENT_NAME` will create the named experiment if it doesn't already exist (previously this value was ignored and `default` was used). 

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

With reference to https://github.com/mlflow/mlflow/issues/3656