### PR TITLE
Unpin mxnet

### DIFF
--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -11,7 +11,7 @@ h5py<3.0.0
 # Required by mlflow.sklearn
 scikit-learn
 # Required by mlflow.gluon
-mxnet==1.5.0
+mxnet
 # Required by mlflow.fastai
 fastai==1.0.60
 # Required by mlflow.spacy

--- a/tests/gluon/test_gluon_model_export.py
+++ b/tests/gluon/test_gluon_model_export.py
@@ -217,6 +217,7 @@ def test_gluon_model_serving_and_scoring_as_pyfunc(gluon_model, model_data):
         model_uri=model_uri,
         data=pd.DataFrame(test_data.asnumpy()),
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+        extra_args=["--no-conda"],
     )
     response_values = pd.read_json(scoring_response.content, orient="records").values.astype(
         np.float32

--- a/tests/gluon/test_gluon_model_export.py
+++ b/tests/gluon/test_gluon_model_export.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import os
 import warnings
 import yaml
@@ -65,8 +66,11 @@ def gluon_model(model_data):
     trainer = Trainer(
         model.collect_params(), "adam", optimizer_params={"learning_rate": 0.001, "epsilon": 1e-07}
     )
+
+    # `metrics` was renmaed in mxnet 1.6.0: https://github.com/apache/incubator-mxnet/pull/17048
+    arg_name = "metrics" if LooseVersion(mx.__version) < LooseVersion("1.6.0") else "train_metrics"
     est = estimator.Estimator(
-        net=model, loss=SoftmaxCrossEntropyLoss(), metrics=Accuracy(), trainer=trainer
+        net=model, loss=SoftmaxCrossEntropyLoss(), trainer=trainer, **{arg_name: Accuracy()}
     )
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")

--- a/tests/gluon/test_gluon_model_export.py
+++ b/tests/gluon/test_gluon_model_export.py
@@ -68,7 +68,7 @@ def gluon_model(model_data):
     )
 
     # `metrics` was renmaed in mxnet 1.6.0: https://github.com/apache/incubator-mxnet/pull/17048
-    arg_name = "metrics" if LooseVersion(mx.__version) < LooseVersion("1.6.0") else "train_metrics"
+    arg_name = "metrics" if LooseVersion(mx.__version__) < LooseVersion("1.6.0") else "train_metrics"
     est = estimator.Estimator(
         net=model, loss=SoftmaxCrossEntropyLoss(), trainer=trainer, **{arg_name: Accuracy()}
     )

--- a/tests/gluon/test_gluon_model_export.py
+++ b/tests/gluon/test_gluon_model_export.py
@@ -67,8 +67,10 @@ def gluon_model(model_data):
         model.collect_params(), "adam", optimizer_params={"learning_rate": 0.001, "epsilon": 1e-07}
     )
 
-    # `metrics` was renmaed in mxnet 1.6.0: https://github.com/apache/incubator-mxnet/pull/17048
-    arg_name = "metrics" if LooseVersion(mx.__version__) < LooseVersion("1.6.0") else "train_metrics"
+    # `metrics` was renamed in mxnet 1.6.0: https://github.com/apache/incubator-mxnet/pull/17048
+    arg_name = (
+        "metrics" if LooseVersion(mx.__version__) < LooseVersion("1.6.0") else "train_metrics"
+    )
     est = estimator.Estimator(
         net=model, loss=SoftmaxCrossEntropyLoss(), trainer=trainer, **{arg_name: Accuracy()}
     )

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -84,13 +84,10 @@ def test_gluon_autolog_logs_expected_data(gluon_random_data_run):
     assert "{} accuracy".format(train_prefix) in data.metrics
     assert "validation accuracy" in data.metrics
 
-    # In mxnet >= 1.6.0, `Estimator` doesn't monitor `loss` if it's instantiated with
-    # `train_metrics`.
+    # In mxnet >= 1.6.0, `Estimator` monitors `loss` only when `train_metrics` is specified.
     #
-    # ```
-    # Estimator(loss=SomeLoss()) -> monitors `loss`
-    # Estimator(loss=SomeLoss(), train_metrics=SomeMetric()) -> doesn't monitor `loss`
-    # ```
+    # estimator.Estimator(loss=SomeLoss())  # monitors `loss`
+    # estimator.Estimator(loss=SomeLoss(), train_metrics=SomeMetric()) # doesn't monitor `loss`
     if LooseVersion(mx.__version__) < LooseVersion("1.6.0"):
         assert "{} softmaxcrossentropyloss".format(train_prefix) in data.metrics
         assert "validation softmaxcrossentropyloss" in data.metrics

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import random
 import warnings
 
@@ -29,6 +30,12 @@ class LogsDataset(Dataset):
         return self.len
 
 
+def get_metrics():
+    # `metrics` was renmaed in mxnet 1.6.0: https://github.com/apache/incubator-mxnet/pull/17048
+    arg_name = "metrics" if LooseVersion(mx.__version) < LooseVersion("1.6.0") else "train_metrics"
+    return {arg_name: Accuracy()}
+
+
 @pytest.fixture
 def gluon_random_data_run(log_models=True):
     mlflow.gluon.autolog(log_models)
@@ -49,7 +56,7 @@ def gluon_random_data_run(log_models=True):
             optimizer_params={"learning_rate": 0.001, "epsilon": 1e-07},
         )
         est = estimator.Estimator(
-            net=model, loss=SoftmaxCrossEntropyLoss(), metrics=Accuracy(), trainer=trainer
+            net=model, loss=SoftmaxCrossEntropyLoss(), trainer=trainer, **get_metrics()
         )
 
         with warnings.catch_warnings():
@@ -139,7 +146,7 @@ def test_autolog_ends_auto_created_run():
         model.collect_params(), "adam", optimizer_params={"learning_rate": 0.001, "epsilon": 1e-07}
     )
     est = estimator.Estimator(
-        net=model, loss=SoftmaxCrossEntropyLoss(), metrics=Accuracy(), trainer=trainer
+        net=model, loss=SoftmaxCrossEntropyLoss(), trainer=trainer, **get_metrics()
     )
 
     with warnings.catch_warnings():
@@ -169,7 +176,7 @@ def test_autolog_persists_manually_created_run():
             optimizer_params={"learning_rate": 0.001, "epsilon": 1e-07},
         )
         est = estimator.Estimator(
-            net=model, loss=SoftmaxCrossEntropyLoss(), metrics=Accuracy(), trainer=trainer
+            net=model, loss=SoftmaxCrossEntropyLoss(), trainer=trainer, **get_metrics()
         )
 
         with warnings.catch_warnings():

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -83,8 +83,17 @@ def test_gluon_autolog_logs_expected_data(gluon_random_data_run):
     train_prefix = get_train_prefix()
     assert "{} accuracy".format(train_prefix) in data.metrics
     assert "validation accuracy" in data.metrics
-    assert "{} softmaxcrossentropyloss".format(train_prefix) in data.metrics
-    assert "validation softmaxcrossentropyloss" in data.metrics
+
+    # In mxnet >= 1.6.0, `Estimator` doesn't monitor `loss` if it's instantiated with
+    # `train_metrics`.
+    #
+    # ```
+    # Estimator(loss=SomeLoss()) -> monitors `loss`
+    # Estimator(loss=SomeLoss(), train_metrics=SomeMetrics()) -> doesn't monitor `loss`
+    # ```
+    if LooseVersion(mx.__version__) < LooseVersion("1.6.0"):
+        assert "{} softmaxcrossentropyloss".format(train_prefix) in data.metrics
+        assert "validation softmaxcrossentropyloss" in data.metrics
     assert "optimizer_name" in data.params
     assert data.params["optimizer_name"] == "Adam"
     assert "epsilon" in data.params

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -30,21 +30,21 @@ class LogsDataset(Dataset):
         return self.len
 
 
-def is_older_than_1_6_0():
+def is_mxnet_older_than_1_6_0():
     return LooseVersion(mx.__version__) < LooseVersion("1.6.0")
 
 
 def get_metrics():
     # `metrics` argument was split into `train_metrics` and `val_metrics` in mxnet 1.6.0:
     # https://github.com/apache/incubator-mxnet/pull/17048
-    arg_name = "metrics" if is_older_than_1_6_0() else "train_metrics"
+    arg_name = "metrics" if is_mxnet_older_than_1_6_0() else "train_metrics"
     return {arg_name: Accuracy()}
 
 
 def get_train_prefix():
     # training prefix was renamed to `training` in mxnet 1.6.0:
     # https://github.com/apache/incubator-mxnet/pull/17048
-    return "train" if is_older_than_1_6_0() else "training"
+    return "train" if is_mxnet_older_than_1_6_0() else "training"
 
 
 @pytest.fixture
@@ -88,7 +88,7 @@ def test_gluon_autolog_logs_expected_data(gluon_random_data_run):
     #
     # estimator.Estimator(loss=SomeLoss())  # monitors `loss`
     # estimator.Estimator(loss=SomeLoss(), train_metrics=SomeMetric()) # doesn't monitor `loss`
-    if LooseVersion(mx.__version__) < LooseVersion("1.6.0"):
+    if is_mxnet_older_than_1_6_0():
         assert "{} softmaxcrossentropyloss".format(train_prefix) in data.metrics
         assert "validation softmaxcrossentropyloss" in data.metrics
     assert "optimizer_name" in data.params

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -89,7 +89,7 @@ def test_gluon_autolog_logs_expected_data(gluon_random_data_run):
     #
     # ```
     # Estimator(loss=SomeLoss()) -> monitors `loss`
-    # Estimator(loss=SomeLoss(), train_metrics=SomeMetrics()) -> doesn't monitor `loss`
+    # Estimator(loss=SomeLoss(), train_metrics=SomeMetric()) -> doesn't monitor `loss`
     # ```
     if LooseVersion(mx.__version__) < LooseVersion("1.6.0"):
         assert "{} softmaxcrossentropyloss".format(train_prefix) in data.metrics

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -32,7 +32,7 @@ class LogsDataset(Dataset):
 
 def get_metrics():
     # `metrics` was renmaed in mxnet 1.6.0: https://github.com/apache/incubator-mxnet/pull/17048
-    arg_name = "metrics" if LooseVersion(mx.__version) < LooseVersion("1.6.0") else "train_metrics"
+    arg_name = "metrics" if LooseVersion(mx.__version__) < LooseVersion("1.6.0") else "train_metrics"
     return {arg_name: Accuracy()}
 
 

--- a/tests/gluon_autolog/test_gluon_autolog.py
+++ b/tests/gluon_autolog/test_gluon_autolog.py
@@ -31,8 +31,10 @@ class LogsDataset(Dataset):
 
 
 def get_metrics():
-    # `metrics` was renmaed in mxnet 1.6.0: https://github.com/apache/incubator-mxnet/pull/17048
-    arg_name = "metrics" if LooseVersion(mx.__version__) < LooseVersion("1.6.0") else "train_metrics"
+    # `metrics` was renamed in mxnet 1.6.0: https://github.com/apache/incubator-mxnet/pull/17048
+    arg_name = (
+        "metrics" if LooseVersion(mx.__version__) < LooseVersion("1.6.0") else "train_metrics"
+    )
     return {arg_name: Accuracy()}
 
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?


Unpin `mxnet`.

## How is this patch tested?

Existing + fixed unit tests.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
