### PR TITLE
[ML-13739] Model version creation should fail if the status returned is not READY

### DIFF
--- a/mlflow/entities/model_registry/model_version.py
+++ b/mlflow/entities/model_registry/model_version.py
@@ -26,7 +26,7 @@ class ModelVersion(_ModelRegistryEntity):
         current_stage=None,
         source=None,
         run_id=None,
-        status=None,
+        status=ModelVersionStatus.to_string(ModelVersionStatus.READY),
         status_message=None,
         tags=None,
         run_link=None,

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -215,8 +215,10 @@ class ModelRegistryClient(object):
                 mv = self.get_model_version(mv.name, mv.version)
                 sleep(AWAIT_MODEL_VERSION_CREATE_SLEEP_DURATION_SECONDS)
             if mv.status != ModelVersionStatus.to_string(ModelVersionStatus.READY):
-                raise MlflowException("Failed to successfully register the model version. \
-                Please check that the source location of the model is correct.")
+                raise MlflowException(
+                    "Failed to successfully create the model version. \
+                Please check that the source location of the model is correct."
+                )
         return mv
 
     def update_model_version(self, name, version, description):

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -214,6 +214,9 @@ class ModelRegistryClient(object):
                     )
                 mv = self.get_model_version(mv.name, mv.version)
                 sleep(AWAIT_MODEL_VERSION_CREATE_SLEEP_DURATION_SECONDS)
+            if mv.status != ModelVersionStatus.to_string(ModelVersionStatus.READY):
+                raise MlflowException("Failed to successfully register the model version. \
+                Please check that the source location of the model is correct.")
         return mv
 
     def update_model_version(self, name, version, description):

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -216,8 +216,10 @@ class ModelRegistryClient(object):
                 sleep(AWAIT_MODEL_VERSION_CREATE_SLEEP_DURATION_SECONDS)
             if mv.status != ModelVersionStatus.to_string(ModelVersionStatus.READY):
                 raise MlflowException(
-                    "Failed to successfully create the model version. \
-                Please check that the source location of the model is correct."
+                    "Model version creation failed for model name: {} version: {} with status: {} \
+                    and message: {}".format(
+                        mv.name, mv.version, mv.status, mv.status_message
+                    )
                 )
         return mv
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -392,7 +392,7 @@ def test_create_model_version_non_ready_model(mock_registry_store):
     )
     with pytest.raises(MlflowException) as exc:
         client.create_model_version("name", "source")
-        assert "Failed to successfully create the model version" in exc.value
+        assert "Model version creation failed for model name" in exc.value
 
 
 def test_create_model_version_run_link_with_configured_profile(mock_registry_store):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -3,6 +3,7 @@ from unittest import mock
 
 from mlflow.entities import SourceType, ViewType, RunTag, Run, RunInfo
 from mlflow.entities.model_registry import ModelVersion, ModelVersionTag
+from mlflow.entities.model_registry.model_version_status import ModelVersionStatus
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import ErrorCode, FEATURE_DISABLED
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
@@ -17,6 +18,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_PROJECT_ENTRY_POINT,
 )
 from mlflow.utils.uri import construct_run_url
+
 
 
 @pytest.fixture
@@ -297,7 +299,7 @@ def test_create_model_version_nondatabricks_source_no_runlink(mock_registry_stor
     run_id = "runid"
     client = MlflowClient(tracking_uri="http://10.123.1231.11")
     mock_registry_store.create_model_version.return_value = ModelVersion(
-        "name", 1, 0, 1, source="source", run_id=run_id
+        "name", 1, 0, 1, source="source", run_id=run_id,
     )
     model_version = client.create_model_version("name", "source", "runid")
     assert model_version.name == "name"


### PR DESCRIPTION
Signed-off-by: Ankit Mathur <ankit.mathur@databricks.com>

## What changes are proposed in this pull request?

This PR fails model version creation if the status returned is not "READY" after exiting the pending state - in MLflow 1.12, we added a flag that awaits model version creation, but this was implemented in a way where it would wait until the status returned would not be checked, so long as it was not PENDING.

## How is this patch tested?

Added a unit test for this

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
