### PR TITLE
Use dev version of MLflow in mlflow-test-plugin

### DIFF
--- a/tests/resources/mlflow-test-plugin/setup.py
+++ b/tests/resources/mlflow-test-plugin/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup, find_packages
 
-ROOT_DIR = os.path.abspath(os.path.join(__file__, "../../../.."))
+ROOT_DIR = os.path.abspath(os.path.join(__file__, os.sep.join([".."] * 4)))
 
 setup(
     name="mlflow-test-plugin",

--- a/tests/resources/mlflow-test-plugin/setup.py
+++ b/tests/resources/mlflow-test-plugin/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
 
+
 setup(
     name="mlflow-test-plugin",
     version="0.0.1",

--- a/tests/resources/mlflow-test-plugin/setup.py
+++ b/tests/resources/mlflow-test-plugin/setup.py
@@ -1,5 +1,7 @@
+import os
 from setuptools import setup, find_packages
 
+ROOT_DIR = os.path.abspath(os.path.join(__file__, "../../../.."))
 
 setup(
     name="mlflow-test-plugin",
@@ -8,7 +10,7 @@ setup(
     packages=find_packages(),
     # Require MLflow as a dependency of the plugin, so that plugin users can simply install
     # the plugin & then immediately use it with MLflow
-    install_requires=["mlflow"],
+    install_requires=["mlflow @ file://{}".format(ROOT_DIR)],
     entry_points={
         # Define a Tracking Store plugin for tracking URIs with scheme 'file-plugin'
         "mlflow.tracking_store": "file-plugin=mlflow_test_plugin.file_store:PluginFileStore",

--- a/tests/resources/mlflow-test-plugin/setup.py
+++ b/tests/resources/mlflow-test-plugin/setup.py
@@ -1,16 +1,10 @@
-import os
 from setuptools import setup, find_packages
-
-ROOT_DIR = os.path.abspath(os.path.join(__file__, os.sep.join([".."] * 4)))
 
 setup(
     name="mlflow-test-plugin",
     version="0.0.1",
     description="Test plugin for MLflow",
     packages=find_packages(),
-    # Require MLflow as a dependency of the plugin, so that plugin users can simply install
-    # the plugin & then immediately use it with MLflow
-    install_requires=["mlflow @ file://{}".format(ROOT_DIR)],
     entry_points={
         # Define a Tracking Store plugin for tracking URIs with scheme 'file-plugin'
         "mlflow.tracking_store": "file-plugin=mlflow_test_plugin.file_store:PluginFileStore",


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
