### PR TITLE
Avoid duplicate metrics logging in pytorch-lightning 1.2.0

### DIFF
--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -4,7 +4,6 @@ import mlflow.pytorch
 import os
 import shutil
 import tempfile
-from distutils.version import LooseVersion
 import pytorch_lightning as pl
 from pytorch_lightning.core.memory import ModelSummary
 from pytorch_lightning.utilities import rank_zero_only

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -120,10 +120,7 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
                 :param trainer: pytorch lightning trainer instance
                 :param pl_module: pytorch lightning base module
                 """
-                # pytorch-lightning runs a few steps of validation in the beginning of training
-                # as a sanity check during which we should avoid logging metrics
-                if not trainer.running_sanity_check:
-                    self._log_metrics(trainer, pl_module)
+                self._log_metrics(trainer, pl_module)
 
             def on_train_start(self, trainer, pl_module):
                 """

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -110,7 +110,7 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
                 """
                 # If validation loop is enabled (meaning `validation_step` is overridden),
                 # log metrics in `on_validaion_epoch_end` to avoid duplicate logging of metrics
-                if not trainer.enable_validation:
+                if trainer.disable_validation:
                     self._log_metrics(trainer, pl_module)
 
             def on_validation_epoch_end(self, trainer, pl_module):

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -136,7 +136,7 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
 
                 Related PR: https://github.com/PyTorchLightning/pytorch-lightning/pull/5986
 
-                As a workaround, use `on_train_epoch_end` and `on_validation_epoch_end` isntead
+                As a workaround, use `on_train_epoch_end` and `on_validation_epoch_end` instead
                 in pytorch-lightning >= 1.2.0.
 
                 :param trainer: pytorch lightning trainer instance

--- a/tests/pytorch/iris_data_module.py
+++ b/tests/pytorch/iris_data_module.py
@@ -9,7 +9,7 @@ from sklearn.datasets import load_iris
 from torch.utils.data import DataLoader, random_split, TensorDataset
 
 
-class IrisDataModule(pl.LightningDataModule):
+class IrisDataModuleBase(pl.LightningDataModule):
     def __init__(self):
         super().__init__()
         self.columns = None
@@ -35,11 +35,21 @@ class IrisDataModule(pl.LightningDataModule):
         if stage == "test" or stage is None:
             self.train_set, self.test_set = random_split(self.train_set, [110, 20])
 
+
+class IrisDataModule(IrisDataModuleBase):
     def train_dataloader(self):
         return DataLoader(self.train_set, batch_size=4)
 
     def val_dataloader(self):
         return DataLoader(self.val_set, batch_size=4)
+
+    def test_dataloader(self):
+        return DataLoader(self.test_set, batch_size=4)
+
+
+class IrisDataModuleWithoutValidation(IrisDataModuleBase):
+    def train_dataloader(self):
+        return DataLoader(self.train_set, batch_size=4)
 
     def test_dataloader(self):
         return DataLoader(self.test_set, batch_size=4)

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -92,13 +92,13 @@ def test_pytorch_autolog_logs_expected_data(pytorch_model):
 
 
 def test_pytorch_autolog_logs_expected_metrics_without_validation(pytorch_model_without_validation):
-    _, run = pytorch_model_without_validation
-    data = run.data
-    client = mlflow.tracking.MlflowClient()
+    trainer, run = pytorch_model_without_validation
+    assert not trainer.enable_validation
 
+    client = mlflow.tracking.MlflowClient()
     for metric_key in ["loss", "train_acc"]:
-        assert metric_key in data.metrics
-        metric_history = client.get_metric_history(run.info.run_id, "loss")
+        assert metric_key in run.data.metrics
+        metric_history = client.get_metric_history(run.info.run_id, metric_key)
         assert len(metric_history) == NUM_EPOCHS
 
 

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -78,7 +78,7 @@ def test_pytorch_autolog_logs_expected_data(pytorch_model):
 
     # Checking if metrics are logged
     assert "loss" in data.metrics
-    assert "train_acc" in data.metrics
+    assert "val_loss" in data.metrics
 
     # Testing optimizer parameters are logged
     assert "optimizer_name" in data.params

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -93,7 +93,7 @@ def test_pytorch_autolog_logs_expected_data(pytorch_model):
 
 def test_pytorch_autolog_logs_expected_metrics_without_validation(pytorch_model_without_validation):
     trainer, run = pytorch_model_without_validation
-    assert not trainer.enable_validation
+    assert trainer.disable_validation
 
     client = mlflow.tracking.MlflowClient()
     for metric_key in ["loss", "train_acc"]:

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -2,13 +2,13 @@ from distutils.version import LooseVersion
 import pytest
 import pytorch_lightning as pl
 import torch
-from iris import IrisClassification
+from iris import IrisClassification, IrisClassificationWithoutValidation
 import mlflow
 import mlflow.pytorch
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 from pytorch_lightning.callbacks import ModelCheckpoint
 from mlflow.utils.file_utils import TempDir
-from iris_data_module import IrisDataModule
+from iris_data_module import IrisDataModule, IrisDataModuleWithoutValidation
 from mlflow.utils.autologging_utils import BatchMetricsLogger
 from mlflow.pytorch._pytorch_autolog import _get_optimizer_name
 from unittest.mock import patch
@@ -30,11 +30,25 @@ def pytorch_model():
     return trainer, run
 
 
+@pytest.fixture
+def pytorch_model_without_validation():
+    mlflow.pytorch.autolog()
+    model = IrisClassificationWithoutValidation()
+    dm = IrisDataModuleWithoutValidation()
+    dm.prepare_data()
+    dm.setup(stage="fit")
+    trainer = pl.Trainer(max_epochs=NUM_EPOCHS)
+    trainer.fit(model, dm)
+    client = mlflow.tracking.MlflowClient()
+    run = client.get_run(client.list_run_infos(experiment_id="0")[0].run_id)
+    return trainer, run
+
+
 @pytest.mark.large
 @pytest.mark.parametrize("log_models", [True, False])
 def test_pytorch_autolog_log_models_configuration(log_models):
     mlflow.pytorch.autolog(log_models=log_models)
-    model = IrisClassification()
+    model = IrisClassificationWithoutValidation()
     dm = IrisDataModule()
     dm.prepare_data()
     dm.setup(stage="fit")
@@ -64,7 +78,7 @@ def test_pytorch_autolog_logs_expected_data(pytorch_model):
 
     # Checking if metrics are logged
     assert "loss" in data.metrics
-    assert "val_loss" in data.metrics
+    assert "train_acc" in data.metrics
 
     # Testing optimizer parameters are logged
     assert "optimizer_name" in data.params
@@ -75,6 +89,17 @@ def test_pytorch_autolog_logs_expected_data(pytorch_model):
     artifacts = client.list_artifacts(run.info.run_id)
     artifacts = map(lambda x: x.path, artifacts)
     assert "model_summary.txt" in artifacts
+
+
+def test_pytorch_autolog_logs_expected_metrics_without_validation(pytorch_model_without_validation):
+    _, run = pytorch_model_without_validation
+    data = run.data
+    client = mlflow.tracking.MlflowClient()
+
+    for metric_key in ["loss", "train_acc"]:
+        assert metric_key in data.metrics
+        metric_history = client.get_metric_history(run.info.run_id, "loss")
+        assert len(metric_history) == NUM_EPOCHS
 
 
 # pylint: disable=unused-argument


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

In pytorch-lightning 1.2.0 (released yesterday), the `on_epoch_callback` is called twice, once after train epoch, and once after validation epoch: See the PR below for details:

https://github.com/PyTorchLightning/pytorch-lightning/pull/5986 

This change makes our pytorch autologging callback log the same metrics:

https://github.com/mlflow/mlflow/runs/1933446600?check_suite_focus=true#step:8:33

```
E       AssertionError: assert 40 == 20
E        +  where 40 = len([<Metric: key='loss', step=0, timestamp=1613719593042, value=0.9595870971679688>, <Metric: key='loss', step=0, timesta...93481, value=0.7134160995483398>, <Metric: key='loss', step=2, timestamp=1613719593495, value=0.7134160995483398>, ...])
```

This PR fixes this issue by using `on_train_epoch_end` and `on_validation_epoch_end`.


## How is this patch tested?

Existing unit tests + a test ensuring pytorch autologging works a model which doesn't contain `validation_step`

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
