### PR TITLE
Fix broken pytorch-lightning tests for dev in cross version tests

### DIFF
--- a/tests/pytorch/iris.py
+++ b/tests/pytorch/iris.py
@@ -36,7 +36,7 @@ class IrisClassification(pl.LightningModule):
         x, y = batch
         logits = self.forward(x)
         loss = self.cross_entropy_loss(logits, y)
-        self.train_acc(logits, y)
+        self.train_acc(torch.argmax(logits, dim=1), y)
         self.log("train_acc", self.train_acc.compute(), on_step=False, on_epoch=True)
         self.log("loss", loss)
         return {"loss": loss}

--- a/tests/pytorch/iris.py
+++ b/tests/pytorch/iris.py
@@ -45,7 +45,7 @@ class IrisClassification(pl.LightningModule):
         x, y = batch
         logits = self.forward(x)
         loss = F.cross_entropy(logits, y)
-        self.val_acc(logits, y)
+        self.val_acc(torch.argmax(logits, dim=1), y)
         self.log("val_acc", self.val_acc.compute())
         self.log("val_loss", loss, sync_dist=True)
 
@@ -53,8 +53,7 @@ class IrisClassification(pl.LightningModule):
         x, y = batch
         logits = self.forward(x)
         loss = F.cross_entropy(logits, y)
-        _, y_hat = torch.max(logits, dim=1)
-        self.test_acc(y_hat, y)
+        self.test_acc(torch.argmax(logits, dim=1), y)
         self.log("test_loss", loss)
         self.log("test_acc", self.test_acc.compute())
 

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -112,13 +112,13 @@ def pytorch_model_with_callback(patience):
     )
 
     with TempDir() as tmp:
+        kwargs = (
+            {"dirpath": tmp.path()}
+            if LooseVersion(pl.__version__) >= LooseVersion("1.2.0")
+            else {"filepath": tmp.path()}
+        )
         checkpoint_callback = ModelCheckpoint(
-            filepath=tmp.path(),
-            save_top_k=1,
-            verbose=True,
-            monitor="val_loss",
-            mode="min",
-            prefix="",
+            **kwargs, save_top_k=1, verbose=True, monitor="val_loss", mode="min", prefix="",
         )
 
         trainer = pl.Trainer(

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -114,7 +114,7 @@ def pytorch_model_with_callback(patience):
     with TempDir() as tmp:
         keyword = "dirpath" if LooseVersion(pl.__version__) >= LooseVersion("1.2.0") else "filepath"
         checkpoint_callback = ModelCheckpoint(
-            **{keyword: tmp.path},
+            **{keyword: tmp.path()},
             save_top_k=1,
             verbose=True,
             monitor="val_loss",

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -112,13 +112,14 @@ def pytorch_model_with_callback(patience):
     )
 
     with TempDir() as tmp:
-        kwargs = (
-            {"dirpath": tmp.path()}
-            if LooseVersion(pl.__version__) >= LooseVersion("1.2.0")
-            else {"filepath": tmp.path()}
-        )
+        keyword = "dirpath" if LooseVersion(pl.__version__) >= LooseVersion("1.2.0") else "filepath"
         checkpoint_callback = ModelCheckpoint(
-            **kwargs, save_top_k=1, verbose=True, monitor="val_loss", mode="min", prefix="",
+            **{keyword: tmp.path},
+            save_top_k=1,
+            verbose=True,
+            monitor="val_loss",
+            mode="min",
+            prefix="",
         )
 
         trainer = pl.Trainer(
@@ -168,8 +169,9 @@ def test_pytorch_with_early_stopping_autolog_log_models_configuration_with(log_m
     early_stopping = EarlyStopping(monitor="val_loss", mode="min", patience=patience, verbose=True)
 
     with TempDir() as tmp:
+        keyword = "dirpath" if LooseVersion(pl.__version__) >= LooseVersion("1.2.0") else "filepath"
         checkpoint_callback = ModelCheckpoint(
-            filepath=tmp.path(),
+            **{keyword: tmp.path()},
             save_top_k=1,
             verbose=True,
             monitor="val_loss",


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix broken pytorch-lightning tests for dev in cross version tests

## How is this patch tested?

Fixed unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
