### PR TITLE
Disable `broad-except` in Pylint

### DIFF
--- a/mlflow/_spark_autologging.py
+++ b/mlflow/_spark_autologging.py
@@ -125,7 +125,7 @@ def _listen_for_spark_activity(spark_context):
         if callback_server_started:
             try:
                 gw.shutdown_callback_server()
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception as e:
                 _logger.warning(
                     "Failed to shut down Spark callback server for autologging: %s", str(e)
                 )
@@ -189,7 +189,7 @@ class PythonSubscriber(object, metaclass=ExceptionSafeClass):
     def notify(self, path, version, data_format):
         try:
             self._notify(path, version, data_format)
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             _logger.error(
                 "Unexpected exception %s while attempting to log Spark datasource "
                 "info. Exception:\n",

--- a/mlflow/azureml/__init__.py
+++ b/mlflow/azureml/__init__.py
@@ -419,7 +419,7 @@ def deploy(
             try:
                 registered_model = AzureModel(workspace, id=azure_model_id)
                 _logger.info("Found registered model in AzureML with ID '%s'", azure_model_id)
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception as e:
                 _logger.info(
                     "Unable to find model in AzureML with ID '%s', will register the model.\n"
                     "Exception was: %s",

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -273,7 +273,7 @@ def ui(backend_store_uri, default_artifact_root, port, host):
 
     try:
         initialize_backend_stores(backend_store_uri, default_artifact_root)
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as e:
         _logger.error("Error initializing backend store")
         _logger.exception(e)
         sys.exit(1)
@@ -384,7 +384,7 @@ def server(
 
     try:
         initialize_backend_stores(backend_store_uri, default_artifact_root)
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as e:
         _logger.error("Error initializing backend store")
         _logger.exception(e)
         sys.exit(1)

--- a/mlflow/lightgbm.py
+++ b/mlflow/lightgbm.py
@@ -346,7 +346,7 @@ def autolog(
                 input_example_info = _InputExampleInfo(
                     input_example=deepcopy(data[:INPUT_EXAMPLE_SAMPLE_ROWS])
                 )
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception as e:
                 input_example_info = _InputExampleInfo(error_msg=str(e))
 
             setattr(self, "input_example_info", input_example_info)
@@ -468,7 +468,7 @@ def autolog(
             importance = model.feature_importance(importance_type=imp_type)
             try:
                 log_feature_importance_plot(features, importance, imp_type)
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 _logger.exception(
                     "Failed to log feature importance plot. LightGBM autologging "
                     "will ignore the failure and continue. Exception: "

--- a/mlflow/projects/databricks.py
+++ b/mlflow/projects/databricks.py
@@ -122,7 +122,7 @@ class DatabricksJobRunner(object):
         )
         try:
             json_response_obj = json.loads(response.text)
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             raise MlflowException(
                 "API request to check existence of file at DBFS path %s failed with status code "
                 "%s. Response body: %s" % (dbfs_path, response.status_code, response.text)

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -76,7 +76,7 @@ def build_docker_image(work_dir, repository_uri, base_image, run_id):
         )
     try:
         os.remove(build_ctx_path)
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         _logger.info("Temporary docker context file %s was not deleted.", build_ctx_path)
     tracking.MlflowClient().set_tag(run_id, MLFLOW_DOCKER_IMAGE_URI, image_uri)
     tracking.MlflowClient().set_tag(run_id, MLFLOW_DOCKER_IMAGE_ID, image.id)

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -68,7 +68,7 @@ def parse_json_input(json_input, orient="split", schema: Schema = None):
                    or 'records'.
     :param schema: Optional schema specification to be used during parsing.
     """
-    # pylint: disable=broad-except
+
     try:
         return _dataframe_from_json(json_input, pandas_orient=orient, schema=schema)
     except Exception:
@@ -88,7 +88,7 @@ def parse_csv_input(csv_input):
     :param csv_input: A CSV-formatted string representation of a Pandas DataFrame, or a stream
                       containing such a string representation.
     """
-    # pylint: disable=broad-except
+
     try:
         return pd.read_csv(csv_input)
     except Exception:
@@ -107,7 +107,7 @@ def parse_split_oriented_json_input_to_numpy(json_input):
     :param json_input: A JSON-formatted string representation of a Pandas DataFrame with split
                        orient, or a stream containing such a string representation.
     """
-    # pylint: disable=broad-except
+
     try:
         json_input_list = json.loads(json_input, object_pairs_hook=OrderedDict)
         return pd.DataFrame(
@@ -208,7 +208,7 @@ def init(model: PyFuncModel):
             )
 
         # Do the prediction
-        # pylint: disable=broad-except
+
         try:
             raw_predictions = model.predict(data)
         except MlflowException as e:

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -588,7 +588,7 @@ def _load_model(path, **kwargs):
         try:
             # load the model as an eager model.
             return torch.load(model_path, **kwargs)
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             # If fails, assume the model as a scripted model
             return torch.jit.load(model_path)
 

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -813,7 +813,7 @@ def autolog(
             try:
                 score_args = _get_args_for_score(estimator.score, estimator.fit, args, kwargs)
                 training_score = estimator.score(*score_args)
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception as e:
                 msg = (
                     estimator.score.__qualname__
                     + " failed. The 'training_score' metric will not be recorded. Scoring error: "
@@ -894,7 +894,7 @@ def autolog(
                         parent_run=mlflow.active_run(),
                         child_tags=child_tags,
                     )
-                except Exception as e:  # pylint: disable=broad-except
+                except Exception as e:
 
                     msg = (
                         "Encountered exception during creation of child runs for parameter search."
@@ -907,7 +907,7 @@ def autolog(
                     _log_parameter_search_results_as_artifact(
                         cv_results_df, mlflow.active_run().info.run_id
                     )
-                except Exception as e:  # pylint: disable=broad-except
+                except Exception as e:
 
                     msg = (
                         "Failed to log parameter search results as an artifact."

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -133,7 +133,7 @@ def _get_metrics_value_dict(metrics_list):
     for metric in metrics_list:
         try:
             metric_value = metric.function(**metric.arguments)
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             _log_warning_for_metrics(metric.name, metric.function, e)
         else:
             metric_value_dict[metric.name] = metric_value
@@ -460,7 +460,7 @@ def _log_specialized_estimator_content(fitted_estimator, run_id, fit_args, fit_k
 
         elif sklearn.base.is_regressor(fitted_estimator):
             name_metric_dict = _get_regressor_metrics(fitted_estimator, fit_args, fit_kwargs)
-    except Exception as err:  # pylint: disable=broad-except
+    except Exception as err:
         msg = (
             "Failed to autolog metrics for "
             + fitted_estimator.__class__.__name__
@@ -482,7 +482,7 @@ def _log_specialized_estimator_content(fitted_estimator, run_id, fit_args, fit_k
     if sklearn.base.is_classifier(fitted_estimator):
         try:
             artifacts = _get_classifier_artifacts(fitted_estimator, fit_args, fit_kwargs)
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             msg = (
                 "Failed to autolog artifacts for "
                 + fitted_estimator.__class__.__name__
@@ -502,7 +502,7 @@ def _log_specialized_estimator_content(fitted_estimator, run_id, fit_args, fit_k
                     import matplotlib.pyplot as plt
 
                     plt.close(display.figure_)
-                except Exception as e:  # pylint: disable=broad-except
+                except Exception as e:
                     _log_warning_for_artifacts(artifact.name, artifact.function, e)
 
             try_mlflow_log(mlflow_client.log_artifacts, run_id, tmp_dir.path())

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -319,7 +319,7 @@ class _HadoopFileSystem:
     def _try_file_exists(cls, dfs_path):
         try:
             return cls._fs().exists(dfs_path)
-        except Exception as ex:  # pylint: disable=broad-except
+        except Exception as ex:
             # Log a debug-level message, since existence checks may raise exceptions
             # in normal operating circumstances that do not warrant warnings
             _logger.debug(
@@ -341,7 +341,7 @@ class _HadoopFileSystem:
             if cls._try_file_exists(dfs_path):
                 _logger.info("File '%s' is already on DFS, copy is not necessary.", src_uri)
                 return src_uri
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             _logger.info("URI '%s' does not point to the current DFS.", src_uri)
         _logger.info("File '%s' not found on DFS. Will attempt to upload the file.", src_uri)
         return cls.maybe_copy_from_local_file(_download_artifact_from_uri(src_uri), dst_path)

--- a/mlflow/store/db_migrations/versions/0a8213491aaa_drop_duplicate_killed_constraint.py
+++ b/mlflow/store/db_migrations/versions/0a8213491aaa_drop_duplicate_killed_constraint.py
@@ -32,7 +32,7 @@ def upgrade():
     # outside of the batch operation context.
     try:
         op.drop_constraint(constraint_name="status", table_name="runs", type_="check")
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as e:
         _logger.warning(
             "Failed to drop check constraint. Dropping check constraints may not be supported"
             " by your SQL database. Exception content: %s",

--- a/mlflow/tracking/context/registry.py
+++ b/mlflow/tracking/context/registry.py
@@ -75,7 +75,7 @@ def resolve_tags(tags=None):
         try:
             if provider.in_context():
                 all_tags.update(provider.tags())
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             _logger.warning("Encountered unexpected error during resolving tags: %s", e)
 
     if tags is not None:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1318,7 +1318,7 @@ def autolog(
         try:
             needed_params = list(inspect.signature(autolog_fn).parameters.keys())
             return {k: v for k, v in locals_copy if k in needed_params}
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             return {}
 
     def setup_autologging(module):
@@ -1327,7 +1327,7 @@ def autolog(
             autologging_params = get_autologging_params(autolog_fn)
             autolog_fn(**autologging_params)
             _logger.info("Autologging successfully enabled for %s.", module.__name__)
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             if _is_testing():
                 # Raise unexpected exceptions in test mode in order to detect
                 # errors within dependent autologging integrations
@@ -1356,7 +1356,7 @@ def autolog(
         #   of their session so we want to enable autologging once they do
         if "pyspark" in str(ie):
             register_post_import_hook(setup_autologging, "pyspark", overwrite=True)
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as e:
         if _is_testing():
             # Raise unexpected exceptions in test mode in order to detect
             # errors within dependent autologging integrations

--- a/mlflow/utils/_spark_utils.py
+++ b/mlflow/utils/_spark_utils.py
@@ -7,6 +7,6 @@ def _get_active_spark_session():
     try:
         # getActiveSession() only exists in Spark 3.0 and above
         return SparkSession.getActiveSession()
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         # Fall back to this internal field for Spark 2.x and below.
         return SparkSession._instantiatedSession

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -40,7 +40,7 @@ def try_mlflow_log(fn, *args, **kwargs):
     """
     try:
         return fn(*args, **kwargs)
-    except Exception as e:  # pylint: disable=broad-except
+    except Exception as e:
         if _is_testing():
             raise
         else:
@@ -101,7 +101,7 @@ def _update_wrapper_extended(wrapper, wrapped):
     # One such example is the `tensorflow.estimator.Estimator.export_savedmodel()` function
     try:
         updated_wrapper.__signature__ = inspect.signature(wrapped)
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         _logger.debug("Failed to restore original signature for wrapper around %s", wrapped)
     return updated_wrapper
 
@@ -175,7 +175,7 @@ def resolve_input_example_and_signature(
     if log_input_example or log_model_signature:
         try:
             input_example = get_input_example()
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             input_example_failure_msg = str(e)
             input_example_user_msg = "Failed to gather input example: " + str(e)
 
@@ -188,7 +188,7 @@ def resolve_input_example_and_signature(
                     "could not sample data to infer model signature: " + input_example_failure_msg
                 )
             model_signature = infer_model_signature(input_example)
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             model_signature_user_msg = "Failed to infer model signature: " + str(e)
 
     if log_input_example and input_example_user_msg is not None:
@@ -332,7 +332,7 @@ def autologging_integration(name):
         def autolog(*args, **kwargs):
             try:
                 AutologgingEventLogger.get_logger().log_autolog_called(name, args, kwargs)
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 pass
 
             config_to_store = dict(default_params)
@@ -406,7 +406,7 @@ def exception_safe_function(function):
     def safe_function(*args, **kwargs):
         try:
             return function(*args, **kwargs)
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             if _is_testing():
                 raise
             else:
@@ -508,7 +508,7 @@ class PatchFunction:
     def __call__(self, original, *args, **kwargs):
         try:
             return self._patch_implementation(original, *args, **kwargs)
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             try:
                 self._on_exception(e)
             finally:
@@ -946,7 +946,7 @@ def safe_patch(
         def try_log_autologging_event(log_fn, *args):
             try:
                 log_fn(*args)
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception as e:
                 _logger.debug("Failed to log autologging event via '%s'. Exception: %s", log_fn, e)
 
         with _augment_mlflow_warnings(
@@ -993,7 +993,7 @@ def safe_patch(
                         )
 
                         return original_result
-                    except Exception as e:  # pylint: disable=broad-except
+                    except Exception as e:
                         try_log_autologging_event(
                             AutologgingEventLogger.get_logger().log_original_function_error,
                             session,
@@ -1035,7 +1035,7 @@ def safe_patch(
                     args,
                     kwargs,
                 )
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception as e:
                 # Exceptions thrown during execution of the original function should be propagated
                 # to the caller. Additionally, exceptions encountered during test mode should be
                 # reraised to detect bugs in autologging implementations

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -53,7 +53,7 @@ def _get_context_tag(context_tag_key):
 def acl_path_of_acl_root():
     try:
         return _get_command_context().aclPathOfAclRoot().get()
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         return _get_extra_context("aclPathOfAclRoot")
 
 
@@ -64,7 +64,7 @@ def _get_property_from_spark_context(key):
         task_context = TaskContext.get()
         if task_context:
             return task_context.getLocalProperty(key)
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         return None
 
 
@@ -77,14 +77,14 @@ def is_in_databricks_notebook():
         return True
     try:
         return acl_path_of_acl_root().startswith("/workspace")
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         return False
 
 
 def is_in_databricks_job():
     try:
         return get_job_id() is not None and get_job_run_id() is not None
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         return False
 
 
@@ -97,7 +97,7 @@ def is_dbfs_fuse_available():
                 )
                 == 0
             )
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             return False
 
 
@@ -108,7 +108,7 @@ def is_in_cluster():
             spark_session is not None
             and spark_session.conf.get("spark.databricks.clusterUsageTags.clusterId") is not None
         )
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         return False
 
 
@@ -130,7 +130,7 @@ def get_notebook_path():
         return path
     try:
         return _get_command_context().notebookPath().get()
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         return _get_extra_context("notebook_path")
 
 
@@ -144,14 +144,14 @@ def get_cluster_id():
 def get_job_id():
     try:
         return _get_command_context().jobId().get()
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         return _get_context_tag("jobId")
 
 
 def get_job_run_id():
     try:
         return _get_command_context().idInJob().get()
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         return _get_context_tag("idInJob")
 
 
@@ -159,7 +159,7 @@ def get_job_type():
     """Should only be called if is_in_databricks_job is true"""
     try:
         return _get_command_context().jobTaskType().get()
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         return _get_context_tag("jobTaskType")
 
 
@@ -170,21 +170,21 @@ def get_webapp_url():
         return url
     try:
         return _get_command_context().apiUrl().get()
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         return _get_extra_context("api_url")
 
 
 def get_workspace_id():
     try:
         return _get_command_context().workspaceId().get()
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         return _get_context_tag("orgId")
 
 
 def get_browser_hostname():
     try:
         return _get_command_context().browserHostName().get()
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         return _get_context_tag("browserHostName")
 
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -99,7 +99,7 @@ def _can_parse_as_json(string):
     try:
         json.loads(string)
         return True
-    except Exception:  # pylint: disable=broad-except
+    except Exception:
         return False
 
 

--- a/mlflow/xgboost.py
+++ b/mlflow/xgboost.py
@@ -352,7 +352,7 @@ def autolog(
                 input_example_info = _InputExampleInfo(
                     input_example=deepcopy(data[:INPUT_EXAMPLE_SAMPLE_ROWS])
                 )
-            except Exception as e:  # pylint: disable=broad-except
+            except Exception as e:
                 input_example_info = _InputExampleInfo(error_msg=str(e))
 
             setattr(self, "input_example_info", input_example_info)
@@ -468,7 +468,7 @@ def autolog(
                 imp = model.get_score(importance_type=imp_type)
                 features, importance = zip(*imp.items())
                 log_feature_importance_plot(features, importance, imp_type)
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 _logger.exception(
                     "Failed to log feature importance plot. XGBoost autologging "
                     "will ignore the failure and continue. Exception: "

--- a/pylintrc
+++ b/pylintrc
@@ -149,6 +149,7 @@ disable=print-statement,
         redefined-outer-name,
         # Ignore errors raised against `ExceptionSafeClass` and `ExceptionSafeAbstractClass`
         invalid-metaclass,
+        broad-except,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -202,7 +202,7 @@ class RestEndpoint:
                 print("connection attempt", i, "server is up! ping status", ping_status)
                 if ping_status.status_code == 200:
                     break
-            except Exception:  # pylint: disable=broad-except
+            except Exception:
                 print("connection attempt", i, "failed, server is not up yet")
         if ping_status.status_code != 200:
             raise Exception("ping failed, server is not happy")

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -68,7 +68,7 @@ def spark_context():
         try:
             spark = get_spark_session(conf)
             return spark.sparkContext
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             if num_tries >= max_tries - 1:
                 raise
             _logger.exception(

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -129,7 +129,7 @@ class TestFileStore(unittest.TestCase, AbstractStoreTest):
         file_store = FileStore(self.test_root)
         try:
             file_store._check_root_dir()
-        except Exception as e:  # pylint: disable=broad-except
+        except Exception as e:
             self.fail("test_valid_root raised exception '%s'" % e.message)
 
         # Test removing root

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -42,7 +42,7 @@ def reset_global_states():
     for integration_name in library_to_mlflow_module.keys():
         try:
             del mlflow.utils.import_hooks._post_import_hooks[integration_name.__name__]
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             pass
 
     assert mlflow.utils.import_hooks._post_import_hooks == {}
@@ -52,7 +52,7 @@ def reset_global_states():
     for integration_name in library_to_mlflow_module.keys():
         try:
             del mlflow.utils.import_hooks._post_import_hooks[integration_name.__name__]
-        except Exception:  # pylint: disable=broad-except
+        except Exception:
             pass
 
     assert mlflow.utils.import_hooks._post_import_hooks == {}


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Addresses https://github.com/mlflow/mlflow/pull/3870#discussion_r546170707

## How is this patch tested?

- Manually verified `pylint: disable=broad-except` no longer exists

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
