### PR TITLE
Unpin TF / Keras and fix bugs in autologging integrations for newer versions

### DIFF
--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -14,7 +14,7 @@ fastai==1.0.60
 # Required by mlflow.spacy
 spacy==2.2.3
 # Required by mlflow.tensorflow
-tensorflow==1.15.2
+tensorflow
 # Required by mlflow.pytorch
 torch==1.6.0
 torchvision==0.5.0

--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -14,7 +14,7 @@ fastai==1.0.60
 # Required by mlflow.spacy
 spacy==2.2.3
 # Required by mlflow.tensorflow
-tensorflow
+tensorflow<=1.15.4 # TensorFlow 2.x is also supported
 # Required by mlflow.pytorch
 torch==1.6.0
 torchvision==0.5.0

--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -4,7 +4,7 @@
 # Required by mlflow.azureml
 azureml-sdk==1.2.0; python_version >= "3.0"
 # Required by mlflow.keras
-keras==2.3.1
+keras
 # Required by mlflow.sklearn
 scikit-learn==0.23.2
 # Required by mlflow.gluon
@@ -14,7 +14,7 @@ fastai==1.0.60
 # Required by mlflow.spacy
 spacy==2.2.3
 # Required by mlflow.tensorflow
-tensorflow<=1.15.4 # TensorFlow 2.x is also supported
+tensorflow
 # Required by mlflow.pytorch
 torch==1.6.0
 torchvision==0.5.0

--- a/dev/run-python-tf-tests.sh
+++ b/dev/run-python-tf-tests.sh
@@ -6,13 +6,16 @@ err=0
 trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
-pytest --verbose tests/keras --large
-pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
-pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
-pip install 'tensorflow'
 pytest --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
 pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
 pytest --verbose tests/keras --large
+pytest --verbose tests/keras_autolog --large
+# Downgrade TensorFlow and Keras in order to test compatibility with older versions
+pip install 'tensorflow==1.15.4'
+pip install 'keras==2.2.5'
+pytest --verbose tests/keras --large
+pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
+pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
 pytest --verbose tests/keras_autolog --large
 
 # Run Spark autologging tests, which rely on tensorflow

--- a/dev/run-python-tf-tests.sh
+++ b/dev/run-python-tf-tests.sh
@@ -9,9 +9,7 @@ export MLFLOW_HOME=$(pwd)
 pytest --verbose tests/keras --large
 pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
 pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
-# TODO(smurching) Unpin TensorFlow dependency version once test failures with TF 2.1.0 have been
-# fixed
-pip install 'tensorflow==2.0.0'
+pip install 'tensorflow'
 pytest --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
 pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
 pytest --verbose tests/keras --large

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -405,7 +405,7 @@ def autolog(log_models=True):
             callbacks += list(args[callback_arg_index])
             tmp_list[callback_arg_index] += [__MLflowFastaiCallback(self)]
             args = tuple(tmp_list)
-        elif "callbacks" in kwargs:
+        elif kwargs.get("callbacks"):
             callbacks += list(kwargs["callbacks"])
             kwargs["callbacks"] += [__MLflowFastaiCallback(self)]
         else:

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -395,7 +395,7 @@ def autolog(log_models=True):
         else:
             auto_end_run = False
 
-        log_fn_args_as_params(original, [self] + list(args), kwargs, unlogged_params)
+        log_fn_args_as_params(original, list(args), kwargs, unlogged_params)
 
         callbacks = [cb(self) for cb in self.callback_fns] + (self.callbacks or [])
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1017,10 +1017,10 @@ def autolog(every_n_iter=100, log_models=True):
 
     def fit_generator(self, *args, **kwargs):
         """
-        NOTE: `fit_generator()` is deprecated in TF > 2.0.0 and simply wraps `fit()`.
+        NOTE: `fit_generator()` is deprecated in TF >= 2.1.0 and simply wraps `fit()`.
         To avoid unintentional creation of nested MLflow runs caused by a patched
         `fit_generator()` method calling a patched `fit()` method, we only patch
-        `fit_generator()` in TF <= 2.0.0.
+        `fit_generator()` in TF < 2.1.0.
         """
         with _manage_active_run():
             original = gorilla.get_original_attribute(tensorflow.keras.Model, "fit_generator")
@@ -1068,11 +1068,11 @@ def autolog(every_n_iter=100, log_models=True):
         (tensorflow.estimator.Estimator, "export_savedmodel", export_savedmodel),
         (FileWriter, "add_summary", add_summary),
     ]
-    if LooseVersion(tensorflow.__version__) <= LooseVersion("2.0.0"):
-        # `fit_generator()` is deprecated in TF > 2.0.0 and simply wraps `fit()`.
+    if LooseVersion(tensorflow.__version__) < LooseVersion("2.1.0"):
+        # `fit_generator()` is deprecated in TF >= 2.1.0 and simply wraps `fit()`.
         # To avoid unintentional creation of nested MLflow runs caused by a patched
         # `fit_generator()` method calling a patched `fit()` method, we only patch
-        # `fit_generator()` in TF <= 2.0.0
+        # `fit_generator()` in TF < 2.1.0
         patches.append((tensorflow.keras.Model, "fit_generator", fit_generator))
 
     for p in patches:

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -652,6 +652,7 @@ def _setup_callbacks(lst, log_models):
         """
 
         def __init__(self, log_models):
+            super(__MLflowTfKerasCallback, self).__init__()
             self.log_models = log_models
 
         def __enter__(self):
@@ -719,6 +720,7 @@ def _setup_callbacks(lst, log_models):
         """
 
         def __init__(self, log_models):
+            super(__MLflowTfKeras2Callback, self).__init__()
             self.log_models = log_models
 
         def __enter__(self):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1016,6 +1016,12 @@ def autolog(every_n_iter=100, log_models=True):
             return history
 
     def fit_generator(self, *args, **kwargs):
+        """
+        NOTE: `fit_generator()` is deprecated in TF > 2.0.0 and simply wraps `fit()`.
+        To avoid unintentional creation of nested MLflow runs caused by a patched
+        `fit_generator()` method calling a patched `fit()` method, we only patch
+        `fit_generator()` in TF <= 2.0.0.
+        """
         with _manage_active_run():
             original = gorilla.get_original_attribute(tensorflow.keras.Model, "fit_generator")
 
@@ -1063,6 +1069,10 @@ def autolog(every_n_iter=100, log_models=True):
         (FileWriter, "add_summary", add_summary),
     ]
     if LooseVersion(tensorflow.__version__) <= LooseVersion("2.0.0"):
+        # `fit_generator()` is deprecated in TF > 2.0.0 and simply wraps `fit()`.
+        # To avoid unintentional creation of nested MLflow runs caused by a patched
+        # `fit_generator()` method calling a patched `fit()` method, we only patch
+        # `fit_generator()` in TF <= 2.0.0
         patches.append((tensorflow.keras.Model, "fit_generator", fit_generator))
 
     for p in patches:

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -652,7 +652,7 @@ def _setup_callbacks(lst, log_models):
         """
 
         def __init__(self, log_models):
-            super(__MLflowTfKerasCallback, self).__init__()
+            super().__init__()
             self.log_models = log_models
 
         def __enter__(self):
@@ -720,7 +720,7 @@ def _setup_callbacks(lst, log_models):
         """
 
         def __init__(self, log_models):
-            super(__MLflowTfKeras2Callback, self).__init__()
+            super().__init__()
             self.log_models = log_models
 
         def __enter__(self):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -994,7 +994,7 @@ def autolog(every_n_iter=100, log_models=True):
                 early_stop_callback = _early_stop_check(tmp_list[5])
                 tmp_list[5], log_dir = _setup_callbacks(tmp_list[5], log_models)
                 args = tuple(tmp_list)
-            elif "callbacks" in kwargs:
+            elif kwargs.get("callbacks"):
                 early_stop_callback = _early_stop_check(kwargs["callbacks"])
                 kwargs["callbacks"], log_dir = _setup_callbacks(kwargs["callbacks"], log_models)
             else:
@@ -1028,7 +1028,7 @@ def autolog(every_n_iter=100, log_models=True):
                 tmp_list = list(args)
                 tmp_list[4], log_dir = _setup_callbacks(tmp_list[4], log_models)
                 args = tuple(tmp_list)
-            elif "callbacks" in kwargs:
+            elif kwargs.get("callbacks"):
                 kwargs["callbacks"], log_dir = _setup_callbacks(kwargs["callbacks"], log_models)
             else:
                 kwargs["callbacks"], log_dir = _setup_callbacks([], log_models)
@@ -1058,11 +1058,12 @@ def autolog(every_n_iter=100, log_models=True):
         (EventFileWriterV2, "add_event", add_event),
         (tensorflow.estimator.Estimator, "train", train),
         (tensorflow.keras.Model, "fit", fit),
-        (tensorflow.keras.Model, "fit_generator", fit_generator),
         (tensorflow.estimator.Estimator, "export_saved_model", export_saved_model),
         (tensorflow.estimator.Estimator, "export_savedmodel", export_savedmodel),
         (FileWriter, "add_summary", add_summary),
     ]
+    if LooseVersion(tensorflow.__version__) <= LooseVersion("2.0.0"):
+        patches.append((tensorflow.keras.Model, "fit_generator", fit_generator))
 
     for p in patches:
         wrap_patch(*p)

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -45,7 +45,7 @@ def log_fn_args_as_params(fn, args, kwargs, unlogged=[]):  # pylint: disable=W01
     # signature & create a mapping from positional argument name to specified value
     params_to_log = {
         param_info.name: param_val
-        for param_info, param_val in zip(list(relevant_params)[:len(args)], args)
+        for param_info, param_val in zip(list(relevant_params)[: len(args)], args)
     }
     # Add all user-specified keyword arguments to the set of parameters to log
     params_to_log.update(kwargs)

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -27,40 +27,6 @@ def try_mlflow_log(fn, *args, **kwargs):
         warnings.warn("Logging to MLflow failed: " + str(e), stacklevel=2)
 
 
-def get_unspecified_default_args(user_args, user_kwargs, all_param_names, all_default_values):
-    """
-    Determine which default values are used in a call, given args and kwargs that are passed in.
-
-    :param user_args: list of arguments passed in by the user
-    :param user_kwargs: dictionary of kwargs passed in by the user
-    :param all_param_names: names of all of the parameters of the function
-    :param all_default_values: values of all default parameters
-    :return: a dictionary mapping arguments not specified by the user -> default value
-    """
-    num_args_without_default_value = len(all_param_names) - len(all_default_values)
-
-    # all_default_values correspond to the last len(all_default_values) elements of the arguments
-    default_param_names = all_param_names[num_args_without_default_value:]
-
-    default_args = dict(zip(default_param_names, all_default_values))
-
-    # The set of keyword arguments that should not be logged with default values
-    user_specified_arg_names = set(user_kwargs.keys())
-
-    num_user_args = len(user_args)
-
-    # This checks if the user passed values for arguments with default values
-    if num_user_args > num_args_without_default_value:
-        num_default_args_passed_as_positional = num_user_args - num_args_without_default_value
-        # Adding the set of positional arguments that should not be logged with default values
-        names_to_exclude = default_param_names[:num_default_args_passed_as_positional]
-        user_specified_arg_names.update(names_to_exclude)
-
-    return {
-        name: value for name, value in default_args.items() if name not in user_specified_arg_names
-    }
-
-
 def log_fn_args_as_params(fn, args, kwargs, unlogged=[]):  # pylint: disable=W0102
     """
     Log parameters explicitly passed to a function.
@@ -70,39 +36,29 @@ def log_fn_args_as_params(fn, args, kwargs, unlogged=[]):  # pylint: disable=W01
     :param unlogged: parameters not to be logged
     :return: None
     """
-    # all_default_values has length n, corresponding to values of the
-    # last n elements in all_param_names
-    pos_params, _, _, pos_defaults, kw_params, kw_defaults, _ = inspect.getfullargspec(fn)
-
-    kw_params = list(kw_params) if kw_params else []
-    pos_defaults = list(pos_defaults) if pos_defaults else []
-    all_param_names = pos_params + kw_params
-    all_default_values = pos_defaults + [kw_defaults[param] for param in kw_params]
-
-    # Checking if default values are present for logging. Known bug that getargspec will return an
-    # empty argspec for certain functions, despite the functions having an argspec.
-    if all_default_values is not None and len(all_default_values) > 0:
-        # Logging the default arguments not passed by the user
-        defaults = get_unspecified_default_args(args, kwargs, all_param_names, all_default_values)
-
-        for name in [name for name in defaults.keys() if name in unlogged]:
-            del defaults[name]
-        try_mlflow_log(mlflow.log_params, defaults)
-
-    # Logging the arguments passed by the user
-    args_dict = dict(
-        (param_name, param_val)
-        for param_name, param_val in zip(all_param_names, args)
-        if param_name not in unlogged
-    )
-
-    if args_dict:
-        try_mlflow_log(mlflow.log_params, args_dict)
-
-    # Logging the kwargs passed by the user
-    for param_name in kwargs:
-        if param_name not in unlogged:
-            try_mlflow_log(mlflow.log_param, param_name, kwargs[param_name])
+    param_spec = inspect.signature(fn).parameters
+    # Fetch the parameter names for specified positional arguments from the function
+    # signature & create a mapping from positional argument name to specified value
+    params_to_log = {
+        param_info.name: param_val
+        for param_info, param_val in zip(list(param_spec.values())[len(args):], args)
+    }
+    # Add all user-specified keyword arguments to the set of parameters to log
+    params_to_log.update(kwargs)
+    # Add parameters that were not explicitly specified by the caller to the mapping,
+    # using their default values
+    params_to_log.update({
+        param.name: param.default
+        for param in list(param_spec.values())[len(args):]
+        if param.name not in kwargs
+    })
+    # Filter out any parameters that should not be logged, as specified by the `unlogged` parameter
+    params_to_log = {
+        key: value
+        for key, value in params_to_log.items()
+        if key not in unlogged
+    }
+    try_mlflow_log(mlflow.log_params, params_to_log)
 
 
 def wrap_patch(destination, name, patch, settings=None):

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -41,7 +41,7 @@ def log_fn_args_as_params(fn, args, kwargs, unlogged=[]):  # pylint: disable=W01
     # signature & create a mapping from positional argument name to specified value
     params_to_log = {
         param_info.name: param_val
-        for param_info, param_val in zip(list(param_spec.values())[len(args) :], args)
+        for param_info, param_val in zip(list(param_spec.values())[:len(args)], args)
     }
     # Add all user-specified keyword arguments to the set of parameters to log
     params_to_log.update(kwargs)

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -41,23 +41,21 @@ def log_fn_args_as_params(fn, args, kwargs, unlogged=[]):  # pylint: disable=W01
     # signature & create a mapping from positional argument name to specified value
     params_to_log = {
         param_info.name: param_val
-        for param_info, param_val in zip(list(param_spec.values())[len(args):], args)
+        for param_info, param_val in zip(list(param_spec.values())[len(args) :], args)
     }
     # Add all user-specified keyword arguments to the set of parameters to log
     params_to_log.update(kwargs)
     # Add parameters that were not explicitly specified by the caller to the mapping,
     # using their default values
-    params_to_log.update({
-        param.name: param.default
-        for param in list(param_spec.values())[len(args):]
-        if param.name not in kwargs
-    })
+    params_to_log.update(
+        {
+            param.name: param.default
+            for param in list(param_spec.values())[len(args) :]
+            if param.name not in kwargs
+        }
+    )
     # Filter out any parameters that should not be logged, as specified by the `unlogged` parameter
-    params_to_log = {
-        key: value
-        for key, value in params_to_log.items()
-        if key not in unlogged
-    }
+    params_to_log = {key: value for key, value in params_to_log.items() if key not in unlogged}
     try_mlflow_log(mlflow.log_params, params_to_log)
 
 

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -30,15 +30,18 @@ def try_mlflow_log(fn, *args, **kwargs):
 def log_fn_args_as_params(fn, args, kwargs, unlogged=[]):  # pylint: disable=W0102
     """
     Log parameters explicitly passed to a function.
+
     :param fn: function whose parameters are to be logged
-    :param args: arguments explicitly passed into fn
+    :param args: arguments explicitly passed into fn. If `fn` is defined on a class,
+                 `self` should not be part of `args`; the caller is responsible for
+                 filtering out `self` before calling this function.
     :param kwargs: kwargs explicitly passed into fn
     :param unlogged: parameters not to be logged
     :return: None
     """
     param_spec = inspect.signature(fn).parameters
-    # Filter out `self` from the signature under the assumption that it is not specified
-    # as an explicit parameter in the call to `fn`
+    # Filter out `self` from the signature under the assumption that it is not contained
+    # within the specified `args`, as stipulated by the documentation
     relevant_params = [param for param in param_spec.values() if param.name != "self"]
 
     # Fetch the parameter names for specified positional arguments from the function

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -37,11 +37,15 @@ def log_fn_args_as_params(fn, args, kwargs, unlogged=[]):  # pylint: disable=W01
     :return: None
     """
     param_spec = inspect.signature(fn).parameters
+    # Filter out `self` from the signature under the assumption that it is not specified
+    # as an explicit parameter in the call to `fn`
+    relevant_params = [param for param in param_spec.values() if param.name != "self"]
+
     # Fetch the parameter names for specified positional arguments from the function
     # signature & create a mapping from positional argument name to specified value
     params_to_log = {
         param_info.name: param_val
-        for param_info, param_val in zip(list(param_spec.values())[:len(args)], args)
+        for param_info, param_val in zip(list(relevant_params)[:len(args)], args)
     }
     # Add all user-specified keyword arguments to the set of parameters to log
     params_to_log.update(kwargs)
@@ -50,7 +54,7 @@ def log_fn_args_as_params(fn, args, kwargs, unlogged=[]):  # pylint: disable=W01
     params_to_log.update(
         {
             param.name: param.default
-            for param in list(param_spec.values())[len(args) :]
+            for param in list(relevant_params)[len(args) :]
             if param.name not in kwargs
         }
     )

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -75,7 +75,7 @@ def model(data):
     model.add(Dense(1))
     # Use a small learning rate to prevent exploding gradients which may produce
     # infinite prediction values
-    model.compile(loss="mean_squared_error", optimizer=SGD(learning_rate=0.001))
+    model.compile(loss="mean_squared_error", optimizer=SGD())
     model.fit(x, y)
     return model
 
@@ -86,7 +86,7 @@ def tf_keras_model(data):
     model = TfSequential()
     model.add(TfDense(3, input_dim=4))
     model.add(TfDense(1))
-    model.compile(loss="mean_squared_error", optimizer=TfSGD(learning_rate=0.001))
+    model.compile(loss="mean_squared_error", optimizer=TfSGD())
     model.fit(x, y)
     return model
 

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -193,6 +193,7 @@ def keras_random_data_run_with_callback(
             restore_best_weights=restore_weights,
         )
     else:
+
         class CustomCallback(keras.callbacks.Callback):
             def on_train_end(self, logs=None):
                 print("Training completed")

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -42,7 +42,7 @@ def create_model():
     model.compile(
         optimizer=keras.optimizers.Adam(lr=0.001, epsilon=1e-07),
         loss="categorical_crossentropy",
-        metrics=["accuracy"],
+        metrics=["acc"],
     )
     return model
 
@@ -125,7 +125,7 @@ def keras_random_data_run(random_train_data, fit_variant, random_one_hot_labels,
 @pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
 def test_keras_autolog_logs_expected_data(keras_random_data_run):
     data = keras_random_data_run.data
-    assert "accuracy" in data.metrics
+    assert "acc" in data.metrics
     assert "loss" in data.metrics
     # Testing explicitly passed parameters are logged correctly
     assert "epochs" in data.params

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -186,18 +186,18 @@ def keras_random_data_run_with_callback(
     model = create_model()
     if callback == "early":
         # min_delta is set as such to guarantee early stopping
-        callback = keras.callbacks.callbacks.EarlyStopping(
+        callback = keras.callbacks.EarlyStopping(
             monitor="loss",
             patience=patience,
             min_delta=99999999,
             restore_best_weights=restore_weights,
         )
     else:
-        if fit_variant == "fit_generator":
-            count_mode = "steps"
-        else:
-            count_mode = "samples"
-        callback = keras.callbacks.callbacks.ProgbarLogger(count_mode=count_mode)
+        class CustomCallback(keras.callbacks.Callback):
+            def on_train_end(self, logs=None):
+                print("Training completed")
+
+        callback = CustomCallback()
 
     if fit_variant == "fit_generator":
 

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -10,7 +10,7 @@ import pandas as pd
 import numpy as np
 import yaml
 
-import tensorflow.compat.v1 as tf
+import tensorflow.compat.v1 as tf  # pylint: disable=import-error
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.models import infer_signature, Model

--- a/tests/onnx/test_onnx_model_export.py
+++ b/tests/onnx/test_onnx_model_export.py
@@ -10,7 +10,7 @@ import pandas as pd
 import numpy as np
 import yaml
 
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 from mlflow import pyfunc
 from mlflow.models import infer_signature, Model

--- a/tests/tensorflow/test_tensorflow_model_export.py
+++ b/tests/tensorflow/test_tensorflow_model_export.py
@@ -258,7 +258,7 @@ def test_save_and_load_model_persists_and_restores_model_in_custom_graph_context
     tf_graph = tf.Graph()
     tf_sess = tf.Session(graph=tf_graph)
     custom_tf_context = tf_graph.device("/cpu:0")
-    with custom_tf_context:
+    with custom_tf_context:  # pylint: disable=not-context-manager
         signature_def = mlflow.tensorflow.load_model(model_uri=model_path, tf_sess=tf_sess)
 
         for _, input_signature in signature_def.inputs.items():
@@ -286,7 +286,7 @@ def test_iris_model_can_be_loaded_and_evaluated_successfully(saved_tf_iris_model
 
     tf_graph_2 = tf.Graph()
     tf_sess_2 = tf.Session(graph=tf_graph_2)
-    with tf_graph_1.device("/cpu:0"):
+    with tf_graph_1.device("/cpu:0"):  # pylint: disable=not-context-manager
         load_and_evaluate(model_path=model_path, tf_sess=tf_sess_2, tf_graph=tf_graph_2)
 
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -222,7 +222,7 @@ def tf_keras_random_data_run_with_callback(
         )
     else:
         class CustomCallback(tf.keras.callbacks.Callback):
-            def on_train_end(self, logs):
+            def on_train_end(self, logs=None):
                 print("Training completed") 
 
         callback = CustomCallback() 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -221,7 +221,11 @@ def tf_keras_random_data_run_with_callback(
             restore_best_weights=restore_weights,
         )
     else:
-        callback = tf.keras.callbacks.ProgbarLogger(count_mode="samples")
+        class CustomCallback(tf.keras.callbacks.Callback):
+            def on_train_end(self, logs):
+                print("Training completed") 
+
+        callback = CustomCallback() 
 
     history = model.fit(data, labels, epochs=10, callbacks=[callback])
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -190,7 +190,9 @@ def test_tf_keras_autolog_logs_expected_data(tf_keras_random_data_run):
 
 
 @pytest.mark.large
-def test_tf_keras_autolog_names_positional_parameters_correctly(random_train_data, random_one_hot_labels):
+def test_tf_keras_autolog_names_positional_parameters_correctly(
+    random_train_data, random_one_hot_labels
+):
     mlflow.tensorflow.autolog(every_n_iter=5)
 
     data = random_train_data

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -221,11 +221,12 @@ def tf_keras_random_data_run_with_callback(
             restore_best_weights=restore_weights,
         )
     else:
+
         class CustomCallback(tf.keras.callbacks.Callback):
             def on_train_end(self, logs=None):
-                print("Training completed") 
+                print("Training completed")
 
-        callback = CustomCallback() 
+        callback = CustomCallback()
 
     history = model.fit(data, labels, epochs=10, callbacks=[callback])
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -190,6 +190,25 @@ def test_tf_keras_autolog_logs_expected_data(tf_keras_random_data_run):
 
 
 @pytest.mark.large
+def test_tf_keras_autolog_names_positional_parameters_correctly(random_train_data, random_one_hot_labels):
+    mlflow.tensorflow.autolog(every_n_iter=5)
+
+    data = random_train_data
+    labels = random_one_hot_labels
+
+    model = create_tf_keras_model()
+
+    with mlflow.start_run():
+        # Pass `batch_size` as a positional argument for testing purposes
+        model.fit(data, labels, 8, epochs=10, steps_per_epoch=1)
+        run_id = mlflow.active_run().info.run_id
+
+    client = mlflow.tracking.MlflowClient()
+    run_info = client.get_run(run_id)
+    assert run_info.data.params.get("batch_size") == "8"
+
+
+@pytest.mark.large
 @pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
 def test_tf_keras_autolog_model_can_load_from_artifact(tf_keras_random_data_run, random_train_data):
     client = mlflow.tracking.MlflowClient()

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -60,11 +60,12 @@ def create_tf_keras_model():
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
+@pytest.mark.parametrize("fit_variant", ["fit_generator", "fit"])
+# @pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
 def test_tf_keras_autolog_ends_auto_created_run(
     random_train_data, random_one_hot_labels, fit_variant
 ):
-    # pylint: disable=unused-argument
+    # pylint: disable=uNused-argument
     mlflow.tensorflow.autolog()
 
     data = random_train_data
@@ -75,28 +76,6 @@ def test_tf_keras_autolog_ends_auto_created_run(
     model.fit(data, labels, epochs=10)
 
     assert mlflow.active_run() is None
-
-
-@pytest.mark.large
-@pytest.mark.parametrize("log_models", [True, False])
-def test_tf_keras_autolog_log_models_configuration(
-    random_train_data, random_one_hot_labels, log_models
-):
-    # pylint: disable=unused-argument
-    mlflow.tensorflow.autolog(log_models=log_models)
-
-    data = random_train_data
-    labels = random_one_hot_labels
-
-    model = create_tf_keras_model()
-
-    model.fit(data, labels, epochs=10)
-
-    client = mlflow.tracking.MlflowClient()
-    run_id = client.list_run_infos(experiment_id="0")[0].run_id
-    artifacts = client.list_artifacts(run_id)
-    artifacts = map(lambda x: x.path, artifacts)
-    assert ("model" in artifacts) == log_models
 
 
 @pytest.mark.large

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -60,12 +60,11 @@ def create_tf_keras_model():
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("fit_variant", ["fit_generator", "fit"])
-# @pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
+@pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
 def test_tf_keras_autolog_ends_auto_created_run(
     random_train_data, random_one_hot_labels, fit_variant
 ):
-    # pylint: disable=uNused-argument
+    # pylint: disable=unused-argument
     mlflow.tensorflow.autolog()
 
     data = random_train_data
@@ -76,6 +75,28 @@ def test_tf_keras_autolog_ends_auto_created_run(
     model.fit(data, labels, epochs=10)
 
     assert mlflow.active_run() is None
+
+
+@pytest.mark.large
+@pytest.mark.parametrize("log_models", [True, False])
+def test_tf_keras_autolog_log_models_configuration(
+    random_train_data, random_one_hot_labels, log_models
+):
+    # pylint: disable=unused-argument
+    mlflow.tensorflow.autolog(log_models=log_models)
+
+    data = random_train_data
+    labels = random_one_hot_labels
+
+    model = create_tf_keras_model()
+
+    model.fit(data, labels, epochs=10)
+
+    client = mlflow.tracking.MlflowClient()
+    run_id = client.list_run_infos(experiment_id="0")[0].run_id
+    artifacts = client.list_artifacts(run_id)
+    artifacts = map(lambda x: x.path, artifacts)
+    assert ("model" in artifacts) == log_models
 
 
 @pytest.mark.large

--- a/tests/utils/test_autologging_utils.py
+++ b/tests/utils/test_autologging_utils.py
@@ -9,7 +9,6 @@ import mlflow
 from mlflow.utils import gorilla
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils.autologging_utils import (
-    get_unspecified_default_args,
     log_fn_args_as_params,
     wrap_patch,
     resolve_input_example_and_signature,
@@ -41,21 +40,6 @@ two_default_test_args = [
 ]
 
 
-@pytest.mark.large
-@pytest.mark.parametrize(
-    "user_args,user_kwargs,all_param_names,all_default_values,expected", two_default_test_args
-)
-def test_get_two_unspecified_default_args(
-    user_args, user_kwargs, all_param_names, all_default_values, expected
-):
-
-    default_dict = get_unspecified_default_args(
-        user_args, user_kwargs, all_param_names, all_default_values
-    )
-
-    assert default_dict == expected
-
-
 # Test function signature for the following tests
 # def fn_default_default(default1=1, default2=2, default3=3):
 #     pass
@@ -77,21 +61,6 @@ three_default_test_args = [
         {"default1": 1, "default3": 3},
     ),
 ]
-
-
-@pytest.mark.large
-@pytest.mark.parametrize(
-    "user_args,user_kwargs,all_param_names,all_default_values,expected", three_default_test_args
-)
-def test_get_three_unspecified_default_args(
-    user_args, user_kwargs, all_param_names, all_default_values, expected
-):
-
-    default_dict = get_unspecified_default_args(
-        user_args, user_kwargs, all_param_names, all_default_values
-    )
-
-    assert default_dict == expected
 
 
 @pytest.fixture


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes a number of issues in MLflow's TensorFlow & Keras autologging integrations and unpins these libraries for testing purposes in order to catch regressions in the future.

## How is this patch tested?

MLflow autologging tests

## Release Notes

Bug fixes for autologging compatibility with the latest versions of TensorFlow and Keras

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
