### PR TITLE
Don't allow schema creation for multiple unnamed TensorSpecs

### DIFF
--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -280,8 +280,8 @@ class Schema(object):
             and any(map(lambda x: x.name is None, inputs))
         ):
             raise MlflowException(
-                "Creating Schema with multiple unnamed TensorSpecs is not allowed. "
-                "Please provide names for each TensorSpec or use a single unnamed TensorSpec."
+                "Creating Schema with multiple unnamed TensorSpecs is not supported. "
+                "Please provide names for each TensorSpec."
             )
         self._inputs = inputs
 

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -263,8 +263,8 @@ class Schema(object):
             or all(map(lambda x: x.name is not None, inputs))
         ):
             raise MlflowException(
-                "Creating Schema with a combination of named and unnamed columns "
-                "is not allowed. Got column names {}".format([x.name for x in inputs])
+                "Creating Schema with a combination of named and unnamed inputs "
+                "is not allowed. Got input names {}".format([x.name for x in inputs])
             )
         if not (
             all(map(lambda x: isinstance(x, TensorSpec), inputs))
@@ -273,6 +273,15 @@ class Schema(object):
             raise MlflowException(
                 "Creating Schema with a combination of {0} and {1} is not supported. "
                 "Please choose one of {0} or {1}".format(ColSpec.__class__, TensorSpec.__class__)
+            )
+        if (
+            all(map(lambda x: isinstance(x, TensorSpec), inputs))
+            and len(inputs) > 1
+            and any(map(lambda x: x.name is None, inputs))
+        ):
+            raise MlflowException(
+                "Creating Schema with multiple unnamed TensorSpecs is not allowed. "
+                "Please provide names for each TensorSpec or use a single unnamed TensorSpec."
             )
         self._inputs = inputs
 

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -40,31 +40,23 @@ def test_model_signature_with_colspec():
 
 def test_model_signature_with_tensorspec():
     signature1 = ModelSignature(
-        inputs=Schema(
-            [TensorSpec(np.dtype("float"), (-1, 28, 28))]
-        ),
+        inputs=Schema([TensorSpec(np.dtype("float"), (-1, 28, 28))]),
         outputs=Schema([TensorSpec(np.dtype("float"), (-1, 10))]),
     )
     signature2 = ModelSignature(
-        inputs=Schema(
-            [TensorSpec(np.dtype("float"), (-1, 28, 28))]
-        ),
+        inputs=Schema([TensorSpec(np.dtype("float"), (-1, 28, 28))]),
         outputs=Schema([TensorSpec(np.dtype("float"), (-1, 10))]),
     )
     # Single type mismatch
     assert signature1 == signature2
     signature3 = ModelSignature(
-        inputs=Schema(
-            [TensorSpec(np.dtype("float"), (-1, 28, 28))]
-        ),
+        inputs=Schema([TensorSpec(np.dtype("float"), (-1, 28, 28))]),
         outputs=Schema([TensorSpec(np.dtype("int"), (-1, 10))]),
     )
     assert signature3 != signature1
     # Name mismatch
     signature4 = ModelSignature(
-        inputs=Schema(
-            [TensorSpec(np.dtype("float"), (-1, 28, 28))]
-        ),
+        inputs=Schema([TensorSpec(np.dtype("float"), (-1, 28, 28))]),
         outputs=Schema([TensorSpec(np.dtype("float"), (-1, 10), "misMatch")]),
     )
     assert signature3 != signature4

--- a/tests/models/test_signature.py
+++ b/tests/models/test_signature.py
@@ -41,13 +41,13 @@ def test_model_signature_with_colspec():
 def test_model_signature_with_tensorspec():
     signature1 = ModelSignature(
         inputs=Schema(
-            [TensorSpec(np.dtype("float"), (-1, 28, 28)), TensorSpec(np.dtype("int"), (-1, 10))]
+            [TensorSpec(np.dtype("float"), (-1, 28, 28))]
         ),
         outputs=Schema([TensorSpec(np.dtype("float"), (-1, 10))]),
     )
     signature2 = ModelSignature(
         inputs=Schema(
-            [TensorSpec(np.dtype("float"), (-1, 28, 28)), TensorSpec(np.dtype("int"), (-1, 10))]
+            [TensorSpec(np.dtype("float"), (-1, 28, 28))]
         ),
         outputs=Schema([TensorSpec(np.dtype("float"), (-1, 10))]),
     )
@@ -55,7 +55,7 @@ def test_model_signature_with_tensorspec():
     assert signature1 == signature2
     signature3 = ModelSignature(
         inputs=Schema(
-            [TensorSpec(np.dtype("float"), (-1, 28, 28)), TensorSpec(np.dtype("int"), (-1, 10))]
+            [TensorSpec(np.dtype("float"), (-1, 28, 28))]
         ),
         outputs=Schema([TensorSpec(np.dtype("int"), (-1, 10))]),
     )
@@ -63,7 +63,7 @@ def test_model_signature_with_tensorspec():
     # Name mismatch
     signature4 = ModelSignature(
         inputs=Schema(
-            [TensorSpec(np.dtype("float"), (-1, 28, 28)), TensorSpec(np.dtype("int"), (-1, 10))]
+            [TensorSpec(np.dtype("float"), (-1, 28, 28))]
         ),
         outputs=Schema([TensorSpec(np.dtype("float"), (-1, 10), "misMatch")]),
     )

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -120,7 +120,7 @@ def test_schema_creation():
     # multiple unnamed tensor specs is not allowed
     with pytest.raises(MlflowException) as ex:
         Schema([TensorSpec(np.dtype("double"), (-1,)), TensorSpec(np.dtype("double"), (-1,))])
-    assert "Creating Schema with multiple unnamed TensorSpecs is not allowed" in ex.value.message
+    assert "Creating Schema with multiple unnamed TensorSpecs is not supported" in ex.value.message
 
 
 def test_get_schema_type(dict_of_ndarrays):

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -88,22 +88,39 @@ def dict_of_ndarrays():
     }
 
 
-def test_schema_creation_with_tensor_and_col_spec():
+def test_schema_creation():
+    # can create schema with named col specs
+    Schema([ColSpec("double", "a"), ColSpec("integer", "b")])
+
+    # can create schema with unnamed col specs
+    Schema([ColSpec("double"), ColSpec("integer")])
+
+    # can create schema with multiple named tensor specs
+    Schema([TensorSpec(np.dtype("float64"), (-1,), "a"), TensorSpec(np.dtype("uint8"), (-1,), "b")])
+
+    # can create schema with single unnamed tensor spec
+    Schema([TensorSpec(np.dtype("float64"), (-1,))])
+
+    # combination of tensor and col spec is not allowed
     with pytest.raises(MlflowException) as ex:
         Schema([TensorSpec(np.dtype("float64"), (-1,)), ColSpec("double")])
     assert "Please choose one of" in ex.value.message
 
-
-def test_schema_creation_with_named_and_unnamed_spec():
+    # combination of named and unnamed inputs is not allowed
     with pytest.raises(MlflowException) as ex:
         Schema(
             [TensorSpec(np.dtype("float64"), (-1,), "blah"), TensorSpec(np.dtype("float64"), (-1,))]
         )
-    assert "Creating Schema with a combination of named and unnamed columns" in ex.value.message
+    assert "Creating Schema with a combination of named and unnamed inputs" in ex.value.message
 
     with pytest.raises(MlflowException) as ex:
         Schema([ColSpec("double", "blah"), ColSpec("double")])
-    assert "Creating Schema with a combination of named and unnamed columns" in ex.value.message
+    assert "Creating Schema with a combination of named and unnamed inputs" in ex.value.message
+
+    # multiple unnamed tensor specs is not allowed
+    with pytest.raises(MlflowException) as ex:
+        Schema([TensorSpec(np.dtype("double"), (-1,)), TensorSpec(np.dtype("double"), (-1,))])
+    assert "Creating Schema with multiple unnamed TensorSpecs is not allowed" in ex.value.message
 
 
 def test_get_schema_type(dict_of_ndarrays):


### PR DESCRIPTION
Signed-off-by: Wendy Hu <wendy.hu@databricks.com>

## What changes are proposed in this pull request?
Don't allow schema creation for multiple unnamed TensorSpecs

## How is this patch tested?
Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
