### PR TITLE
Fix spacy 3.0 issue

### DIFF
--- a/examples/spacy/train.py
+++ b/examples/spacy/train.py
@@ -16,7 +16,7 @@ if __name__ == "__main__":
 
     # create blank model and add ner to the pipeline
     nlp = spacy.blank("en")
-    nlp.add_pipe("ner", last=True)
+    ner = nlp.add_pipe("ner", last=True)
 
     # add labels
     for _, annotations in TRAIN_DATA:

--- a/examples/spacy/train.py
+++ b/examples/spacy/train.py
@@ -1,9 +1,14 @@
 import random
+from distutils.version import LooseVersion
 
 import spacy
 from spacy.util import minibatch, compounding
 
 import mlflow.spacy
+
+IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = LooseVersion(spacy.__version__) >= LooseVersion(
+    "3.0.0"
+)
 
 # training data
 TRAIN_DATA = [
@@ -16,7 +21,11 @@ if __name__ == "__main__":
 
     # create blank model and add ner to the pipeline
     nlp = spacy.blank("en")
-    ner = nlp.add_pipe("ner", last=True)
+    if IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0:
+        ner = nlp.add_pipe("ner", last=True)
+    else:
+        ner = nlp.create_pipe("ner")
+        nlp.add_pipe(ner, last=True)
 
     # add labels
     for _, annotations in TRAIN_DATA:

--- a/examples/spacy/train.py
+++ b/examples/spacy/train.py
@@ -16,8 +16,7 @@ if __name__ == "__main__":
 
     # create blank model and add ner to the pipeline
     nlp = spacy.blank("en")
-    ner = nlp.create_pipe("ner")
-    nlp.add_pipe(ner, last=True)
+    nlp.add_pipe("ner", last=True)
 
     # add labels
     for _, annotations in TRAIN_DATA:

--- a/ml-package-versions.yml
+++ b/ml-package-versions.yml
@@ -223,3 +223,17 @@ onnx:
     requirements: ["onnxruntime", "torch", "scikit-learn"]
     run: |
       pytest tests/onnx/test_onnx_model_export.py --large
+
+
+spacy:
+  package_info:
+    pip_release: "spacy"
+    install_dev: |
+      pip install spacy-nightly
+
+  models:
+    minimum: "2.2.4"
+    maximum: "3.0.0"
+    requirements: ["scikit-learn"]
+    run: |
+      pytest tests/spacy/test_spacy_model_export.py --large

--- a/ml-package-versions.yml
+++ b/ml-package-versions.yml
@@ -224,7 +224,6 @@ onnx:
     run: |
       pytest tests/onnx/test_onnx_model_export.py --large
 
-
 spacy:
   package_info:
     pip_release: "spacy"

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -28,9 +28,7 @@ ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 def spacy_model_with_data():
     # Creating blank model and setting up the spaCy pipeline
     nlp = spacy.blank("en")
-    textcat = nlp.add_pipe(
-        "textcat", config={"exclusive_classes": True, "architecture": "simple_cnn"}, last=True
-    )
+    textcat = nlp.add_pipe("textcat", last=True)
 
     # Training the model to recognize between computer graphics and baseball in 20newsgroups dataset
     categories = ["comp.graphics", "rec.sport.baseball"]

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -28,10 +28,9 @@ ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 def spacy_model_with_data():
     # Creating blank model and setting up the spaCy pipeline
     nlp = spacy.blank("en")
-    textcat = nlp.create_pipe(
-        "textcat", config={"exclusive_classes": True, "architecture": "simple_cnn"}, validate=False,
+    nlp.add_pipe(
+        "textcat", config={"exclusive_classes": True, "architecture": "simple_cnn"}, last=True
     )
-    nlp.add_pipe(textcat, last=True)
 
     # Training the model to recognize between computer graphics and baseball in 20newsgroups dataset
     categories = ["comp.graphics", "rec.sport.baseball"]
@@ -261,8 +260,7 @@ def test_model_log_without_pyfunc_flavor():
     nlp = spacy.blank("en")
 
     # Add a component not compatible with pyfunc
-    ner = nlp.create_pipe("ner")
-    nlp.add_pipe(ner, last=True)
+    nlp.add_pipe("ner", last=True)
 
     # Ensure the pyfunc flavor is not present after logging and loading the model
     with mlflow.start_run():

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -57,6 +57,12 @@ def spacy_model_with_data():
     # Split train/test and train the model
     train_x, train_y, test_x, _ = _get_train_test_dataset(categories)
     train_data = list(zip(train_x, [{"cats": cats} for cats in train_y]))
+
+    if IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0:
+        from spacy.training import Example
+
+        train_data = [Example.from_dict(nlp.make_doc(text), cats) for text, cats in train_data]
+
     _train_model(nlp, train_data)
     return ModelWithData(nlp, pd.DataFrame(test_x))
 

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -281,8 +281,7 @@ def _train_model(nlp, train_data, n_iter=5):
         random.shuffle(train_data)
         batches = minibatch(train_data, size=batch_sizes)
         for batch in batches:
-            texts, annotations = zip(*batch)
-            nlp.update(texts, annotations, sgd=optimizer, drop=0.2, losses=losses)
+            nlp.update(batch, sgd=optimizer, drop=0.2, losses=losses)
 
 
 def _get_train_test_dataset(cats_to_fetch, limit=100):

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -35,11 +35,8 @@ def spacy_model_with_data():
     # Creating blank model and setting up the spaCy pipeline
     nlp = spacy.blank("en")
     if IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0:
-        textcat = nlp.add_pipe(
-            "textcat",
-            config={"@architectures": "spacy.TextCatCNN.v1", "exclusive_classes": True},
-            last=True,
-        )
+        model = {"@architectures": "spacy.TextCatCNN.v1", "exclusive_classes": True}
+        textcat = nlp.add_pipe("textcat", config={"model": model}, last=True,)
     else:
         textcat = nlp.create_pipe(
             "textcat", config={"exclusive_classes": True, "architecture": "simple_cnn"}

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -28,7 +28,7 @@ ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 def spacy_model_with_data():
     # Creating blank model and setting up the spaCy pipeline
     nlp = spacy.blank("en")
-    nlp.add_pipe(
+    textcat = nlp.add_pipe(
         "textcat", config={"exclusive_classes": True, "architecture": "simple_cnn"}, last=True
     )
 

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -28,7 +28,14 @@ ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 def spacy_model_with_data():
     # Creating blank model and setting up the spaCy pipeline
     nlp = spacy.blank("en")
-    textcat = nlp.add_pipe("textcat", last=True)
+    textcat = nlp.add_pipe(
+        "textcat",
+        config={
+            "@architectures": "spacy.TextCatCNN.v1",
+            "exclusive_classes": True,
+        },
+        last=True,
+    )
 
     # Training the model to recognize between computer graphics and baseball in 20newsgroups dataset
     categories = ["comp.graphics", "rec.sport.baseball"]

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -42,7 +42,7 @@ def spacy_model_with_data():
             "exclusive_classes": True,
             "tok2vec": DEFAULT_TOK2VEC_MODEL,
         }
-        textcat = nlp.add_pipe("textcat", config={"model": model}, last=True,)
+        textcat = nlp.add_pipe("textcat", config={"model": model}, last=True)
     else:
         textcat = nlp.create_pipe(
             "textcat", config={"exclusive_classes": True, "architecture": "simple_cnn"}

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -35,7 +35,13 @@ def spacy_model_with_data():
     # Creating blank model and setting up the spaCy pipeline
     nlp = spacy.blank("en")
     if IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0:
-        model = {"@architectures": "spacy.TextCatCNN.v1", "exclusive_classes": True}
+        from spacy.pipeline.tok2vec import DEFAULT_TOK2VEC_MODEL
+
+        model = {
+            "@architectures": "spacy.TextCatCNN.v1",
+            "exclusive_classes": True,
+            "tok2vec": DEFAULT_TOK2VEC_MODEL,
+        }
         textcat = nlp.add_pipe("textcat", config={"model": model}, last=True,)
     else:
         textcat = nlp.create_pipe(

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -29,7 +29,7 @@ def spacy_model_with_data():
     # Creating blank model and setting up the spaCy pipeline
     nlp = spacy.blank("en")
     textcat = nlp.create_pipe(
-        "textcat", config={"exclusive_classes": True, "architecture": "simple_cnn"}
+        "textcat", config={"exclusive_classes": True, "architecture": "simple_cnn"}, validate=False,
     )
     nlp.add_pipe(textcat, last=True)
 

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -1,6 +1,7 @@
 import os
 import random
 from collections import namedtuple
+from distutils.version import LooseVersion
 
 import pandas as pd
 import pytest
@@ -24,18 +25,26 @@ from tests.conftest import tracking_uri_mock  # pylint: disable=unused-import, E
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 
 
+IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = LooseVersion(spacy.__version__) >= LooseVersion(
+    "3.0.0"
+)
+
+
 @pytest.fixture(scope="module")
 def spacy_model_with_data():
     # Creating blank model and setting up the spaCy pipeline
     nlp = spacy.blank("en")
-    textcat = nlp.add_pipe(
-        "textcat",
-        config={
-            "@architectures": "spacy.TextCatCNN.v1",
-            "exclusive_classes": True,
-        },
-        last=True,
-    )
+    if IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0:
+        textcat = nlp.add_pipe(
+            "textcat",
+            config={"@architectures": "spacy.TextCatCNN.v1", "exclusive_classes": True},
+            last=True,
+        )
+    else:
+        textcat = nlp.create_pipe(
+            "textcat", config={"exclusive_classes": True, "architecture": "simple_cnn"}
+        )
+        nlp.add_pipe(textcat, last=True)
 
     # Training the model to recognize between computer graphics and baseball in 20newsgroups dataset
     categories = ["comp.graphics", "rec.sport.baseball"]
@@ -265,7 +274,11 @@ def test_model_log_without_pyfunc_flavor():
     nlp = spacy.blank("en")
 
     # Add a component not compatible with pyfunc
-    nlp.add_pipe("ner", last=True)
+    if IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0:
+        nlp.add_pipe("ner", last=True)
+    else:
+        ner = nlp.create_pipe("ner")
+        nlp.add_pipe(ner, last=True)
 
     # Ensure the pyfunc flavor is not present after logging and loading the model
     with mlflow.start_run():
@@ -288,7 +301,11 @@ def _train_model(nlp, train_data, n_iter=5):
         random.shuffle(train_data)
         batches = minibatch(train_data, size=batch_sizes)
         for batch in batches:
-            nlp.update(batch, sgd=optimizer, drop=0.2, losses=losses)
+            if IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0:
+                nlp.update(batch, sgd=optimizer, drop=0.2, losses=losses)
+            else:
+                texts, annotations = zip(*batch)
+                nlp.update(texts, annotations, sgd=optimizer, drop=0.2, losses=losses)
 
 
 def _get_train_test_dataset(cats_to_fetch, limit=100):


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Spacy 3.0 has been released and it broke spacy tests:

https://github.com/mlflow/mlflow/pull/3773/checks?check_run_id=1807130640#step:4:837

```
tests/spacy/test_spacy_model_export.py::test_model_save_load ERROR
tests/spacy/test_spacy_model_export.py::test_model_export_with_schema_and_examples ERROR
tests/spacy/test_spacy_model_export.py::test_predict_df_with_wrong_shape ERROR
tests/spacy/test_spacy_model_export.py::test_model_log ERROR
tests/spacy/test_spacy_model_export.py::test_model_save_persists_specified_conda_env_in_mlflow_model_directory ERROR
tests/spacy/test_spacy_model_export.py::test_model_save_accepts_conda_env_as_dict ERROR
tests/spacy/test_spacy_model_export.py::test_model_log_persists_specified_conda_env_in_mlflow_model_directory ERROR
tests/spacy/test_spacy_model_export.py::test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies ERROR
tests/spacy/test_spacy_model_export.py::test_model_log_without_specified_conda_env_uses_default_env_with_expected_dependencies ERROR
tests/spacy/test_spacy_model_export.py::test_model_log_with_pyfunc_flavor ERROR
tests/spacy/test_spacy_model_export.py::test_model_log_without_pyfunc_flavor FAILED
```

## How is this patch tested?

Updated unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
