### PR TITLE
include run_id to `create_run` tracking event callback

### DIFF
--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -75,9 +75,11 @@ mlflow_create_run <- function(start_time = NULL, tags = NULL, experiment_id = NU
   response <- mlflow_rest(
     "runs", "create", client = client, verb = "POST", data = data
   )
+  run_id <- response$run$info$run_uuid
+  data$run_id <- run_id
   mlflow_register_tracking_event("create_run", data)
 
-  mlflow_get_run(run_id = response$run$info$run_uuid, client = client)
+  mlflow_get_run(run_id = run_id, client = client)
 }
 
 #' Delete a Run

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -602,6 +602,10 @@ test_that("mlflow observers receive tracking event callbacks", {
   expect_equal(length(tracking_events), num_observers)
   for (idx in seq(num_observers)) {
     expect_equal(
+      tracking_events[[idx]]$create_run[[1]]$run_id,
+      run$run_id
+    )
+    expect_equal(
       tracking_events[[idx]]$create_run[[1]]$experiment_id,
       experiment_id
     )


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>

## What changes are proposed in this pull request?

Make `mlflow_create_run` include `run_id` in the optional tracking event callback

## How is this patch tested?

Unit test (see changes in `test-tracking-runs.R`)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
