### PR TITLE
Use SavedModel format by default in mlflow.keras.log_model

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -48,6 +48,11 @@ jobs:
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          # GitHub Actions' Ubuntu 20.04 image uses Java 11 (which is incompatible with Spark 2.4.x) by default:
+          # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#java
+          java-version: 8
       - name: Enable conda
         run: |
           echo "/usr/share/miniconda/bin" >> $GITHUB_PATH

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -234,9 +234,8 @@ def save_model(
     with open(os.path.join(data_path, _KERAS_MODULE_SPEC_PATH), "w") as f:
         f.write(keras_module.__name__)
 
-    # By default, Keras uses the SavedModel format -- specified by "tf"
-    # However, we choose to align with prior default of mlflow, HDF5
-    save_format = kwargs.get("save_format", "h5")
+    # Use the SavedModel format if `save_format` is unspecified
+    save_format = kwargs.get("save_format", "tf")
 
     # save keras save_format to path/data/save_format.txt
     with open(os.path.join(data_path, _KERAS_SAVE_FORMAT_PATH), "w") as f:

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -557,7 +557,7 @@ def test_save_and_load_model_with_tf_save_format(tf_keras_model, model_path):
     assert flavor_conf is not None
     assert flavor_conf.get("save_format") == "tf"
     assert not os.path.exists(
-        os.path.join(model_path, "data", "model")
+        os.path.join(model_path, "data", "model.h5")
     ), "TF model was saved with HDF5 format; expected SavedModel"
     assert os.path.isdir(
         os.path.join(model_path, "data", "model")

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -497,13 +497,13 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
 
 @pytest.mark.large
 def test_model_load_succeeds_with_missing_data_key_when_data_exists_at_default_path(
-    model, model_path, data, predicted
+    tf_keras_model, model_path, data
 ):
     """
     This is a backwards compatibility test to ensure that models saved in MLflow version <= 0.8.0
     can be loaded successfully. These models are missing the `data` flavor configuration key.
     """
-    mlflow.keras.save_model(keras_model=model, path=model_path, save_format="h5")
+    mlflow.keras.save_model(keras_model=tf_keras_model, path=model_path, save_format="h5")
     shutil.move(os.path.join(model_path, "data", "model.h5"), os.path.join(model_path, "model.h5"))
     model_conf_path = os.path.join(model_path, "MLmodel")
     model_conf = Model.load(model_conf_path)
@@ -513,7 +513,7 @@ def test_model_load_succeeds_with_missing_data_key_when_data_exists_at_default_p
     model_conf.save(model_conf_path)
 
     model_loaded = mlflow.keras.load_model(model_path)
-    assert all(model_loaded.predict(data[0].values) == predicted)
+    assert all(model_loaded.predict(data[0].values) == tf_keras_model.predict(data[0].values))
 
 
 @pytest.mark.release

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -502,7 +502,7 @@ def test_model_load_succeeds_with_missing_data_key_when_data_exists_at_default_p
     can be loaded successfully. These models are missing the `data` flavor configuration key.
     """
     mlflow.keras.save_model(keras_model=model, path=model_path)
-    shutil.move(os.path.join(model_path, "data", "model.h5"), os.path.join(model_path, "model.h5"))
+    shutil.move(os.path.join(model_path, "data", "model"), os.path.join(model_path, "model"))
     model_conf_path = os.path.join(model_path, "MLmodel")
     model_conf = Model.load(model_conf_path)
     flavor_conf = model_conf.flavors.get(mlflow.keras.FLAVOR_NAME, None)
@@ -555,7 +555,7 @@ def test_save_and_load_model_with_tf_save_format(tf_keras_model, model_path):
     assert flavor_conf is not None
     assert flavor_conf.get("save_format") == "tf"
     assert not os.path.exists(
-        os.path.join(model_path, "data", "model.h5")
+        os.path.join(model_path, "data", "model")
     ), "TF model was saved with HDF5 format; expected SavedModel"
     assert os.path.isdir(
         os.path.join(model_path, "data", "model")

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -503,8 +503,8 @@ def test_model_load_succeeds_with_missing_data_key_when_data_exists_at_default_p
     This is a backwards compatibility test to ensure that models saved in MLflow version <= 0.8.0
     can be loaded successfully. These models are missing the `data` flavor configuration key.
     """
-    mlflow.keras.save_model(keras_model=model, path=model_path)
-    shutil.move(os.path.join(model_path, "data", "model"), os.path.join(model_path, "model"))
+    mlflow.keras.save_model(keras_model=model, path=model_path, save_format="h5")
+    shutil.move(os.path.join(model_path, "data", "model.h5"), os.path.join(model_path, "model.h5"))
     model_conf_path = os.path.join(model_path, "MLmodel")
     model_conf = Model.load(model_conf_path)
     flavor_conf = model_conf.flavors.get(mlflow.keras.FLAVOR_NAME, None)

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -204,21 +204,23 @@ def test_that_keras_module_arg_works(model_path):
         path0 = os.path.join(model_path, "0")
         with pytest.raises(MlflowException):
             mlflow.keras.save_model(x, path0)
-        mlflow.keras.save_model(x, path0, keras_module=FakeKerasModule)
+        mlflow.keras.save_model(x, path0, keras_module=FakeKerasModule, save_format="h5")
         y = mlflow.keras.load_model(path0)
         assert x == y
         path1 = os.path.join(model_path, "1")
-        mlflow.keras.save_model(x, path1, keras_module=FakeKerasModule.__name__)
+        mlflow.keras.save_model(x, path1, keras_module=FakeKerasModule.__name__, save_format="h5")
         z = mlflow.keras.load_model(path1)
         assert x == z
         # Tests model log
         with mlflow.start_run() as active_run:
             with pytest.raises(MlflowException):
                 mlflow.keras.log_model(x, "model0")
-            mlflow.keras.log_model(x, "model0", keras_module=FakeKerasModule)
+            mlflow.keras.log_model(x, "model0", keras_module=FakeKerasModule, save_format="h5")
             a = mlflow.keras.load_model("runs:/{}/model0".format(active_run.info.run_id))
             assert x == a
-            mlflow.keras.log_model(x, "model1", keras_module=FakeKerasModule.__name__)
+            mlflow.keras.log_model(
+                x, "model1", keras_module=FakeKerasModule.__name__, save_format="h5"
+            )
             b = mlflow.keras.load_model("runs:/{}/model1".format(active_run.info.run_id))
             assert x == b
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -727,10 +727,9 @@ def get_text_vec_model(train_samples):
         "https://github.com/tensorflow/tensorflow/issues/38250"
     ),
 )
-def test_autolog_logs_text_vec_model(tmpdir):
+def test_autolog_text_vec_model(tmpdir):
     """
-    Verifies autolog successfully saves a `TextVectorization` model that can't be saved
-    in the H5 format
+    Verifies autolog successfully saves a model that can't be saved in the H5 format
     """
     mlflow.tensorflow.autolog()
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -2,6 +2,7 @@
 
 import collections
 import pytest
+from distutils.version import LooseVersion
 
 import numpy as np
 import pandas as pd
@@ -685,3 +686,63 @@ def test_flush_queue_is_thread_safe():
     flush_thread2.start()
     flush_thread2.join()
     assert len(mlflow.tensorflow._metric_queue) == 0
+
+
+def get_text_vec_model(train_samples):
+    # Taken from: https://github.com/mlflow/mlflow/issues/3910
+
+    from tensorflow.keras.layers.experimental.preprocessing import TextVectorization
+
+    VOCAB_SIZE = 10
+    SEQUENCE_LENGTH = 16
+    EMBEDDING_DIM = 16
+
+    vectorizer_layer = TextVectorization(
+        input_shape=(1,),
+        max_tokens=VOCAB_SIZE,
+        output_mode="int",
+        output_sequence_length=SEQUENCE_LENGTH,
+    )
+    vectorizer_layer.adapt(train_samples)
+    model = tf.keras.Sequential(
+        [
+            vectorizer_layer,
+            tf.keras.layers.Embedding(
+                VOCAB_SIZE, EMBEDDING_DIM, name="embedding", mask_zero=True, input_shape=(1,),
+            ),
+            tf.keras.layers.GlobalAveragePooling1D(),
+            tf.keras.layers.Dense(16, activation="relu"),
+            tf.keras.layers.Dense(1, activation="tanh"),
+        ]
+    )
+    model.compile(optimizer="adam", loss="mse", metrics="mae")
+    return model
+
+
+@pytest.mark.skipif(
+    LooseVersion(tf.__version__) < LooseVersion("2.3.0"),
+    reason=(
+        "Deserializing a model with `TextVectorization` and `Embedding`"
+        "fails in tensorflow < 2.3.0. See this issue:"
+        "https://github.com/tensorflow/tensorflow/issues/38250"
+)
+def test_autolog_logs_text_vec_model(tmpdir):
+    """
+    Verifies autolog successfully saves a `TextVectorization` model that can't be saved
+    in the H5 format
+    """
+    mlflow.tensorflow.autolog()
+
+    train_samples = np.array(["this is an example", "another example"])
+    train_labels = np.array([0.4, 0.2])
+    model = get_text_vec_model(train_samples)
+
+    # Saving in the H5 format should fail
+    with pytest.raises(NotImplementedError, match="is not supported in h5"):
+        model.save(tmpdir.join("model.h5").strpath, save_format="h5")
+
+    with mlflow.start_run() as run:
+        model.fit(train_samples, train_labels, epochs=1)
+
+    loaded_model = mlflow.keras.load_model("runs:/" + run.info.run_id + "/model")
+    np.testing.assert_array_equal(loaded_model.predict(train_samples), model.predict(train_samples))

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -725,6 +725,7 @@ def get_text_vec_model(train_samples):
         "Deserializing a model with `TextVectorization` and `Embedding`"
         "fails in tensorflow < 2.3.0. See this issue:"
         "https://github.com/tensorflow/tensorflow/issues/38250"
+    ),
 )
 def test_autolog_logs_text_vec_model(tmpdir):
     """


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- Use the `SavedModel` format by default in `mlflow.keras.log_model`.
- Fixes #3910

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow.sklearn.log_model` now saves a keras model in the `SavedModel` format.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
