### PR TITLE
Fix library incompatibility for exported Keras models

### DIFF
--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -5,6 +5,9 @@
 azureml-sdk==1.2.0
 # Required by mlflow.keras
 keras==2.3.1
+# Pin h5py < 3.0.0 to avoid this issue: https://github.com/tensorflow/tensorflow/issues/44467
+# TODO: unpin after we use tensorflow >= 2.4
+h5py<3.0.0
 # Required by mlflow.sklearn
 scikit-learn
 # Required by mlflow.gluon

--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -5,8 +5,6 @@
 azureml-sdk==1.2.0
 # Required by mlflow.keras
 keras==2.3.1
-# Pin h5py < 3.0.0 to avoid this issue: https://github.com/h5py/h5py/issues/1732
-h5py<3.0.0
 # Required by mlflow.sklearn
 scikit-learn
 # Required by mlflow.gluon

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -5,11 +5,11 @@ install.packages(package)
 mlflow:::mlflow_maybe_create_conda_env(python_version = "3.6")
 library(reticulate)
 use_condaenv(mlflow:::mlflow_conda_env_name())
+# pinning tensorflow version to 1.14 until test_keras_model.R is fixed
+keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
 # pinning h5py < 3.0.0 to avoid this issue:  https://github.com/tensorflow/tensorflow/issues/44467
 # TODO: unpin after we use tensorflow >= 2.4
 reticulate::conda_install("'h5py<3.0.0'", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
-# pinning tensorflow version to 1.14 until test_keras_model.R is fixed
-keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
 # Pin h2o to prevent version-mismatch between python and R

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -5,6 +5,9 @@ install.packages(package)
 mlflow:::mlflow_maybe_create_conda_env(python_version = "3.6")
 library(reticulate)
 use_condaenv(mlflow:::mlflow_conda_env_name())
+# pinning h5py < 3.0.0 to avoid this issue:  https://github.com/tensorflow/tensorflow/issues/44467
+# TODO: unpin after we use tensorflow >= 2.4
+reticulate::conda_install("'h5py<3.0.0'", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 # pinning tensorflow version to 1.14 until test_keras_model.R is fixed
 keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -7,8 +7,6 @@ library(reticulate)
 use_condaenv(mlflow:::mlflow_conda_env_name())
 # pinning tensorflow version to 1.14 until test_keras_model.R is fixed
 keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
-# pinning h5py < 3.0.0 to avoid this issue: https://github.com/h5py/h5py/issues/1732
-reticulate::conda_install("'h5py<3.0.0'", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
 # Pin h2o to prevent version-mismatch between python and R

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -75,6 +75,10 @@ def get_default_conda_env(include_cloudpickle=False, keras_module=None):
     else:
         pip_deps.append("tensorflow=={}".format(tf.__version__))
 
+    # Tensorflow<2.4 does not work with h5py>=3.0.0`
+    if LooseVersion(tf.__version__) < LooseVersion("2.4"):
+        pip_deps.append("h5py<3.0.0")
+
     return _mlflow_conda_env(
         additional_conda_deps=conda_deps,
         additional_pip_deps=pip_deps,

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -75,7 +75,8 @@ def get_default_conda_env(include_cloudpickle=False, keras_module=None):
     else:
         pip_deps.append("tensorflow=={}".format(tf.__version__))
 
-    # Tensorflow<2.4 does not work with h5py>=3.0.0`
+    # Tensorflow<2.4 does not work with h5py>=3.0.0
+    # see https://github.com/tensorflow/tensorflow/issues/44467
     if LooseVersion(tf.__version__) < LooseVersion("2.4"):
         pip_deps.append("h5py<3.0.0")
 

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -277,7 +277,6 @@ def test_signature_and_examples_are_saved_correctly(model, data):
                     assert all((_read_example(mlflow_model, path) == example).all())
 
 
-@pytest.mark.skip("Unskip this test once https://github.com/h5py/h5py/issues/1732 is fixed")
 @pytest.mark.large
 def test_custom_model_save_load(custom_model, custom_layer, data, custom_predicted, model_path):
     x, _ = data

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -212,7 +212,7 @@ def test_that_keras_module_arg_works(model_path):
 
 @pytest.mark.parametrize(
     "build_model,save_format",
-    [(model, None), (tf_keras_model, None), (tf_keras_model, "h5"), (tf_keras_model, "tf")]
+    [(model, None), (tf_keras_model, None), (tf_keras_model, "h5"), (tf_keras_model, "tf")],
 )
 @pytest.mark.large
 def test_model_save_load(build_model, save_format, model_path, data):

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -212,9 +212,7 @@ def test_that_keras_module_arg_works(model_path):
 
 @pytest.mark.parametrize(
     "build_model,save_format",
-    # TODO: Unskip these parameters once https://github.com/h5py/h5py/issues/1732 is fixed
-    # [(model, None), (tf_keras_model, None), (tf_keras_model, "h5"),
-    [(tf_keras_model, "tf")],
+    [(model, None), (tf_keras_model, None), (tf_keras_model, "h5"), (tf_keras_model, "tf")]
 )
 @pytest.mark.large
 def test_model_save_load(build_model, save_format, model_path, data):


### PR DESCRIPTION
## What changes are proposed in this pull request?
Tensorflow (Keras models are loaded via functions defined in tensorflow package) versions <2.4 do not work with h5py>=3.0.0, see https://github.com/tensorflow/tensorflow/issues/4446

To avoid this issue, we pin the version of h5py in model conda environment. Since the issue is (will be) fixed in tf 2.4, we only pin h5py for older tf versions.

## How is this patch tested?
Existing tests. 

## Release Notes
Updated Keras model export to avoid an incompatibility between some versions of Keras/Tensorflow and h5py library.

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ x] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
