### PR TITLE
Merge tensorflow-1.x and tensorflow-2.x in cross version tests config

### DIFF
--- a/ml-package-versions.yml
+++ b/ml-package-versions.yml
@@ -67,9 +67,15 @@ tensorflow:
     requirements:
       "< 2.2": ["h5py<3.0", "scikit-learn"]
     run: |
-      TF_MAJOR_VERSION=$(python -c "import tensorflow; print(tensorflow.__version__.split('.')[0])")
+      python_code="
+      import tensorflow as tf
+      major_ver = tf.__version__.split('.')[0]
+      assert major_ver in ['1', '2']
+      print(major_ver)
+      "
+      tf_major_version=$(python -c "$python_code")
 
-      if [ "$TF_MAJOR_VERSION" == "1" ]; then
+      if [ "$tf_major_version" == "1" ]; then
         pytest tests/tensorflow/test_tensorflow_model_export.py --large
       else
         pytest tests/tensorflow/test_tensorflow2_model_export.py --large
@@ -81,9 +87,15 @@ tensorflow:
     requirements:
       "< 2.2": ["h5py<3.0"]
     run: |
-      TF_MAJOR_VERSION=$(python -c "import tensorflow; print(tensorflow.__version__.split('.')[0])")
+      python_code="
+      import tensorflow as tf
+      major_ver = tf.__version__.split('.')[0]
+      assert major_ver in ['1', '2']
+      print(major_ver)
+      "
+      tf_major_version=$(python -c "$python_code")
 
-      if [ "$TF_MAJOR_VERSION" == "1" ]; then
+      if [ "$tf_major_version" == "1" ]; then
         pytest tests/tensorflow_autolog/test_tensorflow_autolog.py --large
       else
         pytest tests/tensorflow_autolog/test_tensorflow2_autolog.py --large

--- a/ml-package-versions.yml
+++ b/ml-package-versions.yml
@@ -53,25 +53,7 @@ pytorch-lightning:
     run: |
       pytest tests/pytorch/test_pytorch_autolog.py --large
 
-tensorflow-1.x:
-  package_info:
-    pip_release: "tensorflow"
-
-  models:
-    minimum: "1.15.4"
-    maximum: "1.15.4"
-    requirements: ["h5py<3.0", "scikit-learn"]
-    run: |
-      pytest tests/tensorflow/test_tensorflow_model_export.py --large
-
-  autologging:
-    minimum: "1.15.4"
-    maximum: "1.15.4"
-    requirements: ["h5py<3.0"]
-    run: |
-      pytest tests/tensorflow_autolog/test_tensorflow_autolog.py --large
-
-tensorflow-2.x:
+tensorflow:
   package_info:
     pip_release: "tensorflow"
     install_dev: |
@@ -80,18 +62,32 @@ tensorflow-2.x:
       pip install 'tf-nightly==2.5.0.dev20210112'
 
   models:
-    minimum: "2.0.0"
+    minimum: "1.15.4"
     maximum: "2.3.1"
+    requirements:
+      "< 2.2": ["h5py<3.0", "scikit-learn"]
     run: |
-      pytest tests/tensorflow/test_tensorflow2_model_export.py --large
+      TF_MAJOR_VERSION=$(python -c "import tensorflow; print(tensorflow.__version__.split('.')[0])")
+
+      if [ "$TF_MAJOR_VERSION" == "1" ]; then
+        pytest tests/tensorflow/test_tensorflow_model_export.py --large
+      else
+        pytest tests/tensorflow/test_tensorflow2_model_export.py --large
+      fi
 
   autologging:
-    minimum: "2.0.0"
+    minimum: "1.15.4"
     maximum: "2.3.1"
     requirements:
       "< 2.2": ["h5py<3.0"]
     run: |
-      pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
+      TF_MAJOR_VERSION=$(python -c "import tensorflow; print(tensorflow.__version__.split('.')[0])")
+
+      if [ "$TF_MAJOR_VERSION" == "1" ]; then
+        pytest tests/tensorflow_autolog/test_tensorflow_autolog.py --large
+      else
+        pytest tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
+      fi
 
 keras:
   package_info:


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Merge `tensorflow-1.x` and `tensorflow-2.x` in the cross-version-tests config.


## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
