### PR TITLE
#3969 Implement .dockerignore parsing to ignore files when creating temporary work dir

### DIFF
--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -107,11 +107,14 @@ def _get_paths_to_ignore(work_dir):
         return patterns
     with open(path) as f:
         for line in f:
+            clean_line = line.strip()
             # Ignore comments
-            if line.strip().startswith("#"):
+            if clean_line.startswith("#"):
                 continue
-            # Parse the line
-            patterns += [line.strip().replace("/", "")] # Trailing slashes are not part of directory names
+            # Trailing slashes are not part of directory names
+            if clean_line[-1] == "/":
+                clean_line = clean_line[:-1]
+            patterns += [clean_line]
     return patterns
 
 

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -111,7 +111,7 @@ def _get_paths_to_ignore(work_dir):
             if line.strip().startswith("#"):
                 continue
             # Parse the line
-            patterns += [line.strip()]
+            patterns += [line.strip().replace("/", "")] # Trailing slashes are not part of directory names
     return patterns
 
 

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 import urllib.parse
 import urllib.request
+import glob
 
 import docker
 
@@ -99,14 +100,31 @@ def _get_docker_image_uri(repository_uri, work_dir):
     return repository_uri + version_string
 
 
+def _get_paths_to_ignore(work_dir):
+    """Parse the .dockerignore file."""
+    patterns = []
+    path = os.path.join(work_dir, ".dockerignore")
+    if not os.path.exists(path):
+        return patterns
+    with open(path) as f:
+        for line in f:
+            # Ignore comments
+            if line.strip().startswith("#"):
+                continue
+        # Parse the line
+        patterns += line.strip()
+    return patterns
+
+
 def _create_docker_build_ctx(work_dir, dockerfile_contents):
     """
     Creates build context tarfile containing Dockerfile and project code, returning path to tarfile
     """
+    ignore_func = shutil.ignore_patterns(_get_paths_to_ignore(work_dir))
     directory = tempfile.mkdtemp()
     try:
         dst_path = os.path.join(directory, "mlflow-project-contents")
-        shutil.copytree(src=work_dir, dst=dst_path)
+        shutil.copytree(src=work_dir, dst=dst_path, ignore=ignore_func)
         with open(os.path.join(dst_path, _GENERATED_DOCKERFILE_NAME), "w") as handle:
             handle.write(dockerfile_contents)
         _, result_path = tempfile.mkstemp()

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -5,7 +5,6 @@ import shutil
 import tempfile
 import urllib.parse
 import urllib.request
-import glob
 
 import docker
 
@@ -120,7 +119,7 @@ def _create_docker_build_ctx(work_dir, dockerfile_contents):
     """
     Creates build context tarfile containing Dockerfile and project code, returning path to tarfile
     """
-    ignore_func = shutil.ignore_patterns(_get_paths_to_ignore(work_dir))
+    ignore_func = shutil.ignore_patterns(*_get_paths_to_ignore(work_dir))
     directory = tempfile.mkdtemp()
     try:
         dst_path = os.path.join(directory, "mlflow-project-contents")

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -110,8 +110,8 @@ def _get_paths_to_ignore(work_dir):
             # Ignore comments
             if line.strip().startswith("#"):
                 continue
-        # Parse the line
-        patterns += [line.strip()]
+            # Parse the line
+            patterns += [line.strip()]
     return patterns
 
 

--- a/mlflow/projects/docker.py
+++ b/mlflow/projects/docker.py
@@ -111,7 +111,7 @@ def _get_paths_to_ignore(work_dir):
             if line.strip().startswith("#"):
                 continue
         # Parse the line
-        patterns += line.strip()
+        patterns += [line.strip()]
     return patterns
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
Fix for #3969, workaround for #2016 
Parsing `.dockerignore` and ignoring mentioned patterns when creating temporary build context. This is an optimization to avoid copying ignored files when creating the temporary build context directory & a workaround for `docker-py` ignoring `.dockerignore`.

## How is this patch tested?
TODO

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Implements `.dockerignore` pattern matching to accelerate runs and avoid copying ignored files and directories.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
