### PR TITLE
Add `log_dict`

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -86,6 +86,7 @@ delete_tag = mlflow.tracking.fluent.delete_tag
 log_artifacts = mlflow.tracking.fluent.log_artifacts
 log_artifact = mlflow.tracking.fluent.log_artifact
 log_text = mlflow.tracking.fluent.log_text
+log_dict = mlflow.tracking.fluent.log_dict
 active_run = mlflow.tracking.fluent.active_run
 get_run = mlflow.tracking.fluent.get_run
 start_run = mlflow.tracking.fluent.start_run
@@ -124,6 +125,7 @@ __all__ = [
     "log_artifacts",
     "log_artifact",
     "log_text",
+    "log_dict",
     "active_run",
     "start_run",
     "end_run",

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -992,7 +992,7 @@ class MlflowClient(object):
 
             # If the file extension doesn't exist or match any of [".json", ".yaml", ".yml"],
             # JSON format is used.
-            mlflow.log_dict(run.info.run_id, {"key": "value"}, "dir/data.yml")
+            mlflow.log_dict(run.info.run_id, {"key": "value"}, "data")
         """
         extension = os.path.splitext(artifact_file)[1]
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -997,12 +997,11 @@ class MlflowClient(object):
         extension = os.path.splitext(artifact_file)[1]
 
         with self._log_artifact_helper(run_id, artifact_file) as tmp_path:
-            if extension in [".yml", ".yaml"]:
-                with open(tmp_path, "w") as f:
+            with open(tmp_path, "w") as f:
+                # TODO: Make `indent` and `sort_keys` configurable by exposing them as arguments
+                if extension in [".yml", ".yaml"]:
                     yaml.dump(dictionary, f)
-            else:
-                with open(tmp_path, "w") as f:
-                    # TODO: Make `indent` and `sort_keys` configurable
+                else:
                     json.dump(dictionary, f)
 
     def _record_logged_model(self, run_id, mlflow_model):

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -983,17 +983,20 @@ class MlflowClient(object):
 
             client = MlflowClient()
             run = client.create_run(experiment_id="0")
+            run_id = run.info.run_id
+
+            dictionary = {"k": "v"}
 
             # Log a dictionary as a JSON file under the run's root artifact directory
-            client.log_dict(run.info.run_id, {"key": "value"}, "data.json")
+            client.log_dict(run_id, dictionary, "data.json")
 
             # Log a dictionary as a YAML file in a subdirectory of the run's root artifact directory
-            client.log_dict(run.info.run_id, {"key": "value"}, "dir/data.yml")
+            client.log_dict(run_id, dictionary, "dir/data.yml")
 
             # If the file extension doesn't exist or match any of [".json", ".yaml", ".yml"],
             # JSON format is used.
-            mlflow.log_dict(run.info.run_id, {"key": "value"}, "data")
-            mlflow.log_dict(run.info.run_id, {"key": "value"}, "data.txt")
+            mlflow.log_dict(run_id, dictionary, "data")
+            mlflow.log_dict(run_id, dictionary, "data.txt")
         """
         extension = os.path.splitext(artifact_file)[1]
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -973,8 +973,7 @@ class MlflowClient(object):
         :param run_id: String ID of the run.
         :param dictionary: Dictionary to log.
         :param artifact_file: The run-relative artifact file path in posixpath format to which
-                              the dictionary is saved (e.g. "dir/data.json"). The file extension
-                              must be one of [".json", ".yml", ".yaml"].
+                              the dictionary is saved (e.g. "dir/data.json").
 
         .. code-block:: python
             :caption: Example
@@ -991,18 +990,18 @@ class MlflowClient(object):
             client.log_dict(run.info.run_id, {"key": "value"}, "dir/data.yml")
         """
         extension = os.path.splitext(artifact_file)[1]
-        accepts = [".json", ".yml", ".yaml"]
-        if extension not in accepts:
-            raise TypeError(
-                "Invalid file format: '{}', expected one of {}".format(extension, accepts)
-            )
+
+        if extension in [".yml", ".yaml"]:
+            fmt = "yaml"
+        else:
+            fmt = "json"
 
         with self._log_artifact_helper(run_id, artifact_file) as tmp_path:
-            if extension == ".json":
+            if fmt == "json":
                 with open(tmp_path, "w") as f:
                     # TODO: Make `indent` and `sort_keys` configurable
                     json.dump(dictionary, f)
-            elif extension in [".yml", ".yaml"]:
+            elif fmt == "yaml":
                 with open(tmp_path, "w") as f:
                     yaml.dump(dictionary, f)
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -968,8 +968,8 @@ class MlflowClient(object):
     def log_dict(self, run_id, dictionary, artifact_file):
         """
         Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
-        inferred from the extension of `artifact_file`. If the file extension doesn't match any of
-        [".json", ".yml", ".yaml"], JSON is used.
+        inferred from the extension of `artifact_file`. If the file extension doesn't exist or
+        match any of [".json", ".yml", ".yaml"], JSON format is used.
 
         :param run_id: String ID of the run.
         :param dictionary: Dictionary to log.
@@ -989,6 +989,10 @@ class MlflowClient(object):
 
             # Log a dictionary as a YAML file in a subdirectory of the run's root artifact directory
             client.log_dict(run.info.run_id, {"key": "value"}, "dir/data.yml")
+
+            # If the file extension doesn't exist or match any of [".json", ".yaml", ".yml"],
+            # JSON format is used.
+            mlflow.log_dict(run.info.run_id, {"key": "value"}, "dir/data.yml")
         """
         extension = os.path.splitext(artifact_file)[1]
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -993,6 +993,7 @@ class MlflowClient(object):
             # If the file extension doesn't exist or match any of [".json", ".yaml", ".yml"],
             # JSON format is used.
             mlflow.log_dict(run.info.run_id, {"key": "value"}, "data")
+            mlflow.log_dict(run.info.run_id, {"key": "value"}, "data.txt")
         """
         extension = os.path.splitext(artifact_file)[1]
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1000,10 +1000,11 @@ class MlflowClient(object):
         with self._log_artifact_helper(run_id, artifact_file) as tmp_path:
             if extension == ".json":
                 with open(tmp_path, "w") as f:
-                    json.dump(dct, f, indent=2)
+                    # TODO: Make `indent` and `sort_keys` configurable
+                    json.dump(dct, f)
             elif extension in [".yml", ".yaml"]:
                 with open(tmp_path, "w") as f:
-                    yaml.dump(dct, f, indent=2)
+                    yaml.dump(dct, f)
 
     def _record_logged_model(self, run_id, mlflow_model):
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -965,13 +965,13 @@ class MlflowClient(object):
             with open(tmp_path, "w") as f:
                 f.write(text)
 
-    def log_dict(self, run_id, dct, artifact_file):
+    def log_dict(self, run_id, dictionary, artifact_file):
         """
         Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
         inferred from the extension of `artifact_file`.
 
         :param run_id: String ID of the run.
-        :param dct: Dictionary to log.
+        :param dictionary: Dictionary to log.
         :param artifact_file: The run-relative artifact file path in posixpath format to which
                               the dictionary is saved (e.g. "dir/data.json"). The file extension
                               must be one of [".json", ".yml", ".yaml"].
@@ -1001,10 +1001,10 @@ class MlflowClient(object):
             if extension == ".json":
                 with open(tmp_path, "w") as f:
                     # TODO: Make `indent` and `sort_keys` configurable
-                    json.dump(dct, f)
+                    json.dump(dictionary, f)
             elif extension in [".yml", ".yaml"]:
                 with open(tmp_path, "w") as f:
-                    yaml.dump(dct, f)
+                    yaml.dump(dictionary, f)
 
     def _record_logged_model(self, run_id, mlflow_model):
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -968,7 +968,8 @@ class MlflowClient(object):
     def log_dict(self, run_id, dictionary, artifact_file):
         """
         Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
-        inferred from the extension of `artifact_file`.
+        inferred from the extension of `artifact_file`. If the file extension doesn't match any of
+        [".json", ".yml", ".yaml"], JSON is used.
 
         :param run_id: String ID of the run.
         :param dictionary: Dictionary to log.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -992,19 +992,14 @@ class MlflowClient(object):
         """
         extension = os.path.splitext(artifact_file)[1]
 
-        if extension in [".yml", ".yaml"]:
-            fmt = "yaml"
-        else:
-            fmt = "json"
-
         with self._log_artifact_helper(run_id, artifact_file) as tmp_path:
-            if fmt == "json":
+            if extension in [".yml", ".yaml"]:
+                with open(tmp_path, "w") as f:
+                    yaml.dump(dictionary, f)
+            else:
                 with open(tmp_path, "w") as f:
                     # TODO: Make `indent` and `sort_keys` configurable
                     json.dump(dictionary, f)
-            elif fmt == "yaml":
-                with open(tmp_path, "w") as f:
-                    yaml.dump(dictionary, f)
 
     def _record_logged_model(self, run_id, mlflow_model):
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1000,10 +1000,10 @@ class MlflowClient(object):
         with self._log_artifact_helper(run_id, artifact_file) as tmp_path:
             if extension == ".json":
                 with open(tmp_path, "w") as f:
-                    json.dump(dct, f)
+                    json.dump(dct, f, indent=2)
             elif extension in [".yml", ".yaml"]:
                 with open(tmp_path, "w") as f:
-                    yaml.dump(dct, f)
+                    yaml.dump(dct, f, indent=2)
 
     def _record_logged_model(self, run_id, mlflow_model):
         """

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -587,7 +587,8 @@ def log_text(text, artifact_file):
 def log_dict(dictionary, artifact_file):
     """
     Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
-    inferred from the extension of `artifact_file`.
+    inferred from the extension of `artifact_file`. If the file extension doesn't match any of
+    [".json", ".yml", ".yaml"], JSON is used.
 
     :param run_id: String ID of the run.
     :param dictionary: Dictionary to log.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -600,17 +600,19 @@ def log_dict(dictionary, artifact_file):
 
         import mlflow
 
+        dictionary = {"k": "v"}
+
         with mlflow.start_run():
             # Log a dictionary as a JSON file under the run's root artifact directory
-            mlflow.log_dict({"key": "value"}, "data.json")
+            mlflow.log_dict(dictionary, "data.json")
 
             # Log a dictionary as a YAML file in a subdirectory of the run's root artifact directory
-            mlflow.log_dict({"key": "value"}, "dir/data.yml")
+            mlflow.log_dict(dictionary, "dir/data.yml")
 
             # If the file extension doesn't exist or match any of [".json", ".yaml", ".yml"],
             # JSON format is used.
-            mlflow.log_dict({"key": "value"}, "data")
-            mlflow.log_dict({"key": "value"}, "data.txt")
+            mlflow.log_dict(dictionary, "data")
+            mlflow.log_dict(dictionary, "data.txt")
     """
     run_id = _get_or_start_run().info.run_id
     MlflowClient().log_dict(run_id, dictionary, artifact_file)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -584,6 +584,35 @@ def log_text(text, artifact_file):
     MlflowClient().log_text(run_id, text, artifact_file)
 
 
+def log_dict(dct, artifact_file):
+    """
+    Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
+    inferred from the extension of `artifact_file`.
+
+    :param run_id: String ID of the run.
+    :param dct: Dictionary to log.
+    :param artifact_file: The run-relative artifact file path in posixpath format to which
+                            the dictionary is saved (e.g. "dir/data.json"). The file extension
+                            must be one of [".json", ".yml", ".yaml"].
+
+    .. code-block:: python
+        :caption: Example
+
+        from mlflow.tracking import MlflowClient
+
+        client = MlflowClient()
+        run = client.create_run(experiment_id="0")
+
+        # Log a dictionary as a JSON file under the run's root artifact directory
+        client.log_dict({"key": "value"}, "data.json")
+
+        # Log a dictionary as a YAML file in a subdirectory of the run's root artifact directory
+        client.log_dict({"key": "value"}, "dir/data.yml")
+    """
+    run_id = _get_or_start_run().info.run_id
+    MlflowClient().log_dict(run_id, dct, artifact_file)
+
+
 def _record_logged_model(mlflow_model):
     run_id = _get_or_start_run().info.run_id
     MlflowClient()._record_logged_model(run_id, mlflow_model)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -590,7 +590,6 @@ def log_dict(dictionary, artifact_file):
     inferred from the extension of `artifact_file`. If the file extension doesn't exist or match
     any of [".json", ".yml", ".yaml"], JSON format is used.
 
-    :param run_id: String ID of the run.
     :param dictionary: Dictionary to log.
     :param artifact_file: The run-relative artifact file path in posixpath format to which
                             the dictionary is saved (e.g. "dir/data.json").

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -584,13 +584,13 @@ def log_text(text, artifact_file):
     MlflowClient().log_text(run_id, text, artifact_file)
 
 
-def log_dict(dct, artifact_file):
+def log_dict(dictionary, artifact_file):
     """
     Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
     inferred from the extension of `artifact_file`.
 
     :param run_id: String ID of the run.
-    :param dct: Dictionary to log.
+    :param dictionary: Dictionary to log.
     :param artifact_file: The run-relative artifact file path in posixpath format to which
                             the dictionary is saved (e.g. "dir/data.json"). The file extension
                             must be one of [".json", ".yml", ".yaml"].
@@ -608,7 +608,7 @@ def log_dict(dct, artifact_file):
             mlflow.log_dict({"key": "value"}, "dir/data.yml")
     """
     run_id = _get_or_start_run().info.run_id
-    MlflowClient().log_dict(run_id, dct, artifact_file)
+    MlflowClient().log_dict(run_id, dictionary, artifact_file)
 
 
 def _record_logged_model(mlflow_model):

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -587,8 +587,8 @@ def log_text(text, artifact_file):
 def log_dict(dictionary, artifact_file):
     """
     Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
-    inferred from the extension of `artifact_file`. If the file extension doesn't match any of
-    [".json", ".yml", ".yaml"], JSON is used.
+    inferred from the extension of `artifact_file`. If the file extension doesn't exist or match
+    any of [".json", ".yml", ".yaml"], JSON format is used.
 
     :param run_id: String ID of the run.
     :param dictionary: Dictionary to log.
@@ -606,6 +606,10 @@ def log_dict(dictionary, artifact_file):
 
             # Log a dictionary as a YAML file in a subdirectory of the run's root artifact directory
             mlflow.log_dict({"key": "value"}, "dir/data.yml")
+
+            # If the file extension doesn't exist or match any of [".json", ".yaml", ".yml"],
+            # JSON format is used.
+            mlflow.log_dict({"key": "value"}, "data")
     """
     run_id = _get_or_start_run().info.run_id
     MlflowClient().log_dict(run_id, dictionary, artifact_file)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -593,8 +593,7 @@ def log_dict(dictionary, artifact_file):
     :param run_id: String ID of the run.
     :param dictionary: Dictionary to log.
     :param artifact_file: The run-relative artifact file path in posixpath format to which
-                            the dictionary is saved (e.g. "dir/data.json"). The file extension
-                            must be one of [".json", ".yml", ".yaml"].
+                            the dictionary is saved (e.g. "dir/data.json").
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -598,16 +598,14 @@ def log_dict(dct, artifact_file):
     .. code-block:: python
         :caption: Example
 
-        from mlflow.tracking import MlflowClient
+        import mlflow
 
-        client = MlflowClient()
-        run = client.create_run(experiment_id="0")
+        with mlflow.start_run():
+            # Log a dictionary as a JSON file under the run's root artifact directory
+            mlflow.log_dict({"key": "value"}, "data.json")
 
-        # Log a dictionary as a JSON file under the run's root artifact directory
-        client.log_dict({"key": "value"}, "data.json")
-
-        # Log a dictionary as a YAML file in a subdirectory of the run's root artifact directory
-        client.log_dict({"key": "value"}, "dir/data.yml")
+            # Log a dictionary as a YAML file in a subdirectory of the run's root artifact directory
+            mlflow.log_dict({"key": "value"}, "dir/data.yml")
     """
     run_id = _get_or_start_run().info.run_id
     MlflowClient().log_dict(run_id, dct, artifact_file)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -610,6 +610,7 @@ def log_dict(dictionary, artifact_file):
             # If the file extension doesn't exist or match any of [".json", ".yaml", ".yml"],
             # JSON format is used.
             mlflow.log_dict({"key": "value"}, "data")
+            mlflow.log_dict({"key": "value"}, "data.txt")
     """
     run_id = _get_or_start_run().info.run_id
     MlflowClient().log_dict(run_id, dictionary, artifact_file)

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -517,7 +517,7 @@ def test_log_text(subdir):
 
 
 @pytest.mark.parametrize("subdir", [None, ".", "dir", "dir1/dir2", "dir/.."])
-@pytest.mark.parametrize("filename", ["data.json", "data.yml", "data.yaml", "data"])
+@pytest.mark.parametrize("filename", ["data.json", "data.yml", "data.yaml", "data", "data.txt"])
 def test_log_dict(subdir, filename):
     dct = {"k": "v"}
     artifact_file = filename if subdir is None else posixpath.join(subdir, filename)

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -517,13 +517,14 @@ def test_log_text(subdir):
 
 
 @pytest.mark.parametrize("subdir", [None, ".", "dir", "dir1/dir2", "dir/.."])
-@pytest.mark.parametrize("filename", ["data.json", "data.yml", "data.yaml", "data", "data.txt"])
-def test_log_dict(subdir, filename):
-    dct = {"k": "v"}
+@pytest.mark.parametrize("extension", [".json", ".yml", ".yaml", ".txt", ""])
+def test_log_dict(subdir, extension):
+    dictionary = {"k": "v"}
+    filename = "data" + extension
     artifact_file = filename if subdir is None else posixpath.join(subdir, filename)
 
     with mlflow.start_run():
-        mlflow.log_dict(dct, artifact_file)
+        mlflow.log_dict(dictionary, artifact_file)
 
         artifact_path = None if subdir is None else posixpath.normpath(subdir)
         artifact_uri = mlflow.get_artifact_uri(artifact_path)
@@ -533,12 +534,8 @@ def test_log_dict(subdir, filename):
         filepath = os.path.join(run_artifact_dir, filename)
         extension = os.path.splitext(filename)[1]
         with open(filepath) as f:
-            if extension in [".yml", ".yaml"]:
-                data = yaml.load(f)
-            else:
-                data = json.load(f)
-
-            assert data == dct
+            loaded = yaml.load(f) if (extension in [".yml", ".yaml"]) else json.load(f)
+            assert loaded == dictionary
 
 
 def test_with_startrun():

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -541,7 +541,7 @@ def test_log_dict(subdir, filename):
             assert data == dct
 
 
-def test_log_dict_raises_error_for_invalid_file_format():
+def test_log_dict_raises_exception_for_invalid_file_format():
     with mlflow.start_run(), pytest.raises(TypeError, match="Invalid file format"):
         mlflow.log_dict({"k": "v"}, "data.txt")
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -517,7 +517,7 @@ def test_log_text(subdir):
 
 
 @pytest.mark.parametrize("subdir", [None, ".", "dir", "dir1/dir2", "dir/.."])
-@pytest.mark.parametrize("filename", ["data.json", "data.yml", "data.yaml"])
+@pytest.mark.parametrize("filename", ["data.json", "data.yml", "data.yaml", "data"])
 def test_log_dict(subdir, filename):
     dct = {"k": "v"}
     artifact_file = filename if subdir is None else posixpath.join(subdir, filename)
@@ -533,17 +533,12 @@ def test_log_dict(subdir, filename):
         filepath = os.path.join(run_artifact_dir, filename)
         extension = os.path.splitext(filename)[1]
         with open(filepath) as f:
-            if extension == ".json":
-                data = json.load(f)
-            elif extension in [".yml", ".yaml"]:
+            if extension in [".yml", ".yaml"]:
                 data = yaml.load(f)
+            else:
+                data = json.load(f)
 
             assert data == dct
-
-
-def test_log_dict_raises_exception_for_invalid_file_format():
-    with mlflow.start_run(), pytest.raises(TypeError, match="Invalid file format"):
-        mlflow.log_dict({"k": "v"}, "data.txt")
 
 
 def test_with_startrun():


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Add `log_dict` which logs a dictionary as an artifact.

```python
mlflow.log_dict({"k": "v"}, "data.json")
```


## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add `log_dict` which logs a dictionary as an artifact.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
