### PR TITLE
Fix lint error in `sklearn/utils.py`

### DIFF
--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -771,7 +771,7 @@ def _backported_all_estimators(type_filter=None):
     import sklearn
     from importlib import import_module
     from operator import itemgetter
-    from sklearn.utils.testing import ignore_warnings  # pylint: disable=no-name-in-module
+    from sklearn.utils.testing import ignore_warnings  # pylint: disable=import-error
     from sklearn.base import (
         BaseEstimator,
         ClassifierMixin,

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -771,7 +771,9 @@ def _backported_all_estimators(type_filter=None):
     import sklearn
     from importlib import import_module
     from operator import itemgetter
-    from sklearn.utils.testing import ignore_warnings  # pylint: no-name-in-module, import-error
+    from sklearn.utils.testing import (
+        ignore_warnings,  # pylint: disable=no-name-in-module, import-error
+    )
     from sklearn.base import (
         BaseEstimator,
         ClassifierMixin,

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -771,7 +771,7 @@ def _backported_all_estimators(type_filter=None):
     import sklearn
     from importlib import import_module
     from operator import itemgetter
-    from sklearn.utils.testing import ignore_warnings  # pylint: disable=import-error
+    from sklearn.utils.testing import ignore_warnings  # pylint: no-name-in-module, import-error
     from sklearn.base import (
         BaseEstimator,
         ClassifierMixin,

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -771,9 +771,9 @@ def _backported_all_estimators(type_filter=None):
     import sklearn
     from importlib import import_module
     from operator import itemgetter
-    from sklearn.utils.testing import (
-        ignore_warnings,  # pylint: disable=no-name-in-module, import-error
-    )
+
+    # pylint: disable=no-name-in-module, import-error
+    from sklearn.utils.testing import ignore_warnings
     from sklearn.base import (
         BaseEstimator,
         ClassifierMixin,


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

scikit-learn 0.24.0 has been releasd (https://pypi.org/project/scikit-learn/#history). In this version, `sklearn.utils.testing` doesn't exist and the lint check started failing due to the folllowing error:

```sh
mlflow/sklearn/utils.py (774,4): [E0401 import-error] Unable to import 'sklearn.utils.testing'
```

https://github.com/mlflow/mlflow/runs/1595561077#step:4:21

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
