### PR TITLE
Fix run_link for cross-workspace model versions

### DIFF
--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -191,7 +191,8 @@ def get_browser_hostname():
 def get_workspace_info_from_dbutils():
     dbutils = _get_dbutils()
     if dbutils:
-        workspace_host = "https://" + get_browser_hostname()
+        browser_hostname = get_browser_hostname()
+        workspace_host = "https://" + browser_hostname if browser_hostname else get_webapp_url()
         workspace_id = get_workspace_id()
         return workspace_host, workspace_id
     return None, None

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -164,7 +164,7 @@ def get_job_type():
 
 
 def get_webapp_url():
-    """Should only be called if is_in_databricks_notebook is true"""
+    """Should only be called if is_in_databricks_notebook or is_in_databricks_jobs is true"""
     url = _get_property_from_spark_context("spark.databricks.api.url")
     if url is not None:
         return url

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -191,7 +191,7 @@ def get_browser_hostname():
 def get_workspace_info_from_dbutils():
     dbutils = _get_dbutils()
     if dbutils:
-        workspace_host = get_browser_hostname()
+        workspace_host = 'https://' + get_browser_hostname()
         workspace_id = get_workspace_id()
         return workspace_host, workspace_id
     return None, None

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -191,7 +191,7 @@ def get_browser_hostname():
 def get_workspace_info_from_dbutils():
     dbutils = _get_dbutils()
     if dbutils:
-        workspace_host = 'https://' + get_browser_hostname()
+        workspace_host = "https://" + get_browser_hostname()
         workspace_id = get_workspace_id()
         return workspace_host, workspace_id
     return None, None

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -104,7 +104,7 @@ def test_get_workspace_info_from_databricks_secrets():
 def test_get_workspace_info_from_dbutils():
     mock_dbutils = mock.MagicMock()
     mock_dbutils.notebook.entry_point.getDbutils.return_value.notebook.return_value.getContext.return_value.browserHostName.return_value.get.return_value = (  # noqa
-        "https://mlflow.databricks.com"
+        "mlflow.databricks.com"
     )
     mock_dbutils.notebook.entry_point.getDbutils.return_value.notebook.return_value.getContext.return_value.workspaceId.return_value.get.return_value = (  # noqa
         "1111"
@@ -121,7 +121,7 @@ def test_get_workspace_info_from_dbutils_old_runtimes():
         '{"tags": {"orgId" : "1111", "browserHostName": "mlflow.databricks.com"}}'
     )
     mock_dbutils.notebook.entry_point.getDbutils.return_value.notebook.return_value.getContext.return_value.browserHostName.return_value.get.return_value = (  # noqa
-        "https://mlflow.databricks.com"
+        "mlflow.databricks.com"
     )
     # Mock out workspace ID tag
     mock_workspace_id_tag_opt = mock.MagicMock()

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -115,6 +115,23 @@ def test_get_workspace_info_from_dbutils():
         assert workspace_id == "1111"
 
 
+def test_get_workspace_info_from_dbutils_no_browser_host_name():
+    mock_dbutils = mock.MagicMock()
+    mock_dbutils.notebook.entry_point.getDbutils.return_value.notebook.return_value.getContext.return_value.browserHostName.return_value.get.return_value = (  # noqa
+        None
+    )
+    mock_dbutils.notebook.entry_point.getDbutils.return_value.notebook.return_value.getContext.return_value.apiUrl.return_value.get.return_value = (  # noqa
+        "https://mlflow.databricks.com"
+    )
+    mock_dbutils.notebook.entry_point.getDbutils.return_value.notebook.return_value.getContext.return_value.workspaceId.return_value.get.return_value = (  # noqa
+        "1111"
+    )
+    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+        workspace_host, workspace_id = get_workspace_info_from_dbutils()
+        assert workspace_host == "https://mlflow.databricks.com"
+        assert workspace_id == "1111"
+
+
 def test_get_workspace_info_from_dbutils_old_runtimes():
     mock_dbutils = mock.MagicMock()
     mock_dbutils.notebook.entry_point.getDbutils.return_value.notebook.return_value.getContext.return_value.toJson.return_value = (  # noqa


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fixing the following issues:
* If the run_link for a model version is created in a Databricks notebook, it will be missing the `https://` prefix needed for the model version creation to succeed against some servers (bug introduced in #3398).
* If the run_link for a model version is created in a Databricks job, it will be empty (because the context variable currently used is not filled for a job).

## How is this patch tested?
- Unit tests (fixed)
- Test against a Databricks server (from a notebook & a job)

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
