### PR TITLE
Autologging: Fix exclusive session management

### DIFF
--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1116,11 +1116,8 @@ def autolog(
         return result
 
     managed = [
-        (EventFileWriter, "add_event", add_event),
-        (EventFileWriterV2, "add_event", add_event),
         (tensorflow.estimator.Estimator, "train", train),
         (tensorflow.keras.Model, "fit", FitPatch),
-        (FileWriter, "add_summary", add_summary),
     ]
 
     if LooseVersion(tensorflow.__version__) < LooseVersion("2.1.0"):
@@ -1131,6 +1128,9 @@ def autolog(
         managed.append((tensorflow.keras.Model, "fit_generator", FitGeneratorPatch))
 
     non_managed = [
+        (EventFileWriter, "add_event", add_event),
+        (EventFileWriterV2, "add_event", add_event),
+        (FileWriter, "add_summary", add_summary),
         (tensorflow.estimator.Estimator, "export_saved_model", export_saved_model),
         (tensorflow.estimator.Estimator, "export_savedmodel", export_saved_model),
     ]

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -530,19 +530,24 @@ class _AutologgingSessionManager:
     @contextmanager
     def start_session(cls, integration):
         try:
-            session_id = uuid.uuid4().hex
-            if cls._session is None:
+            prev_session = cls._session
+            if prev_session is None:
+                session_id = uuid.uuid4().hex
                 cls._session = AutologgingSession(integration, session_id)
             yield cls._session
         finally:
-            cls.end_session()
+            # Only end the session upon termination of the context if we created
+            # the session; otherwise, leave the session open for later termination
+            # by its creator
+            if prev_session is None:
+                cls._end_session()
 
     @classmethod
     def active_session(cls):
         return cls._session
 
     @classmethod
-    def end_session(cls):
+    def _end_session(cls):
         cls._session = None
 
 


### PR DESCRIPTION
Signed-off-by: Corey Zumar <corey.zumar@databricks.com>

This PR fixes a bug in autologging session management which is relevant to the new `exclusive=True` mode for autologging. Consider the scenario where patched function A creates an MLflow Run calls patched function B. Previously, patched function A would start an autologging session, then patched function B would end the autologging session upon termination, leaving patched function A without a session. If patched function A then called another patched function C in `exclusive` mode (prior to terminating the MLflow run), the patched variant of C would never be invoked due to https://github.com/mlflow/mlflow/blob/cbe0627428bc2692d851f4180a2ea59073040a63/mlflow/utils/autologging_utils.py#L926. 

This caused problems with TensorFlow autologging in exclusive mode, where the first patched call to `EventFileWriter.add_event` invoked by `tf.estimator.Estimator.train()` would terminate the autologging session created by `tf.estimator.Estimator.train()`; all subsequent invocations of `EventFileWriter.add_event` would bypass patched code, which resulted in training metrics being discarded.

This PR addresses the issue by ensuring that a given `AutologgingSessionManager` context only terminates the active session if it was created within its scope. This way, if A calls B, then B will not end the session.

Finally, this PR addresses an adjacent issue where `manage_run=True` was being applied erroneously to `add_event` and `add_summary` in TensorFlow autologging, which produced a large volume of redundant info logs of the form `2020/12/27 00:58:37 INFO mlflow.utils.autologging_utils: tensorflow autologging will track hyperparameters, performance metrics, model artifacts, and lineage information for the current tensorflow workflow to the MLflow run with ID 'dbd69ee5d14147beabb76bac96e5a27f'` every time `add_event` and `add_summary` were called.

## How is this patch tested?

New unit tests for autologging session manager & integration tests for TensorFlow autologging

## Release Notes

Fix the following autologging bugs for TensorFlow estimators: 1. metrics are not recorded in `exclusive` autologging mode, 2. redundant info logs are printed each time a metric is recorded.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
