### PR TITLE
Pin the version of mlflow in the databricks job to the same version as that of the client

### DIFF
--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -25,7 +25,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_DATABRICKS_WEBAPP_URL,
 )
 from mlflow.utils.uri import is_databricks_uri, is_http_uri
-from mlflow.version import VERSION
+from mlflow.version import is_release_version, VERSION
 
 # Base directory within driver container for storing files related to MLflow
 DB_CONTAINER_BASE = "/databricks/mlflow"
@@ -193,10 +193,16 @@ class DatabricksJobRunner(object):
                  Databricks
                  `Runs Get <https://docs.databricks.com/api/latest/jobs.html#runs-get>`_ API.
         """
-        # NB: We use <= on the version specifier to allow running projects on pre-release
-        # versions, where we will select the most up-to-date mlflow version available.
-        # Also note, that we escape this so '<' is not treated as a shell pipe.
-        libraries = [{"pypi": {"package": "'mlflow<=%s'" % VERSION}}]
+        if is_release_version():
+            libraries = [{"pypi": {"package": "'mlflow==%s'" % VERSION}}]
+        else:
+            # When running a non-release version as the client the same version will not be available
+            # within Databricks. Therefore, fallback to the default version by the runtime.
+            _logger.warning(("Your client is running a non-release version of MLFlow. "
+                             "This version is not avaialable on the databricks runtime. "
+                             "MLFlow will fallback the MLFlow version provided by the runtime. "
+                             "This might lead to unforeseen issues. "))
+            libraries = [{"pypi": {"package": "'mlflow<=%s'" % VERSION}}]
 
         # Check syntax of JSON - if it contains libraries and new_cluster, pull those out
         if "new_cluster" in cluster_spec:

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -194,7 +194,7 @@ class DatabricksJobRunner(object):
                  `Runs Get <https://docs.databricks.com/api/latest/jobs.html#runs-get>`_ API.
         """
         if is_release_version():
-            libraries = [{"pypi": {"package": "'mlflow==%s'" % VERSION}}]
+            libraries = [{"pypi": {"package": "mlflow==%s" % VERSION}}]
         else:
             # When running a non-release version as the client the same version will not be
             # available within Databricks.

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -196,12 +196,16 @@ class DatabricksJobRunner(object):
         if is_release_version():
             libraries = [{"pypi": {"package": "'mlflow==%s'" % VERSION}}]
         else:
-            # When running a non-release version as the client the same version will not be available
-            # within Databricks. Therefore, fallback to the default version by the runtime.
-            _logger.warning(("Your client is running a non-release version of MLFlow. "
-                             "This version is not avaialable on the databricks runtime. "
-                             "MLFlow will fallback the MLFlow version provided by the runtime. "
-                             "This might lead to unforeseen issues. "))
+            # When running a non-release version as the client the same version will not be
+            # available within Databricks.
+            _logger.warning(
+                (
+                    "Your client is running a non-release version of MLFlow. "
+                    "This version is not avaialable on the databricks runtime. "
+                    "MLFlow will fallback the MLFlow version provided by the runtime. "
+                    "This might lead to unforeseen issues. "
+                )
+            )
             libraries = [{"pypi": {"package": "'mlflow<=%s'" % VERSION}}]
 
         # Check syntax of JSON - if it contains libraries and new_cluster, pull those out

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,4 +1,9 @@
 # Copyright 2018 Databricks, Inc.
+import re
 
 
 VERSION = "1.12.2.dev0"
+
+
+def is_release_version():
+    return re.match(r"^\d+\.\d+\.\d+$", VERSION)

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -6,4 +6,4 @@ VERSION = "1.12.2.dev0"
 
 
 def is_release_version():
-    return re.match(r"^\d+\.\d+\.\d+$", VERSION)
+    return bool(re.match(r"^\d+\.\d+\.\d+$", VERSION))

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -2,8 +2,8 @@ from mlflow import version
 
 
 def test_is_release_version(monkeypatch):
-    monkeypatch.setattr(version, 'VERSION', '1.19.0')
-    assert version.is_release_version() == True
+    monkeypatch.setattr(version, "VERSION", "1.19.0")
+    assert version.is_release_version()
 
-    monkeypatch.setattr(version, 'VERSION', '1.19.0.dev0')
-    assert version.is_release_version() == False
+    monkeypatch.setattr(version, "VERSION", "1.19.0.dev0")
+    assert not version.is_release_version()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,9 @@
+from mlflow import version
+
+
+def test_is_release_version(monkeypatch):
+    monkeypatch.setattr(version, 'VERSION', '1.19.0')
+    assert version.is_release_version() == True
+
+    monkeypatch.setattr(version, 'VERSION', '1.19.0.dev0')
+    assert version.is_release_version() == False


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR ensures that the version of MLFlow used to start the run on the Databricks cluster is the same version as that of the client used to kick off the run. This prevents bugs caused by version discrepancies and would resolve #3787.

## How is this patch tested?

Unittests are added for newly added utility methods related to the version type. Changes in the Databricks backend are tested by submitting jobs to Databricks (one while mimicking a "release" version of MLFlow)

## Release Notes

Consolidate versions of the client, the Databricks runtime and the project while running a project using the Databricks backend.

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
