### PR TITLE
Fix UI crashes / inconsistencies related to path normalization

### DIFF
--- a/mlflow/server/js/src/common/utils/FileUtils.js
+++ b/mlflow/server/js/src/common/utils/FileUtils.js
@@ -16,6 +16,12 @@ export const getLanguage = (path) => {
   return ext;
 };
 
+export const normalize = (path) => {
+  const without_redundant_slashes = path.replace(/([^:]\/)\/+/g, '$1');
+  const without_trailing_slash = without_redundant_slashes.replace(/\/$/, '');
+  return without_trailing_slash;
+};
+
 export const MLPROJECT_FILE_NAME = 'mlproject';
 export const MLMODEL_FILE_NAME = 'mlmodel';
 

--- a/mlflow/server/js/src/common/utils/FileUtils.js
+++ b/mlflow/server/js/src/common/utils/FileUtils.js
@@ -16,12 +16,6 @@ export const getLanguage = (path) => {
   return ext;
 };
 
-export const normalize = (path) => {
-  const without_redundant_slashes = path.replace(/([^:]\/)\/+/g, '$1');
-  const without_trailing_slash = without_redundant_slashes.replace(/\/$/, '');
-  return without_trailing_slash;
-};
-
 export const MLPROJECT_FILE_NAME = 'mlproject';
 export const MLMODEL_FILE_NAME = 'mlmodel';
 

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -161,9 +161,11 @@ class Utils {
    * For example, normalize("foo://bar///baz/") === "foo://bar/baz"
    */
   static normalize(uri) {
+    // Remove empty authority component (e.g., "foo:///" becomes "foo:/")
+    const withNormalizedAuthority = uri.replace(/[:]\/\/\/+/, ':/');
     // Remove redundant slashes while ensuring that double slashes immediately following
     // the scheme component are preserved
-    const withoutRedundantSlashes = uri.replace(/([^:]\/)\/+/g, '$1');
+    const withoutRedundantSlashes = withNormalizedAuthority.replace(/(^\/|[^:]\/)\/+/g, '$1');
     const withoutTrailingSlash = withoutRedundantSlashes.replace(/\/$/, '');
     return withoutTrailingSlash;
   }

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -156,6 +156,18 @@ class Utils {
     return path.replace(/(.*[^/])\.[^/.]+$/, '$1');
   }
 
+  /**
+   * Normalizes a URI, removing redundant slashes and trailing slashes
+   * For example, normalize("foo://bar///baz/") === "foo://bar/baz"
+   */
+  static normalize = (uri) => {
+    // Remove redundant slashes while ensuring that double slashes immediately following
+    // the scheme component are preserved
+    const without_redundant_slashes = uri.replace(/([^:]\/)\/+/g, '$1');
+    const without_trailing_slash = without_redundant_slashes.replace(/\/$/, '');
+    return without_trailing_slash;
+  };
+
   static getGitHubRegex() {
     return /[@/]github.com[:/]([^/.]+)\/([^/#]+)#?(.*)/;
   }

--- a/mlflow/server/js/src/common/utils/Utils.js
+++ b/mlflow/server/js/src/common/utils/Utils.js
@@ -160,13 +160,13 @@ class Utils {
    * Normalizes a URI, removing redundant slashes and trailing slashes
    * For example, normalize("foo://bar///baz/") === "foo://bar/baz"
    */
-  static normalize = (uri) => {
+  static normalize(uri) {
     // Remove redundant slashes while ensuring that double slashes immediately following
     // the scheme component are preserved
-    const without_redundant_slashes = uri.replace(/([^:]\/)\/+/g, '$1');
-    const without_trailing_slash = without_redundant_slashes.replace(/\/$/, '');
-    return without_trailing_slash;
-  };
+    const withoutRedundantSlashes = uri.replace(/([^:]\/)\/+/g, '$1');
+    const withoutTrailingSlash = withoutRedundantSlashes.replace(/\/$/, '');
+    return withoutTrailingSlash;
+  }
 
   static getGitHubRegex() {
     return /[@/]github.com[:/]([^/.]+)\/([^/#]+)#?(.*)/;

--- a/mlflow/server/js/src/common/utils/Utils.test.js
+++ b/mlflow/server/js/src/common/utils/Utils.test.js
@@ -349,3 +349,16 @@ test('compareExperiments', () => {
 
   expect([expB, exp1, expA, exp0].sort(Utils.compareExperiments)).toEqual([exp0, exp1, expA, expB]);
 });
+
+test('normalize', () => {
+  expect(Utils.normalize('/normalized/absolute/path')).toEqual('/normalized/absolute/path');
+  expect(Utils.normalize('normalized/relative/path')).toEqual('normalized/relative/path');
+  expect(Utils.normalize('http://mlflow.org/resource')).toEqual('http://mlflow.org/resource');
+  expect(Utils.normalize('s3:/bucket/resource')).toEqual('s3:/bucket/resource');
+  expect(Utils.normalize('C:\\Windows\\Filesystem\\Path')).toEqual('C:\\Windows\\Filesystem\\Path');
+
+  expect(Utils.normalize('///redundant//absolute/path')).toEqual('/redundant/absolute/path');
+  expect(Utils.normalize('redundant//relative///path///')).toEqual('redundant/relative/path');
+  expect(Utils.normalize('http://mlflow.org///redundant/')).toEqual('http://mlflow.org/redundant');
+  expect(Utils.normalize('s3:///bucket/resource/')).toEqual('s3:/bucket/resource');
+});

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
@@ -52,7 +52,7 @@ export class ArtifactViewImpl extends Component {
 
   getExistingModelVersions() {
     const { modelVersionsBySource } = this.props;
-    const activeNodeRealPath = this.getActiveNodeRealPath();
+    const activeNodeRealPath = Utils.normalize(this.getActiveNodeRealPath());
     return modelVersionsBySource[activeNodeRealPath];
   }
 
@@ -291,7 +291,10 @@ const mapStateToProps = (state, ownProps) => {
   const { apis } = state;
   const artifactNode = getArtifacts(runUuid, state);
   const artifactRootUri = getArtifactRootUri(runUuid, state);
-  const modelVersionsBySource = _.groupBy(getAllModelVersions(state), 'source');
+  const modelVersionsWithNormalizedSource = _.flatMap(getAllModelVersions(state), (version) => {
+    return { ...version, source: Utils.normalize(version.source) };
+  });
+  const modelVersionsBySource = _.groupBy(modelVersionsWithNormalizedSource, 'source');
   return { artifactNode, artifactRootUri, modelVersionsBySource, apis };
 };
 

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -7,7 +7,6 @@ import { RunInfo } from '../sdk/MlflowMessages';
 import { Link } from 'react-router-dom';
 import Routes from '../routes';
 import Utils from '../../common/utils/Utils';
-import { normalize } from '../../common/utils/FileUtils';
 
 import { AgGridReact } from '@ag-grid-community/react/main';
 import { Grid } from '@ag-grid-community/core';
@@ -593,7 +592,9 @@ export function ModelsCellRenderer(props) {
         version,
       } = registeredModels[0];
 
-      const normalizedSourceArtifactPath = Utils.normalize(registeredModelSource).split(`${runId}/artifacts/`)[1];
+      const normalizedSourceArtifactPath = Utils.normalize(registeredModelSource).split(
+        `${runId}/artifacts/`,
+      )[1];
       const matchingModels = loggedModels.filter(
         (model) => Utils.normalize(model['artifact_path']) === normalizedSourceArtifactPath,
       );
@@ -604,7 +605,7 @@ export function ModelsCellRenderer(props) {
             {' - '}
             <img
               data-test-id='registered-model-icon'
-              alt=''
+              alt='registered model icon'
               title='Registered Model'
               src={registeredModelSvg}
             />

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.js
@@ -7,6 +7,7 @@ import { RunInfo } from '../sdk/MlflowMessages';
 import { Link } from 'react-router-dom';
 import Routes from '../routes';
 import Utils from '../../common/utils/Utils';
+import { normalize } from '../../common/utils/FileUtils';
 
 import { AgGridReact } from '@ag-grid-community/react/main';
 import { Grid } from '@ag-grid-community/core';
@@ -591,28 +592,34 @@ export function ModelsCellRenderer(props) {
         source: registeredModelSource,
         version,
       } = registeredModels[0];
-      const artifactPath = registeredModelSource.split(`${runId}/artifacts/`)[1];
-      [loggedModel] = loggedModels.filter((model) => model['artifact_path'].includes(artifactPath));
-      registeredModelDiv = (
-        <>
-          {' - '}
-          <img
-            data-test-id='registered-model-icon'
-            alt=''
-            title='Registered Model'
-            src={registeredModelSvg}
-          />
-          <a
-            href={getModelVersionPageURL(registeredModelName, version)}
-            className='model-version-link'
-            title={`${registeredModelName}, v${version}`}
-            target='_blank'
-          >
-            <TrimmedText text={registeredModelName} maxSize={10} className={'model-name'} />
-            {`/${version}`}
-          </a>
-        </>
+
+      const normalizedSourceArtifactPath = Utils.normalize(registeredModelSource).split(`${runId}/artifacts/`)[1];
+      const matchingModels = loggedModels.filter(
+        (model) => Utils.normalize(model['artifact_path']) === normalizedSourceArtifactPath,
       );
+      if (matchingModels.length > 0) {
+        [loggedModel] = matchingModels;
+        registeredModelDiv = (
+          <>
+            {' - '}
+            <img
+              data-test-id='registered-model-icon'
+              alt=''
+              title='Registered Model'
+              src={registeredModelSvg}
+            />
+            <a
+              href={getModelVersionPageURL(registeredModelName, version)}
+              className='model-version-link'
+              title={`${registeredModelName}, v${version}`}
+              target='_blank'
+            >
+              <TrimmedText text={registeredModelName} maxSize={10} className={'model-name'} />
+              {`/${version}`}
+            </a>
+          </>
+        );
+      }
     }
     const loggedModelFlavorText = loggedModel['flavors'] ? loggedModel['flavors'][0] : 'Model';
     const loggedModelLink = Routes.getRunArtifactRoute(

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
@@ -123,6 +123,42 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
     expect(wrapper.find('img[data-test-id="registered-model-icon"]')).toHaveLength(1);
   });
 
+  test('should show registered model link for semantically equivalent artifact paths', () => {
+    const runArtifactPath = 'somePath////subdir///';
+    const loggedModelHistoryTag = {
+      'mlflow.log-model.history': RunTag.fromJs({
+        key: 'mlflow.log-model.history',
+        value:
+          `[{"run_id":"someUuid","artifact_path":"${runArtifactPath}",` +
+          '"utc_time_created":"2020-10-22 23:18:51.726087","flavors":' +
+          '{"keras":{"keras_module":"tensorflow.keras","keras_version":"2.4.0","data":"data"},' +
+          '"python_function":{"loader_module":"mlflow.keras","python_version":"3.7.6",' +
+          '"data":"data","env":"conda.yaml"}}}]',
+      }),
+    };
+
+    const props = {
+      data: {
+        runInfo: { run_uuid: 'someUuid' },
+        tags: loggedModelHistoryTag,
+        modelVersionsByRunUuid: {
+          someUuid: [
+            {
+              name: 'someName',
+              source: 'dbfs:///someUuid/artifacts///somePath///subdir/',
+              version: 2,
+            },
+          ],
+        },
+      },
+    };
+    const output = ModelsCellRenderer(props);
+    wrapper = shallow(<Router>{output}</Router>);
+    expect(wrapper.html()).toContain('keras');
+    expect(wrapper.find('img[data-test-id="logged-model-icon"]')).toHaveLength(1);
+    expect(wrapper.find('img[data-test-id="registered-model-icon"]')).toHaveLength(1);
+  });
+
   test('should show 1 more if two logged models', () => {
     const tag = {
       'mlflow.log-model.history': RunTag.fromJs({

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentRunsTableMultiColumnView2.test.js
@@ -123,6 +123,13 @@ describe('ExperimentRunsTableMultiColumnView2', () => {
     expect(wrapper.find('img[data-test-id="registered-model-icon"]')).toHaveLength(1);
   });
 
+  /**
+   * A model version's source may be semantically equivalent to a run artifact path
+   * but syntactically distinct; this occurs when there are redundant or trailing
+   * slashes present in the version source or run artifact path. This test verifies that,
+   * in these cases, associated registered model links are still displayed correctly for runs
+   * containing model artifacts with semantically equivalent paths.
+   */
   test('should show registered model link for semantically equivalent artifact paths', () => {
     const runArtifactPath = 'somePath////subdir///';
     const loggedModelHistoryTag = {


### PR DESCRIPTION
## What changes are proposed in this pull request?

As outlined in #3919, the MLflow UI's experiment runs compact view table contains brittle artifact path comparison logic that does not handle the case where two artifact paths are semantically equivalent but syntactically different, which can happen if one artifact path contains duplicate forward slashes or trailing slashes.

Similar brittle comparison logic exists in MLflow's artifact viewer. If a model version exists with source `/tmp/foo///bar/` and a run artifact with path `/tmp/foo/bar` is examined in the MLflow Artifact Viewer, this run artifact won't be associated with the model version in the UI (instead of seeing version info, users see the blue "Register Model" button, as if no existing versions are associated with it).

This PR fixes #3919 and addresses the artifact viewer issue.

## How is this patch tested?

Unit tests pending

## Release Notes

Fix experiment UI crash and artifact viewer inconsistency when model versions sources and run artifact paths differ by trailing or duplicate slashes.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [X] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
