### PR TITLE
[xgboost autologging test] Fix expected value for `maximize` argument in `xgboost.train`

### DIFF
--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -69,7 +69,7 @@ def test_xgb_autolog_logs_default_params(bst_params, dtrain):
 
     expected_params = {
         "num_boost_round": 10,
-        # In xgboost>=1.3.0, the default value for `maximize`in `xgboost.train` is None.
+        # In xgboost>=1.3.0, the default value for `maximize` in `xgboost.train` is None
         # https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
         "maximize": None if LooseVersion(xgb.__version__) >= LooseVersion("1.3.0") else False,
         "early_stopping_rounds": None,

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -70,10 +70,9 @@ def test_xgb_autolog_logs_default_params(bst_params, dtrain):
     expected_params = {
         "num_boost_round": 10,
         # In xgboost >= 1.3.0, the default value for `maximize` in `xgboost.train` is None:
-        # https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
-        #
+        #   https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
         # In < 1.3.0, it's False:
-        # https://xgboost.readthedocs.io/en/release_1.2.0/python/python_api.html#xgboost.train
+        #   https://xgboost.readthedocs.io/en/release_1.2.0/python/python_api.html#xgboost.train
         "maximize": None if LooseVersion(xgb.__version__) >= LooseVersion("1.3.0") else False,
         "early_stopping_rounds": None,
         "verbose_eval": True,

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -69,8 +69,11 @@ def test_xgb_autolog_logs_default_params(bst_params, dtrain):
 
     expected_params = {
         "num_boost_round": 10,
-        # In xgboost>=1.3.0, the default value for `maximize` in `xgboost.train` is None
-        # https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
+        # In xgboost >= 1.3.0, the default value for `maximize` in `xgboost.train` is None
+        # - https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
+        #
+        # In < 1.3.0, it's False
+        # - https://xgboost.readthedocs.io/en/release_1.2.0/python/python_api.html#xgboost.train
         "maximize": None if LooseVersion(xgb.__version__) >= LooseVersion("1.3.0") else False,
         "early_stopping_rounds": None,
         "verbose_eval": True,

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -69,11 +69,11 @@ def test_xgb_autolog_logs_default_params(bst_params, dtrain):
 
     expected_params = {
         "num_boost_round": 10,
-        # In xgboost >= 1.3.0, the default value for `maximize` in `xgboost.train` is None
-        # - https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
+        # In xgboost >= 1.3.0, the default value for `maximize` in `xgboost.train` is None:
+        # https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
         #
-        # In < 1.3.0, it's False
-        # - https://xgboost.readthedocs.io/en/release_1.2.0/python/python_api.html#xgboost.train
+        # In < 1.3.0, it's False:
+        # https://xgboost.readthedocs.io/en/release_1.2.0/python/python_api.html#xgboost.train
         "maximize": None if LooseVersion(xgb.__version__) >= LooseVersion("1.3.0") else False,
         "early_stopping_rounds": None,
         "verbose_eval": True,

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import os
 import json
 import pytest
@@ -68,7 +69,9 @@ def test_xgb_autolog_logs_default_params(bst_params, dtrain):
 
     expected_params = {
         "num_boost_round": 10,
-        "maximize": False,
+        # In xgboost>=1.3.0, the default value for `maximize`in `xgboost.train` is None.
+        # https://xgboost.readthedocs.io/en/latest/python/python_api.html#xgboost.train
+        "maximize": None if LooseVersion(xgb.__version__) >= LooseVersion("1.3.0") else False,
         "early_stopping_rounds": None,
         "verbose_eval": True,
     }


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

In xgboost>=1.3.0 (not released yet), the default value for `maximize` in `xgboost.train` is None.

Releated error: https://github.com/mlflow/mlflow/pull/3731/checks?check_run_id=1473925235#step:8:42

## How is this patch tested?

Fixed test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
