### PR TITLE
Update documentation with support for tensor-input types

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -416,8 +416,8 @@ method, which has the following signature::
 
   predict(model_input: [pandas.DataFrame, numpy.ndarray, Dict[str, np.ndarray]]) -> [numpy.ndarray | pandas.(Series | DataFrame)]
   
-All model flavors will support pandas.DataFrame as input and DL flavors will also support tensor inputs in the form
-of numpy.ndarrays. To verify whether a model flavor supports tensor inputs, please check the flavor's documentation.
+All model flavors will support `pandas.DataFrame` as input and DL flavors will also support tensor inputs in the form
+of `numpy.ndarrays`. To verify whether a model flavor supports tensor inputs, please check the flavor's documentation.
   
 For models with a column-based schema, inputs are typically provided in the form of a `pandas.DataFrame`.
 If a dictionary mapping column name to values is provided as input for schemas with named columns or if a

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -416,8 +416,8 @@ method, which has the following signature::
 
   predict(model_input: [pandas.DataFrame, numpy.ndarray, Dict[str, np.ndarray]]) -> [numpy.ndarray | pandas.(Series | DataFrame)]
   
-All model flavors will support `pandas.DataFrame` as input and DL flavors will also support tensor inputs in the form
-of `numpy.ndarrays`. To verify whether a model flavor supports tensor inputs, please check the flavor's documentation.
+All PyFunc models will support `pandas.DataFrame` as input and DL PyFunc models will also support tensor
+inputs in the form of `numpy.ndarrays`. To verify whether a model flavor supports tensor inputs, please check the flavor's documentation.
   
 For models with a column-based schema, inputs are typically provided in the form of a `pandas.DataFrame`.
 If a dictionary mapping column name to values is provided as input for schemas with named columns or if a

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -105,13 +105,12 @@ downstream tooling:
 Model Signature
 ^^^^^^^^^^^^^^^
 The Model signature defines the schema of a model's inputs and outputs. Model inputs and outputs can
-be either column-based or tensor-based. There are two different signature types: column-based and
-tensor-based. Column-based inputs and outputs can be described as a sequence of (optionally) named
-columns with type specified as one of the :py:class:`MLflow data types <mlflow.types.DataType>`.
-Tensor-based inputs and outputs can be described as a sequence of (optionally) named tensors with
-type specified as one of the `numpy data types <https://numpy.org/devdocs/user/basics.types.html>`_.
-The signature is stored in JSON format in the :ref:`MLmodel file <pyfunc-model-config>`, together with
-other model metadata.
+be either column-based or tensor-based. Column-based inputs and outputs can be described as a
+sequence of (optionally) named columns with type specified as one of the
+:py:class:`MLflow data types <mlflow.types.DataType>`. Tensor-based inputs and outputs can be
+described as a sequence of (optionally) named tensors with type specified as one of the
+`numpy data types <https://numpy.org/devdocs/user/basics.types.html>`_. The signature is stored in
+JSON format in the :ref:`MLmodel file <pyfunc-model-config>`, together with other model metadata.
 
 Model signatures are recognized and enforced by standard :ref:`MLflow model deployment tools
 <built-in-deployment>`. For example, the :ref:`mlflow models serve <local_model_deployment>` tool,
@@ -414,8 +413,9 @@ method, which has the following signature::
 
   predict(model_input: [pandas.DataFrame, numpy.ndarray, Dict[str, np.ndarray]]) -> [numpy.ndarray | pandas.(Series | DataFrame)]
   
-All PyFunc models will support `pandas.DataFrame` as input and DL PyFunc models will also support tensor
-inputs in the form of `numpy.ndarrays`. To verify whether a model flavor supports tensor inputs, please check the flavor's documentation.
+All PyFunc models will support `pandas.DataFrame` as an input. In addition to `pandas.DataFrame`,
+DL PyFunc models will also support tensor inputs in the form of `numpy.ndarrays`. To verify
+whether a model flavor supports tensor inputs, please check the flavor's documentation.
   
 For models with a column-based schema, inputs are typically provided in the form of a `pandas.DataFrame`.
 If a dictionary mapping column name to values is provided as input for schemas with named columns or if a
@@ -949,10 +949,10 @@ For more information about serializing pandas DataFrames, see
 For more information about serializing tensor inputs using the TF serving format, see
 `TF serving's request format docs <https://www.tensorflow.org/tfx/serving/api_rest#request_format_2>`_.
 
-The predict command only accepts DataFrame inputs. The format is specified as command line arguments.
+Command Line Interface
+~~~~~~~~~~~~~~~~~~~~~~
 
-Commands
-~~~~~~~~
+MLflow also has a CLI that supports the following commands:
 
 * `serve <cli.html#mlflow-models-serve>`_ deploys the model as a local REST API server.
 * `build_docker <cli.html#mlflow-models-build-docker>`_ packages a REST API endpoint serving the

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -499,9 +499,9 @@ You can save Spark models in MLflow format with the ``mleap`` flavor by specifyi
 defines :py:func:`save_model() <mlflow.mleap.save_model>` and
 :py:func:`log_model() <mlflow.mleap.log_model>` methods for saving MLeap models in MLflow format,
 but these methods do not include the ``python_function`` flavor in the models they produce.
-Similarly, ``mleap`` models can be saved in R with `mlflow_save_model <R-api.rst#mlflow-save-model>`
-and loaded with `mlflow_load_model <R-api.rst#mlflow-load-model>`, with
-`mlflow_save_model <R-api.rst#mlflow-save-model>` requiring `sample_input` to be specified as a
+Similarly, ``mleap`` models can be saved in R with `mlflow_save_model <R-api.rst#mlflow-save-model>`__
+and loaded with `mlflow_load_model <R-api.rst#mlflow-load-model>`__, with
+`mlflow_save_model <R-api.rst#mlflow-save-model>`__ requiring `sample_input` to be specified as a
 sample Spark dataframe containing input data to the model is required by MLeap for data schema
 inference.
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -904,27 +904,49 @@ The REST API server accepts the following data formats as POST input to the ``/i
 * CSV-serialized pandas DataFrames. For example, ``data = pandas_df.to_csv()``. This format is
   specified using a ``Content-Type`` request header value of ``text/csv``.
 
+* Numpy arrays formatted as described in `TF Serving's API docs
+  <https://www.tensorflow.org/tfx/serving/api_rest#request_format_2>`_.
+  This format is specified using a ``Content-Type`` request header value of ``application/json``
+  and the ``instances`` or ``inputs`` key in the request body dictionary.
+
 Example requests:
 
 .. code-block:: bash
 
-    # split-oriented
+    # split-oriented DataFrame input
     curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
         "columns": ["a", "b", "c"],
         "data": [[1, 2, 3], [4, 5, 6]]
     }'
 
-    # record-oriented (fine for vector rows, loses ordering for JSON records)
+    # record-oriented DataFrame input (fine for vector rows, loses ordering for JSON records)
     curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json; format=pandas-records' -d '[
         {"a": 1,"b": 2,"c": 3},
         {"a": 4,"b": 5,"c": 6}
     ]'
 
+    # numpy/tensor input using TF serving's "instances" format
+    curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
+        "instances": [
+            {"a": "s1", "b": 1, "c": [1, 2, 3]},
+            {"a": "s2", "b": 2, "c": [4, 5, 6]},
+            {"a": "s3", "b": 3, "c": [7, 8, 9]}
+        ]
+    }'
+
+    # numpy/tensor input using TF serving's "inputs" format
+    curl http://127.0.0.1:5000/invocations -H 'Content-Type: application/json' -d '{
+        "inputs": {"a": ["s1", "s2", "s3"], "b": [1, 2, 3], "c": [[1, 2, 3], [4, 5, 6], [7, 8, 9]]}
+    }'
+
 
 For more information about serializing pandas DataFrames, see
 `pandas.DataFrame.to_json <https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.to_json.html>`_.
 
-The predict command accepts the same input formats. The format is specified as command line arguments.
+For more information about serializing tensor inputs using the TF serving format, see
+`TF serving's request format docs <https://www.tensorflow.org/tfx/serving/api_rest#request_format_2>`_.
+
+The predict command only accepts DataFrame inputs. The format is specified as command line arguments.
 
 Commands
 ~~~~~~~~
@@ -933,7 +955,7 @@ Commands
 * `build_docker <cli.html#mlflow-models-build-docker>`_ packages a REST API endpoint serving the
   model as a docker image.
 * `predict <cli.html#mlflow-models-predict>`_ uses the model to generate a prediction for a local
-  CSV or JSON file.
+  CSV or JSON file. Note that this method only supports DataFrame input.
 
 For more info, see:
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -904,10 +904,15 @@ The REST API server accepts the following data formats as POST input to the ``/i
 * CSV-serialized pandas DataFrames. For example, ``data = pandas_df.to_csv()``. This format is
   specified using a ``Content-Type`` request header value of ``text/csv``.
 
-* Numpy arrays formatted as described in `TF Serving's API docs
-  <https://www.tensorflow.org/tfx/serving/api_rest#request_format_2>`_.
-  This format is specified using a ``Content-Type`` request header value of ``application/json``
-  and the ``instances`` or ``inputs`` key in the request body dictionary.
+* Tensor input formatted as described in `TF Serving's API docs
+  <https://www.tensorflow.org/tfx/serving/api_rest#request_format_2>`_ where the provided inputs
+  will be cast to Numpy arrays. This format is specified using a ``Content-Type`` request header
+  value of ``application/json`` and the ``instances`` or ``inputs`` key in the request body dictionary.
+
+If the ``Content-Type`` request header has a value of ``application/json``, MLflow will infer whether
+the input format is a pandas DataFrame or TF serving (i.e tensor) input based on the data in the request
+body. For pandas DataFrame input, the orient can  also be provided explicitly by specifying the format
+in the request header as shown in the record-oriented example below.
 
 Example requests:
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -906,6 +906,9 @@ The REST API server accepts the following data formats as POST input to the ``/i
   <https://www.tensorflow.org/tfx/serving/api_rest#request_format_2>`_ where the provided inputs
   will be cast to Numpy arrays. This format is specified using a ``Content-Type`` request header
   value of ``application/json`` and the ``instances`` or ``inputs`` key in the request body dictionary.
+  For models with tensor-based schemas, the Numpy array input will be cast to the type specified in
+  the model's schema. We recommend that DL PyFunc models have have a schema to guarantee it can be
+  served correctly. Otherwise, failures may occur at inference time due to type mismatches.
 
 If the ``Content-Type`` request header has a value of ``application/json``, MLflow will infer whether
 the input format is a pandas DataFrame or TF serving (i.e tensor) input based on the data in the request

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -906,14 +906,17 @@ The REST API server accepts the following data formats as POST input to the ``/i
   <https://www.tensorflow.org/tfx/serving/api_rest#request_format_2>`_ where the provided inputs
   will be cast to Numpy arrays. This format is specified using a ``Content-Type`` request header
   value of ``application/json`` and the ``instances`` or ``inputs`` key in the request body dictionary.
-  For models with tensor-based schemas, the Numpy array input will be cast to the type specified in
-  the model's schema. We recommend that DL PyFunc models have have a schema to guarantee it can be
-  served correctly. Otherwise, failures may occur at inference time due to type mismatches.
 
 If the ``Content-Type`` request header has a value of ``application/json``, MLflow will infer whether
 the input format is a pandas DataFrame or TF serving (i.e tensor) input based on the data in the request
 body. For pandas DataFrame input, the orient can  also be provided explicitly by specifying the format
 in the request header as shown in the record-oriented example below.
+
+.. note:: Since JSON loses type information, MLflow will cast the JSON input to the input type specified
+    in the model's schema if available. If your model is sensitive to input types, it is recommended that
+    a schema is provided for the model to ensure that type mismatch errors do not occur at inference time.
+    In particular, DL models are typically strict about input types and will need model schema in order
+    for the model to score correctly.
 
 Example requests:
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -253,11 +253,8 @@ on the ``MNIST dataset``:
     from keras.datasets import mnist
     from keras.utils import to_categorical
     from keras.models import Sequential
-    from keras.layers import Conv2D
-    from keras.layers import MaxPooling2D
-    from keras.layers import Dense
-    from keras.layers import Flatten
-    from keras.optimizers import SG
+    from keras.layers import Conv2D, MaxPooling2D, Dense, Flatten
+    from keras.optimizers import SGD
     import mlflow
     import mlflow.keras
     from mlflow.models.signature import infer_signature
@@ -285,13 +282,14 @@ The same signature can be created explicitly as follows:
 
 .. code-block:: python
 
+    import numpy as np
     from mlflow.models.signature import ModelSignature
     from mlflow.types.schema import Schema, TensorSpec
 
     input_schema = Schema([
-      TensorSpec("uint8", (-1, 28, 28, 1)),
+      TensorSpec(np.dtype(np.uint8), (-1, 28, 28, 1)),
     ])
-    output_schema = Schema([TensorSpec("float32", (-1, 10))])
+    output_schema = Schema([TensorSpec(np.dtype(np.float32), (-1, 10))])
     signature = ModelSignature(inputs=input_schema, outputs=output_schema)
 
 .. _input-example:

--- a/mlflow/gluon.py
+++ b/mlflow/gluon.py
@@ -149,9 +149,10 @@ def save_model(
                         signature = infer_signature(train, predictions)
     :param input_example: (Experimental) Input example provides one or several instances of valid
                           model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
+                          model. The given example can be a Pandas DataFrame where the given
+                          example will be serialized to json using the Pandas split-oriented
+                          format, or a numpy array where the example will be serialized to json
+                          by converting it to a list. Bytes are base64-encoded.
 
 
 
@@ -270,9 +271,10 @@ def log_model(
                         signature = infer_signature(train, predictions)
     :param input_example: (Experimental) Input example provides one or several instances of valid
                           model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
+                          model. The given example can be a Pandas DataFrame where the given
+                          example will be serialized to json using the Pandas split-oriented
+                          format, or a numpy array where the example will be serialized to json
+                          by converting it to a list. Bytes are base64-encoded.
 
 
 

--- a/mlflow/keras.py
+++ b/mlflow/keras.py
@@ -152,9 +152,10 @@ def save_model(
                         signature = infer_signature(train, predictions)
     :param input_example: (Experimental) Input example provides one or several instances of valid
                           model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
+                          model. The given example can be a Pandas DataFrame where the given
+                          example will be serialized to json using the Pandas split-oriented
+                          format, or a numpy array where the example will be serialized to json
+                          by converting it to a list. Bytes are base64-encoded.
 
     .. code-block:: python
         :caption: Example
@@ -350,9 +351,10 @@ def log_model(
                         signature = infer_signature(train, predictions)
     :param input_example: (Experimental) Input example provides one or several instances of valid
                           model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
+                          model. The given example can be a Pandas DataFrame where the given
+                          example will be serialized to json using the Pandas split-oriented
+                          format, or a numpy array where the example will be serialized to json
+                          by converting it to a list. Bytes are base64-encoded.
     :param await_registration_for: Number of seconds to wait for the model version to finish
                             being created and is in ``READY`` status. By default, the function
                             waits for five minutes. Specify 0 or None to skip waiting.

--- a/mlflow/onnx.py
+++ b/mlflow/onnx.py
@@ -101,9 +101,10 @@ def save_model(
                         signature = infer_signature(train, predictions)
     :param input_example: (Experimental) Input example provides one or several instances of valid
                           model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
+                          model. The given example can be a Pandas DataFrame where the given
+                          example will be serialized to json using the Pandas split-oriented
+                          format, or a numpy array where the example will be serialized to json
+                          by converting it to a list. Bytes are base64-encoded.
 
     """
     import onnx
@@ -299,9 +300,10 @@ def log_model(
                         signature = infer_signature(train, predictions)
     :param input_example: (Experimental) Input example provides one or several instances of valid
                           model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
+                          model. The given example can be a Pandas DataFrame where the given
+                          example will be serialized to json using the Pandas split-oriented
+                          format, or a numpy array where the example will be serialized to json
+                          by converting it to a list. Bytes are base64-encoded.
     :param await_registration_for: Number of seconds to wait for the model version to finish
                             being created and is in ``READY`` status. By default, the function
                             waits for five minutes. Specify 0 or None to skip waiting.

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -25,6 +25,10 @@ metadata (MLmodel file). You can score the model by calling the :py:func:`predic
 
   predict(model_input: [pandas.DataFrame, Dict[str, numpy.ndarray], numpy.ndarray]) -> [numpy.ndarray | pandas.(Series | DataFrame)]
 
+All model flavors will support `pandas.DataFrame` as input and DL flavors will also support tensor
+inputs in the form of Dict[str, numpy.ndarray] (named tensors) and `numpy.ndarrays` (unnamed
+tensors).
+
 
 .. _pyfunc-filesystem-format:
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -25,7 +25,7 @@ metadata (MLmodel file). You can score the model by calling the :py:func:`predic
 
   predict(model_input: [pandas.DataFrame, Dict[str, numpy.ndarray], numpy.ndarray]) -> [numpy.ndarray | pandas.(Series | DataFrame)]
 
-All model flavors will support `pandas.DataFrame` as input and DL flavors will also support tensor
+All PyFunc models will support `pandas.DataFrame` as input and DL PyFunc models will also support tensor
 inputs in the form of Dict[str, numpy.ndarray] (named tensors) and `numpy.ndarrays` (unnamed
 tensors).
 

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -23,11 +23,13 @@ Python function models are loaded as an instance of :py:class:`PyFuncModel
 metadata (MLmodel file). You can score the model by calling the :py:func:`predict()
 <mlflow.pyfunc.PyFuncModel.predict>` method, which has the following signature::
 
-  predict(model_input: [pandas.DataFrame, Dict[str, numpy.ndarray], numpy.ndarray]) -> [numpy.ndarray | pandas.(Series | DataFrame)]
+  predict(
+    model_input: [pandas.DataFrame, Dict[str, numpy.ndarray], numpy.ndarray]
+  ) -> [numpy.ndarray | pandas.(Series | DataFrame)]
 
-All PyFunc models will support `pandas.DataFrame` as input and DL PyFunc models will also support tensor
-inputs in the form of Dict[str, numpy.ndarray] (named tensors) and `numpy.ndarrays` (unnamed
-tensors).
+All PyFunc models will support `pandas.DataFrame` as input and DL PyFunc models will also support
+tensor inputs in the form of Dict[str, numpy.ndarray] (named tensors) and `numpy.ndarrays`
+(unnamed tensors).
 
 
 .. _pyfunc-filesystem-format:
@@ -67,7 +69,9 @@ following parameters:
          directory. The model implementation is expected to be an object with a
          ``predict`` method with the following signature::
 
-           predict(model_input: [pandas.DataFrame, Dict[str, numpy.ndarray], numpy.ndarray]) -> [numpy.ndarray | pandas.(Series | DataFrame)]
+          predict(
+              model_input: [pandas.DataFrame, Dict[str, numpy.ndarray], numpy.ndarray]
+          ) -> [numpy.ndarray | pandas.(Series | DataFrame)]
 
 - code [optional]:
         Relative path to a directory containing the code packaged with this model.
@@ -438,7 +442,7 @@ class PyFuncModel(object):
 
     Wrapper around model implementation and metadata. This class is not meant to be constructed
     directly. Instead, instances of this class are constructed and returned from
-    py:func:`mlflow.pyfunc.load_model`.
+    :py:func:`load_model() <mlflow.pyfunc.load_model>`.
 
     ``model_impl`` can be any Python object that implements the `Pyfunc interface
     <https://mlflow.org/docs/latest/python_api/mlflow.pyfunc.html#pyfunc-inference-api>`_, and is
@@ -464,7 +468,8 @@ class PyFuncModel(object):
         the input is passed to the model implementation as is. See `Model Signature Enforcement
         <https://www.mlflow.org/docs/latest/models.html#signature-enforcement>`_ for more details."
 
-        :param data: Model input as one of pandas.DataFrame, numpy.ndarray, or Dict[str, numpy.ndarray]
+        :param data: Model input as one of pandas.DataFrame, numpy.ndarray, or
+                     Dict[str, numpy.ndarray]
         :return: Model predictions as one of pandas.DataFrame, pandas.Series, numpy.ndarray or list.
         """
         input_schema = self.metadata.get_input_schema()

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -23,7 +23,7 @@ Python function models are loaded as an instance of :py:class:`PyFuncModel
 metadata (MLmodel file). You can score the model by calling the :py:func:`predict()
 <mlflow.pyfunc.PyFuncModel.predict>` method, which has the following signature::
 
-  predict(model_input: pandas.DataFrame) -> [numpy.ndarray | pandas.(Series | DataFrame)]
+  predict(model_input: [pandas.DataFrame, Dict[str, numpy.ndarray], numpy.ndarray]) -> [numpy.ndarray | pandas.(Series | DataFrame)]
 
 
 .. _pyfunc-filesystem-format:
@@ -63,7 +63,7 @@ following parameters:
          directory. The model implementation is expected to be an object with a
          ``predict`` method with the following signature::
 
-           predict(model_input: pandas.DataFrame) -> [numpy.ndarray | pandas.(Series | DataFrame)]
+           predict(model_input: [pandas.DataFrame, Dict[str, numpy.ndarray], numpy.ndarray]) -> [numpy.ndarray | pandas.(Series | DataFrame)]
 
 - code [optional]:
         Relative path to a directory containing the code packaged with this model.
@@ -460,7 +460,7 @@ class PyFuncModel(object):
         the input is passed to the model implementation as is. See `Model Signature Enforcement
         <https://www.mlflow.org/docs/latest/models.html#signature-enforcement>`_ for more details."
 
-        :param data: Model input
+        :param data: Model input as one of pandas.DataFrame, numpy.ndarray, or Dict[str, numpy.ndarray]
         :return: Model predictions as one of pandas.DataFrame, pandas.Series, numpy.ndarray or list.
         """
         input_schema = self.metadata.get_input_schema()
@@ -849,9 +849,10 @@ def save_model(
                         signature = infer_signature(train, predictions)
     :param input_example: (Experimental) Input example provides one or several instances of valid
                           model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
+                          model. The given example can be a Pandas DataFrame where the given
+                          example will be serialized to json using the Pandas split-oriented
+                          format, or a numpy array where the example will be serialized to json
+                          by converting it to a list. Bytes are base64-encoded.
     """
     mlflow_model = kwargs.pop("model", mlflow_model)
     if len(kwargs) > 0:
@@ -1028,9 +1029,10 @@ def log_model(
                         signature = infer_signature(train, predictions)
     :param input_example: (Experimental) Input example provides one or several instances of valid
                           model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
+                          model. The given example can be a Pandas DataFrame where the given
+                          example will be serialized to json using the Pandas split-oriented
+                          format, or a numpy array where the example will be serialized to json
+                          by converting it to a list. Bytes are base64-encoded.
     :param await_registration_for: Number of seconds to wait for the model version to finish
                             being created and is in ``READY`` status. By default, the function
                             waits for five minutes. Specify 0 or None to skip waiting.

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -167,9 +167,10 @@ def log_model(
                         signature = infer_signature(train, predictions)
     :param input_example: (Experimental) Input example provides one or several instances of valid
                           model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
+                          model. The given example can be a Pandas DataFrame where the given
+                          example will be serialized to json using the Pandas split-oriented
+                          format, or a numpy array where the example will be serialized to json
+                          by converting it to a list. Bytes are base64-encoded.
 
     :param await_registration_for: Number of seconds to wait for the model version to finish
                             being created and is in ``READY`` status. By default, the function
@@ -361,9 +362,10 @@ def save_model(
                         signature = infer_signature(train, predictions)
     :param input_example: (Experimental) Input example provides one or several instances of valid
                           model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
+                          model. The given example can be a Pandas DataFrame where the given
+                          example will be serialized to json using the Pandas split-oriented
+                          format, or a numpy array where the example will be serialized to json
+                          by converting it to a list. Bytes are base64-encoded.
 
     :param requirements_file: A string containing the path to requirements file. Remote URIs
                       are resolved to absolute filesystem paths.

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -156,9 +156,10 @@ def log_model(
                         signature = infer_signature(train, predictions)
     :param input_example: (Experimental) Input example provides one or several instances of valid
                           model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
+                          model. The given example can be a Pandas DataFrame where the given
+                          example will be serialized to json using the Pandas split-oriented
+                          format, or a numpy array where the example will be serialized to json
+                          by converting it to a list. Bytes are base64-encoded.
     :param await_registration_for: Number of seconds to wait for the model version to finish
                             being created and is in ``READY`` status. By default, the function
                             waits for five minutes. Specify 0 or None to skip waiting.
@@ -238,9 +239,10 @@ def save_model(
                         signature = infer_signature(train, predictions)
     :param input_example: (Experimental) Input example provides one or several instances of valid
                           model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
+                          model. The given example can be a Pandas DataFrame where the given
+                          example will be serialized to json using the Pandas split-oriented
+                          format, or a numpy array where the example will be serialized to json
+                          by converting it to a list. Bytes are base64-encoded.
 
     """
     _logger.info(


### PR DESCRIPTION
## What changes are proposed in this pull request?
Update documentation with support for tensor-input types and schemas

## How is this patch tested?
N/A

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
Update documentation with support for tensor-input types and schemas

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
