### PR TITLE
Created request_header_provider and implemented databricks_request_header

### DIFF
--- a/mlflow/tracking/request_header/abstract_request_header_provider.py
+++ b/mlflow/tracking/request_header/abstract_request_header_provider.py
@@ -1,0 +1,34 @@
+from abc import ABCMeta, abstractmethod
+
+
+class RequestHeaderProvider(object):
+    """
+    Abstract base class for specifying custom request headers to add to outgoing requests
+    (e.g. request headers specifying the environment from which mlflow is running).
+
+    When a request is sent, Mlflow will iterate through all registered RequestHeaderProviders.
+    For each provider where ``in_context`` returns ``True``, Mlflow calls the ``request_headers``
+    method on the provider to compute request headers.
+
+    All resulting request headers will then be merged together and sent with the request.
+    """
+
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def in_context(self):
+        """
+        Determine if MLflow is running in this context.
+
+        :return: bool indicating if in this context
+        """
+        pass
+
+    @abstractmethod
+    def request_headers(self):
+        """
+        Generate context-specific request headers.
+
+        :return: dict of request headers
+        """
+        pass

--- a/mlflow/tracking/request_header/databricks_request_header_provider.py
+++ b/mlflow/tracking/request_header/databricks_request_header_provider.py
@@ -9,7 +9,6 @@ class DatabricksRequestHeaderProvider(RequestHeaderProvider):
     def request_headers(self):
         request_headers = {}
         if databricks_utils.is_in_databricks_notebook():
-            print("hello")
             request_headers["notebook_id"] = databricks_utils.get_notebook_id()
         if databricks_utils.is_in_databricks_job():
             request_headers["job_id"] = databricks_utils.get_job_id()

--- a/mlflow/tracking/request_header/databricks_request_header_provider.py
+++ b/mlflow/tracking/request_header/databricks_request_header_provider.py
@@ -4,7 +4,11 @@ from mlflow.utils import databricks_utils
 
 class DatabricksRequestHeaderProvider(RequestHeaderProvider):
     def in_context(self):
-        return databricks_utils.is_in_cluster()
+        return (
+            databricks_utils.is_in_cluster()
+            or databricks_utils.is_in_databricks_notebook()
+            or databricks_utils.is_in_databricks_job()
+        )
 
     def request_headers(self):
         request_headers = {}

--- a/mlflow/tracking/request_header/databricks_request_header_provider.py
+++ b/mlflow/tracking/request_header/databricks_request_header_provider.py
@@ -1,0 +1,21 @@
+from mlflow.tracking.request_header.abstract_request_header_provider import RequestHeaderProvider
+from mlflow.utils import databricks_utils
+
+
+class DatabricksRequestHeaderProvider(RequestHeaderProvider):
+    def in_context(self):
+        return databricks_utils.is_in_cluster()
+
+    def request_headers(self):
+        request_headers = {}
+        if databricks_utils.is_in_databricks_notebook():
+            print("hello")
+            request_headers["notebook_id"] = databricks_utils.get_notebook_id()
+        if databricks_utils.is_in_databricks_job():
+            request_headers["job_id"] = databricks_utils.get_job_id()
+            request_headers["job_run_id"] = databricks_utils.get_job_run_id()
+            request_headers["job_type"] = databricks_utils.get_job_type()
+        if databricks_utils.is_in_cluster():
+            request_headers["cluster_id"] = databricks_utils.get_cluster_id()
+
+        return request_headers

--- a/tests/tracking/request_header/test_databricks_request_header_provider.py
+++ b/tests/tracking/request_header/test_databricks_request_header_provider.py
@@ -17,13 +17,12 @@ def test_notebook_request_headers(is_in_databricks_notebook):
         "mlflow.utils.databricks_utils.is_in_databricks_notebook",
         return_value=is_in_databricks_notebook,
     ), mock.patch("mlflow.utils.databricks_utils.get_notebook_id") as notebook_id_mock:
+        request_headers = DatabricksRequestHeaderProvider().request_headers()
+
         if is_in_databricks_notebook:
-            assert (
-                DatabricksRequestHeaderProvider().request_headers()["notebook_id"]
-                == notebook_id_mock.return_value
-            )
+            assert request_headers["notebook_id"] == notebook_id_mock.return_value
         else:
-            assert "notebook_id" not in DatabricksRequestHeaderProvider().request_headers()
+            assert "notebook_id" not in request_headers
 
 
 @pytest.mark.parametrize("is_in_databricks_job", [True, False])
@@ -35,23 +34,16 @@ def test_job_request_headers(is_in_databricks_job):
     ) as job_run_id_mock, mock.patch(
         "mlflow.utils.databricks_utils.get_job_type"
     ) as job_type_mock:
+        request_headers = DatabricksRequestHeaderProvider().request_headers()
+
         if is_in_databricks_job:
-            assert (
-                DatabricksRequestHeaderProvider().request_headers()["job_id"]
-                == job_id_mock.return_value
-            )
-            assert (
-                DatabricksRequestHeaderProvider().request_headers()["job_run_id"]
-                == job_run_id_mock.return_value
-            )
-            assert (
-                DatabricksRequestHeaderProvider().request_headers()["job_type"]
-                == job_type_mock.return_value
-            )
+            assert request_headers["job_id"] == job_id_mock.return_value
+            assert request_headers["job_run_id"] == job_run_id_mock.return_value
+            assert request_headers["job_type"] == job_type_mock.return_value
         else:
-            assert "job_id" not in DatabricksRequestHeaderProvider().request_headers()
-            assert "job_run_id" not in DatabricksRequestHeaderProvider().request_headers()
-            assert "job_type" not in DatabricksRequestHeaderProvider().request_headers()
+            assert "job_id" not in request_headers
+            assert "job_run_id" not in request_headers
+            assert "job_type" not in request_headers
 
 
 @pytest.mark.parametrize("is_in_cluster", [True, False])
@@ -59,10 +51,9 @@ def test_cluster_request_headers(is_in_cluster):
     with mock.patch(
         "mlflow.utils.databricks_utils.is_in_cluster", return_value=is_in_cluster,
     ), mock.patch("mlflow.utils.databricks_utils.get_cluster_id") as cluster_id_mock:
+        request_headers = DatabricksRequestHeaderProvider().request_headers()
+
         if is_in_cluster:
-            assert (
-                DatabricksRequestHeaderProvider().request_headers()["cluster_id"]
-                == cluster_id_mock.return_value
-            )
+            assert request_headers["cluster_id"] == cluster_id_mock.return_value
         else:
-            assert "cluster_id" not in DatabricksRequestHeaderProvider().request_headers()
+            assert "cluster_id" not in request_headers

--- a/tests/tracking/request_header/test_databricks_request_header_provider.py
+++ b/tests/tracking/request_header/test_databricks_request_header_provider.py
@@ -13,7 +13,7 @@ bool_values = [True, False]
     "is_in_databricks_notebook,is_in_databricks_job,is_in_cluster",
     itertools.product(bool_values, bool_values, bool_values),
 )
-def test_databricks_cluster_run_context_in_context(
+def test_databricks_request_header_provider_in_context(
     is_in_databricks_notebook, is_in_databricks_job, is_in_cluster
 ):
     with mock.patch(
@@ -30,31 +30,27 @@ def test_databricks_cluster_run_context_in_context(
             or is_in_cluster
         )
 
-
-@pytest.mark.parametrize("is_in_databricks_notebook", bool_values)
-def test_notebook_request_headers(is_in_databricks_notebook):
+@pytest.mark.parametrize(
+    "is_in_databricks_notebook,is_in_databricks_job,is_in_cluster",
+    itertools.product(bool_values, bool_values, bool_values),
+)
+def test_databricks_request_header_provider_request_headers(
+    is_in_databricks_notebook, is_in_databricks_job, is_in_cluster
+):
     with mock.patch(
         "mlflow.utils.databricks_utils.is_in_databricks_notebook",
         return_value=is_in_databricks_notebook,
-    ), mock.patch("mlflow.utils.databricks_utils.get_notebook_id") as notebook_id_mock:
+    ), mock.patch(
+        "mlflow.utils.databricks_utils.is_in_databricks_job", return_value=is_in_databricks_job
+    ), mock.patch(
+        "mlflow.utils.databricks_utils.is_in_cluster", return_value=is_in_cluster
+    ):
         request_headers = DatabricksRequestHeaderProvider().request_headers()
 
         if is_in_databricks_notebook:
             assert request_headers["notebook_id"] == notebook_id_mock.return_value
         else:
             assert "notebook_id" not in request_headers
-
-
-@pytest.mark.parametrize("is_in_databricks_job", bool_values)
-def test_job_request_headers(is_in_databricks_job):
-    with mock.patch(
-        "mlflow.utils.databricks_utils.is_in_databricks_job", return_value=is_in_databricks_job
-    ), mock.patch("mlflow.utils.databricks_utils.get_job_id") as job_id_mock, mock.patch(
-        "mlflow.utils.databricks_utils.get_job_run_id"
-    ) as job_run_id_mock, mock.patch(
-        "mlflow.utils.databricks_utils.get_job_type"
-    ) as job_type_mock:
-        request_headers = DatabricksRequestHeaderProvider().request_headers()
 
         if is_in_databricks_job:
             assert request_headers["job_id"] == job_id_mock.return_value
@@ -65,15 +61,54 @@ def test_job_request_headers(is_in_databricks_job):
             assert "job_run_id" not in request_headers
             assert "job_type" not in request_headers
 
-
-@pytest.mark.parametrize("is_in_cluster", bool_values)
-def test_cluster_request_headers(is_in_cluster):
-    with mock.patch(
-        "mlflow.utils.databricks_utils.is_in_cluster", return_value=is_in_cluster,
-    ), mock.patch("mlflow.utils.databricks_utils.get_cluster_id") as cluster_id_mock:
-        request_headers = DatabricksRequestHeaderProvider().request_headers()
-
         if is_in_cluster:
             assert request_headers["cluster_id"] == cluster_id_mock.return_value
         else:
             assert "cluster_id" not in request_headers
+
+# @pytest.mark.parametrize("is_in_databricks_notebook", bool_values)
+# def test_notebook_request_headers(is_in_databricks_notebook):
+#     with mock.patch(
+#         "mlflow.utils.databricks_utils.is_in_databricks_notebook",
+#         return_value=is_in_databricks_notebook,
+#     ), mock.patch("mlflow.utils.databricks_utils.get_notebook_id") as notebook_id_mock:
+#         request_headers = DatabricksRequestHeaderProvider().request_headers()
+
+#         if is_in_databricks_notebook:
+#             assert request_headers["notebook_id"] == notebook_id_mock.return_value
+#         else:
+#             assert "notebook_id" not in request_headers
+
+
+# @pytest.mark.parametrize("is_in_databricks_job", bool_values)
+# def test_job_request_headers(is_in_databricks_job):
+#     with mock.patch(
+#         "mlflow.utils.databricks_utils.is_in_databricks_job", return_value=is_in_databricks_job
+#     ), mock.patch("mlflow.utils.databricks_utils.get_job_id") as job_id_mock, mock.patch(
+#         "mlflow.utils.databricks_utils.get_job_run_id"
+#     ) as job_run_id_mock, mock.patch(
+#         "mlflow.utils.databricks_utils.get_job_type"
+#     ) as job_type_mock:
+#         request_headers = DatabricksRequestHeaderProvider().request_headers()
+
+#         if is_in_databricks_job:
+#             assert request_headers["job_id"] == job_id_mock.return_value
+#             assert request_headers["job_run_id"] == job_run_id_mock.return_value
+#             assert request_headers["job_type"] == job_type_mock.return_value
+#         else:
+#             assert "job_id" not in request_headers
+#             assert "job_run_id" not in request_headers
+#             assert "job_type" not in request_headers
+
+
+# @pytest.mark.parametrize("is_in_cluster", bool_values)
+# def test_cluster_request_headers(is_in_cluster):
+#     with mock.patch(
+#         "mlflow.utils.databricks_utils.is_in_cluster", return_value=is_in_cluster,
+#     ), mock.patch("mlflow.utils.databricks_utils.get_cluster_id") as cluster_id_mock:
+#         request_headers = DatabricksRequestHeaderProvider().request_headers()
+
+#         if is_in_cluster:
+#             assert request_headers["cluster_id"] == cluster_id_mock.return_value
+#         else:
+#             assert "cluster_id" not in request_headers

--- a/tests/tracking/request_header/test_databricks_request_header_provider.py
+++ b/tests/tracking/request_header/test_databricks_request_header_provider.py
@@ -1,0 +1,68 @@
+import pytest
+from unittest import mock
+
+from mlflow.tracking.request_header.databricks_request_header_provider import (
+    DatabricksRequestHeaderProvider,
+)
+
+
+def test_databricks_cluster_run_context_in_context():
+    with mock.patch("mlflow.utils.databricks_utils.is_in_cluster") as in_cluster_mock:
+        assert DatabricksRequestHeaderProvider().in_context() == in_cluster_mock.return_value
+
+
+@pytest.mark.parametrize("is_in_databricks_notebook", [True, False])
+def test_notebook_request_headers(is_in_databricks_notebook):
+    with mock.patch(
+        "mlflow.utils.databricks_utils.is_in_databricks_notebook",
+        return_value=is_in_databricks_notebook,
+    ), mock.patch("mlflow.utils.databricks_utils.get_notebook_id") as notebook_id_mock:
+        if is_in_databricks_notebook:
+            assert (
+                DatabricksRequestHeaderProvider().request_headers()["notebook_id"]
+                == notebook_id_mock.return_value
+            )
+        else:
+            assert "notebook_id" not in DatabricksRequestHeaderProvider().request_headers()
+
+
+@pytest.mark.parametrize("is_in_databricks_job", [True, False])
+def test_job_request_headers(is_in_databricks_job):
+    with mock.patch(
+        "mlflow.utils.databricks_utils.is_in_databricks_job", return_value=is_in_databricks_job
+    ), mock.patch("mlflow.utils.databricks_utils.get_job_id") as job_id_mock, mock.patch(
+        "mlflow.utils.databricks_utils.get_job_run_id"
+    ) as job_run_id_mock, mock.patch(
+        "mlflow.utils.databricks_utils.get_job_type"
+    ) as job_type_mock:
+        if is_in_databricks_job:
+            assert (
+                DatabricksRequestHeaderProvider().request_headers()["job_id"]
+                == job_id_mock.return_value
+            )
+            assert (
+                DatabricksRequestHeaderProvider().request_headers()["job_run_id"]
+                == job_run_id_mock.return_value
+            )
+            assert (
+                DatabricksRequestHeaderProvider().request_headers()["job_type"]
+                == job_type_mock.return_value
+            )
+        else:
+            assert "job_id" not in DatabricksRequestHeaderProvider().request_headers()
+            assert "job_run_id" not in DatabricksRequestHeaderProvider().request_headers()
+            assert "job_type" not in DatabricksRequestHeaderProvider().request_headers()
+
+
+@pytest.mark.parametrize("is_in_cluster", [True, False])
+def test_notebook_request_headers(is_in_cluster):
+    with mock.patch(
+        "mlflow.utils.databricks_utils.is_in_cluster", return_value=is_in_cluster,
+    ), mock.patch("mlflow.utils.databricks_utils.get_cluster_id") as cluster_id_mock:
+        if is_in_cluster:
+            assert (
+                DatabricksRequestHeaderProvider().request_headers()["cluster_id"]
+                == cluster_id_mock.return_value
+            )
+        else:
+            assert "cluster_id" not in DatabricksRequestHeaderProvider().request_headers()

--- a/tests/tracking/request_header/test_databricks_request_header_provider.py
+++ b/tests/tracking/request_header/test_databricks_request_header_provider.py
@@ -55,7 +55,7 @@ def test_job_request_headers(is_in_databricks_job):
 
 
 @pytest.mark.parametrize("is_in_cluster", [True, False])
-def test_notebook_request_headers(is_in_cluster):
+def test_cluster_request_headers(is_in_cluster):
     with mock.patch(
         "mlflow.utils.databricks_utils.is_in_cluster", return_value=is_in_cluster,
     ), mock.patch("mlflow.utils.databricks_utils.get_cluster_id") as cluster_id_mock:

--- a/tests/tracking/request_header/test_databricks_request_header_provider.py
+++ b/tests/tracking/request_header/test_databricks_request_header_provider.py
@@ -30,6 +30,8 @@ def test_databricks_request_header_provider_in_context(
             or is_in_cluster
         )
 
+
+# test that request_headers returns whatever is available
 @pytest.mark.parametrize(
     "is_in_databricks_notebook,is_in_databricks_job,is_in_cluster",
     itertools.product(bool_values, bool_values, bool_values),
@@ -44,7 +46,17 @@ def test_databricks_request_header_provider_request_headers(
         "mlflow.utils.databricks_utils.is_in_databricks_job", return_value=is_in_databricks_job
     ), mock.patch(
         "mlflow.utils.databricks_utils.is_in_cluster", return_value=is_in_cluster
-    ):
+    ), mock.patch(
+        "mlflow.utils.databricks_utils.get_notebook_id"
+    ) as notebook_id_mock, mock.patch(
+        "mlflow.utils.databricks_utils.get_job_id"
+    ) as job_id_mock, mock.patch(
+        "mlflow.utils.databricks_utils.get_job_run_id"
+    ) as job_run_id_mock, mock.patch(
+        "mlflow.utils.databricks_utils.get_job_type"
+    ) as job_type_mock, mock.patch(
+        "mlflow.utils.databricks_utils.get_cluster_id"
+    ) as cluster_id_mock:
         request_headers = DatabricksRequestHeaderProvider().request_headers()
 
         if is_in_databricks_notebook:
@@ -65,50 +77,3 @@ def test_databricks_request_header_provider_request_headers(
             assert request_headers["cluster_id"] == cluster_id_mock.return_value
         else:
             assert "cluster_id" not in request_headers
-
-# @pytest.mark.parametrize("is_in_databricks_notebook", bool_values)
-# def test_notebook_request_headers(is_in_databricks_notebook):
-#     with mock.patch(
-#         "mlflow.utils.databricks_utils.is_in_databricks_notebook",
-#         return_value=is_in_databricks_notebook,
-#     ), mock.patch("mlflow.utils.databricks_utils.get_notebook_id") as notebook_id_mock:
-#         request_headers = DatabricksRequestHeaderProvider().request_headers()
-
-#         if is_in_databricks_notebook:
-#             assert request_headers["notebook_id"] == notebook_id_mock.return_value
-#         else:
-#             assert "notebook_id" not in request_headers
-
-
-# @pytest.mark.parametrize("is_in_databricks_job", bool_values)
-# def test_job_request_headers(is_in_databricks_job):
-#     with mock.patch(
-#         "mlflow.utils.databricks_utils.is_in_databricks_job", return_value=is_in_databricks_job
-#     ), mock.patch("mlflow.utils.databricks_utils.get_job_id") as job_id_mock, mock.patch(
-#         "mlflow.utils.databricks_utils.get_job_run_id"
-#     ) as job_run_id_mock, mock.patch(
-#         "mlflow.utils.databricks_utils.get_job_type"
-#     ) as job_type_mock:
-#         request_headers = DatabricksRequestHeaderProvider().request_headers()
-
-#         if is_in_databricks_job:
-#             assert request_headers["job_id"] == job_id_mock.return_value
-#             assert request_headers["job_run_id"] == job_run_id_mock.return_value
-#             assert request_headers["job_type"] == job_type_mock.return_value
-#         else:
-#             assert "job_id" not in request_headers
-#             assert "job_run_id" not in request_headers
-#             assert "job_type" not in request_headers
-
-
-# @pytest.mark.parametrize("is_in_cluster", bool_values)
-# def test_cluster_request_headers(is_in_cluster):
-#     with mock.patch(
-#         "mlflow.utils.databricks_utils.is_in_cluster", return_value=is_in_cluster,
-#     ), mock.patch("mlflow.utils.databricks_utils.get_cluster_id") as cluster_id_mock:
-#         request_headers = DatabricksRequestHeaderProvider().request_headers()
-
-#         if is_in_cluster:
-#             assert request_headers["cluster_id"] == cluster_id_mock.return_value
-#         else:
-#             assert "cluster_id" not in request_headers


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adding a new plugin interface: the RequestHeaderProvider. This plugin will create a dict of request headers to attach to outgoing requests. The actual attaching to requests will happen in a follow up PR.

Implemented the DatabricksRequestHeaderProvider, which creates request headers for databricks environments.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
