### PR TITLE
Example: show working usage of `mlflow.pytorch.log_model` using cloudpickle

### DIFF
--- a/examples/pytorch/mnist_tensorboard_artifact.py
+++ b/examples/pytorch/mnist_tensorboard_artifact.py
@@ -205,8 +205,10 @@ with mlflow.start_run():
 
     # Create a SummaryWriter to write TensorBoard events locally
     output_dir = dirpath = tempfile.mkdtemp()
-    writer = SummaryWriter(output_dir)
-    print("Writing TensorBoard events locally to %s\n" % output_dir)
+    ### NOTE(sid): We comment out tensorboardx calls as they introduce unpicklable thread.Lock
+    ### objects that cause pickling the Pytorch model to fail during torch.save()
+    # writer = SummaryWriter(output_dir)
+    # print("Writing TensorBoard events locally to %s\n" % output_dir)
 
     # Perform the training
     for epoch in range(1, args.epochs + 1):
@@ -214,16 +216,18 @@ with mlflow.start_run():
         test(epoch)
 
     # Upload the TensorBoard event logs as a run artifact
-    print("Uploading TensorBoard events as a run artifact...")
-    mlflow.log_artifacts(output_dir, artifact_path="events")
-    print(
-        "\nLaunch TensorBoard with:\n\ntensorboard --logdir=%s"
-        % os.path.join(mlflow.get_artifact_uri(), "events")
-    )
+    # print("Uploading TensorBoard events as a run artifact...")
+    # mlflow.log_artifacts(output_dir, artifact_path="events")
+    # print(
+    #     "\nLaunch TensorBoard with:\n\ntensorboard --logdir=%s"
+    #     % os.path.join(mlflow.get_artifact_uri(), "events")
+    # )
 
     # Log the model as an artifact of the MLflow run.
     print("\nLogging the trained model as a run artifact...")
-    mlflow.pytorch.log_model(model, artifact_path="pytorch-model", pickle_module=pickle)
+    # Log model using the default serialization format (cloudpickle). This succeeds only when the
+    # tensorboardX usage above is commented-out or otherwise disabled.
+    mlflow.pytorch.log_model(model, artifact_path="pytorch-model")
     print(
         "\nThe model is logged at:\n%s" % os.path.join(mlflow.get_artifact_uri(), "pytorch-model")
     )


### PR DESCRIPTION
Signed-off-by: Sid Murching <sid.murching@databricks.com>

## What changes are proposed in this pull request?

This PR demonstrates usage of ``mlflow.pytorch.log_model``, followed by successful usage of ``mlflow.pytorch.load_model`` in a separate Python process where the original model class has not been loaded, when using the default ``cloudpickle`` persistence format with `mlflow.pytorch.log_model`. 

In particular, from this branch, run:

```
python examples/pytorch/mnist_tensorboard_artifact.py --epochs=0
```

Which will produce output like:

```
Logging the trained model as a run artifact...

The model is logged at:
./mlruns/0/5867bc041d744c2db2db43ef41e9dc32/artifacts/pytorch-model

Sample predictions
Sample 0 : Ground truth is "2", model prediction is "6"
Sample 1 : Ground truth is "5", model prediction is "4"
Sample 2 : Ground truth is "2", model prediction is "0"
Sample 3 : Ground truth is "1", model prediction is "6"
Sample 4 : Ground truth is "5", model prediction is "1"
```

And then in a *separate* Python process, attempt to load the model back from the logged path, and note that it succeeds:

```
(mlflow-python3) ➜  mlflow git:(master) ✗ python
>>> import mlflow.pytorch
>>> mlflow.pytorch.load_model("./mlruns/0/5867bc041d744c2db2db43ef41e9dc32/artifacts/pytorch-model")
Net(
  (conv1): Conv2d(1, 10, kernel_size=(5, 5), stride=(1, 1))
  (conv2): Conv2d(10, 20, kernel_size=(5, 5), stride=(1, 1))
  (conv2_drop): Dropout2d(p=0.5, inplace=False)
  (fc1): Linear(in_features=320, out_features=50, bias=True)
  (fc2): Linear(in_features=50, out_features=10, bias=True)
)
```

See https://github.com/mlflow/mlflow/pull/3408#pullrequestreview-489127574 for a contrasting example where using `pickle` fails



## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
