### PR TITLE
Remove failure when deployment uri has two slashes

### DIFF
--- a/mlflow/deployments/utils.py
+++ b/mlflow/deployments/utils.py
@@ -13,9 +13,4 @@ def parse_target_uri(target_uri):
             "Not a proper deployment URI: %s. " % target_uri
             + "Deployment URIs must be of the form 'target' or 'target:/suffix'"
         )
-    if parsed.netloc:  # Handle e.g. target_name://suffix, where 'suffix' gets parsed as netloc
-        raise MlflowException(
-            "Not a proper deployment URI: %s. " % target_uri
-            + "Deployment URIs must be of the form 'target:/suffix'"
-        )
     return parsed.scheme

--- a/tests/deployments/test_deployments.py
+++ b/tests/deployments/test_deployments.py
@@ -73,3 +73,4 @@ def test_plugin_raising_error():
 def test_target_uri_parsing():
     deployments.get_deploy_client(f_target)
     deployments.get_deploy_client("{target}:/somesuffix".format(target=f_target))
+    deployments.get_deploy_client("{target}://somesuffix".format(target=f_target))

--- a/tests/deployments/test_deployments.py
+++ b/tests/deployments/test_deployments.py
@@ -73,5 +73,3 @@ def test_plugin_raising_error():
 def test_target_uri_parsing():
     deployments.get_deploy_client(f_target)
     deployments.get_deploy_client("{target}:/somesuffix".format(target=f_target))
-    with pytest.raises(MlflowException):
-        deployments.get_deploy_client("{target}://somesuffix".format(target=f_target))


### PR DESCRIPTION
## What changes are proposed in this pull request?

The PR removes the failure when a provided deployment uri contains two slashes. This aligns the handling for deployment URIs with how the tracking store uri target is retrieved: https://github.com/mlflow/mlflow/blob/master/mlflow/utils/uri.py#L159

## How is this patch tested?

Automated tests.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
