### PR TITLE
Add autologging safety utils to pytorch integration

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -740,7 +740,7 @@ def autolog(log_every_n_epoch=1, log_models=True, disable=False):  # pylint: dis
     :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
                        If ``False``, trained models are not logged.
     :param disable: If ``True``, disables all supported autologging integrations. If ``False``,
-                enables all supported autologging integrations.
+                    enables all supported autologging integrations.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -34,7 +34,7 @@ from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import _copy_file_or_tree, TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
-from mlflow.utils.autologging_utils import autologging_integration
+from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 FLAVOR_NAME = "pytorch"
 
@@ -838,6 +838,8 @@ def autolog(log_every_n_epoch=1, log_models=True, disable=False):  # pylint: dis
 
         PyTorch autologged MLflow entities
     """
-    from mlflow.pytorch._pytorch_autolog import _autolog
+    import pytorch_lightning as pl
+    from mlflow.pytorch._pytorch_autolog import _create_patch_fit
 
-    _autolog(log_every_n_epoch=log_every_n_epoch, log_models=log_models)
+    fit = _create_patch_fit(log_every_n_epoch=log_every_n_epoch, log_models=log_models)
+    safe_patch(FLAVOR_NAME, pl.Trainer, "fit", fit, manage_run=True)

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -29,10 +29,12 @@ from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.pytorch import pickle_module as mlflow_pytorch_pickle_module
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.utils.annotations import experimental
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import _copy_file_or_tree, TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+from mlflow.utils.autologging_utils import autologging_integration
 
 FLAVOR_NAME = "pytorch"
 
@@ -710,7 +712,9 @@ class _PyTorchWrapper(object):
             return predicted
 
 
-def autolog(log_every_n_epoch=1, log_models=True):
+@experimental
+@autologging_integration(FLAVOR_NAME)
+def autolog(log_every_n_epoch=1, log_models=True, disable=False):  # pylint: disable=unused-argument
     """
     Automatically log metrics, params, and models from `PyTorch Lightning
     <https://pytorch-lightning.readthedocs.io/en/latest>`_ model training.
@@ -734,6 +738,8 @@ def autolog(log_every_n_epoch=1, log_models=True):
                        are logged after every epoch.
     :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
                        If ``False``, trained models are not logged.
+    :param disable: If ``True``, disables all supported autologging integrations. If ``False``,
+                enables all supported autologging integrations.
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -716,8 +716,9 @@ class _PyTorchWrapper(object):
 @autologging_integration(FLAVOR_NAME)
 def autolog(log_every_n_epoch=1, log_models=True, disable=False):  # pylint: disable=unused-argument
     """
-    Automatically log metrics, params, and models from `PyTorch Lightning
-    <https://pytorch-lightning.readthedocs.io/en/latest>`_ model training.
+    Enables (or disables) and configures autologging from `PyTorch Lightning
+    <https://pytorch-lightning.readthedocs.io/en/latest>`_ to MLflow.
+
     Autologging is performed when you call the `fit` method of
     `pytorch_lightning.Trainer() \
     <https://pytorch-lightning.readthedocs.io/en/latest/trainer.html#>`_.

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -12,7 +12,7 @@ from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     safe_patch,
-    ExceptionSafeClass,
+    ExceptionSafeAbstractClass,
     try_mlflow_log,
     BatchMetricsLogger,
 )
@@ -62,7 +62,7 @@ def _autolog(
     every_n_epoch = log_every_n_epoch
 
     def getPLCallback(log_models, metrics_logger):
-        class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeClass):
+        class __MLflowPLCallback(pl.Callback, metaclass=ExceptionSafeAbstractClass):
             """
             Callback for auto-logging metrics and parameters.
             """
@@ -233,4 +233,4 @@ def _autolog(
         """
         return _run_and_log_function(self, original, args, kwargs)
 
-    safe_patch(FLAVOR_NAME, pl.Trainer, "fit", fit)
+    safe_patch(FLAVOR_NAME, pl.Trainer, "fit", fit, manage_run=True)

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -39,7 +39,9 @@ every_n_epoch = 1
 @rank_zero_only
 @experimental
 @autologging_integration(FLAVOR_NAME)
-def _autolog(log_every_n_epoch=1, log_models=True, disable=False):
+def _autolog(
+    log_every_n_epoch=1, log_models=True, disable=False
+):  # pylint: disable=unused-argument
     """
     Enable automatic logging from pytorch to MLflow.
     Logs loss and any other metrics specified in the fit

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -35,13 +35,18 @@ every_n_epoch = 1
 @rank_zero_only
 def _create_patch_fit(log_every_n_epoch=1, log_models=True):
     """
-    Enable automatic logging from pytorch to MLflow.
-    Logs loss and any other metrics specified in the fit
-    function, and optimizer data as parameters. Model checkpoints
-    are logged as artifacts and pytorch model is stored under `model` directory.
+    Creates a patch implementation of `pytorch_lightning.Trainer.fit` which enables logging the
+    following parameters, metrics and artifacts.
 
-    MLflow will also log the parameters of the
-    `EarlyStoppingCallback <https://pytorch-lightning.readthedocs.io/en/latest/early_stopping.html>`
+    - Training epochs
+    - Optimizer parameters
+    - `EarlyStoppingCallback`_ parameters
+    - Metrics stored in `trainer.callback_metrics`
+    - Model checkpoints
+    - Trained model
+
+    .. _EarlyStoppingCallback:
+        https://pytorch-lightning.readthedocs.io/en/latest/early_stopping.html
 
     :param log_every_n_epoch: parameter to log metrics once in `n` epoch. By default, metrics
                        are logged after every epoch.

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -8,9 +8,7 @@ from pytorch_lightning.core.memory import ModelSummary
 from pytorch_lightning.utilities import rank_zero_only
 
 from mlflow.pytorch import FLAVOR_NAME
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
-    autologging_integration,
     safe_patch,
     ExceptionSafeAbstractClass,
     try_mlflow_log,

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -7,9 +7,7 @@ import tempfile
 from pytorch_lightning.core.memory import ModelSummary
 from pytorch_lightning.utilities import rank_zero_only
 
-from mlflow.pytorch import FLAVOR_NAME
 from mlflow.utils.autologging_utils import (
-    safe_patch,
     ExceptionSafeAbstractClass,
     try_mlflow_log,
     BatchMetricsLogger,
@@ -35,7 +33,7 @@ every_n_epoch = 1
 
 
 @rank_zero_only
-def _autolog(log_every_n_epoch=1, log_models=True):
+def _create_patch_fit(log_every_n_epoch=1, log_models=True):
     """
     Enable automatic logging from pytorch to MLflow.
     Logs loss and any other metrics specified in the fit
@@ -225,4 +223,4 @@ def _autolog(log_every_n_epoch=1, log_models=True):
         """
         return _run_and_log_function(self, original, args, kwargs)
 
-    safe_patch(FLAVOR_NAME, pl.Trainer, "fit", fit, manage_run=True)
+    return fit

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -37,11 +37,7 @@ every_n_epoch = 1
 
 
 @rank_zero_only
-@experimental
-@autologging_integration(FLAVOR_NAME)
-def _autolog(
-    log_every_n_epoch=1, log_models=True, disable=False
-):  # pylint: disable=unused-argument
+def _autolog(log_every_n_epoch=1, log_models=True):
     """
     Enable automatic logging from pytorch to MLflow.
     Logs loss and any other metrics specified in the fit
@@ -55,8 +51,6 @@ def _autolog(
                        are logged after every epoch.
     :param log_models: If ``True``, trained models are logged as MLflow model artifacts.
                        If ``False``, trained models are not logged.
-    :param disable: If ``True``, disables all supported autologging integrations. If ``False``,
-                    enables all supported autologging integrations.
     """
     global every_n_epoch
     every_n_epoch = log_every_n_epoch

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -407,8 +407,12 @@ def exception_safe_function(function):
     return safe_function
 
 
-def _create_exception_safe_class(base):
-    class _ExceptionSafeClass(base):
+def _exception_safe_class_factory(base_class):
+    """
+    Creates an exception safe class that inherits from `base_class`.
+    """
+
+    class _ExceptionSafeClass(base_class):
         """
         Metaclass that wraps all functions defined on the specified class with broad error handling
         logic to guard against unexpected errors during autlogging.
@@ -427,13 +431,13 @@ def _create_exception_safe_class(base):
             for m in dct:
                 if callable(dct[m]):
                     dct[m] = exception_safe_function(dct[m])
-            return base.__new__(cls, name, bases, dct)
+            return base_class.__new__(cls, name, bases, dct)
 
     return _ExceptionSafeClass
 
 
-ExceptionSafeClass = _create_exception_safe_class(type)
-ExceptionSafeAbstractClass = _create_exception_safe_class(abc.ABCMeta)
+ExceptionSafeClass = _exception_safe_class_factory(type)
+ExceptionSafeAbstractClass = _exception_safe_class_factory(abc.ABCMeta)
 
 
 class PatchFunction:

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -409,7 +409,7 @@ def exception_safe_function(function):
 
 def _exception_safe_class_factory(base_class):
     """
-    Creates an exception safe class that inherits from `base_class`.
+    Creates an exception safe metaclass that inherits from `base_class`.
     """
 
     class _ExceptionSafeClass(base_class):

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -437,6 +437,25 @@ def _exception_safe_class_factory(base_class):
 
 
 ExceptionSafeClass = _exception_safe_class_factory(type)
+
+# `ExceptionSafeClass` causes an error when used with an abstract class.
+#
+# ```
+# class AbstractClass(abc.ABC):
+#    ...
+#
+# class MyClass(AbstractClass, metaclass=ExceptionSafeClass):
+#    ...
+# ```
+#
+# This raises:
+#
+# ```
+# TypeError: metaclass conflict: the metaclass of a derived class must be
+#            a (non-strict) subclass of the metaclasses of all its bases.
+# ```
+#
+# To avoid this error, create `ExceptionSafeAbstractClass` that is based on `abc.ABCMeta`.
 ExceptionSafeAbstractClass = _exception_safe_class_factory(abc.ABCMeta)
 
 

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -417,11 +417,11 @@ def _exception_safe_class_factory(base_class):
         Metaclass that wraps all functions defined on the specified class with broad error handling
         logic to guard against unexpected errors during autlogging.
 
-        Rationale: Patched autologging functions commonly pass additional class instances as arguments
-        to their underlying original training routines; for example, Keras autologging constructs
-        a subclass of `keras.callbacks.Callback` and forwards it to `Model.fit()`. To prevent errors
-        encountered during method execution within such classes from disrupting model training,
-        this metaclass wraps all class functions in a broad try / catch statement.
+        Rationale: Patched autologging functions commonly pass additional class instances as
+        arguments to their underlying original training routines; for example, Keras autologging
+        constructs a subclass of `keras.callbacks.Callback` and forwards it to `Model.fit()`.
+        To prevent errors encountered during method execution within such classes from disrupting
+        model training, this metaclass wraps all class functions in a broad try / catch statement.
 
         Note: `ExceptionSafeClass` does not handle exceptions in class methods or static methods,
         as these are not always Python callables and are difficult to wrap

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -408,7 +408,7 @@ def exception_safe_function(function):
 
 
 def _create_exception_safe_class(base):
-    class ExceptionSafeClass(base):
+    class _ExceptionSafeClass(base):
         """
         Metaclass that wraps all functions defined on the specified class with broad error handling
         logic to guard against unexpected errors during autlogging.
@@ -429,7 +429,7 @@ def _create_exception_safe_class(base):
                     dct[m] = exception_safe_function(dct[m])
             return base.__new__(cls, name, bases, dct)
 
-    return ExceptionSafeClass
+    return _ExceptionSafeClass
 
 
 ExceptionSafeClass = _create_exception_safe_class(type)

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -444,7 +444,7 @@ ExceptionSafeClass = _exception_safe_class_factory(type)
 # class AbstractClass(abc.ABC):
 #    ...
 #
-# class MyClass(AbstractClass, metaclass=ExceptionSafeClass):
+# class DerivedClass(AbstractClass, metaclass=ExceptionSafeClass):
 #    ...
 # ```
 #

--- a/pylintrc
+++ b/pylintrc
@@ -147,6 +147,7 @@ disable=print-statement,
         # redefined-outer-name disabled to avoid linting errors when using pytest fixtures
         # (see https://stackoverflow.com/questions/46089480/pytest-fixtures-redefining-name-from-outer-scope-pylint)
         redefined-outer-name,
+        # Ignore errors raised against `ExceptionSafeClass` and `ExceptionSafeAbstractClass`
         invalid-metaclass,
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/pylintrc
+++ b/pylintrc
@@ -147,6 +147,7 @@ disable=print-statement,
         # redefined-outer-name disabled to avoid linting errors when using pytest fixtures
         # (see https://stackoverflow.com/questions/46089480/pytest-fixtures-redefining-name-from-outer-scope-pylint)
         redefined-outer-name,
+        invalid-metaclass,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/tests/autologging/test_autologging_safety_integration.py
+++ b/tests/autologging/test_autologging_safety_integration.py
@@ -21,6 +21,7 @@ AUTOLOGGING_INTEGRATIONS_TO_TEST = {
     mlflow.keras: "keras",
     mlflow.xgboost: "xgboost",
     mlflow.lightgbm: "lightgbm",
+    mlflow.pytorch: "torch",
 }
 
 

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -463,7 +463,7 @@ def test_exception_safe_function_exhibits_expected_behavior_in_test_mode():
 
 
 @pytest.mark.parametrize(
-    "baseclass,metaclass", [(object, ExceptionSafeClass), (abc.ABC, ExceptionSafeAbstractClass)]
+    "baseclass, metaclass", [(object, ExceptionSafeClass), (abc.ABC, ExceptionSafeAbstractClass)]
 )
 def test_exception_safe_class_exhibits_expected_behavior_in_standard_mode(baseclass, metaclass):
     assert not autologging_utils._is_testing()
@@ -492,7 +492,7 @@ def test_exception_safe_class_exhibits_expected_behavior_in_standard_mode(basecl
 
 @pytest.mark.usefixtures(test_mode_on.__name__)
 @pytest.mark.parametrize(
-    "baseclass,metaclass", [(object, ExceptionSafeClass), (abc.ABC, ExceptionSafeAbstractClass)]
+    "baseclass, metaclass", [(object, ExceptionSafeClass), (abc.ABC, ExceptionSafeAbstractClass)]
 )
 def test_exception_safe_class_exhibits_expected_behavior_in_test_mode(baseclass, metaclass):
     assert autologging_utils._is_testing()
@@ -741,7 +741,7 @@ def test_validate_args_throws_when_extra_args_are_not_exception_safe():
 
 @pytest.mark.usefixtures(test_mode_on.__name__)
 @pytest.mark.parametrize(
-    "baseclass,metaclass", [(object, ExceptionSafeClass), (abc.ABC, ExceptionSafeAbstractClass)]
+    "baseclass, metaclass", [(object, ExceptionSafeClass), (abc.ABC, ExceptionSafeAbstractClass)]
 )
 def test_validate_args_succeeds_when_extra_args_are_exception_safe_functions_or_classes(
     baseclass, metaclass

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1,5 +1,6 @@
 # pylint: disable=unused-argument
 
+import abc
 import copy
 import inspect
 import os
@@ -15,6 +16,7 @@ from mlflow.utils.autologging_utils import (
     autologging_integration,
     exception_safe_function,
     ExceptionSafeClass,
+    ExceptionSafeAbstractClass,
     PatchFunction,
     with_managed_run,
     _validate_args,
@@ -460,10 +462,13 @@ def test_exception_safe_function_exhibits_expected_behavior_in_test_mode():
     assert exc.value == exc_to_throw
 
 
-def test_exception_safe_class_exhibits_expected_behavior_in_standard_mode():
+@pytest.mark.parametrize(
+    "baseclass,metaclass", [(object, ExceptionSafeClass), (abc.ABC, ExceptionSafeAbstractClass)]
+)
+def test_exception_safe_class_exhibits_expected_behavior_in_standard_mode(baseclass, metaclass):
     assert not autologging_utils._is_testing()
 
-    class NonThrowingClass(metaclass=ExceptionSafeClass):
+    class NonThrowingClass(baseclass, metaclass=metaclass):
         def function(self):
             return 10
 
@@ -471,7 +476,7 @@ def test_exception_safe_class_exhibits_expected_behavior_in_standard_mode():
 
     exc_to_throw = Exception("function error")
 
-    class ThrowingClass(metaclass=ExceptionSafeClass):
+    class ThrowingClass(baseclass, metaclass=metaclass):
         def function(self):
             raise exc_to_throw
 
@@ -486,10 +491,13 @@ def test_exception_safe_class_exhibits_expected_behavior_in_standard_mode():
 
 
 @pytest.mark.usefixtures(test_mode_on.__name__)
-def test_exception_safe_class_exhibits_expected_behavior_in_test_mode():
+@pytest.mark.parametrize(
+    "baseclass,metaclass", [(object, ExceptionSafeClass), (abc.ABC, ExceptionSafeAbstractClass)]
+)
+def test_exception_safe_class_exhibits_expected_behavior_in_test_mode(baseclass, metaclass):
     assert autologging_utils._is_testing()
 
-    class NonThrowingClass(metaclass=ExceptionSafeClass):
+    class NonThrowingClass(baseclass, metaclass=metaclass):
         def function(self):
             return 10
 
@@ -497,7 +505,7 @@ def test_exception_safe_class_exhibits_expected_behavior_in_test_mode():
 
     exc_to_throw = Exception("function error")
 
-    class ThrowingClass(metaclass=ExceptionSafeClass):
+    class ThrowingClass(baseclass, metaclass=metaclass):
         def function(self):
             raise exc_to_throw
 
@@ -732,13 +740,18 @@ def test_validate_args_throws_when_extra_args_are_not_exception_safe():
 
 
 @pytest.mark.usefixtures(test_mode_on.__name__)
-def test_validate_args_succeeds_when_extra_args_are_exception_safe_functions_or_classes():
+@pytest.mark.parametrize(
+    "baseclass,metaclass", [(object, ExceptionSafeClass), (abc.ABC, ExceptionSafeAbstractClass)]
+)
+def test_validate_args_succeeds_when_extra_args_are_exception_safe_functions_or_classes(
+    baseclass, metaclass
+):
     user_call_args = (1, "b", ["c"])
     user_call_kwargs = {
         "foo": ["bar"],
     }
 
-    class Safe(metaclass=ExceptionSafeClass):
+    class Safe(baseclass, metaclass=metaclass):
         pass
 
     autologging_call_args = copy.deepcopy(user_call_args)


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Add autologging safety utils to pytorch integration

## How is this patch tested?

Existing unit tests.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
