### PR TITLE
[Follow-up for #4101] Fix broken autologging example tests

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,4 +1,3 @@
-# Dummy change to trigger example tests. Remove this before merge
 name: Examples
 
 on:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,3 +1,4 @@
+
 name: Examples
 
 on:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,4 +1,4 @@
-
+# Dummy change to trigger example tests. Remove this before merge
 name: Examples
 
 on:

--- a/mlflow/fastai.py
+++ b/mlflow/fastai.py
@@ -511,7 +511,6 @@ def autolog(log_models=True, disable=False, exclusive=False):  # pylint: disable
                     try_mlflow_log(mlflow.log_param, "train_bn", self.train_bn)
 
                 summary = model_summary(self.learner)
-                try_mlflow_log(mlflow.set_tag, "model_summary", summary)
 
                 tempdir = tempfile.mkdtemp()
                 try:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -18,6 +18,16 @@ _logger = logging.getLogger(__name__)
 MLMODEL_FILE_NAME = "MLmodel"
 
 
+_LOG_MODEL_METADATA_WARNING_TEMPLATE = (
+    "Logging model metadata to the tracking server has failed, possibly due older "
+    "server version. The model artifacts have been logged successfully under %s. "
+    "In addition to exporting model artifacts, MLflow clients 1.7.0 and above "
+    "attempt to record model metadata to the  tracking store. If logging to a "
+    "mlflow server via REST, consider  upgrading the server version to MLflow "
+    "1.7.0 or above."
+)
+
+
 class Model(object):
     """
     An MLflow Model that can support multiple model flavors. Provides APIs for implementing
@@ -178,15 +188,7 @@ class Model(object):
             except MlflowException:
                 # We need to swallow all mlflow exceptions to maintain backwards compatibility with
                 # older tracking servers. Only print out a warning for now.
-                _logger.warning(
-                    "Logging model metadata to the tracking server has failed, possibly due older "
-                    "server version. The model artifacts have been logged successfully under %s. "
-                    "In addition to exporting model artifacts, MLflow clients 1.7.0 and above "
-                    "attempt to record model metadata to the  tracking store. If logging to a "
-                    "mlflow server via REST, consider  upgrading the server version to MLflow "
-                    "1.7.0 or above.",
-                    mlflow.get_artifact_uri(),
-                )
+                _logger.warning(_LOG_MODEL_METADATA_WARNING_TEMPLATE, mlflow.get_artifact_uri())
             if registered_model_name is not None:
                 run_id = mlflow.tracking.fluent.active_run().info.run_id
                 mlflow.register_model(

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -16,8 +16,6 @@ _logger = logging.getLogger(__name__)
 
 
 MLMODEL_FILE_NAME = "MLmodel"
-
-
 _LOG_MODEL_METADATA_WARNING_TEMPLATE = (
     "Logging model metadata to the tracking server has failed, possibly due older "
     "server version. The model artifacts have been logged successfully under %s. "

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -36,7 +36,6 @@ from mlflow.utils.annotations import keyword_only, experimental
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import _copy_file_or_tree, TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
-from mlflow.utils.mlflow_tags import MLFLOW_AUTOLOGGING
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     safe_patch,

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -899,7 +899,7 @@ def autolog(
 
     def train(original, self, *args, **kwargs):
         active_run = mlflow.active_run()
-        if MLFLOW_AUTOLOGGING in active_run.data.tags:
+        if active_run:
             global _AUTOLOG_RUN_ID
             _AUTOLOG_RUN_ID = active_run.info.run_id
 

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -25,7 +25,7 @@ import mlflow
 import mlflow.keras
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
-from mlflow.models import Model
+from mlflow.models import Model, _LOG_MODEL_METADATA_WARNING_TEMPLATE
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
@@ -955,16 +955,11 @@ def autolog(
                     try:
                         client._record_logged_model(_AUTOLOG_RUN_ID, mlflow_model)
                     except MlflowException:
-                        # We need to swallow all mlflow exceptions to maintain backwards compatibility with
-                        # older tracking servers. Only print out a warning for now.
+                        # We need to swallow all mlflow exceptions to maintain backwards
+                        # compatibility with older tracking servers. Only print out a warning
+                        # for now.
                         _logger.warning(
-                            "Logging model metadata to the tracking server has failed, possibly due older "
-                            "server version. The model artifacts have been logged successfully under %s. "
-                            "In addition to exporting model artifacts, MLflow clients 1.7.0 and above "
-                            "attempt to record model metadata to the  tracking store. If logging to a "
-                            "mlflow server via REST, consider  upgrading the server version to MLflow "
-                            "1.7.0 or above.",
-                            get_artifact_uri(_AUTOLOG_RUN_ID),
+                            _LOG_MODEL_METADATA_WARNING_TEMPLATE, get_artifact_uri(_AUTOLOG_RUN_ID),
                         )
 
             try_mlflow_log(log_model_without_starting_new_run)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -899,9 +899,8 @@ def autolog(
 
     def train(original, self, *args, **kwargs):
         active_run = mlflow.active_run()
-        if active_run:
-            global _AUTOLOG_RUN_ID
-            _AUTOLOG_RUN_ID = active_run.info.run_id
+        global _AUTOLOG_RUN_ID
+        _AUTOLOG_RUN_ID = active_run.info.run_id
 
         # Checking step and max_step parameters for logging
         if len(args) >= 3:

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -25,8 +25,8 @@ import mlflow
 import mlflow.keras
 from mlflow import pyfunc
 from mlflow.exceptions import MlflowException
-from mlflow.models import Model, _LOG_MODEL_METADATA_WARNING_TEMPLATE
-from mlflow.models.model import MLMODEL_FILE_NAME
+from mlflow.models import Model
+from mlflow.models.model import MLMODEL_FILE_NAME, _LOG_MODEL_METADATA_WARNING_TEMPLATE
 from mlflow.models.signature import ModelSignature
 from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.protos.databricks_pb2 import DIRECTORY_NOT_EMPTY

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -130,6 +130,7 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False, tags
                      Used only when ``run_id`` is unspecified.
     :param nested: Controls whether run is nested in parent run. ``True`` creates a nested run.
     :param tags: An optional dictionary of string keys and values to set as tags on the new run.
+                 If an existing run is being resumed, this argument is ignored.
     :return: :py:class:`mlflow.ActiveRun` object that acts as a context manager wrapping
              the run's state.
 

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -17,7 +17,6 @@ import mlflow
 from mlflow.entities.run_status import RunStatus
 from mlflow.entities import Metric
 from mlflow.tracking.client import MlflowClient
-from mlflow.tracking.fluent import _RUN_ID_ENV_VAR
 from mlflow.utils import gorilla
 from mlflow.utils.mlflow_tags import MLFLOW_AUTOLOGGING
 from mlflow.utils.validation import MAX_METRICS_PER_BATCH
@@ -805,7 +804,7 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
     """
 
     def create_managed_run():
-        run_id_env_var_exists = _RUN_ID_ENV_VAR in os.environ
+        run_id_env_var_exists = mlflow.tracking._RUN_ID_ENV_VAR in os.environ
         managed_run = mlflow.start_run(tags=tags)
         _logger.info(
             "Created MLflow autologging run with ID '%s', which will track hyperparameters,"

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -17,6 +17,7 @@ import mlflow
 from mlflow.entities.run_status import RunStatus
 from mlflow.entities import Metric
 from mlflow.tracking.client import MlflowClient
+from mlflow.tracking.fluent import _RUN_ID_ENV_VAR
 from mlflow.utils import gorilla
 from mlflow.utils.mlflow_tags import MLFLOW_AUTOLOGGING
 from mlflow.utils.validation import MAX_METRICS_PER_BATCH
@@ -804,6 +805,7 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
     """
 
     def create_managed_run():
+        run_id_env_var_exists = _RUN_ID_ENV_VAR in os.environ
         managed_run = mlflow.start_run(tags=tags)
         _logger.info(
             "Created MLflow autologging run with ID '%s', which will track hyperparameters,"
@@ -812,6 +814,8 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
             managed_run.info.run_id,
             autologging_integration,
         )
+        if run_id_env_var_exists:
+            try_mlflow_log(mlflow.set_tags, tags)
         return managed_run
 
     if inspect.isclass(patch_function):

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -804,8 +804,8 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
     """
 
     def create_managed_run():
-        run_id_env_var_exists = mlflow.tracking._RUN_ID_ENV_VAR in os.environ
-        managed_run = mlflow.start_run(tags=tags)
+        managed_run = mlflow.start_run()
+        try_mlflow_log(mlflow.set_tags, tags)
         _logger.info(
             "Created MLflow autologging run with ID '%s', which will track hyperparameters,"
             " performance metrics, model artifacts, and lineage information for the"
@@ -813,8 +813,6 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
             managed_run.info.run_id,
             autologging_integration,
         )
-        if run_id_env_var_exists:
-            try_mlflow_log(mlflow.set_tags, tags)
         return managed_run
 
     if inspect.isclass(patch_function):

--- a/tests/fastai/test_fastai_autolog.py
+++ b/tests/fastai/test_fastai_autolog.py
@@ -125,7 +125,6 @@ def test_fastai_autolog_logs_expected_data(fastai_random_data_run, fit_variant):
     # Testing optimizer parameters are logged
     assert "opt_func" in data.params
     assert data.params["opt_func"] == "Adam"
-    assert "model_summary" in data.tags
 
     # Testing model_summary.txt is saved
     client = mlflow.tracking.MlflowClient()


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

#4101 enabled the autologging testing mode. This change has revealed several hidden errors in the example tests. This PR fixes them:

https://github.com/mlflow/mlflow/runs/1896644303?check_suite_focus=true

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
