### PR TITLE
Update client to pass request headers created by all RequestHeaderProviders

### DIFF
--- a/mlflow/tracking/request_header/registry.py
+++ b/mlflow/tracking/request_header/registry.py
@@ -36,6 +36,7 @@ _request_header_provider_registry.register(DatabricksRequestHeaderProvider)
 
 _request_header_provider_registry.register_entrypoints()
 
+
 def resolve_request_headers(request_headers=None):
     """Generate a set of request headers from registered providers. Request headers are resolved in the order that
     providers are registered. Argument headers are applied last.

--- a/mlflow/tracking/request_header/registry.py
+++ b/mlflow/tracking/request_header/registry.py
@@ -58,7 +58,7 @@ def resolve_request_headers(request_headers=None):
             if provider.in_context():
                 all_request_headers.update(provider.request_headers())
         except Exception as e:
-            _logger.warning(f"Encountered unexpected error during resolving request headers: {e}")
+            _logger.warning("Encountered unexpected error during resolving request headers: %s", e)
 
     if request_headers is not None:
         all_request_headers.update(request_headers)

--- a/mlflow/tracking/request_header/registry.py
+++ b/mlflow/tracking/request_header/registry.py
@@ -23,7 +23,9 @@ class RequestHeaderProviderRegistry(object):
                 self.register(entrypoint.load())
             except (AttributeError, ImportError) as exc:
                 warnings.warn(
-                    f'Failure attempting to register request header provider "{entrypoint.name}": {str(exc)}',
+                    'Failure attempting to register request header provider "{}": {}'.format(
+                        entrypoint.name, str(exc)
+                    ),
                     stacklevel=2,
                 )
 

--- a/mlflow/tracking/request_header/registry.py
+++ b/mlflow/tracking/request_header/registry.py
@@ -40,15 +40,15 @@ _request_header_provider_registry.register_entrypoints()
 
 
 def resolve_request_headers(request_headers=None):
-    """Generate a set of request headers from registered providers. Request headers are resolved in the order that
-    providers are registered. Argument headers are applied last.
+    """Generate a set of request headers from registered providers. Request headers are resolved in
+    the order that providers are registered. Argument headers are applied last.
 
     This function iterates through all request header providers in the registry. Additional context
     providers can be registered as described in
     :py:class:`mlflow.tracking.request_header.RequestHeaderProvider`.
 
-    :param tags: A dictionary of request headers to override. If specified, headers passed in this argument will
-                 override those inferred from the context.
+    :param tags: A dictionary of request headers to override. If specified, headers passed in this
+        argument will override those inferred from the context.
     :return: A dicitonary of resolved headers.
     """
 

--- a/mlflow/tracking/request_header/registry.py
+++ b/mlflow/tracking/request_header/registry.py
@@ -6,6 +6,9 @@ from mlflow.tracking.request_header.databricks_request_header_provider import (
     DatabricksRequestHeaderProvider,
 )
 
+_logger = logging.getLogger(__name__)
+
+
 class RequestHeaderProviderRegistry(object):
     def __init__(self):
         self._registry = []
@@ -30,6 +33,8 @@ class RequestHeaderProviderRegistry(object):
 
 _request_header_provider_registry = RequestHeaderProviderRegistry()
 _request_header_provider_registry.register(DatabricksRequestHeaderProvider)
+
+_request_header_provider_registry.register_entrypoints()
 
 def resolve_request_headers(request_headers=None):
     """Generate a set of request headers from registered providers. Request headers are resolved in the order that

--- a/mlflow/tracking/request_header/registry.py
+++ b/mlflow/tracking/request_header/registry.py
@@ -1,0 +1,58 @@
+import entrypoints
+import warnings
+import logging
+
+from mlflow.tracking.request_header.databricks_request_header_provider import (
+    DatabricksRequestHeaderProvider,
+)
+
+class RequestHeaderProviderRegistry(object):
+    def __init__(self):
+        self._registry = []
+
+    def register(self, request_header_provider):
+        self._registry.append(request_header_provider())
+
+    def register_entrypoints(self):
+        """Register tracking stores provided by other packages"""
+        for entrypoint in entrypoints.get_group_all("mlflow.request_header_provider"):
+            try:
+                self.register(entrypoint.load())
+            except (AttributeError, ImportError) as exc:
+                warnings.warn(
+                    f'Failure attempting to register request header provider "{entrypoint.name}": {str(exc)}',
+                    stacklevel=2,
+                )
+
+    def __iter__(self):
+        return iter(self._registry)
+
+
+_request_header_provider_registry = RequestHeaderProviderRegistry()
+_request_header_provider_registry.register(DatabricksRequestHeaderProvider)
+
+def resolve_request_headers(request_headers=None):
+    """Generate a set of request headers from registered providers. Request headers are resolved in the order that
+    providers are registered. Argument headers are applied last.
+
+    This function iterates through all request header providers in the registry. Additional context
+    providers can be registered as described in
+    :py:class:`mlflow.tracking.request_header.RequestHeaderProvider`.
+
+    :param tags: A dictionary of request headers to override. If specified, headers passed in this argument will
+                 override those inferred from the context.
+    :return: A dicitonary of resolved headers.
+    """
+
+    all_request_headers = {}
+    for provider in _request_header_provider_registry:
+        try:
+            if provider.in_context():
+                all_request_headers.update(provider.request_headers())
+        except Exception as e:
+            _logger.warning(f"Encountered unexpected error during resolving request headers: {e}")
+
+    if request_headers is not None:
+        all_request_headers.update(request_headers)
+
+    return all_request_headers

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -43,7 +43,7 @@ def http_request(
 
     from mlflow.tracking.request_header.registry import resolve_request_headers
 
-    headers = dict(_DEFAULT_HEADERS, resolve_request_headers())
+    headers = dict({**_DEFAULT_HEADERS, **resolve_request_headers()})
     if auth_str:
         headers["Authorization"] = auth_str
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -2,7 +2,6 @@ import base64
 import time
 import logging
 import json
-
 import requests
 
 from mlflow import __version__
@@ -11,7 +10,6 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.utils.proto_json_utils import parse_dict
 from mlflow.utils.string_utils import strip_suffix
 from mlflow.exceptions import MlflowException, RestException
-from mlflow.tracking.request_header.registry import resolve_request_headers
 
 _REST_API_PATH_PREFIX = "/api/2.0"
 RESOURCE_DOES_NOT_EXIST = "RESOURCE_DOES_NOT_EXIST"
@@ -42,6 +40,8 @@ def http_request(
         auth_str = "Basic " + base64.standard_b64encode(basic_auth_str).decode("utf-8")
     elif host_creds.token:
         auth_str = "Bearer %s" % host_creds.token
+
+    from mlflow.tracking.request_header.registry import resolve_request_headers
 
     headers = dict(_DEFAULT_HEADERS, resolve_request_headers())
     if auth_str:

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -11,6 +11,7 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.utils.proto_json_utils import parse_dict
 from mlflow.utils.string_utils import strip_suffix
 from mlflow.exceptions import MlflowException, RestException
+from mlflow.tracking.request_header.registry import resolve_request_headers
 
 _REST_API_PATH_PREFIX = "/api/2.0"
 RESOURCE_DOES_NOT_EXIST = "RESOURCE_DOES_NOT_EXIST"
@@ -42,7 +43,7 @@ def http_request(
     elif host_creds.token:
         auth_str = "Bearer %s" % host_creds.token
 
-    headers = dict(_DEFAULT_HEADERS)
+    headers = dict(_DEFAULT_HEADERS, resolve_request_headers())
     if auth_str:
         headers["Authorization"] = auth_str
 

--- a/tests/resources/mlflow-test-plugin/mlflow_test_plugin/request_header_provider.py
+++ b/tests/resources/mlflow-test-plugin/mlflow_test_plugin/request_header_provider.py
@@ -1,0 +1,11 @@
+from mlflow.tracking.request_header.abstract_request_header_provider import RequestHeaderProvider
+
+
+class PluginRequestHeaderProvider(RequestHeaderProvider):
+    """RequestHeaderProvider provided through plugin system"""
+
+    def in_context(self):
+        return False
+
+    def request_headers(self):
+        return {"test": "header"}

--- a/tests/resources/mlflow-test-plugin/setup.py
+++ b/tests/resources/mlflow-test-plugin/setup.py
@@ -17,6 +17,9 @@ setup(
         # Define a RunContextProvider plugin. The entry point name for run context providers
         # is not used, and so is set to the string "unused" here
         "mlflow.run_context_provider": "unused=mlflow_test_plugin.run_context_provider:PluginRunContextProvider",  # noqa
+        # Define a RequestHeaderProvider plugin. The entry point name for request header providers
+        # is not used, and so is set to the string "unused" here
+        "mlflow.request_header_provider": "unused=mlflow_test_plugin.request_header_provider:PluginRequestHeaderProvider",  # noqa
         # Define a Model Registry Store plugin for tracking URIs with scheme 'file-plugin'
         "mlflow.model_registry_store": "file-plugin=mlflow_test_plugin.sqlalchemy_store:PluginRegistrySqlAlchemyStore",  # noqa
         # Define a MLflow Project Backend plugin called 'dummy-backend'

--- a/tests/tracking/context/test_registry.py
+++ b/tests/tracking/context/test_registry.py
@@ -83,7 +83,7 @@ def test_registry_instance_loads_entrypoints():
     with mock.patch(
         "entrypoints.get_group_all", return_value=[mock_entrypoint]
     ) as mock_get_group_all:
-        # Entrypoints are registered at import time, so we need to reload the module to register th
+        # Entrypoints are registered at import time, so we need to reload the module to register the
         # entrypoint given by the mocked extrypoints.get_group_all
         reload(mlflow.tracking.context.registry)
 

--- a/tests/tracking/request_header/test_registry.py
+++ b/tests/tracking/request_header/test_registry.py
@@ -1,0 +1,150 @@
+import pytest
+from unittest import mock
+from importlib import reload
+
+import mlflow.tracking.request_header.registry
+from mlflow.tracking.request_header.registry import RequestHeaderProviderRegistry, resolve_request_headers
+from mlflow.tracking.request_header.abstract_request_header_provider import RequestHeaderProvider
+from mlflow.tracking.request_header.databricks_request_header_provider import DatabricksRequestHeaderProvider
+
+def test_request_header_context_provider_registry_register():
+    provider_class = mock.Mock()
+
+    registry = RequestHeaderProviderRegistry()
+    registry.register(provider_class)
+
+    assert set(registry) == {provider_class.return_value}
+
+def test_request_header_provider_registry_register_entrypoints():
+    provider_class = mock.Mock()
+    mock_entrypoint = mock.Mock()
+    mock_entrypoint.load.return_value = provider_class
+
+    with mock.patch(
+        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+    ) as mock_get_group_all:
+        registry = RequestHeaderProviderRegistry()
+        registry.register_entrypoints()
+
+    assert set(registry) == {provider_class.return_value}
+    mock_entrypoint.load.assert_called_once_with()
+    mock_get_group_all.assert_called_once_with("mlflow.request_header_provider")
+
+@pytest.mark.parametrize(
+    "exception", [AttributeError("test exception"), ImportError("test exception")]
+)
+def test_request_header_provider_registry_register_entrypoints_handles_exception(exception):
+    mock_entrypoint = mock.Mock()
+    mock_entrypoint.load.side_effect = exception
+
+    with mock.patch(
+        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+    ) as mock_get_group_all:
+        registry = RequestHeaderProviderRegistry()
+        # Check that the raised warning contains the message from the original exception
+        with pytest.warns(UserWarning, match="test exception"):
+            registry.register_entrypoints()
+
+    mock_entrypoint.load.assert_called_once_with()
+    mock_get_group_all.assert_called_once_with("mlflow.request_header_provider")
+
+
+def _currently_registered_request_header_provider_classes():
+    return {
+        provider.__class__
+        for provider in mlflow.tracking.request_header.registry._request_header_provider_registry
+    }
+
+
+def test_registry_instance_defaults():
+    expected_classes = {DatabricksRequestHeaderProvider}
+    assert expected_classes.issubset(_currently_registered_request_header_provider_classes())
+
+
+def test_registry_instance_loads_entrypoints():
+    class MockRequestHeaderProvider(object):
+        pass
+
+    mock_entrypoint = mock.Mock()
+    mock_entrypoint.load.return_value = MockRequestHeaderProvider
+
+    with mock.patch(
+        "entrypoints.get_group_all", return_value=[mock_entrypoint]
+    ) as mock_get_group_all:
+        # Entrypoints are registered at import time, so we need to reload the module to register the
+        # entrypoint given by the mocked extrypoints.get_group_all
+        reload(mlflow.tracking.request_header.registry)
+
+    assert MockRequestHeaderProvider in _currently_registered_request_header_provider_classes()
+    mock_get_group_all.assert_called_once_with("mlflow.request_header_provider")
+
+
+@pytest.mark.large
+def test_run_context_provider_registry_with_installed_plugin(tmp_wkdir):
+    """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
+
+    reload(mlflow.tracking.request_header.registry)
+
+    from mlflow_test_plugin.request_header_provider import PluginRequestHeaderProvider
+
+    assert PluginRequestHeaderProvider in _currently_registered_request_header_provider_classes()
+
+    # The test plugin's request header provider always returns False from in_context
+    # to avoid polluting request headers in developers' environments. The following mock overrides this to
+    # perform the integration test.
+    with mock.patch.object(PluginRequestHeaderProvider, "in_context", return_value=True):
+        assert resolve_request_headers()["test"] == "header"
+
+
+@pytest.fixture
+def mock_request_header_providers():
+    base_provider = mock.Mock()
+    base_provider.in_context.return_value = True
+    base_provider.request_headers.return_value = {
+        "one": "one-val",
+        "two": "two-val",
+        "three": "three-val"
+    }
+
+    skipped_provider = mock.Mock()
+    skipped_provider.in_context.return_value = False
+
+    exception_provider = mock.Mock()
+    exception_provider.in_context.return_value = True
+    exception_provider.request_headers.return_value = {
+        "random-header": "This val will never make it to header resolution"
+    }
+    exception_provider.request_headers.side_effect = Exception(
+        "This should be caught by logic in resolve_request_headers()"
+    )
+
+    override_provider = mock.Mock()
+    override_provider.in_context.return_value = True
+    override_provider.request_headers.return_value = {"one": "override", "new": "new-val"}
+
+    providers = [base_provider, skipped_provider, exception_provider, override_provider]
+
+    with mock.patch("mlflow.tracking.request_header.registry._request_header_provider_registry", providers):
+        yield
+
+    skipped_provider.tags.assert_not_called()
+
+
+def test_resolve_request_headers(mock_request_header_providers):
+    request_headers_arg = {"two": "arg-override", "arg": "arg-val"}
+    assert resolve_request_headers(request_headers_arg) == {
+        "one": "override",
+        "two": "arg-override",
+        "three": "three-val",
+        "new": "new-val",
+        "arg": "arg-val",
+    }
+
+
+def test_resolve_request_headers_no_arg(mock_request_header_providers):
+    assert resolve_request_headers() == {
+        "one": "override",
+        "two": "two-val",
+        "three": "three-val",
+        "new": "new-val",
+    }

--- a/tests/tracking/request_header/test_registry.py
+++ b/tests/tracking/request_header/test_registry.py
@@ -13,6 +13,7 @@ from mlflow.tracking.request_header.databricks_request_header_provider import (
 
 # pylint: disable=unused-argument
 
+
 def test_request_header_context_provider_registry_register():
     provider_class = mock.Mock()
 

--- a/tests/tracking/request_header/test_registry.py
+++ b/tests/tracking/request_header/test_registry.py
@@ -11,6 +11,7 @@ from mlflow.tracking.request_header.databricks_request_header_provider import (
     DatabricksRequestHeaderProvider,
 )
 
+# pylint: disable=unused-argument
 
 def test_request_header_context_provider_registry_register():
     provider_class = mock.Mock()

--- a/tests/tracking/request_header/test_registry.py
+++ b/tests/tracking/request_header/test_registry.py
@@ -98,7 +98,7 @@ def test_run_context_provider_registry_with_installed_plugin():
 
     assert PluginRequestHeaderProvider in _currently_registered_request_header_provider_classes()
 
-    # The test plugin's request header provider always returns False from in_contex to avoid
+    # The test plugin's request header provider always returns False from in_context to avoid
     # polluting request headers in developers' environments. The following mock overrides this to
     # perform the integration test.
     with mock.patch.object(PluginRequestHeaderProvider, "in_context", return_value=True):

--- a/tests/tracking/request_header/test_registry.py
+++ b/tests/tracking/request_header/test_registry.py
@@ -7,7 +7,6 @@ from mlflow.tracking.request_header.registry import (
     RequestHeaderProviderRegistry,
     resolve_request_headers,
 )
-from mlflow.tracking.request_header.abstract_request_header_provider import RequestHeaderProvider
 from mlflow.tracking.request_header.databricks_request_header_provider import (
     DatabricksRequestHeaderProvider,
 )
@@ -97,8 +96,8 @@ def test_run_context_provider_registry_with_installed_plugin(tmp_wkdir):
 
     assert PluginRequestHeaderProvider in _currently_registered_request_header_provider_classes()
 
-    # The test plugin's request header provider always returns False from in_context
-    # to avoid polluting request headers in developers' environments. The following mock overrides this to
+    # The test plugin's request header provider always returns False from in_contex to avoid
+    # polluting request headers in developers' environments. The following mock overrides this to
     # perform the integration test.
     with mock.patch.object(PluginRequestHeaderProvider, "in_context", return_value=True):
         assert resolve_request_headers()["test"] == "header"

--- a/tests/tracking/request_header/test_registry.py
+++ b/tests/tracking/request_header/test_registry.py
@@ -3,9 +3,15 @@ from unittest import mock
 from importlib import reload
 
 import mlflow.tracking.request_header.registry
-from mlflow.tracking.request_header.registry import RequestHeaderProviderRegistry, resolve_request_headers
+from mlflow.tracking.request_header.registry import (
+    RequestHeaderProviderRegistry,
+    resolve_request_headers,
+)
 from mlflow.tracking.request_header.abstract_request_header_provider import RequestHeaderProvider
-from mlflow.tracking.request_header.databricks_request_header_provider import DatabricksRequestHeaderProvider
+from mlflow.tracking.request_header.databricks_request_header_provider import (
+    DatabricksRequestHeaderProvider,
+)
+
 
 def test_request_header_context_provider_registry_register():
     provider_class = mock.Mock()
@@ -14,6 +20,7 @@ def test_request_header_context_provider_registry_register():
     registry.register(provider_class)
 
     assert set(registry) == {provider_class.return_value}
+
 
 def test_request_header_provider_registry_register_entrypoints():
     provider_class = mock.Mock()
@@ -29,6 +36,7 @@ def test_request_header_provider_registry_register_entrypoints():
     assert set(registry) == {provider_class.return_value}
     mock_entrypoint.load.assert_called_once_with()
     mock_get_group_all.assert_called_once_with("mlflow.request_header_provider")
+
 
 @pytest.mark.parametrize(
     "exception", [AttributeError("test exception"), ImportError("test exception")]
@@ -103,7 +111,7 @@ def mock_request_header_providers():
     base_provider.request_headers.return_value = {
         "one": "one-val",
         "two": "two-val",
-        "three": "three-val"
+        "three": "three-val",
     }
 
     skipped_provider = mock.Mock()
@@ -124,7 +132,9 @@ def mock_request_header_providers():
 
     providers = [base_provider, skipped_provider, exception_provider, override_provider]
 
-    with mock.patch("mlflow.tracking.request_header.registry._request_header_provider_registry", providers):
+    with mock.patch(
+        "mlflow.tracking.request_header.registry._request_header_provider_registry", providers
+    ):
         yield
 
     skipped_provider.tags.assert_not_called()

--- a/tests/tracking/request_header/test_registry.py
+++ b/tests/tracking/request_header/test_registry.py
@@ -89,7 +89,7 @@ def test_registry_instance_loads_entrypoints():
 
 
 @pytest.mark.large
-def test_run_context_provider_registry_with_installed_plugin(tmp_wkdir):
+def test_run_context_provider_registry_with_installed_plugin():
     """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
 
     reload(mlflow.tracking.request_header.registry)

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -4,6 +4,7 @@ from unittest import mock
 import numpy
 import pytest
 
+from importlib import reload
 from mlflow.exceptions import MlflowException, RestException
 from mlflow.pyfunc.scoring_server import NumpyEncoder
 from mlflow.utils.rest_utils import (
@@ -152,6 +153,30 @@ def test_http_request_server_cert_path(request):
     request.assert_called_with(
         url="http://my-host/my/endpoint", verify="/some/path", headers=_DEFAULT_HEADERS,
     )
+
+
+@pytest.mark.large
+@mock.patch("requests.request")
+def test_http_request_request_headers(request):
+    """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
+
+    from mlflow_test_plugin.request_header_provider import PluginRequestHeaderProvider
+
+    # The test plugin's request header provider always returns False from in_context to avoid
+    # polluting request headers in developers' environments. The following mock overrides this to
+    # perform the integration test.
+    with mock.patch.object(PluginRequestHeaderProvider, "in_context", return_value=True):
+        host_only = MlflowHostCreds("http://my-host", server_cert_path="/some/path")
+
+        response = mock.MagicMock()
+        response.status_code = 200
+        request.return_value = response
+        http_request(host_only, "/my/endpoint")
+        request.assert_called_with(
+            url="http://my-host/my/endpoint",
+            verify="/some/path",
+            headers={**_DEFAULT_HEADERS, "test": "header",},
+        )
 
 
 def test_ignore_tls_verification_not_server_cert_path():

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -4,7 +4,6 @@ from unittest import mock
 import numpy
 import pytest
 
-from importlib import reload
 from mlflow.exceptions import MlflowException, RestException
 from mlflow.pyfunc.scoring_server import NumpyEncoder
 from mlflow.utils.rest_utils import (
@@ -175,7 +174,7 @@ def test_http_request_request_headers(request):
         request.assert_called_with(
             url="http://my-host/my/endpoint",
             verify="/some/path",
-            headers={**_DEFAULT_HEADERS, "test": "header",},
+            headers={**_DEFAULT_HEADERS, "test": "header"},
         )
 
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

In this pull request, we will pass all request headers created by RequestHeaderProviders in outgoing requests. This follows up https://github.com/mlflow/mlflow/pull/3946

## How is this patch tested?

New unit tests

## Release Notes
MLflow will now add all request headers from registered RequestHeaderProviders to outgoing requests.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

All outgoing requests will now have request headers provided by all RequestHeaderProviders attached.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
