### PR TITLE
#4055 allow infer_signature to read pandas ExtensionDtype

### DIFF
--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -139,7 +139,9 @@ def _infer_pandas_column(col: pd.Series) -> DataType:
     if not isinstance(col, pd.Series):
         raise TypeError("Expected pandas.Series, got '{}'.".format(type(col)))
 
-    if pd.api.types.is_bool_dtype(col):
+    if pd.api.types.infer_dtype(col) == "bytes":
+        return DataType.binary
+    elif pd.api.types.is_bool_dtype(col):
         return DataType.boolean
     elif pd.api.types.is_integer_dtype(col) and not pd.api.types.is_int64_dtype(col):
         return DataType.integer

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -141,12 +141,20 @@ def _infer_pandas_column(col: pd.Series) -> DataType:
 
     if pd.api.types.is_bool_dtype(col):
         return DataType.boolean
-    elif pd.api.types.is_integer_dtype(col):
+    elif pd.api.types.is_integer_dtype(col) and not pd.api.types.is_int64_dtype(col):
+        return DataType.integer
+    elif pd.api.types.is_integer_dtype(col) and pd.api.types.is_int64_dtype(col):
         return DataType.long
-    elif pd.api.types.is_float_dtype(col):
+    elif pd.api.types.is_dtype_equal(col, np.float32):
+        return DataType.float
+    elif pd.api.types.is_dtype_equal(col, np.float64):
         return DataType.double
     elif pd.api.types.is_string_dtype(col):
         return DataType.string
+    else:
+        raise MlflowException(
+            "Unable to map col of type {} to MLflow DataType.".format(type(col))
+        )
 
 
 def _infer_numpy_array(col: np.ndarray) -> DataType:

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -153,7 +153,7 @@ def _infer_pandas_column(col: pd.Series) -> DataType:
         return DataType.string
     else:
         raise MlflowException(
-            "Unable to map col of type {} to MLflow DataType.".format(type(col))
+            "Unable to map col of type {} to MLflow DataType.".format(type(col.dtype))
         )
 
 

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -58,10 +58,10 @@ def _infer_schema(data: Any) -> Schema:
                 )
         schema = Schema(res)
     elif isinstance(data, pd.Series):
-        schema = Schema([ColSpec(type=_infer_numpy_array(data.values))])
+        schema = Schema([ColSpec(type=_infer_pandas_column(data))])
     elif isinstance(data, pd.DataFrame):
         schema = Schema(
-            [ColSpec(type=_infer_numpy_array(data[col].values), name=col) for col in data.columns]
+            [ColSpec(type=_infer_pandas_column(data[col]), name=col) for col in data.columns]
         )
     elif isinstance(data, np.ndarray):
         if len(data.shape) > 2:
@@ -133,6 +133,20 @@ def _infer_numpy_dtype(dtype: np.dtype) -> DataType:
             "_map_numpy_array instead."
         )
     raise MlflowException("Unsupported numpy data type '{0}', kind '{1}'".format(dtype, dtype.kind))
+
+
+def _infer_pandas_column(col: pd.Series) -> DataType:
+    if not isinstance(col, pd.Series):
+        raise TypeError("Expected pandas.Series, got '{}'.".format(type(col)))
+
+    if pd.api.types.is_bool_dtype(col):
+        return DataType.boolean
+    elif pd.api.types.is_integer_dtype(col):
+        return DataType.long
+    elif pd.api.types.is_float_dtype(col):
+        return DataType.double
+    elif pd.api.types.is_string_dtype(col):
+        return DataType.string
 
 
 def _infer_numpy_array(col: np.ndarray) -> DataType:

--- a/tests/models/test_model_input_examples.py
+++ b/tests/models/test_model_input_examples.py
@@ -13,7 +13,7 @@ from mlflow.utils.proto_json_utils import _dataframe_from_json
 
 @pytest.fixture
 def pandas_df_with_all_types():
-    return pd.DataFrame(
+    df = pd.DataFrame(
         {
             "boolean": [True, False, True],
             "integer": np.array([1, 2, 3], np.int32),
@@ -22,8 +22,15 @@ def pandas_df_with_all_types():
             "double": [math.pi, 2 * math.pi, 3 * math.pi],
             "binary": [bytes([1, 2, 3]), bytes([4, 5, 6]), bytes([7, 8, 9])],
             "string": ["a", "b", "c"],
+            "boolean_ext": [True, False, True],
+            "integer_ext": [1, 2, 3],
+            "string_ext": ["a", "b", "c"],
         }
     )
+    df["boolean_ext"] = df["boolean_ext"].astype("boolean")
+    df["integer_ext"] = df["integer_ext"].astype("Int64")
+    df["string_ext"] = df["string_ext"].astype("string")
+    return df
 
 
 def test_input_examples(pandas_df_with_all_types):

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -57,20 +57,20 @@ def test_model_signature():
     signature1 = ModelSignature(
         inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
         outputs=Schema(
-            [ColSpec(name=None, type=DataType.double), ColSpec(name=None, type=DataType.double), ]
+            [ColSpec(name=None, type=DataType.double), ColSpec(name=None, type=DataType.double)]
         ),
     )
     signature2 = ModelSignature(
         inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
         outputs=Schema(
-            [ColSpec(name=None, type=DataType.double), ColSpec(name=None, type=DataType.double), ]
+            [ColSpec(name=None, type=DataType.double), ColSpec(name=None, type=DataType.double)]
         ),
     )
     assert signature1 == signature2
     signature3 = ModelSignature(
         inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
         outputs=Schema(
-            [ColSpec(name=None, type=DataType.float), ColSpec(name=None, type=DataType.double), ]
+            [ColSpec(name=None, type=DataType.float), ColSpec(name=None, type=DataType.double)]
         ),
     )
     assert signature3 != signature1

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -1,5 +1,4 @@
 import json
-
 import numpy as np
 
 from mlflow.models.signature import ModelSignature, infer_signature
@@ -32,7 +31,7 @@ def test_model_signature():
     signature4 = ModelSignature.from_dict(json.loads(as_json))
     assert signature1 == signature4
     signature5 = ModelSignature(
-        inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]), outputs=None,
+        inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]), outputs=None
     )
     as_json = json.dumps(signature5.to_dict())
     signature6 = ModelSignature.from_dict(json.loads(as_json))

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -1,56 +1,10 @@
 import json
-import math
 
 import numpy as np
-import pandas as pd
-import pytest
 
 from mlflow.models.signature import ModelSignature, infer_signature
 from mlflow.types import DataType
 from mlflow.types.schema import Schema, ColSpec
-
-
-@pytest.fixture
-def pandas_df_with_all_types():
-    df = pd.DataFrame(
-        {
-            "boolean": [True, False, True],
-            "integer": np.array([1, 2, 3], np.int32),
-            "long": np.array([1, 2, 3], np.int64),
-            "float": np.array([math.pi, 2 * math.pi, 3 * math.pi], np.float32),
-            "double": [math.pi, 2 * math.pi, 3 * math.pi],
-            "binary": [bytes([1, 2, 3]), bytes([4, 5, 6]), bytes([7, 8, 9])],
-            "string": ["a", "b", "c"],
-            "boolean_ext": [True, False, pd.NA],
-            "integer_ext": [1, 2, pd.NA],
-            "string_ext": ["a", "b", "c"],
-        }
-    )
-    df["boolean_ext"] = df["boolean_ext"].astype("boolean")
-    df["integer_ext"] = df["integer_ext"].astype("Int64")
-    df["string_ext"] = df["string_ext"].astype("string")
-    return df
-
-
-def test_pandas_signature_inference(pandas_df_with_all_types):
-    signature1 = ModelSignature(
-        inputs=Schema(
-            [
-                ColSpec(DataType.boolean, "boolean"),
-                ColSpec(DataType.integer, "integer"),
-                ColSpec(DataType.long, "long"),
-                ColSpec(DataType.float, "float"),
-                ColSpec(DataType.double, "double"),
-                ColSpec(DataType.binary, "binary"),
-                ColSpec(DataType.string, "string"),
-                ColSpec(DataType.boolean, "boolean_ext"),
-                ColSpec(DataType.long, "integer_ext"),
-                ColSpec(DataType.string, "string_ext"),
-            ]
-        )
-    )
-    signature2 = infer_signature(pandas_df_with_all_types)
-    assert signature1 == signature2
 
 
 def test_model_signature():

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -37,9 +37,9 @@ def test_pandas_signature_inference(pandas_df_with_all_types):
         inputs=Schema(
             [
                 ColSpec(DataType.boolean, "boolean"),
-                ColSpec(DataType.long, "integer"),
+                ColSpec(DataType.integer, "integer"),
                 ColSpec(DataType.long, "long"),
-                ColSpec(DataType.double, "float"),
+                ColSpec(DataType.float, "float"),
                 ColSpec(DataType.double, "double"),
                 ColSpec(DataType.string, "binary"),
                 ColSpec(DataType.string, "string"),

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -57,20 +57,20 @@ def test_model_signature():
     signature1 = ModelSignature(
         inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
         outputs=Schema(
-            [ColSpec(name=None, type=DataType.double), ColSpec(name=None, type=DataType.double),]
+            [ColSpec(name=None, type=DataType.double), ColSpec(name=None, type=DataType.double), ]
         ),
     )
     signature2 = ModelSignature(
         inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
         outputs=Schema(
-            [ColSpec(name=None, type=DataType.double), ColSpec(name=None, type=DataType.double),]
+            [ColSpec(name=None, type=DataType.double), ColSpec(name=None, type=DataType.double), ]
         ),
     )
     assert signature1 == signature2
     signature3 = ModelSignature(
         inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
         outputs=Schema(
-            [ColSpec(name=None, type=DataType.float), ColSpec(name=None, type=DataType.double),]
+            [ColSpec(name=None, type=DataType.float), ColSpec(name=None, type=DataType.double), ]
         ),
     )
     assert signature3 != signature1

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -1,29 +1,85 @@
 import json
+import math
+
 import numpy as np
+import pandas as pd
+import pytest
 
 from mlflow.models.signature import ModelSignature, infer_signature
 from mlflow.types import DataType
 from mlflow.types.schema import Schema, ColSpec
 
 
+@pytest.fixture
+def pandas_df_with_all_types():
+    df = pd.DataFrame(
+        {
+            "boolean": [True, False, True],
+            "integer": np.array([1, 2, 3], np.int32),
+            "long": np.array([1, 2, 3], np.int64),
+            "float": np.array([math.pi, 2 * math.pi, 3 * math.pi], np.float32),
+            "double": [math.pi, 2 * math.pi, 3 * math.pi],
+            "binary": [bytes([1, 2, 3]), bytes([4, 5, 6]), bytes([7, 8, 9])],
+            "string": ["a", "b", "c"],
+            "boolean_ext": [True, False, pd.NA],
+            "integer_ext": [1, 2, pd.NA],
+            "string_ext": ["a", "b", "c"],
+        }
+    )
+    df["boolean_ext"] = df["boolean_ext"].astype("boolean")
+    df["integer_ext"] = df["integer_ext"].astype("Int64")
+    df["string_ext"] = df["string_ext"].astype("string")
+    return df
+
+
+def test_pandas_signature_inference(pandas_df_with_all_types):
+    signature1 = ModelSignature(
+        inputs=Schema(
+            [
+                ColSpec(DataType.boolean, "boolean"),
+                ColSpec(DataType.long, "integer"),
+                ColSpec(DataType.long, "long"),
+                ColSpec(DataType.double, "float"),
+                ColSpec(DataType.double, "double"),
+                ColSpec(DataType.string, "binary"),
+                ColSpec(DataType.string, "string"),
+                ColSpec(DataType.boolean, "boolean_ext"),
+                ColSpec(DataType.long, "integer_ext"),
+                ColSpec(DataType.string, "string_ext"),
+            ]
+        )
+    )
+    signature2 = infer_signature(pandas_df_with_all_types)
+    assert signature1 == signature2
+
+
 def test_model_signature():
     signature1 = ModelSignature(
         inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
         outputs=Schema(
-            [ColSpec(name=None, type=DataType.double), ColSpec(name=None, type=DataType.double)]
+            [
+                ColSpec(name=None, type=DataType.double),
+                ColSpec(name=None, type=DataType.double),
+            ]
         ),
     )
     signature2 = ModelSignature(
         inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
         outputs=Schema(
-            [ColSpec(name=None, type=DataType.double), ColSpec(name=None, type=DataType.double)]
+            [
+                ColSpec(name=None, type=DataType.double),
+                ColSpec(name=None, type=DataType.double),
+            ]
         ),
     )
     assert signature1 == signature2
     signature3 = ModelSignature(
         inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
         outputs=Schema(
-            [ColSpec(name=None, type=DataType.float), ColSpec(name=None, type=DataType.double)]
+            [
+                ColSpec(name=None, type=DataType.float),
+                ColSpec(name=None, type=DataType.double),
+            ]
         ),
     )
     assert signature3 != signature1
@@ -31,7 +87,8 @@ def test_model_signature():
     signature4 = ModelSignature.from_dict(json.loads(as_json))
     assert signature1 == signature4
     signature5 = ModelSignature(
-        inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]), outputs=None
+        inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
+        outputs=None,
     )
     as_json = json.dumps(signature5.to_dict())
     signature6 = ModelSignature.from_dict(json.loads(as_json))

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -41,7 +41,7 @@ def test_pandas_signature_inference(pandas_df_with_all_types):
                 ColSpec(DataType.long, "long"),
                 ColSpec(DataType.float, "float"),
                 ColSpec(DataType.double, "double"),
-                ColSpec(DataType.string, "binary"),
+                ColSpec(DataType.binary, "binary"),
                 ColSpec(DataType.string, "string"),
                 ColSpec(DataType.boolean, "boolean_ext"),
                 ColSpec(DataType.long, "integer_ext"),

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -57,29 +57,20 @@ def test_model_signature():
     signature1 = ModelSignature(
         inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
         outputs=Schema(
-            [
-                ColSpec(name=None, type=DataType.double),
-                ColSpec(name=None, type=DataType.double),
-            ]
+            [ColSpec(name=None, type=DataType.double), ColSpec(name=None, type=DataType.double),]
         ),
     )
     signature2 = ModelSignature(
         inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
         outputs=Schema(
-            [
-                ColSpec(name=None, type=DataType.double),
-                ColSpec(name=None, type=DataType.double),
-            ]
+            [ColSpec(name=None, type=DataType.double), ColSpec(name=None, type=DataType.double),]
         ),
     )
     assert signature1 == signature2
     signature3 = ModelSignature(
         inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
         outputs=Schema(
-            [
-                ColSpec(name=None, type=DataType.float),
-                ColSpec(name=None, type=DataType.double),
-            ]
+            [ColSpec(name=None, type=DataType.float), ColSpec(name=None, type=DataType.double),]
         ),
     )
     assert signature3 != signature1
@@ -87,8 +78,7 @@ def test_model_signature():
     signature4 = ModelSignature.from_dict(json.loads(as_json))
     assert signature1 == signature4
     signature5 = ModelSignature(
-        inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]),
-        outputs=None,
+        inputs=Schema([ColSpec(DataType.boolean), ColSpec(DataType.binary)]), outputs=None,
     )
     as_json = json.dumps(signature5.to_dict())
     signature6 = ModelSignature.from_dict(json.loads(as_json))


### PR DESCRIPTION
## What changes are proposed in this pull request?

Allows `infer_signature` to handle dataframes containing ExtensionDtype, addresses #4055 

## How is this patch tested?

Modified `tests/models/test_model_input_examples.py` to contain additional datatypes.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`infer_signature` no longer fails when given a pandas dataframe containing an `ExtensionDtype`

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
