### PR TITLE
Only import matplotlib where necessary for artifact plotting

### DIFF
--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -4,7 +4,6 @@ from itertools import islice
 import inspect
 import logging
 from numbers import Number
-import matplotlib.pyplot as plt
 import numpy as np
 import time
 
@@ -500,6 +499,7 @@ def _log_specialized_estimator_content(fitted_estimator, run_id, fit_args, fit_k
                     display.ax_.set_title(artifact.title)
                     filepath = tmp_dir.path("{}.png".format(artifact.name))
                     display.figure_.savefig(filepath)
+                    import matplotlib.pyplot as plt
                     plt.close(display.figure_)
                 except Exception as e:  # pylint: disable=broad-except
                     _log_warning_for_artifacts(artifact.name, artifact.function, e)

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -500,6 +500,7 @@ def _log_specialized_estimator_content(fitted_estimator, run_id, fit_args, fit_k
                     filepath = tmp_dir.path("{}.png".format(artifact.name))
                     display.figure_.savefig(filepath)
                     import matplotlib.pyplot as plt
+
                     plt.close(display.figure_)
                 except Exception as e:  # pylint: disable=broad-except
                     _log_warning_for_artifacts(artifact.name, artifact.function, e)


### PR DESCRIPTION
Signed-off-by: Corey Zumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Moves a top-level matplotlib import for `mlflow.sklearn.autolog()` into the exception-caught artifact logging block where its required. This ensures that matplotlib is not a hard dependency for `mlflow.sklearn.autolog()`.

## How is this patch tested?

Existing unit tests ensure that artifact logging continues to function properly with the presence of matplotlib. @eedeleon and I will discuss strategies for testing the degraded functionality when matplotlib is unavailable, which is important in the context of a skinny client

## Release Notes

Bug fix: `mlflow.sklearn.autolog()` no longer has a hard dependency on matplotlib.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
