### PR TITLE
Fix R cache key to refresh package cache when ubuntu version is updated

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,10 +37,6 @@ jobs:
     - uses: r-lib/actions/setup-r@v1
     # This step dumps the current set of R dependencies and R version into files to be used
     # as a cache key when caching/restoring R dependencies.
-    - run: |
-        echo "${{ toJson(github) }}"
-        echo "${{ toJson(job) }}"
-        echo "${{ toJson(runner) }}"
     - name: Query dependencies
       run: |
         print(R.version)
@@ -48,7 +44,11 @@ jobs:
         saveRDS(remotes::dev_package_deps("mlflow/R/mlflow", dependencies = TRUE), ".github/depends.Rds", version = 2)
         writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
       shell: Rscript {0}
-
+    - name: Get OS name
+      id: os-name
+      run: |
+        os_name=$(lsb_release -ds | sed "s/ /-/g")
+        echo "::set-output name=os-name::$os_name"
     - name: Cache R packages
       if: runner.os != 'Windows'
       uses: actions/cache@v2
@@ -56,7 +56,7 @@ jobs:
         path: ${{ env.R_LIBS_USER }}
         # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
         # R dependencies
-        key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+        key: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
         restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
     - name: Install system dependencies
       run: |

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -44,11 +44,12 @@ jobs:
         saveRDS(remotes::dev_package_deps("mlflow/R/mlflow", dependencies = TRUE), ".github/depends.Rds", version = 2)
         writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
       shell: Rscript {0}
+
     - name: Get OS name
       id: os-name
       run: |
+        # `os_name` looks like "Ubuntu-20.04.1-LTS"
         os_name=$(lsb_release -ds | sed 's/\s/-/g')
-        echo $os_name
         echo "::set-output name=os-name::$os_name"
     - name: Cache R packages
       if: runner.os != 'Windows'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,6 +37,7 @@ jobs:
     - uses: r-lib/actions/setup-r@v1
     # This step dumps the current set of R dependencies and R version into files to be used
     # as a cache key when caching/restoring R dependencies.
+    - run: echo ${{ toJson(runner.os) }}
     - name: Query dependencies
       run: |
         print(R.version)

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Get OS name
       id: os-name
       run: |
-        # `os_name` looks like "Ubuntu-20.04.1-LTS"
+        # `os_name` will be like "Ubuntu-20.04.1-LTS"
         os_name=$(lsb_release -ds | sed 's/\s/-/g')
         echo "::set-output name=os-name::$os_name"
     - name: Cache R packages

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -47,7 +47,8 @@ jobs:
     - name: Get OS name
       id: os-name
       run: |
-        os_name=$(lsb_release -ds | sed "s/ /-/g")
+        os_name=$(lsb_release -ds | sed 's/\s/-/g')
+        echo $os_name
         echo "::set-output name=os-name::$os_name"
     - name: Cache R packages
       if: runner.os != 'Windows'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -58,7 +58,7 @@ jobs:
         # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
         # R dependencies
         key: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-        restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+        restore-keys: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('.github/R-version') }}-1-
     - name: Install system dependencies
       run: |
         sudo apt-get install -y libcurl4-openssl-dev

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,7 +37,7 @@ jobs:
     - uses: r-lib/actions/setup-r@v1
     # This step dumps the current set of R dependencies and R version into files to be used
     # as a cache key when caching/restoring R dependencies.
-    - run: echo ${{ toJson(runner.os) }}
+    - run: echo ${{ toJson(runner) }}
     - name: Query dependencies
       run: |
         print(R.version)

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -37,7 +37,10 @@ jobs:
     - uses: r-lib/actions/setup-r@v1
     # This step dumps the current set of R dependencies and R version into files to be used
     # as a cache key when caching/restoring R dependencies.
-    - run: echo ${{ toJson(runner) }}
+    - run: |
+        echo "${{ toJson(github) }}"
+        echo "${{ toJson(job) }}"
+        echo "${{ toJson(runner) }}"
     - name: Query dependencies
       run: |
         print(R.version)


### PR DESCRIPTION
## What changes are proposed in this pull request?

GitHub Actios started using Ubuntu 20.04. This change broke an XGBoost test in R (seems related to old package cache generated in Ubuntu 18.04). This PR fixes it by refreshing the package cache using a pretty OS name.

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
