### PR TITLE
Add Pytorch lightning autologging to universal autologging

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -24,7 +24,7 @@ from mlflow.utils.import_hooks import register_post_import_hook
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_RUN_NAME
 from mlflow.utils.validation import _validate_run_id
 
-from mlflow import tensorflow, keras, gluon, xgboost, lightgbm, spark, sklearn, fastai
+from mlflow import tensorflow, keras, gluon, xgboost, lightgbm, spark, sklearn, fastai, pytorch
 
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"
 _EXPERIMENT_NAME_ENV_VAR = "MLFLOW_EXPERIMENT_NAME"
@@ -1058,6 +1058,9 @@ def autolog(log_input_examples=False, log_model_signatures=True):  # pylint: dis
         "sklearn": sklearn.autolog,
         "fastai": fastai.autolog,
         "pyspark": spark.autolog,
+        # TODO: Broaden this beyond pytorch_lightning as we add autologging support for more
+        # Pytorch frameworks under mlflow.pytorch.autolog
+        "pytorch_lightning": pytorch.autolog,
     }
 
     def setup_autologging(module):

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -12,6 +12,7 @@ import xgboost
 import lightgbm
 import mxnet.gluon
 import pyspark
+import pytorch_lightning
 
 library_to_mlflow_module_without_pyspark = {
     tensorflow: "tensorflow",
@@ -21,6 +22,7 @@ library_to_mlflow_module_without_pyspark = {
     xgboost: "xgboost",
     lightgbm: "lightgbm",
     mxnet.gluon: "gluon",
+    pytorch_lightning: "pytorch",
 }
 
 library_to_mlflow_module = {**library_to_mlflow_module_without_pyspark, pyspark: "spark"}


### PR DESCRIPTION
Signed-off-by: Sid Murching <sid.murching@databricks.com>

## What changes are proposed in this pull request?

Adds ``mlflow.pytorch.autolog`` API to the universal ``mlflow.autolog`` API

## How is this patch tested?

Extending tests verifying that pytorch autologging is enabled when users import the appropriate module (``pytorch_lightning``)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

User-facing, but will be mentioned indirectly as part of the release note item for "Universal autologging for all supported frameworks"

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
