### PR TITLE
Captured Tensorboard log in autologging for tf.Estimator APIs

### DIFF
--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -914,12 +914,13 @@ def autolog(
         result = original(self, *args, **kwargs)
         # Logs Tensorboard to artifacts.
         for file in os.listdir(self.model_dir):
-            if 'tfevents' not in file:
+            if "tfevents" not in file:
                 continue
-            try_mlflow_log(mlflow.log_artifact,
-                           local_path=os.path.join(self.model_dir, file),
-                           artifact_path="tensorboard_logs",
-                           )
+            try_mlflow_log(
+                mlflow.log_artifact,
+                local_path=os.path.join(self.model_dir, file),
+                artifact_path="tensorboard_logs",
+            )
         return result
 
     def export_saved_model(original, self, *args, **kwargs):

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -912,7 +912,14 @@ def autolog(
             try_mlflow_log(mlflow.log_param, "max_steps", kwargs["max_steps"])
 
         result = original(self, *args, **kwargs)
-
+        # Logs Tensorboard to artifacts.
+        for file in os.listdir(self.model_dir):
+            if 'tfevents' not in file:
+                continue
+            try_mlflow_log(mlflow.log_artifact,
+                           local_path=os.path.join(self.model_dir, file),
+                           artifact_path="tensorboard_logs",
+                           )
         return result
 
     def export_saved_model(original, self, *args, **kwargs):
@@ -1040,7 +1047,6 @@ def autolog(
                     )
 
                 _log_early_stop_callback_params(early_stop_callback)
-
                 history = original(inst, *args, **kwargs)
 
                 _log_early_stop_callback_metrics(early_stop_callback, history, metrics_logger)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -912,7 +912,7 @@ def autolog(
             try_mlflow_log(mlflow.log_param, "max_steps", kwargs["max_steps"])
 
         result = original(self, *args, **kwargs)
-        # Logs Tensorboard to artifacts.
+        # Log Tensorboard event files as artifacts
         for file in os.listdir(self.model_dir):
             if "tfevents" not in file:
                 continue

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -913,14 +913,15 @@ def autolog(
 
         result = original(self, *args, **kwargs)
         # Log Tensorboard event files as artifacts
-        for file in os.listdir(self.model_dir):
-            if "tfevents" not in file:
-                continue
-            try_mlflow_log(
-                mlflow.log_artifact,
-                local_path=os.path.join(self.model_dir, file),
-                artifact_path="tensorboard_logs",
-            )
+        if os.path.exists(self.model_dir):
+            for file in os.listdir(self.model_dir):
+                if "tfevents" not in file:
+                    continue
+                try_mlflow_log(
+                    mlflow.log_artifact,
+                    local_path=os.path.join(self.model_dir, file),
+                    artifact_path="tensorboard_logs",
+                )
         return result
 
     def export_saved_model(original, self, *args, **kwargs):

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -606,6 +606,14 @@ def test_tf_estimator_autolog_logs_metrics(tf_estimator_random_data_run):
 
 
 @pytest.mark.large
+@pytest.mark.parametrize("export", [True, False])
+def test_tf_estimator_autolog_logs_tensorboard_logs(tf_estimator_random_data_run):
+    client = mlflow.tracking.MlflowClient()
+    artifacts = client.list_artifacts(tf_estimator_random_data_run.info.run_id)
+    assert any(['tensorboard_logs' in a.path and a.is_dir for a in artifacts])
+
+
+@pytest.mark.large
 def test_tf_estimator_autolog_logs_metrics_in_exclusive_mode(tmpdir):
     mlflow.tensorflow.autolog(exclusive=True)
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -610,7 +610,7 @@ def test_tf_estimator_autolog_logs_metrics(tf_estimator_random_data_run):
 def test_tf_estimator_autolog_logs_tensorboard_logs(tf_estimator_random_data_run):
     client = mlflow.tracking.MlflowClient()
     artifacts = client.list_artifacts(tf_estimator_random_data_run.info.run_id)
-    assert any(['tensorboard_logs' in a.path and a.is_dir for a in artifacts])
+    assert any(["tensorboard_logs" in a.path and a.is_dir for a in artifacts])
 
 
 @pytest.mark.large

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -542,7 +542,7 @@ def test_tf_estimator_autolog_logs_metrics(tf_estimator_random_data_run):
 def test_tf_estimator_autolog_logs_tensorboard_logs(tf_estimator_random_data_run):
     client = mlflow.tracking.MlflowClient()
     artifacts = client.list_artifacts(tf_estimator_random_data_run.info.run_id)
-    assert any(['tensorboard_logs' in a.path and a.is_dir for a in artifacts])
+    assert any(["tensorboard_logs" in a.path and a.is_dir for a in artifacts])
 
 
 @pytest.mark.large

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -538,6 +538,14 @@ def test_tf_estimator_autolog_logs_metrics(tf_estimator_random_data_run):
 
 
 @pytest.mark.large
+@pytest.mark.parametrize("export", [True, False])
+def test_tf_estimator_autolog_logs_tensorboard_logs(tf_estimator_random_data_run):
+    client = mlflow.tracking.MlflowClient()
+    artifacts = client.list_artifacts(tf_estimator_random_data_run.info.run_id)
+    assert any(['tensorboard_logs' in a.path and a.is_dir for a in artifacts])
+
+
+@pytest.mark.large
 @pytest.mark.parametrize("export", [True])
 def test_tf_estimator_autolog_model_can_load_from_artifact(tf_estimator_random_data_run):
     client = mlflow.tracking.MlflowClient()


### PR DESCRIPTION
## What changes are proposed in this pull request?
Added support for Tensorboard log in autologging with tf.Estimator.train() API.

## How is this patch tested?
1. Added 2 unit tests.
2. Tested and verified locally via mlflow ui.

## Release Notes
Training via Tensorflow Estimator APIs now saves Tensorboard logs in MLFlow tracking when autologging is enabled.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
