### PR TITLE
Run test scripts under tests/autologging

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -65,6 +65,7 @@ def pytest_ignore_collect(path, config):
     if not outcome.get_result() and config.getoption("ignore_flavors"):
         # If not ignored by the default hook and `--ignore-flavors` specified
 
+        # Ignored files and directories must be included in dev/run-python-flavor-tests.sh
         model_flavors = [
             "tests/h2o",
             "tests/keras",

--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -25,6 +25,6 @@ pytest --verbose tests/fastai --large
 pytest --verbose tests/shap --large
 pytest --verbose tests/utils/test_model_utils.py --large
 pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large
-pytest --verbose tests/autologging
+pytest --verbose tests/autologging --large
 
 test $err = 0

--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -25,6 +25,6 @@ pytest --verbose tests/fastai --large
 pytest --verbose tests/shap --large
 pytest --verbose tests/utils/test_model_utils.py --large
 pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large
-
+pytest --verbose tests/autologging
 
 test $err = 0


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Run test scripts under `tests/autologging` that are ignored now (see https://github.com/mlflow/mlflow/pull/4119#discussion_r580984303 for details)

## How is this patch tested?

Existing tests + unignored tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
