### PR TITLE
Run lint check faster

### DIFF
--- a/dev/lint-requirements.txt
+++ b/dev/lint-requirements.txt
@@ -1,7 +1,7 @@
 prospector[with_pyroma]==0.12.7
 pep8==1.7.1
 pyarrow==0.17.0
-pylint==1.8.2
+pylint==2.6.0
 rstcheck==3.2
 black==19.10b0
 # Pin isort version to prevent pylint from raising an error

--- a/lint.sh
+++ b/lint.sh
@@ -49,8 +49,8 @@ exclude="^\($(join "\|" "${exclude_dirs[@]}")\)/.\+\.py$"
 include="^\($(join "\|" "${include_dirs[@]}")\)/.\+\.py$"
 msg_template="{path} ({line},{column}): [{msg_id} {symbol}] {msg}"
 
-git ls-files | grep $include | grep -v $exclude | \
-xargs pylint --msg-template="$msg_template" --rcfile="$FWDIR/pylintrc"
+pylint --msg-template="$msg_template" --rcfile="$FWDIR/pylintrc" \
+$(git ls-files | grep $include | grep -v $exclude)
 
 echo -e "\n========== rstcheck ==========\n"
 rstcheck README.rst

--- a/pylintrc
+++ b/pylintrc
@@ -19,7 +19,7 @@ ignore-patterns=
 #init-hook=
 
 # Use multiple processes to speed up Pylint.
-jobs=0
+jobs=1
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.

--- a/pylintrc
+++ b/pylintrc
@@ -19,7 +19,7 @@ ignore-patterns=
 #init-hook=
 
 # Use multiple processes to speed up Pylint.
-jobs=1
+jobs=0
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
