### PR TITLE
updated the _load_model to be compatible to fastai_v2

### DIFF
--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -305,11 +305,14 @@ def log_model(
 
 
 def _load_model(path):
-    from fastai.basic_train import load_learner
+    from fastai.learner import load_learner
+
 
     abspath = os.path.abspath(path)
-    path, file = os.path.split(abspath)
-    return load_learner(path, file)
+    
+    # fastaiV2 load_learner function takes only the fname path
+    # For detail please see https://docs.fast.ai/learner.html#load_learner
+    return load_learner(abspath)
 
 
 class _FastaiModelWrapper:


### PR DESCRIPTION
Problem: 
Currenly with fastaiv2, the original funcion would yield: ModuleNotFoundError: No module named 'fastai.basic_train'

Solution:
fastaiv2's load_learner (called within _load_model function) function takes only the fname path
For detail please see https://docs.fast.ai/learner.html#load_learner

## What changes are proposed in this pull request?

Updated the new load_learner function and changed the parameter passed in it.

## How is this patch tested?

Tested on personal use cases.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
