### PR TITLE
Fix invalid metric error in statsmodels tests

### DIFF
--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -464,7 +464,9 @@ def autolog():
                         renamed_keys_dict = prepend_to_keys(d, f)
                         results_dict.update(renamed_keys_dict)
 
-                    elif isinstance(field, (int, float)):
+                    # `not isinstance(field, bool)` is required because `bool` is a subclass of
+                    # `int`
+                    elif not isinstance(field, bool) and isinstance(field, (int, float)):
                         results_dict[f] = field
 
             except AttributeError:

--- a/mlflow/statsmodels.py
+++ b/mlflow/statsmodels.py
@@ -30,6 +30,7 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import try_mlflow_log, log_fn_args_as_params
+from mlflow.utils.validation import _is_numeric
 
 import itertools
 import inspect
@@ -464,9 +465,7 @@ def autolog():
                         renamed_keys_dict = prepend_to_keys(d, f)
                         results_dict.update(renamed_keys_dict)
 
-                    # `not isinstance(field, bool)` is required because `bool` is a subclass of
-                    # `int`
-                    elif not isinstance(field, bool) and isinstance(field, (int, float)):
+                    elif _is_numeric(field):
                         results_dict[f] = field
 
             except AttributeError:

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -63,6 +63,15 @@ def _validate_metric_name(name):
         )
 
 
+def _is_numeric(value):
+    """
+    Returns True if the passed-in value is numeric.
+    """
+    # Note that `isinstance(bool_value, numbers.Number)` returns `True` because `bool` is a
+    # subclass of `int`.
+    return not isinstance(value, bool) and isinstance(value, numbers.Number)
+
+
 def _validate_metric(key, value, timestamp, step):
     """
     Check that a param with the specified key, value, timestamp is valid and raise an exception if
@@ -71,7 +80,7 @@ def _validate_metric(key, value, timestamp, step):
     _validate_metric_name(key)
     # value must be a Number
     # since bool is an instance of Number check for bool additionally
-    if isinstance(value, bool) or not isinstance(value, numbers.Number):
+    if not _is_numeric(value):
         raise MlflowException(
             "Got invalid value %s for metric '%s' (timestamp=%s). Please specify value as a valid "
             "double (64-bit floating point)" % (value, key, timestamp),

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -5,6 +5,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.entities import Metric, Param, RunTag
 from mlflow.protos.databricks_pb2 import ErrorCode, INVALID_PARAMETER_VALUE
 from mlflow.utils.validation import (
+    _is_numeric,
     _validate_metric_name,
     _validate_param_name,
     _validate_tag_name,
@@ -41,6 +42,15 @@ BAD_METRIC_OR_PARAM_NAMES = [
     "./",
     "/./",
 ]
+
+
+def test_is_numeric():
+    assert _is_numeric(0)
+    assert _is_numeric(0.0)
+    assert not _is_numeric(True)
+    assert not _is_numeric(False)
+    assert not _is_numeric("0")
+    assert not _is_numeric(None)
 
 
 def test_validate_metric_name():


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix metric validation failures in statsmodels tests.

```
Got invalid value False for metric 'use_t' (timestamp=1607920609380). Please specify value as a valid double (64-bit floating point)
```

https://github.com/mlflow/mlflow/runs/1547920024#step:4:1041

Related PR: https://github.com/mlflow/mlflow/pull/3822


## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
