### PR TITLE
Use `20newsgroups` dataset instead of `AG_NEWS` in `best_classification.py` + Fix no-disk-space-left issue in `test_examples.py`

### DIFF
--- a/examples/pytorch/BertNewsClassification/MLproject
+++ b/examples/pytorch/BertNewsClassification/MLproject
@@ -12,7 +12,7 @@ entry_points:
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
       num_samples: {type: int, default: 15000}
-      dataset: {type: int, default: "20newsgroups"}
+      dataset: {type: str, default: "20newsgroups"}
 
     command: |
           python bert_classification.py \

--- a/examples/pytorch/BertNewsClassification/MLproject
+++ b/examples/pytorch/BertNewsClassification/MLproject
@@ -12,6 +12,7 @@ entry_points:
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
       num_samples: {type: int, default: 15000}
+      dataset: {type: int, default: "20news"}
 
     command: |
           python bert_classification.py \
@@ -21,4 +22,5 @@ entry_points:
             --batch_size {batch_size} \
             --num_workers {num_workers} \
             --num_samples {num_samples} \
-            --lr {learning_rate}
+            --lr {learning_rate} \
+            --dataset {dataset}

--- a/examples/pytorch/BertNewsClassification/MLproject
+++ b/examples/pytorch/BertNewsClassification/MLproject
@@ -12,7 +12,7 @@ entry_points:
       num_workers: {type: int, default: 3}
       learning_rate: {type: float, default: 0.001}
       num_samples: {type: int, default: 15000}
-      dataset: {type: int, default: "20news"}
+      dataset: {type: int, default: "20newsgroups"}
 
     command: |
           python bert_classification.py \

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -126,9 +126,10 @@ class BertDataModule(pl.LightningDataModule):
         """
 
         num_samples = self.args["num_samples"]
-        dataset = self.args["dataset"]
         df = (
-            get_20newsgroups(num_samples) if dataset == "20newsgroups" else get_ag_news(num_samples)
+            get_20newsgroups(num_samples)
+            if self.args["dataset"] == "20newsgroups"
+            else get_ag_news(num_samples)
         )
 
         self.tokenizer = BertTokenizer.from_pretrained(self.PRE_TRAINED_MODEL_NAME)
@@ -236,7 +237,12 @@ class BertNewsClassifier(pl.LightningModule):
             param.requires_grad = False
         self.drop = nn.Dropout(p=0.2)
         # assigning labels
-        n_classes = 4
+        self.class_names = (
+            ["alt.atheism", "talk.religion.misc", "comp.graphics", "sci.space"]
+            if kwargs["dataset"] == "20newsgroups"
+            else ["world", "Sports", "Business", "Sci/Tech"]
+        )
+        n_classes = len(self.class_names)
 
         self.fc1 = nn.Linear(self.bert_model.config.hidden_size, 512)
         self.out = nn.Linear(512, n_classes)

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -37,7 +37,7 @@ def get_ag_news(num_samples):
     train_csv_path = list(filter(lambda x: x.endswith("train.csv"), extracted_files))[0]
     return (
         pd.read_csv(train_csv_path, usecols=[0, 2], names=["label", "description"])
-        .assign(label=lambda df: df["label"] - 1)
+        .assign(label=lambda df: df["label"] - 1)  # make labels zero-based
         .sample(n=num_samples)
     )
 

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -17,6 +17,7 @@ from pytorch_lightning.callbacks import (
 )
 from sklearn.metrics import accuracy_score
 from sklearn.model_selection import train_test_split
+from sklearn.datasets import fetch_20newsgroups
 from torch import nn
 from torch.utils.data import Dataset, DataLoader
 from transformers import BertModel, BertTokenizer, AdamW
@@ -24,7 +25,24 @@ from torchtext.utils import download_from_url, extract_archive
 from torchtext.datasets.text_classification import URLS
 
 
-class AGNewsDataset(Dataset):
+def get_20newsgroups(num_samples):
+    categories = ["alt.atheism", "talk.religion.misc", "comp.graphics", "sci.space"]
+    X, y = fetch_20newsgroups(subset="train", categories=categories, return_X_y=True)
+    return pd.DataFrame(data=X, columns=["description"]).assign(label=y).sample(n=num_samples)
+
+
+def get_ag_news(num_samples):
+    dataset_tar = download_from_url(URLS["AG_NEWS"], root=".data")
+    extracted_files = extract_archive(dataset_tar)
+    train_csv_path = list(filter(lambda x: x.endswith("train.csv"), extracted_files))[0]
+    return (
+        pd.read_csv(train_csv_path, usecols=[0, 2], names=["label", "description"])
+        .assign(label=lambda df: df["label"] - 1)
+        .sample(n=num_samples)
+    )
+
+
+class NewsDataset(Dataset):
     def __init__(self, reviews, targets, tokenizer, max_length):
         """
         Performs initialization of tokenizer
@@ -95,13 +113,6 @@ class BertDataModule(pl.LightningDataModule):
         self.tokenizer = None
         self.args = kwargs
 
-    def to_label(self, rating):
-        """
-        Returns the rating minus one to make it for zero position start
-        """
-        rating = int(rating)
-        return rating - 1
-
     def prepare_data(self):
         """
         Implementation of abstract class
@@ -113,22 +124,12 @@ class BertDataModule(pl.LightningDataModule):
 
         :param stage: Stage - training or testing
         """
-        # reading  the input
-        dataset_tar = download_from_url(URLS["AG_NEWS"], root=".data")
-        extracted_files = extract_archive(dataset_tar)
 
-        train_csv_path = None
-        for fname in extracted_files:
-            if fname.endswith("train.csv"):
-                train_csv_path = fname
-
-        df = pd.read_csv(train_csv_path)
-
-        df.columns = ["label", "title", "description"]
-        df.sample(frac=1)
-        df = df.iloc[: self.args["num_samples"]]
-
-        df["label"] = df.label.apply(self.to_label)
+        num_samples = self.args["num_samples"]
+        dataset = self.args["dataset"]
+        df = (
+            get_20newsgroups(num_samples) if dataset == "20newsgroups" else get_ag_news(num_samples)
+        )
 
         self.tokenizer = BertTokenizer.from_pretrained(self.PRE_TRAINED_MODEL_NAME)
 
@@ -184,7 +185,7 @@ class BertDataModule(pl.LightningDataModule):
 
         :return: Returns the constructed dataloader
         """
-        ds = AGNewsDataset(
+        ds = NewsDataset(
             reviews=df.description.to_numpy(),
             targets=df.label.to_numpy(),
             tokenizer=tokenizer,
@@ -235,8 +236,7 @@ class BertNewsClassifier(pl.LightningModule):
             param.requires_grad = False
         self.drop = nn.Dropout(p=0.2)
         # assigning labels
-        self.class_names = ["world", "Sports", "Business", "Sci/Tech"]
-        n_classes = len(self.class_names)
+        n_classes = 4
 
         self.fc1 = nn.Linear(self.bert_model.config.hidden_size, 512)
         self.out = nn.Linear(512, n_classes)
@@ -371,6 +371,13 @@ if __name__ == "__main__":
         default=15000,
         metavar="N",
         help="Number of samples to be used for training and evaluation steps (default: 15000) Maximum:100000",
+    )
+    parser.add_argument(
+        "--dataset",
+        default="20newsgroups",
+        metavar="DATASET",
+        help="Dataset to use",
+        choices=["20newsgroups", "ag_news"],
     )
 
     parser = pl.Trainer.add_argparse_args(parent_parser=parser)

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -102,7 +102,7 @@ def report_free_disk_space(capsys):
         (os.path.join("pytorch", "MNIST/example2"), ["-P", "max_epochs=1"]),
         (
             os.path.join("pytorch", "BertNewsClassification"),
-            ["-P", "max_epochs=1", "-P", "num_samples=100"],
+            ["-P", "max_epochs=1", "-P", "num_samples=100", "-P", "datasest=20newsgroups"],
         ),
     ],
 )

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -57,6 +57,14 @@ def replace_mlflow_with_dev_version(yml_path):
 
 
 @pytest.fixture(scope="function", autouse=True)
+def clean_envs_and_cache():
+    yield
+
+    if get_free_disk_space() < 7.0:  # unit: GiB
+        process.exec_cmd(["./dev/remove-conda-envs.sh"])
+
+
+@pytest.fixture(scope="function", autouse=True)
 def report_free_disk_space(capsys):
     yield
 

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -102,7 +102,7 @@ def report_free_disk_space(capsys):
         (os.path.join("pytorch", "MNIST/example2"), ["-P", "max_epochs=1"]),
         (
             os.path.join("pytorch", "BertNewsClassification"),
-            ["-P", "max_epochs=1", "-P", "num_samples=100", "-P", "datasest=20newsgroups"],
+            ["-P", "max_epochs=1", "-P", "num_samples=100", "-P", "dataset=20newsgroups"],
         ),
     ],
 )


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

In `bert_classification.py`, `torchtext.utils.download_from_url(URLS["AG_NEWS"], ...)` fails due to a quota-limit error in Google drive:

https://github.com/pytorch/text/pull/1150

As a workaround, use scikit-learn's `news20groups` instead

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
