### PR TITLE
mlflow_get_experiment() should return same tag structure as mlflow_list_experiments()

### DIFF
--- a/mlflow/R/mlflow/R/tracking-experiments.R
+++ b/mlflow/R/mlflow/R/tracking-experiments.R
@@ -98,6 +98,7 @@ mlflow_get_experiment <- function(experiment_id = NULL, name = NULL, client = NU
       client = client, query = list(experiment_id = experiment_id)
     )
   }
+  response$experiment$tags <- parse_run_data(response$experiment$tags)
   response$experiment %>%
     new_mlflow_experiment()
 }


### PR DESCRIPTION
## What changes are proposed in this pull request?

Follow up to https://github.com/mlflow/mlflow/pull/3942, specifically to the request of @tomasatdatabricks in https://github.com/mlflow/mlflow/pull/3942#issuecomment-763227858. This PR completes a consistent structure in the `tags` column of `mlflow_get_experiment()`, `mlflow_list_experiments()`, `mlflow_get_run()` . Not sure this should be classified user facing because it is a breaking change in the return value structure in some circumstances (same as #3942), but it's not likely that it will break much code in downstream projects and in principle a minor change.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [x] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
