### PR TITLE
Support tensor-based model signatures in schema enforcement

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -472,9 +472,9 @@ def _enforce_schema(pfInput: PyFuncInput, input_schema: Schema):
                 for col_name, tensor_spec in zip(input_schema.input_names(), input_schema.inputs):
                     if not isinstance(pfInput[col_name], np.ndarray):
                         message = (
-                            "This model contains a tensor-based model signature with input names, which"
-                            " suggests a dictionary input mapping input name to a numpy array, but a dict with"
-                            " value type {0} was found."
+                            "This model contains a tensor-based model signature with input names,"
+                            " which suggests a dictionary input mapping input name to a numpy"
+                            " array, but a dict with value type {0} was found."
                         ).format(type(pfInput[col_name]))
                         raise MlflowException(message)
                     new_pfInput[col_name] = _enforce_tensor_spec(pfInput[col_name], tensor_spec)

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -283,7 +283,7 @@ def _load_model_env(path):
     return _get_flavor_configuration(model_path=path, flavor_name=FLAVOR_NAME).get(ENV, None)
 
 
-def _enforce_mlflow_type(name, values: pandas.Series, t: DataType):
+def _enforce_mlflow_datatype(name, values: pandas.Series, t: DataType):
     """
     Enforce the input column type matches the declared in model input schema.
 
@@ -409,7 +409,7 @@ def _enforce_col_schema(pfInput: PyFuncInput, input_schema: Schema):
     input_types = input_schema.input_types()
     new_pfInput = pandas.DataFrame()
     for i, x in enumerate(input_names):
-        new_pfInput[x] = _enforce_mlflow_type(x, pfInput[x], input_types[i])
+        new_pfInput[x] = _enforce_mlflow_datatype(x, pfInput[x], input_types[i])
     return new_pfInput
 
 

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -453,7 +453,7 @@ def test_schema_enforcement_single_named_tensor_schema():
 def test_schema_enforcement_named_tensor_schema_1d():
     m = Model()
     input_schema = Schema(
-        [TensorSpec(np.dtype(np.uint64), (-1,), "a"), TensorSpec(np.dtype(np.float32), (-1,), "b"),]
+        [TensorSpec(np.dtype(np.uint64), (-1,), "a"), TensorSpec(np.dtype(np.float32), (-1,), "b")]
     )
     m.signature = ModelSignature(inputs=input_schema)
     pyfunc_model = PyFuncModel(model_meta=m, model_impl=TestModel())

--- a/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
+++ b/tests/pyfunc/test_model_export_with_loader_module_and_data_path.py
@@ -18,10 +18,16 @@ from mlflow.exceptions import MlflowException
 from mlflow.models import Model, infer_signature, ModelSignature
 from mlflow.models.utils import _read_example
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.types import Schema, ColSpec
+from mlflow.types import Schema, ColSpec, TensorSpec
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
+
+
+class TestModel(object):
+    @staticmethod
+    def predict(pdf):
+        return pdf
 
 
 def _load_pyfunc(path):
@@ -123,12 +129,7 @@ def test_signature_and_examples_are_saved_correctly(sklearn_knn_model, iris_data
                     assert np.array_equal(_read_example(mlflow_model, path), example)
 
 
-def test_schema_enforcement():
-    class TestModel(object):
-        @staticmethod
-        def predict(pdf):
-            return pdf
-
+def test_column_schema_enforcement():
     m = Model()
     input_schema = Schema(
         [
@@ -155,7 +156,7 @@ def test_schema_enforcement():
     # test that missing column raises
     with pytest.raises(MlflowException) as ex:
         res = pyfunc_model.predict(pdf[["b", "d", "a", "e", "g", "f"]])
-    assert "Model input is missing columns" in str(ex)
+    assert "Model is missing inputs" in str(ex)
 
     # test that extra column is ignored
     pdf["x"] = 1
@@ -270,7 +271,7 @@ def test_schema_enforcement():
     # 8. np.ndarrays can be converted to dataframe but have no columns
     with pytest.raises(MlflowException) as ex:
         pyfunc_model.predict(pdf.values)
-    assert "Model input is missing columns" in str(ex)
+    assert "Model is missing inputs" in str(ex)
 
     # 9. dictionaries of str -> list/nparray work
     arr = np.array([1, 2, 3])
@@ -308,15 +309,178 @@ def test_schema_enforcement():
     }
     with pytest.raises(MlflowException) as ex:
         pyfunc_model.predict(d)
-    assert "This model contains a model signature, which suggests a DataFrame input." in str(ex)
+    assert "This model contains a column-based signature, which suggests a DataFrame input." in str(
+        ex
+    )
+
+
+def _compare_exact_tensor_dict_input(d1, d2):
+    """Return whether two dicts of np arrays are exactly equal"""
+    if d1.keys() != d2.keys():
+        return False
+    return all(np.array_equal(d1[key], d2[key]) for key in d1)
+
+
+def test_tensor_multi_named_schema_enforcement():
+    m = Model()
+    input_schema = Schema(
+        [
+            TensorSpec(np.dtype(np.uint64), (-1, 5), "a"),
+            TensorSpec(np.dtype(np.short), (-1, 2), "b"),
+            TensorSpec(np.dtype(np.float32), (2, -1, 2), "c"),
+        ]
+    )
+    m.signature = ModelSignature(inputs=input_schema)
+    pyfunc_model = PyFuncModel(model_meta=m, model_impl=TestModel())
+    inp = {
+        "a": np.array([[0, 0, 0, 0, 0], [1, 1, 1, 1, 1]], dtype=np.uint64),
+        "b": np.array([[0, 0], [1, 1], [2, 2]], dtype=np.short),
+        "c": np.array([[[0, 0], [1, 1]], [[2, 2], [3, 3]]], dtype=np.float32),
+    }
+
+    # test that missing column raises
+    inp1 = {k: v for k, v in inp.items()}
+    with pytest.raises(MlflowException) as ex:
+        pyfunc_model.predict(inp1.pop("b"))
+    assert "Model is missing inputs" in str(ex)
+
+    # test that extra column is ignored
+    inp2 = {k: v for k, v in inp.items()}
+    inp2["x"] = 1
+
+    # test that extra column is removed
+    res = pyfunc_model.predict(inp2)
+    assert res == {k: v for k, v in inp.items() if k in {"a", "b", "c"}}
+    expected_types = dict(zip(input_schema.input_names(), input_schema.input_types()))
+    actual_types = {k: v.dtype for k, v in res.items()}
+    assert expected_types == actual_types
+
+    # test that variable axes are supported
+    inp3 = {
+        "a": np.array([[0, 0, 0, 0, 0], [1, 1, 1, 1, 1], [2, 2, 2, 2, 2]], dtype=np.uint64),
+        "b": np.array([[0, 0], [1, 1]], dtype=np.short),
+        "c": np.array([[[0, 0]], [[2, 2]]], dtype=np.float32),
+    }
+    res = pyfunc_model.predict(inp3)
+    assert _compare_exact_tensor_dict_input(res, inp3)
+    expected_types = dict(zip(input_schema.input_names(), input_schema.input_types()))
+    actual_types = {k: v.dtype for k, v in res.items()}
+    assert expected_types == actual_types
+
+    # test that type casting is not supported
+    inp4 = {k: v for k, v in inp.items()}
+    inp4["a"] = inp4["a"].astype(np.int32)
+    with pytest.raises(MlflowException) as ex:
+        pyfunc_model.predict(inp4)
+    assert "dtype of input int32 does not match expected dtype uint64" in str(ex)
+
+    # test wrong shape
+    inp5 = {
+        "a": np.array([[0, 0, 0, 0]], dtype=np.uint),
+        "b": np.array([[0, 0], [1, 1]], dtype=np.short),
+        "c": np.array([[[0, 0]]], dtype=np.float32),
+    }
+    with pytest.raises(MlflowException) as ex:
+        pyfunc_model.predict(inp5)
+    assert "Shape of input (1, 4) does not match expected shape (-1, 5)" in str(ex)
+
+    # test non-dictionary input
+    inp6 = [
+        np.array([[0, 0, 0, 0, 0]], dtype=np.uint64),
+        np.array([[0, 0], [1, 1]], dtype=np.short),
+        np.array([[[0, 0]]], dtype=np.float32),
+    ]
+    with pytest.raises(MlflowException) as ex:
+        pyfunc_model.predict(inp6)
+    assert "Model is missing inputs ['a', 'b', 'c']." in str(ex)
+
+    # test empty ndarray does not work
+    inp7 = {k: v for k, v in inp.items()}
+    inp7["a"] = np.array([])
+    with pytest.raises(MlflowException) as ex:
+        pyfunc_model.predict(inp7)
+    assert "Shape of input (0,) does not match expected shape" in str(ex)
+
+    # test dictionary of str -> list does not work
+    inp8 = {k: list(v) for k, v in inp.items()}
+    with pytest.raises(MlflowException) as ex:
+        pyfunc_model.predict(inp8)
+    assert "This model contains a tensor-based model signature with input names" in str(ex)
+    assert (
+        "suggests a dictionary input mapping input name to a numpy array, but a dict"
+        " with value type <class 'list'> was found"
+    ) in str(ex)
+
+    # test dataframe input fails at shape enforcement
+    pdf = pd.DataFrame(data=[[1, 2, 3]], columns=["a", "b", "c"],)
+    pdf["a"] = pdf["a"].astype(np.uint64)
+    pdf["b"] = pdf["b"].astype(np.short)
+    pdf["c"] = pdf["c"].astype(np.float32)
+    with pytest.raises(MlflowException) as ex:
+        pyfunc_model.predict(pdf)
+    assert "Shape of input (1,) does not match expected shape (-1, 5)" in str(ex)
+
+
+def test_schema_enforcement_single_named_tensor_schema():
+    m = Model()
+    input_schema = Schema([TensorSpec(np.dtype(np.uint64), (-1, 2), "a")])
+    m.signature = ModelSignature(inputs=input_schema)
+    pyfunc_model = PyFuncModel(model_meta=m, model_impl=TestModel())
+    inp = {
+        "a": np.array([[0, 0], [1, 1]], dtype=np.uint64),
+    }
+
+    # sanity test that dictionary with correct input works
+    res = pyfunc_model.predict(inp)
+    assert res == inp
+    expected_types = dict(zip(input_schema.input_names(), input_schema.input_types()))
+    actual_types = {k: v.dtype for k, v in res.items()}
+    assert expected_types == actual_types
+
+    # test single np.ndarray input works and is converted to dictionary
+    res = pyfunc_model.predict(inp["a"])
+    assert res == inp
+    expected_types = dict(zip(input_schema.input_names(), input_schema.input_types()))
+    actual_types = {k: v.dtype for k, v in res.items()}
+    assert expected_types == actual_types
+
+    # test list does not work
+    with pytest.raises(MlflowException) as ex:
+        pyfunc_model.predict([[0, 0], [1, 1]])
+    assert "Model is missing inputs ['a']" in str(ex)
+
+
+def test_schema_enforcement_named_tensor_schema_1d():
+    m = Model()
+    input_schema = Schema(
+        [TensorSpec(np.dtype(np.uint64), (-1,), "a"), TensorSpec(np.dtype(np.float32), (-1,), "b"),]
+    )
+    m.signature = ModelSignature(inputs=input_schema)
+    pyfunc_model = PyFuncModel(model_meta=m, model_impl=TestModel())
+    pdf = pd.DataFrame(data=[[0, 0], [1, 1]], columns=["a", "b"])
+    pdf["a"] = pdf["a"].astype(np.uint64)
+    pdf["b"] = pdf["a"].astype(np.float32)
+    d_inp = {
+        "a": np.array(pdf["a"], dtype=np.uint64),
+        "b": np.array(pdf["b"], dtype=np.float32),
+    }
+
+    # test dataframe input works for 1d tensor specs and input is converted to dict
+    res = pyfunc_model.predict(pdf)
+    assert _compare_exact_tensor_dict_input(res, d_inp)
+    expected_types = dict(zip(input_schema.input_names(), input_schema.input_types()))
+    actual_types = {k: v.dtype for k, v in res.items()}
+    assert expected_types == actual_types
+
+    # test that dictionary works too
+    res = pyfunc_model.predict(d_inp)
+    assert res == d_inp
+    expected_types = dict(zip(input_schema.input_names(), input_schema.input_types()))
+    actual_types = {k: v.dtype for k, v in res.items()}
+    assert expected_types == actual_types
 
 
 def test_missing_value_hint_is_displayed_when_it_should():
-    class TestModel(object):
-        @staticmethod
-        def predict(pdf):
-            return pdf
-
     m = Model()
     input_schema = Schema([ColSpec("integer", "a")])
     m.signature = ModelSignature(inputs=input_schema)
@@ -339,12 +503,7 @@ def test_missing_value_hint_is_displayed_when_it_should():
     assert hint not in str(ex.value.message)
 
 
-def test_schema_enforcement_no_col_names():
-    class TestModel(object):
-        @staticmethod
-        def predict(pdf):
-            return pdf
-
+def test_column_schema_enforcement_no_col_names():
     m = Model()
     input_schema = Schema([ColSpec("double"), ColSpec("double"), ColSpec("double")])
     m.signature = ModelSignature(inputs=input_schema)
@@ -367,7 +526,7 @@ def test_schema_enforcement_no_col_names():
     # Must provide the right number of arguments
     with pytest.raises(MlflowException) as ex:
         pyfunc_model.predict([[1.0, 2.0]])
-    assert "the provided input only has 2 columns." in str(ex)
+    assert "the provided value only has 2 inputs." in str(ex)
 
     # Must provide the right types
     with pytest.raises(MlflowException) as ex:
@@ -382,6 +541,49 @@ def test_schema_enforcement_no_col_names():
     # 9. dictionaries of str -> list/nparray work
     d = {"a": [1.0], "b": [2.0], "c": [3.0]}
     assert pyfunc_model.predict(d).equals(pd.DataFrame(d))
+
+
+def test_tensor_schema_enforcement_no_col_names():
+    m = Model()
+    input_schema = Schema([TensorSpec(np.dtype(np.float32), (-1, 3))])
+    m.signature = ModelSignature(inputs=input_schema)
+    pyfunc_model = PyFuncModel(model_meta=m, model_impl=TestModel())
+    test_data = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], dtype=np.float32)
+
+    # Can call with numpy array of correct shape
+    assert np.array_equal(pyfunc_model.predict(test_data), test_data)
+
+    # Or can call with a dataframe
+    assert np.array_equal(pyfunc_model.predict(pd.DataFrame(test_data)), test_data)
+
+    # Can not call with a list
+    with pytest.raises(MlflowException) as ex:
+        pyfunc_model.predict([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    assert "This model contains a tensor-based model signature with no input names" in str(ex)
+
+    # Can not call with a dict
+    with pytest.raises(MlflowException) as ex:
+        pyfunc_model.predict({"blah": test_data})
+    assert "This model contains a tensor-based model signature with no input names" in str(ex)
+
+    # Can not call with a np.ndarray of a wrong shape
+    with pytest.raises(MlflowException) as ex:
+        pyfunc_model.predict(np.array([[1.0, 2.0], [4.0, 5.0]]))
+    assert "Shape of input (2, 2) does not match expected shape (-1, 3)" in str(ex)
+
+    # Can not call with a np.ndarray of a wrong type
+    with pytest.raises(MlflowException) as ex:
+        pyfunc_model.predict(test_data.astype(np.uint32))
+    assert "dtype of input uint32 does not match expected dtype float32" in str(ex)
+
+    # Can call with a np.ndarray with more elements along variable axis
+    test_data2 = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]], dtype=np.float32)
+    assert np.array_equal(pyfunc_model.predict(test_data2), test_data2)
+
+    # Can not call with an empty ndarray
+    with pytest.raises(MlflowException) as ex:
+        pyfunc_model.predict(np.ndarray([]))
+    assert "Shape of input () does not match expected shape (-1, 3)" in str(ex)
 
 
 @pytest.mark.large

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -871,46 +871,45 @@ def test_autolog_does_not_throw_when_mlflow_logging_fails(func_to_fail):
         mock_func.assert_called_once()
 
 
-# TODO : @wendyhu/@arjundc uncomment this test in enforcement PR
-# @pytest.mark.parametrize("data_type", [pd.DataFrame, np.array])
-# def test_autolog_logs_signature_and_input_example(data_type):
-#     mlflow.sklearn.autolog(log_input_examples=True, log_model_signatures=True)
-#
-#     X, y = get_iris()
-#     X = data_type(X)
-#     y = data_type(y)
-#     model = sklearn.linear_model.LinearRegression()
-#
-#     with mlflow.start_run() as run:
-#         model.fit(X, y)
-#         model_path = os.path.join(run.info.artifact_uri, MODEL_DIR)
-#
-#     model_conf = get_model_conf(run.info.artifact_uri)
-#     input_example = _read_example(model_conf, model_path)
-#     pyfunc_model = mlflow.pyfunc.load_model(model_path)
-#
-#     assert model_conf.signature == infer_signature(X, model.predict(X[:5]))
-#
-#     # On GitHub Actions, `pyfunc_model.predict` and `model.predict` sometimes return
-#     # slightly different results:
-#     #
-#     # >>> pyfunc_model.predict(input_example)
-#     # [[0.171504346208176  ]
-#     #  [0.34346150441640155]  <- diff
-#     #  [0.06895096846585114]  <- diff
-#     #  [0.05925789882165455]
-#     #  [0.03424907823290102]]
-#     #
-#     # >>> model.predict(X[:5])
-#     # [[0.171504346208176  ]
-#     #  [0.3434615044164018 ]  <- diff
-#     #  [0.06895096846585136]  <- diff
-#     #  [0.05925789882165455]
-#     #  [0.03424907823290102]]
-#     #
-#     # As a workaround, use `assert_array_almost_equal` instead of `assert_array_equal`
-#     np.testing.assert_array_almost_equal(pyfunc_model.predict(input_example),
-#     model.predict(X[:5]))
+@pytest.mark.parametrize("data_type", [pd.DataFrame, np.array])
+def test_autolog_logs_signature_and_input_example(data_type):
+    mlflow.sklearn.autolog(log_input_examples=True, log_model_signatures=True)
+
+    X, y = get_iris()
+    X = data_type(X)
+    y = data_type(y)
+    model = sklearn.linear_model.LinearRegression()
+
+    with mlflow.start_run() as run:
+        model.fit(X, y)
+        model_path = os.path.join(run.info.artifact_uri, MODEL_DIR)
+
+    model_conf = get_model_conf(run.info.artifact_uri)
+    input_example = _read_example(model_conf, model_path)
+    pyfunc_model = mlflow.pyfunc.load_model(model_path)
+
+    assert model_conf.signature == infer_signature(X, model.predict(X[:5]))
+
+    # On GitHub Actions, `pyfunc_model.predict` and `model.predict` sometimes return
+    # slightly different results:
+    #
+    # >>> pyfunc_model.predict(input_example)
+    # [[0.171504346208176  ]
+    #  [0.34346150441640155]  <- diff
+    #  [0.06895096846585114]  <- diff
+    #  [0.05925789882165455]
+    #  [0.03424907823290102]]
+    #
+    # >>> model.predict(X[:5])
+    # [[0.171504346208176  ]
+    #  [0.3434615044164018 ]  <- diff
+    #  [0.06895096846585136]  <- diff
+    #  [0.05925789882165455]
+    #  [0.03424907823290102]]
+    #
+    # As a workaround, use `assert_array_almost_equal` instead of `assert_array_equal`
+    np.testing.assert_array_almost_equal(pyfunc_model.predict(input_example),
+    model.predict(X[:5]))
 
 
 def test_autolog_does_not_throw_when_failing_to_sample_X():

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -908,8 +908,7 @@ def test_autolog_logs_signature_and_input_example(data_type):
     #  [0.03424907823290102]]
     #
     # As a workaround, use `assert_array_almost_equal` instead of `assert_array_equal`
-    np.testing.assert_array_almost_equal(pyfunc_model.predict(input_example),
-    model.predict(X[:5]))
+    np.testing.assert_array_almost_equal(pyfunc_model.predict(input_example), model.predict(X[:5]))
 
 
 def test_autolog_does_not_throw_when_failing_to_sample_X():


### PR DESCRIPTION
## What changes are proposed in this pull request?

Schema enforcement is performed against models with tensor-based signatures (`TensorSpec`s). The input's names, dtype, and shape is checked against expected values from the model signature.

## How is this patch tested?

Added unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
Schema enforcement is performed against models with tensor-based signatures (`TensorSpec`s). The input's names, dtype, and shape is checked against expected values from the model signature.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
