### PR TITLE
fix some of the Windows-related interop issues and partially enable MLflow R CI workflow on Windows

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,10 +31,20 @@ jobs:
         source activate test-environment
         ./lint.sh
   r:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@master
-    - uses: r-lib/actions/setup-r@v1
+    - uses: r-lib/actions/setup-r@master
+    - name: Install Miniconda (Windows-only)
+      if: runner.os == 'windows'
+      uses: conda-incubator/setup-miniconda@v2.0.1
+      with:
+        auto-update-conda: true
+        python-version: 3.6
     # This step dumps the current set of R dependencies and R version into files to be used
     # as a cache key when caching/restoring R dependencies.
     - name: Query dependencies
@@ -46,7 +56,7 @@ jobs:
       shell: Rscript {0}
 
     - name: Cache R packages
-      if: runner.os != 'Windows'
+      if: runner.os != 'windows'
       uses: actions/cache@v2
       with:
         path: ${{ env.R_LIBS_USER }}
@@ -55,6 +65,7 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
         restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
     - name: Install system dependencies
+      if: runner.os == 'ubuntu-latest'
       run: |
         sudo apt-get install -y libcurl4-openssl-dev
     - name: Install dependencies
@@ -64,30 +75,41 @@ jobs:
       shell: Rscript {0}
     - name: Create test environment
       run: |
+        cd "${GITHUB_WORKSPACE}"
         source ./dev/install-common-deps.sh
+        source ./dev/add-r-home-to-path-on-windows.sh
         cd mlflow/R/mlflow
         R CMD build .
         cd tests
         Rscript ../.create-test-env.R
+      shell: bash -l {0}
     - name: Run tests
       run: |
         export LINTR_COMMENT_BOT=false
-        cd mlflow/R/mlflow/tests
+        source "${GITHUB_WORKSPACE}"/dev/fix-path-variable-on-windows.sh
+        cd "${GITHUB_WORKSPACE}"/mlflow/R/mlflow/tests
         Rscript ../.run-tests.R
+      shell: bash -l {0}
     - name: Calculate code coverage
       if: ${{ success() }}
       run: |
-        export MLFLOW_HOME=$(pwd)
-        cd mlflow/R/mlflow/tests
-        Rscript -e 'covr::codecov()' || :
+        # for some reason this is prohibitively slow on Windows
+        if [[ "${OSTYPE}" == linux* ]]; then
+          export MLFLOW_HOME="${GITHUB_WORKSPACE}"
+          source "${GITHUB_WORKSPACE}"/dev/add-r-home-to-path-on-windows.sh
+          cd "${GITHUB_WORKSPACE}"/mlflow/R/mlflow/tests
+          Rscript -e 'covr::codecov()' || :
+        fi
       env:
         COVR_RUNNING: true
+      shell: bash -l {0}
     - name: Show 00check.log on failure
       if: ${{ failure() }}
       run: |
         LOG_FILE="${HOME}/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
         [ -r "${LOG_FILE}" ] && cat "${LOG_FILE}"
         cp "${LOG_FILE}" /tmp
+      shell: bash -l {0}
     - uses: actions/upload-artifact@v1
       if: failure()
       with:

--- a/dev/add-r-home-to-path-on-windows.sh
+++ b/dev/add-r-home-to-path-on-windows.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Because $OSTYPE could be cygwin, msys, or win32, etc on Windows. The possibilities are endless.
+if [[ "${OSTYPE}" != linux* && "${OSTYPE}" != darwin* ]]; then
+  R_HOME='/c/R'
+  export PATH="${PATH}:${R_HOME}/bin"
+fi

--- a/dev/fix-path-variable-on-windows.sh
+++ b/dev/fix-path-variable-on-windows.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Because $OSTYPE could be cygwin, msys, or win32, etc on Windows. The possibilities are endless.
+if [[ "${OSTYPE}" != linux* && "${OSTYPE}" != darwin* ]]; then
+  export PATH=\
+"${PATH}:\
+$(
+  R_HOME='/c/R'
+  MINICONDA_ENVS_DIR='/c/Miniconda/envs'
+  MLFLOW_CONDA_ENV_NAME="$(${R_HOME}/bin/Rscript -e 'cat(mlflow:::mlflow_conda_env_name())')"
+  ADDITIONAL_PATHS_ARR=(
+    "${R_HOME}/bin"
+    "${MINICONDA_ENVS_DIR}"/{'test-environment',"${MLFLOW_CONDA_ENV_NAME}"}/'Scripts'
+  )
+
+  export IFS=':'
+  echo "${ADDITIONAL_PATHS_ARR[*]}"
+)
+"
+
+  # fail fast if any of these required binaries is not present
+  which waitress-serve
+  which mlflow
+fi

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -2,15 +2,35 @@ parent_dir <- dir("../", full.names = TRUE)
 package <- parent_dir[grepl("mlflow_", parent_dir)]
 install.packages(package)
 
+# Pin h2o to prevent version-mismatch between python and R
+install.packages("https://cran.r-project.org/src/contrib/Archive/h2o/h2o_3.30.1.3.tar.gz", repos=NULL, type="source")
+
 mlflow:::mlflow_maybe_create_conda_env(python_version = "3.6")
 library(reticulate)
 use_condaenv(mlflow:::mlflow_conda_env_name())
 # pinning tensorflow version to 1.14 until test_keras_model.R is fixed
 keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(), tensorflow="1.15.2")
+
 # pinning h5py < 3.0.0 to avoid this issue:  https://github.com/tensorflow/tensorflow/issues/44467
 # TODO: unpin after we use tensorflow >= 2.4
-reticulate::conda_install("'h5py<3.0.0'", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
+h5py_pkg <- (
+  if (.Platform$OS.type != "windows") {
+    "'h5py<3.0.0'"
+  } else {
+    "h5py<3.0.0"
+  }
+)
+reticulate::conda_install(h5py_pkg, envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
-reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
+
+xgboost_pkg <- (
+  if (.Platform$OS.type != "windows") {
+    "xgboost"
+  } else {
+    "py-xgboost"
+  }
+)
+reticulate::conda_install(xgboost_pkg, envname = mlflow:::mlflow_conda_env_name())
+
 # Pin h2o to prevent version-mismatch between python and R
 reticulate::conda_install("h2o==3.30.1.3", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)

--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -40,7 +40,7 @@ Imports:
     xml2,
     yaml,
     zeallot
-Suggests: 
+Suggests:
   covr,
   carrier,
   keras,
@@ -50,7 +50,7 @@ Suggests:
   xgboost,
   h2o
 RoxygenNote: 7.1.1
-Collate: 
+Collate:
     'cli.R'
     'databricks-utils.R'
     'globals.R'
@@ -66,6 +66,7 @@ Collate:
     'model-serve.R'
     'model-swagger.R'
     'model-xgboost.R'
+    'utils.R'
     'model.R'
     'project-param.R'
     'project-run.R'

--- a/mlflow/R/mlflow/R/cli.R
+++ b/mlflow/R/mlflow/R/cli.R
@@ -5,7 +5,7 @@
 #   Defaults to \code{FALSE}.
 # @param echo Print the standard output and error to the screen? Defaults to
 #   \code{TRUE}, does not apply to background tasks.
-# @param stderr_callback \code{NULL} (the default), or a function to call for 
+# @param stderr_callback \code{NULL} (the default), or a function to call for
 #   every chunk of the standard error, passed to \code{\link[=processx:run]{processx::run()}}.
 # @param client Mlflow client to provide environment for the cli process.
 #

--- a/mlflow/R/mlflow/R/model-serve.R
+++ b/mlflow/R/mlflow/R/model-serve.R
@@ -1,5 +1,8 @@
 # nocov start
 
+#' @include utils.R
+NULL
+
 #' Serve an RFunc MLflow Model
 #'
 #' Serves an RFunc MLflow model as a local REST API server. This interface provides similar
@@ -44,7 +47,8 @@ mlflow_rfunc_serve <- function(model_uri,
                                ...) {
   model_path <- mlflow_download_artifacts_from_uri(model_uri)
   httpuv_start <- if (daemonized) httpuv::startDaemonizedServer else httpuv::runServer
-  serve_run(model_path, host, port, httpuv_start, browse && interactive(), ...)
+  local_model_uri <- paste0("file://", strip_prefix(model_path, "file://"))
+  serve_run(local_model_uri, host, port, httpuv_start, browse && interactive(), ...)
 }
 
 serve_content_type <- function(file_path) {

--- a/mlflow/R/mlflow/R/model.R
+++ b/mlflow/R/mlflow/R/model.R
@@ -1,3 +1,6 @@
+#' @include utils.R
+NULL
+
 #' Save Model for MLflow
 #'
 #' Saves model in MLflow format that can later be used for prediction and serving. This method is
@@ -76,6 +79,7 @@ mlflow_timestamp <- function() {
 #' @export
 mlflow_load_model <- function(model_uri, flavor = NULL, client = mlflow_client()) {
   model_path <- mlflow_download_artifacts_from_uri(model_uri, client = client)
+  model_path <- strip_prefix(model_path, "file://")
   supported_flavors <- supported_model_flavors()
   spec <- yaml::read_yaml(fs::path(model_path, "MLmodel"))
   available_flavors <- intersect(names(spec$flavors), supported_flavors)

--- a/mlflow/R/mlflow/R/python.R
+++ b/mlflow/R/mlflow/R/python.R
@@ -33,7 +33,12 @@ python_mlflow_bin <- function() {
     return(in_env)
   }
   python_bin_dir <- dirname(python_bin())
-  file.path(python_bin_dir, "mlflow")
+
+  if (.Platform$OS.type == "windows") {
+    file.path(python_bin_dir, "Scripts", "mlflow.exe")
+  } else {
+    file.path(python_bin_dir, "mlflow")
+  }
 }
 
 # Return path to conda home directory, such that the `conda` executable can be found

--- a/mlflow/R/mlflow/R/tracking-client.R
+++ b/mlflow/R/mlflow/R/tracking-client.R
@@ -151,5 +151,6 @@ mlflow_client <- function(tracking_uri = NULL) {
   tracking_uri <- new_mlflow_uri(tracking_uri %||% mlflow_get_tracking_uri())
   client <- new_mlflow_client(tracking_uri)
   if (inherits(client, "mlflow_file_client")) mlflow_validate_server(client)
+
   client
 }

--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -1,4 +1,5 @@
 #' @include tracking-globals.R
+#' @include utils.R
 NULL
 
 # Translate metric to value to safe format for REST.
@@ -421,13 +422,15 @@ mlflow_download_artifacts <- function(path, run_id = NULL, client = NULL) {
     },
     client = client
   )
-  gsub("\n", "", result$stdout)
+
+  extract_path(result$stdout)
 }
 
 # ' Download Artifacts from URI.
 mlflow_download_artifacts_from_uri <- function(artifact_uri, client = mlflow_client()) {
   result <- mlflow_cli("artifacts", "download", "-u", artifact_uri, echo = FALSE, client = client)
-  gsub("\n", "", result$stdout)
+
+  extract_path(result$stdout)
 }
 
 #' List Run Infos

--- a/mlflow/R/mlflow/R/utils.R
+++ b/mlflow/R/mlflow/R/utils.R
@@ -1,0 +1,15 @@
+# extract a file path from CLI output with consideration of interop requirements
+# on Windows
+extract_path <- function(output) {
+  path <- gsub("\r|\n", "", output)
+
+  normalizePath(path, winslash = "/")
+}
+
+strip_prefix <- function(x, prefix) {
+  if (identical(substr(x, 1, nchar(prefix)), prefix)) {
+    substr(x, nchar(prefix) + 1, nchar(x))
+  } else {
+    x
+  }
+}

--- a/mlflow/R/mlflow/man/mlflow_server.Rd
+++ b/mlflow/R/mlflow/man/mlflow_server.Rd
@@ -9,7 +9,7 @@ mlflow_server(
   default_artifact_root = NULL,
   host = "127.0.0.1",
   port = 5000,
-  workers = 4,
+  workers = NULL,
   static_prefix = NULL
 )
 }

--- a/mlflow/R/mlflow/tests/testthat/helpers.R
+++ b/mlflow/R/mlflow/tests/testthat/helpers.R
@@ -11,3 +11,26 @@ deregister_local_servers <- function() {
   purrr::walk(as.list(mlflow:::.globals$url_mapping), ~ .x$handle$kill())
   rlang::env_unbind(mlflow:::.globals, "url_mapping")
 }
+
+as_uri <- function(file_path) {
+  if (.Platform$OS.type == "windows") {
+    # normalize file path such as c:/directory into file://c:/directory on
+    # Windows so that MLflow CLI does not confuse 'c' as the scheme of the URI
+    # Also, replacing back slashes with forward slashes
+    gsub("\\\\", "/", paste0("file://", normalizePath(file_path)))
+  } else {
+    # UNIX file paths such as ., dir1, dir1/dir2, / or, /dir1/dir2 etc do not
+    # have this problem so we don't need to do anything
+    file_path
+  }
+}
+
+skip_on_windows <- function(reason = NULL) {
+  if (identical(.Platform$OS.type, "windows")) {
+    msg <- "Test will be skipped on Windows."
+    if (!is.null(reason)) {
+      msg <- paste(msg, "Reason:", reason)
+    }
+    skip(msg)
+  }
+}

--- a/mlflow/R/mlflow/tests/testthat/test-keras-model.R
+++ b/mlflow/R/mlflow/tests/testthat/test-keras-model.R
@@ -2,7 +2,7 @@ context("Model")
 
 library("keras")
 
-testthat_model_dir <- tempfile("model_")
+testthat_model_dir <- basename(tempfile("model_"))
 
 teardown({
   mlflow_clear_test_dir(testthat_model_dir)
@@ -25,7 +25,7 @@ test_that("mlflow can save keras model ", {
   model %>% mlflow_save_model(testthat_model_dir)
   expect_true(dir.exists(testthat_model_dir))
   detach("package:keras", unload = TRUE)
-  model_reloaded <- mlflow_load_model(testthat_model_dir)
+  model_reloaded <- mlflow_load_model(as_uri(testthat_model_dir))
   expect_equal(
     predict(model, train_x),
     predict(model_reloaded, train_x),

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -10,22 +10,17 @@ predictors <- setdiff(colnames(iris), prediction)
 train <- iris[idx[1:100], ]
 test <- iris[idx[101:nrow(iris)], ]
 
-# Installing most recent h2o package, see https://docs.h2o.ai/h2o/latest-stable/h2o-docs/downloading.html#install-in-r
-if ("package:h2o" %in% search()) { detach("package:h2o", unload=TRUE) }
-if ("h2o" %in% rownames(installed.packages())) { remove.packages("h2o") }
 pkgs <- c("RCurl","jsonlite")
 for (pkg in pkgs) {
   if (! (pkg %in% rownames(installed.packages()))) { install.packages(pkg) }
 }
-# Pin h2o to prevent version-mismatch between python and R
-install.packages("https://cran.r-project.org/src/contrib/Archive/h2o/h2o_3.30.1.3.tar.gz", repos=NULL, type="source")
 
 h2o::h2o.init()
 
 model <- h2o::h2o.randomForest(
   x = predictors, y = prediction, training_frame = h2o::as.h2o(train)
 )
-testthat_model_dir <- tempfile("model_")
+testthat_model_dir <- basename(tempfile("model_"))
 
 teardown({
   h2o::h2o.shutdown(prompt = FALSE)
@@ -38,7 +33,7 @@ test_that("mlflow can save model", {
 })
 
 test_that("can load model and predict with rfunc backend", {
-  saved_model <- mlflow_load_model(testthat_model_dir)
+  saved_model <- mlflow_load_model(as_uri(testthat_model_dir))
   prediction <- mlflow_predict(saved_model, test)
   expect_equal(
     prediction,
@@ -47,13 +42,13 @@ test_that("can load model and predict with rfunc backend", {
 })
 
 test_that("can print model correctly after it is loaded", {
-  saved_model <- mlflow_load_model(testthat_model_dir)
+  saved_model <- mlflow_load_model(as_uri(testthat_model_dir))
   expect_equal(capture_output(print(model)), capture_output(print(saved_model)))
 })
 
 test_that("can load and predict with python pyfunct and h2o backend", {
   pyfunc <- import("mlflow.pyfunc")
-  py_model <- pyfunc$load_model(testthat_model_dir)
+  py_model <- pyfunc$load_model(as_uri(testthat_model_dir))
 
   expected <- as.data.frame(h2o::h2o.predict(model, h2o::as.h2o(test)))
   expected$predict <- as.character(expected$predict)
@@ -63,7 +58,7 @@ test_that("can load and predict with python pyfunct and h2o backend", {
   )
 
   mlflow.h2o <- import("mlflow.h2o")
-  h2o_native_model <- mlflow.h2o$load_model(testthat_model_dir)
+  h2o_native_model <- mlflow.h2o$load_model(as_uri(testthat_model_dir))
   h2o <- import("h2o")
 
   expect_equivalent(
@@ -75,6 +70,8 @@ test_that("can load and predict with python pyfunct and h2o backend", {
 })
 
 test_that("Can predict with cli backend", {
+  skip_on_windows("'conda' is not recognized as an internal or external command, operable program or batch file.")
+
   expected <- as.data.frame(h2o::h2o.predict(model, h2o::as.h2o(test)))
 
   # # Test that we can score this model with pyfunc backend
@@ -96,7 +93,7 @@ test_that("Can predict with cli backend", {
 
   write.csv(test[, predictors], temp_in_csv, row.names = FALSE)
   mlflow_cli(
-    "models", "predict", "-m", testthat_model_dir, "-i", temp_in_csv,
+    "models", "predict", "-m", as_uri(testthat_model_dir), "-i", temp_in_csv,
     "-o", temp_out, "-t", "csv"
   )
   check_output()
@@ -104,7 +101,7 @@ test_that("Can predict with cli backend", {
   # json records
   jsonlite::write_json(test[, predictors], temp_in_json)
   mlflow_cli(
-    "models", "predict", "-m", testthat_model_dir, "-i", temp_in_json, "-o", temp_out,
+    "models", "predict", "-m", as_uri(testthat_model_dir), "-i", temp_in_json, "-o", temp_out,
     "-t", "json",
     "--json-format", "records"
   )
@@ -116,7 +113,7 @@ test_that("Can predict with cli backend", {
   )
   jsonlite::write_json(mtcars_split, temp_in_json_split)
   mlflow_cli(
-    "models", "predict", "-m", testthat_model_dir, "-i", temp_in_json_split,
+    "models", "predict", "-m", as_uri(testthat_model_dir), "-i", temp_in_json_split,
     "-o", temp_out, "-t",
     "json", "--json-format", "split"
   )

--- a/mlflow/R/mlflow/tests/testthat/test-model.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model.R
@@ -9,6 +9,8 @@ teardown({
 })
 
 test_that("mlflow can save model function", {
+  skip_on_windows("ValueError: close_fds is not supported on Windows platforms if you redirect stdin/stdout/stderr")
+
   mlflow_clear_test_dir(testthat_model_name)
   model <- lm(Sepal.Width ~ Sepal.Length, iris)
   fn <- crate(~ stats::predict(model, .x), model = model)
@@ -59,6 +61,8 @@ test_that("mlflow can save model function", {
 })
 
 test_that("mlflow can log model and load it back with a uri", {
+  skip_on_windows("ValueError: close_fds is not supported on Windows platforms if you redirect stdin/stdout/stderr")
+
   with(run <- mlflow_start_run(), {
     model <- structure(
       list(some = "stuff"),
@@ -89,6 +93,8 @@ test_that("mlflow can log model and load it back with a uri", {
 })
 
 test_that("mlflow log model records correct metadata with the tracking server", {
+  skip_on_windows("'conda' is not recognized as an internal or external command, operable program or batch file.")
+
   with(run <- mlflow_start_run(), {
     print(run$run_uuid[1])
     model <- structure(

--- a/mlflow/R/mlflow/tests/testthat/test-params.R
+++ b/mlflow/R/mlflow/tests/testthat/test-params.R
@@ -1,6 +1,9 @@
 context("Params")
 
 test_that("mlflow can read typed command line parameters", {
+  # TODO: why does this not work on Windows
+  skip_on_windows("System command 'mlflow.exe' failed, exit status: 1")
+
   mlflow_clear_test_dir("mlruns")
 
   mlflow_cli(

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -44,12 +44,12 @@ test_that("mlflow_list_experiments() works properly", {
   client <- mlflow_client()
   mlflow_create_experiment(client = client, "foo1", "art_loc1")
   mlflow_create_experiment(client = client, "foo2", "art_loc2")
+  default_artifact_loc <- paste0("file://", file.path(getwd(), "mlruns", "0", fsep = "/"))
 
   # client
   experiments_list <- mlflow_list_experiments(client = client)
   expect_setequal(experiments_list$experiment_id, c("0", "1", "2"))
   expect_setequal(experiments_list$name, c("Default", "foo1", "foo2"))
-  default_artifact_loc <- file.path(getwd(), "mlruns", "0", fsep = "/")
   expect_setequal(experiments_list$artifact_location, c(default_artifact_loc,
                                                         "art_loc1",
                                                         "art_loc2"))
@@ -58,7 +58,6 @@ test_that("mlflow_list_experiments() works properly", {
   experiments_list <- mlflow_list_experiments()
   expect_setequal(experiments_list$experiment_id, c("0", "1", "2"))
   expect_setequal(experiments_list$name, c("Default", "foo1", "foo2"))
-  default_artifact_loc <- file.path(getwd(), "mlruns", "0", fsep = "/")
   expect_setequal(experiments_list$artifact_location, c(default_artifact_loc,
                                                         "art_loc1",
                                                         "art_loc2"))

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -358,7 +358,14 @@ test_that("mlflow_log_artifact and mlflow_list_artifacts work", {
       paste("artifact_subdirectory", "a-my-file", sep = "/"), ]
     expect_equal(nrow(logged_file2), 1)
     expect_equal(logged_file2$is_dir, FALSE)
-    expect_equal(strtoi(logged_file2$file_size), nchar(contents))
+    expect_equal(
+      strtoi(logged_file2$file_size),
+      if (identical(.Platform$OS.type, "windows")) {
+        nchar(contents) + 1
+      } else {
+        nchar(contents)
+      }
+    )
     # Verify contents of file logged under directory
     artifact_list2 <- mlflow_list_artifacts("directory_for_file")
     expect_equal(nrow(artifact_list2), 1)
@@ -366,7 +373,14 @@ test_that("mlflow_log_artifact and mlflow_list_artifacts work", {
     paste("directory_for_file", "a-my-file", sep = "/"), ]
     expect_equal(nrow(logged_file3), 1)
     expect_equal(logged_file3$is_dir, FALSE)
-    expect_equal(strtoi(logged_file3$file_size), nchar(contents))
+    expect_equal(
+      strtoi(logged_file3$file_size),
+      if (identical(.Platform$OS.type, "windows")) {
+        nchar(contents) + 1
+      } else {
+        nchar(contents)
+      }
+    )
   })
 })
 

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -108,7 +108,7 @@ class Model(object):
     def load(cls, path):
         """Load a model from its YAML representation."""
         if os.path.isdir(path):
-            path = os.path.join(path, MLMODEL_FILE_NAME)
+            path = os.path.normpath(os.path.join(path, MLMODEL_FILE_NAME))
         with open(path) as f:
             return cls.from_dict(yaml.safe_load(f.read()))
 

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -112,7 +112,9 @@ class _Example(object):
 
     def save(self, parent_dir_path: str):
         """Save the example as json at ``parent_dir_path``/`self.info['artifact_path']`.  """
-        with open(os.path.join(parent_dir_path, self.info["artifact_path"]), "w") as f:
+        with open(
+            os.path.normpath(os.path.join(parent_dir_path, self.info["artifact_path"])), "w",
+        ) as f:
             json.dump(self.data, f, cls=NumpyEncoder)
 
 
@@ -151,5 +153,7 @@ def _read_example(mlflow_model: Model, path: str):
             "This version of mlflow can not load example of type {}".format(example_type)
         )
     input_schema = mlflow_model.signature.inputs if mlflow_model.signature is not None else None
-    path = os.path.join(path, mlflow_model.saved_input_example_info["artifact_path"])
+    path = os.path.normpath(
+        os.path.join(path, mlflow_model.saved_input_example_info["artifact_path"])
+    )
     return _dataframe_from_json(path, schema=input_schema, precise_float=True)

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -189,9 +189,8 @@ def _run_entry_point(command, work_dir, experiment_id, run_id):
     env.update(get_run_env_vars(run_id, experiment_id))
     env.update(get_databricks_env_vars(tracking_uri=mlflow.get_tracking_uri()))
     _logger.info("=== Running command '%s' in run with ID '%s' === ", command, run_id)
-    # in case os name is not 'nt', we are not running on windows. It introduces
-    # bash command otherwise.
-    if os.name != "nt":
+    # Run the bash command if not on Windows
+    if platform.system() != "Windows":
         process = subprocess.Popen(["bash", "-c", command], close_fds=True, cwd=work_dir, env=env)
     else:
         # process = subprocess.Popen(command, close_fds=True, cwd=work_dir, env=env)

--- a/mlflow/pyfunc/utils.py
+++ b/mlflow/pyfunc/utils.py
@@ -18,7 +18,7 @@ def _get_code_dirs(src_code_path, dst_code_path=None):
     if not dst_code_path:
         dst_code_path = src_code_path
     return [
-        (os.path.join(dst_code_path, x))
+        (os.path.normpath(os.path.join(dst_code_path, x)))
         for x in os.listdir(src_code_path)
         if os.path.isdir(x) and not x == "__pycache__"
     ]

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -23,7 +23,7 @@ PROMETHEUS_EXPORTER_ENV_VAR = "prometheus_multiproc_dir"
 REL_STATIC_DIR = "js/build"
 
 app = Flask(__name__, static_folder=REL_STATIC_DIR)
-STATIC_DIR = os.path.join(app.root_path, REL_STATIC_DIR)
+STATIC_DIR = os.path.normpath(os.path.join(app.root_path, REL_STATIC_DIR))
 
 
 for http_path, handler, methods in handlers.get_endpoints():
@@ -66,7 +66,7 @@ def serve_static_file(path):
 # Serve the index.html for the React App for all other routes.
 @app.route(_add_static_prefix("/"))
 def serve():
-    if os.path.exists(os.path.join(STATIC_DIR, "index.html")):
+    if os.path.exists(os.path.normpath(os.path.join(STATIC_DIR, "index.html"))):
         return send_from_directory(STATIC_DIR, "index.html")
 
     text = textwrap.dedent(

--- a/mlflow/tracking/artifact_utils.py
+++ b/mlflow/tracking/artifact_utils.py
@@ -2,6 +2,7 @@
 Utilities for dealing with artifacts in the context of a Run.
 """
 import pathlib
+import platform
 import posixpath
 import shutil
 import tempfile
@@ -61,8 +62,9 @@ def _download_artifact_from_uri(artifact_uri, output_path=None):
     """
     parsed_uri = urllib.parse.urlparse(str(artifact_uri))
     prefix = ""
-    if parsed_uri.scheme and not parsed_uri.path.startswith("/"):
-        # relative path is a special case, urllib does not reconstruct it properly
+
+    if platform.system() != "Windows" and parsed_uri.scheme and not parsed_uri.path.startswith("/"):
+        # UNIX relative path is a special case, urllib does not reconstruct it properly
         prefix = parsed_uri.scheme + ":"
         parsed_uri = parsed_uri._replace(scheme="")
 

--- a/tests/store/artifact/test_cli.py
+++ b/tests/store/artifact/test_cli.py
@@ -1,5 +1,6 @@
 import json
 import os
+import platform
 import posixpath
 
 from unittest import mock
@@ -42,14 +43,6 @@ def test_download_from_uri():
         ("/path", ("/", "path")),
         ("/path/", ("/path", "")),
         ("path/to/dir", ("path/to", "dir")),
-        ("file:", ("file:", "")),
-        ("file:path", ("file:", "path")),
-        ("file:path/", ("file:path", "")),
-        ("file:path/to/dir", ("file:path/to", "dir")),
-        ("file:/", ("file:///", "")),
-        ("file:/path", ("file:///", "path")),
-        ("file:/path/", ("file:///path", "")),
-        ("file:/path/to/dir", ("file:///path/to", "dir")),
         ("file:///", ("file:///", "")),
         ("file:///path", ("file:///", "path")),
         ("file:///path/", ("file:///path", "")),
@@ -61,6 +54,19 @@ def test_download_from_uri():
         ("s3://path/to", ("s3://path/", "to")),
         ("s3://path/to/dir", ("s3://path/to", "dir")),
     ]
+    if platform.system() != "Windows":
+        # Not applicable on Windows
+        pairs += [
+            ("file:", ("file:", "")),
+            ("file:path", ("file:", "path")),
+            ("file:path/", ("file:path", "")),
+            ("file:path/to/dir", ("file:path/to", "dir")),
+            ("file:/", ("file:///", "")),
+            ("file:/path", ("file:///", "path")),
+            ("file:/path/", ("file:///path", "")),
+            ("file:/path/to/dir", ("file:///path/to", "dir")),
+        ]
+
     with mock.patch(
         "mlflow.tracking.artifact_utils.get_artifact_repository"
     ) as get_artifact_repo_mock:


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>

## What changes are proposed in this pull request?

This PR enables GitHub CI workflow for the MLflow R package and fixes a number of issues affecting MLflow on Windows:

- `python_mlflow_bin()` should return <python_bin_dir>/Scripts/mlflow.exe on Windows
- When extracting a file path from MLflow CLI output, both `\r` and `\n`  must be removed on Windows, not just `\n`
- Prefixing local file paths with `file://` whenever necessary, as otherwise paths like "C:/dir1/dir2" gets interpreted as some invalid URI with scheme `C:` in Python
- Taking into account the fact that currently `waitress-serve` (the equivalent of `gunicorn` for Windows) cannot support `--workers` specification of MLflow server, so `mlflow::mlflow_server()` must omit the `--workers` flag with a warning if running on Windows
- Replacing `os.path.join(...)` with `os.path.normpath(os.path.join(...))` whenever necessary so that in case part of the path contains back slashes and other parts contain forward slashes, the resulting path will still only contain back slashes on Windows (in fact this will only be not necessary when within if branches that are UNIX-only or when `os.path.join()` is wrapped with `os.path.abspath()` which calls `os.path.normpath()` internally)
- Replacing `if os.name != "nt":` with `if platform.system() != "Windows":` everywhere -- Because checking `os.name` is clearly a rookie mistake, as it could return `"nt"` or `"ce"` or possibly some other value in some future version of Windows, whereas `platform.system()` is the most portable and future-proof way to check whether we are running on Windows or not
 
closes #1009
closes #3206
closes #3319
closes #3393
closes #3430

 
## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Several Windows-related platform-specific issues were addressed in this release

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [x] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [x] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
