### PR TITLE
Record branch name for local run

### DIFF
--- a/mlflow/projects/utils.py
+++ b/mlflow/projects/utils.py
@@ -13,7 +13,7 @@ from mlflow.entities import SourceType, Param
 from mlflow.exceptions import ExecutionException
 from mlflow.projects import _project_spec
 from mlflow import tracking
-from mlflow.tracking.context.git_context import _get_git_commit
+from mlflow.tracking.context.git_context import _get_git_commit, _get_git_branch_name
 from mlflow.tracking import fluent
 from mlflow.tracking.context.default_context import _get_user
 from mlflow.utils.mlflow_tags import (
@@ -232,6 +232,7 @@ def _create_run(uri, experiment_id, work_dir, version, entry_point, parameters):
     else:
         source_name = _expand_uri(uri)
     source_version = _get_git_commit(work_dir)
+    branch_name_version = _get_git_branch_name(work_dir)
     existing_run = fluent.active_run()
     if existing_run:
         parent_run_id = existing_run.info.run_id
@@ -246,6 +247,9 @@ def _create_run(uri, experiment_id, work_dir, version, entry_point, parameters):
     }
     if source_version is not None:
         tags[MLFLOW_GIT_COMMIT] = source_version
+    if branch_name_version is not None:
+        tags[MLFLOW_GIT_BRANCH] = branch_name_version
+        tags[LEGACY_MLFLOW_GIT_BRANCH_NAME] = branch_name_version
     if parent_run_id is not None:
         tags[MLFLOW_PARENT_RUN_ID] = parent_run_id
 

--- a/mlflow/tracking/context/git_context.py
+++ b/mlflow/tracking/context/git_context.py
@@ -28,6 +28,26 @@ def _get_git_commit(path):
         return None
 
 
+def _get_git_branch_name(path):
+    try:
+        import git
+    except ImportError as e:
+        _logger.warning(
+            "Failed to import Git (the Git executable is probably not on your PATH),"
+            " so Git SHA is not available. Error: %s",
+            e,
+        )
+        return None
+    try:
+        if os.path.isfile(path):
+            path = os.path.dirname(path)
+        repo = git.Repo(path, search_parent_directories=True)
+        branch_name = repo.active_branch
+        return branch_name
+    except (git.InvalidGitRepositoryError, git.GitCommandNotFound, ValueError, git.NoSuchPathError):
+        return None
+
+
 def _get_source_version():
     main_file = _get_main_file()
     if main_file is not None:


### PR DESCRIPTION
## What changes are proposed in this pull request?

MLflow will record the current branch used in the run. This is useful for people using MLflow locally.

## How is this patch tested?

No test added. Can I have a mentor to add the tests needed?

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
