### PR TITLE
Cleanup `dev-requirements.txt` and use it when building docs in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,9 +18,7 @@ jobs:
           name: Install Python dependencies
           command: |
             pip --version
-            pip install --progress-bar off . \
-              -r ./dev/large-requirements.txt \
-              sphinx sphinx-click
+            pip install --progress-bar off -r dev-requirements.txt .
       - run:
           name: Build documentation
           working_directory: docs

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 # Dev/Deployment
-sphinx==2.2.1
-sphinx-autobuild==0.7.1
-sphinx-click==2.3.1
+sphinx
+sphinx-autobuild
+sphinx-click
 scikit-learn
 scipy
 kubernetes

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,13 +1,7 @@
 # Dev/Deployment
 sphinx==2.2.1
-sphinx_rtd_theme==0.4.3
 sphinx-autobuild==0.7.1
 sphinx-click==2.3.1
-gitpython>=2.1.0
-nose
-codecov
-coverage
-pypi-publisher
 scikit-learn
 scipy
 kubernetes

--- a/docs/build-rdoc.sh
+++ b/docs/build-rdoc.sh
@@ -2,7 +2,7 @@
 
 set -ex
 pushd ../mlflow/R/mlflow
-sudo apt-get install libgit2-dev
+sudo apt-get install --yes libgit2-dev
 Rscript -e 'install.packages("devtools", repos = "https://cloud.r-project.org")'
 Rscript -e 'devtools::install_dev_deps(dependencies = TRUE)'
 # Install Rd2md from source as a temporary fix for the rendering of code examples, until

--- a/docs/build-rdoc.sh
+++ b/docs/build-rdoc.sh
@@ -4,7 +4,7 @@ set -ex
 pushd ../mlflow/R/mlflow
 sudo add-apt-repository ppa:cran/libgit2
 sudo apt-get update
-sudo apt-get install libssh2-1-dev libgit2-dev
+sudo apt-get install --yes libssh2-1-dev libgit2-dev
 Rscript -e 'install.packages("devtools", repos = "https://cloud.r-project.org")'
 Rscript -e 'devtools::install_dev_deps(dependencies = TRUE)'
 # Install Rd2md from source as a temporary fix for the rendering of code examples, until

--- a/docs/build-rdoc.sh
+++ b/docs/build-rdoc.sh
@@ -2,7 +2,9 @@
 
 set -ex
 pushd ../mlflow/R/mlflow
-sudo apt-get install --yes libgit2-dev
+sudo add-apt-repository ppa:cran/libgit2
+sudo apt-get update
+sudo apt-get install libssh2-1-dev libgit2-dev
 Rscript -e 'install.packages("devtools", repos = "https://cloud.r-project.org")'
 Rscript -e 'devtools::install_dev_deps(dependencies = TRUE)'
 # Install Rd2md from source as a temporary fix for the rendering of code examples, until

--- a/docs/build-rdoc.sh
+++ b/docs/build-rdoc.sh
@@ -2,6 +2,7 @@
 
 set -ex
 pushd ../mlflow/R/mlflow
+sudo apt-get install libgit2-dev
 Rscript -e 'install.packages("devtools", repos = "https://cloud.r-project.org")'
 Rscript -e 'devtools::install_dev_deps(dependencies = TRUE)'
 # Install Rd2md from source as a temporary fix for the rendering of code examples, until

--- a/docs/build-rdoc.sh
+++ b/docs/build-rdoc.sh
@@ -2,9 +2,13 @@
 
 set -ex
 pushd ../mlflow/R/mlflow
+
+# `gert` requires `libgit2`:
+# https://github.com/r-lib/gert#installation
 sudo add-apt-repository ppa:cran/libgit2
 sudo apt-get update
 sudo apt-get install --yes libssh2-1-dev libgit2-dev
+
 Rscript -e 'install.packages("devtools", repos = "https://cloud.r-project.org")'
 Rscript -e 'devtools::install_dev_deps(dependencies = TRUE)'
 # Install Rd2md from source as a temporary fix for the rendering of code examples, until


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Cleanup `dev-requirements.txt` and use it when building docs in CircleCI.

## How is this patch tested?

Existing unit tests & CI checks.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
