### PR TITLE
Fix gc OSError

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -402,10 +402,10 @@ class FileStore(AbstractStore):
         This is used by the ``mlflow gc`` command line and is not intended to be used elsewhere.
         """
         _, run_dir = self._find_run_root(run_id)
-        try:
+        if run_dir is None:
+            print("{} not found. Continuing with gc ...".format(run_dir))
+        else:
             shutil.rmtree(run_dir)
-        except OSError as err:
-            print("{}. Failed to permanently delete run. Continuing with gc ...".format(err))
 
     def _get_deleted_runs(self):
         experiment_ids = self._get_active_experiments() + self._get_deleted_experiments()

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -402,7 +402,10 @@ class FileStore(AbstractStore):
         This is used by the ``mlflow gc`` command line and is not intended to be used elsewhere.
         """
         _, run_dir = self._find_run_root(run_id)
-        shutil.rmtree(run_dir)
+        try:
+            shutil.rmtree(run_dir)
+         except OSError as err:
+             print("{}. Failed to permanently delete run. Continuing with gc ...".format(err))
 
     def _get_deleted_runs(self):
         experiment_ids = self._get_active_experiments() + self._get_deleted_experiments()

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -404,8 +404,8 @@ class FileStore(AbstractStore):
         _, run_dir = self._find_run_root(run_id)
         try:
             shutil.rmtree(run_dir)
-         except OSError as err:
-             print("{}. Failed to permanently delete run. Continuing with gc ...".format(err))
+        except OSError as err:
+            print("{}. Failed to permanently delete run. Continuing with gc ...".format(err))
 
     def _get_deleted_runs(self):
         experiment_ids = self._get_active_experiments() + self._get_deleted_experiments()

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -358,6 +358,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
             fs.get_all_metrics(run_id)
         with self.assertRaises(MlflowException):
             fs.get_all_params(run_id)
+        fs._hard_delete_run(run_id)
 
     def test_get_deleted_runs(self):
         fs = FileStore(self.test_root)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Complement #3661 for fixing #3595 where `FileStore` is used instead of `SqlAlchemyStore`

## How is this patch tested?

- `test_file_store.py`
Added an extra `_hard_delete_run` call after dir has already been removed.

## Release Notes

### Is this a user-facing change?

- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.
Fix bug #3595 for for users using `FileStore` instead of `SqlAlchemyStore` as backend.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

### How should the PR be classified in the release notes? Choose one:

- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
