### PR TITLE
TensorFlow autologging: Fix longstanding race condition

### DIFF
--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -615,7 +615,7 @@ def _flush_queue():
         # (e.g., if the queue is at its flush threshold and several more items
         # are added before a flush occurs). For correctness and efficiency, only one such
         # flush operation should proceed; all others are redundant and should be dropped
-        acquired_lock = _metric_queue_lock.acquire()
+        acquired_lock = _metric_queue_lock.acquire(blocking=False)
         if acquired_lock:
             global _metric_queue
             client = mlflow.tracking.MlflowClient()

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -610,9 +610,6 @@ def _flush_queue():
     Flush the metric queue and log contents in batches to MLflow.
     Queue is divided into batches according to run id.
     """
-    global _metric_queue
-    global _metric_queue_lock
-
     try:
         # Multiple queue flushes may be scheduled simultaneously on different threads
         # (e.g., if the queue is at its flush threshold and several more items
@@ -620,6 +617,7 @@ def _flush_queue():
         # flush operation should proceed; all others are redundant and should be dropped
         acquired_lock = _metric_queue_lock.acquire()
         if acquired_lock:
+            global _metric_queue
             client = mlflow.tracking.MlflowClient()
             dic = _assoc_list_to_map(_metric_queue)
             for key in dic:

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -19,6 +19,7 @@ import tempfile
 from collections import namedtuple
 import pandas
 from distutils.version import LooseVersion
+from threading import RLock
 
 import mlflow
 import mlflow.keras
@@ -57,6 +58,7 @@ _MAX_METRIC_QUEUE_SIZE = 500
 
 _LOG_EVERY_N_STEPS = 100
 
+_metric_queue_lock = RLock()
 _metric_queue = []
 
 _thread_pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
@@ -608,15 +610,24 @@ def _flush_queue():
     Flush the metric queue and log contents in batches to MLflow.
     Queue is divided into batches according to run id.
     """
-    from threading import RLock
+    global _metric_queue
+    global _metric_queue_lock
 
-    with RLock():
-        global _metric_queue
-        client = mlflow.tracking.MlflowClient()
-        dic = _assoc_list_to_map(_metric_queue)
-        for key in dic:
-            try_mlflow_log(client.log_batch, key, metrics=dic[key], params=[], tags=[])
-        _metric_queue = []
+    try:
+        # Multiple queue flushes may be scheduled simultaneously on different threads
+        # (e.g., if the queue is at its flush threshold and several more items
+        # are added before a flush occurs). For correctness and efficiency, only one such
+        # flush operation should proceed; all others are redundant and should be dropped
+        acquired_lock = _metric_queue_lock.acquire()
+        if acquired_lock:
+            client = mlflow.tracking.MlflowClient()
+            dic = _assoc_list_to_map(_metric_queue)
+            for key in dic:
+                try_mlflow_log(client.log_batch, key, metrics=dic[key], params=[], tags=[])
+            _metric_queue = []
+    finally:
+        if acquired_lock:
+            _metric_queue_lock.release()
 
 
 def _add_to_queue(key, value, step, time, run_id):

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -637,3 +637,36 @@ def test_duplicate_autolog_second_overrides(tf_estimator_random_data_run):
     client = mlflow.tracking.MlflowClient()
     metrics = client.get_metric_history(tf_estimator_random_data_run.info.run_id, "loss")
     assert all((x.step - 1) % 4 == 0 for x in metrics)
+
+
+@pytest.mark.large
+def test_flush_queue_is_thread_safe():
+    """
+    Autologging augments TensorBoard event logging hooks with MLflow `log_metric` API
+    calls. To prevent these API calls from blocking TensorBoard event logs, `log_metric`
+    API calls are scheduled via `_flush_queue` on a background thread. Accordingly, this test
+    verifies that `_flush_queue` is thread safe.
+    """
+    from threading import Thread
+    from mlflow.entities import Metric
+    from mlflow.tensorflow import _flush_queue, _metric_queue_lock
+
+    metric_queue_item = ("run_id1", Metric("foo", "bar", 100, 1))
+    mlflow.tensorflow._metric_queue.append(metric_queue_item)
+
+    # Verify that, if another thread holds a lock on the metric queue leveraged by
+    # _flush_queue, _flush_queue terminates and does not modify the queue
+    _metric_queue_lock.acquire()
+    flush_thread1 = Thread(target=_flush_queue)
+    flush_thread1.start()
+    flush_thread1.join()
+    assert len(mlflow.tensorflow._metric_queue) == 1
+    assert mlflow.tensorflow._metric_queue[0] == metric_queue_item
+    _metric_queue_lock.release()
+
+    # Verify that, if no other thread holds a lock on the metric queue leveraged by
+    # _flush_queue, _flush_queue flushes the queue as expected
+    flush_thread2 = Thread(target=_flush_queue)
+    flush_thread2.start()
+    flush_thread2.join()
+    assert len(mlflow.tensorflow._metric_queue) == 0


### PR DESCRIPTION
Signed-off-by: Corey Zumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

This PR fixes a race condition that's been present in MLflow's TensorFlow Autologging since inception. MLflow patches TensorFlow's `EventWriter.add_event` method to queue metrics and flush them to the MLflow Tracking server via batch metric logging. Flush operations are scheduled on background threads to avoid blocking TensorBoard events (which may be consumed by third-party applications). 

Unfortunately, these asynchronous flush operations are not currently threadsafe. Namely, `_flush_queue` takes a snapshot of the metrics queue and uses it to constructs a dictionary of metrics to log; it then discards the metrics queue after logging. Any entries inserted into the queue between this conversion to a dictionary representation and the end of the logging procedure are discarded. This PR addresses this gap using a lock.

## How is this patch tested?

Unit test

## Release Notes

Fix longstanding race condition in TensorFlow autologging causing Estimator metrics to be dropped sporadically.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
