### PR TITLE
AutologgingEventLogger: Pass all arguments to `log_autolog_called` in keyword form

### DIFF
--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -611,6 +611,14 @@ class AutologgingEventLogger:
                             Any positional arguments should also be converted to keyword form
                             and passed via `call_kwargs`.
         """
+        if len(call_args) > 0:
+            warnings.warn(
+                "Received %d positional arguments via `call_args`. `call_args` is"
+                " deprecated in MLflow > 1.13.1, and all arguments should be passed"
+                " in keyword form via `call_kwargs`." % len(call_args),
+                category=DeprecationWarning,
+                stacklevel=2
+            )
         _logger.debug(
             "Called autolog() method for %s autologging with args '%s' and kwargs '%s'",
             integration,

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -330,17 +330,21 @@ def autologging_integration(name):
         default_params = {param.name: param.default for param in param_spec.values()}
 
         def autolog(*args, **kwargs):
-            try:
-                AutologgingEventLogger.get_logger().log_autolog_called(name, args, kwargs)
-            except Exception:
-                pass
-
             config_to_store = dict(default_params)
             config_to_store.update(
                 {param.name: arg for arg, param in zip(args, param_spec.values())}
             )
             config_to_store.update(kwargs)
             AUTOLOGGING_INTEGRATIONS[name] = config_to_store
+
+            try:
+                # Pass `autolog()` arguments to `log_autolog_called` in keyword format to enable
+                # event loggers to more easily identify important configuration parameters
+                # (e.g., `disable`) without examining positional arguments. Passing positional
+                # arguments to `log_autolog_called` is deprecated in MLflow > 1.13.1
+                AutologgingEventLogger.get_logger().log_autolog_called(name, (), config_to_store)
+            except Exception:
+                pass
 
             return _autolog(*args, **kwargs)
 
@@ -600,8 +604,10 @@ class AutologgingEventLogger:
         is invoked (e.g., when a user invokes `mlflow.sklearn.autolog()`)
 
         :param integration: The autologging integration for which `autolog()` was called.
-        :param config_args: The positional arguments passed to the `autolog()` call.
-        :param config_kwargs: The keyword arguments passed to the `autolog()` call.
+        :param call_args: **DEPRECATED** The positional arguments passed to the `autolog()` call.
+                          This field is empty in MLflow > 1.13.1; all arguments are passed in
+                          keyword form via `call_kwargs`.
+        :param call_kwargs: The arguments passed to the `autolog()` call in keyword form.
         """
         _logger.debug(
             "Called autolog() method for %s autologging with args '%s' and kwargs '%s'",

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -617,7 +617,7 @@ class AutologgingEventLogger:
                 " deprecated in MLflow > 1.13.1, and all arguments should be passed"
                 " in keyword form via `call_kwargs`." % len(call_args),
                 category=DeprecationWarning,
-                stacklevel=2
+                stacklevel=2,
             )
         _logger.debug(
             "Called autolog() method for %s autologging with args '%s' and kwargs '%s'",

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -608,6 +608,8 @@ class AutologgingEventLogger:
                           This field is empty in MLflow > 1.13.1; all arguments are passed in
                           keyword form via `call_kwargs`.
         :param call_kwargs: The arguments passed to the `autolog()` call in keyword form.
+                            Any positional arguments should also be converted to keyword form
+                            and passed via `call_kwargs`.
         """
         _logger.debug(
             "Called autolog() method for %s autologging with args '%s' and kwargs '%s'",

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -629,3 +629,16 @@ def test_autologging_event_logger_default_implementation_does_not_throw_for_vali
         {"a": 2},
         Exception("patch error"),
     )
+
+
+def test_autologging_event_logger_default_impl_warns_for_log_autolog_called_with_deprecated_args():
+    AutologgingEventLogger.set_logger(AutologgingEventLogger())
+
+    with pytest.warns(DeprecationWarning):
+        AutologgingEventLogger.get_logger().log_autolog_called(
+            "test_integration",
+            # call_args is deprecated in MLflow > 1.13.1; specifying a non-empty
+            # value for this parameter should emit a warning
+            call_args=("a"),
+            call_kwargs={"b": "c"},
+        )

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -634,7 +634,7 @@ def test_autologging_event_logger_default_implementation_does_not_throw_for_vali
 def test_autologging_event_logger_default_impl_warns_for_log_autolog_called_with_deprecated_args():
     AutologgingEventLogger.set_logger(AutologgingEventLogger())
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match="Received 1 positional arguments"):
         AutologgingEventLogger.get_logger().log_autolog_called(
             "test_integration",
             # call_args is deprecated in MLflow > 1.13.1; specifying a non-empty

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -491,18 +491,24 @@ def test_autologging_integration_makes_expected_event_logging_calls():
     assert len(logger.calls) == 1
     call = logger.calls[0]
     assert call.integration == "test_success"
-    assert call.call_args == ("a",)
-    assert call.call_kwargs == {"bar": 9, "disable": True}
+    # NB: In MLflow > 1.13.1, the `call_args` argument to `log_autolog_called` is deprecated.
+    # Positional arguments passed to `autolog()` should be forwarded to `log_autolog_called`
+    # in keyword format
+    assert call.call_args == ()
+    assert call.call_kwargs == {"foo": "a", "bar": 9, "disable": True}
 
     logger.reset()
 
     with pytest.raises(Exception, match="autolog failed"):
-        autolog_failure(82, baz="b", disable=False)
+        autolog_failure(82, disable=False)
     assert len(logger.calls) == 1
     call = logger.calls[0]
     assert call.integration == "test_failure"
-    assert call.call_args == (82,)
-    assert call.call_kwargs == {"baz": "b", "disable": False}
+    # NB: In MLflow > 1.13.1, the `call_args` argument to `log_autolog_called` is deprecated.
+    # Positional arguments passed to `autolog()` should be forwarded to `log_autolog_called`
+    # in keyword format
+    assert call.call_args == ()
+    assert call.call_kwargs == {"biz": 82, "baz": "val", "disable": False}
 
 
 @pytest.mark.usefixtures(test_mode_off.__name__)


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR modifies `@autologging_integration` to pass `autolog()` arguments to `log_autolog_called` in keyword format to enable event loggers to more easily identify important configuration parameters (e.g., `disable`) without examining positional arguments. It also deprecates the `call_args` parameter for positional arguments in `log_autolog_called`.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
