### PR TITLE
Multi-step kubernetes pipelines

### DIFF
--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -2,32 +2,31 @@
 The ``mlflow.projects`` module provides an API for running MLflow projects locally or remotely.
 """
 import json
-import logging
-import os
-
 import yaml
+import os
+import logging
 
 import mlflow.projects.databricks
 import mlflow.tracking as tracking
-import mlflow.utils.uri
 from mlflow.entities import RunStatus
 from mlflow.exceptions import ExecutionException, MlflowException
-from mlflow.projects.backend import loader
-from mlflow.projects.submitted_run import SubmittedRun	
-from mlflow.projects.utils import (	
-    PROJECT_SYNCHRONOUS,	
-    get_entry_point_command,	
-    get_run_env_vars,	
-    fetch_and_validate_project,	
-    get_or_create_run,	
-    load_project,	
-    MLFLOW_LOCAL_BACKEND_RUN_ID_CONFIG,	
-    PROJECT_USE_CONDA,	
-    PROJECT_STORAGE_DIR,	
-    PROJECT_DOCKER_ARGS,	
+from mlflow.projects.submitted_run import SubmittedRun
+from mlflow.projects.utils import (
+    PROJECT_SYNCHRONOUS,
+    get_entry_point_command,
+    get_run_env_vars,
+    fetch_and_validate_project,
+    get_or_create_run,
+    load_project,
+    MLFLOW_LOCAL_BACKEND_RUN_ID_CONFIG,
+    PROJECT_USE_CONDA,
+    PROJECT_STORAGE_DIR,
+    PROJECT_DOCKER_ARGS,
 )
+from mlflow.projects.backend import loader
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_PROJECT_BACKEND
+import mlflow.utils.uri
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -13,15 +13,21 @@ import mlflow.utils.uri
 from mlflow.entities import RunStatus
 from mlflow.exceptions import ExecutionException, MlflowException
 from mlflow.projects.backend import loader
-from mlflow.projects.submitted_run import SubmittedRun
-from mlflow.projects.utils import (MLFLOW_LOCAL_BACKEND_RUN_ID_CONFIG,
-                                   PROJECT_DOCKER_ARGS, PROJECT_STORAGE_DIR,
-                                   PROJECT_SYNCHRONOUS, PROJECT_USE_CONDA,
-                                   fetch_and_validate_project,
-                                   get_entry_point_command, get_or_create_run,
-                                   get_run_env_vars, load_project)
+from mlflow.projects.submitted_run import SubmittedRun	
+from mlflow.projects.utils import (	
+    PROJECT_SYNCHRONOUS,	
+    get_entry_point_command,	
+    get_run_env_vars,	
+    fetch_and_validate_project,	
+    get_or_create_run,	
+    load_project,	
+    MLFLOW_LOCAL_BACKEND_RUN_ID_CONFIG,	
+    PROJECT_USE_CONDA,	
+    PROJECT_STORAGE_DIR,	
+    PROJECT_DOCKER_ARGS,	
+)
 from mlflow.tracking.fluent import _get_experiment_id
-from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_BACKEND, MLFLOW_PROJECT_ENV
+from mlflow.utils.mlflow_tags import MLFLOW_PROJECT_ENV, MLFLOW_PROJECT_BACKEND
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/projects/__init__.py
+++ b/mlflow/projects/__init__.py
@@ -139,9 +139,9 @@ def _run(
         tracking.MlflowClient().set_tag(
             active_run.info.run_id, MLFLOW_PROJECT_BACKEND, "kubernetes"
         )
-        
+
         kube_config = _parse_kubernetes_config(backend_config)
-        if os.environ.get('IMAGE_DIGEST') is None or os.environ.get('IMAGE_TAG') is None:
+        if os.environ.get("IMAGE_DIGEST") is None or os.environ.get("IMAGE_TAG") is None:
             validate_docker_env(project)
             validate_docker_installation()
             image = build_docker_image(
@@ -153,13 +153,13 @@ def _run(
             image_digest = kb.push_image_to_registry(image.tags[0])
             image_tag = image.tags[0]
         else:
-            image_digest = os.environ.get('IMAGE_DIGEST')
-            image_tag = os.environ.get('IMAGE_TAG')
+            image_digest = os.environ.get("IMAGE_DIGEST")
+            image_tag = os.environ.get("IMAGE_TAG")
 
         run_env_vars = get_run_env_vars(
-                run_id=active_run.info.run_uuid, experiment_id=active_run.info.experiment_id
-            )
-        run_env_vars.update({'IMAGE_DIGEST':image_digest, 'IMAGE_TAG':image_tag}),
+            run_id=active_run.info.run_uuid, experiment_id=active_run.info.experiment_id
+        )
+        run_env_vars.update({"IMAGE_DIGEST": image_digest, "IMAGE_TAG": image_tag})
 
         submitted_run = kb.run_kubernetes_job(
             project.name,


### PR DESCRIPTION
## What changes are proposed in this pull request?
This PR allows to start an mlflow kubernetes run *from within a run being executed in a kubernetes pod* without the need to build a new docker image.

Building a docker image from within a pod is currently possible by mounting the `docker.socket`. This, however, will not work any longer after kubernetes deprecates Docker. **Multi-step mlflow pipelines being executed from a kubernetes pod itself will no longer be possible.**

This PR proposes to address this by introducing the environment variables `IMAGE_TAG` and `IMAGE_DIGEST` for the kubernetes backend. If set, mlflow will use the specified image when starting a kubernetes run instead of building a new image. When a new kubernetes run is started, these environment variables are set also in the job spec.

This means the following:
* The user starts a new kubernetes run on her/his dev machine. If the environment variables `IMAGE_TAG` and `IMAGE_DIGEST` have not been set, mlflow builds a new image and starts the kubernetes run with it.
* In the pod executing the started run, the environment variables `IMAGE_TAG` and `IMAGE_DIGEST` are now set. If from within this pod new mlflow kubernetes runs are started, the same image will be used instead of building a new one.

In this way, multi-step kubernetes pipelines controlled from an mlflow kubernetes pod itself will be possible also after the deprecation of Docker.

Closes #3848 
Closes #3741 
Replaces the PR #3742

## How is this patch tested?
`./lint.sh`, `./dev/run-small-python-tests.sh` pass. Large tests have not been performed as neither models or model deployment components have been changed.

In addition, the intended functionality has been tested using our kubernetes training cluster.


## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Kubernetes runs can be launched with an existing image by setting the environment variables `IMAGE_TAG` and `IMAGE_DIGEST`. This feature allows starting additional mlflow kubernetes jobs from within an mlflow kubernetes job itself as building a new image, which will no longer be possible after Kubernetes deprecates Docker, is now not required.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
