### PR TITLE
Fix a flaky pytorch autologging test

### DIFF
--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -70,7 +70,9 @@ def test_pytorch_autolog_ends_auto_created_run(pytorch_model):
 def pytorch_model_with_callback(patience):
     mlflow.pytorch.autolog()
     model = IrisClassification()
-    early_stopping = EarlyStopping(monitor="val_loss", mode="min", patience=patience, verbose=True)
+    early_stopping = EarlyStopping(
+        monitor="val_loss", mode="min", min_delta=99999999, patience=patience, verbose=True
+    )
 
     with TempDir() as tmp:
         checkpoint_callback = ModelCheckpoint(

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -71,7 +71,11 @@ def pytorch_model_with_callback(patience):
     mlflow.pytorch.autolog()
     model = IrisClassification()
     early_stopping = EarlyStopping(
-        monitor="val_loss", mode="min", min_delta=99999999, patience=patience, verbose=True
+        monitor="val_loss",
+        mode="min",
+        min_delta=99999999,  # forces early stopping
+        patience=patience,
+        verbose=True,
     )
 
     with TempDir() as tmp:


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

`test_pytorch_early_stop_metrics_logged` in `test_pytorch_autolog.py` sometimes fails when early stopping doesn't occur.

<img width="785" alt="Screen Shot 2020-11-10 at 0 51 14" src="https://user-images.githubusercontent.com/17039389/98563734-e08f9880-22ee-11eb-85d8-1bc440ff9d28.png">

https://github.com/mlflow/mlflow/runs/1372586680#step:4:100

This PR fixes the issue by setting `min_delta` to force early stopping.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
