### PR TITLE
Fix R client for windows

### DIFF
--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -4,6 +4,7 @@ new_mlflow_client <- function(tracking_uri) {
 }
 
 new_mlflow_uri <- function(raw_uri) {
+  # fix file:///X:/D case
   # Special case 'databricks'
   if (identical(raw_uri, "databricks")) {
     raw_uri <- paste0("databricks", "://")
@@ -12,7 +13,8 @@ new_mlflow_uri <- function(raw_uri) {
   if (!grepl("://", raw_uri)) {
     raw_uri <- paste0("file://", raw_uri)
   }
-  parts <- strsplit(raw_uri, "://")[[1]]
+  pattern <- ifelse(is_windows(), ":///", "://")
+  parts <- strsplit(raw_uri, pattern)[[1]]
   structure(
     list(scheme = parts[1], path = parts[2]),
     class = c(paste("mlflow_", parts[1], sep = ""), "mlflow_uri")

--- a/mlflow/R/mlflow/R/tracking-globals.R
+++ b/mlflow/R/mlflow/R/tracking-globals.R
@@ -44,6 +44,20 @@ mlflow_set_tracking_uri <- function(uri) {
 mlflow_get_tracking_uri <- function() {
   .globals$tracking_uri %||% {
     env_uri <- Sys.getenv("MLFLOW_TRACKING_URI")
-    if (nchar(env_uri)) env_uri else paste("file://", fs::path_abs("mlruns"), sep = "")
+
+    if (nchar(env_uri)) {
+      env_uri
+    } else {
+      # don't use fs::path() because of https://github.com/r-lib/fs/issues/245
+      paste(
+        "file://",
+        fs::path_abs("mlruns"),
+        sep = ifelse(is_windows(), "/", "")
+      )
+    }
   }
+}
+
+is_windows <- function() {
+  identical(.Platform$OS.type, "windows")
 }


### PR DESCRIPTION
Because `fs::path_abs()` retuns `D:/x/y/y`, whereas on unix, it returns `/User/x/y/y`. So on windows, paste("file://", fs::path_abs(...)) returns an invalid URI scheme and lacks a slash. 
In Python:
```python 
import mlflow; print(mlflow.get_tracking_uri())
#> file:///D:/a/mlflow-test-3206/mlflow-test-3206/mlruns
```

In R:
```r
# first fixing the path to the executable
Sys.setenv(MLFLOW_BIN = "C:\\Miniconda\\envs\\r-mlflow-1.12.0\\Scripts\\mlflow.exe")
mlflow:::mlflow_get_tracking_uri()
#> file://D:/a/mlflow-test-3206/mlflow-test-3206/mlruns
```

Log: https://github.com/lorenzwalthert/mlflow-test-3206/runs/1405857066?check_suite_focus=true#step:9:11


https://en.wikipedia.org/wiki/File_URI_scheme

