### PR TITLE
group pytest summaries

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,40 @@ import mlflow
 from mlflow.utils.file_utils import path_to_local_sqlite_uri
 
 
+from _pytest.terminal import TerminalReporter
+
+
+class NewTerminalReporter(TerminalReporter):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.is_is_failure = False
+
+    def summary_errors(self, *args, **kwargs):
+        print("::group::ERRORS")
+        super().summary_errors(*args, **kwargs)
+        print("::endgroup::")
+
+    def summary_failures(self, *args, **kwargs):
+        print("::group::FAILURES")
+        super().summary_errors(*args, **kwargs)
+        print("::endgroup::")
+
+    def summary_warnings(self, *args, **kwargs):
+        print("::group::WARNINGS")
+        super().summary_warnings(*args, **kwargs)
+        print("::endgroup::")
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_configure(config):
+    import sys
+
+    old_reporter = config.pluginmanager.getplugin("terminalreporter")
+    config.pluginmanager.unregister(old_reporter)
+    new_reporter = NewTerminalReporter(config, sys.stdout)
+    config.pluginmanager.register(new_reporter, "terminalreporter")
+
+
 @pytest.fixture
 def reset_mock():
     cache = []


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
