### PR TITLE
test

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -188,6 +188,7 @@ jobs:
         run: |
           export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
+          pip install git+https://github.com/harupy/pytest.git@use-group
           ./dev/run-python-flavor-tests.sh;
 
   import:

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -1,7 +1,7 @@
 ## Small test reqs
 scipy
 ## Test-only dependencies
-pytest @ https://github.com/harupy/pytest.git@use-group
+pytest @ git+https://github.com/harupy/pytest.git@use-group
 pytest-cov==2.6.0
 pytest-localserver==0.5.0
 moto==1.3.16

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -1,7 +1,7 @@
 ## Small test reqs
 scipy
 ## Test-only dependencies
-pytest @ git+https://github.com/harupy/pytest.git@use-group
+pytest==3.2.1
 pytest-cov==2.6.0
 pytest-localserver==0.5.0
 moto==1.3.16

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -1,7 +1,7 @@
 ## Small test reqs
 scipy
 ## Test-only dependencies
-pytest==3.2.1
+pytest @ https://github.com/harupy/pytest.git@use-group
 pytest-cov==2.6.0
 pytest-localserver==0.5.0
 moto==1.3.16

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -463,6 +463,7 @@ def test_xgb_autolog_does_not_break_dmatrix_serialization(bst_params, tmpdir):
 @pytest.mark.parametrize("log_input_examples", [True, False])
 @pytest.mark.parametrize("log_model_signatures", [True, False])
 def test_xgb_autolog_configuration_options(bst_params, log_input_examples, log_model_signatures):
+    raise Exception
     iris = datasets.load_iris()
     X = pd.DataFrame(iris.data[:, :2], columns=iris.feature_names[:2])
     y = iris.target


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
