### PR TITLE
Log scikit-learn version as a pip dependency

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -56,16 +56,12 @@ def get_default_conda_env(include_cloudpickle=False):
     """
     import sklearn
 
-    pip_deps = None
+    pip_deps = ["scikit-learn=={}".format(sklearn.__version__)]
     if include_cloudpickle:
         import cloudpickle
 
-        pip_deps = ["cloudpickle=={}".format(cloudpickle.__version__)]
-    return _mlflow_conda_env(
-        additional_conda_deps=["scikit-learn={}".format(sklearn.__version__)],
-        additional_pip_deps=pip_deps,
-        additional_conda_channels=None,
-    )
+        pip_deps += ["cloudpickle=={}".format(cloudpickle.__version__)]
+    return _mlflow_conda_env(additional_pip_deps=pip_deps, additional_conda_channels=None)
 
 
 def save_model(

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -771,7 +771,7 @@ def _backported_all_estimators(type_filter=None):
     import sklearn
     from importlib import import_module
     from operator import itemgetter
-    from sklearn.utils.testing import ignore_warnings  # pylint: disable=no-name-in-module
+    from sklearn.utils.testing import ignore_warnings  # pylint: disable=import-error
     from sklearn.base import (
         BaseEstimator,
         ClassifierMixin,

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -771,7 +771,9 @@ def _backported_all_estimators(type_filter=None):
     import sklearn
     from importlib import import_module
     from operator import itemgetter
-    from sklearn.utils.testing import ignore_warnings  # pylint: no-name-in-module, import-error
+    from sklearn.utils.testing import (
+        ignore_warnings,  # pylint: disable=no-name-in-module, import-error
+    )
     from sklearn.base import (
         BaseEstimator,
         ClassifierMixin,

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -771,7 +771,7 @@ def _backported_all_estimators(type_filter=None):
     import sklearn
     from importlib import import_module
     from operator import itemgetter
-    from sklearn.utils.testing import ignore_warnings  # pylint: disable=import-error
+    from sklearn.utils.testing import ignore_warnings  # pylint: no-name-in-module, import-error
     from sklearn.base import (
         BaseEstimator,
         ClassifierMixin,

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -771,9 +771,9 @@ def _backported_all_estimators(type_filter=None):
     import sklearn
     from importlib import import_module
     from operator import itemgetter
-    from sklearn.utils.testing import (
-        ignore_warnings,  # pylint: disable=no-name-in-module, import-error
-    )
+
+    # pylint: disable=no-name-in-module, import-error
+    from sklearn.utils.testing import ignore_warnings
     from sklearn.base import (
         BaseEstimator,
         ClassifierMixin,


### PR DESCRIPTION
## What changes are proposed in this pull request?

Include `scikit-learn` as a pip dependency in conda_env.yml to fix the following error:

```
ResolvePackageNotFound:
  - scikit-learn=0.24.0
```

https://github.com/mlflow/mlflow/runs/1595561170#step:4:489

This error occurs when `scikit-learn==0.24.0` exists on PyPI but not on anaconda.


## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Include `scikit-learn` as a pip dependency instead of a conda dependency in the scikit-learn integration.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
