### PR TITLE
Fix issues related to `bert_classification.py`

### DIFF
--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -114,7 +114,16 @@ class BertDataModule(pl.LightningDataModule):
         :param stage: Stage - training or testing
         """
         # reading  the input
-        dataset_tar = download_from_url(URLS["AG_NEWS"], root=".data")
+        # Workaround for this issue: https://github.com/pytorch/text/pull/1150
+        max_attempts = 5
+        for attempt in range(1, max_attempts + 1):
+            try:
+                dataset_tar = download_from_url(URLS["AG_NEWS"], root=".data")
+                break
+            except Exception as e:
+                print("Attempt {}/{} failed: {}".format(attempt, max_attempts, e))
+        else:
+            raise Exception("All attempts failed")
         extracted_files = extract_archive(dataset_tar)
 
         train_csv_path = None

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -114,7 +114,7 @@ class BertDataModule(pl.LightningDataModule):
         :param stage: Stage - training or testing
         """
         # reading  the input
-        # Workaround for this issue: https://github.com/pytorch/text/pull/1150
+        # `torchtext.download_from_url` is flaky: https://github.com/pytorch/text/pull/1150
         max_attempts = 5
         for attempt in range(1, max_attempts + 1):
             try:

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -3,6 +3,7 @@
 # pylint: disable=abstract-method
 
 import os
+import time
 from argparse import ArgumentParser
 import mlflow.pytorch
 import numpy as np
@@ -122,6 +123,7 @@ class BertDataModule(pl.LightningDataModule):
                 break
             except Exception as e:
                 print("Attempt {}/{} failed: {}".format(attempt, max_attempts, e))
+                time.sleep(10)
         else:
             raise Exception("All attempts failed")
         extracted_files = extract_archive(dataset_tar)

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -57,6 +57,14 @@ def replace_mlflow_with_dev_version(yml_path):
 
 
 @pytest.fixture(scope="function", autouse=True)
+def clean_envs_and_cache(capsys):
+    yield
+
+    if get_free_disk_space() < 5.0:  # unit: GiB
+        process.exec_cmd(["./dev/remove-conda-envs.sh"])[1]
+
+
+@pytest.fixture(scope="function", autouse=True)
 def report_free_disk_space(capsys):
     yield
 
@@ -114,10 +122,6 @@ def test_mlflow_run_example(directory, params, tmpdir):
 
     cli_run_list = [tmp_example_dir] + params
     invoke_cli_runner(cli.run, cli_run_list)
-
-    if get_free_disk_space() < 5.0:  # unit: GiB
-        stdout = process.exec_cmd(["./dev/remove-conda-envs.sh"])[1]
-        print(stdout)
 
 
 @pytest.mark.large

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -60,7 +60,7 @@ def replace_mlflow_with_dev_version(yml_path):
 def clean_envs_and_cache():
     yield
 
-    if get_free_disk_space() < 5.0:  # unit: GiB
+    if get_free_disk_space() < 7.0:  # unit: GiB
         process.exec_cmd(["./dev/remove-conda-envs.sh"])
 
 

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -61,7 +61,7 @@ def clean_envs_and_cache():
     yield
 
     if get_free_disk_space() < 5.0:  # unit: GiB
-        process.exec_cmd(["./dev/remove-conda-envs.sh"])[1]
+        process.exec_cmd(["./dev/remove-conda-envs.sh"])
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -112,12 +112,12 @@ def test_mlflow_run_example(directory, params, tmpdir):
     for env in envs_to_remove:
         remove_conda_env(env)
 
+    cli_run_list = [tmp_example_dir] + params
+    invoke_cli_runner(cli.run, cli_run_list)
+
     if get_free_disk_space() < 5.0:  # unit: GiB
         stdout = process.exec_cmd(["./dev/remove-conda-envs.sh"])[1]
         print(stdout)
-
-    cli_run_list = [tmp_example_dir] + params
-    invoke_cli_runner(cli.run, cli_run_list)
 
 
 @pytest.mark.large

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -57,7 +57,7 @@ def replace_mlflow_with_dev_version(yml_path):
 
 
 @pytest.fixture(scope="function", autouse=True)
-def clean_envs_and_cache(capsys):
+def clean_envs_and_cache():
     yield
 
     if get_free_disk_space() < 5.0:  # unit: GiB

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -112,6 +112,10 @@ def test_mlflow_run_example(directory, params, tmpdir):
     for env in envs_to_remove:
         remove_conda_env(env)
 
+    if get_free_disk_space() < 5.0:  # unit: GiB
+        stdout = process.exec_cmd(["./dev/remove-conda-envs.sh"])[1]
+        print(stdout)
+
     cli_run_list = [tmp_example_dir] + params
     invoke_cli_runner(cli.run, cli_run_list)
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix the following issues:
- `torchtext.download_url` is flaky.
- The `BertNewsClassification` example consumes a large amount of disk space. This might result in `no-disk-space-left` errors in the subsequent tests.

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
