### PR TITLE
Avoid XGBoost 1.3.0 which seems broken

### DIFF
--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -23,7 +23,8 @@ torch
 torchvision
 pytorch_lightning>=1.0.2
 # Required by mlflow.xgboost
-xgboost>=0.82
+# Exclude 1.3.0 to avoid this issue: https://github.com/dmlc/xgboost/issues/6481
+xgboost>=0.82,!=1.3.0
 # Required by mlflow.lightgbm
 lightgbm
 # Required by mlflow.statsmodels

--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-set -ex
+set -x
 # Set err=1 if any commands exit with non-zero status as described in
 # https://stackoverflow.com/a/42219754
-# err=0
-# trap 'err=1' ERR
-# export MLFLOW_HOME=$(pwd)
+err=0
+trap 'err=1' ERR
+export MLFLOW_HOME=$(pwd)
 
 # Run ML framework tests in their own Python processes to avoid OOM issues due to per-framework
 # overhead
@@ -26,5 +26,6 @@ pytest --verbose tests/shap --large
 pytest --verbose tests/utils/test_model_utils.py --large
 pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large
 
+sleep 5
 
-# test $err = 0
+test $err = 0

--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-set -x
+set -ex
 # Set err=1 if any commands exit with non-zero status as described in
 # https://stackoverflow.com/a/42219754
-err=0
-trap 'err=1' ERR
-export MLFLOW_HOME=$(pwd)
+# err=0
+# trap 'err=1' ERR
+# export MLFLOW_HOME=$(pwd)
 
 # Run ML framework tests in their own Python processes to avoid OOM issues due to per-framework
 # overhead
@@ -27,4 +27,4 @@ pytest --verbose tests/utils/test_model_utils.py --large
 pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large
 
 
-test $err = 0
+# test $err = 0

--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -27,4 +27,4 @@ pytest --verbose tests/utils/test_model_utils.py --large
 pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large
 
 
-# test $err = 0
+test $err = 0

--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -26,6 +26,5 @@ pytest --verbose tests/shap --large
 pytest --verbose tests/utils/test_model_utils.py --large
 pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large
 
-sleep 5
 
-test $err = 0
+# test $err = 0

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -11,6 +11,7 @@ keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(
 # TODO: unpin after we use tensorflow >= 2.4
 reticulate::conda_install("'h5py<3.0.0'", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
-reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
+# Exclude xgboost 1.3.0 to avoid this issue: https://github.com/dmlc/xgboost/issues/6481
+reticulate::conda_install("xgboost!=1.3.0", envname = mlflow:::mlflow_conda_env_name())
 # Pin h2o to prevent version-mismatch between python and R
 reticulate::conda_install("h2o==3.30.1.3", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -11,7 +11,7 @@ keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(
 # TODO: unpin after we use tensorflow >= 2.4
 reticulate::conda_install("'h5py<3.0.0'", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
-# Exclude xgboost 1.3.0 to avoid this issue: https://github.com/dmlc/xgboost/issues/6481
+# Exclude 1.3.0 to avoid this issue: https://github.com/dmlc/xgboost/issues/6481
 reticulate::conda_install("xgboost!=1.3.0", envname = mlflow:::mlflow_conda_env_name())
 # Pin h2o to prevent version-mismatch between python and R
 reticulate::conda_install("h2o==3.30.1.3", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)

--- a/mlflow/R/mlflow/R/model-xgboost.R
+++ b/mlflow/R/mlflow/R/model-xgboost.R
@@ -19,7 +19,7 @@ mlflow_save_model.xgb.Booster <- function(model,
   )
 
   conda_env <- create_default_conda_env_if_absent(
-    path, conda_env, default_pip_deps = list("mlflow", paste("xgboost>=", version, sep = ""))
+    path, conda_env, default_pip_deps = list("mlflow", paste("xgboost==", version, sep = ""))
   )
   xgboost_conf <- list(
     xgboost = list(xgb_version = version, data = model_data_subpath)


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Avoid using the latest version (1.3.0) of xgboost which seems broken: https://github.com/dmlc/xgboost/issues/6481

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
