### PR TITLE
[bug-fix] add missing client parameter in `mlflow_restore_run()`

### DIFF
--- a/mlflow/R/mlflow/R/tracking-runs.R
+++ b/mlflow/R/mlflow/R/tracking-runs.R
@@ -112,7 +112,7 @@ mlflow_restore_run <- function(run_id, client = NULL) {
   mlflow_rest("runs", "restore", client = client, verb = "POST", data = data)
   mlflow_register_tracking_event("restore_run", data)
 
-  mlflow_get_run(run_id)
+  mlflow_get_run(run_id, client = client)
 }
 
 #' Get Run

--- a/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
+++ b/mlflow/R/mlflow/tests/testthat/test-tracking-runs.R
@@ -66,6 +66,34 @@ test_that("mlflow_start_run()/mlflow_end_run() works properly with nested runs",
   expect_null(mlflow:::mlflow_get_active_run_id())
 })
 
+test_that("mlflow_restore_run() work properly", {
+  mlflow_clear_test_dir("mlruns")
+  client <- mlflow_client()
+  run1 <- mlflow_start_run(
+    client = client,
+    experiment_id = "0",
+    tags = list(foo = "bar", foz = "baz", mlflow.user = "user1")
+  )
+
+  run2 <- mlflow_get_run(client = client, run1$run_uuid)
+  mlflow_delete_run(client = client, run_id = run1$run_uuid)
+  run3 <- mlflow_restore_run(client = client, run_id = run1$run_uuid)
+
+  for (run in list(run1, run2, run3)) {
+    expect_identical(run$user_id, "user1")
+
+    expect_true(
+      all(purrr::transpose(run$tags[[1]]) %in%
+        list(
+          list(key = "foz", value = "baz"),
+          list(key = "foo", value = "bar"),
+          list(key = "mlflow.user", value = "user1")
+        )
+      )
+    )
+  }
+})
+
 test_that("mlflow_set_tag() should return NULL invisibly", {
   mlflow_clear_test_dir("mlruns")
   value <- mlflow_set_tag("foo", "bar")


### PR DESCRIPTION
Signed-off-by: Yitao Li <yitao@rstudio.com>

## What changes are proposed in this pull request?

`mlflow_get_run()` called within `mlflow_restore_run()` should pass along the `client` parameter, otherwise `client` defaults to `NULL` a default `mlflow_client()` gets used instead

## How is this patch tested?

- Running MLflow server and MLflow R client separately, calling `mlflow_delete_run()` followed by `mlflow_restore_run()` on one run (without calling `mlflow::mlflow_set_tracking_uri()` to set a tracking uri globally)
- Unit test on `mlflow_restore_run()`

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
