### PR TITLE
Add info-level logs when new fluent runs are during autologging

### DIFF
--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -896,6 +896,10 @@ def autolog(
         if not mlflow.active_run():
             global _AUTOLOG_RUN_ID
             if _AUTOLOG_RUN_ID:
+                _logger.info(
+                    "Logging TensorFlow Estimator as MLflow Model to run with ID '%s'",
+                    _AUTOLOG_RUN_ID
+                )
                 try_mlflow_log(mlflow.start_run, _AUTOLOG_RUN_ID)
             else:
                 try_mlflow_log(create_autologging_run)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -889,7 +889,7 @@ def autolog(
             _logger.info(
                 "Created MLflow autologging run with ID '%s', which will store the TensorFlow"
                 " model in MLflow Model format",
-                autologging_run.info.run_id, 
+                autologging_run.info.run_id,
             )
 
         auto_end = False

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -884,14 +884,21 @@ def autolog(
         return result
 
     def export_saved_model(original, self, *args, **kwargs):
+        def create_autologging_run():
+            autologging_run = mlflow.start_run(tags={MLFLOW_AUTOLOGGING: FLAVOR_NAME})
+            _logger.info(
+                "Created MLflow autologging run with ID '%s', which will store the TensorFlow"
+                " model in MLflow Model format",
+                autologging_run.info.run_id, 
+            )
+
         auto_end = False
         if not mlflow.active_run():
             global _AUTOLOG_RUN_ID
             if _AUTOLOG_RUN_ID:
                 try_mlflow_log(mlflow.start_run, _AUTOLOG_RUN_ID)
             else:
-                try_mlflow_log(mlflow.start_run)
-                try_mlflow_log(mlflow.set_tag, MLFLOW_AUTOLOGGING, FLAVOR_NAME)
+                try_mlflow_log(create_autologging_run)
                 auto_end = True
 
         serialized = original(self, *args, **kwargs)
@@ -902,32 +909,6 @@ def autolog(
             tf_signature_def_key="predict",
             artifact_path="model",
         )
-        if (
-            mlflow.active_run() is not None and mlflow.active_run().info.run_id == _AUTOLOG_RUN_ID
-        ) or auto_end:
-            try_mlflow_log(mlflow.end_run)
-        return serialized
-
-    def export_savedmodel(original, self, *args, **kwargs):
-        auto_end = False
-        if not mlflow.active_run():
-            global _AUTOLOG_RUN_ID
-            if _AUTOLOG_RUN_ID:
-                try_mlflow_log(mlflow.start_run, _AUTOLOG_RUN_ID)
-            else:
-                try_mlflow_log(mlflow.start_run)
-                try_mlflow_log(mlflow.set_tag, MLFLOW_AUTOLOGGING, FLAVOR_NAME)
-                auto_end = True
-
-        serialized = original(self, *args, **kwargs)
-        try_mlflow_log(
-            log_model,
-            tf_saved_model_dir=serialized.decode("utf-8"),
-            tf_meta_graph_tags=[tag_constants.SERVING],
-            tf_signature_def_key="predict",
-            artifact_path="model",
-        )
-
         if (
             mlflow.active_run() is not None and mlflow.active_run().info.run_id == _AUTOLOG_RUN_ID
         ) or auto_end:
@@ -1131,7 +1112,7 @@ def autolog(
 
     non_managed = [
         (tensorflow.estimator.Estimator, "export_saved_model", export_saved_model),
-        (tensorflow.estimator.Estimator, "export_savedmodel", export_savedmodel),
+        (tensorflow.estimator.Estimator, "export_savedmodel", export_saved_model),
     ]
 
     for p in managed:

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -898,7 +898,7 @@ def autolog(
             if _AUTOLOG_RUN_ID:
                 _logger.info(
                     "Logging TensorFlow Estimator as MLflow Model to run with ID '%s'",
-                    _AUTOLOG_RUN_ID
+                    _AUTOLOG_RUN_ID,
                 )
                 try_mlflow_log(mlflow.start_run, _AUTOLOG_RUN_ID)
             else:

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -577,7 +577,6 @@ def with_managed_run(integration, patch_function, tags=None):
             def _patch_implementation(self, original, *args, **kwargs):
                 if not mlflow.active_run():
                     self.managed_run = try_mlflow_log(create_managed_run)
-                    _logger.info(autologging_run_creation_log_message, mlflow.active_)
 
                 result = super(PatchWithManagedRun, self)._patch_implementation(
                     original, *args, **kwargs

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -567,6 +567,15 @@ def with_managed_run(integration, patch_function, tags=None):
         )
         return managed_run
 
+    def print_autologging_info_for_active_run(active_run):
+        _logger.info(
+            "%s autologging will track hyperparameters, performance metrics, model artifacts,"
+            " and lineage information for this %s workflow to the MLflow run with ID '%s'",
+            integration,
+            integration,
+            active_run.info.run_id,
+        )
+
     if inspect.isclass(patch_function):
 
         class PatchWithManagedRun(patch_function):
@@ -577,6 +586,8 @@ def with_managed_run(integration, patch_function, tags=None):
             def _patch_implementation(self, original, *args, **kwargs):
                 if not mlflow.active_run():
                     self.managed_run = try_mlflow_log(create_managed_run)
+                else:
+                    print_autologging_info_for_active_run(mlflow.active_run())
 
                 result = super(PatchWithManagedRun, self)._patch_implementation(
                     original, *args, **kwargs
@@ -600,6 +611,8 @@ def with_managed_run(integration, patch_function, tags=None):
             managed_run = None
             if not mlflow.active_run():
                 managed_run = try_mlflow_log(create_managed_run)
+            else:
+                print_autologging_info_for_active_run(mlflow.active_run())
 
             try:
                 result = patch_function(original, *args, **kwargs)

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -561,7 +561,8 @@ def with_managed_run(integration, patch_function, tags=None):
         managed_run = mlflow.start_run(tags=tags)
         _logger.info(
             "Created MLflow autologging run with ID '%s', which will track hyperparameters,"
-            " performance metrics, model artifacts, and lineage information for this %s workflow",
+            " performance metrics, model artifacts, and lineage information for the"
+            " current %s workflow",
             managed_run.info.run_id,
             integration,
         )
@@ -570,7 +571,7 @@ def with_managed_run(integration, patch_function, tags=None):
     def print_autologging_info_for_active_run(active_run):
         _logger.info(
             "%s autologging will track hyperparameters, performance metrics, model artifacts,"
-            " and lineage information for this %s workflow to the MLflow run with ID '%s'",
+            " and lineage information for the current %s workflow to the MLflow run with ID '%s'",
             integration,
             integration,
             active_run.info.run_id,

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -556,12 +556,14 @@ def with_managed_run(integration, patch_function, tags=None):
     :param tags: A dictionary of string tags to set on each managed run created during the
                  execution of `patch_function`.
     """
+
     def create_managed_run():
         managed_run = mlflow.start_run(tags=tags)
         _logger.info(
             "Created MLflow autologging run with ID '%s', which will track hyperparameters,"
             " performance metrics, model artifacts, and lineage information for this %s workflow",
-            managed_run.info.run_id, integration
+            managed_run.info.run_id,
+            integration,
         )
         return managed_run
 

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -682,8 +682,8 @@ def test_with_managed_runs_yields_functions_and_classes_as_expected():
         def _on_exception(self, exception):
             pass
 
-    assert callable(with_managed_run(patch_function))
-    assert inspect.isclass(with_managed_run(TestPatch))
+    assert callable(with_managed_run("test_integration", patch_function))
+    assert inspect.isclass(with_managed_run("test_integration", TestPatch))
 
 
 def test_with_managed_run_with_non_throwing_function_exhibits_expected_behavior():
@@ -709,11 +709,12 @@ def test_with_managed_run_with_throwing_function_exhibits_expected_behavior():
     client = MlflowClient()
     patch_function_active_run = None
 
-    @with_managed_run
     def patch_function(original, *args, **kwargs):
         nonlocal patch_function_active_run
         patch_function_active_run = mlflow.active_run()
         raise Exception("bad implementation")
+
+    patch_function = with_managed_run("test_integration", patch_function)
 
     with pytest.raises(Exception):
         patch_function(lambda: "foo")
@@ -734,13 +735,14 @@ def test_with_managed_run_with_throwing_function_exhibits_expected_behavior():
 def test_with_managed_run_with_non_throwing_class_exhibits_expected_behavior():
     client = MlflowClient()
 
-    @with_managed_run
     class TestPatch(PatchFunction):
         def _patch_implementation(self, original, *args, **kwargs):
             return mlflow.active_run()
 
         def _on_exception(self, exception):
             pass
+
+    TestPatch = with_managed_run("test_integration", TestPatch)
 
     run1 = TestPatch.call(lambda: "foo")
     run1_status = client.get_run(run1.info.run_id).info.status
@@ -758,7 +760,6 @@ def test_with_managed_run_with_throwing_class_exhibits_expected_behavior():
     client = MlflowClient()
     patch_function_active_run = None
 
-    @with_managed_run
     class TestPatch(PatchFunction):
         def _patch_implementation(self, original, *args, **kwargs):
             nonlocal patch_function_active_run
@@ -767,6 +768,8 @@ def test_with_managed_run_with_throwing_class_exhibits_expected_behavior():
 
         def _on_exception(self, exception):
             pass
+
+    TestPatch = with_managed_run("test_integration", TestPatch)
 
     with pytest.raises(Exception):
         TestPatch.call(lambda: "foo")
@@ -792,7 +795,7 @@ def test_with_managed_run_sets_specified_run_tags():
     }
 
     patch_function_1 = with_managed_run(
-        lambda original, *args, **kwargs: mlflow.active_run(), tags=tags_to_set
+        "test_integration", lambda original, *args, **kwargs: mlflow.active_run(), tags=tags_to_set
     )
     run1 = patch_function_1(lambda: "foo")
     assert tags_to_set.items() <= client.get_run(run1.info.run_id).data.tags.items()
@@ -804,7 +807,7 @@ def test_with_managed_run_sets_specified_run_tags():
         def _on_exception(self, exception):
             pass
 
-    patch_function_2 = with_managed_run(PatchFunction2, tags=tags_to_set)
+    patch_function_2 = with_managed_run("test_integration", PatchFunction2, tags=tags_to_set)
     run2 = patch_function_2.call(lambda: "foo")
     assert tags_to_set.items() <= client.get_run(run2.info.run_id).data.tags.items()
 

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -956,9 +956,10 @@ def test_with_managed_runs_yields_functions_and_classes_as_expected():
 def test_with_managed_run_with_non_throwing_function_exhibits_expected_behavior():
     client = MlflowClient()
 
-    @with_managed_run
     def patch_function(original, *args, **kwargs):
         return mlflow.active_run()
+
+    patch_function = with_managed_run("test_integration", patch_function)
 
     run1 = patch_function(lambda: "foo")
     run1_status = client.get_run(run1.info.run_id).info.status


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds some additional info logging to indicate when MLflow runs are created as a result of autologging workflows.

## How is this patch tested?

Existing unit / integration tests for continued correctness

## Release Notes

Added new info logs for MLflow run creation during autologging workflows.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
