### PR TITLE
Fix formatting / stack trace level for missing value schema inference

### DIFF
--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -93,7 +93,7 @@ def _infer_schema(data: Any) -> Schema:
     if any([t in (DataType.integer, DataType.long) for t in schema.column_types()]):
         warnings.warn(
             "Hint: Inferred schema contains integer column(s). Integer columns in "
-            "Python can  not represent missing values. If your input data contains"
+            "Python can  not represent missing values. If your input data contains "
             "missing values at inference time, it will be encoded as floats and will "
             "cause a schema enforcement error. The best way to avoid this problem is "
             "to infer the model schema based on a realistic data sample (training "
@@ -101,7 +101,8 @@ def _infer_schema(data: Any) -> Schema:
             "integer columns as doubles (float64) whenever these columns may have "
             "missing values. See `Handling Integers With Missing Values "
             "<https://www.mlflow.org/docs/latest/models.html#"
-            "handling-integers-with-missing-values>`_ for more details."
+            "handling-integers-with-missing-values>`_ for more details.",
+            stacklevel=2,
         )
     return schema
 

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -93,7 +93,7 @@ def _infer_schema(data: Any) -> Schema:
     if any([t in (DataType.integer, DataType.long) for t in schema.column_types()]):
         warnings.warn(
             "Hint: Inferred schema contains integer column(s). Integer columns in "
-            "Python can  not represent missing values. If your input data contains "
+            "Python cannot represent missing values. If your input data contains "
             "missing values at inference time, it will be encoded as floats and will "
             "cause a schema enforcement error. The best way to avoid this problem is "
             "to infer the model schema based on a realistic data sample (training "


### PR DESCRIPTION
Signed-off-by: Corey Zumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Fix formatting / stack trace level for missing value schema inference

## How is this patch tested?

Existing unit / integration tests

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
