### PR TITLE
New env var to choose artifcats storage root when tracking on db

### DIFF
--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -12,6 +12,7 @@ from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 
 _TRACKING_URI_ENV_VAR = "MLFLOW_TRACKING_URI"
+_ARTIFACT_ROOT_ENV_VAR = "MLFLOW_ARTIFACT_ROOT"
 
 # Extra environment variables which take precedence for setting the basic/bearer
 # auth on http requests.
@@ -113,7 +114,8 @@ def _get_sqlalchemy_store(store_uri, artifact_uri):
     from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 
     if artifact_uri is None:
-        artifact_uri = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
+        artifact_uri = os.environ.get(_ARTIFACT_ROOT_ENV_VAR, None) or \
+            DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
     return SqlAlchemyStore(store_uri, artifact_uri)
 
 

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -115,7 +115,7 @@ def _get_sqlalchemy_store(store_uri, artifact_uri):
 
     if artifact_uri is None:
         artifact_uri = (
-            os.environ.get(_ARTIFACT_ROOT_ENV_VAR, None) or DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
+            os.environ.get(_ARTIFACT_ROOT_ENV_VAR, DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH)
         )
     return SqlAlchemyStore(store_uri, artifact_uri)
 

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -114,8 +114,9 @@ def _get_sqlalchemy_store(store_uri, artifact_uri):
     from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 
     if artifact_uri is None:
-        artifact_uri = os.environ.get(_ARTIFACT_ROOT_ENV_VAR, None) or \
-            DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
+        artifact_uri = (
+            os.environ.get(_ARTIFACT_ROOT_ENV_VAR, None) or DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
+        )
     return SqlAlchemyStore(store_uri, artifact_uri)
 
 

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 import mlflow
-from mlflow.store.db.db_types import DATABASE_ENGINES, SQLITE
+from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.tracking.file_store import FileStore
 from mlflow.store.tracking.rest_store import RestStore
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
@@ -168,9 +168,10 @@ def test_get_store_sqlalchemy_store_with_artifact_uri(tmp_wkdir, db_type):
     mock_create_engine.assert_called_once_with(uri, pool_pre_ping=True)
 
 
-def test_get_store_sqlalchemy_store_with_artifact_root():
+@pytest.mark.parametrize("db_type", DATABASE_ENGINES)
+def test_get_store_sqlalchemy_store_with_artifact_root(db_type):
     patch_create_engine = mock.patch("sqlalchemy.create_engine")
-    uri = "{}://hostname/database".format(SQLITE)
+    uri = "{}://hostname/database".format(db_type)
     artifact_root = "file:artifact/path"
     env = {
         _TRACKING_URI_ENV_VAR: uri,


### PR DESCRIPTION
## What changes are proposed in this pull request?

New env var to configure artifacts storage root when tracking to db via SQLAlchemy (#4077).
- When tracking on files, this path is defined via `MLFLOW_TRACKING_URI`
- When tracking to DB, MLFLOW_TRACKING_URI is used to setup the connection to Database and the file storage for artifacts is hard coded to `DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH=./mlruns`

## How is this patch tested?

N/A

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Gives the possibility to configure the root directory where artifacts are stored when tracking on DB.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
