### PR TITLE
Add synchronous flag to mlflow run cli.

### DIFF
--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -121,6 +121,13 @@ def cli():
     "Note: this argument is used internally by the MLflow project APIs "
     "and should not be specified.",
 )
+@click.option(
+    "--synchronous/--asynchronous",
+    metavar="SYNCHRONOUS",
+    help="Specify whether the CLI should wait for the run to finish before returning.",
+    is_flag=True,
+    default=None,
+)
 def run(
     uri,
     entry_point,
@@ -134,6 +141,7 @@ def run(
     no_conda,
     storage_dir,
     run_id,
+    synchronous,
 ):
     """
     Run an MLflow project from the given URI.
@@ -177,7 +185,11 @@ def run(
             backend_config=backend_config,
             use_conda=(not no_conda),
             storage_dir=storage_dir,
-            synchronous=backend in ("local", "kubernetes") or backend is None,
+            synchronous=(
+                synchronous
+                if synchronous is not None
+                else (backend in ("local", "kubernetes") or backend is None)
+            ),
             run_id=run_id,
         )
     except projects.ExecutionException as e:

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -213,3 +213,13 @@ def test_mlflow_run():
         )
         mock_projects.run.assert_not_called()
         assert "Specify only one of 'experiment-name' or 'experiment-id' options." in result.output
+
+    with mock.patch("mlflow.cli.projects") as mock_projects:
+        CliRunner().invoke(cli.run, ["--experiment-id", "51", "uri", "--synchronous"])
+        _, run_kwargs = mock_projects.run.call_args_list[0]
+        assert run_kwargs["synchronous"]
+
+    with mock.patch("mlflow.cli.projects") as mock_projects:
+        CliRunner().invoke(cli.run, ["--experiment-id", "51", "uri", "--asynchronous"])
+        _, run_kwargs = mock_projects.run.call_args_list[0]
+        assert not run_kwargs["synchronous"]

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -200,8 +200,15 @@ def test_mlflow_run_sync_async():
         _, run_kwargs = mock_projects.run.call_args_list[0]
         assert not run_kwargs["synchronous"]
 
+    # The following two assertions test whether the default behaviour for the backends
+    # local and databricks respect the syncronous flag correctly.
     with mock.patch("mlflow.cli.projects") as mock_projects:
         CliRunner().invoke(cli.run, ["--experiment-id", "51", "uri", "--backend", "local"])
+        _, run_kwargs = mock_projects.run.call_args_list[0]
+        assert run_kwargs["synchronous"]
+
+    with mock.patch("mlflow.cli.projects") as mock_projects:
+        CliRunner().invoke(cli.run, ["--experiment-id", "51", "uri", "--backend", "databricks"])
         _, run_kwargs = mock_projects.run.call_args_list[0]
         assert not run_kwargs["synchronous"]
 

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -189,6 +189,23 @@ def test_run_databricks_cluster_spec(tmpdir):
         assert res.exit_code != 0
 
 
+def test_mlflow_run_sync_async():
+    with mock.patch("mlflow.cli.projects") as mock_projects:
+        CliRunner().invoke(cli.run, ["--experiment-id", "51", "uri", "--synchronous"])
+        _, run_kwargs = mock_projects.run.call_args_list[0]
+        assert run_kwargs["synchronous"]
+
+    with mock.patch("mlflow.cli.projects") as mock_projects:
+        CliRunner().invoke(cli.run, ["--experiment-id", "51", "uri", "--asynchronous"])
+        _, run_kwargs = mock_projects.run.call_args_list[0]
+        assert not run_kwargs["synchronous"]
+
+    with mock.patch("mlflow.cli.projects") as mock_projects:
+        CliRunner().invoke(cli.run, ["--experiment-id", "51", "uri", "--backend", "local"])
+        _, run_kwargs = mock_projects.run.call_args_list[0]
+        assert not run_kwargs["synchronous"]
+
+
 def test_mlflow_run():
     with mock.patch("mlflow.cli.projects") as mock_projects:
         result = CliRunner().invoke(cli.run)
@@ -213,13 +230,3 @@ def test_mlflow_run():
         )
         mock_projects.run.assert_not_called()
         assert "Specify only one of 'experiment-name' or 'experiment-id' options." in result.output
-
-    with mock.patch("mlflow.cli.projects") as mock_projects:
-        CliRunner().invoke(cli.run, ["--experiment-id", "51", "uri", "--synchronous"])
-        _, run_kwargs = mock_projects.run.call_args_list[0]
-        assert run_kwargs["synchronous"]
-
-    with mock.patch("mlflow.cli.projects") as mock_projects:
-        CliRunner().invoke(cli.run, ["--experiment-id", "51", "uri", "--asynchronous"])
-        _, run_kwargs = mock_projects.run.call_args_list[0]
-        assert not run_kwargs["synchronous"]


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds the synchronous flag to the `mlflow run` cli. This resolves #3777.

## How is this patch tested?

Test cases are added and a run with local backend was perfomed.

## Release Notes

The `--synchronous` and `--asynchroneous` flags are added to the `mlflow run` cli to allow the user to control how experiments are executed.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The `--synchronous` and `--asyncrhoneous` flags are now available on the `mlflow run` cli command. When not provided the default behaviour remains dependent on the backend chosen as in previous versions.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
