### PR TITLE
Changelog and cherry-picks for MLflow 1.13.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,64 @@
 Changelog
 =========
+1.13 (2020-12-30)
+-----------------
+MLflow 1.13.1 is a patch release containing bug fixes and small changes:
+
+- Fix bug causing Spark autologging to ignore configuration options specified by ``mlflow.autolog()`` (#3917, @dbczumar)
+- Fix bugs causing metrics to be dropped during TensorFlow autologging (#3913, #3914, @dbczumar)
+- Fix model registry database "allow_null_for_run_id" migration failure affecting MySQL databases (#3836, @t-henri)
+- Fix an undefined variable error causing AzureML model deployment to fail (#3922, @eedeleon)
+
+1.13 (2020-12-22)
+-----------------
+MLflow 1.13 includes several major features and improvements:
+
+Features:
+
+New fluent APIs for logging in-memory objects as artifacts:
+
+- Add ``mlflow.log_text`` which logs text as an artifact (#3678, @harupy)
+- Add ``mlflow.log_dict`` which logs a dictionary as an artifact (#3685, @harupy)
+- Add ``mlflow.log_figure`` which logs a figure object as an artifact (#3707, @harupy)
+- Add ``mlflow.log_image`` which logs an image object as an artifact (#3728, @harupy)
+
+UI updates / fixes (#3867, @smurching):
+
+- Add model version link in compact experiment table view
+- Add logged/registered model links in experiment runs page view
+- Enhance artifact viewer for MLflow models
+- Model registry UI settings are now persisted across browser sessions
+- Add model version ``description`` field to model version table
+
+Autologging enhancements:
+
+- Improve robustness of autologging integrations to exceptions (#3682, #3815, dbczumar; #3860, @mohamad-arabi; #3854, #3855, #3861, @harupy)
+- Add ``disable`` configuration option for autologging (#3682, #3815, dbczumar; #3838, @mohamad-arabi; #3854, #3855, #3861, @harupy)
+- Add ``exclusive`` configuration option for autologging (#3851, @apurva-koti; #3869, @dbczumar)
+- Add ``log_models`` configuration option for autologging (#3663, @mohamad-arabi)
+- Set tags on autologged runs for easy identification (and add tags to start_run) (#3847, @dbczumar)
+
+More features and improvements:
+
+- Allow Keras models to be saved with ``SavedModel`` format (#3552, @skylarbpayne)
+- Add support for ``statsmodels`` flavor (#3304, @olbapjose)
+- Add support for nested-run in mlflow R client (#3765, @yitao-li)
+- Deploying a model using ``mlflow.azureml.deploy`` now integrates better with the AzureML tracking/registry. (#3419, @trangevi)
+- Update schema enforcement to handle integers with missing values (#3798, @tomasatdatabricks)
+
+Bug fixes and documentation updates:
+
+- When running an MLflow Project on Databricks, the version of MLflow installed on the Databricks cluster will now match the version used to run the Project (#3880, @FlorisHoogenboom)
+- Fix bug where metrics are not logged for single-epoch ``tf.keras`` training sessions (#3853, @dbczumar)
+- Reject boolean types when logging MLflow metrics (#3822, @HCoban)
+- Fix alignment of Keras / ``tf.Keras`` metric history entries when ``initial_epoch`` is different from zero. (#3575, @garciparedes)
+- Fix bugs in autologging integrations for newer versions of TensorFlow and Keras (#3735, @dbczumar)
+- Drop global ``filterwwarnings`` module at import time (#3621, @jogo)
+- Fix bug that caused preexisting Python loggers to be disabled when using MLflow with the SQLAlchemyStore (#3653, @arthury1n)
+- Fix ``h5py`` library incompatibility for exported Keras models (#3667, @tomasatdatabricks)
+
+Small changes, bug fixes and doc updates (#3887, #3882, #3845, #3833, #3830, #3828, #3826, #3825, #3800, #3809, #3807, #3786, #3794, #3731, #3776, #3760, #3771, #3754, #3750, #3749, #3747, #3736, #3701, #3699, #3698, #3658, #3675, @harupy; #3723, @mohamad-arabi; #3650, #3655, @shrinath-suresh; #3850, #3753, #3725, @dmatrix; ##3867, #3670, #3664, @smurching; #3681, @sueann; #3619, @andrewnitu; #3837, @javierluraschi; #3721, @szczeles; #3653, @arthury1n; #3883, #3874, #3870, #3877, #3878, #3815, #3859, #3844, #3703, @dbczumar; #3768, @wentinghu; #3784, @HCoban; #3643, #3649, @arjundc-db; #3864, @AveshCSingh, #3756, @yitao-li)
+
 1.12.1 (2020-11-19)
 -------------------
 MLflow 1.12.1 is a patch release containing bug fixes and small changes:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 Changelog
 =========
-1.13 (2020-12-30)
+1.13.1 (2020-12-30)
 -----------------
 MLflow 1.13.1 is a patch release containing bug fixes and small changes:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,9 +7,11 @@ MLflow 1.13.1 is a patch release containing bug fixes and small changes:
 - Fix bug causing Spark autologging to ignore configuration options specified by ``mlflow.autolog()`` (#3917, @dbczumar)
 - Fix bugs causing metrics to be dropped during TensorFlow autologging (#3913, #3914, @dbczumar)
 - Fix incorrect value of optimizer name parameter in autologging PyTorch Lightning (#3901, @harupy)
-- Fix model registry database "allow_null_for_run_id" migration failure affecting MySQL databases (#3836, @t-henri)
+- Fix model registry database ``allow_null_for_run_id`` migration failure affecting MySQL databases (#3836, @t-henri)
+- Fix failure in ``transition_model_version_stage`` when uncanonical stage name is passed (#3929, @harupy)
 - Fix an undefined variable error causing AzureML model deployment to fail (#3922, @eedeleon)
 - Reclassify scikit-learn as a pip dependency in MLflow Model conda environments (#3896, @harupy)
+- Fix experiment view crash and artifact view inconsistency caused by artifact URIs with redundant slashes (#3928, @dbczumar)
 
 1.13 (2020-12-22)
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,8 +6,10 @@ MLflow 1.13.1 is a patch release containing bug fixes and small changes:
 
 - Fix bug causing Spark autologging to ignore configuration options specified by ``mlflow.autolog()`` (#3917, @dbczumar)
 - Fix bugs causing metrics to be dropped during TensorFlow autologging (#3913, #3914, @dbczumar)
+- Fix incorrect value of optimizer name parameter in autologging PyTorch Lightning (#3901, @harupy)
 - Fix model registry database "allow_null_for_run_id" migration failure affecting MySQL databases (#3836, @t-henri)
 - Fix an undefined variable error causing AzureML model deployment to fail (#3922, @eedeleon)
+- Reclassify scikit-learn as a pip dependency in MLflow Model conda environments (#3896, @harupy)
 
 1.13 (2020-12-22)
 -----------------

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -410,8 +410,8 @@ def deploy(
 
             _logger.info(
                 "Registered an Azure Model with name: `%s` and version: `%s`",
-                registered_model.name,
-                registered_model.version,
+                mlflow_model.name,
+                azure_model_id,
             )
 
         # Attempt to retrieve an AzureML Model object which we intend to deploy

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import logging
 import mlflow.pytorch
 import os
@@ -30,6 +31,28 @@ every_n_epoch = 1
 # tracking uri, experiment_id and run_id which may lead to a race condition.
 # TODO: Replace __MlflowPLCallback with Pytorch Lightning's built-in MlflowLogger
 # once the above mentioned issues have been addressed
+
+
+def _get_optimizer_name(optimizer):
+    """
+    In pytorch-lightining 1.1.0, `LightningOptimizer` was introduced:
+    https://github.com/PyTorchLightning/pytorch-lightning/pull/4658
+
+    If a user sets `enable_pl_optimizer` to True when instantiating a `Trainer` object,
+    each optimizer will be wrapped by `LightningOptimizer`:
+    https://pytorch-lightning.readthedocs.io/en/stable/api/pytorch_lightning.trainer.trainer.html
+    #pytorch_lightning.trainer.trainer.Trainer.params.enable_pl_optimizer
+    """
+    if LooseVersion(pl.__version__) < LooseVersion("1.1.0"):
+        return optimizer.__class__.__name__
+    else:
+        from pytorch_lightning.core.optimizer import LightningOptimizer
+
+        return (
+            optimizer._optimizer.__class__.__name__
+            if isinstance(optimizer, LightningOptimizer)
+            else optimizer.__class__.__name__
+        )
 
 
 @rank_zero_only
@@ -108,7 +131,9 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
 
                 if hasattr(trainer, "optimizers"):
                     optimizer = trainer.optimizers[0]
-                    try_mlflow_log(mlflow.log_param, "optimizer_name", type(optimizer).__name__)
+                    try_mlflow_log(
+                        mlflow.log_param, "optimizer_name", _get_optimizer_name(optimizer)
+                    )
 
                     if hasattr(optimizer, "defaults"):
                         try_mlflow_log(mlflow.log_params, optimizer.defaults)

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -156,6 +156,20 @@ class Utils {
     return path.replace(/(.*[^/])\.[^/.]+$/, '$1');
   }
 
+  /**
+   * Normalizes a URI, removing redundant slashes and trailing slashes
+   * For example, normalize("foo://bar///baz/") === "foo://bar/baz"
+   */
+  static normalize(uri) {
+    // Remove empty authority component (e.g., "foo:///" becomes "foo:/")
+    const withNormalizedAuthority = uri.replace(/[:]\/\/\/+/, ':/');
+    // Remove redundant slashes while ensuring that double slashes immediately following
+    // the scheme component are preserved
+    const withoutRedundantSlashes = withNormalizedAuthority.replace(/(^\/|[^:]\/)\/+/g, '$1');
+    const withoutTrailingSlash = withoutRedundantSlashes.replace(/\/$/, '');
+    return withoutTrailingSlash;
+  }
+
   static getGitHubRegex() {
     return /[@/]github.com[:/]([^/.]+)\/([^/#]+)#?(.*)/;
   }

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -349,3 +349,16 @@ test('compareExperiments', () => {
 
   expect([expB, exp1, expA, exp0].sort(Utils.compareExperiments)).toEqual([exp0, exp1, expA, expB]);
 });
+
+test('normalize', () => {
+  expect(Utils.normalize('/normalized/absolute/path')).toEqual('/normalized/absolute/path');
+  expect(Utils.normalize('normalized/relative/path')).toEqual('normalized/relative/path');
+  expect(Utils.normalize('http://mlflow.org/resource')).toEqual('http://mlflow.org/resource');
+  expect(Utils.normalize('s3:/bucket/resource')).toEqual('s3:/bucket/resource');
+  expect(Utils.normalize('C:\\Windows\\Filesystem\\Path')).toEqual('C:\\Windows\\Filesystem\\Path');
+
+  expect(Utils.normalize('///redundant//absolute/path')).toEqual('/redundant/absolute/path');
+  expect(Utils.normalize('redundant//relative///path///')).toEqual('redundant/relative/path');
+  expect(Utils.normalize('http://mlflow.org///redundant/')).toEqual('http://mlflow.org/redundant');
+  expect(Utils.normalize('s3:///bucket/resource/')).toEqual('s3:/bucket/resource');
+});

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
@@ -52,7 +52,7 @@ export class ArtifactViewImpl extends Component {
 
   getExistingModelVersions() {
     const { modelVersionsBySource } = this.props;
-    const activeNodeRealPath = this.getActiveNodeRealPath();
+    const activeNodeRealPath = Utils.normalize(this.getActiveNodeRealPath());
     return modelVersionsBySource[activeNodeRealPath];
   }
 
@@ -291,7 +291,10 @@ const mapStateToProps = (state, ownProps) => {
   const { apis } = state;
   const artifactNode = getArtifacts(runUuid, state);
   const artifactRootUri = getArtifactRootUri(runUuid, state);
-  const modelVersionsBySource = _.groupBy(getAllModelVersions(state), 'source');
+  const modelVersionsWithNormalizedSource = _.flatMap(getAllModelVersions(state), (version) => {
+    return { ...version, source: Utils.normalize(version.source) };
+  });
+  const modelVersionsBySource = _.groupBy(modelVersionsWithNormalizedSource, 'source');
   return { artifactNode, artifactRootUri, modelVersionsBySource, apis };
 };
 

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -591,28 +591,36 @@ export function ModelsCellRenderer(props) {
         source: registeredModelSource,
         version,
       } = registeredModels[0];
-      const artifactPath = registeredModelSource.split(`${runId}/artifacts/`)[1];
-      [loggedModel] = loggedModels.filter((model) => model['artifact_path'].includes(artifactPath));
-      registeredModelDiv = (
-        <>
-          {' - '}
-          <img
-            data-test-id='registered-model-icon'
-            alt=''
-            title='Registered Model'
-            src={registeredModelSvg}
-          />
-          <a
-            href={getModelVersionPageURL(registeredModelName, version)}
-            className='model-version-link'
-            title={`${registeredModelName}, v${version}`}
-            target='_blank'
-          >
-            <TrimmedText text={registeredModelName} maxSize={10} className={'model-name'} />
-            {`/${version}`}
-          </a>
-        </>
+
+      const normalizedSourceArtifactPath = Utils.normalize(registeredModelSource).split(
+        `${runId}/artifacts/`,
+      )[1];
+      const matchingModels = loggedModels.filter(
+        (model) => Utils.normalize(model['artifact_path']) === normalizedSourceArtifactPath,
       );
+      if (matchingModels.length > 0) {
+        [loggedModel] = matchingModels;
+        registeredModelDiv = (
+          <>
+            {' - '}
+            <img
+              data-test-id='registered-model-icon'
+              alt='registered model icon'
+              title='Registered Model'
+              src={registeredModelSvg}
+            />
+            <a
+              href={getModelVersionPageURL(registeredModelName, version)}
+              className='model-version-link'
+              title={`${registeredModelName}, v${version}`}
+              target='_blank'
+            >
+              <TrimmedText text={registeredModelName} maxSize={10} className={'model-name'} />
+              {`/${version}`}
+            </a>
+          </>
+        );
+      }
     }
     const loggedModelFlavorText = loggedModel['flavors'] ? loggedModel['flavors'][0] : 'Model';
     const loggedModelLink = Routes.getRunArtifactRoute(

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
@@ -123,6 +123,49 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
     expect(wrapper.find('img[data-test-id="registered-model-icon"]')).toHaveLength(1);
   });
 
+  /**
+   * A model version's source may be semantically equivalent to a run artifact path
+   * but syntactically distinct; this occurs when there are redundant or trailing
+   * slashes present in the version source or run artifact path. This test verifies that,
+   * in these cases, associated registered model links are still displayed correctly for runs
+   * containing model artifacts with semantically equivalent paths.
+   */
+  test('should show registered model link for semantically equivalent artifact paths', () => {
+    const runArtifactPath = 'somePath////subdir///';
+    const loggedModelHistoryTag = {
+      'mlflow.log-model.history': RunTag.fromJs({
+        key: 'mlflow.log-model.history',
+        value:
+          `[{"run_id":"someUuid","artifact_path":"${runArtifactPath}",` +
+          '"utc_time_created":"2020-10-22 23:18:51.726087","flavors":' +
+          '{"keras":{"keras_module":"tensorflow.keras","keras_version":"2.4.0","data":"data"},' +
+          '"python_function":{"loader_module":"mlflow.keras","python_version":"3.7.6",' +
+          '"data":"data","env":"conda.yaml"}}}]',
+      }),
+    };
+
+    const props = {
+      data: {
+        runInfo: { run_uuid: 'someUuid' },
+        tags: loggedModelHistoryTag,
+        modelVersionsByRunUuid: {
+          someUuid: [
+            {
+              name: 'someName',
+              source: 'dbfs:///someUuid/artifacts///somePath///subdir/',
+              version: 2,
+            },
+          ],
+        },
+      },
+    };
+    const output = ModelsCellRenderer(props);
+    wrapper = shallow(<Router>{output}</Router>);
+    expect(wrapper.html()).toContain('keras');
+    expect(wrapper.find('img[data-test-id="logged-model-icon"]')).toHaveLength(1);
+    expect(wrapper.find('img[data-test-id="registered-model-icon"]')).toHaveLength(1);
+  });
+
   test('should show 1 more if two logged models', () => {
     const tag = {
       'mlflow.log-model.history': RunTag.fromJs({

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -56,16 +56,12 @@ def get_default_conda_env(include_cloudpickle=False):
     """
     import sklearn
 
-    pip_deps = None
+    pip_deps = ["scikit-learn=={}".format(sklearn.__version__)]
     if include_cloudpickle:
         import cloudpickle
 
-        pip_deps = ["cloudpickle=={}".format(cloudpickle.__version__)]
-    return _mlflow_conda_env(
-        additional_conda_deps=["scikit-learn={}".format(sklearn.__version__)],
-        additional_pip_deps=pip_deps,
-        additional_conda_channels=None,
-    )
+        pip_deps += ["cloudpickle=={}".format(cloudpickle.__version__)]
+    return _mlflow_conda_env(additional_pip_deps=pip_deps, additional_conda_channels=None)
 
 
 def save_model(

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -771,7 +771,9 @@ def _backported_all_estimators(type_filter=None):
     import sklearn
     from importlib import import_module
     from operator import itemgetter
-    from sklearn.utils.testing import ignore_warnings  # pylint: disable=no-name-in-module
+
+    # pylint: disable=no-name-in-module, import-error
+    from sklearn.utils.testing import ignore_warnings
     from sklearn.base import (
         BaseEstimator,
         ClassifierMixin,

--- a/mlflow/store/db_migrations/versions/a8c4a736bde6_allow_nulls_for_run_id.py
+++ b/mlflow/store/db_migrations/versions/a8c4a736bde6_allow_nulls_for_run_id.py
@@ -19,7 +19,7 @@ depends_on = None
 
 def upgrade():
     with op.batch_alter_table(SqlModelVersion.__tablename__) as batch_op:
-        batch_op.alter_column("run_id", nullable=True)
+        batch_op.alter_column("run_id", nullable=True, existing_type=sa.VARCHAR(32))
 
 
 def downgrade():

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -662,7 +662,7 @@ class SqlAlchemyStore(AbstractStore):
                 conditions = [
                     SqlModelVersion.name == name,
                     SqlModelVersion.version != version,
-                    SqlModelVersion.current_stage == stage,
+                    SqlModelVersion.current_stage == get_canonical_stage(stage),
                 ]
                 model_versions = session.query(SqlModelVersion).filter(*conditions).all()
                 for mv in model_versions:

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1106,11 +1106,8 @@ def autolog(
         return result
 
     managed = [
-        (EventFileWriter, "add_event", add_event),
-        (EventFileWriterV2, "add_event", add_event),
         (tensorflow.estimator.Estimator, "train", train),
         (tensorflow.keras.Model, "fit", FitPatch),
-        (FileWriter, "add_summary", add_summary),
     ]
 
     if LooseVersion(tensorflow.__version__) < LooseVersion("2.1.0"):
@@ -1121,6 +1118,9 @@ def autolog(
         managed.append((tensorflow.keras.Model, "fit_generator", FitGeneratorPatch))
 
     non_managed = [
+        (EventFileWriter, "add_event", add_event),
+        (EventFileWriterV2, "add_event", add_event),
+        (FileWriter, "add_summary", add_summary),
         (tensorflow.estimator.Estimator, "export_saved_model", export_saved_model),
         (tensorflow.estimator.Estimator, "export_savedmodel", export_saved_model),
     ]

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -530,19 +530,24 @@ class _AutologgingSessionManager:
     @contextmanager
     def start_session(cls, integration):
         try:
-            session_id = uuid.uuid4().hex
-            if cls._session is None:
+            prev_session = cls._session
+            if prev_session is None:
+                session_id = uuid.uuid4().hex
                 cls._session = AutologgingSession(integration, session_id)
             yield cls._session
         finally:
-            cls.end_session()
+            # Only end the session upon termination of the context if we created
+            # the session; otherwise, leave the session open for later termination
+            # by its creator
+            if prev_session is None:
+                cls._end_session()
 
     @classmethod
     def active_session(cls):
         return cls._session
 
     @classmethod
-    def end_session(cls):
+    def _end_session(cls):
         cls._session = None
 
 

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -10,6 +10,7 @@ from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.callbacks import ModelCheckpoint
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.autologging_utils import BatchMetricsLogger
+from mlflow.pytorch._pytorch_autolog import _get_optimizer_name
 from unittest.mock import patch
 
 NUM_EPOCHS = 20
@@ -61,10 +62,7 @@ def test_pytorch_autolog_logs_expected_data(pytorch_model):
 
     # Testing optimizer parameters are logged
     assert "optimizer_name" in data.params
-
-    # In pytorch-lightning >= 1.1.0, optimizer names are prefixed with "Lightning".
-    prefix = "Lightning" if LooseVersion(pl.__version__) >= LooseVersion("1.1.0") else ""
-    assert data.params["optimizer_name"] == prefix + "Adam"
+    assert data.params["optimizer_name"] == "Adam"
 
     # Testing model_summary.txt is saved
     client = mlflow.tracking.MlflowClient()
@@ -254,3 +252,19 @@ def test_pytorch_test_metrics_logged(pytorch_model_tests):
     data = run.data
     assert "test_loss" in data.metrics
     assert "test_acc" in data.metrics
+
+
+def test_get_optimizer_name():
+    adam = torch.optim.Adam(torch.nn.Linear(1, 1).parameters())
+    assert _get_optimizer_name(adam) == "Adam"
+
+
+@pytest.mark.skipif(
+    LooseVersion(pl.__version__) < LooseVersion("1.1.0"),
+    reason="`LightningOptimizer` doesn't exist in pytorch-lightning < 1.1.0",
+)
+def test_get_optimizer_name_with_lightning_optimizer():
+    from pytorch_lightning.core.optimizer import LightningOptimizer
+
+    adam = torch.optim.Adam(torch.nn.Linear(1, 1).parameters())
+    assert _get_optimizer_name(LightningOptimizer(adam)) == "Adam"

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -617,6 +617,20 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(mvd3.current_stage, "Production")
         self.assertEqual(mvd2.last_updated_timestamp, mvd3.last_updated_timestamp)
 
+        for uncanonical_stage_name in ["STAGING", "staging", "StAgInG"]:
+            self.store.transition_model_version_stage(mv1.name, mv1.version, "Staging", False)
+            self.store.transition_model_version_stage(mv2.name, mv2.version, "None", False)
+
+            # stage names are case-insensitive and auto-corrected to system stage names
+            self.store.transition_model_version_stage(
+                mv2.name, mv2.version, uncanonical_stage_name, True
+            )
+
+            mvd1 = self.store.get_model_version(name=mv1.name, version=mv1.version)
+            mvd2 = self.store.get_model_version(name=mv2.name, version=mv2.version)
+            self.assertEqual(mvd1.current_stage, "Archived")
+            self.assertEqual(mvd2.current_stage, "Staging")
+
     def test_delete_model_version(self):
         name = "test_for_delete_MV"
         initial_tags = [

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -637,3 +637,36 @@ def test_duplicate_autolog_second_overrides(tf_estimator_random_data_run):
     client = mlflow.tracking.MlflowClient()
     metrics = client.get_metric_history(tf_estimator_random_data_run.info.run_id, "loss")
     assert all((x.step - 1) % 4 == 0 for x in metrics)
+
+
+@pytest.mark.large
+def test_flush_queue_is_thread_safe():
+    """
+    Autologging augments TensorBoard event logging hooks with MLflow `log_metric` API
+    calls. To prevent these API calls from blocking TensorBoard event logs, `log_metric`
+    API calls are scheduled via `_flush_queue` on a background thread. Accordingly, this test
+    verifies that `_flush_queue` is thread safe.
+    """
+    from threading import Thread
+    from mlflow.entities import Metric
+    from mlflow.tensorflow import _flush_queue, _metric_queue_lock
+
+    metric_queue_item = ("run_id1", Metric("foo", "bar", 100, 1))
+    mlflow.tensorflow._metric_queue.append(metric_queue_item)
+
+    # Verify that, if another thread holds a lock on the metric queue leveraged by
+    # _flush_queue, _flush_queue terminates and does not modify the queue
+    _metric_queue_lock.acquire()
+    flush_thread1 = Thread(target=_flush_queue)
+    flush_thread1.start()
+    flush_thread1.join()
+    assert len(mlflow.tensorflow._metric_queue) == 1
+    assert mlflow.tensorflow._metric_queue[0] == metric_queue_item
+    _metric_queue_lock.release()
+
+    # Verify that, if no other thread holds a lock on the metric queue leveraged by
+    # _flush_queue, _flush_queue flushes the queue as expected
+    flush_thread2 = Thread(target=_flush_queue)
+    flush_thread2.start()
+    flush_thread2.join()
+    assert len(mlflow.tensorflow._metric_queue) == 0


### PR DESCRIPTION
## What changes are proposed in this pull request?

Changelog and cherry-picks for MLflow 1.13.1.

## How is this patch tested?

MLflow unit & integration tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
