### PR TITLE
Eedeleon/release skinny client

### DIFF
--- a/README_SKINNY.rst
+++ b/README_SKINNY.rst
@@ -13,3 +13,4 @@ Additional dependencies can be installed to leverage the full feature set of MLf
 
 * To use the `mlflow.sklearn` component of MLflow Models, install `scikit-learn`, `numpy`, and `pandas`.
 * To use SQL-based metadata storage, install `sqlalchemy`, `alembic`, and `sqlparse`.
+

--- a/README_SKINNY.rst
+++ b/README_SKINNY.rst
@@ -6,13 +6,10 @@ MLflow Skinny is a lightweight MLflow package without SQL storage, server, UI, o
 MLflow Skinny supports:
 
 * Tracking operations (logging / loading / searching params, metrics, tags + logging / loading artifacts
-
 * Model registration, search, artifact loading, and transitions
-
 * Execution of GitHub projects within notebook & against a remote target.
 
 Additional dependencies can be installed to leverage the full feature set of MLflow. For example:
 
 * To use the `mlflow.sklearn` component of MLflow Models, install `scikit-learn`, `numpy`, and `pandas`.
 * To use SQL-based metadata storage, install `sqlalchemy`, `alembic`, and `sqlparse`.
-

--- a/README_SKINNY.rst
+++ b/README_SKINNY.rst
@@ -5,7 +5,7 @@ MLflow Skinny: A Lightweight Machine Learning Lifecycle Platform Client
 MLflow Skinny is a lightweight MLflow package without SQL storage, server, UI, or data science dependencies.
 MLflow Skinny supports:
 
-* Tracking operations (logging / loading / searching params, metrics, tags + logging / loading artifacts
+* Tracking operations (logging / loading / searching params, metrics, tags + logging / loading artifacts)
 * Model registration, search, artifact loading, and transitions
 * Execution of GitHub projects within notebook & against a remote target.
 
@@ -13,4 +13,3 @@ Additional dependencies can be installed to leverage the full feature set of MLf
 
 * To use the `mlflow.sklearn` component of MLflow Models, install `scikit-learn`, `numpy`, and `pandas`.
 * To use SQL-based metadata storage, install `sqlalchemy`, `alembic`, and `sqlparse`.
-

--- a/README_SKINNY.rst
+++ b/README_SKINNY.rst
@@ -1,0 +1,18 @@
+=======================================================================
+MLflow Skinny: A Lightweight Machine Learning Lifecycle Platform Client
+=======================================================================
+
+MLflow Skinny is a lightweight MLflow package without SQL storage, server, UI, or data science dependencies.
+MLflow Skinny supports:
+
+* Tracking operations (logging / loading / searching params, metrics, tags + logging / loading artifacts
+
+* Model registration, search, artifact loading, and transitions
+
+* Execution of GitHub projects within notebook & against a remote target.
+
+Additional dependencies can be installed to leverage the full feature set of MLflow. For example:
+
+* To use the `mlflow.sklearn` component of MLflow Models, install `scikit-learn`, `numpy`, and `pandas`.
+* To use SQL-based metadata storage, install `sqlalchemy`, `alembic`, and `sqlparse`.
+

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,7 @@ setup(
     long_description=open("README.rst").read()
     if not _is_mlflow_skinny
     else open("README_SKINNY.rst").read() + open("README.rst").read(),
+    long_description_content_type="text/x-rst",
     license="Apache License 2.0",
     classifiers=["Intended Audience :: Developers", "Programming Language :: Python :: 3.6"],
     keywords="ml ai databricks",

--- a/setup.py
+++ b/setup.py
@@ -75,11 +75,13 @@ _is_mlflow_skinny = bool(os.environ.get(_MLFLOW_SKINNY_ENV_VAR))
 logging.debug("{} env var is set: {}".format(_MLFLOW_SKINNY_ENV_VAR, _is_mlflow_skinny))
 
 setup(
-    name="mlflow",
+    name="mlflow" if not _is_mlflow_skinny else "mlflow-skinny",
     version=version,
     packages=find_packages(exclude=["tests", "tests.*"]),
-    package_data={"mlflow": js_files + models_container_server_files + alembic_files},
-    install_requires=SKINNY_REQUIREMENTS if _is_mlflow_skinny else CORE_REQUIREMENTS,
+    package_data={"mlflow": js_files + models_container_server_files + alembic_files}
+    if not _is_mlflow_skinny
+    else {},
+    install_requires=CORE_REQUIREMENTS if not _is_mlflow_skinny else SKINNY_REQUIREMENTS,
     extras_require={
         "extras": [
             "scikit-learn",
@@ -107,8 +109,9 @@ setup(
     zip_safe=False,
     author="Databricks",
     description="MLflow: A Platform for ML Development and Productionization",
-    long_description=open("README.rst").read(),
-    long_description_content_type="text/x-rst",
+    long_description=open("README.rst").read()
+    if not _is_mlflow_skinny
+    else open("README_SKINNY.rst").read() + open("README.rst").read(),
     license="Apache License 2.0",
     classifiers=["Intended Audience :: Developers", "Programming Language :: Python :: 3.6"],
     keywords="ml ai databricks",


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR releases the mlflow-skinny library. The MLflow Skinny library has the same code of the MLflow library with a reduced dependency set that omits server, store, and data science specific libraries such as Flask, sqlalchemy, pandas, and numpy.

## How is this patch tested?

A new build is added for mlflow-skinny

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Release `mlflow-skinny` an MLflow package with fewer baked in dependencies to allow for a reduced footprint training and deployment option for mlflow users. `mlflow` functionality can be added for store and model scenarios by adding the corresponding dependencies along with `mlflow-skinny`

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
