### PR TITLE
Fix bug causing `transition_model_version_stage` to fail archiving existing model versions when uncanonical stage name is passed

### DIFF
--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -662,7 +662,7 @@ class SqlAlchemyStore(AbstractStore):
                 conditions = [
                     SqlModelVersion.name == name,
                     SqlModelVersion.version != version,
-                    SqlModelVersion.current_stage == stage,
+                    SqlModelVersion.current_stage == get_canonical_stage(stage),
                 ]
                 model_versions = session.query(SqlModelVersion).filter(*conditions).all()
                 for mv in model_versions:

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -617,6 +617,18 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(mvd3.current_stage, "Production")
         self.assertEqual(mvd2.last_updated_timestamp, mvd3.last_updated_timestamp)
 
+        for stage_name in ["STAGING", "staging", "StAgInG"]:
+            self.store.transition_model_version_stage(mv1.name, mv1.version, "None", False)
+            self.store.transition_model_version_stage(mv2.name, mv2.version, "Staging", False)
+
+            # stage names are case-insensitive and auto-corrected to system stage names
+            self.store.transition_model_version_stage(mv1.name, mv1.version, stage_name, True)
+
+            mvd1 = self.store.get_model_version(name=mv1.name, version=mv1.version)
+            mvd2 = self.store.get_model_version(name=mv2.name, version=mv2.version)
+            self.assertEqual(mvd1.current_stage, "Staging")
+            self.assertEqual(mvd2.current_stage, "Archived")
+
     def test_delete_model_version(self):
         name = "test_for_delete_MV"
         initial_tags = [

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -617,12 +617,14 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(mvd3.current_stage, "Production")
         self.assertEqual(mvd2.last_updated_timestamp, mvd3.last_updated_timestamp)
 
-        for stage_name in ["STAGING", "staging", "StAgInG"]:
+        for uncanonical_stage_name in ["STAGING", "staging", "StAgInG"]:
             self.store.transition_model_version_stage(mv1.name, mv1.version, "None", False)
             self.store.transition_model_version_stage(mv2.name, mv2.version, "Staging", False)
 
             # stage names are case-insensitive and auto-corrected to system stage names
-            self.store.transition_model_version_stage(mv1.name, mv1.version, stage_name, True)
+            self.store.transition_model_version_stage(
+                mv1.name, mv1.version, uncanonical_stage_name, True
+            )
 
             mvd1 = self.store.get_model_version(name=mv1.name, version=mv1.version)
             mvd2 = self.store.get_model_version(name=mv2.name, version=mv2.version)

--- a/tests/store/model_registry/test_sqlalchemy_store.py
+++ b/tests/store/model_registry/test_sqlalchemy_store.py
@@ -618,18 +618,18 @@ class TestSqlAlchemyStoreSqlite(unittest.TestCase):
         self.assertEqual(mvd2.last_updated_timestamp, mvd3.last_updated_timestamp)
 
         for uncanonical_stage_name in ["STAGING", "staging", "StAgInG"]:
-            self.store.transition_model_version_stage(mv1.name, mv1.version, "None", False)
-            self.store.transition_model_version_stage(mv2.name, mv2.version, "Staging", False)
+            self.store.transition_model_version_stage(mv1.name, mv1.version, "Staging", False)
+            self.store.transition_model_version_stage(mv2.name, mv2.version, "None", False)
 
             # stage names are case-insensitive and auto-corrected to system stage names
             self.store.transition_model_version_stage(
-                mv1.name, mv1.version, uncanonical_stage_name, True
+                mv2.name, mv2.version, uncanonical_stage_name, True
             )
 
             mvd1 = self.store.get_model_version(name=mv1.name, version=mv1.version)
             mvd2 = self.store.get_model_version(name=mv2.name, version=mv2.version)
-            self.assertEqual(mvd1.current_stage, "Staging")
-            self.assertEqual(mvd2.current_stage, "Archived")
+            self.assertEqual(mvd1.current_stage, "Archived")
+            self.assertEqual(mvd2.current_stage, "Staging")
 
     def test_delete_model_version(self):
         name = "test_for_delete_MV"


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- Fixes #3926

## How is this patch tested?

Unit test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
