### PR TITLE
Expose additional SpaCy functionality when using pyfunc to load model

### DIFF
--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -5,9 +5,7 @@ This module exports spacy models with the following flavors:
 spaCy (native) format
     This is the main flavor that can be loaded back into spaCy.
 :py:mod:`mlflow.pyfunc`
-    Produced for use by generic pyfunc-based deployment tools and batch inference, this
-    flavor is created only if spaCy's model pipeline has at least one
-    `TextCategorizer <https://spacy.io/api/textcategorizer>`_.
+    Produced for use by generic pyfunc-based deployment tools and batch inference.
 """
 import logging
 import os
@@ -130,27 +128,12 @@ def save_model(
     with open(os.path.join(path, conda_env_subpath), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
-    # Save the pyfunc flavor if at least one text categorizer in spaCy pipeline
-    if any(
-        [
-            isinstance(pipe_component[1], spacy.pipeline.TextCategorizer)
-            for pipe_component in spacy_model.pipeline
-        ]
-    ):
-        pyfunc.add_to_model(
-            mlflow_model,
-            loader_module="mlflow.spacy",
-            data=model_data_subpath,
-            env=conda_env_subpath,
-        )
-    else:
-        _logger.warning(
-            "Generating only the spacy flavor for the provided spacy model. This means the model "
-            "can be loaded back via `mlflow.spacy.load_model`, but cannot be loaded back using "
-            "pyfunc APIs like `mlflow.pyfunc.load_model` or via the `mlflow models` CLI commands. "
-            "MLflow will only generate the pyfunc flavor for spacy models containing a pipeline "
-            "component that is an instance of spacy.pipeline.TextCategorizer."
-        )
+    pyfunc.add_to_model(
+        mlflow_model,
+        loader_module="mlflow.spacy",
+        data=model_data_subpath,
+        env=conda_env_subpath,
+    )
 
     mlflow_model.add_flavor(FLAVOR_NAME, spacy_version=spacy.__version__, data=model_data_subpath)
     mlflow_model.save(os.path.join(path, MLMODEL_FILE_NAME))
@@ -239,18 +222,33 @@ class _SpacyModelWrapper:
 
     def predict(self, dataframe):
         """
-        Only works for predicting using text categorizer.
-        Not suitable for other pipeline components (e.g: parser)
-        :param dataframe: pandas dataframe containing texts to be categorized
-                          expected shape is (n_rows,1 column)
-        :return: dataframe with predictions
+        Makes predictions based on the contents of the spacy pipeline, including text
+        categorization, named-entity recognition, part-of-speech tagging, etc.
+        :param dataframe: pandas dataframe containing texts to be evaluated
+                          expected shape is (n_rows, 1_column)
+        :return: dataframe with a column for each of the object keys in `doc.to_json()`
         """
         if len(dataframe.columns) != 1:
-            raise MlflowException("Shape of input dataframe must be (n_rows, 1column)")
+            _logger.warning(
+                "Shape of input dataframe expected to be (n_rows, 1_column). "
+                "Only using the first column."
+            )
 
-        return pd.DataFrame(
-            {"predictions": dataframe.iloc[:, 0].apply(lambda text: self.spacy_model(text).cats)}
-        )
+        # Note: `to_json` returns a `dict`, not a JSON string (https://spacy.io/api/doc#to_json)
+        objs = dataframe.iloc[:, 0].apply(lambda text: self.spacy_model(text).to_json())
+
+        # Columns:
+        # `text` (original text)
+        # `ents` (named entity offsets and labels)
+        # `sents` (sentence offsets)
+        # `cats` (category dictionary, like `predictions` previously)
+        # `tokens` (token offsets along with POS tagging)
+        pdf = pd.DataFrame.from_records(objs)
+
+        # preserve old `predictions` column name for backwards compatibility
+        pdf["predictions"] = pdf["cats"]
+
+        return pdf
 
 
 def _load_pyfunc(path):

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -129,10 +129,7 @@ def save_model(
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
     pyfunc.add_to_model(
-        mlflow_model,
-        loader_module="mlflow.spacy",
-        data=model_data_subpath,
-        env=conda_env_subpath,
+        mlflow_model, loader_module="mlflow.spacy", data=model_data_subpath, env=conda_env_subpath,
     )
 
     mlflow_model.add_flavor(FLAVOR_NAME, spacy_version=spacy.__version__, data=model_data_subpath)

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -226,10 +226,7 @@ class _SpacyModelWrapper:
         :return: dataframe with a column for each of the object keys in `doc.to_json()`
         """
         if len(dataframe.columns) != 1:
-            _logger.warning(
-                "Shape of input dataframe expected to be (n_rows, 1_column). "
-                "Only using the first column."
-            )
+            raise MlflowException("Shape of input dataframe must be (n_rows, 1column)")
 
         # Note: `to_json` returns a `dict`, not a JSON string (https://spacy.io/api/doc#to_json)
         objs = dataframe.iloc[:, 0].apply(lambda text: self.spacy_model(text).to_json())

--- a/mlflow/spacy.py
+++ b/mlflow/spacy.py
@@ -246,7 +246,8 @@ class _SpacyModelWrapper:
         pdf = pd.DataFrame.from_records(objs)
 
         # preserve old `predictions` column name for backwards compatibility
-        pdf["predictions"] = pdf["cats"]
+        if "cats" in pdf.columns:
+            pdf["predictions"] = pdf["cats"]
 
         return pdf
 

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -274,7 +274,7 @@ def test_model_log_without_pyfunc_flavor():
         )
 
         loaded_model = Model.load(model_path)
-        assert loaded_model.flavors.keys() == {"spacy"}
+        assert "spacy" in loaded_model.flavors
 
 
 def _train_model(nlp, train_data, n_iter=5):
@@ -306,6 +306,8 @@ def _get_train_test_dataset(cats_to_fetch, limit=100):
 
 
 def _predict(spacy_model, test_x):
-    return pd.DataFrame(
-        {"predictions": test_x.iloc[:, 0].apply(lambda text: spacy_model(text).cats)}
-    )
+    objs = test_x.iloc[:, 0].apply(lambda text: spacy_model(text).to_json())
+    pdf = pd.DataFrame.from_records(objs)
+    if "cats" in pdf.columns:
+        pdf["predictions"] = pdf["cats"]
+    return pdf


### PR DESCRIPTION
## What changes are proposed in this pull request?

This change addresses the "textcat-only" limitations of the spacy pyfunc flavor as described in #2772 . This change surfaces more of spacy's functionality in the dataframe returned by `predict`.

This means, that instead of getting a single `predictions` column that contains a `dict` of text categorization predictions, like this:

|  | predictions |
| --- | --: |
| **0** | {'SPAM': 0.9, 'HAM': 0.21} |
| **1** | {'SPAM': 0.72, 'HAM': 0.46} |

You get more of the spacy `doc` features as additional columns, like this:

| | text | ents | sents | cats | tokens | predictions
| --- | --- | --- | --- | --- | --- | --- |
**0** | Patient has pneumonia | [{'start': 12, 'end': 21, 'label': 'PNA'}] | [{'start': 0, 'end': 21}] | {'MILD': 0.8353676199913025, 'SEVERE': 0.98652... | [{'id': 0, 'start': 0, 'end': 7, 'pos': 'PROPN... | {'MILD': 0.8353676199913025, 'SEVERE': 0.98652...
**1** | Patient has pneumothorax | [{'start': 12, 'end': 24, 'label': 'PTX'}] | [{'start': 0, 'end': 24}] | {'MILD': 0.018907491117715836, 'SEVERE': 0.883... | [{'id': 0, 'start': 0, 'end': 7, 'pos': 'PROPN... | {'MILD': 0.018907491117715836, 'SEVERE': 0.883...

More detail on the columns:
* `text` (original text)
* `ents` (named entity offsets and labels)
* `sents` (sentence offsets)
* `cats` (category dictionary, like `predictions` previously)
* `tokens` (token offsets along with POS tagging)
* `predictions` (just here for backwards compatibility)

## How is this patch tested?

I could use feedback on how to properly test this change. Other than running it successfully on my own installation of mlflow, I haven't done extensive testing or unit testing.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Previously, SpaCy models loaded via `pyfunc` were limited to text categorization predictions (the SpaCy `doc.cats` attribute on a pipeline that includes a `TextCategorizer`). This change makes additional SpaCy doc functionality available when loaded via `pyfunc` -- including text categorization, named-entity recognition, part-of-speech tagging, etc.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

Note, this PR is essentially identical to #3892 -- but without the rebase/signoff issues