### PR TITLE
Kubernetes jobs cancel does not delete pod

### DIFF
--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -1,19 +1,17 @@
 import logging
-import docker
-import time
 import os
-from threading import RLock
+import time
 from datetime import datetime
+from shlex import quote, split
+from threading import RLock
 
-import kubernetes
-from kubernetes.config.config_exception import ConfigException
-
+from mlflow.entities import RunStatus
 from mlflow.exceptions import ExecutionException
 from mlflow.projects.submitted_run import SubmittedRun
-from mlflow.entities import RunStatus
 
-from shlex import split
-from shlex import quote
+import docker
+import kubernetes
+from kubernetes.config.config_exception import ConfigException
 
 _logger = logging.getLogger(__name__)
 
@@ -155,7 +153,7 @@ class KubernetesSubmittedRun(SubmittedRun):
                 kube_api.delete_namespaced_job(
                     name=self._job_name,
                     namespace=self._job_namespace,
-                    body=kubernetes.client.V1DeleteOptions(),
+                    body=kubernetes.client.V1DeleteOptions(propagation_policy="Background"),
                     pretty=True,
                 )
                 self._status = RunStatus.KILLED

--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -1,17 +1,19 @@
 import logging
-import os
-import time
-from datetime import datetime
-from shlex import quote, split
-from threading import RLock
-
-from mlflow.entities import RunStatus
-from mlflow.exceptions import ExecutionException
-from mlflow.projects.submitted_run import SubmittedRun
-
 import docker
+import time
+import os
+from threading import RLock
+from datetime import datetime
+
 import kubernetes
 from kubernetes.config.config_exception import ConfigException
+
+from mlflow.exceptions import ExecutionException
+from mlflow.projects.submitted_run import SubmittedRun
+from mlflow.entities import RunStatus
+
+from shlex import split
+from shlex import quote
 
 _logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## What changes are proposed in this pull request?
When calling `submitted_kubernetes_run.cancel()`, the job is deleted but the associated pod continues to do its work. 
Replacing `kubernetes.client.V1DeleteOptions()` with `kubernetes.client.V1DeleteOptions(propagation_policy="Background")` ensures that the pod is deleted as well.

## How is this patch tested?
All tests in `./dev/run-small-python-tests.sh` pass.


## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.



### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
