### PR TITLE
reject bool metric value

### DIFF
--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -69,7 +69,7 @@ def _validate_metric(key, value, timestamp, step):
     it isn't.
     """
     _validate_metric_name(key)
-    if not isinstance(value, numbers.Number):
+    if isinstance(value, bool) or not isinstance(value, numbers.Number):
         raise MlflowException(
             "Got invalid value %s for metric '%s' (timestamp=%s). Please specify value as a valid "
             "double (64-bit floating point)" % (value, key, timestamp),

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -69,6 +69,8 @@ def _validate_metric(key, value, timestamp, step):
     it isn't.
     """
     _validate_metric_name(key)
+    # value must be a Number
+    # since bool is an instance of Number check for bool additionally
     if isinstance(value, bool) or not isinstance(value, numbers.Number):
         raise MlflowException(
             "Got invalid value %s for metric '%s' (timestamp=%s). Please specify value as a valid "

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -122,6 +122,7 @@ def test_validate_batch_log_data():
         Metric("super-long-bad-key" * 1000, 4.0, 0, 0),
     ]
     metrics_with_bad_val = [Metric("good-metric-key", "not-a-double-val", 0, 0)]
+    metrics_with_bool_val = [Metric("good-metric-key", True, 0, 0)]
     metrics_with_bad_ts = [Metric("good-metric-key", 1.0, "not-a-timestamp", 0)]
     metrics_with_neg_ts = [Metric("good-metric-key", 1.0, -123, 0)]
     metrics_with_bad_step = [Metric("good-metric-key", 1.0, 0, "not-a-step")]
@@ -145,6 +146,7 @@ def test_validate_batch_log_data():
         "metrics": [
             metrics_with_bad_key,
             metrics_with_bad_val,
+            metrics_with_bool_val,
             metrics_with_bad_ts,
             metrics_with_neg_ts,
             metrics_with_bad_step,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes #3752 

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Reject boolean values to be logged as a metric.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
