### PR TITLE
Add `log_image`

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -85,6 +85,7 @@ log_artifacts = mlflow.tracking.fluent.log_artifacts
 log_artifact = mlflow.tracking.fluent.log_artifact
 log_text = mlflow.tracking.fluent.log_text
 log_dict = mlflow.tracking.fluent.log_dict
+log_image = mlflow.tracking.fluent.log_image
 log_figure = mlflow.tracking.fluent.log_figure
 active_run = mlflow.tracking.fluent.active_run
 get_run = mlflow.tracking.fluent.get_run
@@ -126,6 +127,7 @@ __all__ = [
     "log_text",
     "log_dict",
     "log_figure",
+    "log_image",
     "active_run",
     "start_run",
     "end_run",

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1148,7 +1148,7 @@ class MlflowClient(object):
             return isinstance(image, np.ndarray)
 
         def _normalize_to_uint8(x):
-            # Based on: https://github.com/matplotlib/matplotlib/blob/06567e021f21be046b6d6dcf00380c1cb9adaf3c/lib/matplotlib/image.py#L684
+            # Based on: https://github.com/matplotlib/matplotlib/blob/06567e021f21be046b6d6dcf00380c1cb9adaf3c/lib/matplotlib/image.py#L684  # noqa
 
             is_int = np.issubdtype(x.dtype, np.integer)
             low = 0
@@ -1179,7 +1179,7 @@ class MlflowClient(object):
                         "Please install it via: pip install Pillow"
                     ) from exc
 
-                # Ref.: https://numpy.org/doc/stable/reference/generated/numpy.dtype.kind.html#numpy-dtype-kind
+                # Ref.: https://numpy.org/doc/stable/reference/generated/numpy.dtype.kind.html#numpy-dtype-kind  # noqa
                 valid_data_types = {
                     "b": "bool",
                     "i": "signed integer",

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1104,8 +1104,8 @@ class MlflowClient(object):
 
             - shape (H: height, W: width):
 
-                - H x W (Gray)
-                - H x W x 1 (Gray)
+                - H x W (Grayscale)
+                - H x W x 1 (Grayscale)
                 - H x W x 3 (RGB)
                 - H x W x 4 (RGBA)
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1155,7 +1155,9 @@ class MlflowClient(object):
             high = 255 if is_int else 1
             if x.min() < low or x.max() > high:
                 _logger.warning(
-                    "Clipping array (dtype: '{}') to [{}, {}]".format(x.dtype, low, high)
+                    "Out-of-range values are detected. Clipping array (dtype: '{}') to [{}, {}]".format(
+                        x.dtype, low, high
+                    )
                 )
                 x = np.clip(x, low, high)
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1154,11 +1154,11 @@ class MlflowClient(object):
             low = 0
             high = 255 if is_int else 1
             if x.min() < low or x.max() > high:
-                _logger.warning(
-                    "Out-of-range values are detected. Clipping array (dtype: '{}') to [{}, {}]".format(
-                        x.dtype, low, high
-                    )
+                msg = (
+                    "Out-of-range values are detected. "
+                    "Clipping array (dtype: '{}') to [{}, {}]".format(x.dtype, low, high)
                 )
+                _logger.warning(msg)
                 x = np.clip(x, low, high)
 
             # float or bool

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1128,6 +1128,8 @@ class MlflowClient(object):
             return isinstance(image, np.ndarray)
 
         def _normalize_to_uint8(x):
+            # Based on: https://github.com/matplotlib/matplotlib/blob/06567e021f21be046b6d6dcf00380c1cb9adaf3c/lib/matplotlib/image.py#L684
+
             is_int = np.issubdtype(x.dtype, np.integer)
             low = 0
             high = 255 if is_int else 1

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1089,6 +1089,28 @@ class MlflowClient(object):
         .. _PIL.Image.Image:
             https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image
 
+        Numpy array support:
+            - data type:
+
+                - bool (True or False)
+                - integer (0 ~ 255)
+                - unsigned integer (0 ~ 255)
+                - float (0.0 ~ 1.0)
+
+                () represents a valid value range.
+
+                .. warning::
+
+                    - Out-of-range integer values will be **clipped** to [0, 255].
+                    - Out-of-range float values will be **clipped** to [0.0, 1.0].
+
+            - shape:
+
+                - H x W (Gray)
+                - H x W x 1 (Gray)
+                - H x W x 3 (RGB)
+                - H x W x 4 (RGBA)
+
         :param run_id: String ID of the run.
         :param image: Image to log.
         :param artifact_file: The run-relative artifact file path in posixpath format to which

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1100,7 +1100,7 @@ class MlflowClient(object):
                 .. warning::
 
                     - Out-of-range integer values will be **clipped** to [0, 255].
-                    - Out-of-range float values will be **clipped** to [0.0, 1.0].
+                    - Out-of-range float values will be **clipped** to [0, 1].
 
             - shape (H: height, W: width):
 
@@ -1155,7 +1155,7 @@ class MlflowClient(object):
             high = 255 if is_int else 1
             if x.min() < low or x.max() > high:
                 _logger.warning(
-                    "Clipping array (dtype: '{}') to [{}..{}]".format(x.dtype, low, high)
+                    "Clipping array (dtype: '{}') to [{}, {}]".format(x.dtype, low, high)
                 )
                 x = np.clip(x, low, high)
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1089,22 +1089,20 @@ class MlflowClient(object):
         .. _PIL.Image.Image:
             https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image
 
-        Numpy array support:
-            - data type:
+        Numpy array support
+            - data type (( ) represents a valid value range):
 
-                - bool (True or False)
+                - bool
                 - integer (0 ~ 255)
                 - unsigned integer (0 ~ 255)
                 - float (0.0 ~ 1.0)
-
-                () represents a valid value range.
 
                 .. warning::
 
                     - Out-of-range integer values will be **clipped** to [0, 255].
                     - Out-of-range float values will be **clipped** to [0.0, 1.0].
 
-            - shape:
+            - shape (H: height, W: width):
 
                 - H x W (Gray)
                 - H x W x 1 (Gray)
@@ -1114,7 +1112,7 @@ class MlflowClient(object):
         :param run_id: String ID of the run.
         :param image: Image to log.
         :param artifact_file: The run-relative artifact file path in posixpath format to which
-                              the figure is saved (e.g. "dir/image.png").
+                              the image is saved (e.g. "dir/image.png").
 
         .. code-block:: python
             :caption: Numpy Example

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1148,7 +1148,7 @@ class MlflowClient(object):
                     from PIL import Image
                 except ImportError as exc:
                     raise ImportError(
-                        "`log_image` requires Pillow to serialize the array as an image."
+                        "`log_image` requires Pillow to serialize a numpy array as an image."
                         "Please install it via: pip install Pillow"
                     ) from exc
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1167,7 +1167,6 @@ class MlflowClient(object):
                     "f": "floating",
                 }
 
-                # validate data type
                 if image.dtype.kind not in valid_data_types.keys():
                     raise TypeError(
                         "Invalid array data type: '{}'. Must be one of {}".format(
@@ -1175,13 +1174,11 @@ class MlflowClient(object):
                         )
                     )
 
-                # validate dimension
                 if image.ndim not in [2, 3]:
                     raise ValueError(
                         "`image` must be a 2D or 3D array but got a {}D array".format(image.ndim)
                     )
 
-                # validate channel length
                 if (image.ndim == 3) and (image.shape[2] not in [1, 3, 4]):
                     raise ValueError(
                         "Invalid channel length: {}. Must be one of [1, 3, 4]".format(

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1106,8 +1106,8 @@ class MlflowClient(object):
 
                 - H x W (Grayscale)
                 - H x W x 1 (Grayscale)
-                - H x W x 3 (RGB)
-                - H x W x 4 (RGBA)
+                - H x W x 3 (an RGB channel order is assumed)
+                - H x W x 4 (an RGBA channel order is assumed)
 
         :param run_id: String ID of the run.
         :param image: Image to log.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -665,6 +665,44 @@ def log_figure(figure, artifact_file):
     MlflowClient().log_figure(run_id, figure, artifact_file)
 
 
+def log_image(image, artifact_file):
+    """
+    Log an image as an artifact. The following image objects are supported:
+
+    - `numpy.ndarray`_
+    - `PIL.Image.Image`_
+
+    :param run_id: String ID of the run.
+    :param image: Image to log.
+    :param artifact_file: The run-relative artifact file path in posixpath format to which
+                          the figure is saved (e.g. "dir/image.png").
+
+    .. code-block:: python
+        :caption: Numpy Example
+
+        import mlflow
+        import numpy as np
+
+        image = np.random.randint(0, 256, size=(100, 100, 3), dtype=np.uint8)
+
+        with mlflow.start_run():
+            mlflow.log_image(image, "image.png")
+
+    .. code-block:: python
+        :caption: Pillow Example
+
+        import mlflow
+        from PIL import Image
+
+        image = Image.new("RGB", (100, 100))
+
+        with mlflow.start_run():
+            mlflow.log_image(image, "image.png")
+    """
+    run_id = _get_or_start_run().info.run_id
+    MlflowClient().log_image(run_id, image, artifact_file)
+
+
 def _record_logged_model(mlflow_model):
     run_id = _get_or_start_run().info.run_id
     MlflowClient()._record_logged_model(run_id, mlflow_model)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -696,8 +696,8 @@ def log_image(image, artifact_file):
 
             - H x W (Grayscale)
             - H x W x 1 (Grayscale)
-            - H x W x 3 (RGB)
-            - H x W x 4 (RGBA)
+            - H x W x 3 (an RGB channel order is assumed)
+            - H x W x 4 (an RGBA channel order is assumed)
 
     :param run_id: String ID of the run.
     :param image: Image to log.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -665,6 +665,7 @@ def log_figure(figure, artifact_file):
     MlflowClient().log_figure(run_id, figure, artifact_file)
 
 
+@experimental
 def log_image(image, artifact_file):
     """
     Log an image as an artifact. The following image objects are supported:
@@ -679,7 +680,7 @@ def log_image(image, artifact_file):
         https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image
 
     Numpy array support
-        - data type (() represents a valid value range):
+        - data type (( ) represents a valid value range):
 
             - bool
             - integer (0 ~ 255)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -672,10 +672,36 @@ def log_image(image, artifact_file):
     - `numpy.ndarray`_
     - `PIL.Image.Image`_
 
+    .. _numpy.ndarray:
+        https://numpy.org/doc/stable/reference/generated/numpy.ndarray.html
+
+    .. _PIL.Image.Image:
+        https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image
+
+    Numpy array support
+        - data type (() represents a valid value range):
+
+            - bool
+            - integer (0 ~ 255)
+            - unsigned integer (0 ~ 255)
+            - float (0.0 ~ 1.0)
+
+            .. warning::
+
+                - Out-of-range integer values will be **clipped** to [0, 255].
+                - Out-of-range float values will be **clipped** to [0.0, 1.0].
+
+        - shape (H: height, W: width):
+
+            - H x W (Gray)
+            - H x W x 1 (Gray)
+            - H x W x 3 (RGB)
+            - H x W x 4 (RGBA)
+
     :param run_id: String ID of the run.
     :param image: Image to log.
     :param artifact_file: The run-relative artifact file path in posixpath format to which
-                          the figure is saved (e.g. "dir/image.png").
+                          the image is saved (e.g. "dir/image.png").
 
     .. code-block:: python
         :caption: Numpy Example

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -690,7 +690,7 @@ def log_image(image, artifact_file):
             .. warning::
 
                 - Out-of-range integer values will be **clipped** to [0, 255].
-                - Out-of-range float values will be **clipped** to [0.0, 1.0].
+                - Out-of-range float values will be **clipped** to [0, 1].
 
         - shape (H: height, W: width):
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -694,8 +694,8 @@ def log_image(image, artifact_file):
 
         - shape (H: height, W: width):
 
-            - H x W (Gray)
-            - H x W x 1 (Gray)
+            - H x W (Grayscale)
+            - H x W x 1 (Grayscale)
             - H x W x 3 (RGB)
             - H x W x 4 (RGBA)
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -635,7 +635,7 @@ def test_log_image_pillow(subdir):
 
         logged_path = os.path.join(run_artifact_dir, filename)
         loaded_image = Image.open(logged_path)
-        # How to check pillow image equality: https://stackoverflow.com/a/6204954/6943581
+        # How to check Pillow image equality: https://stackoverflow.com/a/6204954/6943581
         assert ImageChops.difference(loaded_image, image).getbbox() is None
 
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -691,7 +691,9 @@ def test_log_image_numpy_emits_warning_for_out_of_range_values(array):
     with mlflow.start_run(), mock.patch("mlflow.tracking.client._logger.warning") as warn_mock:
         mlflow.log_image(image, "image.png")
         range_str = "[0, 255]" if isinstance(array[0][0], int) else "[0, 1]"
-        msg = "Clipping array (dtype: '{}') to {}".format(image.dtype, range_str)
+        msg = "Out-of-range values are detected. Clipping array (dtype: '{}') to {}".format(
+            image.dtype, range_str
+        )
         assert any(msg in args[0] for args in warn_mock.call_args_list)
 
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -696,7 +696,7 @@ def test_log_image_numpy_dtype(dtype):
 
 @pytest.mark.large
 @pytest.mark.parametrize(
-    # 1 pixel images
+    # 1 pixel images with out-of-range values
     "array", [[[-1]], [[256]], [[-0.1]], [[1.1]]],
 )
 def test_log_image_numpy_emits_warning_for_out_of_range_values(array):

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -664,7 +664,22 @@ def test_log_image_numpy_shape(size):
 
 @pytest.mark.large
 @pytest.mark.parametrize(
-    "dtype", ["uint8", "int", "float", "bool"],
+    "dtype",
+    [
+        # Ref.: https://numpy.org/doc/stable/user/basics.types.html#array-types-and-conversions-between-types
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float16",
+        "float32",
+        "float64",
+        "bool",
+    ],
 )
 def test_log_image_numpy_dtype(dtype):
     import numpy as np

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -696,7 +696,8 @@ def test_log_image_numpy_dtype(dtype):
 
 @pytest.mark.large
 @pytest.mark.parametrize(
-    "array", [[[-1, 0]], [[0, 256]], [[-0.1, 0.0]], [[0.0, 1.1]]],
+    # 1 pixel images
+    "array", [[[-1]], [[256]], [[-0.1]], [[1.1]]],
 )
 def test_log_image_numpy_emits_warning_for_out_of_range_values(array):
     import numpy as np

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -594,6 +594,7 @@ def test_log_figure_raises_error_for_unsupported_figure_object_type():
 @pytest.mark.parametrize("subdir", [None, ".", "dir", "dir1/dir2", "dir/.."])
 def test_log_image_numpy(subdir):
     import numpy as np
+    from PIL import Image
 
     filename = "image.png"
     artifact_file = filename if subdir is None else posixpath.join(subdir, filename)
@@ -608,11 +609,16 @@ def test_log_image_numpy(subdir):
         run_artifact_dir = local_file_uri_to_path(artifact_uri)
         assert os.listdir(run_artifact_dir) == [filename]
 
+        logged_path = os.path.join(run_artifact_dir, filename)
+        loaded_image = np.asarray(Image.open(logged_path), dtype=np.uint8)
+        np.testing.assert_array_equal(loaded_image, image)
+
 
 @pytest.mark.large
 @pytest.mark.parametrize("subdir", [None, ".", "dir", "dir1/dir2", "dir/.."])
 def test_log_image_pillow(subdir):
     from PIL import Image
+    from PIL import ImageChops
 
     filename = "image.png"
     artifact_file = filename if subdir is None else posixpath.join(subdir, filename)
@@ -626,6 +632,11 @@ def test_log_image_pillow(subdir):
         artifact_uri = mlflow.get_artifact_uri(artifact_path)
         run_artifact_dir = local_file_uri_to_path(artifact_uri)
         assert os.listdir(run_artifact_dir) == [filename]
+
+        logged_path = os.path.join(run_artifact_dir, filename)
+        loaded_image = Image.open(logged_path)
+        # How to check pillow image equality: https://stackoverflow.com/a/6204954/6943581
+        assert ImageChops.difference(loaded_image, image).getbbox() is None
 
 
 @pytest.mark.large

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -669,6 +669,22 @@ def test_log_image_numpy_dtype(dtype):
 
 
 @pytest.mark.large
+@pytest.mark.parametrize(
+    "array", [[[-1, 0]], [[0, 256]], [[-0.1, 0.0]], [[0.0, 1.1]]],
+)
+def test_log_image_numpy_emits_warning_for_out_of_range_values(array):
+    import numpy as np
+
+    image = np.array(array).astype(type(array[0][0]))
+
+    with mlflow.start_run(), mock.patch("mlflow.tracking.client._logger.warning") as warn_mock:
+        mlflow.log_image(image, "image.png")
+        range_str = "[0, 255]" if isinstance(array[0][0], int) else "[0, 1]"
+        msg = "Clipping array (dtype: '{}') to {}".format(image.dtype, range_str)
+        assert any(msg in args[0] for args in warn_mock.call_args_list)
+
+
+@pytest.mark.large
 def test_log_image_numpy_raises_exception_for_invalid_array_data_type():
     import numpy as np
 

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -696,8 +696,9 @@ def test_log_image_numpy_dtype(dtype):
 
 @pytest.mark.large
 @pytest.mark.parametrize(
+    "array",
     # 1 pixel images with out-of-range values
-    "array", [[[-1]], [[256]], [[-0.1]], [[1.1]]],
+    [[[-1]], [[256]], [[-0.1]], [[1.1]]],
 )
 def test_log_image_numpy_emits_warning_for_out_of_range_values(array):
     import numpy as np

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -638,7 +638,7 @@ def test_log_image_pillow(subdir):
         (100, 100, 4),  # RGBA
     ],
 )
-def test_log_image_numpy_with_various_array_shapes(size):
+def test_log_image_numpy_shape(size):
     import numpy as np
 
     filename = "image.png"
@@ -649,6 +649,31 @@ def test_log_image_numpy_with_various_array_shapes(size):
         artifact_uri = mlflow.get_artifact_uri()
         run_artifact_dir = local_file_uri_to_path(artifact_uri)
         assert os.listdir(run_artifact_dir) == [filename]
+
+
+@pytest.mark.large
+@pytest.mark.parametrize(
+    "dtype", ["uint8", "int", "float", "bool"],
+)
+def test_log_image_numpy_dtype(dtype):
+    import numpy as np
+
+    filename = "image.png"
+    image = np.random.randint(0, 2, size=(100, 100, 3)).astype(np.dtype(dtype))
+
+    with mlflow.start_run():
+        mlflow.log_image(image, filename)
+        artifact_uri = mlflow.get_artifact_uri()
+        run_artifact_dir = local_file_uri_to_path(artifact_uri)
+        assert os.listdir(run_artifact_dir) == [filename]
+
+
+@pytest.mark.large
+def test_log_image_numpy_raises_exception_for_invalid_array_data_type():
+    import numpy as np
+
+    with mlflow.start_run(), pytest.raises(TypeError, match="Invalid array data type"):
+        mlflow.log_image(np.tile("a", (1, 1, 3)), "image.png")
 
 
 @pytest.mark.large

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -666,7 +666,7 @@ def test_log_image_numpy_shape(size):
 @pytest.mark.parametrize(
     "dtype",
     [
-        # Ref.: https://numpy.org/doc/stable/user/basics.types.html#array-types-and-conversions-between-types
+        # Ref.: https://numpy.org/doc/stable/user/basics.types.html#array-types-and-conversions-between-types  # noqa
         "int8",
         "int16",
         "int32",


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Adds `log_image` that logs an in-memory image object as an artifact.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds `log_image` that logs an in-memory image object as an artifact.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
