### PR TITLE
fix a bug with attributes of MLflow model flavor in R

### DIFF
--- a/mlflow/R/mlflow/R/model.R
+++ b/mlflow/R/mlflow/R/model.R
@@ -106,7 +106,7 @@ mlflow_load_model <- function(model_uri, flavor = NULL, client = mlflow_client()
     flavor <- available_flavors[[1]]
   }
 
-  flavor <- mlflow_flavor(flavor, spec[[flavor]])
+  flavor <- mlflow_flavor(flavor, spec$flavors[[flavor]])
   mlflow_load_flavor(flavor, model_path)
 }
 

--- a/mlflow/R/mlflow/tests/testthat.R
+++ b/mlflow/R/mlflow/tests/testthat.R
@@ -1,3 +1,21 @@
+# `trivial` is a fictional MLflow flavor that exists only for unit test purposes
+
+mlflow_save_model.trivial <- function(model, path, model_spec = list(), ...) {
+  if (dir.exists(path)) unlink(path, recursive = TRUE)
+  dir.create(path, recursive = TRUE)
+  path <- normalizePath(path)
+
+  trivial_conf = list(
+    trivial = list(type = "trivial")
+  )
+  model_spec$flavors <- c(model_spec$flavors, trivial_conf)
+  mlflow:::mlflow_write_model_spec(path, model_spec)
+}
+
+mlflow_load_flavor.mlflow_flavor_trivial <- function(flavor, model_path) {
+  list(flavor = flavor)
+}
+
 library(testthat)
 library(mlflow)
 

--- a/mlflow/R/mlflow/tests/testthat.R
+++ b/mlflow/R/mlflow/tests/testthat.R
@@ -1,4 +1,4 @@
-# `trivial` is a fictional MLflow flavor that exists only for unit test purposes
+# `trivial` is a dummy MLflow flavor that exists only for unit testing purposes
 
 mlflow_save_model.trivial <- function(model, path, model_spec = list(), ...) {
   if (dir.exists(path)) unlink(path, recursive = TRUE)
@@ -6,7 +6,7 @@ mlflow_save_model.trivial <- function(model, path, model_spec = list(), ...) {
   path <- normalizePath(path)
 
   trivial_conf = list(
-    trivial = list(type = "trivial")
+    trivial = list(key1 = "value1", key2 = "value2")
   )
   model_spec$flavors <- c(model_spec$flavors, trivial_conf)
   mlflow:::mlflow_write_model_spec(path, model_spec)

--- a/mlflow/R/mlflow/tests/testthat/test-model.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model.R
@@ -116,5 +116,6 @@ test_that("mlflow can save and load attributes of model flavor correctly", {
   mlflow_save_model(model, path = path)
   model <- mlflow_load_model(path)
 
-  expect_equal(attributes(model$flavor)$spec$type, "trivial")
+  expect_equal(attributes(model$flavor)$spec$key1, "value1")
+  expect_equal(attributes(model$flavor)$spec$key2, "value2")
 })

--- a/mlflow/R/mlflow/tests/testthat/test-model.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model.R
@@ -108,3 +108,13 @@ test_that("mlflow log model records correct metadata with the tracking server", 
     expect_equal(model_spec_expected$flavors, model_spec_actual$flavors)
   })
 })
+
+test_that("mlflow can save and load attributes of model flavor correctly", {
+  model_name <- basename(tempfile("model_"))
+  model <- structure(list(), class = "trivial")
+  path <- file.path(tempdir(), model_name)
+  mlflow_save_model(model, path = path)
+  model <- mlflow_load_model(path)
+
+  expect_equal(attributes(model$flavor)$spec$type, "trivial")
+})


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>

## What changes are proposed in this pull request?

This PR fixes a bug with how metadata associated with a MLflow model flavor is loaded in R.

We don't make use of such metadata in R yet, but it will become something that is useful in future.

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
