### PR TITLE
Expose additional SpaCy functionality when using pyfunc to load model

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -195,7 +195,11 @@ def get_changed_flavors(changed_files, flavors):
     ['pytorch', 'xgboost']
     >>> get_changed_flavors(["mlflow/xgboost.py"], flavors)
     ['xgboost']
-    >>> get_changed_flavors(["tests/xgboost/test_xgboost_autolog.py"], flavors)
+    >>> get_changed_flavors(["tests/xgboost/test_xxx.py"], flavors)
+    ['xgboost']
+    >>> get_changed_flavors(["tests/xgboost_autolog/test_xxx.py"], flavors)
+    ['xgboost']
+    >>> get_changed_flavors(["tests/xgboost_autologging/test_xxx.py"], flavors)
     ['xgboost']
     >>> get_changed_flavors(["README.rst"], flavors)
     []
@@ -204,7 +208,10 @@ def get_changed_flavors(changed_files, flavors):
     """
     changed_flavors = []
     for f in changed_files:
-        match = re.search(r"^(mlflow|tests)/(.+?)(\.py|/)", f)
+        pattern = r"^(mlflow|tests)/(.+?)(_autolog(ging)?)?(\.py|/)"
+        #                           ~~~~~
+        #                           # This group captures a flavor name
+        match = re.search(pattern, f)
 
         if (match is not None) and (match.group(2) in flavors):
             changed_flavors.append(match.group(2))

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -25,7 +25,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_DATABRICKS_WEBAPP_URL,
 )
 from mlflow.utils.uri import is_databricks_uri, is_http_uri
-from mlflow.version import VERSION
+from mlflow.version import is_release_version, VERSION
 
 # Base directory within driver container for storing files related to MLflow
 DB_CONTAINER_BASE = "/databricks/mlflow"
@@ -193,10 +193,20 @@ class DatabricksJobRunner(object):
                  Databricks
                  `Runs Get <https://docs.databricks.com/api/latest/jobs.html#runs-get>`_ API.
         """
-        # NB: We use <= on the version specifier to allow running projects on pre-release
-        # versions, where we will select the most up-to-date mlflow version available.
-        # Also note, that we escape this so '<' is not treated as a shell pipe.
-        libraries = [{"pypi": {"package": "'mlflow<=%s'" % VERSION}}]
+        if is_release_version():
+            libraries = [{"pypi": {"package": "mlflow==%s" % VERSION}}]
+        else:
+            # When running a non-release version as the client the same version will not be
+            # available within Databricks.
+            _logger.warning(
+                (
+                    "Your client is running a non-release version of MLFlow. "
+                    "This version is not avaialable on the databricks runtime. "
+                    "MLFlow will fallback the MLFlow version provided by the runtime. "
+                    "This might lead to unforeseen issues. "
+                )
+            )
+            libraries = [{"pypi": {"package": "'mlflow<=%s'" % VERSION}}]
 
         # Check syntax of JSON - if it contains libraries and new_cluster, pull those out
         if "new_cluster" in cluster_spec:

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -248,7 +248,7 @@ class _SpacyModelWrapper:
         docs = dataframe.iloc[:, 0].apply(lambda text: self.spacy_model(text))
 
         return pd.DataFrame(
-            {"predictions": docs.apply(lambda doc: doc.cats), "docs": docs}
+            {"predictions": docs.apply(lambda doc: doc.cats), "docs": docs.apply(lambda doc: doc.to_json())}
         )
 
 

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -130,26 +130,23 @@ def save_model(
     with open(os.path.join(path, conda_env_subpath), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
+    pyfunc.add_to_model(
+        mlflow_model,
+        loader_module="mlflow.spacy",
+        data=model_data_subpath,
+        env=conda_env_subpath,
+    )
+
     # Save the pyfunc flavor if at least one text categorizer in spaCy pipeline
-    if any(
+    if not any(
         [
             isinstance(pipe_component[1], spacy.pipeline.TextCategorizer)
             for pipe_component in spacy_model.pipeline
         ]
     ):
-        pyfunc.add_to_model(
-            mlflow_model,
-            loader_module="mlflow.spacy",
-            data=model_data_subpath,
-            env=conda_env_subpath,
-        )
-    else:
         _logger.warning(
-            "Generating only the spacy flavor for the provided spacy model. This means the model "
-            "can be loaded back via `mlflow.spacy.load_model`, but cannot be loaded back using "
-            "pyfunc APIs like `mlflow.pyfunc.load_model` or via the `mlflow models` CLI commands. "
-            "MLflow will only generate the pyfunc flavor for spacy models containing a pipeline "
-            "component that is an instance of spacy.pipeline.TextCategorizer."
+            "pyfunc flavor of this spacy models was generated, however non `cats` results "
+            "are not yet accessible in the output of the `predict` method"
         )
 
     mlflow_model.add_flavor(FLAVOR_NAME, spacy_version=spacy.__version__, data=model_data_subpath)

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -229,7 +229,10 @@ class _SpacyModelWrapper:
         :return: dataframe with a column for each of the object keys in `doc.to_json()`
         """
         if len(dataframe.columns) != 1:
-            _logger.warning("Shape of input dataframe expected to be (n_rows, 1_column). Only using the first column.")
+            _logger.warning(
+                "Shape of input dataframe expected to be (n_rows, 1_column). "
+                "Only using the first column."
+            )
 
         # Note: `to_json` returns a `dict`, not a JSON string (https://spacy.io/api/doc#to_json)
         objs = dataframe.iloc[:, 0].apply(lambda text: self.spacy_model(text).to_json())

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -245,8 +245,10 @@ class _SpacyModelWrapper:
         if len(dataframe.columns) != 1:
             raise MlflowException("Shape of input dataframe must be (n_rows, 1column)")
 
+        docs = dataframe.iloc[:, 0].apply(lambda text: self.spacy_model(text))
+
         return pd.DataFrame(
-            {"predictions": dataframe.iloc[:, 0].apply(lambda text: self.spacy_model(text).cats)}
+            {"predictions": docs.apply(lambda doc: doc.cats), "docs": docs}
         )
 
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -646,7 +646,6 @@ def log_figure(figure, artifact_file):
     .. _plotly.graph_objects.Figure:
         https://plotly.com/python-api-reference/generated/plotly.graph_objects.Figure.html
 
-    :param run_id: String ID of the run.
     :param figure: Figure to log.
     :param artifact_file: The run-relative artifact file path in posixpath format to which
                           the figure is saved (e.g. "dir/file.png").
@@ -712,7 +711,6 @@ def log_image(image, artifact_file):
             - H x W x 3 (an RGB channel order is assumed)
             - H x W x 4 (an RGBA channel order is assumed)
 
-    :param run_id: String ID of the run.
     :param image: Image to log.
     :param artifact_file: The run-relative artifact file path in posixpath format to which
                           the image is saved (e.g. "dir/image.png").

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -19,7 +19,7 @@ from mlflow.tracking import artifact_utils, _get_store
 from mlflow.tracking.context import registry as context_registry
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.utils import env
-from mlflow.utils.autologging_utils import _is_testing
+from mlflow.utils.autologging_utils import _is_testing, autologging_integration
 from mlflow.utils.databricks_utils import is_in_databricks_notebook, get_notebook_id
 from mlflow.utils.import_hooks import register_post_import_hook
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_RUN_NAME
@@ -1211,6 +1211,7 @@ def _get_experiment_id():
     ) or deprecated_default_exp_id
 
 
+@autologging_integration("mlflow")
 def autolog(
     log_input_examples=False,
     log_model_signatures=True,

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -1,3 +1,4 @@
+import os
 import abc
 import inspect
 import itertools
@@ -10,6 +11,7 @@ import uuid
 from collections import namedtuple
 from contextlib import contextmanager
 from abc import abstractmethod
+from pathlib import Path
 
 import mlflow
 from mlflow.entities.run_status import RunStatus
@@ -385,8 +387,6 @@ def _is_testing():
         - Disables exception handling for patched function logic, ensuring that patch code
           executes without errors during testing
     """
-    import os
-
     return os.environ.get(_AUTOLOGGING_TEST_MODE_ENV_VAR, "false") == "true"
 
 
@@ -944,7 +944,9 @@ def safe_patch(
             except Exception as e:  # pylint: disable=broad-except
                 _logger.debug("Failed to log autologging event via '%s'. Exception: %s", log_fn, e)
 
-        with _AutologgingSessionManager.start_session(autologging_integration) as session:
+        with _augment_mlflow_warnings(
+            autologging_integration
+        ), _AutologgingSessionManager.start_session(autologging_integration) as session:
             try:
 
                 def call_original(*og_args, **og_kwargs):
@@ -1068,6 +1070,54 @@ def safe_patch(
                 return original(*args, **kwargs)
 
     wrap_patch(destination, function_name, safe_patch_function)
+
+
+@contextmanager
+def _augment_mlflow_warnings(autologging_integration):
+    """
+    MLflow routines called by autologging patch code may issue warnings via the `warnings.warn`
+    API. In many cases, the user cannot remediate the cause of these warnings because
+    they result from the autologging patch implementation, rather than a user-facing API call.
+
+    Accordingly, this context manager is designed to augment MLflow warnings issued during
+    autologging patch code execution, explaining that such warnings were raised as a result of
+    MLflow's autologging implementation. MLflow warnings are also redirected from `sys.stderr`
+    to an MLflow logger with level WARNING. Warnings issued by code outside of MLflow are
+    not modified. When the context manager exits, the original output behavior for MLflow warnings
+    is restored.
+
+    :param autologging_integration: The name of the active autologging integration for which
+                                    MLflow warnings are to be augmented during patch code
+                                    execution.
+    """
+    original_showwarning = warnings.showwarning
+
+    def autologging_showwarning(message, category, filename, lineno, *args, **kwargs):
+        mlflow_root_path = Path(os.path.dirname(mlflow.__file__)).resolve()
+        warning_source_path = Path(filename).resolve()
+        # If the warning's source file is contained within the MLflow package's base
+        # directory, it is an MLflow warning and should be emitted via `logger.warning`
+        if mlflow_root_path in warning_source_path.parents:
+            _logger.warning(
+                "MLflow issued a warning during %s autologging:" ' "%s:%d: %s: %s"',
+                autologging_integration,
+                filename,
+                lineno,
+                category.__name__,
+                message,
+            )
+        else:
+            original_showwarning(message, category, filename, lineno, *args, **kwargs)
+
+    try:
+        # NB: Reassigning `warnings.showwarning` is the standard / recommended approach for
+        # specifying an alternative destination and output format for warning messages
+        # (i.e. a sink other than `sys.stderr`). For reference, see
+        # https://docs.python.org/3/library/warnings.html#warnings.showwarning
+        warnings.showwarning = autologging_showwarning
+        yield
+    finally:
+        warnings.showwarning = original_showwarning
 
 
 def _validate_autologging_run(autologging_integration, run_id):

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,4 +1,9 @@
 # Copyright 2018 Databricks, Inc.
+import re
 
 
 VERSION = "1.12.2.dev0"
+
+
+def is_release_version():
+    return bool(re.match(r"^\d+\.\d+\.\d+$", VERSION))

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -5,6 +5,7 @@ import copy
 import inspect
 import os
 import pytest
+import warnings
 from collections import namedtuple
 from unittest import mock
 
@@ -732,6 +733,76 @@ def test_safe_patch_makes_expected_event_logging_calls_when_original_function_th
     patch_start, original_start, original_error = mock_event_logger.calls
     assert patch_start.exception is original_start.exception is None
     assert original_error.exception == exc_to_raise
+
+
+def test_safe_patch_augments_mlflow_warnings_and_preserves_others(
+    patch_destination, test_autologging_integration
+):
+    """
+    MLflow routines called by autologging patch code may issue warnings via the `warnings.warn`
+    API. In many cases, the user cannot remediate the cause of these warnings because
+    they result from the autologging patch implementation, rather than a user-facing API call.
+
+    This test case verifies that, for user clarity, such MLflow warnings are augmented with
+    context about their origin (i.e. MLflow's autologging patch implementation, rather than
+    user behavior) during autologging patch code execution.
+    """
+    mlflow_warning_kwargs = {
+        "message": "Mock MLflow warning",
+        "category": UserWarning,
+        "filename": mlflow.__file__,
+        "lineno": 7,
+    }
+    external_warning_kwargs = {
+        "message": "Mock external warning",
+        "category": UserWarning,
+        "filename": "/some/tensorflow/module.py",
+        "lineno": 14,
+    }
+
+    def patch_impl(original, *args, **kwargs):
+        warnings.warn_explicit(**mlflow_warning_kwargs)
+        warnings.warn_explicit(**external_warning_kwargs)
+
+    safe_patch(test_autologging_integration, patch_destination, "fn", patch_impl)
+
+    with pytest.warns(UserWarning) as user_warnings_from_patch, mock.patch(
+        "mlflow.utils.autologging_utils._logger.warning"
+    ) as logger_mock:
+        patch_destination.fn()
+
+    assert len(user_warnings_from_patch) == 1
+    # Verify that the warning message (which is the first argument to the UserWarning)
+    # issued via the standard warning mechanism (i.e. printing to `sys.stderr`) corresponds
+    # to the external warning
+    external_warning = user_warnings_from_patch[0]
+    assert external_warning.message.args[0] == "Mock external warning"
+    assert external_warning.lineno == 14
+    assert external_warning.filename == "/some/tensorflow/module.py"
+
+    # Verify that the warning message routed to the MLflow logger corresponds to the MLflow warning
+    assert logger_mock.call_count == 1
+    logger_warn_args = logger_mock.call_args[0]
+    message = logger_warn_args[0]
+    formatting_args = logger_warn_args[1:]
+    full_logger_warning = message % formatting_args
+    assert "Mock MLflow warning" in full_logger_warning
+    assert str(7) in full_logger_warning  # Ensure that the warning line number is present
+    assert mlflow.__file__ in full_logger_warning
+
+    with pytest.warns(UserWarning) as user_warnings_outside_patch:
+        warnings.warn_explicit(**mlflow_warning_kwargs)
+        warnings.warn_explicit(**external_warning_kwargs)
+
+    # Verify that MLflow warnings and external warnings are emitted as normal outside
+    # of autologging patch execution
+    assert set([warning.message.args[0] for warning in user_warnings_outside_patch]) == set(
+        ["Mock MLflow warning", "Mock external warning"]
+    )
+    assert set([warning.lineno for warning in user_warnings_outside_patch]) == set([7, 14])
+    assert set([warning.filename for warning in user_warnings_outside_patch]) == set(
+        [mlflow.__file__, "/some/tensorflow/module.py"]
+    )
 
 
 @pytest.mark.usefixtures(test_mode_off.__name__)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,9 @@
+from mlflow import version
+
+
+def test_is_release_version(monkeypatch):
+    monkeypatch.setattr(version, "VERSION", "1.19.0")
+    assert version.is_release_version()
+
+    monkeypatch.setattr(version, "VERSION", "1.19.0.dev0")
+    assert not version.is_release_version()


### PR DESCRIPTION
## What changes are proposed in this pull request?

This change addresses the "textcat-only" limitations of the spacy pyfunc flavor as described in #2772 . This change surfaces more of spacy's functionality in the dataframe returned by `predict`.

This means, that instead of getting a single `predictions` column that contains a `dict` of text categorization predictions, like this:

|  | predictions |
| --- | --: |
| **0** | {'SPAM': 0.9, 'HAM': 0.21} |
| **1** | {'SPAM': 0.72, 'HAM': 0.46} |

You get more of the spacy `doc` features as additional columns, like this:

| | text | ents | sents | cats | tokens | predictions
| --- | --- | --- | --- | --- | --- | --- |
**0** | Patient has pneumonia | [{'start': 12, 'end': 21, 'label': 'PNA'}] | [{'start': 0, 'end': 21}] | {'MILD': 0.8353676199913025, 'SEVERE': 0.98652... | [{'id': 0, 'start': 0, 'end': 7, 'pos': 'PROPN... | {'MILD': 0.8353676199913025, 'SEVERE': 0.98652...
**1** | Patient has pneumothorax | [{'start': 12, 'end': 24, 'label': 'PTX'}] | [{'start': 0, 'end': 24}] | {'MILD': 0.018907491117715836, 'SEVERE': 0.883... | [{'id': 0, 'start': 0, 'end': 7, 'pos': 'PROPN... | {'MILD': 0.018907491117715836, 'SEVERE': 0.883...

More detail on the columns:
* `text` (original text)
* `ents` (named entity offsets and labels)
* `sents` (sentence offsets)
* `cats` (category dictionary, like `predictions` previously)
* `tokens` (token offsets along with POS tagging)
* `predictions` (just here for backwards compatibility)

## How is this patch tested?

I could use feedback on how to properly test this change. Other than running it successfully on my own installation of mlflow, I haven't done extensive testing or unit testing.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Previously, SpaCy models loaded via `pyfunc` were limited to text categorization predictions (the SpaCy `doc.cats` attribute on a pipeline that includes a `TextCategorizer`). This change makes additional SpaCy doc functionality available when loaded via `pyfunc` -- including text categorization, named-entity recognition, part-of-speech tagging, etc.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
