### PR TITLE
Fix bad links in R READMEs

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -35,6 +35,7 @@ jobs:
     # as a cache key when caching/restoring R dependencies.
     - name: Query dependencies
       run: |
+        print(R.version)
         install.packages('remotes')
         saveRDS(remotes::dev_package_deps("mlflow/R/mlflow", dependencies = TRUE), ".github/depends.Rds", version = 2)
         writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")

--- a/mlflow/R/mlflow/README.Rmd
+++ b/mlflow/R/mlflow/README.Rmd
@@ -29,7 +29,7 @@ devtools::install_github("mlflow/mlflow", subdir = "mlflow/R/mlflow")
 mlflow::install_mlflow()
 ```
 
-Notice also that [Anaconda](https://www.anaconda.com/download/) or [Miniconda](https://conda.io/miniconda.html) need to be manually installed.
+Notice also that [Anaconda](https://www.anaconda.com/products/individual) or [Miniconda](https://docs.conda.io/en/latest/miniconda.html) need to be manually installed.
 
 ### Development
 

--- a/mlflow/R/mlflow/README.md
+++ b/mlflow/R/mlflow/README.md
@@ -20,8 +20,8 @@ devtools::install_github("mlflow/mlflow", subdir = "mlflow/R/mlflow")
 mlflow::install_mlflow()
 ```
 
-Notice also that [Anaconda](https://www.anaconda.com/download/) or
-[Miniconda](https://conda.io/miniconda.html) need to be manually
+Notice also that [Anaconda](https://www.anaconda.com/products/individual) or
+[Miniconda](https://docs.conda.io/en/latest/miniconda.html) need to be manually
 installed.
 
 ### Development


### PR DESCRIPTION
Signed-off-by: Sid Murching <sid.murching@databricks.com>

## What changes are proposed in this pull request?

Fix bad links (that have since been moved) in R READMEs that broke CRAN checks for the 1.11 release

## How is this patch tested?

CRAN check in CI. Also manually ran CRAN checks using the [release version](https://cran.r-project.org/) (4.0.3) and [development version](https://mac.r-project.org/#nightly) (4.1.0) of R on my laptop

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
