### PR TITLE
Log the original optimizer name when `enable_pl_optimizer` is True

### DIFF
--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -44,14 +44,14 @@ def _get_optimizer_name(optimizer):
     #pytorch_lightning.trainer.trainer.Trainer.params.enable_pl_optimizer
     """
     if LooseVersion(pl.__version__) < LooseVersion("1.1.0"):
-        return type(optimizer).__name__
+        return optimizer.__class__.__name__
     else:
         from pytorch_lightning.core.optimizer import LightningOptimizer
 
         return (
-            type(optimizer._optimizer).__name__
+            optimizer._optimizer.__class__.__name__
             if isinstance(optimizer, LightningOptimizer)
-            else type(optimizer).__name__
+            else optimizer.__class__.__name__
         )
 
 

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -10,6 +10,7 @@ from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.callbacks import ModelCheckpoint
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.autologging_utils import BatchMetricsLogger
+from mlflow.pytorch._pytorch_autolog import _get_optimizer_name
 from unittest.mock import patch
 
 NUM_EPOCHS = 20
@@ -61,10 +62,7 @@ def test_pytorch_autolog_logs_expected_data(pytorch_model):
 
     # Testing optimizer parameters are logged
     assert "optimizer_name" in data.params
-
-    # In pytorch-lightning >= 1.1.0, optimizer names are prefixed with "Lightning".
-    prefix = "Lightning" if LooseVersion(pl.__version__) >= LooseVersion("1.1.0") else ""
-    assert data.params["optimizer_name"] == prefix + "Adam"
+    assert data.params["optimizer_name"] == "Adam"
 
     # Testing model_summary.txt is saved
     client = mlflow.tracking.MlflowClient()
@@ -254,3 +252,19 @@ def test_pytorch_test_metrics_logged(pytorch_model_tests):
     data = run.data
     assert "test_loss" in data.metrics
     assert "test_acc" in data.metrics
+
+
+def test_get_optimizer_name():
+    adam = torch.optim.Adam(torch.nn.Linear(1, 1).parameters())
+    assert _get_optimizer_name(adam) == "Adam"
+
+
+@pytest.mark.skipif(
+    LooseVersion(pl.__version__) < LooseVersion("1.1.0"),
+    reason="`LightningOptimizer` doesn't exist in pytorch-lightning < 1.1.0",
+)
+def test_get_optimizer_name_with_lightning_optimizer():
+    from pytorch_lightning.core.optimizer import LightningOptimizer
+
+    adam = torch.optim.Adam(torch.nn.Linear(1, 1).parameters())
+    assert _get_optimizer_name(LightningOptimizer(adam)) == "Adam"


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

`pytorch-lightning` 1.1.2 has been released. In this version, `LightningOptimizer` is disabled by default:

https://github.com/PyTorchLightning/pytorch-lightning/pull/5163

This change caused the following error:

https://github.com/mlflow/mlflow/pull/3899/checks?check_run_id=1599858698#step:4:116

```
https://github.com/mlflow/mlflow/pull/3899/checks?check_run_id=1599858698#step:4:116
```


## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
