### PR TITLE
Temporary workaround for keras EarlyStopping issue

### DIFF
--- a/ml-package-versions.yml
+++ b/ml-package-versions.yml
@@ -97,7 +97,7 @@ keras:
       # https://github.com/keras-team/keras#multi-backend-keras-and-tfkeras
       # Unpin `tf-nightly` once the following issue has been fixed:
       # https://github.com/tensorflow/tensorflow/issues/46429
-      pip install 'tf-nightly==2.5.0.dev20210113' 'keras>=2.4.0'
+      pip install 'tf-nightly==2.5.0.dev20210112' 'keras>=2.4.0'
 
   models:
     minimum: "2.2.4"

--- a/ml-package-versions.yml
+++ b/ml-package-versions.yml
@@ -73,6 +73,7 @@ tensorflow-2.x:
   package_info:
     pip_release: "tensorflow"
     install_dev: |
+      # Unpin `tf-nightly` once the following issue is addressed:
       # https://github.com/tensorflow/tensorflow/issues/46429
       pip install 'tf-nightly==2.5.0.dev20210112'
 
@@ -96,7 +97,7 @@ keras:
     install_dev: |
       # In keras >= 2.4.0, `keras` simply redirects to `tensorflow.keras`:
       # https://github.com/keras-team/keras#multi-backend-keras-and-tfkeras
-      # Unpin `tf-nightly` once the following issue has been fixed:
+      # Unpin `tf-nightly` once the following issue is addressed:
       # https://github.com/tensorflow/tensorflow/issues/46429
       pip install 'tf-nightly==2.5.0.dev20210112' 'keras>=2.4.0'
 

--- a/ml-package-versions.yml
+++ b/ml-package-versions.yml
@@ -73,7 +73,8 @@ tensorflow-2.x:
   package_info:
     pip_release: "tensorflow"
     install_dev: |
-      pip install tf-nightly
+      # https://github.com/tensorflow/tensorflow/issues/46429
+      pip install 'tf-nightly==2.5.0.dev20210112'
 
   models:
     minimum: "2.0.0"

--- a/ml-package-versions.yml
+++ b/ml-package-versions.yml
@@ -95,7 +95,9 @@ keras:
     install_dev: |
       # In keras >= 2.4.0, `keras` simply redirects to `tensorflow.keras`:
       # https://github.com/keras-team/keras#multi-backend-keras-and-tfkeras
-      pip install tf-nightly 'keras>=2.4.0'
+      # Unpin `tf-nightly` once the following issue has been fixed:
+      # https://github.com/tensorflow/tensorflow/issues/46429
+      pip install 'tf-nightly==2.5.0.dev20210113' 'keras>=2.4.0'
 
   models:
     minimum: "2.2.4"

--- a/tests/keras_autolog/test_keras_autolog.py
+++ b/tests/keras_autolog/test_keras_autolog.py
@@ -205,6 +205,7 @@ def keras_random_data_run_with_callback(
             patience=patience,
             min_delta=99999999,
             restore_best_weights=restore_weights,
+            verbose=1,
         )
     else:
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -289,6 +289,7 @@ def tf_keras_random_data_run_with_callback(
             patience=patience,
             min_delta=99999999,
             restore_best_weights=restore_weights,
+            verbose=1,
         )
     else:
 

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -225,6 +225,7 @@ def tf_keras_random_data_run_with_callback(
             patience=patience,
             min_delta=99999999,
             restore_best_weights=restore_weights,
+            verbose=1,
         )
     else:
         callback = tf.keras.callbacks.ProgbarLogger(count_mode="samples")


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

A temporary workaround for https://github.com/tensorflow/tensorflow/issues/46429

### tf-nightly 2.5.0.dev20210113 (broken)

```
# training log for `EarlyStopping.patience = 0`

Epoch 1/10
5/5 [==============================] - 0s 871us/step - loss: 5.1400 - acc: 0.3351
Restoring model weights from the end of the best epoch.
Epoch 00001: early stopping

# training should not early stop after the first epoch
# because the loss has improved from inf (automatically set by keras when traning starts) to 5.1400
```

### tf-nightly 2.5.0.dev20210112 (fine)

```
# training log for `EarlyStopping.patience = 0`

Epoch 1/10
5/5 [==============================] - 0s 871us/step - loss: 5.1400 - acc: 0.3351
Epoch 2/10
5/5 [==============================] - 0s 837us/step - loss: 4.3136 - acc: 0.3537
Restoring model weights from the end of the best epoch.
Epoch 00002: early stopping

# training continues after the first epoch and early stops after the second epoch
# because loss improvement (5.14000 - 4.3136) is smaller than specified `min_delta`
# which is 99999999 (we intentionally use this value to enforce early stopping regardless of loss value)
# This is what our unit tests expect
```

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
