### PR TITLE
Mutual exclusivity for autologged runs

### DIFF
--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -563,7 +563,7 @@ def load_model(model_uri, **kwargs):
 
 @experimental
 @autologging_integration(FLAVOR_NAME)
-def autolog(log_models=True, disable=False):  # pylint: disable=unused-argument
+def autolog(log_models=True, disable=False, exclusive=False):  # pylint: disable=unused-argument
     # pylint: disable=E0611
     """
     Enables (or disables) and configures autologging from Keras to MLflow. Autologging captures
@@ -616,6 +616,9 @@ def autolog(log_models=True, disable=False):  # pylint: disable=unused-argument
                        If ``False``, trained models are not logged.
     :param disable: If ``True``, disables all supported autologging integrations. If ``False``,
                     enables all supported autologging integrations.
+    :param exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
+                      If ``False``, autologged content is logged to the active fluent run,
+                      which may be user-created.
     """
     import keras
 

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -534,7 +534,11 @@ class _SklearnTrainingSession(object):
 @experimental
 @autologging_integration(FLAVOR_NAME)
 def autolog(
-    log_input_examples=False, log_model_signatures=True, log_models=True, disable=False
+    log_input_examples=False,
+    log_model_signatures=True,
+    log_models=True,
+    disable=False,
+    exclusive=False,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging for scikit-learn estimators.
@@ -717,6 +721,9 @@ def autolog(
                        are also omitted when ``log_models`` is ``False``.
     :param disable: If ``True``, disables all supported autologging integrations. If ``False``,
                     enables all supported autologging integrations.
+    :param exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
+                      If ``False``, autologged content is logged to the active fluent run,
+                      which may be user-created.
     """
     import pandas as pd
     import sklearn

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1213,7 +1213,11 @@ def _get_experiment_id():
 
 
 def autolog(
-    log_input_examples=False, log_model_signatures=True, log_models=True, disable=False
+    log_input_examples=False,
+    log_model_signatures=True,
+    log_models=True,
+    disable=False,
+    exclusive=False,
 ):  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging for all supported integrations.
@@ -1240,6 +1244,9 @@ def autolog(
                        are also omitted when ``log_models`` is ``False``.
     :param disable: If ``True``, disables all supported autologging integrations. If ``False``,
                     enables all supported autologging integrations.
+    :param exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
+                      If ``False``, autologged content is logged to the active fluent run,
+                      which may be user-created.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -6,6 +6,7 @@ import warnings
 import logging
 import time
 import contextlib
+from contextlib import contextmanager
 from abc import abstractmethod
 
 import mlflow
@@ -508,6 +509,29 @@ class PatchFunction:
                 raise e
 
 
+class _AutologgingSessionManager:
+    _session = None
+
+    @classmethod
+    @contextmanager
+    def start_session(cls, integration):
+        try:
+            cls._session = integration
+            if cls._session is None:
+                cls._session = integration
+            yield integration
+        finally:
+            cls.end_session()
+
+    @classmethod
+    def active_session(cls):
+        return cls._session
+
+    @classmethod
+    def end_session(cls):
+        cls._session = None
+
+
 def with_managed_run(patch_function, tags=None):
     """
     Given a `patch_function`, returns an `augmented_patch_function` that wraps the execution of
@@ -583,8 +607,8 @@ def safe_patch(
 ):
     """
     Patches the specified `function_name` on the specified `destination` class for autologging
-    purposes, replacing its implementation with an error-safe copy of the specified patch
-    `function` with the following error handling behavior:
+    purposes, preceding its implementation with an error-safe copy of the specified patch
+    `patch_function` with the following error handling behavior:
 
         - Exceptions thrown from the underlying / original function
           (`<destination>.<function_name>`) are propagated to the caller.
@@ -643,6 +667,15 @@ def safe_patch(
         if autologging_is_disabled(autologging_integration):
             return original(*args, **kwargs)
 
+        # Whether or not to exclude auto-autologged content from content explicitly logged via
+        # `mlflow.start_run()`
+        exclusive = get_autologging_config(autologging_integration, "exclusive", False)
+
+        active_run = mlflow.active_run()
+
+        if active_run and exclusive and not _AutologgingSessionManager.active_session():
+            return original(*args, **kwargs)
+
         # Whether or not the original / underlying function has been called during the
         # execution of patched code
         original_has_been_called = False
@@ -655,68 +688,71 @@ def safe_patch(
         # The active MLflow run (if any) associated with patch code execution
         patch_function_run_for_testing = None
 
-        try:
+        with _AutologgingSessionManager.start_session(autologging_integration):
+            try:
 
-            def call_original(*og_args, **og_kwargs):
-                try:
-                    if _is_testing():
-                        _validate_args(args, kwargs, og_args, og_kwargs)
-                        # By the time `original` is called by the patch implementation, we assume
-                        # that either: 1. the patch implementation has already created an MLflow
-                        # run or 2. the patch code will not create an MLflow run during the
-                        # current execution. Here, we capture a reference to the active run, which
-                        # we will use later on to determine whether or not the patch
-                        # implementation created a run and perform validation if necessary
-                        nonlocal patch_function_run_for_testing
-                        patch_function_run_for_testing = mlflow.active_run()
+                def call_original(*og_args, **og_kwargs):
+                    try:
+                        if _is_testing():
+                            _validate_args(args, kwargs, og_args, og_kwargs)
+                            # By the time `original` is called by the patch implementation, we assume
+                            # that either: 1. the patch implementation has already created an MLflow
+                            # run or 2. the patch code will not create an MLflow run during the
+                            # current execution. Here, we capture a reference to the active run, which
+                            # we will use later on to determine whether or not the patch
+                            # implementation created a run and perform validation if necessary
+                            nonlocal patch_function_run_for_testing
+                            patch_function_run_for_testing = mlflow.active_run()
 
-                    nonlocal original_has_been_called
-                    original_has_been_called = True
+                        nonlocal original_has_been_called
+                        original_has_been_called = True
 
-                    nonlocal original_result
-                    original_result = original(*og_args, **og_kwargs)
-                    return original_result
-                except Exception:  # pylint: disable=broad-except
-                    nonlocal failed_during_original
-                    failed_during_original = True
+                        nonlocal original_result
+                        original_result = original(*og_args, **og_kwargs)
+                        return original_result
+                    except Exception:  # pylint: disable=broad-except
+                        nonlocal failed_during_original
+                        failed_during_original = True
+                        raise
+
+                # Apply the name, docstring, and signature of `original` to `call_original`.
+                # This is important because several autologging patch implementations inspect
+                # the signature of the `original` argument during execution
+                call_original = _update_wrapper_extended(call_original, original)
+
+                if patch_is_class:
+                    patch_function.call(call_original, *args, **kwargs)
+                else:
+                    patch_function(call_original, *args, **kwargs)
+
+            except Exception as e:  # pylint: disable=broad-except
+                # Exceptions thrown during execution of the original function should be propagated
+                # to the caller. Additionally, exceptions encountered during test mode should be
+                # reraised to detect bugs in autologging implementations
+                if failed_during_original or _is_testing():
                     raise
 
-            # Apply the name, docstring, and signature of `original` to `call_original`.
-            # This is important because several autologging patch implementations inspect
-            # the signature of the `original` argument during execution
-            call_original = _update_wrapper_extended(call_original, original)
-
-            if patch_is_class:
-                patch_function.call(call_original, *args, **kwargs)
-            else:
-                patch_function(call_original, *args, **kwargs)
-
-        except Exception as e:  # pylint: disable=broad-except
-            # Exceptions thrown during execution of the original function should be propagated
-            # to the caller. Additionally, exceptions encountered during test mode should be
-            # reraised to detect bugs in autologging implementations
-            if failed_during_original or _is_testing():
-                raise
-
-            _logger.warning(
-                "Encountered unexpected error during %s autologging: %s", autologging_integration, e
-            )
-
-        if _is_testing() and not preexisting_run_for_testing:
-            # If an MLflow run was created during the execution of patch code, verify that
-            # it is no longer active and that it contains expected autologging tags
-            assert not mlflow.active_run(), (
-                "Autologging integration %s leaked an active run" % autologging_integration
-            )
-            if patch_function_run_for_testing:
-                _validate_autologging_run(
-                    autologging_integration, patch_function_run_for_testing.info.run_id
+                _logger.warning(
+                    "Encountered unexpected error during %s autologging: %s",
+                    autologging_integration,
+                    e,
                 )
 
-        if original_has_been_called:
-            return original_result
-        else:
-            return original(*args, **kwargs)
+            if _is_testing() and not preexisting_run_for_testing:
+                # If an MLflow run was created during the execution of patch code, verify that
+                # it is no longer active and that it contains expected autologging tags
+                assert not mlflow.active_run(), (
+                    "Autologging integration %s leaked an active run" % autologging_integration
+                )
+                if patch_function_run_for_testing:
+                    _validate_autologging_run(
+                        autologging_integration, patch_function_run_for_testing.info.run_id
+                    )
+
+            if original_has_been_called:
+                return original_result
+            else:
+                return original(*args, **kwargs)
 
     wrap_patch(destination, function_name, safe_patch_function)
 

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -876,3 +876,4 @@ def _validate_args(
 
     _validate(autologging_call_args, user_call_args)
     _validate(autologging_call_kwargs, user_call_kwargs)
+#dummy

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -695,12 +695,13 @@ def safe_patch(
                     try:
                         if _is_testing():
                             _validate_args(args, kwargs, og_args, og_kwargs)
-                            # By the time `original` is called by the patch implementation, we assume
-                            # that either: 1. the patch implementation has already created an MLflow
-                            # run or 2. the patch code will not create an MLflow run during the
-                            # current execution. Here, we capture a reference to the active run, which
-                            # we will use later on to determine whether or not the patch
-                            # implementation created a run and perform validation if necessary
+                            # By the time `original` is called by the patch implementation, we
+                            # assume that either: 1. the patch implementation has already
+                            # created an MLflow run or 2. the patch code will not create an
+                            # MLflow run during the current execution. Here, we capture a
+                            # reference to the active run, which we will use later on to
+                            # determine whether or not the patch implementation created
+                            # a run and perform validation if necessary
                             nonlocal patch_function_run_for_testing
                             patch_function_run_for_testing = mlflow.active_run()
 

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -876,4 +876,3 @@ def _validate_args(
 
     _validate(autologging_call_args, user_call_args)
     _validate(autologging_call_kwargs, user_call_kwargs)
-#dummy

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -291,6 +291,7 @@ def autolog(
     log_model_signatures=True,
     log_models=True,
     disable=False,
+    exclusive=False,
 ):  # pylint: disable=W0102,unused-argument
     """
     Enables (or disables) and configures autologging from XGBoost to MLflow. Logs the following:
@@ -324,6 +325,9 @@ def autolog(
                        are also omitted when ``log_models`` is ``False``.
     :param disable: If ``True``, disables all supported autologging integrations. If ``False``,
                     enables all supported autologging integrations.
+    :param exclusive: If ``True``, autologged content is not logged to user-created fluent runs.
+                      If ``False``, autologged content is logged to the active fluent run,
+                      which may be user-created.
     """
     import xgboost
     import numpy as np

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1080,3 +1080,108 @@ def test_try_mlflow_log_propagates_exceptions_in_test_mode():
 
     with pytest.raises(Exception, match="bad implementation"):
         try_mlflow_log(throwing_function)
+
+
+def test_session_manager_creates_session_before_patch_executes(
+    patch_destination, test_autologging_integration
+):
+    is_session_active = None
+
+    def check_session_manager_status(original):
+        nonlocal is_session_active
+        is_session_active = autologging_utils._AutologgingSessionManager.active_session()
+
+    safe_patch(test_autologging_integration, patch_destination, "fn", check_session_manager_status)
+    patch_destination.fn()
+    assert is_session_active is not None
+
+
+def test_session_manager_exits_session_after_patch_executes(
+    patch_destination, test_autologging_integration
+):
+    def patch_fn(original):
+        assert autologging_utils._AutologgingSessionManager.active_session() is not None
+
+    safe_patch(test_autologging_integration, patch_destination, "fn", patch_fn)
+    patch_destination.fn()
+    assert autologging_utils._AutologgingSessionManager.active_session() is None
+
+
+def test_session_manager_exits_session_if_error_in_patch(
+    patch_destination, test_autologging_integration
+):
+    def patch_fn(original):
+        raise Exception("Exception that should stop autologging session")
+
+    # If use safe_patch to patch, exception would not come from original fn and so would be logged
+    patch_destination.fn = patch_fn
+    with pytest.raises(Exception):
+        patch_destination.fn()
+
+    assert autologging_utils._AutologgingSessionManager.active_session() is None
+
+
+def test_original_fn_runs_if_patch_should_not_be_applied(patch_destination):
+    patch_impl_call_count = 0
+
+    @autologging_integration("test_respects_exclusive")
+    def autolog(disable=False, exclusive=False):
+        def patch_impl(original, *args, **kwargs):
+            nonlocal patch_impl_call_count
+            patch_impl_call_count += 1
+            return original(*args, **kwargs)
+
+        safe_patch("test_respects_exclusive", patch_destination, "fn", patch_impl)
+
+    autolog(exclusive=True)
+    with mlflow.start_run():
+        patch_destination.fn()
+    assert patch_impl_call_count == 0
+    assert patch_destination.fn_call_count == 1
+
+
+def test_patch_runs_if_patch_should_be_applied():
+    patch_impl_call_count = 0
+
+    class TestPatchWithNewFnObj:
+        def __init__(self):
+            self.fn_call_count = 0
+
+        def fn(self, *args, **kwargs):
+            self.fn_call_count += 1
+            return PATCH_DESTINATION_FN_DEFAULT_RESULT
+
+        def new_fn(self, *args, **kwargs):
+            a = "Dumbledores army"
+            with mlflow.start_run():
+                self.fn()
+
+    patch_obj = TestPatchWithNewFnObj()
+
+    @autologging_integration("test_respects_exclusive")
+    def autolog(disable=False, exclusive=False):
+        def patch_impl(original, *args, **kwargs):
+            nonlocal patch_impl_call_count
+            patch_impl_call_count += 1
+
+        def new_fn_patch(original, *args, **kwargs):
+            b = "Voldemort"
+
+        safe_patch("test_respects_exclusive", patch_obj, "fn", patch_impl)
+        safe_patch("test_respects_exclusive", patch_obj, "new_fn", new_fn_patch)
+
+    # Should patch if no active run
+    autolog()
+    patch_obj.fn()
+    assert patch_impl_call_count == 1
+
+    # Should patch if active run, but not exclusive
+    autolog(exclusive=False)
+    with mlflow.start_run():
+        patch_obj.fn()
+    assert patch_impl_call_count == 2
+
+    # Should patch if active run and exclusive, but active autologging session
+    autolog(exclusive=True)
+    patch_obj.new_fn()
+    assert patch_impl_call_count == 3

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1152,7 +1152,6 @@ def test_patch_runs_if_patch_should_be_applied():
             return PATCH_DESTINATION_FN_DEFAULT_RESULT
 
         def new_fn(self, *args, **kwargs):
-            a = "Dumbledores army"
             with mlflow.start_run():
                 self.fn()
 
@@ -1165,7 +1164,7 @@ def test_patch_runs_if_patch_should_be_applied():
             patch_impl_call_count += 1
 
         def new_fn_patch(original, *args, **kwargs):
-            b = "Voldemort"
+            pass
 
         safe_patch("test_respects_exclusive", patch_obj, "fn", patch_impl)
         safe_patch("test_respects_exclusive", patch_obj, "new_fn", new_fn_patch)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Implement logic for allowing mutual exclusivity between autolog-created and user-created runs,
according to the user's specification in the `autolog(exclusive=False)` flag.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
