### PR TITLE
Ensure azure-storage-blob>=12.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     install_requires=[
         "alembic<=1.4.1",
         # Required
-        "azure-storage-blob",
+        "azure-storage-blob>=12.0.0",
         "click>=7.0",
         "cloudpickle",
         "databricks-cli>=0.8.7",


### PR DESCRIPTION
## What changes are proposed in this pull request?

Package requirements are modified to ensure the `azure-storage-blob` is at least 12.0.0. If <12 version is installed, the exception is thrown:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/mlflow/store/artifact/dbfs_artifact_repo.py", line 10, in <module>
    from mlflow.store.artifact.databricks_artifact_repo import DatabricksArtifactRepository
  File "/usr/local/lib/python3.8/site-packages/mlflow/store/artifact/databricks_artifact_repo.py", line 9, in <module>
    from azure.storage.blob import BlobClient
ImportError: cannot import name 'BlobClient' from 'azure.storage.blob' (/home/airflow/.local/lib/python3.8/site-packages/azure/storage/blob/__init__.py)
```

## How is this patch tested?

Manually:

```
$ pip3 install azure-storage-blob==2.1.0
Requirement already satisfied: azure-storage-blob==2.1.0 in /home/mario/.local/lib/python3.8/site-packages (2.1.0)
...
$ python3
Python 3.8.2 (default, Jul 16 2020, 14:00:26) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from azure.storage.blob import BlobClient
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: cannot import name 'BlobClient' from 'azure.storage.blob' (/home/mario/.local/lib/python3.8/site-packages/azure/storage/blob/__init__.py)
>>> 
$ pip3 install azure-storage-blob==12.0.0
...
Successfully installed azure-storage-blob-12.0.0
$ python3
Python 3.8.2 (default, Jul 16 2020, 14:00:26) 
[GCC 9.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from azure.storage.blob import BlobClient
>>> 
```

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
