### PR TITLE
Autologging: Add context to MLflow warnings raised by patch implementations

### DIFF
--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -387,8 +387,6 @@ def _is_testing():
         - Disables exception handling for patched function logic, ensuring that patch code
           executes without errors during testing
     """
-    import os
-
     return os.environ.get(_AUTOLOGGING_TEST_MODE_ENV_VAR, "false") == "true"
 
 

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -1066,6 +1066,8 @@ def _augment_mlflow_warnings(autologging_integration):
     def autologging_showwarning(message, category, filename, lineno, *args, **kwargs):
         mlflow_root_path = Path(os.path.dirname(mlflow.__file__)).resolve()
         warning_source_path = Path(filename).resolve()
+        # If the warning's source file is contained within the MLflow package's base
+        # directory, it is an MLflow warning and should be emitted via `logger.warning`
         if mlflow_root_path in warning_source_path.parents:
             _logger.warning(
                 "MLflow issued a warning during %s autologging:" ' "%s:%d: %s: %s"',
@@ -1076,7 +1078,7 @@ def _augment_mlflow_warnings(autologging_integration):
                 message,
             )
         else:
-            original_showwarning(message, category, filename, *args, **kwargs)
+            original_showwarning(message, category, filename, lineno, *args, **kwargs)
 
     try:
         # NB: Reassigning `warnings.showwarning` is the standard / recommended approach for

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -919,7 +919,7 @@ def safe_patch(
 
         with _augment_mlflow_warnings(
             autologging_integration
-        ), _AutologgingSessionManager.start_session(autologging_integration):
+        ), _AutologgingSessionManager.start_session(autologging_integration) as session:
             try:
 
                 def call_original(*og_args, **og_kwargs):

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -691,7 +691,7 @@ def safe_patch(
         # The active MLflow run (if any) associated with patch code execution
         patch_function_run_for_testing = None
 
-        with _redirect_mlflow_warnings(
+        with _augment_mlflow_warnings(
             autologging_integration
         ), _AutologgingSessionManager.start_session(autologging_integration):
             try:

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -1051,7 +1051,7 @@ def _augment_mlflow_warnings(autologging_integration):
     they result from the autologging patch implementation, rather than a user-facing API call.
 
     Accordingly, this context manager is designed to augment MLflow warnings issued during
-    autologging patch code execution, explaining the warnings were raised as a result of
+    autologging patch code execution, explaining that such warnings were raised as a result of
     MLflow's autologging implementation. MLflow warnings are also redirected from `sys.stderr`
     to an MLflow logger with level WARNING. Warnings issued by code outside of MLflow are
     not modified. When the context manager exits, the original output behavior for MLflow warnings

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -867,7 +867,6 @@ def test_safe_patch_succeeds_when_event_logging_throws_in_standard_mode(
     assert patch_postamble_called
     expected_calls = ["patch_start", "original_start", "original_success", "patch_success"]
     assert [call.method for call in logger.calls] == expected_calls
->>>>>>> origin/master
 
 
 def test_exception_safe_function_exhibits_expected_behavior_in_standard_mode():

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -552,7 +552,7 @@ def test_safe_patch_augments_mlflow_warnings_and_preserves_others(
 
     This test case verifies that, for user clarity, such MLflow warnings are augmented with
     context about their origin (i.e. MLflow's autologging patch implementation, rather than
-    user behavior).
+    user behavior) during autologging patch code execution.
     """
     mlflow_warning_kwargs = {
         "message": "Mock MLflow warning",

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -787,7 +787,7 @@ def test_safe_patch_augments_mlflow_warnings_and_preserves_others(
     formatting_args = logger_warn_args[1:]
     full_logger_warning = message % formatting_args
     assert "Mock MLflow warning" in full_logger_warning
-    assert str(lineno) in full_logger_warning
+    assert str(7) in full_logger_warning  # Ensure that the warning line number is present
     assert mlflow.__file__ in full_logger_warning
 
     with pytest.warns(UserWarning) as user_warnings_outside_patch:

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -545,6 +545,15 @@ def test_safe_patch_provides_original_function_with_expected_signature(
 def test_safe_patch_augments_mlflow_warnings_and_preserves_others(
     patch_destination, test_autologging_integration
 ):
+    """
+    MLflow routines called by autologging patch code may issue warnings via the `warnings.warn`
+    API. In many cases, the user cannot remediate the cause of these warnings because
+    they result from the autologging patch implementation, rather than a user-facing API call.
+
+    This test case verifies that, for user clarity, such MLflow warnings are augmented with
+    context about their origin (i.e. MLflow's autologging patch implementation, rather than
+    user behavior).
+    """
     mlflow_warning_kwargs = {
         "message": "Mock MLflow warning",
         "category": UserWarning,


### PR DESCRIPTION
## What changes are proposed in this pull request?

MLflow routines called by autologging patch code may issue warnings via the `warnings.warn` API. In many cases, the user cannot remediate the cause of these warnings because they result from the autologging patch implementation, rather than a user-facing API call.

Accordingly, this PR introduces a context manager that is designed to augment MLflow warnings issued during
autologging patch code execution, explaining the warnings were raised as a result of MLflow's autologging implementation. MLflow warnings are also redirected from `sys.stderr` to an MLflow logger with level WARNING. Warnings issued by code outside of MLflow are not modified. When the context manager exits, the original output behavior for MLflow warnings
is restored.

On Databricks, this helps reroute potentially confusing warning messages that may arise during autologging; e.g., warnings about integer columns during schema inference.

**Example - run the following workflow:**

```
import mlflow
mlflow.autolog()

from sklearn import datasets
iris = datasets.load_iris()

from sklearn.linear_model import LogisticRegression
from scipy.stats import uniform

logistic = LogisticRegression(solver="saga", tol=1e-2, max_iter=200, random_state=0)
train_out = logistic.fit(iris.data, iris.target)
```

**Before**:
```
2020/12/21 01:22:43 INFO mlflow.tracking.fluent: Autologging successfully enabled for sklearn.
/Users/czumar/mlflow/mlflow/models/signature.py:124: UserWarning: Hint: Inferred schema contains integer column(s).
 Integer columns in Python cannot represent missing values. If your input data contains missing values at inference time, it
 will be encoded as floats and will cause a schema enforcement error. The best way to avoid this problem is to infer the
 model schema based on a realistic data sample (training dataset) that includes missing values. Alternatively, you can
 declare integer columns as doubles (float64) whenever these columns may have missing values. See `Handling Integers
 With Missing Values <https://www.mlflow.org/docs/latest/models.html#handling-integers-with-missing-values>`_ for more
 details.
 outputs = _infer_schema(model_output) if model_output is not None else None
```

**After**:
```
2020/12/21 01:23:12 INFO mlflow.tracking.fluent: Autologging successfully enabled for sklearn.
2020/12/21 01:23:13 WARNING mlflow.utils.autologging_utils: MLflow issued a warning during sklearn autologging:
 "/Users/czumar/mlflow/mlflow/models/signature.py:124: UserWarning: Hint: Inferred schema contains integer column(s).
 Integer columns in Python cannot represent missing values. If your input data contains missing values at inference time, it
 will be encoded as floats and will cause a schema enforcement error. The best way to avoid this problem is to infer the
 model schema based on a realistic data sample (training dataset) that includes missing values. Alternatively, you can
 declare integer columns as doubles (float64) whenever these columns may have missing values. See `Handling Integers
 With Missing Values <https://www.mlflow.org/docs/latest/models.html#handling-integers-with-missing-values>`_ for more
 details."
```

## How is this patch tested?

New unit tests for warning behavior, existing unit + integration tests for correctness

## Release Notes

Improve clarity of warning messages raised during autologging

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
