### PR TITLE
Extend java client to support list-registeredmodels API

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -2,6 +2,7 @@ package org.mlflow.tracking;
 
 import com.google.common.collect.Lists;
 import org.apache.http.client.utils.URIBuilder;
+import org.mlflow.api.proto.ModelRegistry;
 import org.mlflow.artifacts.ArtifactRepository;
 import org.mlflow.artifacts.ArtifactRepositoryFactory;
 import org.mlflow.artifacts.CliBasedArtifactRepository;
@@ -790,4 +791,11 @@ public class MlflowClient implements Serializable {
       return downloadModelVersion(modelName, details.getVersion());
   }
 
+  /**
+   * @return A list of all registered models
+   */
+  public List<ModelRegistry.RegisteredModel> listRegisteredModels() {
+    return mapper.toListRegisteredModelsResponse(httpCaller.get("registered-models/list"))
+            .getRegisteredModelsList();
+  }
 }

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
@@ -235,6 +235,12 @@ class MlflowProtobufMapper {
     return builder.getArtifactUri();
   }
 
+  ListRegisteredModels.Response toListRegisteredModelsResponse(String json) {
+    ListRegisteredModels.Response.Builder builder = ListRegisteredModels.Response.newBuilder();
+    merge(json, builder);
+    return builder.build();
+  }
+
   private String print(MessageOrBuilder message) {
     try {
       return JsonFormat.printer().preservingProtoFieldNames().print(message);

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/ModelRegistryMlflowClientTest.java
@@ -35,6 +35,7 @@ public class ModelRegistryMlflowClientTest {
     private MlflowClient client;
 
     private String modelName;
+    private String anotherModelName;
     private File tempDir;
     private File tempFile;
 
@@ -53,12 +54,16 @@ public class ModelRegistryMlflowClientTest {
     public void before() throws IOException {
         client = testClientProvider.initializeClientAndSqlLiteBasedServer();
         modelName = "Model-" + UUID.randomUUID().toString();
+        anotherModelName = "Model-" + UUID.randomUUID().toString();
 
         String expName = createExperimentName();
         String expId = client.createExperiment(expName);
 
         RunInfo runCreated = client.createRun(expId);
         String runId = runCreated.getRunUuid();
+
+        RunInfo anotherRunCreated = client.createRun(expId);
+        String anotherRunId = anotherRunCreated.getRunUuid();
 
         tempDir = Files.createTempDirectory("tempDir").toFile();
         tempFile = Files.createTempFile(tempDir.toPath(), "file", ".txt").toFile();
@@ -69,6 +74,12 @@ public class ModelRegistryMlflowClientTest {
 
         client.sendPost("model-versions/create",
                 mapper.makeCreateModelVersion(modelName, runId, tempDir.getAbsolutePath()));
+
+        client.sendPost("registered-models/create",
+                mapper.makeCreateModel(anotherModelName));
+
+        client.sendPost("model-versions/create",
+                mapper.makeCreateModelVersion(anotherModelName, anotherRunId, tempDir.getAbsolutePath()));
     }
 
     @AfterTest
@@ -141,5 +152,14 @@ public class ModelRegistryMlflowClientTest {
         Assert.assertEquals(details.getCurrentStage(), stage);
         Assert.assertEquals(details.getName(), modelName);
         Assert.assertEquals(details.getVersion(), version);
+    }
+
+    @Test
+    public void testListRegisteredModels() {
+        final List<ModelRegistry.RegisteredModel> modelVersions = client.listRegisteredModels();
+
+        Assert.assertEquals(modelVersions.size(), 2);
+        Assert.assertEquals(modelVersions.get(0).getLatestVersions(0).getName(), modelName);
+        Assert.assertEquals(modelVersions.get(1).getLatestVersions(0).getName(), anotherModelName);
     }
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Java client does not support calls to [list registered model API](https://www.mlflow.org/docs/latest/rest-api.html#list-registeredmodels).

## How is this patch tested?

tested with setting up [MLFlow Kafka source connector](https://github.com/dwarszawski/kafka-connect-mlflow) to track the changes in the MLFlow Model Registry.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [x] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
