### PR TITLE
Minor fixes for schema warning against integer values

### DIFF
--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -90,10 +90,10 @@ def _infer_schema(data: Any) -> Schema:
             "dictionary of (name -> numpy.ndarray), pyspark.sql.DataFrame) "
             "but got '{}'".format(type(data))
         )
-    if any([t in (DataType.integer, DataType.long) for t in schema.column_types()]):
+    if any(t in (DataType.integer, DataType.long) for t in schema.column_types()):
         warnings.warn(
             "Hint: Inferred schema contains integer column(s). Integer columns in "
-            "Python can  not represent missing values. If your input data contains"
+            "Python can  not represent missing values. If your input data contains "
             "missing values at inference time, it will be encoded as floats and will "
             "cause a schema enforcement error. The best way to avoid this problem is "
             "to infer the model schema based on a realistic data sample (training "

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -93,7 +93,7 @@ def _infer_schema(data: Any) -> Schema:
     if any(t in (DataType.integer, DataType.long) for t in schema.column_types()):
         warnings.warn(
             "Hint: Inferred schema contains integer column(s). Integer columns in "
-            "Python can  not represent missing values. If your input data contains "
+            "Python can not represent missing values. If your input data contains "
             "missing values at inference time, it will be encoded as floats and will "
             "cause a schema enforcement error. The best way to avoid this problem is "
             "to infer the model schema based on a realistic data sample (training "


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
