### PR TITLE
Refactor hyperparam example to make it run faster

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -46,6 +46,8 @@ jobs:
         echo "/usr/share/miniconda/bin" >> $GITHUB_PATH
 
     - run: |
+        conda create -n test python=3.6
+        conda activate test
         pip install numpy
         pip install -r requirements.txt
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         echo "/usr/share/miniconda/bin" >> $GITHUB_PATH
 
-    - run:
+    - run: |
         pip install numpy
         pip install -r requirements.txt
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -46,6 +46,7 @@ jobs:
         echo "/usr/share/miniconda/bin" >> $GITHUB_PATH
 
     - run:
+        pip install numpy
         pip install -r requirements.txt
 
     - name: Install dependencies

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -45,6 +45,9 @@ jobs:
       run: |
         echo "/usr/share/miniconda/bin" >> $GITHUB_PATH
 
+    - run:
+        pip install -r requirements.txt
+
     - name: Install dependencies
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}
       env:

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -47,7 +47,7 @@ jobs:
 
     - run: |
         conda create --yes -n test python=3.6
-        conda activate test
+        source activate test
         pip install numpy
         pip install -r requirements.txt
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -46,7 +46,7 @@ jobs:
         echo "/usr/share/miniconda/bin" >> $GITHUB_PATH
 
     - run: |
-        conda create -n test python=3.6
+        conda create --yes -n test python=3.6
         conda activate test
         pip install numpy
         pip install -r requirements.txt

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -57,7 +57,7 @@ jobs:
       if: ${{ github.event_name == 'schedule' || steps.check-diff.outputs.examples_changed == 'true' }}
       run: |
         source activate test-environment
-        pytest --verbose tests/examples --durations=30 --large
+        pytest --verbose tests/examples -s --durations=30 --large
 
     - name: Remove conda environments
       run: |

--- a/examples/hyperparam/conda.yaml
+++ b/examples/hyperparam/conda.yaml
@@ -5,10 +5,10 @@ channels:
   - conda-forge
 dependencies:
   - python=3.6
-  - numpy=1.14.3
-  - pandas=0.22.0
-  - scikit-learn=0.19.1
-  - matplotlib=2.2.2
+  - numpy==1.14.3
+  - pandas==0.22.0
+  - scikit-learn==0.19.1
+  - matplotlib==2.2.2
   - keras==2.2.2
   - pip
   - pip:

--- a/examples/hyperparam/train.py
+++ b/examples/hyperparam/train.py
@@ -112,7 +112,7 @@ class MLflowCheckpoint(Callback):
 @click.argument("training_data")
 def run(training_data, epochs, batch_size, learning_rate, momentum, seed):
     warnings.filterwarnings("ignore")
-    data = pd.read_csv(training_data, sep=";").sample(frac=0.1, random_state=0)
+    data = pd.read_csv(training_data, sep=";").sample(frac=0.1, random_state=0).iloc[:, :4]
     # Split the data into training and test sets. (0.75, 0.25) split.
     train, test = train_test_split(data, random_state=seed)
     train, valid = train_test_split(train, random_state=seed)
@@ -146,7 +146,6 @@ def run(training_data, epochs, batch_size, learning_rate, momentum, seed):
                         input_shape=(train_x.shape[1],),
                     )
                 )
-                model.add(Dense(16, activation="relu", kernel_initializer="normal"))
                 model.add(Dense(16, activation="relu", kernel_initializer="normal"))
                 model.add(Dense(1, kernel_initializer="normal", activation="linear"))
                 model.compile(

--- a/examples/hyperparam/train.py
+++ b/examples/hyperparam/train.py
@@ -112,7 +112,7 @@ class MLflowCheckpoint(Callback):
 @click.argument("training_data")
 def run(training_data, epochs, batch_size, learning_rate, momentum, seed):
     warnings.filterwarnings("ignore")
-    data = pd.read_csv(training_data, sep=";")
+    data = pd.read_csv(training_data, sep=";").sample(frac=0.1, random_state=0)
     # Split the data into training and test sets. (0.75, 0.25) split.
     train, test = train_test_split(data, random_state=seed)
     train, valid = train_test_split(train, random_state=seed)

--- a/examples/hyperparam/train.py
+++ b/examples/hyperparam/train.py
@@ -112,7 +112,7 @@ class MLflowCheckpoint(Callback):
 @click.argument("training_data")
 def run(training_data, epochs, batch_size, learning_rate, momentum, seed):
     warnings.filterwarnings("ignore")
-    data = pd.read_csv(training_data, sep=";").sample(frac=0.1, random_state=0).iloc[:, :4]
+    data = pd.read_csv(training_data, sep=";").sample(frac=0.1, random_state=0)
     # Split the data into training and test sets. (0.75, 0.25) split.
     train, test = train_test_split(data, random_state=seed)
     train, valid = train_test_split(train, random_state=seed)

--- a/examples/hyperparam/train.py
+++ b/examples/hyperparam/train.py
@@ -147,6 +147,7 @@ def run(training_data, epochs, batch_size, learning_rate, momentum, seed):
                     )
                 )
                 model.add(Dense(16, activation="relu", kernel_initializer="normal"))
+                model.add(Dense(16, activation="relu", kernel_initializer="normal"))
                 model.add(Dense(1, kernel_initializer="normal", activation="linear"))
                 model.compile(
                     loss="mean_squared_error",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Gpy==1.9.2
+GpyOpt==1.2.5
+pyDOE==0.3.8
+hyperopt==0.1

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -78,9 +78,9 @@ def report_free_disk_space(capsys):
     [
         ("h2o", []),
         ("hyperparam", ["-e", "train", "-P", "epochs=1"]),
-        ("hyperparam", ["-e", "random", "-P", "epochs=1"]),
-        ("hyperparam", ["-e", "gpyopt", "-P", "epochs=1"]),
-        ("hyperparam", ["-e", "hyperopt", "-P", "epochs=1"]),
+        ("hyperparam", ["-e", "random", "-P", "epochs=1", "-P", "max_runs=2"]),
+        ("hyperparam", ["-e", "gpyopt", "-P", "epochs=1", "-P", "max_runs=2"]),
+        ("hyperparam", ["-e", "hyperopt", "-P", "epochs=1", "-P", "max_runs=2"]),
         (
             "lightgbm",
             ["-P", "learning_rate=0.1", "-P", "colsample_bytree=0.8", "-P", "subsample=0.9"],


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
