### PR TITLE
Expand documentation for MLflow Skinny

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,10 @@ MLflow requires ``conda`` to be on the ``PATH`` for the projects feature.
 
 Nightly snapshots of MLflow master are also available `here <https://mlflow-snapshots.s3-us-west-2.amazonaws.com/>`_.
 
+Install a lower dependency subset of MLflow from PyPI via ``pip install mlflow-skinny``
+Extra dependencies can be added per desired scenario.
+For example, ``pip install mlflow-skinny pandas numpy`` allows for mlflow.pyfunc.log_model support.
+
 Documentation
 -------------
 Official documentation for MLflow can be found at https://mlflow.org/docs/latest/index.html.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -28,11 +28,13 @@ You install MLflow by running:
     MLflow works on MacOS. If you run into issues with the default system Python on MacOS, try
     installing Python 3 through the `Homebrew <https://brew.sh/>`_ package manager using
     ``brew install python``. (In this case, installing MLflow is now ``pip3 install mlflow``).
-    MLflow skinny supports a subset of MLflow where extra dependencies can be added as needed.
 
 To use certain MLflow modules and functionality (ML model persistence/inference, artifact storage options, etc),
 you may need to install extra libraries. For example, the ``mlflow.tensorflow`` module requires TensorFlow to be installed.
 See https://github.com/mlflow/mlflow/blob/master/EXTRA_DEPENDENCIES.rst for more details
+
+MLflow skinny will also need installation of extra dependencies for certain MLflow modules and functionality. For example, 
+``mlflow.set_tracking_uri("sqlite://my.db")`` requires ``pip install mlflow-skinny sqlalchemy alembic sqlparse``.
 
 At this point we recommend you follow the :doc:`tutorial<tutorials-and-examples/tutorial>` for a walk-through on how you
 can leverage MLflow in your daily workflow.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -19,11 +19,16 @@ You install MLflow by running:
         install.packages("mlflow")
         mlflow::install_mlflow()
 
+    .. code-block:: python
+
+        pip install mlflow-skinny
+
 .. note::
 
     MLflow works on MacOS. If you run into issues with the default system Python on MacOS, try
     installing Python 3 through the `Homebrew <https://brew.sh/>`_ package manager using
     ``brew install python``. (In this case, installing MLflow is now ``pip3 install mlflow``).
+    MLflow skinny supports a subset of MLflow where extra dependencies can be added as needed.
 
 To use certain MLflow modules and functionality (ML model persistence/inference, artifact storage options, etc),
 you may need to install extra libraries. For example, the ``mlflow.tensorflow`` module requires TensorFlow to be installed.

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -34,7 +34,7 @@ you may need to install extra libraries. For example, the ``mlflow.tensorflow`` 
 See https://github.com/mlflow/mlflow/blob/master/EXTRA_DEPENDENCIES.rst for more details
 
 MLflow skinny will also need installation of extra dependencies for certain MLflow modules and functionality. For example, 
-``mlflow.set_tracking_uri("sqlite://my.db")`` requires ``pip install mlflow-skinny sqlalchemy alembic sqlparse``.
+``mlflow.set_tracking_uri("sqlite:///my.db")`` requires ``pip install mlflow-skinny sqlalchemy alembic sqlparse``.
 
 At this point we recommend you follow the :doc:`tutorial<tutorials-and-examples/tutorial>` for a walk-through on how you
 can leverage MLflow in your daily workflow.


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add installation sections with brief explanations on how to use MLflow Skinny and unlock extra functionality from MLflow proper.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
