### PR TITLE
Improve method to parse tf-serving json

### DIFF
--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -68,7 +68,7 @@ class _Example(object):
                     result[name] = input_tensor[name].tolist()
                 return {"inputs": result}
             else:
-                return {"instances": input_example.tolist()}
+                return {"inputs": input_example.tolist()}
 
         def _handle_dataframe_input(input_ex):
             if isinstance(input_ex, dict):
@@ -176,12 +176,12 @@ def _read_example(mlflow_model: Model, path: str):
     input_schema = mlflow_model.signature.inputs if mlflow_model.signature is not None else None
     path = os.path.join(path, mlflow_model.saved_input_example_info["artifact_path"])
     if example_type == "ndarray":
-        return _read_tensor_input_from_json(path)
+        return _read_tensor_input_from_json(path, schema=input_schema)
     else:
         return _dataframe_from_json(path, schema=input_schema, precise_float=True)
 
 
-def _read_tensor_input_from_json(path):
+def _read_tensor_input_from_json(path, schema=None):
     with open(path, "r") as handle:
         inp_dict = json.load(handle)
-        return parse_tf_serving_input(inp_dict)
+        return parse_tf_serving_input(inp_dict, schema)

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -68,7 +68,7 @@ class _Example(object):
                     result[name] = input_tensor[name].tolist()
                 return {"inputs": result}
             else:
-                return {"inputs": input_example.tolist()}
+                return {"inputs": input_tensor.tolist()}
 
         def _handle_dataframe_input(input_ex):
             if isinstance(input_ex, dict):

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -87,7 +87,7 @@ def infer_and_parse_json_input(json_input, schema: Schema = None):
     elif isinstance(decoded_input, dict):
         if "instances" in decoded_input or "inputs" in decoded_input:
             try:
-                return parse_tf_serving_input(decoded_input)
+                return parse_tf_serving_input(decoded_input, schema=schema)
             except MlflowException as ex:
                 _handle_serving_error(
                     error_message=(ex.message), error_code=MALFORMED_REQUEST,

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -154,18 +154,20 @@ def parse_tf_serving_input(inp_dict, schema=None):
                     input_data = {input_names[0]: input_data}
                 if not isinstance(input_data, dict):
                     raise MlflowException(
-                        "This model contains a tensor-based model signature with input names, which"
-                        " suggests a dictionary input mapping input name to tensor, but an input of"
-                        " type {0} was found.".format(type(input_data))
+                        "Failed to parse input data. This model contains a tensor-based model"
+                        " signature with input names, which suggests a dictionary input mapping"
+                        " input name to tensor, but an input of type {0} was found.".format(
+                            type(input_data)
+                        )
                     )
                 for col_name, tensor_spec in zip(schema.input_names(), schema.inputs):
                     input_data[col_name] = np.array(input_data[col_name], dtype=tensor_spec.type)
             else:
                 if not isinstance(input_data, list):
                     raise MlflowException(
-                        "This model contains an un-named tensor-based model signature which"
-                        " expects a single n-dimensional array as input, however, an input of"
-                        " type {0} was found.".format(type(input_data))
+                        "Failed to parse input data. This model contains an un-named tensor-based"
+                        " model signature which expects a single n-dimensional array as input,"
+                        " however, an input of type {0} was found.".format(type(input_data))
                     )
                 input_data = np.array(input_data, dtype=schema.inputs[0].type)
         else:

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -149,12 +149,24 @@ def parse_tf_serving_input(inp_dict, schema=None):
         if schema is not None:
             if schema.has_input_names():
                 input_names = schema.input_names()
-                if len(input_names) == 1 and isinstance(input_data, (np.ndarray, list)):
+                if len(input_names) == 1 and isinstance(input_data, list):
                     # for schemas with a single column, match input with column
                     input_data = {input_names[0]: input_data}
+                if not isinstance(input_data, dict):
+                    raise MlflowException(
+                        "This model contains a tensor-based model signature with input names, which"
+                        " suggests a dictionary input mapping input name to tensor, but an input of"
+                        " type {0} was found.".format(type(input_data))
+                    )
                 for col_name, tensor_spec in zip(schema.input_names(), schema.inputs):
                     input_data[col_name] = np.array(input_data[col_name], dtype=tensor_spec.type)
             else:
+                if not isinstance(input_data, list):
+                    raise MlflowException(
+                        "This model contains an un-named tensor-based model signature which"
+                        " expects a single n-dimensional array as input, however, an input of"
+                        " type {0} was found.".format(type(input_data))
+                    )
                 input_data = np.array(input_data, dtype=schema.inputs[0].type)
         else:
             if isinstance(input_data, dict):

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -136,11 +136,12 @@ def _get_jsonable_obj(data, pandas_orient="records"):
         return data
 
 
-def parse_tf_serving_input(inp_dict, schema = None):
+def parse_tf_serving_input(inp_dict, schema=None):
     """
     :param inp_dict: A dict deserialized from a JSON string formatted as described in TF's
                      serving API doc
                      (https://www.tensorflow.org/tfx/serving/api_rest#request_format_2)
+    :param schema: Mlflow schema used when parsing the data.
     """
     import numpy as np
 

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -96,10 +96,11 @@ def test_parse_tf_serving_dictionary():
     }
     # Without Schema
     result = parse_tf_serving_input(tfserving_input)
-    expected_result_no_schema = {}
-    expected_result_no_schema["a"] = np.array(["s1", "s2", "s3"])
-    expected_result_no_schema["b"] = np.array([1.1, 2.2, 3.3], dtype="float64")
-    expected_result_no_schema["c"] = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype="int64")
+    expected_result_no_schema = {
+        "a": np.array(["s1", "s2", "s3"]),
+        "b": np.array([1.1, 2.2, 3.3], dtype="float64"),
+        "c": np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype="int64"),
+    }
     assert_result(result, expected_result_no_schema)
 
     # With schema
@@ -111,10 +112,11 @@ def test_parse_tf_serving_dictionary():
         ]
     )
     result = parse_tf_serving_input(tfserving_input, schema)
-    expected_result_schema = {}
-    expected_result_schema["a"] = np.array(["s1", "s2", "s3"])
-    expected_result_schema["b"] = np.array([1.1, 2.2, 3.3], dtype="float32")
-    expected_result_schema["c"] = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype="int32")
+    expected_result_schema = {
+        "a": np.array(["s1", "s2", "s3"]),
+        "b": np.array([1.1, 2.2, 3.3], dtype="float32"),
+        "c": np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype="int32"),
+    }
     assert_result(result, expected_result_schema)
 
     # input provided as a dict
@@ -178,7 +180,7 @@ def test_parse_tf_serving_single_array():
 
 def test_parse_tf_serving_raises_expected_errors():
     # input is bad if a column value is missing for a row/instance
-    tfserving_input_instances = {
+    tfserving_instances = {
         "instances": [
             {"a": "s1", "b": 1},
             {"a": "s2", "b": 2, "c": [4, 5, 6]},
@@ -188,15 +190,15 @@ def test_parse_tf_serving_raises_expected_errors():
     with pytest.raises(
         MlflowException, match="The length of values for each input/column name are not the same"
     ):
-        parse_tf_serving_input(tfserving_input_instances)
+        parse_tf_serving_input(tfserving_instances)
 
-    tfserving_input_inputs = {
+    tfserving_inputs = {
         "inputs": {"a": ["s1", "s2", "s3"], "b": [1, 2, 3], "c": [[1, 2, 3], [4, 5, 6]]}
     }
     with pytest.raises(
         MlflowException, match="The length of values for each input/column name are not the same"
     ):
-        parse_tf_serving_input(tfserving_input_inputs)
+        parse_tf_serving_input(tfserving_inputs)
 
     # cannot specify both instance and inputs
     tfserving_input = {

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -6,6 +6,7 @@ from mlflow.entities import Experiment, Metric
 from mlflow.exceptions import MlflowException
 from mlflow.protos.service_pb2 import Experiment as ProtoExperiment
 from mlflow.protos.service_pb2 import Metric as ProtoMetric
+from mlflow.types import Schema, TensorSpec
 
 from mlflow.utils.proto_json_utils import (
     message_to_json,
@@ -79,22 +80,105 @@ def test_back_compat():
     assert exp_json == in_json
 
 
-def test_parse_tf_serving_input():
+def test_parse_tf_serving_dictionary():
+    def assert_result(result, expected_result):
+        assert result.keys() == expected_result.keys()
+        for key in result:
+            assert (result[key] == expected_result[key]).all()
+
     # instances are correctly aggregated to dict of input name -> tensor
     tfserving_input = {
         "instances": [
-            {"a": "s1", "b": 1, "c": [1, 2, 3]},
-            {"a": "s2", "b": 2, "c": [4, 5, 6]},
-            {"a": "s3", "b": 3, "c": [7, 8, 9]},
+            {"a": "s1", "b": 1.1, "c": [1, 2, 3]},
+            {"a": "s2", "b": 2.2, "c": [4, 5, 6]},
+            {"a": "s3", "b": 3.3, "c": [7, 8, 9]},
         ]
     }
+    # Without Schema
     result = parse_tf_serving_input(tfserving_input)
-    assert (result["a"] == np.array(["s1", "s2", "s3"])).all()
-    assert (result["b"] == np.array([1, 2, 3])).all()
-    assert (result["c"] == np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])).all()
+    expected_result_no_schema = {}
+    expected_result_no_schema["a"] = np.array(["s1", "s2", "s3"])
+    expected_result_no_schema["b"] = np.array([1.1, 2.2, 3.3], dtype="float64")
+    expected_result_no_schema["c"] = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype="int64")
+    assert_result(result, expected_result_no_schema)
 
-    # input is bad if a column value is missing for a row/instance
+    # With schema
+    schema = Schema(
+        [
+            TensorSpec(np.dtype("object"), [-1], "a"),
+            TensorSpec(np.dtype("float32"), [-1], "b"),
+            TensorSpec(np.dtype("int32"), [-1], "c"),
+        ]
+    )
+    result = parse_tf_serving_input(tfserving_input, schema)
+    expected_result_schema = {}
+    expected_result_schema["a"] = np.array(["s1", "s2", "s3"])
+    expected_result_schema["b"] = np.array([1.1, 2.2, 3.3], dtype="float32")
+    expected_result_schema["c"] = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype="int32")
+    assert_result(result, expected_result_schema)
+
+    # input provided as a dict
     tfserving_input = {
+        "inputs": {
+            "a": ["s1", "s2", "s3"],
+            "b": [1.1, 2.2, 3.3],
+            "c": [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        }
+    }
+    # Without Schema
+    result = parse_tf_serving_input(tfserving_input)
+    assert_result(result, expected_result_no_schema)
+
+    # With Schema
+    result = parse_tf_serving_input(tfserving_input, schema)
+    assert_result(result, expected_result_schema)
+
+
+def test_parse_tf_serving_single_array():
+    def assert_result(result, expected_result):
+        assert (result == expected_result).all()
+
+    # values for each column are properly converted to a tensor
+    arr = [
+        [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+        [[3, 2, 1], [6, 5, 4], [9, 8, 7]],
+    ]
+    tfserving_instances = {"instances": arr}
+    tfserving_inputs = {"inputs": arr}
+
+    # Without schema
+    instance_result = parse_tf_serving_input(tfserving_instances)
+    assert instance_result.shape == (2, 3, 3)
+    assert_result(instance_result, np.array(arr, dtype="int64"))
+
+    input_result = parse_tf_serving_input(tfserving_inputs)
+    assert input_result.shape == (2, 3, 3)
+    assert_result(input_result, np.array(arr, dtype="int64"))
+
+    # Unnamed schema
+    schema = Schema([TensorSpec(np.dtype("float32"), [-1]),])
+    instance_result = parse_tf_serving_input(tfserving_instances, schema)
+    assert_result(instance_result, np.array(arr, dtype="float32"))
+
+    input_result = parse_tf_serving_input(tfserving_inputs, schema)
+    assert_result(input_result, np.array(arr, dtype="float32"))
+
+    # named schema
+    schema = Schema([TensorSpec(np.dtype("float32"), [-1], "a"),])
+    instance_result = parse_tf_serving_input(tfserving_instances, schema)
+    assert isinstance(instance_result, dict)
+    assert len(instance_result.keys()) == 1 and "a" in instance_result
+    assert_result(instance_result["a"], np.array(arr, dtype="float32"))
+
+    input_result = parse_tf_serving_input(tfserving_inputs, schema)
+    assert isinstance(input_result, dict)
+    assert len(input_result.keys()) == 1 and "a" in input_result
+    assert_result(input_result["a"], np.array(arr, dtype="float32"))
+
+
+def test_parse_tf_serving_raises_expected_errors():
+    # input is bad if a column value is missing for a row/instance
+    tfserving_input_instances = {
         "instances": [
             {"a": "s1", "b": 1},
             {"a": "s2", "b": 2, "c": [4, 5, 6]},
@@ -104,36 +188,19 @@ def test_parse_tf_serving_input():
     with pytest.raises(
         MlflowException, match="The length of values for each input/column name are not the same"
     ):
-        parse_tf_serving_input(tfserving_input)
+        parse_tf_serving_input(tfserving_input_instances)
 
-    # values for each column are properly converted to a tensor
-    arr = [
-        [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
-        [[3, 2, 1], [6, 5, 4], [9, 8, 7]],
-    ]
-    tfserving_input = {"instances": arr}
-    result = parse_tf_serving_input(tfserving_input)
-    assert result.shape == (2, 3, 3)
-    assert (result == np.array(arr)).all()
-
-    # input data specified via "inputs" must be a dictionary
-    tfserving_input = {"inputs": arr}
-    with pytest.raises(MlflowException) as ex:
-        parse_tf_serving_input(tfserving_input)
-    assert "Failed to parse data as TF serving input." in str(ex)
-
-    # input can be provided in column format
-    tfserving_input = {
-        "inputs": {"a": ["s1", "s2", "s3"], "b": [1, 2, 3], "c": [[1, 2, 3], [4, 5, 6], [7, 8, 9]]}
+    tfserving_input_inputs = {
+        "inputs": {"a": ["s1", "s2", "s3"], "b": [1, 2, 3], "c": [[1, 2, 3], [4, 5, 6]]}
     }
-    result = parse_tf_serving_input(tfserving_input)
-    assert (result["a"] == np.array(["s1", "s2", "s3"])).all()
-    assert (result["b"] == np.array([1, 2, 3])).all()
-    assert (result["c"] == np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])).all()
+    with pytest.raises(
+        MlflowException, match="The length of values for each input/column name are not the same"
+    ):
+        parse_tf_serving_input(tfserving_input_inputs)
 
     # cannot specify both instance and inputs
     tfserving_input = {
-        "instances": arr,
+        "instances": [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
         "inputs": {"a": ["s1", "s2", "s3"], "b": [1, 2, 3], "c": [[1, 2, 3], [4, 5, 6], [7, 8, 9]]},
     }
     with pytest.raises(MlflowException) as ex:

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -156,7 +156,7 @@ def test_parse_tf_serving_single_array():
     assert_result(input_result, np.array(arr, dtype="int64"))
 
     # Unnamed schema
-    schema = Schema([TensorSpec(np.dtype("float32"), [-1]),])
+    schema = Schema([TensorSpec(np.dtype("float32"), [-1])])
     instance_result = parse_tf_serving_input(tfserving_instances, schema)
     assert_result(instance_result, np.array(arr, dtype="float32"))
 
@@ -164,7 +164,7 @@ def test_parse_tf_serving_single_array():
     assert_result(input_result, np.array(arr, dtype="float32"))
 
     # named schema
-    schema = Schema([TensorSpec(np.dtype("float32"), [-1], "a"),])
+    schema = Schema([TensorSpec(np.dtype("float32"), [-1], "a")])
     instance_result = parse_tf_serving_input(tfserving_instances, schema)
     assert isinstance(instance_result, dict)
     assert len(instance_result.keys()) == 1 and "a" in instance_result


### PR DESCRIPTION
Signed-off-by: Arjun DCunha <arjun.dcunha@databricks.com>

## What changes are proposed in this pull request?
This improves parsing the tf-serving json to perform two tasks:
- 'inputs' now interprets (nested) list as a singular tensor
- Casting the inputted data into the type defined in the dataset schema.

(Please fill in changes proposed in this fix)

## How is this patch tested?
Unit tests added.

## Release Notes

### Is this a user-facing change?

- [ x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ x] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
