### PR TITLE
Avoid using mutable default argument value

### DIFF
--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -284,10 +284,7 @@ class _XGBModelWrapper:
 
 @experimental
 def autolog(
-    importance_types=None,
-    log_input_examples=False,
-    log_model_signatures=True,
-    log_models=True,
+    importance_types=None, log_input_examples=False, log_model_signatures=True, log_models=True,
 ):
     """
     Enables automatic logging from XGBoost to MLflow. Logs the following.
@@ -322,6 +319,9 @@ def autolog(
     """
     import xgboost
     import numpy as np
+
+    if importance_types is None:
+        importance_types = ["weight"]
 
     # Patching this function so we can get a copy of the data given to DMatrix.__init__
     #   to use as an input example and for inferring the model signature.

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -284,11 +284,11 @@ class _XGBModelWrapper:
 
 @experimental
 def autolog(
-    importance_types=["weight"],
+    importance_types=None,
     log_input_examples=False,
     log_model_signatures=True,
     log_models=True,
-):  # pylint: disable=W0102
+):
     """
     Enables automatic logging from XGBoost to MLflow. Logs the following.
 
@@ -302,7 +302,7 @@ def autolog(
 
     Note that the `scikit-learn API`_ is not supported.
 
-    :param importance_types: importance types to log.
+    :param importance_types: Importance types to log. If unspecified, defaults to ``["weight"]``.
     :param log_input_examples: If ``True``, input examples from training datasets are collected and
                                logged along with XGBoost model artifacts during training. If
                                ``False``, input examples are not logged.


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix a mutable default value in `mlflow.xgboost.autolog`.

https://stackoverflow.com/a/9526480/6943581

## How is this patch tested?

Exisiting unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
