### PR TITLE
Make run_id an optional parameter for python client

### DIFF
--- a/mlflow/store/db_migrations/versions/a8c4a736bde6_allow_nulls_for_run_id.py
+++ b/mlflow/store/db_migrations/versions/a8c4a736bde6_allow_nulls_for_run_id.py
@@ -1,0 +1,26 @@
+"""allow nulls for run_id
+
+Revision ID: a8c4a736bde6
+Revises: 84291f40a231
+Create Date: 2020-12-02 12:14:35.220815
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from mlflow.store.model_registry.dbmodels.models import SqlModelVersion
+
+
+# revision identifiers, used by Alembic.
+revision = "a8c4a736bde6"
+down_revision = "84291f40a231"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table(SqlModelVersion.__tablename__) as batch_op:
+        batch_op.alter_column("run_id", nullable=True)
+
+
+def downgrade():
+    pass

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -147,7 +147,7 @@ class AbstractStore:
 
     @abstractmethod
     def create_model_version(
-        self, name, source, run_id, tags=None, run_link=None, description=None
+        self, name, source, run_id=None, tags=None, run_link=None, description=None
     ):
         """
         Create a new model version from given source and run ID.

--- a/mlflow/store/model_registry/dbmodels/models.py
+++ b/mlflow/store/model_registry/dbmodels/models.py
@@ -78,7 +78,7 @@ class SqlModelVersion(Base):
 
     source = Column(String(500), nullable=True, default=None)
 
-    run_id = Column(String(32), nullable=False)
+    run_id = Column(String(32), nullable=True, default=None)
 
     run_link = Column(String(500), nullable=True, default=None)
 

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -219,7 +219,7 @@ class RestStore(AbstractStore):
     # CRUD API for ModelVersion objects
 
     def create_model_version(
-        self, name, source, run_id, tags=None, run_link=None, description=None
+        self, name, source, run_id=None, tags=None, run_link=None, description=None
     ):
         """
         Create a new model version from given source and run ID.

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -499,7 +499,7 @@ class SqlAlchemyStore(AbstractStore):
     # CRUD API for ModelVersion objects
 
     def create_model_version(
-        self, name, source, run_id, tags=None, run_link=None, description=None
+        self, name, source, run_id=None, tags=None, run_link=None, description=None
     ):
         """
         Create a new model version from given source and run ID.

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -168,7 +168,7 @@ class ModelRegistryClient(object):
         self,
         name,
         source,
-        run_id,
+        run_id=None,
         tags=None,
         run_link=None,
         description=None,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2117,7 +2117,12 @@ class MlflowClient(object):
         """
         tracking_uri = self._tracking_client.tracking_uri
         if not run_link and is_databricks_uri(tracking_uri) and tracking_uri != self._registry_uri:
-            run_link = self._get_run_link(tracking_uri, run_id)
+            if not run_id:
+                eprint(
+                    "Warning: no run_link will be recorded with the model version because no run_id was given"
+                )
+            else:
+                run_link = self._get_run_link(tracking_uri, run_id)
         new_source = source
         if is_databricks_uri(self._registry_uri) and tracking_uri != self._registry_uri:
             # Print out some info for user since the copy may take a while for large models.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2054,7 +2054,7 @@ class MlflowClient(object):
         self,
         name,
         source,
-        run_id,
+        run_id=None,
         tags=None,
         run_link=None,
         description=None,
@@ -2116,7 +2116,12 @@ class MlflowClient(object):
             Stage: None
         """
         tracking_uri = self._tracking_client.tracking_uri
-        if not run_link and is_databricks_uri(tracking_uri) and tracking_uri != self._registry_uri:
+        if (
+            not run_link
+            and run_id
+            and is_databricks_uri(tracking_uri)
+            and tracking_uri != self._registry_uri
+        ):
             run_link = self._get_run_link(tracking_uri, run_id)
         new_source = source
         if is_databricks_uri(self._registry_uri) and tracking_uri != self._registry_uri:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2116,12 +2116,7 @@ class MlflowClient(object):
             Stage: None
         """
         tracking_uri = self._tracking_client.tracking_uri
-        if (
-            not run_link
-            and run_id
-            and is_databricks_uri(tracking_uri)
-            and tracking_uri != self._registry_uri
-        ):
+        if not run_link and is_databricks_uri(tracking_uri) and tracking_uri != self._registry_uri:
             run_link = self._get_run_link(tracking_uri, run_id)
         new_source = source
         if is_databricks_uri(self._registry_uri) and tracking_uri != self._registry_uri:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2119,7 +2119,8 @@ class MlflowClient(object):
         if not run_link and is_databricks_uri(tracking_uri) and tracking_uri != self._registry_uri:
             if not run_id:
                 eprint(
-                    "Warning: no run_link will be recorded with the model version because no run_id was given"
+                    "Warning: no run_link will be recorded with the model version "
+                    "because no run_id was given"
                 )
             else:
                 run_link = self._get_run_link(tracking_uri, run_id)

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -44,7 +44,7 @@ CREATE TABLE model_versions (
 	user_id VARCHAR(256),
 	current_stage VARCHAR(20),
 	source VARCHAR(500),
-	run_id VARCHAR(32) NOT NULL,
+	run_id VARCHAR(32),
 	status VARCHAR(20),
 	status_message VARCHAR(500),
 	run_link VARCHAR(500),

--- a/tests/store/model_registry/test_rest_store.py
+++ b/tests/store/model_registry/test_rest_store.py
@@ -203,15 +203,15 @@ class TestRestStore(unittest.TestCase):
 
     @mock.patch("mlflow.utils.rest_utils.http_request")
     def test_create_model_version(self, mock_http):
-        run_id = uuid.uuid4().hex
-        self.store.create_model_version("model_1", "path/to/source", run_id)
+        self.store.create_model_version("model_1", "path/to/source")
         self._verify_requests(
             mock_http,
             "model-versions/create",
             "POST",
-            CreateModelVersion(name="model_1", source="path/to/source", run_id=run_id),
+            CreateModelVersion(name="model_1", source="path/to/source"),
         )
         # test optional fields
+        run_id = uuid.uuid4().hex
         tags = [
             ModelVersionTag(key="key", value="value"),
             ModelVersionTag(key="anotherKey", value="some other value"),

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -486,6 +486,14 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(mvd5.version, 5)
         self.assertEqual(mvd5.description, description)
 
+        # create model version without runId
+        mv6 = self._mv_maker(name, run_id=None)
+        mvd6 = self.store.get_model_version(name, mv6.version)
+        self.assertEqual(mv6.version, 6)
+        self.assertEqual(mv6.run_id, None)
+        self.assertEqual(mvd6.version, 6)
+        self.assertEqual(mvd6.run_id, None)
+
     def test_update_model_version(self):
         name = "test_for_update_MV"
         self._rm_maker(name)

--- a/tests/tracking/_model_registry/test_model_registry_client.py
+++ b/tests/tracking/_model_registry/test_model_registry_client.py
@@ -262,6 +262,34 @@ def test_create_model_version(mock_store):
     assert result.tags == tags_dict
 
 
+def test_create_model_version_no_run_id(mock_store):
+    name = "Model 1"
+    version = "1"
+    tags_dict = {"key": "value", "another key": "some other value"}
+    tags = [ModelVersionTag(key, value) for key, value in tags_dict.items()]
+    description = "best model ever"
+
+    mock_store.create_model_version.return_value = ModelVersion(
+        name=name,
+        version=version,
+        creation_timestamp=123,
+        tags=tags,
+        run_link=None,
+        description=description,
+    )
+    result = newModelRegistryClient().create_model_version(
+        name, "uri:/for/source", tags=tags_dict, run_link=None, description=description
+    )
+    mock_store.create_model_version.assert_called_once_with(
+        name, "uri:/for/source", None, tags, None, description
+    )
+
+    assert result.name == name
+    assert result.version == version
+    assert result.tags == tags_dict
+    assert result.run_id is None
+
+
 def test_update_model_version(mock_store):
     name = "Model 1"
     version = "12"

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -309,6 +309,21 @@ def test_create_model_version_nondatabricks_source_no_runlink(mock_registry_stor
     )
 
 
+def test_create_model_version_nondatabricks_source_no_run_id(mock_registry_store):
+    client = MlflowClient(tracking_uri="http://10.123.1231.11")
+    mock_registry_store.create_model_version.return_value = ModelVersion(
+        "name", 1, 0, 1, source="source"
+    )
+    model_version = client.create_model_version("name", "source")
+    assert model_version.name == "name"
+    assert model_version.source == "source"
+    assert model_version.run_id is None
+    # verify that the store was not provided a run link
+    mock_registry_store.create_model_version.assert_called_once_with(
+        "name", "source", None, [], None, None
+    )
+
+
 def test_create_model_version_explicitly_set_run_link(mock_registry_store):
     run_id = "runid"
     run_link = "my-run-link"

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -318,7 +318,7 @@ def test_create_model_version_nondatabricks_source_no_run_id(mock_registry_store
     assert model_version.name == "name"
     assert model_version.source == "source"
     assert model_version.run_id is None
-    # verify that the store was not provided a run link
+    # verify that the store was not provided a run id
     mock_registry_store.create_model_version.assert_called_once_with(
         "name", "source", None, [], None, None
     )


### PR DESCRIPTION
Signed-off-by: Wendy Hu <wendy.hu@databricks.com>

## What changes are proposed in this pull request?

`run_id` is made an optional parameter in the Python `MlflowClient.create_model_version` method to maintain consistency with the REST API.

## How is this patch tested?

Added unit tests to ensure missing values for run_id is supported

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`run_id` is made an optional parameter in the Python `MlflowClient` to maintain consistency with the REST API.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes