### PR TITLE
[mlflow.log_dict] Specify `Loader` in `yaml.load` to suppress deprecated warning

### DIFF
--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -534,7 +534,13 @@ def test_log_dict(subdir, extension):
         filepath = os.path.join(run_artifact_dir, filename)
         extension = os.path.splitext(filename)[1]
         with open(filepath) as f:
-            loaded = yaml.load(f) if (extension in [".yml", ".yaml"]) else json.load(f)
+            loaded = (
+                # Specify `Loader` to suppress the following deprecation warning:
+                # https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
+                yaml.load(f, Loader=yaml.SafeLoader)
+                if (extension in [".yml", ".yaml"])
+                else json.load(f)
+            )
             assert loaded == dictionary
 
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- A follow-up for #3685 
- Specify `Loader` in `yaml.load` to suppress the following deprecated warning:

```
tests/tracking/test_tracking.py::test_log_dict[.yml-.]
  /home/runner/work/mlflow/mlflow/tests/tracking/test_tracking.py:537: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    loaded = yaml.load(f) if (extension in [".yml", ".yaml"]) else json.load(f)
```

https://github.com/mlflow/mlflow/runs/1405359175?check_suite_focus=true#step:4:1659 

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
