### PR TITLE
support nested-run in mlflow R client

### DIFF
--- a/mlflow/R/mlflow/R/tracking-globals.R
+++ b/mlflow/R/mlflow/R/tracking-globals.R
@@ -1,13 +1,21 @@
 #' @include tracking-observer.R
 NULL
 
-mlflow_set_active_run_id <- function(run_id) {
-  .globals$active_run_id <- run_id
+mlflow_push_active_run_id <- function(run_id) {
+  .globals$active_run_stack <- c(.globals$active_run_stack, run_id)
   mlflow_register_tracking_event("active_run_id", list(run_id = run_id))
 }
 
+mlflow_pop_active_run_id <- function() {
+  .globals$active_run_stack <- .globals$active_run_stack[1:length(.globals$active_run_stack) - 1]
+}
+
 mlflow_get_active_run_id <- function() {
-  .globals$active_run_id
+  if (length(.globals$active_run_stack) == 0) {
+    NULL
+  } else {
+    .globals$active_run_stack[length(.globals$active_run_stack)]
+  }
 }
 
 mlflow_set_active_experiment_id <- function(experiment_id) {

--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -1,4 +1,4 @@
-#' @include tracking-observer.R
+#' @include tracking-globals.R
 NULL
 
 # Translate metric to value to safe format for REST.
@@ -526,6 +526,7 @@ mlflow_record_logged_model <- function(model_spec, run_id = NULL, client = NULL)
 #'   a new experiment with a randomly generated name.
 #' @param start_time Unix timestamp of when the run started in milliseconds. Only used when `client` is specified.
 #' @param tags Additional metadata for run in key-value pairs. Only used when `client` is specified.
+#' @param nested Controls whether the run to be started is nested in a parent run. `TRUE` creates a nest run.
 #' @template roxlate-client
 #'
 #' @examples
@@ -536,7 +537,7 @@ mlflow_record_logged_model <- function(model_spec, run_id = NULL, client = NULL)
 #' }
 #'
 #' @export
-mlflow_start_run <- function(run_id = NULL, experiment_id = NULL, start_time = NULL, tags = NULL, client = NULL) {
+mlflow_start_run <- function(run_id = NULL, experiment_id = NULL, start_time = NULL, tags = NULL, client = NULL, nested = FALSE) {
 
   # When `client` is provided, this function acts as a wrapper for `runs/create` and does not register
   #  an active run.
@@ -553,8 +554,10 @@ mlflow_start_run <- function(run_id = NULL, experiment_id = NULL, start_time = N
   if (!is.null(tags)) stop("`tags` should only be specified when `client` is specified.", call. = FALSE)
 
   active_run_id <- mlflow_get_active_run_id()
-  if (!is.null(active_run_id)) {
-    stop("Run with UUID ", active_run_id, " is already active.",
+  if (!is.null(active_run_id) && !nested) {
+    stop("Run with UUID ",
+         active_run_id,
+         " is already active. To start a nested run, Call `mlflow_start_run()` with `nested = TRUE`.",
          call. = FALSE
     )
   }
@@ -579,7 +582,7 @@ mlflow_start_run <- function(run_id = NULL, experiment_id = NULL, start_time = N
     )
     do.call(mlflow_create_run, args)
   }
-  mlflow_set_active_run_id(mlflow_id(run))
+  mlflow_push_active_run_id(mlflow_id(run))
   mlflow_set_experiment(experiment_id = args$experiment_id)
   run
 }
@@ -636,7 +639,7 @@ mlflow_end_run <- function(status = c("FINISHED", "FAILED", "KILLED"),
                           end_time = end_time)
   }
 
-  if (identical(run_id, active_run_id)) mlflow_set_active_run_id(NULL)
+  if (identical(run_id, active_run_id)) mlflow_pop_active_run_id()
   run
 }
 

--- a/mlflow/R/mlflow/man/mlflow_start_run.Rd
+++ b/mlflow/R/mlflow/man/mlflow_start_run.Rd
@@ -9,7 +9,8 @@ mlflow_start_run(
   experiment_id = NULL,
   start_time = NULL,
   tags = NULL,
-  client = NULL
+  client = NULL,
+  nested = FALSE
 )
 }
 \arguments{
@@ -29,6 +30,8 @@ a new experiment with a randomly generated name.}
 If specified, MLflow will use the tracking server associated with the passed-in client. If
 unspecified (the common case),
 MLflow will use the tracking server associated with the current tracking URI.}
+
+\item{nested}{Controls whether the run to be started is nested in a parent run. `TRUE` creates a nest run.}
 }
 \description{
 Starts a new run. If `client` is not provided, this function infers contextual information such as

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -50,6 +50,22 @@ test_that("mlflow_end_run() works properly", {
   expect_true(!anyNA(run[run_info_names]))
 })
 
+test_that("mlflow_start_run()/mlflow_end_run() works properly with nested runs", {
+  mlflow_clear_test_dir("mlruns")
+  runs <- list(
+    mlflow_start_run(),
+    mlflow_start_run(nested = TRUE),
+    mlflow_start_run(nested = TRUE)
+  )
+  client <- mlflow_client()
+  for (i in seq(3, 1, -1)) {
+    expect_equal(mlflow:::mlflow_get_active_run_id(), runs[[i]]$run_uuid)
+    run <- mlflow_end_run(client = client, run_id = runs[[i]]$run_uuid)
+    expect_identical(run$run_uuid, runs[[i]]$run_uuid)
+  }
+  expect_null(mlflow:::mlflow_get_active_run_id())
+})
+
 test_that("mlflow_set_tag() should return NULL invisibly", {
   mlflow_clear_test_dir("mlruns")
   value <- mlflow_set_tag("foo", "bar")


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>

## What changes are proposed in this pull request?

As suggested in https://github.com/mlflow/mlflow/issues/3537, MLflow R client should supported the "nested runs" use case which the Python client already supports.

"Nested run" is essentially some additional book-keeping that is entirely done on the client-side to ensure if one run is already active, then another run cannot be started unless user specifies `nested = TRUE` explicitly. It ensures user does not accidentally create nested runs, and understands if a nested run is created, then it will, as the name suggests, be nested in the parent run.

Also nested run follows a first-in-last-out semantic in term of the active run ID: the active run ID switches from the parent to child once the child run is started, and once the current child run is ended, then the active run ID reverts back to the run ID of the parent.

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow R client now supports the creation of nested runs. When a run is already active, user must specify `nested = TRUE` when calling `mlflow_start_run()` to create a child run that is nested within the current run.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

closes https://github.com/mlflow/mlflow/issues/3537