### PR TITLE
Remove `six` from dependencies

### DIFF
--- a/mlflow/mleap.py
+++ b/mlflow/mleap.py
@@ -12,7 +12,6 @@ import logging
 import os
 import sys
 import traceback
-from six import reraise
 
 import mlflow
 from mlflow.models import Model
@@ -20,6 +19,7 @@ from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.exceptions import MlflowException
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
+from mlflow.utils import reraise
 from mlflow.utils.annotations import keyword_only
 
 FLAVOR_NAME = "mleap"

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -16,7 +16,6 @@ import json
 import logging
 import numpy as np
 import pandas as pd
-from six import reraise
 import sys
 import traceback
 
@@ -27,6 +26,7 @@ import traceback
 # ALl of the mlfow dependencies below need to be backwards compatible.
 from mlflow.exceptions import MlflowException
 from mlflow.types import Schema
+from mlflow.utils import reraise
 from mlflow.utils.proto_json_utils import NumpyEncoder, _dataframe_from_json, _get_jsonable_obj
 
 try:

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -40,3 +40,16 @@ def get_unique_resource_id(max_length=None):
     if max_length is not None:
         unique_id = unique_id[: int(max_length)]
     return unique_id
+
+
+def reraise(tp, value, tb=None):
+    # Copied from: https://github.com/benjaminp/six/blob/c0be8815d13df45b6ae471c4c436cce8c192245d/six.py#L694-L700  # noqa
+    try:
+        if value is None:
+            value = tp()
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+    finally:
+        value = None
+        tb = None

--- a/mlflow/utils/__init__.py
+++ b/mlflow/utils/__init__.py
@@ -43,7 +43,7 @@ def get_unique_resource_id(max_length=None):
 
 
 def reraise(tp, value, tb=None):
-    # Copied from: https://github.com/benjaminp/six/blob/c0be8815d13df45b6ae471c4c436cce8c192245d/six.py#L694-L700  # noqa
+    # Taken from: https://github.com/benjaminp/six/blob/1.15.0/six.py#L694-L700
     try:
         if value is None:
             value = tp()

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,6 @@ SKINNY_REQUIREMENTS = [
     "pyyaml",
     "protobuf>=3.6.0",
     "requests>=2.17.3",
-    "six>=1.10.0",
 ]
 
 """


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- Vendor the `reraise` function from `six`
- Remove `six` from `install_requires`

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
