### PR TITLE
Use `xgboost.callback.TrainingCallback` in newer versions (>= 1.3.0) of XGBoost

### DIFF
--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -378,6 +378,9 @@ def autolog(
                     xgboost.callback.TrainingCallback, metaclass=ExceptionSafeAbstractClass,
                 ):
                     def after_iteration(self, model, epoch, evals_log):
+                        """
+                        Run after each iteration. Return True when training should stop.
+                        """
                         evaluation_result_dict = {}
                         for data_name, metric_dict in evals_log.items():
                             for metric_name, metric_values in metric_dict.items():
@@ -386,6 +389,8 @@ def autolog(
 
                         metrics_logger.record_metrics(evaluation_result_dict, epoch)
                         eval_results.append(evaluation_result_dict)
+
+                        return False
 
                 return Callback()
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -41,7 +41,9 @@ from mlflow.utils.autologging_utils import (
     autologging_integration,
     safe_patch,
     exception_safe_function,
-    ExceptionSafeAbstractClass,
+    # Pylint doesn't detect objects used in class keyword arguments (e.g., metaclass) and considers
+    # `ExceptionSafeAbstractClass` as 'unused-import': https://github.com/PyCQA/pylint/issues/1630
+    ExceptionSafeAbstractClass,  # pylint: disable=unused-import
     try_mlflow_log,
     log_fn_args_as_params,
     INPUT_EXAMPLE_SAMPLE_ROWS,
@@ -371,8 +373,9 @@ def autolog(
                 # In xgboost >= 1.3.0, user-defined callbacks should inherit
                 # `xgboost.callback.TrainingCallback`:
                 # https://xgboost.readthedocs.io/en/latest/python/callbacks.html#defining-your-own-callback  # noqa
+
                 class Callback(
-                    xgboost.callback.TrainingCallback, metaclass=ExceptionSafeAbstractClass
+                    xgboost.callback.TrainingCallback, metaclass=ExceptionSafeAbstractClass,
                 ):
                     def after_iteration(self, model, epoch, evals_log):
                         evaluation_result_dict = {}

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -41,9 +41,6 @@ from mlflow.utils.autologging_utils import (
     autologging_integration,
     safe_patch,
     exception_safe_function,
-    # Pylint doesn't detect objects used in class keyword arguments (e.g., metaclass) and considers
-    # `ExceptionSafeAbstractClass` as 'unused-import': https://github.com/PyCQA/pylint/issues/1630
-    ExceptionSafeAbstractClass,  # pylint: disable=unused-import
     try_mlflow_log,
     log_fn_args_as_params,
     INPUT_EXAMPLE_SAMPLE_ROWS,
@@ -52,6 +49,13 @@ from mlflow.utils.autologging_utils import (
     ENSURE_AUTOLOGGING_ENABLED_TEXT,
     batch_metrics_logger,
 )
+
+# Pylint doesn't detect objects used in class keyword arguments (e.g., metaclass) and considers
+# `ExceptionSafeAbstractClass` as 'unused-import': https://github.com/PyCQA/pylint/issues/1630
+from mlflow.utils.autologging_utils import (  # pylint: disable=unused-import
+    ExceptionSafeAbstractClass,
+)
+
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
 FLAVOR_NAME = "xgboost"

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -386,7 +386,8 @@ def autolog(
                         """
                         Run after each iteration. Return True when training should stop.
                         """
-                        # `evals_log` is a nested dict that looks like this:
+                        # `evals_log` is a nested dict (type: Dict[str, Dict[str, List[float]]])
+                        # that looks like this:
                         # {
                         #   "train": {
                         #     "auc": [0.5, 0.6, 0.7, ...],

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -395,6 +395,7 @@ def autolog(
                         metrics_logger.record_metrics(evaluation_result_dict, epoch)
                         eval_results.append(evaluation_result_dict)
 
+                        # Return `False` to indicate training should not stop
                         return False
 
                 return Callback()

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -386,10 +386,20 @@ def autolog(
                         """
                         Run after each iteration. Return True when training should stop.
                         """
+                        # `evals_log` (type: Dict[str, Dict[str, List[float]]]) looks like this:
+                        # {
+                        #   "train": {
+                        #     "auc": [0.5, 0.6, 0.7, ...],
+                        #     ...
+                        #   },
+                        #   ...
+                        # }
                         evaluation_result_dict = {}
                         for data_name, metric_dict in evals_log.items():
                             for metric_name, metric_values in metric_dict.items():
                                 key = "{}-{}".format(data_name, metric_name)
+                                # metric value on the current iteration is stored in the last
+                                # element of `metric_values`
                                 evaluation_result_dict[key] = metric_values[-1]
 
                         metrics_logger.record_metrics(evaluation_result_dict, epoch)

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -386,7 +386,7 @@ def autolog(
                         """
                         Run after each iteration. Return True when training should stop.
                         """
-                        # `evals_log` (type: Dict[str, Dict[str, List[float]]]) looks like this:
+                        # `evals_log` is a nested dict that looks like this:
                         # {
                         #   "train": {
                         #     "auc": [0.5, 0.6, 0.7, ...],
@@ -396,11 +396,11 @@ def autolog(
                         # }
                         evaluation_result_dict = {}
                         for data_name, metric_dict in evals_log.items():
-                            for metric_name, metric_values in metric_dict.items():
+                            for metric_name, metric_values_on_each_iter in metric_dict.items():
                                 key = "{}-{}".format(data_name, metric_name)
-                                # metric value on the current iteration is stored in the last
-                                # element of `metric_values`
-                                evaluation_result_dict[key] = metric_values[-1]
+                                # The last element in `metric_values_on_each_iter` corresponds to
+                                # the meric on the current iteration
+                                evaluation_result_dict[key] = metric_values_on_each_iter[-1]
 
                         metrics_logger.record_metrics(evaluation_result_dict, epoch)
                         eval_results.append(evaluation_result_dict)

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -52,6 +52,7 @@ from mlflow.utils.autologging_utils import (
 
 # Pylint doesn't detect objects used in class keyword arguments (e.g., metaclass) and considers
 # `ExceptionSafeAbstractClass` as 'unused-import': https://github.com/PyCQA/pylint/issues/1630
+# To avoid this bug, disable 'unused-import' on this line.
 from mlflow.utils.autologging_utils import (  # pylint: disable=unused-import
     ExceptionSafeAbstractClass,
 )


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

In `xgboost` >= 1.3.0, user-defined callbacks should be an  instance of `xgboost.callback.TrainingCallback`:
https://xgboost.readthedocs.io/en/latest/python/callbacks.html#defining-your-own-callback

```
/usr/share/miniconda/envs/test-environment/lib/python3.6/site-packages/xgboost/training.py:19:
UserWarning: Old style callback is deprecated.  See: https://xgboost.readthedocs.io/en/latest/python/callbacks.html
```

https://github.com/mlflow/mlflow/runs/1630510639#step:4:731

## How is this patch tested?

Verified:

- The xgboost autologging tests no longer emit the deprecation warning in xgboost >= 1.3.0
- The same tests still succeed in xgboost < 1.3.0.


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
