### PR TITLE
[mlflow.log_dict] Make `indent` and `sort_keys` configurable

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1000,9 +1000,6 @@ class MlflowClient(object):
             mlflow.log_dict(run_id, dictionary, "data")
             mlflow.log_dict(run_id, dictionary, "data.txt")
         """
-        if indent is not None:
-            indent = 2
-
         extension = os.path.splitext(artifact_file)[1]
 
         with self._log_artifact_helper(run_id, artifact_file) as tmp_path:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -965,7 +965,7 @@ class MlflowClient(object):
             with open(tmp_path, "w") as f:
                 f.write(text)
 
-    def log_dict(self, run_id, dictionary, artifact_file):
+    def log_dict(self, run_id, dictionary, artifact_file, indent=None, sort_keys=False):
         """
         Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
         inferred from the extension of `artifact_file`. If the file extension doesn't exist or
@@ -975,6 +975,8 @@ class MlflowClient(object):
         :param dictionary: Dictionary to log.
         :param artifact_file: The run-relative artifact file path in posixpath format to which
                               the dictionary is saved (e.g. "dir/data.json").
+        :param indent: The length of whitespace used to indent each record (default: None).
+        :param sort_keys: If True, the output will be sorted by key (default: False).
 
         .. code-block:: python
             :caption: Example
@@ -998,15 +1000,18 @@ class MlflowClient(object):
             mlflow.log_dict(run_id, dictionary, "data")
             mlflow.log_dict(run_id, dictionary, "data.txt")
         """
+        if indent is not None:
+            indent = 2
+
         extension = os.path.splitext(artifact_file)[1]
 
         with self._log_artifact_helper(run_id, artifact_file) as tmp_path:
             with open(tmp_path, "w") as f:
                 # TODO: Make `indent` and `sort_keys` configurable by exposing them as arguments
                 if extension in [".yml", ".yaml"]:
-                    yaml.dump(dictionary, f)
+                    yaml.dump(dictionary, f, indent=indent, sort_keys=sort_keys)
                 else:
-                    json.dump(dictionary, f)
+                    json.dump(dictionary, f, indent=indent, sort_keys=sort_keys)
 
     def _record_logged_model(self, run_id, mlflow_model):
         """

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -584,7 +584,7 @@ def log_text(text, artifact_file):
     MlflowClient().log_text(run_id, text, artifact_file)
 
 
-def log_dict(dictionary, artifact_file):
+def log_dict(dictionary, artifact_file, indent=None, sort_keys=False):
     """
     Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
     inferred from the extension of `artifact_file`. If the file extension doesn't exist or match
@@ -593,6 +593,8 @@ def log_dict(dictionary, artifact_file):
     :param dictionary: Dictionary to log.
     :param artifact_file: The run-relative artifact file path in posixpath format to which
                             the dictionary is saved (e.g. "dir/data.json").
+    :param indent: The length of whitespace used to indent each record (default: None).
+    :param sort_keys: If True, the output will be sorted by key (default: False).
 
     .. code-block:: python
         :caption: Example
@@ -614,7 +616,7 @@ def log_dict(dictionary, artifact_file):
             mlflow.log_dict(dictionary, "data.txt")
     """
     run_id = _get_or_start_run().info.run_id
-    MlflowClient().log_dict(run_id, dictionary, artifact_file)
+    MlflowClient().log_dict(run_id, dictionary, artifact_file, indent, sort_keys)
 
 
 def _record_logged_model(mlflow_model):

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -538,6 +538,56 @@ def test_log_dict(subdir, extension):
             assert loaded == dictionary
 
 
+@pytest.mark.parametrize("extension", [".json", ".yml"])
+def test_log_dict_with_indent(extension):
+    dictionary = {"a": {"b": "c"}}
+    filename = "data" + extension
+    json_expected = """
+{
+  "a": {
+    "b": "c"
+  }
+}
+"""
+
+    yml_expected = """
+a:
+  b: c
+"""
+
+    with mlflow.start_run():
+        mlflow.log_dict(dictionary, filename, indent=2)
+        artifact_uri = mlflow.get_artifact_uri()
+        run_artifact_dir = local_file_uri_to_path(artifact_uri)
+        assert os.listdir(run_artifact_dir) == [filename]
+
+        filepath = os.path.join(run_artifact_dir, filename)
+        extension = os.path.splitext(filename)[1]
+        with open(filepath) as f:
+            expected = yml_expected if (extension in [".yml", ".yaml"]) else json_expected
+            assert f.read().strip() == expected.strip()
+
+
+@pytest.mark.parametrize("extension", [".json", ".yml"])
+def test_log_dict_with_sort_keys(extension):
+    dictionary = {"c": 2, "b": 1, "a": 0}
+    filename = "data" + extension
+    json_expected = '{"a": 0, "b": 1, "c": 2}'
+    yml_expected = "a: 0\nb: 1\nc: 2"
+
+    with mlflow.start_run():
+        mlflow.log_dict(dictionary, filename, sort_keys=True)
+        artifact_uri = mlflow.get_artifact_uri()
+        run_artifact_dir = local_file_uri_to_path(artifact_uri)
+        assert os.listdir(run_artifact_dir) == [filename]
+
+        filepath = os.path.join(run_artifact_dir, filename)
+        extension = os.path.splitext(filename)[1]
+        with open(filepath) as f:
+            expected = yml_expected if (extension in [".yml", ".yaml"]) else json_expected
+            assert f.read().strip() == expected.strip()
+
+
 def test_with_startrun():
     run_id = None
     t0 = int(time.time() * 1000)


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- A follow-up for #3685 
- Make `indent` and `sort_keys` configurable for `mlflow.log_dict`

## How is this patch tested?

New unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
