### PR TITLE
Support parsing df input with tensor schema and parsing tensor input with df schema. 

### DIFF
--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -102,7 +102,7 @@ def _dataframe_from_json(
         if schema.is_tensor_spec():
             # The schema can be either:
             #  - a single tensor: attempt to parse all columns with the same dtype
-            #  - a dictionary of tensors: each column gets the type from ____ named tensor
+            #  - a dictionary of tensors: each column gets the type from an equally named tensor
             if len(schema.inputs) == 1:
                 dtypes = schema.numpy_types()[0]
             else:

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -171,9 +171,11 @@ def parse_tf_serving_input(inp_dict, schema=None):
                             type(input_data)
                         )
                     )
-                for col_name, col_type in zip(schema.input_names(), schema.numpy_types()):
-                    if col_name in input_data:
-                        input_data[col_name] = np.array(input_data[col_name], dtype=col_type)
+                type_dict = dict(zip(schema.input_names(), schema.numpy_types()))
+                for col_name in input_data.keys():
+                    input_data[col_name] = np.array(
+                        input_data[col_name], dtype=type_dict.get(col_name)
+                    )
             else:
                 if not isinstance(input_data, list):
                     raise MlflowException(
@@ -181,7 +183,7 @@ def parse_tf_serving_input(inp_dict, schema=None):
                         " model signature which expects a single n-dimensional array as input,"
                         " however, an input of type {0} was found.".format(type(input_data))
                     )
-                input_data = np.array(input_data, dtype=schema.inputs[0].type)
+                input_data = np.array(input_data, dtype=schema.numpy_types()[0])
         else:
             if isinstance(input_data, dict):
                 input_data = {k: np.array(v) for k, v in input_data.items()}

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -102,7 +102,7 @@ def _dataframe_from_json(
         if schema.is_tensor_spec():
             # The schema can be either:
             #  - a single tensor: attempt to parse all columns with the same dtype
-            #  - a dictionary of tensors: each column gets the type from equaly named tensor
+            #  - a dictionary of tensors: each column gets the type from ____ named tensor
             if len(schema.inputs) == 1:
                 dtypes = schema.numpy_types()[0]
             else:

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -99,14 +99,25 @@ def _dataframe_from_json(
     from mlflow.types import DataType
 
     if schema is not None:
-        dtypes = dict(zip(schema.input_names(), schema.pandas_types()))
+        if schema.is_tensor_spec():
+            # The schema can be either:
+            #  - a single tensor: attempt to parse all columns with the same dtype
+            #  - a dictionary of tensors: each column gets the type from equaly named tensor
+            if len(schema.inputs) == 1:
+                dtypes = schema.numpy_types()[0]
+            else:
+                dtypes = dict(zip(schema.input_names(), schema.numpy_types()))
+        else:
+            dtypes = dict(zip(schema.input_names(), schema.pandas_types()))
+
         df = pd.read_json(
             path_or_str, orient=pandas_orient, dtype=dtypes, precise_float=precise_float
         )
-        actual_cols = set(df.columns)
-        for type_, name in zip(schema.input_types(), schema.input_names()):
-            if type_ == DataType.binary and name in actual_cols:
-                df[name] = df[name].map(lambda x: base64.decodebytes(bytes(x, "utf8")))
+        if not schema.is_tensor_spec():
+            actual_cols = set(df.columns)
+            for type_, name in zip(schema.input_types(), schema.input_names()):
+                if type_ == DataType.binary and name in actual_cols:
+                    df[name] = df[name].map(lambda x: base64.decodebytes(bytes(x, "utf8")))
         return df
     else:
         return pd.read_json(
@@ -160,8 +171,8 @@ def parse_tf_serving_input(inp_dict, schema=None):
                             type(input_data)
                         )
                     )
-                for col_name, tensor_spec in zip(schema.input_names(), schema.inputs):
-                    input_data[col_name] = np.array(input_data[col_name], dtype=tensor_spec.type)
+                for col_name, col_type in zip(schema.input_names(), schema.numpy_types()):
+                    input_data[col_name] = np.array(input_data[col_name], dtype=col_type)
             else:
                 if not isinstance(input_data, list):
                     raise MlflowException(

--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -172,7 +172,8 @@ def parse_tf_serving_input(inp_dict, schema=None):
                         )
                     )
                 for col_name, col_type in zip(schema.input_names(), schema.numpy_types()):
-                    input_data[col_name] = np.array(input_data[col_name], dtype=col_type)
+                    if col_name in input_data:
+                        input_data[col_name] = np.array(input_data[col_name], dtype=col_type)
             else:
                 if not isinstance(input_data, list):
                     raise MlflowException(

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -1,18 +1,21 @@
+import base64
 import json
 import numpy as np
+import pandas as pd
 import pytest
 
 from mlflow.entities import Experiment, Metric
 from mlflow.exceptions import MlflowException
 from mlflow.protos.service_pb2 import Experiment as ProtoExperiment
 from mlflow.protos.service_pb2 import Metric as ProtoMetric
-from mlflow.types import Schema, TensorSpec
+from mlflow.types import Schema, TensorSpec, ColSpec, DataType
 
 from mlflow.utils.proto_json_utils import (
     message_to_json,
     parse_dict,
     _stringify_all_experiment_ids,
     parse_tf_serving_input,
+    _dataframe_from_json,
 )
 
 
@@ -85,6 +88,7 @@ def test_parse_tf_serving_dictionary():
         assert result.keys() == expected_result.keys()
         for key in result:
             assert (result[key] == expected_result[key]).all()
+            assert result[key].dtype == expected_result[key].dtype
 
     # instances are correctly aggregated to dict of input name -> tensor
     tfserving_input = {
@@ -106,17 +110,21 @@ def test_parse_tf_serving_dictionary():
     # With schema
     schema = Schema(
         [
-            TensorSpec(np.dtype("object"), [-1], "a"),
+            TensorSpec(np.dtype("str"), [-1], "a"),
             TensorSpec(np.dtype("float32"), [-1], "b"),
             TensorSpec(np.dtype("int32"), [-1], "c"),
         ]
     )
+    dfSchema = Schema([ColSpec("string", "a"), ColSpec("float", "b"), ColSpec("integer", "c"),])
     result = parse_tf_serving_input(tfserving_input, schema)
     expected_result_schema = {
-        "a": np.array(["s1", "s2", "s3"]),
+        "a": np.array(["s1", "s2", "s3"], dtype=np.dtype("str")),
         "b": np.array([1.1, 2.2, 3.3], dtype="float32"),
         "c": np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype="int32"),
     }
+    assert_result(result, expected_result_schema)
+    # With df Schema
+    result = parse_tf_serving_input(tfserving_input, dfSchema)
     assert_result(result, expected_result_schema)
 
     # input provided as a dict
@@ -133,6 +141,10 @@ def test_parse_tf_serving_dictionary():
 
     # With Schema
     result = parse_tf_serving_input(tfserving_input, schema)
+    assert_result(result, expected_result_schema)
+
+    # With df Schema
+    result = parse_tf_serving_input(tfserving_input, dfSchema)
     assert_result(result, expected_result_schema)
 
 
@@ -223,3 +235,78 @@ def test_parse_tf_serving_raises_expected_errors():
         'Failed to parse data as TF serving input. "signature_name" is currently not supported'
         in str(ex)
     )
+
+
+def test_dataframe_from_json():
+    source = pd.DataFrame(
+        {
+            "boolean": [True, False, True],
+            "string": ["a", "b", "c"],
+            "float": np.array([1.2, 2.3, 3.4], dtype=np.float32),
+            "double": np.array([1.2, 2.3, 3.4], dtype=np.float64),
+            "integer": np.array([3, 4, 5], dtype=np.int32),
+            "long": np.array([3, 4, 5], dtype=np.int64),
+            "binary": [bytes([1, 2, 3]), bytes([4, 5]), bytes([6])],
+        },
+        columns=["boolean", "string", "float", "double", "integer", "long", "binary"],
+    )
+
+    jsonable_df = pd.DataFrame(source, copy=True)
+    jsonable_df["binary"] = jsonable_df["binary"].map(base64.b64encode)
+    print(jsonable_df)
+    schema = Schema(
+        [
+            ColSpec("boolean", "boolean"),
+            ColSpec("string", "string"),
+            ColSpec("float", "float"),
+            ColSpec("double", "double"),
+            ColSpec("integer", "integer"),
+            ColSpec("long", "long"),
+            ColSpec("binary", "binary"),
+        ]
+    )
+    expected_dtypes = {
+        "boolean": DataType.boolean.to_pandas(),
+        "string": np.dtype("object"),
+        "float": DataType.float.to_pandas(),
+        "double": DataType.double.to_pandas(),
+        "integer": DataType.integer.to_pandas(),
+        "long": DataType.long.to_pandas(),
+        "binary": np.dtype("object"),
+    }
+    parsed = _dataframe_from_json(
+        jsonable_df.to_json(orient="split"), pandas_orient="split", schema=schema
+    )
+    assert parsed.equals(source)
+    assert dict(expected_dtypes) == dict(parsed.dtypes)
+    parsed = _dataframe_from_json(
+        jsonable_df.to_json(orient="records"), pandas_orient="records", schema=schema
+    )
+    assert parsed.equals(source)
+    assert dict(expected_dtypes) == dict(parsed.dtypes)
+    # try parsing with tensor schema
+    tensor_schema = Schema(
+        [
+            TensorSpec(np.dtype("bool"), [-1], "boolean"),
+            TensorSpec(np.dtype("str"), [-1], "string"),
+            TensorSpec(np.dtype("float32"), [-1], "float"),
+            TensorSpec(np.dtype("float64"), [-1], "double"),
+            TensorSpec(np.dtype("int32"), [-1], "integer"),
+            TensorSpec(np.dtype("int64"), [-1], "long"),
+            TensorSpec(np.dtype(bytes), [-1], "binary"),
+        ]
+    )
+    parsed = _dataframe_from_json(
+        jsonable_df.to_json(orient="split"), pandas_orient="split", schema=tensor_schema
+    )
+
+    # NB: tensor schema does not automatically decode base64 encoded bytes.
+    assert parsed.equals(jsonable_df)
+    assert dict(expected_dtypes) == dict(parsed.dtypes)
+    parsed = _dataframe_from_json(
+        jsonable_df.to_json(orient="records"), pandas_orient="records", schema=tensor_schema
+    )
+
+    # NB: tensor schema does not automatically decode base64 encoded bytes.
+    assert parsed.equals(jsonable_df)
+    assert dict(expected_dtypes) == dict(parsed.dtypes)

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -264,15 +264,6 @@ def test_dataframe_from_json():
             ColSpec("binary", "binary"),
         ]
     )
-    expected_dtypes = {
-        "boolean": DataType.boolean.to_pandas(),
-        "string": np.dtype("object"),
-        "float": DataType.float.to_pandas(),
-        "double": DataType.double.to_pandas(),
-        "integer": DataType.integer.to_pandas(),
-        "long": DataType.long.to_pandas(),
-        "binary": np.dtype("object"),
-    }
     parsed = _dataframe_from_json(
         jsonable_df.to_json(orient="split"), pandas_orient="split", schema=schema
     )
@@ -311,7 +302,7 @@ def test_dataframe_from_json():
     source = pd.DataFrame(
         {
             "a": np.array([1, 2, 3], dtype=np.float32),
-            "b": np.array([4, 5, 6], dtype=np.float32),
+            "b": np.array([4.1, 5.2, 6.3], dtype=np.float32),
             "c": np.array([7, 8, 9], dtype=np.float32),
         },
         columns=["a", "b", "c"],

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -102,8 +102,8 @@ def test_parse_tf_serving_dictionary():
     result = parse_tf_serving_input(tfserving_input)
     expected_result_no_schema = {
         "a": np.array(["s1", "s2", "s3"]),
-        "b": np.array([1.1, 2.2, 3.3], dtype="float64"),
-        "c": np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]], dtype="int64"),
+        "b": np.array([1.1, 2.2, 3.3]),
+        "c": np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
     }
     assert_result(result, expected_result_no_schema)
 

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -115,7 +115,7 @@ def test_parse_tf_serving_dictionary():
             TensorSpec(np.dtype("int32"), [-1], "c"),
         ]
     )
-    dfSchema = Schema([ColSpec("string", "a"), ColSpec("float", "b"), ColSpec("integer", "c"),])
+    dfSchema = Schema([ColSpec("string", "a"), ColSpec("float", "b"), ColSpec("integer", "c")])
     result = parse_tf_serving_input(tfserving_input, schema)
     expected_result_schema = {
         "a": np.array(["s1", "s2", "s3"], dtype=np.dtype("str")),

--- a/tests/utils/test_proto_json_utils.py
+++ b/tests/utils/test_proto_json_utils.py
@@ -8,7 +8,7 @@ from mlflow.entities import Experiment, Metric
 from mlflow.exceptions import MlflowException
 from mlflow.protos.service_pb2 import Experiment as ProtoExperiment
 from mlflow.protos.service_pb2 import Metric as ProtoMetric
-from mlflow.types import Schema, TensorSpec, ColSpec, DataType
+from mlflow.types import Schema, TensorSpec, ColSpec
 
 from mlflow.utils.proto_json_utils import (
     message_to_json,


### PR DESCRIPTION

Signed-off-by: tomasatdatabricks <tomas.nykodym@databricks.com>

## What changes are proposed in this pull request?
As part of adding support for tensor input to MLflow models, we've introduced a tensor schema and tensor JSON input. The schema is used during JSON parsing to cast the input to correct data types. The assumption is that tensor models will be scored with tensor input and dataframe models will be scored with dataframe input. However, this does not always have to be the case as 2d input can be represented  as both tensor or dataframe input. This PR fixes the behavior of model serving when schema type and json type are not the same. 

## How is this patch tested?
Added tests to test_proto_utils.


## Release Notes
n/a
### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
