### PR TITLE
Autologging: Fix bug where metrics are not logged for single-epoch tf.keras training sessions

### DIFF
--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -750,8 +750,8 @@ def _setup_callbacks(lst, log_models, metrics_logger):
         def on_epoch_end(self, epoch, logs=None):
             # NB: tf.Keras uses zero-indexing for epochs, while other TensorFlow Estimator
             # APIs (e.g., tf.Estimator) use one-indexing. Accordingly, the modular arithmetic
-            # is slightly different from the arithmetic used in `_log_event`, which provides
-            # metric logging hooks for TensorFlow Estimator & other TensorFlow APIs
+            # used here is slightly different from the arithmetic used in `_log_event`, which
+            # provides  metric logging hooks for TensorFlow Estimator & other TensorFlow APIs
             if epoch % _LOG_EVERY_N_STEPS == 0:
                 metrics_logger.record_metrics(logs, epoch)
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -207,7 +207,7 @@ def test_tf_keras_autolog_logs_metrics_for_single_epoch_training(
     Epoch indexing in TF2 and tf.Keras has been known to exhibit inconsistent
     behaviors between training sessions consisting of a single epoch and
     multi-epoch training sessions. This test verifies that metrics are produced
-    for single-epoch training sessions with TensorFlow's Estimator API.
+    for single-epoch training sessions with tf.Keras.
     """
     mlflow.tensorflow.autolog(every_n_iter=5)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes an issue with `tf.keras` autologging where, if a model is trained for exactly 1 epoch, metrics are not recorded. This can be reproduced by running the following code and observing a lack of expected metrics (`loss` and `accuracy`) in the resulting `mlruns` directory:

```
import mlflow

mlflow.autolog()

import tensorflow as tf

mnist = tf.keras.datasets.mnist
(x_train, y_train), (x_test, y_test) = mnist.load_data()
x_train, x_test = x_train / 255.0, x_test / 255.0

model = tf.keras.models.Sequential(
    [
        tf.keras.layers.Flatten(input_shape=(28, 28)),
        tf.keras.layers.Dense(128, activation="relu"),
        tf.keras.layers.Dropout(0.2),
        tf.keras.layers.Dense(10),
    ]
)

model.compile(
    optimizer="adam",
    loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
    metrics=["accuracy"],
)
model.fit(x_train, y_train, epochs=1)
```

This PR fixes the issue and introduces test coverage to ensure that it does not recur in tf.keras and does not arise for other TensorFlow metrics APIs.

## How is this patch tested?

Integration tests

## Release Notes

Fix an autologging bug where tf.keras models trained for a single epoch did not log metrics.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
