### PR TITLE
Add existing type to alter_column in allow_null_for_run_id migration

### DIFF
--- a/mlflow/store/db_migrations/versions/a8c4a736bde6_allow_nulls_for_run_id.py
+++ b/mlflow/store/db_migrations/versions/a8c4a736bde6_allow_nulls_for_run_id.py
@@ -19,7 +19,7 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table(SqlModelVersion.__tablename__) as batch_op:
-        batch_op.alter_column("run_id", nullable=True)
+        batch_op.alter_column("run_id", nullable=True, existing_type=sa.VARCHAR(32))
 
 
 def downgrade():


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix the bug reported in https://github.com/mlflow/mlflow/issues/3835 by adding the existing type in the alter_column operation in the allow_nulls_for_run_id migration.

## How is this patch tested?

Manually, by running a mlflow db upgrade against a MariaDB 10.3 database.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
