### PR TITLE
Fix sklearn_elasticnet_wine example dependencies and doc

### DIFF
--- a/docs/source/tutorials-and-examples/tutorial.rst
+++ b/docs/source/tutorials-and-examples/tutorial.rst
@@ -168,37 +168,11 @@ Now that you have your training code, you can package it so that other data scie
       You do this by using :doc:`../projects` conventions to specify the dependencies and entry points to your code. The ``sklearn_elasticnet_wine/MLproject`` file specifies that the project has the dependencies located in a `Conda environment file <https://conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html#creating-an-environment-file-manually>`_
       called ``conda.yaml`` and has one entry point that takes two parameters: ``alpha`` and ``l1_ratio``.
 
-      .. code-block:: yaml
+      .. literalinclude:: ../../../examples/sklearn_elasticnet_wine/MLproject
 
-          # sklearn_elasticnet_wine/MLproject
+      ``sklearn_elasticnet_wine/conda.yaml`` file lists the dependencies:
 
-          name: tutorial
-
-          conda_env: conda.yaml
-
-          entry_points:
-            main:
-              parameters:
-                alpha: {type: float, default: 0.5}
-                l1_ratio: {type: float, default: 0.1}
-              command: "python train.py {alpha} {l1_ratio}"
-
-
-      The Conda file lists the dependencies:
-
-      .. code-block:: yaml
-
-          # sklearn_elasticnet_wine/conda.yaml
-
-          name: tutorial
-          channels:
-            - defaults
-          dependencies:
-            - python=3.6
-            - scikit-learn=0.23.2
-            - pip
-            - pip:
-              - mlflow>=1.0
+      .. literalinclude:: ../../../examples/sklearn_elasticnet_wine/conda.yaml
 
       To run this project, invoke ``mlflow run examples/sklearn_elasticnet_wine -P alpha=0.42``. After running
       this command, MLflow runs your training code in a new Conda environment with the dependencies

--- a/docs/source/tutorials-and-examples/tutorial.rst
+++ b/docs/source/tutorials-and-examples/tutorial.rst
@@ -179,7 +179,7 @@ Now that you have your training code, you can package it so that other data scie
           entry_points:
             main:
               parameters:
-                alpha: float
+                alpha: {type: float, default: 0.5}
                 l1_ratio: {type: float, default: 0.1}
               command: "python train.py {alpha} {l1_ratio}"
 
@@ -194,11 +194,11 @@ Now that you have your training code, you can package it so that other data scie
           channels:
             - defaults
           dependencies:
-            - numpy=1.14.3
-            - pandas=0.22.0
-            - scikit-learn=0.19.1
+            - python=3.6
+            - scikit-learn=0.23.2
+            - pip
             - pip:
-              - mlflow
+              - mlflow>=1.0
 
       To run this project, invoke ``mlflow run examples/sklearn_elasticnet_wine -P alpha=0.42``. After running
       this command, MLflow runs your training code in a new Conda environment with the dependencies

--- a/examples/sklearn_elasticnet_wine/conda.yaml
+++ b/examples/sklearn_elasticnet_wine/conda.yaml
@@ -3,7 +3,7 @@ channels:
   - defaults
 dependencies:
   - python=3.6
-  - scikit-learn=0.23.2
   - pip
   - pip:
+    - scikit-learn==0.23.2
     - mlflow>=1.0

--- a/examples/sklearn_elasticnet_wine/conda.yaml
+++ b/examples/sklearn_elasticnet_wine/conda.yaml
@@ -1,11 +1,9 @@
 name: tutorial
 channels:
   - defaults
-  - anaconda
-  - conda-forge
 dependencies:
   - python=3.6
-  - scikit-learn=0.19.1
+  - scikit-learn=0.23.2
   - pip
   - pip:
     - mlflow>=1.0


### PR DESCRIPTION
## What changes are proposed in this pull request?

- Fixes #3955
- Update conda dependencies for sklearn_elasticnet_wine tutorial example and sync the changes to the tutorial doc

I have removed `conda-forge` and `anaconda` channels from `conda.yaml`. The doc didn't have them and I didn't notice any difference as the dependencies didn't need those channels. If these channels are required for some reason, I can add them back.

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Update scikit-learn dependency and doc for Wine tutorial

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
