### PR TITLE
add pickle protocol version option

### DIFF
--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -387,7 +387,7 @@ def log_model(
     )
 
 
-def _save_custom_objects(path, custom_objects):
+def _save_custom_objects(path, custom_objects, protocol=None):
     """
     Save custom objects dictionary to a cloudpickle file so a model can be easily loaded later.
 
@@ -398,12 +398,14 @@ def _save_custom_objects(path, custom_objects):
                            CloudPickle and restores them automatically when the model is
                            loaded with :py:func:`mlflow.keras.load_model` and
                            :py:func:`mlflow.pyfunc.load_model`.
+    :param protocol: The pickle protocol version. If ``None``, the default protocol version
+                     from cloudpickle will be used.
     """
     import cloudpickle
 
     custom_objects_path = os.path.join(path, _CUSTOM_OBJECTS_SAVE_PATH)
     with open(custom_objects_path, "wb") as out_f:
-        cloudpickle.dump(custom_objects, out_f)
+        cloudpickle.dump(custom_objects, out_f, protocol)
 
 
 def _load_model(model_path, keras_module, save_format, **kwargs):

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -707,6 +707,7 @@ def save_model(
     mlflow_model=None,
     python_model=None,
     artifacts=None,
+    protocol=None,
     signature: ModelSignature = None,
     input_example: ModelInputExample = None,
     **kwargs
@@ -788,6 +789,9 @@ def save_model(
                       path via ``context.artifacts["my_file"]``.
 
                       If ``None``, no artifacts are added to the model.
+
+    :param protocol: The pickle protocol version. If ``None``, the default protocol version
+                     from cloudpickle will be used.
 
     :param signature: (Experimental) :py:class:`ModelSignature <mlflow.models.ModelSignature>`
                       describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
@@ -875,6 +879,7 @@ def save_model(
             conda_env=conda_env,
             code_paths=code_path,
             mlflow_model=mlflow_model,
+            protocol=protocol,
         )
 
 

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -106,7 +106,13 @@ class PythonModelContext(object):
 
 
 def _save_model_with_class_artifacts_params(
-    path, python_model, artifacts=None, conda_env=None, code_paths=None, mlflow_model=Model()
+    path,
+    python_model,
+    artifacts=None,
+    conda_env=None,
+    code_paths=None,
+    mlflow_model=Model(),
+    protocol=None,
 ):
     """
     :param path: The path to which to save the Python model.
@@ -128,6 +134,8 @@ def _save_model_with_class_artifacts_params(
                        containing file dependencies). These files are *prepended* to the system
                        path before the model is loaded.
     :param mlflow_model: The model configuration to which to add the ``mlflow.pyfunc`` flavor.
+    :param protocol: The pickle protocol version. If ``None``, the default protocol version
+                     from cloudpickle will be used.
     """
     custom_model_config_kwargs = {
         CONFIG_KEY_CLOUDPICKLE_VERSION: cloudpickle.__version__,
@@ -135,7 +143,7 @@ def _save_model_with_class_artifacts_params(
     if isinstance(python_model, PythonModel):
         saved_python_model_subpath = "python_model.pkl"
         with open(os.path.join(path, saved_python_model_subpath), "wb") as out:
-            cloudpickle.dump(python_model, out)
+            cloudpickle.dump(python_model, out, protocol)
         custom_model_config_kwargs[CONFIG_KEY_PYTHON_MODEL] = saved_python_model_subpath
     else:
         raise MlflowException(

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -393,13 +393,15 @@ def _load_pyfunc(path):
     return _load_model_from_local_file(path=path, serialization_format=serialization_format)
 
 
-def _save_model(sk_model, output_path, serialization_format):
+def _save_model(sk_model, output_path, serialization_format, protocol=None):
     """
     :param sk_model: The scikit-learn model to serialize.
     :param output_path: The file path to which to write the serialized model.
     :param serialization_format: The format in which to serialize the model. This should be one of
                                  the following: ``mlflow.sklearn.SERIALIZATION_FORMAT_PICKLE`` or
                                  ``mlflow.sklearn.SERIALIZATION_FORMAT_CLOUDPICKLE``.
+    :param protocol: The pickle protocol version. If ``None``, the default protocol version
+                     from cloudpickle will be used.
     """
     with open(output_path, "wb") as out:
         if serialization_format == SERIALIZATION_FORMAT_PICKLE:
@@ -407,7 +409,7 @@ def _save_model(sk_model, output_path, serialization_format):
         elif serialization_format == SERIALIZATION_FORMAT_CLOUDPICKLE:
             import cloudpickle
 
-            cloudpickle.dump(sk_model, out)
+            cloudpickle.dump(sk_model, out, protocol)
         else:
             raise MlflowException(
                 message="Unrecognized serialization format: {serialization_format}".format(


### PR DESCRIPTION
Signed-off-by: Pohan.Chen <l.w.jasons@gmail.com>

## What changes are proposed in this pull request?

Support specifying the pickle protocol version during the saving time to have better backward compatibility.

## How is this patch tested?

unit test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
