### PR TITLE
Add monkey patching for old and new tf.Estimator classes

### DIFF
--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1146,6 +1146,17 @@ def autolog(
         (tensorflow.estimator.Estimator, "export_savedmodel", export_saved_model),
     ]
 
+    # Add compat.v1 Estimator patching for versions of tensfor that are 2.0+.
+    if LooseVersion(tensorflow.__version__) >= LooseVersion("2.0.0"):
+        old_estimator_class = tensorflow.compat.v1.estimator.Estimator
+        v1_train = (old_estimator_class, "train", train)
+        v1_export_saved_model = (old_estimator_class, "export_saved_model", export_saved_model)
+        v1_export_savedmodel = (old_estimator_class, "export_savedmodel", export_saved_model)
+
+        managed.append(v1_train)
+        non_managed.append(v1_export_saved_model)
+        non_managed.append(v1_export_savedmodel)
+
     for p in managed:
         safe_patch(FLAVOR_NAME, *p, manage_run=True)
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -620,7 +620,7 @@ def test_tf_estimator_autolog_logs_metrics(tf_estimator_random_data_run):
 
 
 @pytest.mark.large
-def test_tf_estimator_v1_autolog_logs_metrics(tmpdir, export):
+def test_tf_estimator_v1_autolog_logs_metrics(tmpdir):
     mlflow.tensorflow.autolog()
 
     create_tf_estimator_model(tmpdir, export=False, use_v1_estimator=True)

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -619,10 +619,13 @@ def test_tf_estimator_autolog_logs_metrics(tf_estimator_random_data_run):
     assert all((x.step - 1) % 100 == 0 for x in metrics)
 
 
-def test_tf_estimator_v1_autolog_logs_metrics(tmpdir):
+@pytest.mark.large
+@pytest.mark.parametrize("export", [True, False])
+def test_tf_estimator_v1_autolog_logs_metrics(tmpdir, export):
+    directory = tmpdir.mkdir("test")
     mlflow.tensorflow.autolog()
 
-    create_tf_estimator_model(tmpdir, export=False, use_v1_estimator=True)
+    create_tf_estimator_model(str(directory), export, use_v1_estimator=True)
     client = mlflow.tracking.MlflowClient()
     tf_estimator_v1_run = client.get_run(client.list_run_infos(experiment_id="0")[0].run_id)
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -620,11 +620,10 @@ def test_tf_estimator_autolog_logs_metrics(tf_estimator_random_data_run):
 
 
 @pytest.mark.large
-@pytest.mark.parametrize("export", [True, False])
 def test_tf_estimator_v1_autolog_logs_metrics(tmpdir, export):
     mlflow.tensorflow.autolog()
 
-    create_tf_estimator_model(tmpdir, export, use_v1_estimator=True)
+    create_tf_estimator_model(tmpdir, export=False, use_v1_estimator=True)
     client = mlflow.tracking.MlflowClient()
     tf_estimator_v1_run = client.get_run(client.list_run_infos(experiment_id="0")[0].run_id)
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -636,6 +636,20 @@ def test_tf_estimator_v1_autolog_logs_metrics(tmpdir, export):
 
 
 @pytest.mark.large
+@pytest.mark.parametrize("export", [True])
+def test_tf_estimator_v1_autolog_can_load_from_artifact(tmpdir, export):
+    directory = tmpdir.mkdir("test")
+    mlflow.tensorflow.autolog()
+
+    create_tf_estimator_model(str(directory), export, use_v1_estimator=True)
+    client = mlflow.tracking.MlflowClient()
+    tf_estimator_v1_run = client.get_run(client.list_run_infos(experiment_id="0")[0].run_id)
+    artifacts = client.list_artifacts(tf_estimator_v1_run.info.run_id)
+    artifacts = map(lambda x: x.path, artifacts)
+    assert "model" in artifacts
+    mlflow.tensorflow.load_model("runs:/" + tf_estimator_v1_run.info.run_id + "/model")
+
+@pytest.mark.large
 @pytest.mark.parametrize("export", [True, False])
 def test_tf_estimator_autolog_logs_tensorboard_logs(tf_estimator_random_data_run):
     client = mlflow.tracking.MlflowClient()

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -649,6 +649,7 @@ def test_tf_estimator_v1_autolog_can_load_from_artifact(tmpdir, export):
     assert "model" in artifacts
     mlflow.tensorflow.load_model("runs:/" + tf_estimator_v1_run.info.run_id + "/model")
 
+
 @pytest.mark.large
 @pytest.mark.parametrize("export", [True, False])
 def test_tf_estimator_autolog_logs_tensorboard_logs(tf_estimator_random_data_run):


### PR DESCRIPTION
Signed-off-by: Mohamad Arabi <mohamad.arabi@databricks.com>

## What changes are proposed in this pull request?
Enable autologging for tensorflow classifiers that extend the older `tf.estimator.Estimator`, not only  classifiers that extend `tf.estimator.EstimatorV2`.
(Please fill in changes proposed in this fix)

## How is this patch tested?
Will add unit test for autologging of a tf estimator that extends `tensorflow.estimator.Estimator`, such as `BoostedTreesClassifier`.

## Release Notes
N/A

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
