### PR TITLE
retry sqlalchemy create engine

### DIFF
--- a/mlflow/db.py
+++ b/mlflow/db.py
@@ -24,7 +24,7 @@ def upgrade(url):
     large migrations and includes information about how to estimate their performance and
     recover from failures.
     """
-    engine = mlflow.store.db.utils.create_sqlalchemy_engine(url)
+    engine = mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(url)
     if mlflow.store.db.utils._is_initialized_before_mlflow_1(engine):
         mlflow.store.db.utils._upgrade_db_initialized_before_mlflow_1(engine)
     mlflow.store.db.utils._upgrade_db(engine)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -1,4 +1,5 @@
 import os
+import time
 
 from contextlib import contextmanager
 import logging
@@ -17,6 +18,7 @@ _logger = logging.getLogger(__name__)
 
 MLFLOW_SQLALCHEMYSTORE_POOL_SIZE = "MLFLOW_SQLALCHEMYSTORE_POOL_SIZE"
 MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW = "MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW"
+MAX_RETRY_COUNT = 15
 
 
 def _get_package_dir():
@@ -182,6 +184,22 @@ def _upgrade_db_initialized_before_mlflow_1(engine):
     # add metric steps, do not need to depend on this one. This allows us to eventually remove this
     # method and the associated migration e.g. in MLflow 1.1.
     command.stamp(config, "base")
+
+
+def create_sqlalchemy_engine_with_retry(db_uri):
+    attempts = 0
+    while True:
+        attempts += 1
+        engine = create_sqlalchemy_engine(db_uri)
+        try:
+            sqlalchemy.inspect(engine)
+            return engine
+        except:
+            if attempts < MAX_RETRY_COUNT:
+                sleep_duration = 0.1 * ((2 ** attempts) - 1)
+                time.sleep(sleep_duration)
+                continue
+            raise
 
 
 def create_sqlalchemy_engine(db_uri):

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -194,9 +194,15 @@ def create_sqlalchemy_engine_with_retry(db_uri):
         try:
             sqlalchemy.inspect(engine)
             return engine
-        except:
+        except Exception as e:
             if attempts < MAX_RETRY_COUNT:
                 sleep_duration = 0.1 * ((2 ** attempts) - 1)
+                _logger.warning(
+                    "SQLAlchemy engine could not be created. The following exception is caught.\n"
+                    "%s\nOperation will be retried in %.1f seconds",
+                    e,
+                    sleep_duration,
+                )
                 time.sleep(sleep_duration)
                 continue
             raise

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -88,7 +88,7 @@ class SqlAlchemyStore(AbstractStore):
         super().__init__()
         self.db_uri = db_uri
         self.db_type = extract_db_type_from_uri(db_uri)
-        self.engine = mlflow.store.db.utils.create_sqlalchemy_engine(db_uri)
+        self.engine = mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(db_uri)
         Base.metadata.create_all(self.engine)
         # Verify that all model registry tables exist.
         SqlAlchemyStore._verify_registry_tables_exist(self.engine)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -100,7 +100,7 @@ class SqlAlchemyStore(AbstractStore):
         self.db_uri = db_uri
         self.db_type = extract_db_type_from_uri(db_uri)
         self.artifact_root_uri = default_artifact_root
-        self.engine = mlflow.store.db.utils.create_sqlalchemy_engine(db_uri)
+        self.engine = mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(db_uri)
         # On a completely fresh MLflow installation against an empty database (verify database
         # emptiness by checking that 'experiments' etc aren't in the list of table names), run all
         # DB migrations

--- a/tests/store/db/test_utils.py
+++ b/tests/store/db/test_utils.py
@@ -1,5 +1,5 @@
 import os
-from unittest import mock
+from unittest import mock, TestCase
 
 from mlflow.store.db import utils
 
@@ -27,3 +27,54 @@ def test_alembic_escape_logic():
     url = "fakesql://cooluser%40stillusername:apassword@localhost:3306/testingdb"
     config = utils._get_alembic_config(url)
     assert config.get_main_option("sqlalchemy.url") == url
+
+
+class TestCreateSqlAlchemyEngineWithRetry(TestCase):
+    def test_create_sqlalchemy_engine_with_retry_success(self):
+        with mock.patch.dict(os.environ, {}):
+            with mock.patch("sqlalchemy.inspect") as mock_sqlalchemy_inspect:
+                with mock.patch(
+                    "mlflow.store.db.utils.create_sqlalchemy_engine"
+                ) as mock_create_sqlalchemy_engine:
+                    with mock.patch("time.sleep") as mock_sleep:
+                        mock_create_sqlalchemy_engine.return_value = "Engine"
+                        engine = utils.create_sqlalchemy_engine_with_retry("mydb://host:port/")
+                        mock_create_sqlalchemy_engine.assert_called_once_with("mydb://host:port/")
+                        mock_sqlalchemy_inspect.assert_called_once()
+                        mock_sleep.assert_not_called()
+                        self.assertEqual(engine, "Engine")
+
+    def test_create_sqlalchemy_engine_with_retry_success_after_third_call(self):
+        with mock.patch.dict(os.environ, {}):
+            with mock.patch("sqlalchemy.inspect") as mock_sqlalchemy_inspect:
+                with mock.patch(
+                    "mlflow.store.db.utils.create_sqlalchemy_engine"
+                ) as mock_create_sqlalchemy_engine:
+                    with mock.patch("time.sleep"):
+                        mock_sqlalchemy_inspect.side_effect = [Exception, Exception, "Inspect"]
+                        mock_create_sqlalchemy_engine.return_value = "Engine"
+                        engine = utils.create_sqlalchemy_engine_with_retry("mydb://host:port/")
+                        assert (
+                            mock_create_sqlalchemy_engine.mock_calls
+                            == [mock.call("mydb://host:port/")] * 3
+                        )
+                        self.assertEqual(engine, "Engine")
+
+    def test_create_sqlalchemy_engine_with_retry_fail(self):
+        with mock.patch.dict(os.environ, {}):
+            with mock.patch("sqlalchemy.inspect") as mock_sqlalchemy_inspect:
+                with mock.patch(
+                    "mlflow.store.db.utils.create_sqlalchemy_engine"
+                ) as mock_create_sqlalchemy_engine:
+                    with mock.patch("time.sleep"):
+                        mock_sqlalchemy_inspect.side_effect = [Exception] * utils.MAX_RETRY_COUNT
+                        mock_create_sqlalchemy_engine.return_value = "Engine"
+                        self.assertRaises(
+                            Exception,
+                            utils.create_sqlalchemy_engine_with_retry,
+                            "mydb://host:port/",
+                        )
+                        assert (
+                            mock_create_sqlalchemy_engine.mock_calls
+                            == [mock.call("mydb://host:port/")] * utils.MAX_RETRY_COUNT
+                        )


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes #1749 

Retry first connection to sqlalchemy backend store with backoff.

Note: I didn't receive a response In the linked issue for more than 2 months and the issue was open for a long time, so decided to open a merge request without approval in the Github issue. I hope that's alright.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add retry with backoff when the service cannot connect to the database

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [X] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
