### PR TITLE
Install mlflow-test-plugin without dependencies

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -279,6 +279,7 @@ jobs:
         run: |
           pip install -r dev-requirements.txt
           pip install -r dev/small-requirements.txt
+          pip install --no-dependencies tests/resources/mlflow-test-plugin
           pip install -e .[extras]
       - name: Run tests
         run: |

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -58,6 +58,9 @@ if [[ "$INSTALL_LARGE_PYTHON_DEPS" == "true" ]]; then
   ls -lha $(find $CONDA_DIR/envs/test-environment/ -path "*bin/spark-*")
 fi
 
+# Install `mlflow-test-plugin` without dependencies
+pip install --no-dependencies tests/resources/mlflow-test-plugin
+
 # Print current environment info
 pip list
 which mlflow

--- a/dev/skinny-requirements.txt
+++ b/dev/skinny-requirements.txt
@@ -1,5 +1,3 @@
 ## Test-only dependencies
 pytest==3.2.1
 pytest-cov==2.6.0
-# Test plugin, used to verify correctness of MLflow plugin APIs
-tests/resources/mlflow-test-plugin/

--- a/dev/small-requirements.txt
+++ b/dev/small-requirements.txt
@@ -8,5 +8,3 @@ pytest==3.2.1
 pytest-cov==2.6.0
 pytest-localserver==0.5.0
 moto==1.3.16
-# Test plugin, used to verify correctness of MLflow plugin APIs
-tests/resources/mlflow-test-plugin/


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Install `mlflow-test-plugin` without dependencies using pip's `--no-dependencies` option.

## Motivation

Currently, installing `tests/resources/mlflow-test-plugin` installs the latest version of MLflow on PyPI and its dependencies. This makes it difficult to test & review a PR that MLflow's dependencies (e.g. https://github.com/mlflow/mlflow/pull/3916).

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
