### PR TITLE
Don't clear spark autologging tags between runs

### DIFF
--- a/mlflow/_spark_autologging.py
+++ b/mlflow/_spark_autologging.py
@@ -241,7 +241,7 @@ class SparkAutologgingContext(RunContextProvider):
                 if info not in seen:
                     unique_infos.append(info)
                     seen.add(info)
-            if len(_table_infos) > 0:
+            if len(unique_infos) > 0:
                 tags = {
                     _SPARK_TABLE_INFO_TAG_NAME: "\n".join(
                         [_get_table_info_string(*info) for info in unique_infos]
@@ -249,5 +249,4 @@ class SparkAutologgingContext(RunContextProvider):
                 }
             else:
                 tags = {}
-            _table_infos = []
             return tags

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -696,7 +696,7 @@ def autolog(disable=False):  # pylint: disable=unused-argument
 
     Datasource information is cached in memory and logged to all subsequent MLflow runs,
     including the active MLflow run (if one exists when the data is read). Note that autologging of
-    Spark ML (MLlib) models is not currently supported via this API. Datasource-autologging is
+    Spark ML (MLlib) models is not currently supported via this API. Datasource autologging is
     best-effort, meaning that if Spark is under heavy load or MLflow logging fails for any reason
     (e.g., if the MLflow server is unavailable), logging may be dropped.
 

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -694,12 +694,11 @@ def autolog(disable=False):  # pylint: disable=unused-argument
     attached. It should be called on the Spark driver, not on the executors (i.e. do not call
     this method within a function parallelized by Spark). This API requires Spark 3.0 or above.
 
-    Datasource information is logged under the current active MLflow run. If no active run
-    exists, datasource information is cached in memory & logged to the next-created active run
-    (but not to successive runs). Note that autologging of Spark ML (MLlib) models is not currently
-    supported via this API. Datasource-autologging is best-effort, meaning that if Spark is under
-    heavy load or MLflow logging fails for any reason (e.g., if the MLflow server is unavailable),
-    logging may be dropped.
+    Data source information is cached in memory and logged to all subsequent MLflow runs,
+    including the active MLflow run (if one exists when the data is read). Note that autologging of
+    Spark ML (MLlib) models is not currently supported via this API. Datasource-autologging is
+    best-effort, meaning that if Spark is under heavy load or MLflow logging fails for any reason
+    (e.g., if the MLflow server is unavailable), logging may be dropped.
 
     For any unexpected issues with autologging, check Spark driver and executor logs in addition
     to stderr & stdout generated from your MLflow code - datasource information is pulled from

--- a/mlflow/spark.py
+++ b/mlflow/spark.py
@@ -694,7 +694,7 @@ def autolog(disable=False):  # pylint: disable=unused-argument
     attached. It should be called on the Spark driver, not on the executors (i.e. do not call
     this method within a function parallelized by Spark). This API requires Spark 3.0 or above.
 
-    Data source information is cached in memory and logged to all subsequent MLflow runs,
+    Datasource information is cached in memory and logged to all subsequent MLflow runs,
     including the active MLflow run (if one exists when the data is read). Note that autologging of
     Spark ML (MLlib) models is not currently supported via this API. Datasource-autologging is
     best-effort, meaning that if Spark is under heavy load or MLflow logging fails for any reason


### PR DESCRIPTION
## What changes are proposed in this pull request?

Presently, Spark datasource information is only applied to the next MLflow run that's created. All subsequent runs do not collect this information. For example:

```
df = read_spark_df(...)

with mlflow.start_run() as run1: # Logs spark datasource information for `df`
    train_model_1(df)

with mlflow.start_run() as run2: # Does not log spark datasource information for `df`
    train_model_2(df)
```

With this change applied, `run1` *and* `run2` will contain the datasource information for `df`.

## How is this patch tested?

Included unit / integration tests

## Release Notes

Spark datasource autologging: datasource information is now added to all MLflow runs. Previously, after loading Spark data, datasource information was only added to the next MLflow run and not to any subsequent runs.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
