### PR TITLE
Fix `enable_test_mode_by_default_for_autologging_integrations`

### DIFF
--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -8,22 +8,22 @@ export MLFLOW_HOME=$(pwd)
 
 # Run ML framework tests in their own Python processes to avoid OOM issues due to per-framework
 # overhead
-# pytest --verbose tests/pytorch --large
-# pytest --verbose tests/h2o --large
-# pytest --verbose tests/onnx --large
-# pytest --verbose tests/pyfunc --large
-# pytest --verbose tests/sklearn --large
-# pytest --verbose tests/azureml --large
-# pytest --verbose tests/models --large
-# pytest --verbose tests/xgboost --large
-# pytest --verbose tests/lightgbm --large
-# pytest --verbose tests/statsmodels --large
-# pytest --verbose tests/gluon --large
-# pytest --verbose tests/gluon_autolog --large
-# pytest --verbose tests/spacy --large
-# pytest --verbose tests/fastai --large
-# pytest --verbose tests/shap --large
-# pytest --verbose tests/utils/test_model_utils.py --large
+pytest --verbose tests/pytorch --large
+pytest --verbose tests/h2o --large
+pytest --verbose tests/onnx --large
+pytest --verbose tests/pyfunc --large
+pytest --verbose tests/sklearn --large
+pytest --verbose tests/azureml --large
+pytest --verbose tests/models --large
+pytest --verbose tests/xgboost --large
+pytest --verbose tests/lightgbm --large
+pytest --verbose tests/statsmodels --large
+pytest --verbose tests/gluon --large
+pytest --verbose tests/gluon_autolog --large
+pytest --verbose tests/spacy --large
+pytest --verbose tests/fastai --large
+pytest --verbose tests/shap --large
+pytest --verbose tests/utils/test_model_utils.py --large
 pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large -s
 
 

--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -8,23 +8,23 @@ export MLFLOW_HOME=$(pwd)
 
 # Run ML framework tests in their own Python processes to avoid OOM issues due to per-framework
 # overhead
-pytest --verbose tests/pytorch --large
-pytest --verbose tests/h2o --large
-pytest --verbose tests/onnx --large
-pytest --verbose tests/pyfunc --large
-pytest --verbose tests/sklearn --large
-pytest --verbose tests/azureml --large
-pytest --verbose tests/models --large
-pytest --verbose tests/xgboost --large
-pytest --verbose tests/lightgbm --large
-pytest --verbose tests/statsmodels --large
-pytest --verbose tests/gluon --large
-pytest --verbose tests/gluon_autolog --large
-pytest --verbose tests/spacy --large
-pytest --verbose tests/fastai --large
-pytest --verbose tests/shap --large
-pytest --verbose tests/utils/test_model_utils.py --large
-pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large
+# pytest --verbose tests/pytorch --large
+# pytest --verbose tests/h2o --large
+# pytest --verbose tests/onnx --large
+# pytest --verbose tests/pyfunc --large
+# pytest --verbose tests/sklearn --large
+# pytest --verbose tests/azureml --large
+# pytest --verbose tests/models --large
+# pytest --verbose tests/xgboost --large
+# pytest --verbose tests/lightgbm --large
+# pytest --verbose tests/statsmodels --large
+# pytest --verbose tests/gluon --large
+# pytest --verbose tests/gluon_autolog --large
+# pytest --verbose tests/spacy --large
+# pytest --verbose tests/fastai --large
+# pytest --verbose tests/shap --large
+# pytest --verbose tests/utils/test_model_utils.py --large
+pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large -s
 
 
 test $err = 0

--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -24,7 +24,7 @@ pytest --verbose tests/spacy --large
 pytest --verbose tests/fastai --large
 pytest --verbose tests/shap --large
 pytest --verbose tests/utils/test_model_utils.py --large
-pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large -s
+pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large
 
 
 test $err = 0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,4 +44,4 @@ def enable_test_mode_by_default_for_autologging_integrations():
     are raised and detected. For more information about autologging test mode, see the docstring
     for :py:func:`mlflow.utils.autologging_utils._is_testing()`.
     """
-    test_mode_on()
+    yield from test_mode_on()

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -675,7 +675,9 @@ def test_flush_queue_is_thread_safe():
     from mlflow.entities import Metric
     from mlflow.tensorflow import _flush_queue, _metric_queue_lock
 
-    metric_queue_item = ("run_id1", Metric("foo", 0.1, 100, 1))
+    client = mlflow.tracking.MlflowClient()
+    run = client.create_run(experiment_id="0")
+    metric_queue_item = (run.info.run_id, Metric("foo", 0.1, 100, 1))
     mlflow.tensorflow._metric_queue.append(metric_queue_item)
 
     # Verify that, if another thread holds a lock on the metric queue leveraged by

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -675,7 +675,7 @@ def test_flush_queue_is_thread_safe():
     from mlflow.entities import Metric
     from mlflow.tensorflow import _flush_queue, _metric_queue_lock
 
-    metric_queue_item = ("run_id1", Metric("foo", "bar", 100, 1))
+    metric_queue_item = ("run_id1", Metric("foo", 0.1, 100, 1))
     mlflow.tensorflow._metric_queue.append(metric_queue_item)
 
     # Verify that, if another thread holds a lock on the metric queue leveraged by

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -149,6 +149,7 @@ def test_universal_autolog_calls_pyspark_immediately():
 @pytest.mark.parametrize("config", [{"disable": False}, {"disable": True}])
 def test_universal_autolog_attaches_pyspark_import_hook_if_pyspark_isnt_installed(config):
     with mock.patch("mlflow.spark.autolog", wraps=mlflow.spark.autolog) as autolog_mock:
+        autolog_mock.integration_name = "spark"
         # simulate pyspark not being installed
         autolog_mock.side_effect = ImportError("no module named pyspark blahblah")
 

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -39,22 +39,32 @@ library_to_mlflow_module = {**library_to_mlflow_module_without_pyspark, pyspark:
 
 @pytest.fixture(autouse=True)
 def reset_global_states():
+    from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
+
+    for key in AUTOLOGGING_INTEGRATIONS.keys():
+        AUTOLOGGING_INTEGRATIONS[key].clear()
+
     for integration_name in library_to_mlflow_module.keys():
         try:
             del mlflow.utils.import_hooks._post_import_hooks[integration_name.__name__]
         except Exception:
             pass
 
+    assert all(v == {} for v in AUTOLOGGING_INTEGRATIONS.values())
     assert mlflow.utils.import_hooks._post_import_hooks == {}
 
     yield
 
+    for key in AUTOLOGGING_INTEGRATIONS.keys():
+        AUTOLOGGING_INTEGRATIONS[key].clear()
+
     for integration_name in library_to_mlflow_module.keys():
         try:
             del mlflow.utils.import_hooks._post_import_hooks[integration_name.__name__]
         except Exception:
             pass
 
+    assert all(v == {} for v in AUTOLOGGING_INTEGRATIONS.values())
     assert mlflow.utils.import_hooks._post_import_hooks == {}
 
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Currently `enable_test_mode_by_default_for_autologging_integrations ` just creates a generator and doesn't actually enable the autologging testing mode. This PR fixes the issue by using `yield from`.

```python
@pytest.fixture(autouse=True, scope="session")
def enable_test_mode_by_default_for_autologging_integrations():
    test_mode_on()
    # this just creates a generator and doesn't enable the autologging testing mode
```

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
