### PR TITLE
[bug-fix] Fix KubernetesSubmittedRun.get_status() (#3962)

### DIFF
--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -119,7 +119,9 @@ class KubernetesSubmittedRun(SubmittedRun):
 
         return self._status == RunStatus.FINISHED
 
-    def _update_status(self, kube_api=kubernetes.client.BatchV1Api()):
+    def _update_status(self, kube_api=None):
+        if not kube_api:
+            kube_api = kubernetes.client.BatchV1Api()
         api_response = kube_api.read_namespaced_job_status(
             name=self._job_name, namespace=self._job_namespace, pretty=True
         )


### PR DESCRIPTION
Signed-off-by: Juan Casse <jcasse@gmail.com>

## What changes are proposed in this pull request?

When submitting an MLflow run to a Kubernetes cluster whose URL hots name is something other than 'localhost', `KubernetesSubmittedRun.get_status()` raises the following exception
`urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='localhost', port=80)`
The `KubernetesSubmittedRun` class has a bug that does not allow it to use the proper Kubernetes host name. Notice in the exception that `host=localhost`. The code only uses 'localhost' as the host for Kubernetes when calling `get_status()`.

(Please fill in changes proposed in this fix)
Change
`def _update_status(self, kube_api=kubernetes.client.BatchV1Api()):`
to
```
def _update_status(self, kube_api=None):
    if not kube_api:
        kube_api = kubernetes.client.BatchV1Api()
```

## How is this patch tested?

Set up Kubernetes or minikube with a URL host that is NOT 'localhost'. Submit an MLflow run to it using
`mlflow_submitted_run = mlflow.projects.run()`
Once the function returns, get run status
`status = mlflow_submitted_run.get_status()`
If the run status is returned, then it works. Otherwise, the exception described above is raised.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

Fixes the following bug: When submitting an MLflow run to a Kubernetes cluster whose URL hots name is something other than 'localhost', `KubernetesSubmittedRun.get_status()` raises the following exception
`urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='localhost', port=80)`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages
- [x] `language/python`: Python APISs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations
- [x] `integrations/kubernetes`: Kubernetes integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
