### PR TITLE
GCP artifact upload / download support

### DIFF
--- a/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
+++ b/mlflow/java/client/src/main/java/com/databricks/api/proto/mlflow/DatabricksArtifacts.java
@@ -41,6 +41,15 @@ public final class DatabricksArtifacts {
      * <code>AWS_PRESIGNED_URL = 2;</code>
      */
     AWS_PRESIGNED_URL(2),
+    /**
+     * <pre>
+     * The credential is a GCP Signed URL. For more information, see
+     * https://cloud.google.com/storage/docs/access-control/signed-urls
+     * </pre>
+     *
+     * <code>GCP_SIGNED_URL = 3;</code>
+     */
+    GCP_SIGNED_URL(3),
     ;
 
     /**
@@ -61,6 +70,15 @@ public final class DatabricksArtifacts {
      * <code>AWS_PRESIGNED_URL = 2;</code>
      */
     public static final int AWS_PRESIGNED_URL_VALUE = 2;
+    /**
+     * <pre>
+     * The credential is a GCP Signed URL. For more information, see
+     * https://cloud.google.com/storage/docs/access-control/signed-urls
+     * </pre>
+     *
+     * <code>GCP_SIGNED_URL = 3;</code>
+     */
+    public static final int GCP_SIGNED_URL_VALUE = 3;
 
 
     public final int getNumber() {
@@ -79,6 +97,7 @@ public final class DatabricksArtifacts {
       switch (value) {
         case 1: return AZURE_SAS_URI;
         case 2: return AWS_PRESIGNED_URL;
+        case 3: return GCP_SIGNED_URL;
         default: return null;
       }
     }
@@ -5824,18 +5843,19 @@ public final class DatabricksArtifacts {
       "flow.ArtifactCredentialInfo:_\342?(\n&com.da" +
       "tabricks.rpc.RPC[$this.Response]\342?1\n/com" +
       ".databricks.mlflow.api.MlflowTrackingMes" +
-      "sage*B\n\026ArtifactCredentialType\022\021\n\rAZURE_" +
-      "SAS_URI\020\001\022\025\n\021AWS_PRESIGNED_URL\020\0022\342\002\n Dat" +
-      "abricksMlflowArtifactsService\022\233\001\n\025getCre" +
-      "dentialsForRead\022\035.mlflow.GetCredentialsF" +
-      "orRead\032&.mlflow.GetCredentialsForRead.Re" +
-      "sponse\";\362\206\0317\n3\n\003GET\022&/mlflow/artifacts/c" +
-      "redentials-for-read\032\004\010\002\020\000\020\003\022\237\001\n\026getCrede" +
-      "ntialsForWrite\022\036.mlflow.GetCredentialsFo" +
-      "rWrite\032\'.mlflow.GetCredentialsForWrite.R" +
-      "esponse\"<\362\206\0318\n4\n\003GET\022\'/mlflow/artifacts/" +
-      "credentials-for-write\032\004\010\002\020\000\020\003B,\n\037com.dat" +
-      "abricks.api.proto.mlflow\220\001\001\240\001\001\342?\002\020\001"
+      "sage*V\n\026ArtifactCredentialType\022\021\n\rAZURE_" +
+      "SAS_URI\020\001\022\025\n\021AWS_PRESIGNED_URL\020\002\022\022\n\016GCP_" +
+      "SIGNED_URL\020\0032\342\002\n DatabricksMlflowArtifac" +
+      "tsService\022\233\001\n\025getCredentialsForRead\022\035.ml" +
+      "flow.GetCredentialsForRead\032&.mlflow.GetC" +
+      "redentialsForRead.Response\";\362\206\0317\n3\n\003GET\022" +
+      "&/mlflow/artifacts/credentials-for-read\032" +
+      "\004\010\002\020\000\020\003\022\237\001\n\026getCredentialsForWrite\022\036.mlf" +
+      "low.GetCredentialsForWrite\032\'.mlflow.GetC" +
+      "redentialsForWrite.Response\"<\362\206\0318\n4\n\003GET" +
+      "\022\'/mlflow/artifacts/credentials-for-writ" +
+      "e\032\004\010\002\020\000\020\003B,\n\037com.databricks.api.proto.ml" +
+      "flow\220\001\001\240\001\001\342?\002\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {

--- a/mlflow/protos/databricks_artifacts.proto
+++ b/mlflow/protos/databricks_artifacts.proto
@@ -55,6 +55,9 @@ enum ArtifactCredentialType {
   // https://docs.aws.amazon.com/AmazonS3/latest/dev/ShareObjectPreSignedURL.html
   AWS_PRESIGNED_URL = 2;
 
+  // The credential is a GCP Signed URL. For more information, see
+  // https://cloud.google.com/storage/docs/access-control/signed-urls
+  GCP_SIGNED_URL = 3;
 }
 
 message ArtifactCredentialInfo {

--- a/mlflow/protos/databricks_artifacts_pb2.py
+++ b/mlflow/protos/databricks_artifacts_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\037com.databricks.api.proto.mlflow\220\001\001\240\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\x1a\x64\x61tabricks_artifacts.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xdf\x01\n\x16\x41rtifactCredentialInfo\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\nsigned_uri\x18\x03 \x01(\t\x12:\n\x07headers\x18\x04 \x03(\x0b\x32).mlflow.ArtifactCredentialInfo.HttpHeader\x12,\n\x04type\x18\x05 \x01(\x0e\x32\x1e.mlflow.ArtifactCredentialType\x1a)\n\nHttpHeader\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xe3\x01\n\x15GetCredentialsForRead\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04path\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a?\n\x08Response\x12\x33\n\x0b\x63redentials\x18\x01 \x01(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\xe4\x01\n\x16GetCredentialsForWrite\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04path\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a?\n\x08Response\x12\x33\n\x0b\x63redentials\x18\x01 \x01(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage*B\n\x16\x41rtifactCredentialType\x12\x11\n\rAZURE_SAS_URI\x10\x01\x12\x15\n\x11\x41WS_PRESIGNED_URL\x10\x02\x32\xe2\x02\n DatabricksMlflowArtifactsService\x12\x9b\x01\n\x15getCredentialsForRead\x12\x1d.mlflow.GetCredentialsForRead\x1a&.mlflow.GetCredentialsForRead.Response\";\xf2\x86\x19\x37\n3\n\x03GET\x12&/mlflow/artifacts/credentials-for-read\x1a\x04\x08\x02\x10\x00\x10\x03\x12\x9f\x01\n\x16getCredentialsForWrite\x12\x1e.mlflow.GetCredentialsForWrite\x1a\'.mlflow.GetCredentialsForWrite.Response\"<\xf2\x86\x19\x38\n4\n\x03GET\x12\'/mlflow/artifacts/credentials-for-write\x1a\x04\x08\x02\x10\x00\x10\x03\x42,\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\x1a\x64\x61tabricks_artifacts.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"\xdf\x01\n\x16\x41rtifactCredentialInfo\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\nsigned_uri\x18\x03 \x01(\t\x12:\n\x07headers\x18\x04 \x03(\x0b\x32).mlflow.ArtifactCredentialInfo.HttpHeader\x12,\n\x04type\x18\x05 \x01(\x0e\x32\x1e.mlflow.ArtifactCredentialType\x1a)\n\nHttpHeader\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xe3\x01\n\x15GetCredentialsForRead\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04path\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a?\n\x08Response\x12\x33\n\x0b\x63redentials\x18\x01 \x01(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage\"\xe4\x01\n\x16GetCredentialsForWrite\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x12\n\x04path\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a?\n\x08Response\x12\x33\n\x0b\x63redentials\x18\x01 \x01(\x0b\x32\x1e.mlflow.ArtifactCredentialInfo:_\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\xe2?1\n/com.databricks.mlflow.api.MlflowTrackingMessage*V\n\x16\x41rtifactCredentialType\x12\x11\n\rAZURE_SAS_URI\x10\x01\x12\x15\n\x11\x41WS_PRESIGNED_URL\x10\x02\x12\x12\n\x0eGCP_SIGNED_URL\x10\x03\x32\xe2\x02\n DatabricksMlflowArtifactsService\x12\x9b\x01\n\x15getCredentialsForRead\x12\x1d.mlflow.GetCredentialsForRead\x1a&.mlflow.GetCredentialsForRead.Response\";\xf2\x86\x19\x37\n3\n\x03GET\x12&/mlflow/artifacts/credentials-for-read\x1a\x04\x08\x02\x10\x00\x10\x03\x12\x9f\x01\n\x16getCredentialsForWrite\x12\x1e.mlflow.GetCredentialsForWrite\x1a\'.mlflow.GetCredentialsForWrite.Response\"<\xf2\x86\x19\x38\n4\n\x03GET\x12\'/mlflow/artifacts/credentials-for-write\x1a\x04\x08\x02\x10\x00\x10\x03\x42,\n\x1f\x63om.databricks.api.proto.mlflow\x90\x01\x01\xa0\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -42,17 +42,22 @@ _ARTIFACTCREDENTIALTYPE = _descriptor.EnumDescriptor(
       name='AWS_PRESIGNED_URL', index=1, number=2,
       serialized_options=None,
       type=None),
+    _descriptor.EnumValueDescriptor(
+      name='GCP_SIGNED_URL', index=2, number=3,
+      serialized_options=None,
+      type=None),
   ],
   containing_type=None,
   serialized_options=None,
   serialized_start=766,
-  serialized_end=832,
+  serialized_end=852,
 )
 _sym_db.RegisterEnumDescriptor(_ARTIFACTCREDENTIALTYPE)
 
 ArtifactCredentialType = enum_type_wrapper.EnumTypeWrapper(_ARTIFACTCREDENTIALTYPE)
 AZURE_SAS_URI = 1
 AWS_PRESIGNED_URL = 2
+GCP_SIGNED_URL = 3
 
 
 
@@ -360,8 +365,8 @@ _DATABRICKSMLFLOWARTIFACTSSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=835,
-  serialized_end=1189,
+  serialized_start=855,
+  serialized_end=1209,
   methods=[
   _descriptor.MethodDescriptor(
     name='getCredentialsForRead',

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -191,7 +191,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
         except Exception as err:
             raise MlflowException(err)
 
-    def _aws_upload_file(self, credentials, local_file):
+    def _signed_url_upload_file(self, credentials, local_file):
         try:
             headers = self._extract_headers_from_credentials(credentials.headers)
             signed_write_uri = credentials.signed_uri
@@ -208,8 +208,11 @@ class DatabricksArtifactRepository(ArtifactRepository):
     def _upload_to_cloud(self, cloud_credentials, local_file, artifact_path):
         if cloud_credentials.credentials.type == ArtifactCredentialType.AZURE_SAS_URI:
             self._azure_upload_file(cloud_credentials.credentials, local_file, artifact_path)
-        elif cloud_credentials.credentials.type == ArtifactCredentialType.AWS_PRESIGNED_URL:
-            self._aws_upload_file(cloud_credentials.credentials, local_file)
+        elif cloud_credentials.credentials.type in [
+            ArtifactCredentialType.AWS_PRESIGNED_URL,
+            ArtifactCredentialType.GCP_SIGNED_URL,
+        ]:
+            self._signed_url_upload_file(cloud_credentials.credentials, local_file)
         else:
             raise MlflowException(
                 message="Cloud provider not supported.", error_code=INTERNAL_ERROR
@@ -231,6 +234,7 @@ class DatabricksArtifactRepository(ArtifactRepository):
         if cloud_credential.type not in [
             ArtifactCredentialType.AZURE_SAS_URI,
             ArtifactCredentialType.AWS_PRESIGNED_URL,
+            ArtifactCredentialType.GCP_SIGNED_URL,
         ]:
             raise MlflowException(
                 message="Cloud provider not supported.", error_code=INTERNAL_ERROR


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR introduces GCP artifact upload / download support to `DatabricksArtifactRepository` and `DatabricksModelsArtifactRepository`, enabling the MLflow client on Databricks to securely upload / download artifacts to / from Google Cloud Storage locations.

## How is this patch tested?

Unit tests have been augmented to capture GCP upload / download workflows. Addition manual testing has been performed on Databricks (ping @dbczumar for details).

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
