### PR TITLE
Add autologging safety utils to gluon

### DIFF
--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -47,7 +47,6 @@ def load_model(model_uri, ctx):
 
     :return: A Gluon model instance.
 
-
     .. code-block:: python
         :caption: Example
 
@@ -274,6 +273,7 @@ def log_model(
                           model. The given example will be converted to a Pandas DataFrame and then
                           serialized to json using the Pandas split-oriented format. Bytes are
                           base64-encoded.
+
 
 
     .. code-block:: python

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -12,10 +12,15 @@ from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils import gorilla
 from mlflow.utils.annotations import experimental
-from mlflow.utils.autologging_utils import try_mlflow_log, wrap_patch, batch_metrics_logger
 from mlflow.utils.environment import _mlflow_conda_env
+from mlflow.utils.autologging_utils import (
+    autologging_integration,
+    safe_patch,
+    ExceptionSafeClass,
+    try_mlflow_log,
+    batch_metrics_logger,
+)
 
 FLAVOR_NAME = "gluon"
 _MODEL_SAVE_PATH = "net"
@@ -270,7 +275,6 @@ def log_model(
                           base64-encoded.
 
 
-
     .. code-block:: python
         :caption: Example
 
@@ -306,7 +310,8 @@ def log_model(
 
 
 @experimental
-def autolog(log_models=True):
+@autologging_integration(FLAVOR_NAME)
+def autolog(log_models=True, disable=False):
     """
     Enable automatic logging from Gluon to MLflow.
     Logs loss and any other metrics specified in the fit
@@ -315,13 +320,15 @@ def autolog(log_models=True):
 
     :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
                        If ``False``, trained models are not logged.
+    :param disable: If ``True``, disables all supported autologging integrations. If ``False``,
+                    enables all supported autologging integrations.
     """
 
     from mxnet.gluon.contrib.estimator import Estimator, EpochEnd, TrainBegin, TrainEnd
     from mxnet.gluon.nn import HybridSequential
 
     def getGluonCallback(metrics_logger):
-        class __MLflowGluonCallback(EpochEnd, TrainEnd, TrainBegin):
+        class __MLflowGluonCallback(EpochEnd, TrainEnd, TrainBegin, metaclass=ExceptionSafeClass):
             def __init__(self):
                 self.current_epoch = 0
 
@@ -358,15 +365,7 @@ def autolog(log_models=True):
 
         return __MLflowGluonCallback()
 
-    def fit(self, *args, **kwargs):
-        if not mlflow.active_run():
-            try_mlflow_log(mlflow.start_run)
-            auto_end_run = True
-        else:
-            auto_end_run = False
-
-        original = gorilla.get_original_attribute(Estimator, "fit")
-
+    def fit(original, self, *args, **kwargs):
         # Wrap `fit` execution within a batch metrics logger context.
         run_id = mlflow.active_run().info.run_id
         with batch_metrics_logger(run_id) as metrics_logger:
@@ -381,8 +380,6 @@ def autolog(log_models=True):
                 kwargs["event_handlers"] = [mlflowGluonCallback]
             result = original(self, *args, **kwargs)
 
-        if auto_end_run:
-            try_mlflow_log(mlflow.end_run)
         return result
 
-    wrap_patch(Estimator, "fit", fit)
+    safe_patch(FLAVOR_NAME, Estimator, "fit", fit, manage_run=True)

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -47,6 +47,7 @@ def load_model(model_uri, ctx):
 
     :return: A Gluon model instance.
 
+
     .. code-block:: python
         :caption: Example
 

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -314,7 +314,7 @@ def log_model(
 @autologging_integration(FLAVOR_NAME)
 def autolog(log_models=True, disable=False):  # pylint: disable=unused-argument
     """
-    Enable automatic logging from Gluon to MLflow.
+    Enables (or disables) and configures autologging from Gluon to MLflow.
     Logs loss and any other metrics specified in the fit
     function, and optimizer data as parameters. Model checkpoints
     are logged as artifacts to a 'models' directory.

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -312,7 +312,7 @@ def log_model(
 
 @experimental
 @autologging_integration(FLAVOR_NAME)
-def autolog(log_models=True, disable=False):
+def autolog(log_models=True, disable=False):  # pylint: disable=unused-argument
     """
     Enable automatic logging from Gluon to MLflow.
     Logs loss and any other metrics specified in the fit

--- a/tests/autologging/test_autologging_safety_integration.py
+++ b/tests/autologging/test_autologging_safety_integration.py
@@ -21,6 +21,7 @@ AUTOLOGGING_INTEGRATIONS_TO_TEST = {
     mlflow.keras: "keras",
     mlflow.xgboost: "xgboost",
     mlflow.lightgbm: "lightgbm",
+    mlflow.gluon: "mxnet.gluon",
 }
 
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Add the autologging safety utils to `gluon` autologging.

## How is this patch tested?

Existing unit tests.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
