### PR TITLE
[HOT FIX] skip `test` job if matrix ends up being empty in cross version tests

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      is_matrix_empty: ${{ steps.set-matrix.outputs.is_matrix_empty }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -40,8 +41,7 @@ jobs:
           fi
   test:
     needs: set-matrix
-    # Skip this job if the matrix is empty.
-    if: ${{ matrix.version != '' }}
+    if: ${{ needs.set-matrix.outputs.is_matrix_empty == 'false' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -40,6 +40,8 @@ jobs:
           fi
   test:
     needs: set-matrix
+    # Skip this job if the matrix is empty.
+    if: ${{ matrix.version != '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -490,7 +490,7 @@ def main():
 
         # Set a flag that represents whether or not the matrix is empty. If this flag is 'false',
         # skip the subsequent jobs.
-        print("::set-output name=is_matrix_empty::{}".format("false" if job_names else "true")
+        print("::set-output name=is_matrix_empty::{}".format("false" if job_names else "true"))
 
 
 if __name__ == "__main__":

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -488,6 +488,10 @@ def main():
         # Note that this actually doesn't print anything to the console.
         print("::set-output name=matrix::{}".format(json.dumps(matrix)))
 
+        # Set a flag that represents whether or not the matrix is empty. If this flag is 'false',
+        # skip the subsequent jobs.
+        print("::set-output name=is_matrix_empty::{}".format("false" if job_names else "true")
+
 
 if __name__ == "__main__":
     main()

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -488,7 +488,7 @@ def main():
         # Note that this actually doesn't print anything to the console.
         print("::set-output name=matrix::{}".format(json.dumps(matrix)))
 
-        # Set a flag that represents whether or not the matrix is empty. If this flag is 'false',
+        # Set a flag that indicates whether or not the matrix is empty. If this flag is 'false',
         # skip the subsequent jobs.
         print("::set-output name=is_matrix_empty::{}".format("false" if job_names else "true"))
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

The `test` job in the `cross-version-tests.yml` workflow fails if the matrix ends up being empty. This PR fixes this issue.

![Screen Shot 2020-12-09 at 12 48 45](https://user-images.githubusercontent.com/17039389/101577475-e925dc80-3a1c-11eb-8641-f713391946c5.png)

Note that GitHub considers the cross-version-tests workflow to have succeeded even if the test job fails.

https://github.com/mlflow/mlflow/actions/runs/409742357

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
