### PR TITLE
Make mlflow::start_run() work again when a run id is set (directly or via MLFLOW_RUN_ID)

### DIFF
--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -585,7 +585,7 @@ mlflow_start_run <- function(run_id = NULL, experiment_id = NULL, start_time = N
     do.call(mlflow_create_run, args)
   }
   mlflow_push_active_run_id(mlflow_id(run))
-  mlflow_set_experiment(experiment_id = args$experiment_id)
+  mlflow_set_experiment(experiment_id = run$experiment_id)
   run
 }
 

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -29,6 +29,30 @@ test_that("mlflow_start_run()/mlflow_get_run() work properly", {
   )
 })
 
+test_that("a run can be started properly if MLFLOW_RUN_ID is set", {
+  mlflow_clear_test_dir("mlruns")
+  # Typical use case: Invoke an R script that interacts with the MLflow API from
+  # outside of R, e.g. MLproject, Python, CLI
+  start_get_id_stop <- function() {
+    tryCatch(
+      mlflow_id(mlflow_start_run()),
+      finally = {
+        mlflow_end_run()
+      }
+    )
+  }
+  id <- start_get_id_stop()
+  withr::with_envvar(list(
+    MLFLOW_RUN_ID = id
+    ), {
+      expect_equal(
+        start_get_id_stop(),
+        id
+      )
+    }
+  )
+})
+
 test_that("mlflow_end_run() works properly", {
   mlflow_clear_test_dir("mlruns")
   mlflow_start_run()

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -34,23 +34,14 @@ test_that("a run can be started properly if MLFLOW_RUN_ID is set", {
   # Typical use case: Invoke an R script that interacts with the MLflow API from
   # outside of R, e.g. MLproject, Python, CLI
   start_get_id_stop <- function() {
-    tryCatch(
-      mlflow_id(mlflow_start_run()),
-      finally = {
-        mlflow_end_run()
-      }
-    )
+    tryCatch(mlflow_id(mlflow_start_run()), finally = {
+      mlflow_end_run()
+    })
   }
   id <- start_get_id_stop()
-  withr::with_envvar(list(
-    MLFLOW_RUN_ID = id
-    ), {
-      expect_equal(
-        start_get_id_stop(),
-        id
-      )
-    }
-  )
+  withr::with_envvar(list(MLFLOW_RUN_ID = id), {
+    expect_equal(start_get_id_stop(), id)
+  })
 })
 
 test_that("mlflow_end_run() works properly", {


### PR DESCRIPTION
## What changes are proposed in this pull request?

This fixes an unobserved problem introduced in #3276 for which we had no test: When no active run can be derived form within R and we check `MLFLOW_RUN_ID` as a last fallback and this is set, the R object `args` is not defined and causes an error in `mlflow_start_run()` (see diff for context). The same error occurs when setting a valid run id in `mlflow::mlflow_start_run()` as described in #3983.
The solution is to rely on the `run` object, which is always available and type stable (in the sense that it is guaranteed to have the column `experiment_id`).


## How is this patch tested?

Unit tests.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
