### PR TITLE
Add autologging safety utils to LightGBM integration

### DIFF
--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -39,6 +39,9 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
+    autologging_integration,
+    safe_patch,
+    exception_safe_function,
     try_mlflow_log,
     log_fn_args_as_params,
     wrap_patch,
@@ -282,9 +285,12 @@ class _LGBModelWrapper:
 
 
 @experimental
-def autolog(log_input_examples=False, log_model_signatures=True, log_models=True):
+@autologging_integration(FLAVOR_NAME)
+def autolog(
+    log_input_examples=False, log_model_signatures=True, log_models=True, disable=False
+):  # pylint: unused-argument
     """
-    Enables automatic logging from LightGBM to MLflow. Logs the following.
+    Enables (or disables) and configures autologging from LightGBM to MLflow. Logs the following:
 
     - parameters specified in `lightgbm.train`_.
     - metrics on each iteration (if ``valid_sets`` specified).
@@ -312,6 +318,8 @@ def autolog(log_input_examples=False, log_model_signatures=True, log_models=True
                        If ``False``, trained models are not logged.
                        Input examples and model signatures, which are attributes of MLflow models,
                        are also omitted when ``log_models`` is ``False``.
+    :param disable: If ``True``, disables all supported autologging integrations. If ``False``,
+                    enables all supported autologging integrations.
     """
     import lightgbm
     import numpy as np
@@ -320,9 +328,8 @@ def autolog(log_input_examples=False, log_model_signatures=True, log_models=True
     #   to use as an input example and for inferring the model signature.
     #   (there is no way to get the data back from a Dataset object once it is consumed by train)
     # We store it on the Dataset object so the train function is able to read it.
-    def __init__(self, *args, **kwargs):
+    def __init__(original, self, *args, **kwargs):
         data = args[0] if len(args) > 0 else kwargs.get("data")
-        original = gorilla.get_original_attribute(lightgbm.Dataset, "__init__")
 
         if data is not None:
             try:
@@ -341,12 +348,13 @@ def autolog(log_input_examples=False, log_model_signatures=True, log_models=True
 
         original(self, *args, **kwargs)
 
-    def train(*args, **kwargs):
+    def train(original, *args, **kwargs):
         def record_eval_results(eval_results, metrics_logger):
             """
             Create a callback function that records evaluation results.
             """
 
+            @exception_safe_function
             def callback(env):
                 res = {}
                 for data_name, eval_name, value, _ in env.evaluation_result_list:
@@ -391,12 +399,6 @@ def autolog(log_input_examples=False, log_model_signatures=True, log_models=True
             finally:
                 plt.close(fig)
                 shutil.rmtree(tmpdir)
-
-        if not mlflow.active_run():
-            try_mlflow_log(mlflow.start_run)
-            auto_end_run = True
-        else:
-            auto_end_run = False
 
         original = gorilla.get_original_attribute(lightgbm, "train")
 
@@ -517,9 +519,7 @@ def autolog(log_input_examples=False, log_model_signatures=True, log_models=True
                 input_example=input_example,
             )
 
-        if auto_end_run:
-            try_mlflow_log(mlflow.end_run)
         return model
 
-    wrap_patch(lightgbm, "train", train)
-    wrap_patch(lightgbm.Dataset, "__init__", __init__)
+    safe_patch(FLAVOR_NAME, lightgbm, "train", train, manage_run=True)
+    safe_patch(FLAVOR_NAME, lightgbm.Dataset, "__init__", __init__)

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -33,7 +33,6 @@ from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils import gorilla
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
@@ -398,8 +397,6 @@ def autolog(
             finally:
                 plt.close(fig)
                 shutil.rmtree(tmpdir)
-
-        original = gorilla.get_original_attribute(lightgbm, "train")
 
         # logging booster params separately via mlflow.log_params to extract key/value pairs
         # and make it easier to compare them across runs.

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -44,7 +44,6 @@ from mlflow.utils.autologging_utils import (
     exception_safe_function,
     try_mlflow_log,
     log_fn_args_as_params,
-    wrap_patch,
     INPUT_EXAMPLE_SAMPLE_ROWS,
     resolve_input_example_and_signature,
     _InputExampleInfo,
@@ -288,7 +287,7 @@ class _LGBModelWrapper:
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_input_examples=False, log_model_signatures=True, log_models=True, disable=False
-):  # pylint: unused-argument
+):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging from LightGBM to MLflow. Logs the following:
 

--- a/tests/autologging/test_autologging_safety_integration.py
+++ b/tests/autologging/test_autologging_safety_integration.py
@@ -20,6 +20,7 @@ AUTOLOGGING_INTEGRATIONS_TO_TEST = {
     mlflow.sklearn: "sklearn",
     mlflow.keras: "keras",
     mlflow.xgboost: "xgboost",
+    mlflow.lightgbm: "lightgbm",
 }
 
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Add autologging safety utils to LightGBM integration.

## How is this patch tested?

Existing unit tests.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
