### PR TITLE
Add mlflow_run convenience decorator to fluent API

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -125,6 +125,7 @@ log_figure = mlflow.tracking.fluent.log_figure
 active_run = mlflow.tracking.fluent.active_run
 get_run = mlflow.tracking.fluent.get_run
 start_run = mlflow.tracking.fluent.start_run
+mlflow_run = mlflow.tracking.fluent.mlflow_run
 end_run = mlflow.tracking.fluent.end_run
 search_runs = mlflow.tracking.fluent.search_runs
 list_run_infos = mlflow.tracking.fluent.list_run_infos
@@ -165,6 +166,7 @@ __all__ = [
     "log_image",
     "active_run",
     "start_run",
+    "mlflow_run",
     "end_run",
     "search_runs",
     "get_artifact_uri",

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -104,7 +104,10 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False, tags
     will be logged. The return value can be used as a context manager within a ``with`` block;
     otherwise, you must call ``end_run()`` to terminate the current run.
 
-    If you pass a ``run_id`` or the ``MLFLOW_RUN_ID`` environment variable is set,
+    If you pass a ``run_id`` or the ``
+    
+    
+    _ID`` environment variable is set,
     ``start_run`` attempts to resume a run with the specified run ID and
     other parameters are ignored. ``run_id`` takes precedence over ``MLFLOW_RUN_ID``.
 
@@ -306,10 +309,7 @@ def mlflow_run(
 
         return run_wrapper
 
-    if _func is None:
-        return run_decorator
-    else:
-        return run_decorator(_func)
+    return run_decorator if _func is None else run_decorator(_func)
 
 
 def active_run():

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -104,10 +104,7 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False, tags
     will be logged. The return value can be used as a context manager within a ``with`` block;
     otherwise, you must call ``end_run()`` to terminate the current run.
 
-    If you pass a ``run_id`` or the ``
-    
-    
-    _ID`` environment variable is set,
+    If you pass a ``run_id`` or the ``MLFLOW_RUN_ID`` environment variable is set,
     ``start_run`` attempts to resume a run with the specified run ID and
     other parameters are ignored. ``run_id`` takes precedence over ``MLFLOW_RUN_ID``.
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -518,6 +518,52 @@ def test_start_existing_run_end_time(empty_active_run_stack):  # pylint: disable
     assert run_obj_info.end_time > old_end
 
 
+def test_mlrun_decorator_with_no_args():
+    target_func = mock.MagicMock()
+    function_arg = mock.Mock()
+    function_kwarg = mock.Mock()
+    mock_active_run = mock.MagicMock()
+    start_run_patch = mock.patch("mlflow.tracking.fluent.start_run", return_value=mock_active_run)
+
+    with start_run_patch as mock_start_run:
+        decorated_func = mlflow.mlflow_run(target_func)
+        decorated_func(function_arg, FUNCTION_KWARG=function_kwarg)
+
+        mock_start_run.assert_called_once_with(
+            run_id=None, experiment_id=None, run_name=None, nested=False, tags=None
+        )
+        mock_active_run.__enter__.assert_called_once()
+        target_func.assert_called_once_with(function_arg, FUNCTION_KWARG=function_kwarg)
+        mock_active_run.__exit__.assert_called_once()
+
+
+def test_mlrun_decorator_with_args():
+    run_id = mock.Mock()
+    experiment_id = mock.Mock()
+    run_name = mock.Mock()
+    tags = mock.Mock()
+    nested = mock.Mock()
+    target_func = mock.MagicMock()
+    function_arg = mock.Mock()
+    function_kwarg = mock.Mock()
+    mock_active_run = mock.MagicMock()
+    start_run_patch = mock.patch("mlflow.tracking.fluent.start_run", return_value=mock_active_run)
+
+    with start_run_patch as mock_start_run:
+        decorator_with_args = mlflow.mlflow_run(
+            run_id=run_id, experiment_id=experiment_id, run_name=run_name, nested=nested, tags=tags
+        )
+        decorated_func = decorator_with_args(target_func)
+        decorated_func(function_arg, FUNCTION_KWARG=function_kwarg)
+
+        mock_start_run.assert_called_once_with(
+            run_id=run_id, experiment_id=experiment_id, run_name=run_name, nested=nested, tags=tags
+        )
+        mock_active_run.__enter__.assert_called_once()
+        target_func.assert_called_once_with(function_arg, FUNCTION_KWARG=function_kwarg)
+        mock_active_run.__exit__.assert_called_once()
+
+
 def test_get_run():
     run_id = uuid.uuid4().hex
     mock_run = mock.Mock()


### PR DESCRIPTION
Signed-off-by: Chris Hughes <31883449+Chris-hughes10@users.noreply.github.com>

## What changes are proposed in this pull request?
Added a convenience decorator to the fluent API which can be used in place of `mlflow.start_run` by wrapping the decorated function in an `ActiveRun` object. The decorator can be used with or without arguments, where the signature and defaults are consistent with `mlflow.start_run`.

This was discussed in : https://github.com/mlflow/mlflow/issues/3950

## How is this patch tested?
Tests have been added to ` tests/tracking/fluent/test_fluent.py` which test the decorator use with and without arguments.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added a convenience decorator to the fluent API which can be used in place of `mlflow.start_run` by wrapping the decorated function in an `ActiveRun` object. The decorator can be used with or without arguments, where the signature and defaults are consistent with `mlflow.start_run`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
