### PR TITLE
Issue 3842 python db connection factory

### DIFF
--- a/docs/source/tracking.rst
+++ b/docs/source/tracking.rst
@@ -626,7 +626,7 @@ on the command line is not desirable. The command line connection string takes t
 - **function_name:** optional; name of the factory function (default: ``get_db_url``)
 - **options:** optional; a query string (``&`` separated pairs, each pair is ``=`` separated. These are parsed into a ``dict`` and passed into the factory function as ``kwargs``
 
-The function should return a valid database URI connection string, as previously described
+The function should return a valid SQLAlchemy database URI connection string, as previously described
 
 **Example Connection Strings:**
 - ``pycallback://my_module`` - attempts to invoke ``my_module.py:get_db_url`` function with no ``kwargs``

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -15,6 +15,7 @@ import mlflow.projects as projects
 import mlflow.runs
 import mlflow.sagemaker.cli
 import mlflow.store.artifact.cli
+import mlflow.store.db.utils
 from mlflow import tracking
 from mlflow.store.tracking import DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
@@ -261,6 +262,8 @@ def ui(backend_store_uri, default_artifact_root, port, host):
     from mlflow.server import _run_server
     from mlflow.server.handlers import initialize_backend_stores
 
+    # Resolve the raw backend URI to true URI if necessary
+    backend_store_uri = mlflow.store.db.utils.resolve_backend_store_uri(backend_store_uri)
     # Ensure that both backend_store_uri and default_artifact_uri are set correctly.
     if not backend_store_uri:
         backend_store_uri = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
@@ -368,6 +371,8 @@ def server(
 
     _validate_server_args(gunicorn_opts=gunicorn_opts, workers=workers, waitress_opts=waitress_opts)
 
+    # Resolve the raw backend URI to true URI if necessary
+    backend_store_uri = mlflow.store.db.utils.resolve_backend_store_uri(backend_store_uri)
     # Ensure that both backend_store_uri and default_artifact_uri are set correctly.
     if not backend_store_uri:
         backend_store_uri = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
@@ -430,6 +435,8 @@ def gc(backend_store_uri, run_ids):
     Permanently delete runs in the `deleted` lifecycle stage from the specified backend store.
     This command deletes all artifacts and metadata associated with the specified runs.
     """
+    # Resolve the raw backend URI to true URI if necessary
+    backend_store_uri = mlflow.store.db.utils.resolve_backend_store_uri(backend_store_uri)
     backend_store = _get_store(backend_store_uri, None)
     if not hasattr(backend_store, "_hard_delete_run"):
         raise MlflowException(

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -190,20 +190,23 @@ def _upgrade_db_initialized_before_mlflow_1(engine):
 
 
 def resolve_backend_store_uri(backend_store_uri: str):
-    callback_prefix = ''.join([MLFLOW_DBURI_PYTHON_CALLBACK_SCHEME, '://'])
+    callback_prefix = "".join([MLFLOW_DBURI_PYTHON_CALLBACK_SCHEME, "://"])
 
     if not backend_store_uri or not backend_store_uri.startswith(callback_prefix):
         return backend_store_uri
 
     # Format: pycallback://{module-name}[:{functionName}][{?optKey1=optVal1[&optKey2=optVal2...]}]
     # options (if any) are passed as kwargs to callback
-    module = backend_store_uri[len(callback_prefix):]
+    module = backend_store_uri[len(callback_prefix) :]
     parts = module.split("?", 1)
 
     if len(parts) == 1:
         extra_args = {}
     else:
-        module, extra_args = parts[0], {e[0]: e[1] for e in (p.split("=", 1) for p in parts[1].split("&"))}
+        module, extra_args = (
+            parts[0],
+            {e[0]: e[1] for e in (p.split("=", 1) for p in parts[1].split("&"))},
+        )
 
     parts = module.split(":", 1)
     if len(parts) == 1:
@@ -211,7 +214,7 @@ def resolve_backend_store_uri(backend_store_uri: str):
     else:
         module, f_name = parts[0], parts[1]
 
-    module = module.replace('/', '.')
+    module = module.replace("/", ".")
 
     mod = importlib.import_module(module)
     conn_str_factory = getattr(mod, f_name)

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -2,6 +2,7 @@ import os
 import time
 
 from contextlib import contextmanager
+import importlib
 import logging
 
 from alembic.migration import MigrationContext  # pylint: disable=import-error
@@ -18,6 +19,8 @@ _logger = logging.getLogger(__name__)
 
 MLFLOW_SQLALCHEMYSTORE_POOL_SIZE = "MLFLOW_SQLALCHEMYSTORE_POOL_SIZE"
 MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW = "MLFLOW_SQLALCHEMYSTORE_MAX_OVERFLOW"
+MLFLOW_DBURI_PYTHON_CALLBACK_SCHEME = "pycallback"
+MLFLOW_DBURI_PYTHON_CALLBACK_DEF_FNAME = "get_db_uri"
 MAX_RETRY_COUNT = 15
 
 
@@ -184,6 +187,35 @@ def _upgrade_db_initialized_before_mlflow_1(engine):
     # add metric steps, do not need to depend on this one. This allows us to eventually remove this
     # method and the associated migration e.g. in MLflow 1.1.
     command.stamp(config, "base")
+
+
+def resolve_backend_store_uri(backend_store_uri: str):
+    callback_prefix = ''.join([MLFLOW_DBURI_PYTHON_CALLBACK_SCHEME, '://'])
+
+    if not backend_store_uri or not backend_store_uri.startswith(callback_prefix):
+        return backend_store_uri
+
+    # Format: pycallback://{module-name}[:{functionName}][{?optKey1=optVal1[&optKey2=optVal2...]}]
+    # options (if any) are passed as kwargs to callback
+    module = backend_store_uri[len(callback_prefix):]
+    parts = module.split("?", 1)
+
+    if len(parts) == 1:
+        extra_args = {}
+    else:
+        module, extra_args = parts[0], {e[0]: e[1] for e in (p.split("=", 1) for p in parts[1].split("&"))}
+
+    parts = module.split(":", 1)
+    if len(parts) == 1:
+        f_name = MLFLOW_DBURI_PYTHON_CALLBACK_DEF_FNAME
+    else:
+        module, f_name = parts[0], parts[1]
+
+    module = module.replace('/', '.')
+
+    mod = importlib.import_module(module)
+    conn_str_factory = getattr(mod, f_name)
+    return conn_str_factory(**extra_args)
 
 
 def create_sqlalchemy_engine_with_retry(db_uri):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds the ability to specify backend-store connection string on command line that invokes a python callback function to ultimately generate a SQLAlchemy database URI connection string; the effective backend-store-uri for MLFlow Tracking Server.

## How is this patch tested?

Manually, by varying backend-store-uri connection strings on mlflow tracker startup

## Release Notes
- Add ability to generate backend-store-uri via python callback function

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry

### How should the PR be classified in the release notes? Choose one:
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
