### PR TITLE
Extend use of BatchMetricsLogger to all autologging integrations

### DIFF
--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -304,9 +304,7 @@ def autolog():
             Records model structural information as params when training begins
             """
 
-            def __init__(
-                self, learner
-            ):
+            def __init__(self, learner):
                 super().__init__(learner)
                 self.learner = learner
                 self.opt = self.learn.opt

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -351,7 +351,7 @@ def autolog(log_models=True):
                 if isinstance(estimator.net, HybridSequential) and log_models:
                     try_mlflow_log(log_model, estimator.net, artifact_path="model")
 
-        return __MLflowGluonCallback
+        return __MLflowGluonCallback()
 
     def fit(self, *args, **kwargs):
         if not mlflow.active_run():
@@ -365,15 +365,15 @@ def autolog(log_models=True):
         # Wrap `fit` execution within a batch metrics logger context.
         run_id = mlflow.active_run().info.run_id
         with batch_metrics_logger(run_id) as metrics_logger:
-            __MLflowGluonCallback = getGluonCallback(metrics_logger)
+            mlflowGluonCallback = getGluonCallback(metrics_logger)
             if len(args) >= 4:
                 l = list(args)
-                l[3] += [__MLflowGluonCallback()]
+                l[3] += [mlflowGluonCallback]
                 args = tuple(l)
             elif "event_handlers" in kwargs:
-                kwargs["event_handlers"] += [__MLflowGluonCallback()]
+                kwargs["event_handlers"] += [mlflowGluonCallback]
             else:
-                kwargs["event_handlers"] = [__MLflowGluonCallback()]
+                kwargs["event_handlers"] = [mlflowGluonCallback]
             result = original(self, *args, **kwargs)
 
         if auto_end_run:

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -312,39 +312,41 @@ def autolog():
     from mxnet.gluon.contrib.estimator import Estimator, EpochEnd, TrainBegin, TrainEnd
     from mxnet.gluon.nn import HybridSequential
 
-    class __MLflowGluonCallback(EpochEnd, TrainEnd, TrainBegin):
-        def __init__(self, metrics_logger):
-            self.current_epoch = 0
-            self.metrics_logger = metrics_logger
+    def getGluonCallback(metrics_logger):
+        class __MLflowGluonCallback(EpochEnd, TrainEnd, TrainBegin):
+            def __init__(self):
+                self.current_epoch = 0
 
-        def epoch_end(self, estimator, *args, **kwargs):
-            logs = {}
-            for metric in estimator.train_metrics:
-                metric_name, metric_val = metric.get()
-                logs[metric_name] = metric_val
-            for metric in estimator.val_metrics:
-                metric_name, metric_val = metric.get()
-                logs[metric_name] = metric_val
-            self.metrics_logger.record_metrics(logs, self.current_epoch)
-            self.current_epoch += 1
+            def epoch_end(self, estimator, *args, **kwargs):
+                logs = {}
+                for metric in estimator.train_metrics:
+                    metric_name, metric_val = metric.get()
+                    logs[metric_name] = metric_val
+                for metric in estimator.val_metrics:
+                    metric_name, metric_val = metric.get()
+                    logs[metric_name] = metric_val
+                metrics_logger.record_metrics(logs, self.current_epoch)
+                self.current_epoch += 1
 
-        def train_begin(self, estimator, *args, **kwargs):
-            try_mlflow_log(mlflow.log_param, "num_layers", len(estimator.net))
-            if estimator.max_epoch is not None:
-                try_mlflow_log(mlflow.log_param, "epochs", estimator.max_epoch)
-            if estimator.max_batch is not None:
-                try_mlflow_log(mlflow.log_param, "batches", estimator.max_batch)
-            try_mlflow_log(
-                mlflow.log_param, "optimizer_name", type(estimator.trainer.optimizer).__name__
-            )
-            if hasattr(estimator.trainer.optimizer, "lr"):
-                try_mlflow_log(mlflow.log_param, "learning_rate", estimator.trainer.optimizer.lr)
-            if hasattr(estimator.trainer.optimizer, "epsilon"):
-                try_mlflow_log(mlflow.log_param, "epsilon", estimator.trainer.optimizer.epsilon)
+            def train_begin(self, estimator, *args, **kwargs):
+                try_mlflow_log(mlflow.log_param, "num_layers", len(estimator.net))
+                if estimator.max_epoch is not None:
+                    try_mlflow_log(mlflow.log_param, "epochs", estimator.max_epoch)
+                if estimator.max_batch is not None:
+                    try_mlflow_log(mlflow.log_param, "batches", estimator.max_batch)
+                try_mlflow_log(
+                    mlflow.log_param, "optimizer_name", type(estimator.trainer.optimizer).__name__
+                )
+                if hasattr(estimator.trainer.optimizer, "lr"):
+                    try_mlflow_log(mlflow.log_param, "learning_rate", estimator.trainer.optimizer.lr)
+                if hasattr(estimator.trainer.optimizer, "epsilon"):
+                    try_mlflow_log(mlflow.log_param, "epsilon", estimator.trainer.optimizer.epsilon)
 
-        def train_end(self, estimator, *args, **kwargs):
-            if isinstance(estimator.net, HybridSequential):
-                try_mlflow_log(log_model, estimator.net, artifact_path="model")
+            def train_end(self, estimator, *args, **kwargs):
+                if isinstance(estimator.net, HybridSequential):
+                    try_mlflow_log(log_model, estimator.net, artifact_path="model")
+
+        return __MLflowGluonCallback
 
     def fit(self, *args, **kwargs):
         if not mlflow.active_run():
@@ -358,14 +360,15 @@ def autolog():
         # Wrap `fit` execution within a batch metrics logger context.
         run_id = mlflow.active_run().info.run_id
         with batch_metrics_logger(run_id) as metrics_logger:
+            __MLflowGluonCallback = getGluonCallback(metrics_logger)
             if len(args) >= 4:
                 l = list(args)
-                l[3] += [__MLflowGluonCallback(metrics_logger)]
+                l[3] += [__MLflowGluonCallback()]
                 args = tuple(l)
             elif "event_handlers" in kwargs:
-                kwargs["event_handlers"] += [__MLflowGluonCallback(metrics_logger)]
+                kwargs["event_handlers"] += [__MLflowGluonCallback()]
             else:
-                kwargs["event_handlers"] = [__MLflowGluonCallback(metrics_logger)]
+                kwargs["event_handlers"] = [__MLflowGluonCallback()]
             result = original(self, *args, **kwargs)
 
         if auto_end_run:

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -338,7 +338,9 @@ def autolog():
                     mlflow.log_param, "optimizer_name", type(estimator.trainer.optimizer).__name__
                 )
                 if hasattr(estimator.trainer.optimizer, "lr"):
-                    try_mlflow_log(mlflow.log_param, "learning_rate", estimator.trainer.optimizer.lr)
+                    try_mlflow_log(
+                        mlflow.log_param, "learning_rate", estimator.trainer.optimizer.lr
+                    )
                 if hasattr(estimator.trainer.optimizer, "epsilon"):
                     try_mlflow_log(mlflow.log_param, "epsilon", estimator.trainer.optimizer.epsilon)
 

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -708,11 +708,11 @@ def autolog(log_models=True):
             if callback_attrs is None:
                 return
             stopped_epoch, restore_best_weights, patience = callback_attrs
-            metrics_logger.record_metrics({"stopped_epoch": stopped_epoch}, stopped_epoch)
+            metrics_logger.record_metrics({"stopped_epoch": stopped_epoch})
             # Weights are restored only if early stopping occurs
             if stopped_epoch != 0 and restore_best_weights:
                 restored_epoch = stopped_epoch - max(1, patience)
-                metrics_logger.record_metrics({"restored_epoch": restored_epoch}, restored_epoch)
+                metrics_logger.record_metrics({"restored_epoch": restored_epoch})
                 restored_metrics = {
                     key: history.history[key][restored_epoch] for key in history.history.keys()
                 }

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -668,7 +668,7 @@ def autolog(log_models=True):
             def _implements_predict_batch_hooks(self):
                 return False
 
-        return __MLflowKerasCallback
+        return __MLflowKerasCallback()
 
     def _early_stop_check(callbacks):
         if LooseVersion(keras.__version__) < LooseVersion("2.3.0") or LooseVersion(
@@ -735,17 +735,17 @@ def autolog(log_models=True):
         # Checking if the 'callback' argument of the function is set
         run_id = mlflow.active_run().info.run_id
         with batch_metrics_logger(run_id) as metrics_logger:
-            __MLflowKerasCallback = getKerasCallback(metrics_logger)
+            mlflowKerasCallback = getKerasCallback(metrics_logger)
             if len(args) > callback_arg_index:
                 tmp_list = list(args)
                 early_stop_callback = _early_stop_check(tmp_list[callback_arg_index])
-                tmp_list[callback_arg_index] += [__MLflowKerasCallback()]
+                tmp_list[callback_arg_index] += [mlflowKerasCallback]
                 args = tuple(tmp_list)
             elif kwargs.get("callbacks"):
                 early_stop_callback = _early_stop_check(kwargs["callbacks"])
-                kwargs["callbacks"] += [__MLflowKerasCallback()]
+                kwargs["callbacks"] += [mlflowKerasCallback]
             else:
-                kwargs["callbacks"] = [__MLflowKerasCallback()]
+                kwargs["callbacks"] = [mlflowKerasCallback]
 
             _log_early_stop_callback_params(early_stop_callback)
 

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -614,7 +614,9 @@ def autolog():
 
             def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
                 try_mlflow_log(mlflow.log_param, "num_layers", len(self.model.layers))
-                try_mlflow_log(mlflow.log_param, "optimizer_name", type(self.model.optimizer).__name__)
+                try_mlflow_log(
+                    mlflow.log_param, "optimizer_name", type(self.model.optimizer).__name__
+                )
                 if hasattr(self.model.optimizer, "lr"):
                     lr = (
                         self.model.optimizer.lr

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -604,66 +604,65 @@ def autolog():
     """
     import keras
 
-    class __MLflowKerasCallback(keras.callbacks.Callback):
-        """
-        Callback for auto-logging metrics and parameters.
-        Records available logs after each epoch.
-        Records model structural information as params when training begins
-        """
+    def getKerasCallback(metrics_logger):
+        class __MLflowKerasCallback(keras.callbacks.Callback):
+            """
+            Callback for auto-logging metrics and parameters.
+            Records available logs after each epoch.
+            Records model structural information as params when training begins
+            """
 
-        def __init__(self, metrics_logger):
-            super().__init__()
-            self.metrics_logger = metrics_logger
+            def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
+                try_mlflow_log(mlflow.log_param, "num_layers", len(self.model.layers))
+                try_mlflow_log(mlflow.log_param, "optimizer_name", type(self.model.optimizer).__name__)
+                if hasattr(self.model.optimizer, "lr"):
+                    lr = (
+                        self.model.optimizer.lr
+                        if type(self.model.optimizer.lr) is float
+                        else keras.backend.eval(self.model.optimizer.lr)
+                    )
+                    try_mlflow_log(mlflow.log_param, "learning_rate", lr)
+                if hasattr(self.model.optimizer, "epsilon"):
+                    epsilon = (
+                        self.model.optimizer.epsilon
+                        if type(self.model.optimizer.epsilon) is float
+                        else keras.backend.eval(self.model.optimizer.epsilon)
+                    )
+                    try_mlflow_log(mlflow.log_param, "epsilon", epsilon)
 
-        def on_train_begin(self, logs=None):  # pylint: disable=unused-argument
-            try_mlflow_log(mlflow.log_param, "num_layers", len(self.model.layers))
-            try_mlflow_log(mlflow.log_param, "optimizer_name", type(self.model.optimizer).__name__)
-            if hasattr(self.model.optimizer, "lr"):
-                lr = (
-                    self.model.optimizer.lr
-                    if type(self.model.optimizer.lr) is float
-                    else keras.backend.eval(self.model.optimizer.lr)
-                )
-                try_mlflow_log(mlflow.log_param, "learning_rate", lr)
-            if hasattr(self.model.optimizer, "epsilon"):
-                epsilon = (
-                    self.model.optimizer.epsilon
-                    if type(self.model.optimizer.epsilon) is float
-                    else keras.backend.eval(self.model.optimizer.epsilon)
-                )
-                try_mlflow_log(mlflow.log_param, "epsilon", epsilon)
+                sum_list = []
+                self.model.summary(print_fn=sum_list.append)
+                summary = "\n".join(sum_list)
+                tempdir = tempfile.mkdtemp()
+                try:
+                    summary_file = os.path.join(tempdir, "model_summary.txt")
+                    with open(summary_file, "w") as f:
+                        f.write(summary)
+                    try_mlflow_log(mlflow.log_artifact, local_path=summary_file)
+                finally:
+                    shutil.rmtree(tempdir)
 
-            sum_list = []
-            self.model.summary(print_fn=sum_list.append)
-            summary = "\n".join(sum_list)
-            tempdir = tempfile.mkdtemp()
-            try:
-                summary_file = os.path.join(tempdir, "model_summary.txt")
-                with open(summary_file, "w") as f:
-                    f.write(summary)
-                try_mlflow_log(mlflow.log_artifact, local_path=summary_file)
-            finally:
-                shutil.rmtree(tempdir)
+            def on_epoch_end(self, epoch, logs=None):
+                if not logs:
+                    return
+                metrics_logger.record_metrics(logs, epoch)
 
-        def on_epoch_end(self, epoch, logs=None):
-            if not logs:
-                return
-            self.metrics_logger.record_metrics(logs, epoch)
+            def on_train_end(self, logs=None):
+                try_mlflow_log(log_model, self.model, artifact_path="model")
 
-        def on_train_end(self, logs=None):
-            try_mlflow_log(log_model, self.model, artifact_path="model")
+            # As of Keras 2.4.0, Keras Callback implementations must define the following
+            # methods indicating whether or not the callback overrides functions for
+            # batch training/testing/inference
+            def _implements_train_batch_hooks(self):
+                return False
 
-        # As of Keras 2.4.0, Keras Callback implementations must define the following
-        # methods indicating whether or not the callback overrides functions for
-        # batch training/testing/inference
-        def _implements_train_batch_hooks(self):
-            return False
+            def _implements_test_batch_hooks(self):
+                return False
 
-        def _implements_test_batch_hooks(self):
-            return False
+            def _implements_predict_batch_hooks(self):
+                return False
 
-        def _implements_predict_batch_hooks(self):
-            return False
+        return __MLflowKerasCallback
 
     def _early_stop_check(callbacks):
         if LooseVersion(keras.__version__) < LooseVersion("2.3.0") or LooseVersion(
@@ -697,17 +696,17 @@ def autolog():
         except Exception:  # pylint: disable=W0703
             return None
 
-    def _log_early_stop_callback_metrics(callback, history):
+    def _log_early_stop_callback_metrics(callback, history, metrics_logger):
         if callback:
             callback_attrs = _get_early_stop_callback_attrs(callback)
             if callback_attrs is None:
                 return
             stopped_epoch, restore_best_weights, patience = callback_attrs
-            try_mlflow_log(mlflow.log_metric, "stopped_epoch", stopped_epoch)
+            metrics_logger.record_metrics({"stopped_epoch": stopped_epoch}, stopped_epoch)
             # Weights are restored only if early stopping occurs
             if stopped_epoch != 0 and restore_best_weights:
                 restored_epoch = stopped_epoch - max(1, patience)
-                try_mlflow_log(mlflow.log_metric, "restored_epoch", restored_epoch)
+                metrics_logger.record_metrics({"restored_epoch": restored_epoch}, restored_epoch)
                 restored_metrics = {
                     key: history.history[key][restored_epoch] for key in history.history.keys()
                 }
@@ -715,7 +714,7 @@ def autolog():
                 metric_key = next(iter(history.history), None)
                 if metric_key is not None:
                     last_epoch = len(history.history[metric_key])
-                    try_mlflow_log(mlflow.log_metrics, restored_metrics, step=last_epoch)
+                    metrics_logger.record_metrics(restored_metrics, last_epoch)
 
     def _run_and_log_function(self, original, args, kwargs, unlogged_params, callback_arg_index):
         if not mlflow.active_run():
@@ -730,22 +729,23 @@ def autolog():
         # Checking if the 'callback' argument of the function is set
         run_id = mlflow.active_run().info.run_id
         with batch_metrics_logger(run_id) as metrics_logger:
+            __MLflowKerasCallback = getKerasCallback(metrics_logger)
             if len(args) > callback_arg_index:
                 tmp_list = list(args)
                 early_stop_callback = _early_stop_check(tmp_list[callback_arg_index])
-                tmp_list[callback_arg_index] += [__MLflowKerasCallback(metrics_logger)]
+                tmp_list[callback_arg_index] += [__MLflowKerasCallback()]
                 args = tuple(tmp_list)
             elif "callbacks" in kwargs:
                 early_stop_callback = _early_stop_check(kwargs["callbacks"])
-                kwargs["callbacks"] += [__MLflowKerasCallback(metrics_logger)]
+                kwargs["callbacks"] += [__MLflowKerasCallback()]
             else:
-                kwargs["callbacks"] = [__MLflowKerasCallback(metrics_logger)]
+                kwargs["callbacks"] = [__MLflowKerasCallback()]
 
             _log_early_stop_callback_params(early_stop_callback)
 
             history = original(self, *args, **kwargs)
 
-        _log_early_stop_callback_metrics(early_stop_callback, history)
+            _log_early_stop_callback_metrics(early_stop_callback, history, metrics_logger)
 
         if auto_end_run:
             try_mlflow_log(mlflow.end_run)

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -450,12 +450,12 @@ def autolog(log_input_examples=False, log_model_signatures=True, log_models=True
             if early_stopping:
                 extra_step = len(eval_results)
 
-                # iteration starts from 1 in LightGBM.
-                early_stopping_metrics = eval_results[model.best_iteration - 1]
-                early_stopping_metrics["stopped_iteration"] = extra_step
+                metrics_logger.record_metrics({"stopped_iteration": extra_step})
                 # best_iteration is set even if training does not stop early.
-                early_stopping_metrics["best_iteration"] = model.best_iteration
-                metrics_logger.record_metrics(early_stopping_metrics, step=extra_step)
+                metrics_logger.record_metrics({"best_iteration": model.best_iteration})
+                # iteration starts from 1 in LightGBM.
+                results = eval_results[model.best_iteration - 1]
+                metrics_logger.record_metrics(results, step=extra_step)
 
         # logging feature importance as artifacts.
         for imp_type in ["split", "gain"]:

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -46,6 +46,7 @@ from mlflow.utils.autologging_utils import (
     resolve_input_example_and_signature,
     _InputExampleInfo,
     ENSURE_AUTOLOGGING_ENABLED_TEXT,
+    batch_metrics_logger,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
@@ -333,7 +334,7 @@ def autolog(log_input_examples=False, log_model_signatures=True):
         original(self, *args, **kwargs)
 
     def train(*args, **kwargs):
-        def record_eval_results(eval_results):
+        def record_eval_results(eval_results, metrics_logger):
             """
             Create a callback function that records evaluation results.
             """
@@ -343,7 +344,7 @@ def autolog(log_input_examples=False, log_model_signatures=True):
                 for data_name, eval_name, value, _ in env.evaluation_result_list:
                     key = data_name + "-" + eval_name
                     res[key] = value
-
+                metrics_logger.record_metrics(res, env.iteration)
                 eval_results.append(res)
 
             return callback
@@ -417,22 +418,20 @@ def autolog(log_input_examples=False, log_model_signatures=True):
         # adding a callback that records evaluation results.
         eval_results = []
         callbacks_index = all_arg_names.index("callbacks")
-        callback = record_eval_results(eval_results)
-        if num_pos_args >= callbacks_index + 1:
-            tmp_list = list(args)
-            tmp_list[callbacks_index] += [callback]
-            args = tuple(tmp_list)
-        elif "callbacks" in kwargs and kwargs["callbacks"] is not None:
-            kwargs["callbacks"] += [callback]
-        else:
-            kwargs["callbacks"] = [callback]
+        run_id = mlflow.active_run().info.run_id
+        with batch_metrics_logger(run_id) as metrics_logger:
+            callback = record_eval_results(eval_results, metrics_logger)
+            if num_pos_args >= callbacks_index + 1:
+                tmp_list = list(args)
+                tmp_list[callbacks_index] += [callback]
+                args = tuple(tmp_list)
+            elif "callbacks" in kwargs and kwargs["callbacks"] is not None:
+                kwargs["callbacks"] += [callback]
+            else:
+                kwargs["callbacks"] = [callback]
 
-        # training model
-        model = original(*args, **kwargs)
-
-        # logging metrics on each iteration.
-        for idx, metrics in enumerate(eval_results):
-            try_mlflow_log(mlflow.log_metrics, metrics, step=idx)
+            # training model
+            model = original(*args, **kwargs)
 
         # If early_stopping_rounds is present, logging metrics at the best iteration
         # as extra metrics with the max step + 1.

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -6,7 +6,7 @@ import shutil
 import tempfile
 from pytorch_lightning.core.memory import ModelSummary
 from pytorch_lightning.utilities import rank_zero_only
-from mlflow.utils.autologging_utils import try_mlflow_log, wrap_patch, batch_metrics_logger
+from mlflow.utils.autologging_utils import try_mlflow_log, wrap_patch, BatchMetricsLogger
 from mlflow.utils.annotations import experimental
 from mlflow.utils import gorilla
 

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -47,148 +47,152 @@ def _autolog(log_every_n_epoch=1):
     global every_n_epoch
     every_n_epoch = log_every_n_epoch
 
-    class __MLflowPLCallback(pl.Callback):
-        """
-        Callback for auto-logging metrics and parameters.
-        """
-
-        def __init__(self, metrics_logger):
-            self.early_stopping = False
-            self.metrics_logger = metrics_logger
-
-        def on_epoch_end(self, trainer, pl_module):
+    def getPLCallback(metrics_logger):
+        class __MLflowPLCallback(pl.Callback):
             """
-            Log loss and other metrics values after each epoch
-
-            :param trainer: pytorch lightning trainer instance
-            :param pl_module: pytorch lightning base module
-            """
-            if (pl_module.current_epoch + 1) % every_n_epoch == 0:
-                cur_metrics = trainer.callback_metrics
-                # Cast metric value as  float before passing into logger.
-                metrics = dict(map(lambda x: (x[0], float(x[1])), cur_metrics.items()))
-                self.metrics_logger.record_metrics(metrics, pl_module.current_epoch)
-
-            for callback in trainer.callbacks:
-                if isinstance(callback, pl.callbacks.early_stopping.EarlyStopping):
-                    self._early_stop_check(callback)
-
-        def on_train_start(self, trainer, pl_module):
-            """
-            Logs Optimizer related metrics when the train begins
-
-            :param trainer: pytorch lightning trainer instance
-            :param pl_module: pytorch lightning base module
-            """
-            try_mlflow_log(mlflow.set_tag, "Mode", "training")
-            try_mlflow_log(mlflow.log_param, "epochs", trainer.max_epochs)
-
-            for callback in trainer.callbacks:
-                if isinstance(callback, pl.callbacks.early_stopping.EarlyStopping):
-                    self.early_stopping = True
-                    self._log_early_stop_params(callback)
-
-            # TODO For logging optimizer params - Following scenarios are to revisited.
-            # 1. In the current scenario, only the first optimizer details are logged.
-            #    Code to be enhanced to log params when multiple optimizers are used.
-            # 2. mlflow.log_params is used to store optimizer default values into mlflow.
-            #    The keys in default dictionary are too short, Ex: (lr - learning_rate).
-            #    Efficient mapping technique needs to be introduced
-            #    to rename the optimizer parameters based on keys in default dictionary.
-
-            if hasattr(trainer, "optimizers"):
-                optimizer = trainer.optimizers[0]
-                try_mlflow_log(mlflow.log_param, "optimizer_name", type(optimizer).__name__)
-
-                if hasattr(optimizer, "defaults"):
-                    try_mlflow_log(mlflow.log_params, optimizer.defaults)
-
-            summary = str(ModelSummary(pl_module, mode="full"))
-            tempdir = tempfile.mkdtemp()
-            try:
-                summary_file = os.path.join(tempdir, "model_summary.txt")
-                with open(summary_file, "w") as f:
-                    f.write(summary)
-
-                try_mlflow_log(mlflow.log_artifact, local_path=summary_file)
-            finally:
-                shutil.rmtree(tempdir)
-
-        def on_train_end(self, trainer, pl_module):
-            """
-            Logs the model checkpoint into mlflow - models folder on the training end
-
-            :param trainer: pytorch lightning trainer instance
-            :param pl_module: pytorch lightning base module
+            Callback for auto-logging metrics and parameters.
             """
 
-            mlflow.pytorch.log_model(pytorch_model=trainer.model, artifact_path="model")
+            def __init__(self):
+                self.early_stopping = False
 
-            if self.early_stopping and trainer.checkpoint_callback.best_model_path:
-                try_mlflow_log(
-                    mlflow.log_artifact,
-                    local_path=trainer.checkpoint_callback.best_model_path,
-                    artifact_path="restored_model_checkpoint",
-                )
+            def on_epoch_end(self, trainer, pl_module):
+                """
+                Log loss and other metrics values after each epoch
 
-        def on_test_end(self, trainer, pl_module):
-            """
-            Logs accuracy and other relevant metrics on the testing end
+                :param trainer: pytorch lightning trainer instance
+                :param pl_module: pytorch lightning base module
+                """
+                if (pl_module.current_epoch + 1) % every_n_epoch == 0:
+                    cur_metrics = trainer.callback_metrics
+                    # Cast metric value as  float before passing into logger.
+                    metrics = dict(map(lambda x: (x[0], float(x[1])), cur_metrics.items()))
+                    metrics_logger.record_metrics(metrics, pl_module.current_epoch)
 
-            :param trainer: pytorch lightning trainer instance
-            :param pl_module: pytorch lightning base module
-            """
-            try_mlflow_log(mlflow.set_tag, "Mode", "testing")
-            for key, value in trainer.callback_metrics.items():
-                try_mlflow_log(mlflow.log_metric, key, float(value))
+                for callback in trainer.callbacks:
+                    if isinstance(callback, pl.callbacks.early_stopping.EarlyStopping):
+                        self._early_stop_check(callback)
 
-        @staticmethod
-        def _log_early_stop_params(early_stop_obj):
-            """
-            Logs Early Stop parameters into mlflow
+            def on_train_start(self, trainer, pl_module):
+                """
+                Logs Optimizer related metrics when the train begins
 
-            :param early_stop_obj: Early stopping callback dict
-            """
-            if hasattr(early_stop_obj, "monitor"):
-                try_mlflow_log(mlflow.log_param, "monitor", early_stop_obj.monitor)
+                :param trainer: pytorch lightning trainer instance
+                :param pl_module: pytorch lightning base module
+                """
+                try_mlflow_log(mlflow.set_tag, "Mode", "training")
+                try_mlflow_log(mlflow.log_param, "epochs", trainer.max_epochs)
 
-            if hasattr(early_stop_obj, "mode"):
-                try_mlflow_log(mlflow.log_param, "mode", early_stop_obj.mode)
+                for callback in trainer.callbacks:
+                    if isinstance(callback, pl.callbacks.early_stopping.EarlyStopping):
+                        self.early_stopping = True
+                        self._log_early_stop_params(callback)
 
-            if hasattr(early_stop_obj, "patience"):
-                try_mlflow_log(mlflow.log_param, "patience", early_stop_obj.patience)
+                # TODO For logging optimizer params - Following scenarios are to revisited.
+                # 1. In the current scenario, only the first optimizer details are logged.
+                #    Code to be enhanced to log params when multiple optimizers are used.
+                # 2. mlflow.log_params is used to store optimizer default values into mlflow.
+                #    The keys in default dictionary are too short, Ex: (lr - learning_rate).
+                #    Efficient mapping technique needs to be introduced
+                #    to rename the optimizer parameters based on keys in default dictionary.
 
-            if hasattr(early_stop_obj, "min_delta"):
-                try_mlflow_log(mlflow.log_param, "min_delta", early_stop_obj.min_delta)
+                if hasattr(trainer, "optimizers"):
+                    optimizer = trainer.optimizers[0]
+                    try_mlflow_log(mlflow.log_param, "optimizer_name", type(optimizer).__name__)
 
-            if hasattr(early_stop_obj, "stopped_epoch"):
-                try_mlflow_log(mlflow.log_param, "stopped_epoch", early_stop_obj.stopped_epoch)
+                    if hasattr(optimizer, "defaults"):
+                        try_mlflow_log(mlflow.log_params, optimizer.defaults)
 
-        @staticmethod
-        def _early_stop_check(early_stop_callback):
-            """
-            Logs all early stopping metrics
+                summary = str(ModelSummary(pl_module, mode="full"))
+                tempdir = tempfile.mkdtemp()
+                try:
+                    summary_file = os.path.join(tempdir, "model_summary.txt")
+                    with open(summary_file, "w") as f:
+                        f.write(summary)
 
-            :param early_stop_callback: Early stopping callback object
-            """
-            if early_stop_callback.stopped_epoch != 0:
+                    try_mlflow_log(mlflow.log_artifact, local_path=summary_file)
+                finally:
+                    shutil.rmtree(tempdir)
 
-                if hasattr(early_stop_callback, "stopped_epoch"):
+            def on_train_end(self, trainer, pl_module):
+                """
+                Logs the model checkpoint into mlflow - models folder on the training end
+
+                :param trainer: pytorch lightning trainer instance
+                :param pl_module: pytorch lightning base module
+                """
+
+                mlflow.pytorch.log_model(pytorch_model=trainer.model, artifact_path="model")
+
+                if self.early_stopping and trainer.checkpoint_callback.best_model_path:
                     try_mlflow_log(
-                        mlflow.log_metric, "stopped_epoch", early_stop_callback.stopped_epoch
-                    )
-                    restored_epoch = early_stop_callback.stopped_epoch - max(
-                        1, early_stop_callback.patience
-                    )
-                    try_mlflow_log(mlflow.log_metric, "restored_epoch", restored_epoch)
-
-                if hasattr(early_stop_callback, "best_score"):
-                    try_mlflow_log(
-                        mlflow.log_metric, "best_score", float(early_stop_callback.best_score)
+                        mlflow.log_artifact,
+                        local_path=trainer.checkpoint_callback.best_model_path,
+                        artifact_path="restored_model_checkpoint",
                     )
 
-                if hasattr(early_stop_callback, "wait_count"):
-                    try_mlflow_log(mlflow.log_metric, "wait_count", early_stop_callback.wait_count)
+            def on_test_end(self, trainer, pl_module):
+                """
+                Logs accuracy and other relevant metrics on the testing end
+
+                :param trainer: pytorch lightning trainer instance
+                :param pl_module: pytorch lightning base module
+                """
+                try_mlflow_log(mlflow.set_tag, "Mode", "testing")
+                for key, value in trainer.callback_metrics.items():
+                    try_mlflow_log(mlflow.log_metric, key, float(value))
+
+            @staticmethod
+            def _log_early_stop_params(early_stop_obj):
+                """
+                Logs Early Stop parameters into mlflow
+
+                :param early_stop_obj: Early stopping callback dict
+                """
+                if hasattr(early_stop_obj, "monitor"):
+                    try_mlflow_log(mlflow.log_param, "monitor", early_stop_obj.monitor)
+
+                if hasattr(early_stop_obj, "mode"):
+                    try_mlflow_log(mlflow.log_param, "mode", early_stop_obj.mode)
+
+                if hasattr(early_stop_obj, "patience"):
+                    try_mlflow_log(mlflow.log_param, "patience", early_stop_obj.patience)
+
+                if hasattr(early_stop_obj, "min_delta"):
+                    try_mlflow_log(mlflow.log_param, "min_delta", early_stop_obj.min_delta)
+
+                if hasattr(early_stop_obj, "stopped_epoch"):
+                    try_mlflow_log(mlflow.log_param, "stopped_epoch", early_stop_obj.stopped_epoch)
+
+            @staticmethod
+            def _early_stop_check(early_stop_callback):
+                """
+                Logs all early stopping metrics
+
+                :param early_stop_callback: Early stopping callback object
+                """
+                if early_stop_callback.stopped_epoch != 0:
+                    early_stop_metrics = {}
+
+                    if hasattr(early_stop_callback, "stopped_epoch"):
+                        early_stop_metrics["stopped_epoch"] = early_stop_callback.stopped_epoch
+
+                        restored_epoch = early_stop_callback.stopped_epoch - max(
+                            1, early_stop_callback.patience
+                        )
+                        early_stop_metrics["restored_epoch"] = restored_epoch
+
+                    if hasattr(early_stop_callback, "best_score"):
+                        early_stop_metrics["best_score"] =  float(early_stop_callback.best_score)
+
+                    if hasattr(early_stop_callback, "wait_count"):
+                        early_stop_metrics["wait_count"] = early_stop_callback.wait_count
+
+                    if early_stop_metrics:
+                        epoch = early_stop_callback.stopped_epoch
+                        metrics_logger.record_metrics(early_stop_metrics, epoch)
+
+        return __MLflowPLCallback
 
     def _run_and_log_function(self, original, args, kwargs):
         """
@@ -203,8 +207,9 @@ def _autolog(log_every_n_epoch=1):
 
         run_id = mlflow.active_run().info.run_id
         with batch_metrics_logger(run_id) as metrics_logger:
+            __MLflowPLCallback = getPLCallback(metrics_logger)
             if not any(isinstance(callbacks, __MLflowPLCallback) for callbacks in self.callbacks):
-                self.callbacks += [__MLflowPLCallback(metrics_logger)]
+                self.callbacks += [__MLflowPLCallback()]
             result = original(self, *args, **kwargs)
 
         if auto_end_run:

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -183,7 +183,7 @@ def _autolog(log_every_n_epoch=1):
                         early_stop_metrics["restored_epoch"] = restored_epoch
 
                     if hasattr(early_stop_callback, "best_score"):
-                        early_stop_metrics["best_score"] =  float(early_stop_callback.best_score)
+                        early_stop_metrics["best_score"] = float(early_stop_callback.best_score)
 
                     if hasattr(early_stop_callback, "wait_count"):
                         early_stop_metrics["wait_count"] = early_stop_callback.wait_count

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -174,25 +174,24 @@ def _autolog(log_every_n_epoch=1, log_models=True):
                 :param early_stop_callback: Early stopping callback object
                 """
                 if early_stop_callback.stopped_epoch != 0:
-                    early_stop_metrics = {}
-
                     if hasattr(early_stop_callback, "stopped_epoch"):
-                        early_stop_metrics["stopped_epoch"] = early_stop_callback.stopped_epoch
-
+                        metrics_logger.record_metrics(
+                            {"stopped_epoch": early_stop_callback.stopped_epoch}
+                        )
                         restored_epoch = early_stop_callback.stopped_epoch - max(
                             1, early_stop_callback.patience
                         )
-                        early_stop_metrics["restored_epoch"] = restored_epoch
+                        metrics_logger.record_metrics({"restored_epoch": restored_epoch})
 
                     if hasattr(early_stop_callback, "best_score"):
-                        early_stop_metrics["best_score"] = float(early_stop_callback.best_score)
+                        metrics_logger.record_metrics(
+                            {"best_score": float(early_stop_callback.best_score)}
+                        )
 
                     if hasattr(early_stop_callback, "wait_count"):
-                        early_stop_metrics["wait_count"] = early_stop_callback.wait_count
-
-                    if early_stop_metrics:
-                        epoch = early_stop_callback.stopped_epoch
-                        metrics_logger.record_metrics(early_stop_metrics, epoch)
+                        metrics_logger.record_metrics(
+                            {"wait_count": early_stop_callback.wait_count}
+                        )
 
         return __MLflowPLCallback
 

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -123,7 +123,7 @@ def _autolog(log_every_n_epoch=1, log_models=True):
                 :param trainer: pytorch lightning trainer instance
                 :param pl_module: pytorch lightning base module
                 """
-                if self.log_models:
+                if log_models:
                     mlflow.pytorch.log_model(pytorch_model=trainer.model, artifact_path="model")
 
                     if self.early_stopping and trainer.checkpoint_callback.best_model_path:

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -52,7 +52,6 @@ def _autolog(log_every_n_epoch=1, log_models=True):
     # There may be no run defined so no run_id is passed to logger
     metrics_logger = BatchMetricsLogger()
 
-
     def getPLCallback(metrics_logger, log_models):
         class __MLflowPLCallback(pl.Callback):
             """

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -6,7 +6,7 @@ import shutil
 import tempfile
 from pytorch_lightning.core.memory import ModelSummary
 from pytorch_lightning.utilities import rank_zero_only
-from mlflow.utils.autologging_utils import try_mlflow_log, wrap_patch, BatchMetricsLogger
+from mlflow.utils.autologging_utils import try_mlflow_log, wrap_patch, batch_metrics_logger
 from mlflow.utils.annotations import experimental
 from mlflow.utils import gorilla
 
@@ -49,10 +49,23 @@ def _autolog(log_every_n_epoch=1, log_models=True):
     global every_n_epoch
     every_n_epoch = log_every_n_epoch
 
-    # There may be no run defined so no run_id is passed to logger
-    metrics_logger = BatchMetricsLogger()
+    class __MetricsLoggerProvider:
+        """
+        This class is used to enable swapping .
+        """
 
-    def getPLCallback(metrics_logger, log_models):
+        def __init__(self):
+            self.metrics_logger = None
+
+        def swap_logger(self, new_metrics_logger):
+            self.metrics_logger = new_metrics_logger
+
+        def get_logger(self):
+            return self.metrics_logger
+
+    metrics_logger_provider = __MetricsLoggerProvider()
+
+    def getPLCallback(log_models):
         class __MLflowPLCallback(pl.Callback):
             """
             Callback for auto-logging metrics and parameters.
@@ -72,6 +85,9 @@ def _autolog(log_every_n_epoch=1, log_models=True):
                     cur_metrics = trainer.callback_metrics
                     # Cast metric value as  float before passing into logger.
                     metrics = dict(map(lambda x: (x[0], float(x[1])), cur_metrics.items()))
+
+                    # Get the BatchMetricsLogger tied to the current mlflow run.
+                    metrics_logger = metrics_logger_provider.get_logger()
                     metrics_logger.record_metrics(metrics, pl_module.current_epoch)
 
                 for callback in trainer.callbacks:
@@ -126,9 +142,6 @@ def _autolog(log_every_n_epoch=1, log_models=True):
                 :param trainer: pytorch lightning trainer instance
                 :param pl_module: pytorch lightning base module
                 """
-                # manually flushing any remaining metrics from training.
-                metrics_logger.flush()
-
                 if log_models:
                     mlflow.pytorch.log_model(pytorch_model=trainer.model, artifact_path="model")
 
@@ -179,6 +192,9 @@ def _autolog(log_every_n_epoch=1, log_models=True):
 
                 :param early_stop_callback: Early stopping callback object
                 """
+                # Get the BatchMetricsLogger tied to the current mlflow run.
+                metrics_logger = metrics_logger_provider.get_logger()
+
                 if early_stop_callback.stopped_epoch != 0:
                     if hasattr(early_stop_callback, "stopped_epoch"):
                         metrics_logger.record_metrics(
@@ -213,13 +229,13 @@ def _autolog(log_every_n_epoch=1, log_models=True):
             auto_end_run = False
 
         run_id = mlflow.active_run().info.run_id
-
-        # Setting run_id on BatchMetricsLogger instance
-        metrics_logger.run_id = run_id
-        __MLflowPLCallback = getPLCallback(metrics_logger, log_models)
-        if not any(isinstance(callbacks, __MLflowPLCallback) for callbacks in self.callbacks):
-            self.callbacks += [__MLflowPLCallback()]
-        result = original(self, *args, **kwargs)
+        with batch_metrics_logger(run_id) as metrics_logger:
+            # Swap the BatchMetricsLogger set on metrics_logger_provider before each fit session.
+            metrics_logger_provider.swap_logger(metrics_logger)
+            __MLflowPLCallback = getPLCallback(log_models)
+            if not any(isinstance(callbacks, __MLflowPLCallback) for callbacks in self.callbacks):
+                self.callbacks += [__MLflowPLCallback()]
+            result = original(self, *args, **kwargs)
 
         if auto_end_run:
             try_mlflow_log(mlflow.end_run)

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -127,7 +127,7 @@ def _autolog(log_every_n_epoch=1, log_models=True):
                 :param pl_module: pytorch lightning base module
                 """
                 # manually flushing any remaining metrics from training.
-                metrics_logger._flush()
+                metrics_logger.flush()
 
                 if log_models:
                     mlflow.pytorch.log_model(pytorch_model=trainer.model, artifact_path="model")

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -218,7 +218,7 @@ def _autolog(log_every_n_epoch=1, log_models=True):
         metrics_logger.run_id = run_id
         __MLflowPLCallback = getPLCallback(metrics_logger, log_models)
         if not any(isinstance(callbacks, __MLflowPLCallback) for callbacks in self.callbacks):
-            self.callbacks += [__MLflowPLCallback]
+            self.callbacks += [__MLflowPLCallback()]
         result = original(self, *args, **kwargs)
 
         if auto_end_run:

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -964,12 +964,12 @@ def autolog(every_n_iter=100, log_models=True):
             if callback_attrs is None:
                 return
             stopped_epoch, restore_best_weights, patience = callback_attrs
-            metrics_logger.record_metrics({"stopped_epoch": stopped_epoch}, stopped_epoch)
+            metrics_logger.record_metrics({"stopped_epoch": stopped_epoch})
 
             # Weights are restored only if early stopping occurs
             if stopped_epoch != 0 and restore_best_weights:
                 restored_epoch = stopped_epoch - max(1, patience)
-                metrics_logger.record_metrics({"restored_epoch": restored_epoch}, restored_epoch)
+                metrics_logger.record_metrics({"restored_epoch": restored_epoch})
 
                 restored_metrics = {
                     key: history.history[key][restored_epoch] for key in history.history.keys()

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -726,7 +726,6 @@ def _setup_callbacks(lst, log_models, metrics_logger):
         def __init__(self):
             super().__init__()
 
-
         def __enter__(self):
             pass
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1001,7 +1001,9 @@ def autolog(every_n_iter=100):
                     args = tuple(tmp_list)
                 elif "callbacks" in kwargs:
                     early_stop_callback = _early_stop_check(kwargs["callbacks"])
-                    kwargs["callbacks"], log_dir = _setup_callbacks(kwargs["callbacks"], metrics_logger)
+                    kwargs["callbacks"], log_dir = _setup_callbacks(
+                        kwargs["callbacks"], metrics_logger
+                    )
                 else:
                     kwargs["callbacks"], log_dir = _setup_callbacks([], metrics_logger)
 
@@ -1033,12 +1035,14 @@ def autolog(every_n_iter=100):
                 # Checking if the 'callback' argument of fit() is set
                 if len(args) >= 5:
                     tmp_list = list(args)
-                    tmp_list[4], log_dir = _setup_callbacks(tmp_list[4],metrics_logger)
+                    tmp_list[4], log_dir = _setup_callbacks(tmp_list[4], metrics_logger)
                     args = tuple(tmp_list)
                 elif "callbacks" in kwargs:
-                    kwargs["callbacks"], log_dir = _setup_callbacks(kwargs["callbacks"],metrics_logger)
+                    kwargs["callbacks"], log_dir = _setup_callbacks(
+                        kwargs["callbacks"], metrics_logger
+                    )
                 else:
-                    kwargs["callbacks"], log_dir = _setup_callbacks([],metrics_logger)
+                    kwargs["callbacks"], log_dir = _setup_callbacks([], metrics_logger)
                 result = original(self, *args, **kwargs)
 
             _flush_queue()

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -656,9 +656,6 @@ def _setup_callbacks(lst, log_models, metrics_logger):
         Records model structural information as params after training finishes.
         """
 
-        def __init__(self):
-            super().__init__()
-
         def __enter__(self):
             pass
 
@@ -722,9 +719,6 @@ def _setup_callbacks(lst, log_models, metrics_logger):
         Callback for auto-logging parameters and metrics in TensorFlow >= 2.0.0.
         Records model structural information as params when training starts.
         """
-
-        def __init__(self):
-            super().__init__()
 
         def __enter__(self):
             pass

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -204,7 +204,7 @@ class BatchMetricsLogger:
         self.total_log_batch_time = 0
         self.previous_training_timestamp = None
 
-    def _purge(self):
+    def _flush(self):
         self._timed_log_batch()
         self.data = []
 
@@ -219,7 +219,7 @@ class BatchMetricsLogger:
         end = time.time()
         self.total_log_batch_time += end - start
 
-    def _should_purge(self):
+    def _should_flush(self):
         target_training_to_logging_time_ratio = 10
         if (
             self.total_training_time
@@ -249,8 +249,8 @@ class BatchMetricsLogger:
         for key, value in metrics.items():
             self.data.append(Metric(key, value, int(current_timestamp * 1000), step))
 
-        if self._should_purge():
-            self._purge()
+        if self._should_flush():
+            self._flush()
 
         self.previous_training_timestamp = current_timestamp
 
@@ -274,4 +274,4 @@ def batch_metrics_logger(run_id):
 
     batch_metrics_logger = BatchMetricsLogger(run_id)
     yield batch_metrics_logger
-    batch_metrics_logger._purge()
+    batch_metrics_logger._flush()

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -156,7 +156,7 @@ def resolve_input_example_and_signature(
 
 
 class BatchMetricsLogger:
-    def __init__(self, run_id):
+    def __init__(self, run_id=None):
         self.run_id = run_id
 
         # data is an array of Metric objects

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -156,7 +156,7 @@ def resolve_input_example_and_signature(
 
 
 class BatchMetricsLogger:
-    def __init__(self, run_id=None):
+    def __init__(self, run_id):
         self.run_id = run_id
 
         # data is an array of Metric objects

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -160,9 +160,10 @@ class BatchMetricsLogger:
     The BatchMetricsLogger will log metrics in batch against an mlflow run.
     If run_id is passed to to constructor then all recording and logging will
     happen against that run_id.
-    If no run_id is passed into constructor, then it is assumed that there is
-    an active mlflow run when there is a need to log_batch metrics. The id of that active run
-    will be retrieved from mlflow.
+    If no run_id is passed into constructor, then the run ID will be fetched
+    from `mlflow.active_run()` each time `record_metrics()` or `flush()` is called; in this
+    case, callers must ensure that an active run is present before invoking
+    `record_metrics()` or `flush()`.
     """
 
     def __init__(self, run_id=None):

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -229,7 +229,7 @@ class BatchMetricsLogger:
 
         return False
 
-    def record_metrics(self, metrics, step):
+    def record_metrics(self, metrics, step=None):
         """
         Submit a set of metrics to be logged. The metrics may not be immediately logged, as this
         class will batch them in order to not increase execution time too much by logging

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -246,7 +246,12 @@ class BatchMetricsLogger:
 
         self.total_training_time += training_time
 
+        # log_batch() requires step to be defined. Therefore will set step to 0 if not defined.
+        if step is None:
+            step = 0
+
         for key, value in metrics.items():
+
             self.data.append(Metric(key, value, int(current_timestamp * 1000), step))
 
         if self._should_flush():

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -165,7 +165,10 @@ class BatchMetricsLogger:
         self.total_log_batch_time = 0
         self.previous_training_timestamp = None
 
-    def _flush(self):
+    def flush(self):
+        """
+        The metrics accumulated by BatchMetricsLogger will be batch logged to MLFlow.
+        """
         self._timed_log_batch()
         self.data = []
 
@@ -216,7 +219,7 @@ class BatchMetricsLogger:
             self.data.append(Metric(key, value, int(current_timestamp * 1000), step))
 
         if self._should_flush():
-            self._flush()
+            self.flush()
 
         self.previous_training_timestamp = current_timestamp
 
@@ -240,4 +243,4 @@ def batch_metrics_logger(run_id):
 
     batch_metrics_logger = BatchMetricsLogger(run_id)
     yield batch_metrics_logger
-    batch_metrics_logger._flush()
+    batch_metrics_logger.flush()

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -167,7 +167,7 @@ class BatchMetricsLogger:
 
     def flush(self):
         """
-        The metrics accumulated by BatchMetricsLogger will be batch logged to MLFlow.
+        The metrics accumulated by BatchMetricsLogger will be batch logged to an MLFlow run.
         """
         self._timed_log_batch()
         self.data = []

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -455,7 +455,7 @@ def autolog(
                 extra_step = len(eval_results)
                 metrics_logger.record_metrics({"stopped_iteration": extra_step - 1})
                 metrics_logger.record_metrics({"best_iteration": model.best_iteration})
-                metrics_logger.record_metrics(eval_results[model.best_iteration], step=extra_step)
+                metrics_logger.record_metrics(eval_results[model.best_iteration], extra_step)
 
         # logging feature importance as artifacts.
         for imp_type in importance_types:

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -434,17 +434,19 @@ def autolog(
             # training model
             model = original(*args, **kwargs)
 
-        # If early_stopping_rounds is present, logging metrics at the best iteration
-        # as extra metrics with the max step + 1.
-        early_stopping_index = all_arg_names.index("early_stopping_rounds")
-        early_stopping = (
-            num_pos_args >= early_stopping_index + 1 or "early_stopping_rounds" in kwargs
-        )
-        if early_stopping:
-            extra_step = len(eval_results)
-            try_mlflow_log(mlflow.log_metric, "stopped_iteration", len(eval_results) - 1)
-            try_mlflow_log(mlflow.log_metric, "best_iteration", model.best_iteration)
-            try_mlflow_log(mlflow.log_metrics, eval_results[model.best_iteration], step=extra_step)
+            # If early_stopping_rounds is present, logging metrics at the best iteration
+            # as extra metrics with the max step + 1.
+            early_stopping_index = all_arg_names.index("early_stopping_rounds")
+            early_stopping = (
+                num_pos_args >= early_stopping_index + 1 or "early_stopping_rounds" in kwargs
+            )
+            if early_stopping:
+                extra_step = len(eval_results)
+
+                early_stopping_metrics = eval_results[model.best_iteration]
+                early_stopping_metrics["stopped_iteration"] = extra_step - 1
+                early_stopping_metrics["best_iteration"] = model.best_iteration
+                metrics_logger.record_metrics(early_stopping_metrics, step=extra_step)
 
         # logging feature importance as artifacts.
         for imp_type in importance_types:

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -453,11 +453,9 @@ def autolog(
             )
             if early_stopping:
                 extra_step = len(eval_results)
-
-                early_stopping_metrics = eval_results[model.best_iteration]
-                early_stopping_metrics["stopped_iteration"] = extra_step - 1
-                early_stopping_metrics["best_iteration"] = model.best_iteration
-                metrics_logger.record_metrics(early_stopping_metrics, step=extra_step)
+                metrics_logger.record_metrics({"stopped_iteration": extra_step - 1})
+                metrics_logger.record_metrics({"best_iteration": model.best_iteration})
+                metrics_logger.record_metrics(eval_results[model.best_iteration], step=extra_step)
 
         # logging feature importance as artifacts.
         for imp_type in importance_types:

--- a/tests/fastai/test_fastai_autolog.py
+++ b/tests/fastai/test_fastai_autolog.py
@@ -9,7 +9,6 @@ from fastai.metrics import accuracy
 import mlflow
 import mlflow.fastai
 from fastai.callbacks import EarlyStoppingCallback
-from mlflow.utils.autologging_utils import BatchMetricsLogger
 from unittest.mock import patch
 
 np.random.seed(1337)
@@ -108,7 +107,7 @@ def test_fastai_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant):
             patched_metrics_data.extend(metrics)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        model, run = fastai_random_data_run(iris_data(), fit_variant, manual_run)
+        model, _ = fastai_random_data_run(iris_data(), fit_variant, manual_run)
 
     assert "train_loss" in patched_metrics_data
     assert "valid_loss" in patched_metrics_data
@@ -309,7 +308,7 @@ def test_fastai_autolog_batch_metrics_logger_logs_early_stopping_metrics(
             patched_metrics_data.extend(metrics)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        model, run = fastai_random_data_run_with_callback(
+        model, _ = fastai_random_data_run_with_callback(
             iris_data(), fit_variant, manual_run, callback, patience
         )
 

--- a/tests/fastai/test_fastai_autolog.py
+++ b/tests/fastai/test_fastai_autolog.py
@@ -100,7 +100,10 @@ def test_fastai_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant):
 
     # Mock patching BatchMetricsLogger.record_metrics()
     # to insure that expected metrics are being logged.
-    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+    with patch(
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+    ) as record_metrics_mock:
+
         def record_metrics_side_effect(metrics, *args):
             patched_metrics_data.extend(metrics)
 
@@ -291,17 +294,24 @@ def test_fastai_autolog_non_early_stop_callback_does_not_log(fastai_random_data_
 @pytest.mark.parametrize("fit_variant", ["fit", "fit_one_cycle"])
 @pytest.mark.parametrize("callback", ["not-early"])
 @pytest.mark.parametrize("patience", [5])
-def test_fastai_autolog_batch_metrics_logger_logs_early_stopping_metrics(fit_variant, callback, patience):
+def test_fastai_autolog_batch_metrics_logger_logs_early_stopping_metrics(
+    fit_variant, callback, patience
+):
     patched_metrics_data = []
 
     # Mock patching BatchMetricsLogger.record_metrics()
     # to insure that expected metrics are being logged.
-    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+    with patch(
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+    ) as record_metrics_mock:
+
         def record_metrics_side_effect(metrics, *args):
             patched_metrics_data.extend(metrics)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        model, run = fastai_random_data_run_with_callback(iris_data(), fit_variant, manual_run, callback, patience)
+        model, run = fastai_random_data_run_with_callback(
+            iris_data(), fit_variant, manual_run, callback, patience
+        )
 
     num_of_epochs = len(model.recorder.val_losses)
     assert "stopped_epoch" not in patched_metrics_data

--- a/tests/fastai/test_fastai_autolog.py
+++ b/tests/fastai/test_fastai_autolog.py
@@ -286,7 +286,7 @@ def test_fastai_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant, 
             original(self, metrics, step)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        model, run = fastai_random_data_run_with_callback(
+        _, run = fastai_random_data_run_with_callback(
             iris_data(), fit_variant, manual_run, callback, patience
         )
 

--- a/tests/fastai/test_fastai_autolog.py
+++ b/tests/fastai/test_fastai_autolog.py
@@ -9,6 +9,7 @@ from fastai.metrics import accuracy
 import mlflow
 import mlflow.fastai
 from fastai.callbacks import EarlyStoppingCallback
+from mlflow.utils.autologging_utils import BatchMetricsLogger
 from unittest.mock import patch
 
 np.random.seed(1337)
@@ -90,31 +91,6 @@ def fastai_random_data_run(iris_data, fit_variant, manual_run):
 
     client = mlflow.tracking.MlflowClient()
     return model, client.get_run(client.list_run_infos(experiment_id="0")[0].run_id)
-
-
-@pytest.mark.large
-@pytest.mark.parametrize("fit_variant", ["fit", "fit_one_cycle"])
-def test_fastai_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant):
-    patched_metrics_data = []
-
-    # Mock patching BatchMetricsLogger.record_metrics()
-    # to insure that expected metrics are being logged.
-    with patch(
-        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
-    ) as record_metrics_mock:
-
-        def record_metrics_side_effect(metrics, *args):
-            # pylint: disable=unused-argument
-            patched_metrics_data.extend(metrics)
-
-        record_metrics_mock.side_effect = record_metrics_side_effect
-        model, _ = fastai_random_data_run(iris_data(), fit_variant, manual_run)
-
-    assert "train_loss" in patched_metrics_data
-    assert "valid_loss" in patched_metrics_data
-
-    for o in model.metrics:
-        assert o.__name__ in patched_metrics_data
 
 
 @pytest.mark.large
@@ -294,27 +270,28 @@ def test_fastai_autolog_non_early_stop_callback_does_not_log(fastai_random_data_
 @pytest.mark.parametrize("fit_variant", ["fit", "fit_one_cycle"])
 @pytest.mark.parametrize("callback", ["not-early"])
 @pytest.mark.parametrize("patience", [5])
-def test_fastai_autolog_batch_metrics_logger_logs_early_stopping_metrics(
-    fit_variant, callback, patience
-):
+def test_fastai_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant, callback, patience):
     patched_metrics_data = []
 
     # Mock patching BatchMetricsLogger.record_metrics()
-    # to insure that expected metrics are being logged.
+    # to ensure that expected metrics are being logged.
+    original = BatchMetricsLogger.record_metrics
+
     with patch(
-        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics", autospec=True
     ) as record_metrics_mock:
 
-        def record_metrics_side_effect(metrics, *args):
-            # pylint: disable=unused-argument
-            patched_metrics_data.extend(metrics)
+        def record_metrics_side_effect(self, metrics, step=None):
+            patched_metrics_data.extend(metrics.items())
+            original(self, metrics, step)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        model, _ = fastai_random_data_run_with_callback(
+        model, run = fastai_random_data_run_with_callback(
             iris_data(), fit_variant, manual_run, callback, patience
         )
 
-    num_of_epochs = len(model.recorder.val_losses)
-    assert "stopped_epoch" not in patched_metrics_data
-    assert "restored_epoch" not in patched_metrics_data
-    assert patched_metrics_data.count("valid_loss") == num_of_epochs
+    patched_metrics_data = dict(patched_metrics_data)
+    original_metrics = run.data.metrics
+    for metric_name in original_metrics:
+        assert metric_name in patched_metrics_data
+        assert original_metrics[metric_name] == patched_metrics_data[metric_name]

--- a/tests/fastai/test_fastai_autolog.py
+++ b/tests/fastai/test_fastai_autolog.py
@@ -104,6 +104,7 @@ def test_fastai_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant):
     ) as record_metrics_mock:
 
         def record_metrics_side_effect(metrics, *args):
+            # pylint: disable=unused-argument
             patched_metrics_data.extend(metrics)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
@@ -305,6 +306,7 @@ def test_fastai_autolog_batch_metrics_logger_logs_early_stopping_metrics(
     ) as record_metrics_mock:
 
         def record_metrics_side_effect(metrics, *args):
+            # pylint: disable=unused-argument
             patched_metrics_data.extend(metrics)
 
         record_metrics_mock.side_effect = record_metrics_side_effect

--- a/tests/fastai/test_fastai_autolog.py
+++ b/tests/fastai/test_fastai_autolog.py
@@ -295,3 +295,6 @@ def test_fastai_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant, 
     for metric_name in original_metrics:
         assert metric_name in patched_metrics_data
         assert original_metrics[metric_name] == patched_metrics_data[metric_name]
+
+    assert "train_loss" in original_metrics
+    assert "train_loss" in patched_metrics_data

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -83,6 +83,7 @@ def test_gluon_autolog_batch_metrics_logger_logs_expected_metrics():
     ) as record_metrics_mock:
 
         def record_metrics_side_effect(metrics, *args):
+            # pylint: disable=unused-argument
             patched_metrics_data.extend(metrics)
 
         record_metrics_mock.side_effect = record_metrics_side_effect

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -97,6 +97,9 @@ def test_gluon_autolog_batch_metrics_logger_logs_expected_metrics():
         assert metric_name in patched_metrics_data
         assert original_metrics[metric_name] == patched_metrics_data[metric_name]
 
+    assert "train accuracy" in original_metrics
+    assert "train accuracy" in patched_metrics_data
+
 
 @pytest.mark.large
 def test_gluon_autolog_model_can_load_from_artifact(gluon_random_data_run):

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -11,13 +11,11 @@ from mxnet.gluon.data import Dataset, DataLoader
 from mxnet.gluon.loss import SoftmaxCrossEntropyLoss
 from mxnet.gluon.nn import HybridSequential, Dense
 from mxnet.metric import Accuracy
-from unittest.mock import patch
-
 
 import mlflow
 import mlflow.gluon
 from mlflow.utils.autologging_utils import BatchMetricsLogger
-
+from unittest.mock import patch
 
 
 class LogsDataset(Dataset):

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -11,7 +11,6 @@ from mxnet.gluon.data import Dataset, DataLoader
 from mxnet.gluon.loss import SoftmaxCrossEntropyLoss
 from mxnet.gluon.nn import HybridSequential, Dense
 from mxnet.metric import Accuracy
-from mlflow.utils.autologging_utils import BatchMetricsLogger
 from unittest.mock import patch
 
 
@@ -87,7 +86,7 @@ def test_gluon_autolog_batch_metrics_logger_logs_expected_metrics():
             patched_metrics_data.extend(metrics)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        run = gluon_random_data_run()
+        gluon_random_data_run()
 
     assert "train accuracy" in patched_metrics_data
     assert "validation accuracy" in patched_metrics_data

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -79,7 +79,10 @@ def test_gluon_autolog_batch_metrics_logger_logs_expected_metrics():
 
     # Mock patching BatchMetricsLogger.record_metrics()
     # to insure that expected metrics are being logged.
-    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+    with patch(
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+    ) as record_metrics_mock:
+
         def record_metrics_side_effect(metrics, *args):
             patched_metrics_data.extend(metrics)
 

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -89,7 +89,7 @@ def test_gluon_autolog_batch_metrics_logger_logs_expected_metrics():
             original(self, metrics, step)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        run  = gluon_random_data_run()
+        run = gluon_random_data_run()
 
     patched_metrics_data = dict(patched_metrics_data)
     original_metrics = run.data.metrics

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -11,6 +11,9 @@ from mxnet.gluon.data import Dataset, DataLoader
 from mxnet.gluon.loss import SoftmaxCrossEntropyLoss
 from mxnet.gluon.nn import HybridSequential, Dense
 from mxnet.metric import Accuracy
+from mlflow.utils.autologging_utils import BatchMetricsLogger
+from unittest.mock import patch
+
 
 import mlflow
 import mlflow.gluon
@@ -68,6 +71,25 @@ def test_gluon_autolog_logs_expected_data(gluon_random_data_run):
     assert data.params["optimizer_name"] == "Adam"
     assert "epsilon" in data.params
     assert data.params["epsilon"] == "1e-07"
+
+
+@pytest.mark.large
+def test_gluon_autolog_batch_metrics_logger_logs_expected_metrics():
+    patched_metrics_data = []
+
+    # Mock patching BatchMetricsLogger.record_metrics()
+    # to insure that expected metrics are being logged.
+    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+        def record_metrics_side_effect(metrics, *args):
+            patched_metrics_data.extend(metrics)
+
+        record_metrics_mock.side_effect = record_metrics_side_effect
+        run = gluon_random_data_run()
+
+    assert "train accuracy" in patched_metrics_data
+    assert "validation accuracy" in patched_metrics_data
+    assert "train softmaxcrossentropyloss" in patched_metrics_data
+    assert "validation softmaxcrossentropyloss" in patched_metrics_data
 
 
 @pytest.mark.large

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -147,6 +147,7 @@ def test_keras_autolog_logs_expected_data(keras_random_data_run):
     artifacts = map(lambda x: x.path, artifacts)
     assert "model_summary.txt" in artifacts
 
+
 @pytest.mark.large
 @pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
 def test_keras_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant):
@@ -154,7 +155,10 @@ def test_keras_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant):
 
     # Mock patching BatchMetricsLogger.record_metrics()
     # to insure that expected metrics are being logged.
-    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+    with patch(
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+    ) as record_metrics_mock:
+
         def record_metrics_side_effect(metrics, *args):
             patched_metrics_data.extend(metrics)
 
@@ -289,12 +293,17 @@ def test_keras_autolog_early_stop_logs(keras_random_data_run_with_callback):
 @pytest.mark.parametrize("restore_weights", [True])
 @pytest.mark.parametrize("callback", ["early"])
 @pytest.mark.parametrize("patience", [0, 1, 5])
-def test_keras_autolog_batch_metrics_logger_logs_early_stopping_metrics(fit_variant, callback, restore_weights, patience):
+def test_keras_autolog_batch_metrics_logger_logs_early_stopping_metrics(
+    fit_variant, callback, restore_weights, patience
+):
     patched_metrics_data = []
 
     # Mock patching BatchMetricsLogger.record_metrics()
     # to insure that expected metrics are being logged.
-    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+    with patch(
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+    ) as record_metrics_mock:
+
         def record_metrics_side_effect(metrics, *args):
             patched_metrics_data.extend(metrics.items())
 

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -165,7 +165,7 @@ def test_keras_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant):
         record_metrics_mock.side_effect = record_metrics_side_effect
         keras_random_data_run(random_train_data(), fit_variant, random_one_hot_labels(), manual_run)
 
-    assert "accuracy" in patched_metrics_data
+    assert "acc" in patched_metrics_data
     assert "loss" in patched_metrics_data
 
 

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -159,6 +159,7 @@ def test_keras_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant):
     ) as record_metrics_mock:
 
         def record_metrics_side_effect(metrics, *args):
+            # pylint: disable=unused-argument
             patched_metrics_data.extend(metrics)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
@@ -304,6 +305,7 @@ def test_keras_autolog_batch_metrics_logger_logs_early_stopping_metrics(
     ) as record_metrics_mock:
 
         def record_metrics_side_effect(metrics, *args):
+            # pylint: disable=unused-argument
             patched_metrics_data.extend(metrics.items())
 
         record_metrics_mock.side_effect = record_metrics_side_effect

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -309,6 +309,8 @@ def test_keras_autolog_batch_metrics_logger_logs_expected_metrics(
 
     restored_epoch = int(patched_metrics_data["restored_epoch"])
     assert int(patched_metrics_data["stopped_epoch"]) - max(1, callback.patience) == restored_epoch
+    restored_epoch = int(original_metrics["restored_epoch"])
+    assert int(original_metrics["stopped_epoch"]) - max(1, callback.patience) == restored_epoch
 
 
 @pytest.mark.large

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -8,8 +8,7 @@ import keras.layers as layers  # noqa
 
 import mlflow  # noqa
 import mlflow.keras  # noqa
-from mlflow.utils.autologging_utils import BatchMetricsLogger
-from unittest.mock import patch
+from unittest.mock import patch # noqa
 
 
 @pytest.fixture
@@ -308,7 +307,7 @@ def test_keras_autolog_batch_metrics_logger_logs_early_stopping_metrics(
             patched_metrics_data.extend(metrics.items())
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        run, history, callback = keras_random_data_run_with_callback(
+        _, _, callback = keras_random_data_run_with_callback(
             random_train_data(),
             fit_variant,
             random_one_hot_labels(),

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -8,7 +8,7 @@ import keras.layers as layers  # noqa
 
 import mlflow  # noqa
 import mlflow.keras  # noqa
-from unittest.mock import patch # noqa
+from unittest.mock import patch  # noqa
 
 
 @pytest.fixture

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -275,13 +275,11 @@ def test_lgb_autolog_batch_metrics_logger_logs_expected_metrics(
         )
 
     run = get_latest_run()
-    metrics = run.data.metrics
+    original_metrics = run.data.metrics
     patched_metrics_data = dict(patched_metrics_data)
-    for valid_name in valid_names:
-        for metric_name in params["metric"]:
-            metric_key = "{}-{}".format(valid_name, metric_name)
-            assert metric_key in patched_metrics_data
-            assert metric_key in metrics
+    for metric_name in original_metrics:
+        assert metric_name in patched_metrics_data
+        assert original_metrics[metric_name] == patched_metrics_data[metric_name]
 
 
 @pytest.mark.large

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -240,12 +240,17 @@ def test_lgb_autolog_logs_metrics_with_multi_validation_data_and_metrics(bst_par
 
 
 @pytest.mark.large
-def test_lgb_autolog_batch_metrics_logger_logs_metrics_with_multi_validation_data_and_metrics(bst_params, train_set):
+def test_lgb_autolog_batch_metrics_logger_logs_metrics_with_multi_validation_data_and_metrics(
+    bst_params, train_set
+):
     patched_metrics_data = []
 
     # Mock patching BatchMetricsLogger.record_metrics()
     # to insure that expected metrics are being logged.
-    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+    with patch(
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+    ) as record_metrics_mock:
+
         def record_metrics_side_effect(metrics, *args):
             patched_metrics_data.extend(metrics.items())
 

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -251,6 +251,7 @@ def test_lgb_autolog_batch_metrics_logger_logs_metrics_with_multi_validation_dat
     ) as record_metrics_mock:
 
         def record_metrics_side_effect(metrics, *args):
+            # pylint: disable=unused-argument
             patched_metrics_data.extend(metrics.items())
 
         record_metrics_mock.side_effect = record_metrics_side_effect

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -12,7 +12,6 @@ import mlflow
 import mlflow.lightgbm
 from mlflow.models import Model
 from mlflow.models.utils import _read_example
-from mlflow.utils.autologging_utils import BatchMetricsLogger
 from unittest.mock import patch
 
 mpl.use("Agg")

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -318,8 +318,6 @@ def test_lgb_autolog_logs_metrics_with_early_stopping(bst_params, train_set):
 
             best_metrics = evals_result[valid_name][metric_name][model.best_iteration - 1]
             assert metric_history == evals_result[valid_name][metric_name] + [best_metrics]
-    assert "train_loss" in original_metrics
-    assert "train_loss" in patched_metrics_data
 
 
 @pytest.mark.large

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -279,6 +279,9 @@ def test_lgb_autolog_batch_metrics_logger_logs_expected_metrics(bst_params, trai
         assert metric_name in patched_metrics_data
         assert original_metrics[metric_name] == patched_metrics_data[metric_name]
 
+    assert "train-multi_logloss" in original_metrics
+    assert "train-multi_logloss" in patched_metrics_data
+
 
 @pytest.mark.large
 def test_lgb_autolog_logs_metrics_with_early_stopping(bst_params, train_set):
@@ -315,6 +318,8 @@ def test_lgb_autolog_logs_metrics_with_early_stopping(bst_params, train_set):
 
             best_metrics = evals_result[valid_name][metric_name][model.best_iteration - 1]
             assert metric_history == evals_result[valid_name][metric_name] + [best_metrics]
+    assert "train_loss" in original_metrics
+    assert "train_loss" in patched_metrics_data
 
 
 @pytest.mark.large

--- a/tests/lightgbm/test_lightgbm_autolog.py
+++ b/tests/lightgbm/test_lightgbm_autolog.py
@@ -240,9 +240,7 @@ def test_lgb_autolog_logs_metrics_with_multi_validation_data_and_metrics(bst_par
 
 
 @pytest.mark.large
-def test_lgb_autolog_batch_metrics_logger_logs_expected_metrics(
-    bst_params, train_set
-):
+def test_lgb_autolog_batch_metrics_logger_logs_expected_metrics(bst_params, train_set):
     patched_metrics_data = []
 
     # Mock patching BatchMetricsLogger.record_metrics()

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -75,7 +75,10 @@ def test_pytorch_autolog_batch_metrics_logger_logs_expected_metrics():
 
     # Mock patching BatchMetricsLogger.record_metrics()
     # to insure that expected metrics are being logged.
-    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+    with patch(
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+    ) as record_metrics_mock:
+
         def record_metrics_side_effect(metrics, *args):
             patched_metrics_data.extend(metrics)
 
@@ -211,13 +214,17 @@ def test_pytorch_early_stop_metrics_logged(pytorch_model_with_callback):
     assert "wait_count" in data.metrics
     assert "restored_epoch" in data.metrics
 
+
 @pytest.mark.parametrize("patience", [3])
 def test_pyrorch_autolog_batch_metrics_logger_logs_early_stopping_metrics(patience):
     patched_metrics_data = []
 
     # Mock patching BatchMetricsLogger.record_metrics()
     # to insure that expected metrics are being logged.
-    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+    with patch(
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+    ) as record_metrics_mock:
+
         def record_metrics_side_effect(metrics, *args):
             patched_metrics_data.extend(metrics)
 

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -7,7 +7,6 @@ import mlflow.pytorch
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.callbacks import ModelCheckpoint
 from mlflow.utils.file_utils import TempDir
-from mlflow.utils.autologging_utils import BatchMetricsLogger
 from unittest.mock import patch
 
 

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -79,6 +79,7 @@ def test_pytorch_autolog_batch_metrics_logger_logs_expected_metrics():
     ) as record_metrics_mock:
 
         def record_metrics_side_effect(metrics, *args):
+            # pylint: disable=unused-argument
             patched_metrics_data.extend(metrics)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
@@ -225,6 +226,7 @@ def test_pyrorch_autolog_batch_metrics_logger_logs_early_stopping_metrics(patien
     ) as record_metrics_mock:
 
         def record_metrics_side_effect(metrics, *args):
+            # pylint: disable=unused-argument
             patched_metrics_data.extend(metrics)
 
         record_metrics_mock.side_effect = record_metrics_side_effect

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -4,12 +4,11 @@ import torch
 from iris import IrisClassification
 import mlflow
 import mlflow.pytorch
-from mlflow.utils.autologging_utils import BatchMetricsLogger
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.callbacks import ModelCheckpoint
 from mlflow.utils.file_utils import TempDir
+from mlflow.utils.autologging_utils import BatchMetricsLogger
 from unittest.mock import patch
-
 
 NUM_EPOCHS = 20
 

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -220,6 +220,9 @@ def test_pytorch_autolog_batch_metrics_logger_logs_expected_metrics(patience):
         assert metric_name in patched_metrics_data
         assert original_metrics[metric_name] == patched_metrics_data[metric_name]
 
+    assert "loss" in original_metrics
+    assert "loss" in patched_metrics_data
+
 
 def test_pytorch_autolog_non_early_stop_callback_does_not_log(pytorch_model):
     trainer, run = pytorch_model

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -550,37 +550,6 @@ def test_tf_estimator_autolog_logs_metrics(tf_estimator_random_data_run):
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("export", [True, False])
-def test_tf_autolog_batch_metrics_logger_logs_expected_metrics(tmpdir, manual_run, export):
-    patched_metrics_data = []
-
-    # Mock patching BatchMetricsLogger.record_metrics()
-    # to ensure that expected metrics are being logged.
-    original = BatchMetricsLogger.record_metrics
-
-    with patch(
-        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics", autospec=True
-    ) as record_metrics_mock:
-
-        def record_metrics_side_effect(self, metrics, step=None):
-            patched_metrics_data.extend(metrics.items())
-            original(self, metrics, step)
-
-        record_metrics_mock.side_effect = record_metrics_side_effect
-        run = tf_estimator_random_data_run(tmpdir, manual_run, export)
-
-    patched_metrics_data = dict(patched_metrics_data)
-    original_metrics = run.data.metrics
-
-    for metric_name in original_metrics:
-        assert metric_name in patched_metrics_data
-        assert original_metrics[metric_name] == patched_metrics_data[metric_name]
-
-    assert "loss" in original_metrics
-    assert "loss" in patched_metrics_data
-
-
-@pytest.mark.large
 @pytest.mark.parametrize("export", [True])
 def test_tf_estimator_autolog_model_can_load_from_artifact(tf_estimator_random_data_run):
     client = mlflow.tracking.MlflowClient()

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -550,6 +550,40 @@ def test_tf_estimator_autolog_logs_metrics(tf_estimator_random_data_run):
 
 
 @pytest.mark.large
+@pytest.mark.parametrize("export", [True, False])
+def test_tf_autolog_batch_metrics_logger_logs_expected_metrics(tmpdir, manual_run, export):
+    patched_metrics_data = []
+
+    # Mock patching BatchMetricsLogger.record_metrics()
+    # to ensure that expected metrics are being logged.
+    original = BatchMetricsLogger.record_metrics
+
+    with patch(
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics", autospec=True
+    ) as record_metrics_mock:
+
+        def record_metrics_side_effect(self, metrics, step=None):
+            patched_metrics_data.extend(metrics.items())
+            original(self, metrics, step)
+
+        record_metrics_mock.side_effect = record_metrics_side_effect
+        run = tf_estimator_random_data_run(tmpdir, manual_run, export)
+
+    patched_metrics_data = dict(patched_metrics_data)
+    original_metrics = run.data.metrics
+
+    for metric_name in original_metrics:
+        assert metric_name in patched_metrics_data
+        assert original_metrics[metric_name] == patched_metrics_data[metric_name]
+
+    restored_epoch = int(patched_metrics_data["restored_epoch"])
+    assert int(patched_metrics_data["stopped_epoch"]) - max(1, callback.patience) == restored_epoch
+
+    assert "loss" in original_metrics
+    assert "loss" in patched_metrics_data
+
+
+@pytest.mark.large
 @pytest.mark.parametrize("export", [True])
 def test_tf_estimator_autolog_model_can_load_from_artifact(tf_estimator_random_data_run):
     client = mlflow.tracking.MlflowClient()

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -163,12 +163,17 @@ def test_tf_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant):
 
     # Mock patching BatchMetricsLogger.record_metrics()
     # to insure that expected metrics are being logged.
-    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+    with patch(
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+    ) as record_metrics_mock:
+
         def record_metrics_side_effect(metrics, *args):
             patched_metrics_data.extend(metrics)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        tf_keras_random_data_run(random_train_data(), random_one_hot_labels(), manual_run, fit_variant)
+        tf_keras_random_data_run(
+            random_train_data(), random_one_hot_labels(), manual_run, fit_variant
+        )
 
     assert "accuracy" in patched_metrics_data
     assert "loss" in patched_metrics_data
@@ -283,12 +288,17 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
 @pytest.mark.parametrize("restore_weights", [True])
 @pytest.mark.parametrize("callback", ["early"])
 @pytest.mark.parametrize("patience", [0, 1, 5])
-def test_tf_keras_autolog_batch_metrics_logger_logs_early_stopping_metrics(callback, restore_weights, patience):
+def test_tf_keras_autolog_batch_metrics_logger_logs_early_stopping_metrics(
+    callback, restore_weights, patience
+):
     patched_metrics_data = []
 
     # Mock patching BatchMetricsLogger.record_metrics()
     # to insure that expected metrics are being logged.
-    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+    with patch(
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+    ) as record_metrics_mock:
+
         def record_metrics_side_effect(metrics, *args):
             patched_metrics_data.extend(metrics.items())
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -11,6 +11,7 @@ from tensorflow.python.keras import layers  # pylint: disable=import-error
 import mlflow
 import mlflow.tensorflow
 import mlflow.keras
+from mlflow.utils.autologging_utils import BatchMetricsLogger
 from unittest.mock import patch
 
 import os
@@ -157,30 +158,6 @@ def tf_keras_random_data_run(random_train_data, random_one_hot_labels, manual_ru
 
 @pytest.mark.large
 @pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
-def test_tf_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant):
-    patched_metrics_data = []
-
-    # Mock patching BatchMetricsLogger.record_metrics()
-    # to insure that expected metrics are being logged.
-    with patch(
-        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
-    ) as record_metrics_mock:
-
-        def record_metrics_side_effect(metrics, *args):
-            # pylint: disable=unused-argument
-            patched_metrics_data.extend(metrics)
-
-        record_metrics_mock.side_effect = record_metrics_side_effect
-        tf_keras_random_data_run(
-            random_train_data(), random_one_hot_labels(), manual_run, fit_variant
-        )
-
-    assert "accuracy" in patched_metrics_data
-    assert "loss" in patched_metrics_data
-
-
-@pytest.mark.large
-@pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
 def test_tf_keras_autolog_logs_expected_data(tf_keras_random_data_run):
     data = tf_keras_random_data_run.data
     assert "accuracy" in data.metrics
@@ -314,23 +291,25 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
 @pytest.mark.parametrize("restore_weights", [True])
 @pytest.mark.parametrize("callback", ["early"])
 @pytest.mark.parametrize("patience", [0, 1, 5])
-def test_tf_keras_autolog_batch_metrics_logger_logs_early_stopping_metrics(
+def test_tf_keras_autolog_batch_metrics_logger_logs_expected_metrics(
     callback, restore_weights, patience
 ):
     patched_metrics_data = []
 
     # Mock patching BatchMetricsLogger.record_metrics()
-    # to insure that expected metrics are being logged.
+    # to ensure that expected metrics are being logged.
+    original = BatchMetricsLogger.record_metrics
+
     with patch(
-        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics", autospec=True
     ) as record_metrics_mock:
 
-        def record_metrics_side_effect(metrics, *args):
-            # pylint: disable=unused-argument
+        def record_metrics_side_effect(self, metrics, step=None):
             patched_metrics_data.extend(metrics.items())
+            original(self, metrics, step)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        _, _, callback = tf_keras_random_data_run_with_callback(
+        run, _, callback = tf_keras_random_data_run_with_callback(
             random_train_data(),
             random_one_hot_labels(),
             manual_run,
@@ -339,9 +318,13 @@ def test_tf_keras_autolog_batch_metrics_logger_logs_early_stopping_metrics(
             patience,
         )
     patched_metrics_data = dict(patched_metrics_data)
+    original_metrics = run.data.metrics
+
+    for metric_name in original_metrics:
+        assert metric_name in patched_metrics_data
+        assert original_metrics[metric_name] == patched_metrics_data[metric_name]
+
     restored_epoch = int(patched_metrics_data["restored_epoch"])
-    assert "stopped_epoch" in patched_metrics_data
-    assert "restored_epoch" in patched_metrics_data
     assert int(patched_metrics_data["stopped_epoch"]) - max(1, callback.patience) == restored_epoch
 
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -11,6 +11,8 @@ from tensorflow.python.keras import layers  # pylint: disable=import-error
 import mlflow
 import mlflow.tensorflow
 import mlflow.keras
+from mlflow.utils.autologging_utils import BatchMetricsLogger
+from unittest.mock import patch
 
 import os
 
@@ -156,6 +158,24 @@ def tf_keras_random_data_run(random_train_data, random_one_hot_labels, manual_ru
 
 @pytest.mark.large
 @pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
+def test_tf_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant):
+    patched_metrics_data = []
+
+    # Mock patching BatchMetricsLogger.record_metrics()
+    # to insure that expected metrics are being logged.
+    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+        def record_metrics_side_effect(metrics, *args):
+            patched_metrics_data.extend(metrics)
+
+        record_metrics_mock.side_effect = record_metrics_side_effect
+        tf_keras_random_data_run(random_train_data(), random_one_hot_labels(), manual_run, fit_variant)
+
+    assert "accuracy" in patched_metrics_data
+    assert "loss" in patched_metrics_data
+
+
+@pytest.mark.large
+@pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
 def test_tf_keras_autolog_logs_expected_data(tf_keras_random_data_run):
     data = tf_keras_random_data_run.data
     assert "accuracy" in data.metrics
@@ -257,6 +277,35 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     assert len(metric_history) == num_of_epochs + 1
     # Check that MLflow has logged the correct data
     assert history.history["loss"][restored_epoch] == metric_history[-1].value
+
+
+@pytest.mark.large
+@pytest.mark.parametrize("restore_weights", [True])
+@pytest.mark.parametrize("callback", ["early"])
+@pytest.mark.parametrize("patience", [0, 1, 5])
+def test_tf_keras_autolog_batch_metrics_logger_logs_early_stopping_metrics(callback, restore_weights, patience):
+    patched_metrics_data = []
+
+    # Mock patching BatchMetricsLogger.record_metrics()
+    # to insure that expected metrics are being logged.
+    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+        def record_metrics_side_effect(metrics, *args):
+            patched_metrics_data.extend(metrics.items())
+
+        record_metrics_mock.side_effect = record_metrics_side_effect
+        run, history, callback = tf_keras_random_data_run_with_callback(
+            random_train_data(),
+            random_one_hot_labels(),
+            manual_run,
+            callback,
+            restore_weights,
+            patience,
+        )
+    patched_metrics_data = dict(patched_metrics_data)
+    restored_epoch = int(patched_metrics_data["restored_epoch"])
+    assert "stopped_epoch" in patched_metrics_data
+    assert "restored_epoch" in patched_metrics_data
+    assert int(patched_metrics_data["stopped_epoch"]) - max(1, callback.patience) == restored_epoch
 
 
 @pytest.mark.large

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -11,7 +11,6 @@ from tensorflow.python.keras import layers  # pylint: disable=import-error
 import mlflow
 import mlflow.tensorflow
 import mlflow.keras
-from mlflow.utils.autologging_utils import BatchMetricsLogger
 from unittest.mock import patch
 
 import os
@@ -303,7 +302,7 @@ def test_tf_keras_autolog_batch_metrics_logger_logs_early_stopping_metrics(
             patched_metrics_data.extend(metrics.items())
 
         record_metrics_mock.side_effect = record_metrics_side_effect
-        run, history, callback = tf_keras_random_data_run_with_callback(
+        _, _, callback = tf_keras_random_data_run_with_callback(
             random_train_data(),
             random_one_hot_labels(),
             manual_run,

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -576,9 +576,6 @@ def test_tf_autolog_batch_metrics_logger_logs_expected_metrics(tmpdir, manual_ru
         assert metric_name in patched_metrics_data
         assert original_metrics[metric_name] == patched_metrics_data[metric_name]
 
-    restored_epoch = int(patched_metrics_data["restored_epoch"])
-    assert int(patched_metrics_data["stopped_epoch"]) - max(1, callback.patience) == restored_epoch
-
     assert "loss" in original_metrics
     assert "loss" in patched_metrics_data
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -167,6 +167,7 @@ def test_tf_autolog_batch_metrics_logger_logs_expected_metrics(fit_variant):
     ) as record_metrics_mock:
 
         def record_metrics_side_effect(metrics, *args):
+            # pylint: disable=unused-argument
             patched_metrics_data.extend(metrics)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
@@ -299,6 +300,7 @@ def test_tf_keras_autolog_batch_metrics_logger_logs_early_stopping_metrics(
     ) as record_metrics_mock:
 
         def record_metrics_side_effect(metrics, *args):
+            # pylint: disable=unused-argument
             patched_metrics_data.extend(metrics.items())
 
         record_metrics_mock.side_effect = record_metrics_side_effect

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -215,6 +215,7 @@ def test_xgb_autolog_batch_metrics_logger_logs_metrics_with_multi_validation_dat
     ) as record_metrics_mock:
 
         def record_metrics_side_effect(metrics, *args):
+            # pylint: disable=unused-argument
             patched_metrics_data.extend(metrics.items())
 
         record_metrics_mock.side_effect = record_metrics_side_effect
@@ -284,6 +285,7 @@ def test_xgb_autolog_batch_metrics_logger_logs_metrics_with_early_stopping(bst_p
     ) as record_metrics_mock:
 
         def record_metrics_side_effect(metrics, *args):
+            # pylint: disable=unused-argument
             patched_metrics_data.extend(metrics.items())
 
         record_metrics_mock.side_effect = record_metrics_side_effect

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -281,6 +281,7 @@ def test_xgb_autolog_batch_metrics_logger_logs_expected_metrics(bst_params, dtra
         assert original_metrics[metric_name] == patched_metrics_data[metric_name]
 
     assert int(patched_metrics_data["best_iteration"]) == model.best_iteration
+    assert int(original_metrics["best_iteration"]) == model.best_iteration
 
 
 @pytest.mark.large

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -241,7 +241,7 @@ def test_xgb_autolog_logs_metrics_with_early_stopping(bst_params, dtrain):
 
 
 @pytest.mark.large
-def test_xgb_autolog_batch_metrics_logger_logs_metrics_with_early_stopping(bst_params, dtrain):
+def test_xgb_autolog_batch_metrics_logger_logs_expected_metrics(bst_params, dtrain):
     patched_metrics_data = []
 
     # Mock patching BatchMetricsLogger.record_metrics()

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -272,7 +272,6 @@ def test_xgb_autolog_batch_metrics_logger_logs_expected_metrics(bst_params, dtra
             evals_result=evals_result,
         )
 
-
     patched_metrics_data = dict(patched_metrics_data)
     run = get_latest_run()
     original_metrics = run.data.metrics

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -202,13 +202,19 @@ def test_xgb_autolog_logs_metrics_with_multi_validation_data_and_metrics(bst_par
             assert len(metric_history) == 20
             assert metric_history == evals_result[eval_name][metric_name]
 
+
 @pytest.mark.large
-def test_xgb_autolog_batch_metrics_logger_logs_metrics_with_multi_validation_data_and_metrics(bst_params, dtrain):
+def test_xgb_autolog_batch_metrics_logger_logs_metrics_with_multi_validation_data_and_metrics(
+    bst_params, dtrain
+):
     patched_metrics_data = []
 
     # Mock patching BatchMetricsLogger.record_metrics()
     # to insure that expected metrics are being logged.
-    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+    with patch(
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+    ) as record_metrics_mock:
+
         def record_metrics_side_effect(metrics, *args):
             patched_metrics_data.extend(metrics.items())
 
@@ -274,7 +280,10 @@ def test_xgb_autolog_batch_metrics_logger_logs_metrics_with_early_stopping(bst_p
 
     # Mock patching BatchMetricsLogger.record_metrics()
     # to insure that expected metrics are being logged.
-    with patch("mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics") as record_metrics_mock:
+    with patch(
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+    ) as record_metrics_mock:
+
         def record_metrics_side_effect(metrics, *args):
             patched_metrics_data.extend(metrics.items())
 

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -12,7 +12,6 @@ import mlflow
 import mlflow.xgboost
 from mlflow.models import Model
 from mlflow.models.utils import _read_example
-from mlflow.utils.autologging_utils import BatchMetricsLogger
 from unittest.mock import patch
 
 mpl.use("Agg")

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -12,6 +12,7 @@ import mlflow
 import mlflow.xgboost
 from mlflow.models import Model
 from mlflow.models.utils import _read_example
+from mlflow.utils.autologging_utils import BatchMetricsLogger
 from unittest.mock import patch
 
 mpl.use("Agg")
@@ -203,41 +204,6 @@ def test_xgb_autolog_logs_metrics_with_multi_validation_data_and_metrics(bst_par
 
 
 @pytest.mark.large
-def test_xgb_autolog_batch_metrics_logger_logs_metrics_with_multi_validation_data_and_metrics(
-    bst_params, dtrain
-):
-    patched_metrics_data = []
-
-    # Mock patching BatchMetricsLogger.record_metrics()
-    # to insure that expected metrics are being logged.
-    with patch(
-        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
-    ) as record_metrics_mock:
-
-        def record_metrics_side_effect(metrics, *args):
-            # pylint: disable=unused-argument
-            patched_metrics_data.extend(metrics.items())
-
-        record_metrics_mock.side_effect = record_metrics_side_effect
-
-        mlflow.xgboost.autolog()
-        evals_result = {}
-        params = {"eval_metric": ["merror", "mlogloss"]}
-        params.update(bst_params)
-        evals = [(dtrain, "train"), (dtrain, "valid")]
-        xgb.train(params, dtrain, num_boost_round=20, evals=evals, evals_result=evals_result)
-
-    for eval_name in [e[1] for e in evals]:
-        for metric_name in params["eval_metric"]:
-            metric_key = "{}-{}".format(eval_name, metric_name)
-            metric_history = [x[1] for x in patched_metrics_data if x[0] == metric_key]
-
-            assert metric_key in dict(patched_metrics_data)
-            assert len(metric_history) == 20
-            assert metric_history == evals_result[eval_name][metric_name]
-
-
-@pytest.mark.large
 def test_xgb_autolog_logs_metrics_with_early_stopping(bst_params, dtrain):
     mlflow.xgboost.autolog()
     evals_result = {}
@@ -279,14 +245,16 @@ def test_xgb_autolog_batch_metrics_logger_logs_metrics_with_early_stopping(bst_p
     patched_metrics_data = []
 
     # Mock patching BatchMetricsLogger.record_metrics()
-    # to insure that expected metrics are being logged.
+    # to ensure that expected metrics are being logged.
+    original = BatchMetricsLogger.record_metrics
+
     with patch(
-        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics"
+        "mlflow.utils.autologging_utils.BatchMetricsLogger.record_metrics", autospec=True
     ) as record_metrics_mock:
 
-        def record_metrics_side_effect(metrics, *args):
-            # pylint: disable=unused-argument
+        def record_metrics_side_effect(self, metrics, step=None):
             patched_metrics_data.extend(metrics.items())
+            original(self, metrics, step)
 
         record_metrics_mock.side_effect = record_metrics_side_effect
 
@@ -303,22 +271,17 @@ def test_xgb_autolog_batch_metrics_logger_logs_metrics_with_early_stopping(bst_p
             evals=evals,
             evals_result=evals_result,
         )
-    metric_dict = dict(patched_metrics_data)
-    assert "best_iteration" in metric_dict
-    assert int(metric_dict["best_iteration"]) == model.best_iteration
-    assert "stopped_iteration" in metric_dict
-    assert int(metric_dict["stopped_iteration"]) == len(evals_result["train"]["merror"]) - 1
 
-    for eval_name in [e[1] for e in evals]:
-        for metric_name in params["eval_metric"]:
-            metric_key = "{}-{}".format(eval_name, metric_name)
-            metric_history = [x[1] for x in patched_metrics_data if x[0] == metric_key]
 
-            assert metric_key in metric_dict
-            assert len(metric_history) == 20 + 1
+    patched_metrics_data = dict(patched_metrics_data)
+    run = get_latest_run()
+    original_metrics = run.data.metrics
 
-            best_metrics = evals_result[eval_name][metric_name][model.best_iteration]
-            assert metric_history == evals_result[eval_name][metric_name] + [best_metrics]
+    for metric_name in original_metrics:
+        assert metric_name in patched_metrics_data
+        assert original_metrics[metric_name] == patched_metrics_data[metric_name]
+
+    assert int(patched_metrics_data["best_iteration"]) == model.best_iteration
 
 
 @pytest.mark.large


### PR DESCRIPTION
Signed-off-by: Mohamad Arabi <mohamad.arabi@databricks.com>

## What changes are proposed in this pull request?

Integrate the use of `BatchMetricsLogger ` for all model flavors, such that metrics are batch logged throughout training phase.

## How is this patch tested?

Added test cases for each relevant ML flavor.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
