### PR TITLE
change default value of verify to None

### DIFF
--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -42,7 +42,7 @@ class S3ArtifactRepository(ArtifactRepository):
         s3_endpoint_url = os.environ.get("MLFLOW_S3_ENDPOINT_URL")
         ignore_tls = os.environ.get("MLFLOW_S3_IGNORE_TLS")
 
-        verify = True
+        verify = None
         if ignore_tls:
             verify = ignore_tls.lower() not in ["true", "yes", "1"]
 

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -42,9 +42,14 @@ class S3ArtifactRepository(ArtifactRepository):
         s3_endpoint_url = os.environ.get("MLFLOW_S3_ENDPOINT_URL")
         ignore_tls = os.environ.get("MLFLOW_S3_IGNORE_TLS")
 
-        verify = None
+        do_verify = True
         if ignore_tls:
-            verify = ignore_tls.lower() not in ["true", "yes", "1"]
+            do_verify = ignore_tls.lower() not in ["true", "yes", "1"]
+
+        # The valid verify argument value is None/False/path to cert bundle file, See
+        # https://github.com/boto/boto3/blob/73865126cad3938ca80a2f567a1c79cb248169a7/
+        # boto3/session.py#L212
+        verify = None if do_verify else False
 
         # NOTE: If you need to specify this env variable, please file an issue at
         # https://github.com/mlflow/mlflow/issues so we know your use-case!

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -10,6 +10,8 @@ from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 
+from unittest import mock
+
 
 @pytest.fixture
 def s3_artifact_root(mock_s3_bucket):
@@ -51,6 +53,20 @@ def test_file_artifact_is_logged_with_content_metadata(s3_artifact_root, tmpdir)
     response = s3_client.head_object(Bucket=bucket, Key="some/path/test.txt")
     assert response.get("ContentType") == "text/plain"
     assert response.get("ContentEncoding") is None
+
+
+@pytest.mark.parametrize("ignore_tls_env, verify",
+                         [("", None), ("true", False), ("false", None)])
+def test_get_s3_client_verify_param_set_correctly(
+        s3_artifact_root, tmpdir, ignore_tls_env, verify):
+    from unittest.mock import ANY
+    with mock.patch.dict('os.environ', {'MLFLOW_S3_IGNORE_TLS': ignore_tls_env}, clear=True):
+        with mock.patch('boto3.client') as mock_get_s3_client:
+            repo = get_artifact_repository(posixpath.join(s3_artifact_root, "some/path"))
+            repo._get_s3_client()
+            mock_get_s3_client.assert_called_with(
+                's3', config=ANY, endpoint_url=ANY, verify=verify
+            )
 
 
 def test_file_artifacts_are_logged_with_content_metadata_in_batch(s3_artifact_root, tmpdir):

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -55,18 +55,15 @@ def test_file_artifact_is_logged_with_content_metadata(s3_artifact_root, tmpdir)
     assert response.get("ContentEncoding") is None
 
 
-@pytest.mark.parametrize("ignore_tls_env, verify",
-                         [("", None), ("true", False), ("false", None)])
-def test_get_s3_client_verify_param_set_correctly(
-        s3_artifact_root, tmpdir, ignore_tls_env, verify):
+@pytest.mark.parametrize("ignore_tls_env, verify", [("", None), ("true", False), ("false", None)])
+def test_get_s3_client_verify_param_set_correctly(s3_artifact_root, ignore_tls_env, verify):
     from unittest.mock import ANY
-    with mock.patch.dict('os.environ', {'MLFLOW_S3_IGNORE_TLS': ignore_tls_env}, clear=True):
-        with mock.patch('boto3.client') as mock_get_s3_client:
+
+    with mock.patch.dict("os.environ", {"MLFLOW_S3_IGNORE_TLS": ignore_tls_env}, clear=True):
+        with mock.patch("boto3.client") as mock_get_s3_client:
             repo = get_artifact_repository(posixpath.join(s3_artifact_root, "some/path"))
             repo._get_s3_client()
-            mock_get_s3_client.assert_called_with(
-                's3', config=ANY, endpoint_url=ANY, verify=verify
-            )
+            mock_get_s3_client.assert_called_with("s3", config=ANY, endpoint_url=ANY, verify=verify)
 
 
 def test_file_artifacts_are_logged_with_content_metadata_in_batch(s3_artifact_root, tmpdir):


### PR DESCRIPTION
## What changes are proposed in this pull request?

Change the default setting of `verify` arg to `None` rather than `true`. The default value of `true` isn't handled correctly by boto3, the library expects either `false`, `None` or a path to a cert bundle. This breaks the reference to the root cert that can be passed via the `REQUESTS_CA_BUNDLE` envar. This was a breaking change caused by PR that only affects cases where the artifact store has a certificate that will not be validated by the default root cert: https://github.com/mlflow/mlflow/pull/3345/files#diff-1fa0af6d2db749b300399663bbc25fcc867ab86a08b3e8c2b3c865561ddedf19

## How is this patch tested?

Patch was tested by running this example (https://github.com/PeterSulcs/mlflow-issue) with a dev install of this branch. Result is the same as mlflow 1.11.0.

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

Closes #4046 and
Closes #3986 as pointed out below by @messlow