### PR TITLE
Fix mlflow_list_experiments()

### DIFF
--- a/mlflow/R/mlflow/R/mlflow-package.R
+++ b/mlflow/R/mlflow/R/mlflow-package.R
@@ -5,4 +5,6 @@
 # roxygen namespace tags. Modify with care!
 ## usethis namespace: start
 ## usethis namespace: end
-NULL
+if (getRversion() >= "2.15.1") {
+  utils::globalVariables(".")
+}

--- a/mlflow/R/mlflow/R/tracking-experiments.R
+++ b/mlflow/R/mlflow/R/tracking-experiments.R
@@ -40,10 +40,26 @@ mlflow_list_experiments <- function(view_type = c("ACTIVE_ONLY", "DELETED_ONLY",
   # Return `NULL` if no experiments
   if (!length(response)) return(NULL)
 
-  response$experiments %>%
-    purrr::transpose() %>%
-    purrr::map(unlist) %>%
+  tags <- purrr::map(response$experiments, ~purrr::pluck(.x, 'tags')) %>%
+    unlist()
+  if (length(tags) > 0) {
+    # has any tags, make sure the all elements have tags set to avoid
+    # https://github.com/tidyverse/purrr/issues/397
+    for (experiment in seq_len(length(response$experiments))) {
+      if (is.null(response$experiments[[experiment]]$tags)) {
+        response$experiments[[experiment]]$tags <- list(NULL)
+      }
+    }
+  }
+  out <- purrr::transpose(response$experiments)
+  if (length(tags) > 0) {
+    # map over tags separately to ensure a list as output for this column
+    out$tags <- purrr::map(out$tags, unlist)
+  }
+  out %>%
+    purrr::map_at(setdiff(names(out), 'tags'), unlist) %>%
     tibble::as_tibble()
+
 }
 
 #' Set Experiment Tag

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -85,6 +85,15 @@ test_that("mlflow_list_experiments() works properly", {
     c(key = "key2", value = "value2")
   ))
 
+  # experiment tags are returned correctly if multiple tags are present in
+  # one experiment
+  mlflow_set_experiment_tag("key1.2", "value1.2", experiment_id = ex1)
+  experiments <- mlflow_list_experiments()
+  expect_setequal(experiments$tags, list(
+    c(key = "key0", value = "value0"),
+    c(key = "key1.2", value = "value1.2", key = "key1", value = 'value1'),
+    c(key = "key2", value = "value2")
+  ))
 
   # `view_type` is respected
   mlflow_delete_experiment(experiment_id = "1")

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -70,16 +70,16 @@ test_that("mlflow_list_experiments() works properly", {
   mlflow_set_experiment_tag("key2", "value2", experiment_id = ex2)
   experiments <- mlflow_list_experiments()
   expect_true("tags" %in% names(experiments))
-  expect_equal(
+  expect_setequal(
     experiments$tags, list(NULL, NULL, c(key = "key2", value = "value2"))
   )
 
   # experiment tags are returned if every experiment has tags
   mlflow_set_experiment_tag("key1", "value1", experiment_id = ex1)
-  mlflow_set_experiment_tag("key0", "value0", experiment_id = 0)
+  mlflow_set_experiment_tag("key0", "value0", experiment_id = "0")
   experiments <- mlflow_list_experiments()
   expect_true("tags" %in% names(experiments))
-  expect_equal(experiments$tags, list(
+  expect_setequal(experiments$tags, list(
     c(key = "key0", value = "value0"),
     c(key = "key1", value = "value1"),
     c(key = "key2", value = "value2")

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -89,10 +89,8 @@ test_that("mlflow_list_experiments() works properly", {
   # one experiment
   mlflow_set_experiment_tag("key1.2", "value1.2", experiment_id = ex1)
   experiments <- mlflow_list_experiments()
-  expect_setequal(experiments$tags, list(
-    c(key = "key0", value = "value0"),
-    c(key = "key1.2", value = "value1.2", key = "key1", value = 'value1'),
-    c(key = "key2", value = "value2")
+  expect_setequal(experiments$tags[experiments$experiment_id %in% ex1], list(
+    c(key = "key1.2", value = "value1.2", key = "key1", value = 'value1')
   ))
 
   # `view_type` is respected

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -42,8 +42,8 @@ test_that("mlflow_get_experiment() not found error", {
 test_that("mlflow_list_experiments() works properly", {
   mlflow_clear_test_dir("mlruns")
   client <- mlflow_client()
-  mlflow_create_experiment(client = client, "foo1", "art_loc1")
-  mlflow_create_experiment(client = client, "foo2", "art_loc2")
+  ex1 <- mlflow_create_experiment(client = client, "foo1", "art_loc1")
+  ex2 <- mlflow_create_experiment(client = client, "foo2", "art_loc2")
 
   # client
   experiments_list <- mlflow_list_experiments(client = client)
@@ -65,6 +65,26 @@ test_that("mlflow_list_experiments() works properly", {
 
   # Returns NULL when no experiments found
   expect_null(mlflow_list_experiments("DELETED_ONLY"))
+
+  # experiment tags are returned if at least one experiment has tags
+  mlflow_set_experiment_tag("key2", "value2", experiment_id = ex2)
+  experiments <- mlflow_list_experiments()
+  expect_true("tags" %in% names(experiments))
+  expect_equal(
+    experiments$tags, list(NULL, NULL, c(key = "key2", value = "value2"))
+  )
+
+  # experiment tags are returned if every experiment has tags
+  mlflow_set_experiment_tag("key1", "value1", experiment_id = ex1)
+  mlflow_set_experiment_tag("key0", "value0", experiment_id = 0)
+  experiments <- mlflow_list_experiments()
+  expect_true("tags" %in% names(experiments))
+  expect_equal(experiments$tags, list(
+    c(key = "key0", value = "value0"),
+    c(key = "key1", value = "value1"),
+    c(key = "key2", value = "value2")
+  ))
+
 
   # `view_type` is respected
   mlflow_delete_experiment(experiment_id = "1")

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-experiments.R
@@ -71,7 +71,7 @@ test_that("mlflow_list_experiments() works properly", {
   experiments <- mlflow_list_experiments()
   expect_true("tags" %in% names(experiments))
   expect_setequal(
-    experiments$tags, list(NULL, NULL, c(key = "key2", value = "value2"))
+    experiments$tags, list(NA, NA, tibble::tibble(key = "key2", value = "value2"))
   )
 
   # experiment tags are returned if every experiment has tags
@@ -80,18 +80,22 @@ test_that("mlflow_list_experiments() works properly", {
   experiments <- mlflow_list_experiments()
   expect_true("tags" %in% names(experiments))
   expect_setequal(experiments$tags, list(
-    c(key = "key0", value = "value0"),
-    c(key = "key1", value = "value1"),
-    c(key = "key2", value = "value2")
+    tibble::tibble(key = "key0", value = "value0"),
+    tibble::tibble(key = "key1", value = "value1"),
+    tibble::tibble(key = "key2", value = "value2")
   ))
 
   # experiment tags are returned correctly if multiple tags are present in
   # one experiment
   mlflow_set_experiment_tag("key1.2", "value1.2", experiment_id = ex1)
   experiments <- mlflow_list_experiments()
-  expect_setequal(experiments$tags[experiments$experiment_id %in% ex1], list(
-    c(key = "key1.2", value = "value1.2", key = "key1", value = 'value1')
-  ))
+  tags <- experiments$tags[experiments$experiment_id %in% ex1][[1]]
+  tags <- tags[order(tags$key),]
+
+  expect_equal(
+    tags,
+    tibble::tibble(key = c("key1", "key1.2"), value = c('value1', 'value1.2'))
+  )
 
   # `view_type` is respected
   mlflow_delete_experiment(experiment_id = "1")


### PR DESCRIPTION
## What changes are proposed in this pull request?

Closes #3941. Not sure this should be classified user facing because it is a breaking change in the return value structure in some circumstances (as described in #3941), but it's not likely that it will break much code in downstream projects and in principle a minor change.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
