### PR TITLE
Fix for universal autolog configs overriding integration-specific configs

### DIFF
--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1347,7 +1347,7 @@ def autolog(
             autolog_fn = LIBRARY_TO_AUTOLOG_FN[module.__name__]
 
             # Only call integration's autolog function with `mlflow.autolog` configs
-            # if the integration's autolog function has not already been called.
+            # if the integration's autolog function has not already been called by the user.
             # Logic is as follows:
             # - if a previous_config exists, that means either `mlflow.autolog` or
             #   `mlflow.integration.autolog` was called.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1300,6 +1300,24 @@ def autolog(
                   'training_mse': 1.9721522630525295e-31}
         tags: {'estimator_class': 'sklearn.linear_model._base.LinearRegression',
                'estimator_name': 'LinearRegression'}
+
+    Note that framework-specific configurations set at any poing will
+    take precedence over any configurations set by this function. For example:
+
+    .. code-block:: python
+        mlflow.autolog(log_models=False, exclusive=True)
+        import sklearn
+
+    would enable autologging for `sklearn` with `log_models=False` and `exclusive=True`,
+    but
+
+    .. code-block:: python
+        mlflow.autolog(log_models=False, exclusive=True)
+        import sklearn
+        mlflow.sklearn.autolog(log_models=True)
+
+    would enable autologging for `sklearn` with `log_models=True` and `exclusive=False`,
+    the latter resulting from the default value for `exclusive` in `mlflow.sklearn.autolog`.
     """
     from mlflow import (
         tensorflow,

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1305,6 +1305,7 @@ def autolog(
     take precedence over any configurations set by this function. For example:
 
     .. code-block:: python
+
         mlflow.autolog(log_models=False, exclusive=True)
         import sklearn
 
@@ -1312,6 +1313,7 @@ def autolog(
     but
 
     .. code-block:: python
+
         mlflow.autolog(log_models=False, exclusive=True)
         import sklearn
         mlflow.sklearn.autolog(log_models=True)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1233,6 +1233,29 @@ def autolog(
     See the :ref:`tracking docs <automatic-logging>` for a list of supported autologging
     integrations.
 
+    Note that framework-specific configurations set at any point will take precedence over
+    any configurations set by this function. For example:
+
+    .. code-block:: python
+
+        mlflow.autolog(log_models=False, exclusive=True)
+        import sklearn
+
+    would enable autologging for `sklearn` with `log_models=False` and `exclusive=True`,
+    but
+
+    .. code-block:: python
+
+        mlflow.autolog(log_models=False, exclusive=True)
+        import sklearn
+        mlflow.sklearn.autolog(log_models=True)
+
+    would enable autologging for `sklearn` with `log_models=True` and `exclusive=False`,
+    the latter resulting from the default value for `exclusive` in `mlflow.sklearn.autolog`;
+    other framework autolog functions (e.g. `mlflow.tensorflow.autolog`) would use the
+    configurations set by `mlflow.autolog` (in this instance, `log_models=False`, `exclusive=True`),
+    until they are explicitly called by the user.
+
     :param log_input_examples: If ``True``, input examples from training datasets are collected and
                                logged along with model artifacts during training. If ``False``,
                                input examples are not logged.
@@ -1300,26 +1323,6 @@ def autolog(
                   'training_mse': 1.9721522630525295e-31}
         tags: {'estimator_class': 'sklearn.linear_model._base.LinearRegression',
                'estimator_name': 'LinearRegression'}
-
-    Note that framework-specific configurations set at any point will
-    take precedence over any configurations set by this function. For example:
-
-    .. code-block:: python
-
-        mlflow.autolog(log_models=False, exclusive=True)
-        import sklearn
-
-    would enable autologging for `sklearn` with `log_models=False` and `exclusive=True`,
-    but
-
-    .. code-block:: python
-
-        mlflow.autolog(log_models=False, exclusive=True)
-        import sklearn
-        mlflow.sklearn.autolog(log_models=True)
-
-    would enable autologging for `sklearn` with `log_models=True` and `exclusive=False`,
-    the latter resulting from the default value for `exclusive` in `mlflow.sklearn.autolog`.
     """
     from mlflow import (
         tensorflow,

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1301,7 +1301,7 @@ def autolog(
         tags: {'estimator_class': 'sklearn.linear_model._base.LinearRegression',
                'estimator_name': 'LinearRegression'}
 
-    Note that framework-specific configurations set at any poing will
+    Note that framework-specific configurations set at any point will
     take precedence over any configurations set by this function. For example:
 
     .. code-block:: python

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -349,6 +349,9 @@ def autologging_integration(name):
             return _autolog(*args, **kwargs)
 
         wrapped_autolog = _update_wrapper_extended(autolog, _autolog)
+        # Set the autologging integration name as a function attribute on the wrapped autologging
+        # function, allowing the integration name to be extracted from the function. This is used
+        # during the execution of import hooks for `mlflow.autolog()`.
         wrapped_autolog.integration_name = name
         return wrapped_autolog
 

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -349,6 +349,7 @@ def autologging_integration(name):
             return _autolog(*args, **kwargs)
 
         wrapped_autolog = _update_wrapper_extended(autolog, _autolog)
+        wrapped_autolog.integration_name = name
         return wrapped_autolog
 
     return wrapper

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -208,7 +208,7 @@ def test_autolog_obeys_disabled():
     mlflow.autolog(disable=False)
     mlflow.utils.import_hooks.notify_module_loaded(sklearn)
     assert not get_autologging_config("sklearn", "disable", False)
-    mlflow.tensorflow.autolog(disable=True)
+    mlflow.sklearn.autolog(disable=True)
     assert get_autologging_config("sklearn", "disable")
 
 

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -194,18 +194,36 @@ def test_universal_autolog_makes_expected_event_logging_calls():
     assert {"disable": True, "exclusive": True}.items() <= call.call_kwargs.items()
 
 
+def test_autolog_obeys_disabled():
+    mlflow.autolog(disable=True)
+    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+    assert get_autologging_config("tensorflow", "disable")
+
+    mlflow.autolog()
+    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+    mlflow.autolog(disable=True)
+    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+    assert get_autologging_config("tensorflow", "disable")
+
+    mlflow.autolog(disable=False)
+    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+    assert not get_autologging_config("tensorflow", "disable", False)
+    mlflow.tensorflow.autolog(disable=True)
+    assert get_autologging_config("tensorflow", "disable")
+
+
 def test_autolog_success_message_obeys_disabled():
     with mock.patch("mlflow.tracking.fluent._logger.info") as autolog_logger_mock:
         mlflow.autolog(disable=True)
-        mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+        mlflow.utils.import_hooks.notify_module_loaded(sklearn)
         autolog_logger_mock.assert_not_called()
 
         mlflow.autolog()
-        mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+        mlflow.utils.import_hooks.notify_module_loaded(sklearn)
         autolog_logger_mock.assert_called()
 
         autolog_logger_mock.reset_mock()
 
         mlflow.autolog(disable=False)
-        mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+        mlflow.utils.import_hooks.notify_module_loaded(sklearn)
         autolog_logger_mock.assert_called()

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -196,34 +196,34 @@ def test_universal_autolog_makes_expected_event_logging_calls():
 
 def test_autolog_obeys_disabled():
     mlflow.autolog(disable=True)
-    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
-    assert get_autologging_config("tensorflow", "disable")
+    mlflow.utils.import_hooks.notify_module_loaded(sklearn)
+    assert get_autologging_config("sklearn", "disable")
 
     mlflow.autolog()
-    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
+    mlflow.utils.import_hooks.notify_module_loaded(sklearn)
     mlflow.autolog(disable=True)
-    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
-    assert get_autologging_config("tensorflow", "disable")
+    mlflow.utils.import_hooks.notify_module_loaded(sklearn)
+    assert get_autologging_config("sklearn", "disable")
 
     mlflow.autolog(disable=False)
-    mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
-    assert not get_autologging_config("tensorflow", "disable", False)
+    mlflow.utils.import_hooks.notify_module_loaded(sklearn)
+    assert not get_autologging_config("sklearn", "disable", False)
     mlflow.tensorflow.autolog(disable=True)
-    assert get_autologging_config("tensorflow", "disable")
+    assert get_autologging_config("sklearn", "disable")
 
 
 def test_autolog_success_message_obeys_disabled():
     with mock.patch("mlflow.tracking.fluent._logger.info") as autolog_logger_mock:
         mlflow.autolog(disable=True)
-        mlflow.utils.import_hooks.notify_module_loaded(sklearn)
+        mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
         autolog_logger_mock.assert_not_called()
 
         mlflow.autolog()
-        mlflow.utils.import_hooks.notify_module_loaded(sklearn)
+        mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
         autolog_logger_mock.assert_called()
 
         autolog_logger_mock.reset_mock()
 
         mlflow.autolog(disable=False)
-        mlflow.utils.import_hooks.notify_module_loaded(sklearn)
+        mlflow.utils.import_hooks.notify_module_loaded(tensorflow)
         autolog_logger_mock.assert_called()


### PR DESCRIPTION
## What changes are proposed in this pull request?

A bug in the code for the `setup_autolog` post import hook for libraries meant that the `disable` flag was only respected when the order of:
- importing the library
- `mlflow.autolog()`
- `mlflow.integration.autolog(disable=True)`

is in a specific order. In particular, the `setup_autolog` function called `mlflow.integration.autolog` as a post-import hook, but with the _default_ values for its params, rather than the ones that may have already been set as stored in `AUTOLOGGING_INTEGRATIONS`.
Fix by only calling `integration.autolog()` with `mlflow.autolog`'s configs, if there is no pre-existing integration-specific configs (ie. `mlflow.integration.autolog` has not been called.

Summary of manually verified fixes:
1. mlflow.autolog, then library autolog disable, then import library
2. mlflow.autolog, then import library, then library autolog disable
3. library autolog disable, then mlflow.autolog, then import library
4. library autolog disable, then import library, then mlflow.autolog
5. import library, then mlflow.autolog, then library autolog disable
6. import library, then library autolog disable, then mlflow.autolog
## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix a bug causing configurations passed to `mlflow.autolog()` to override configurations passed to framework-specific autologging functions  (e.g., `mlflow.sklearn.autolog()`). Framework-specific autologging configurations will now take precedence over all universal `mlflow.autolog()` configurations.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
