### PR TITLE
[CROSS VERSION TEST] Fix regular expression to capture flavor name from changed files

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -195,7 +195,11 @@ def get_changed_flavors(changed_files, flavors):
     ['pytorch', 'xgboost']
     >>> get_changed_flavors(["mlflow/xgboost.py"], flavors)
     ['xgboost']
-    >>> get_changed_flavors(["tests/xgboost/test_xgboost_autolog.py"], flavors)
+    >>> get_changed_flavors(["tests/xgboost/test_xxx.py"], flavors)
+    ['xgboost']
+    >>> get_changed_flavors(["tests/xgboost_autolog/test_xxx.py"], flavors)
+    ['xgboost']
+    >>> get_changed_flavors(["tests/xgboost_autologging/test_xxx.py"], flavors)
     ['xgboost']
     >>> get_changed_flavors(["README.rst"], flavors)
     []
@@ -204,7 +208,10 @@ def get_changed_flavors(changed_files, flavors):
     """
     changed_flavors = []
     for f in changed_files:
-        match = re.search(r"^(mlflow|tests)/(.+?)(\.py|/)", f)
+        pattern = r"^(mlflow|tests)/(.+?)(_autolog(ging)?)?(\.py|/)"
+        #                           ~~~~~
+        #                           # This group captures a flavor name
+        match = re.search(pattern, f)
 
         if (match is not None) and (match.group(2) in flavors):
             changed_flavors.append(match.group(2))


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- A follow-up for the cross version test.
- Curretnly, `get_changed_flavors` in `set_matrix.py` doesn't detect changes on files under `tests/<flavor_name>_autolog` (e.g. tests/keras_autlog) or `tests/<flavor_name>_autologging` (e.g. tests/spark_autologging) because it just expects the format: `tests/<flavor_name>`. This PR fixes this issue by modifying the regular expression to capture a flavor name.

## How is this patch tested?

New doctests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
