### PR TITLE
Test anaconda 2020.11 instead of 2020.02

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -146,7 +146,7 @@ jobs:
         ./dev/run-large-python-tests.sh
     - name: Run anaconda compatibility tests
       run: |
-        ./dev/test-anaconda-compatibility.sh "anaconda3:2020.02"
+        ./dev/test-anaconda-compatibility.sh "anaconda3:2020.11"
         ./dev/test-anaconda-compatibility.sh "anaconda3:2019.03"
 
   java:

--- a/dev/test-anaconda-compatibility.sh
+++ b/dev/test-anaconda-compatibility.sh
@@ -8,7 +8,7 @@ set -eux
 MLFLOW_DIR=$(cd "$(dirname ${BASH_SOURCE[0]})/.."; pwd)
 
 PYTHON_MAJOR_VERSION=$(python -c "import sys; print(sys.version_info[0])")
-DEFAULT_ANACONDA_VERSIONS=([2]="anaconda:2020.02" [3]="anaconda3:2020.02")
+DEFAULT_ANACONDA_VERSIONS=([2]="anaconda:2020.11" [3]="anaconda3:2020.11")
 ANACONDA_VERSION=${1:-${DEFAULT_ANACONDA_VERSIONS["$PYTHON_MAJOR_VERSION"]}}
 docker run --rm -v "${MLFLOW_DIR}:/mnt/mlflow" continuumio/${ANACONDA_VERSION} \
   bash /mnt/mlflow/dev/test-anaconda-compatibility-in-docker.sh


### PR DESCRIPTION
## What changes are proposed in this pull request?

Updating to test against newest release of anaconda (2020.11) and leaving test for 2019.03 intact.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
