### PR TITLE
Include README_skinny.rst in sdist

### DIFF
--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -21,6 +21,11 @@ jobs:
         with:
           python-version: "3.7"
 
+      - name: Set environment variable for skinny client build
+        if: ${{ matrix.type == 'skinny' }}
+        run: |
+          echo "MLFLOW_SKINNY=true" >> $GITHUB_ENV
+
       - name: Build UI
         if: ${{ matrix.type == 'full' }}
         working-directory: mlflow/server/js
@@ -35,11 +40,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install wheel twine
-
-      - name: Set environment variable for skinny client build
-        if: ${{ matrix.type == 'skinny' }}
-        run: |
-          echo "MLFLOW_SKINNY=true" >> $GITHUB_ENV
 
       - name: Build distribution files
         id: build-wheel

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Test installation from wheel
         run: |
-          pip install ${{ steps.build-wheel.outputs.wheel-path }}
+          pip install --force-reinstall ${{ steps.build-wheel.outputs.wheel-path }}
           python -c "import mlflow; print(mlflow.__version__)"
 
       # Anyone with read access can download the uploaded wheel on GitHub.

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -42,7 +42,7 @@ jobs:
           pip install wheel twine
 
       - name: Build distribution files
-        id: build-wheel
+        id: build-dist
         run: |
           # Build distribution files
           python setup.py sdist bdist_wheel
@@ -62,16 +62,16 @@ jobs:
 
       - name: Run twine check
         run: |
-          twine check --strict ${{ steps.build-wheel.outputs.wheel-path }}
+          twine check --strict ${{ steps.build-dist.outputs.wheel-path }}
 
       - name: Test installation from tarball
         run: |
-          pip install ${{ steps.build-wheel.outputs.sdist-path }}
+          pip install ${{ steps.build-dist.outputs.sdist-path }}
           python -c "import mlflow; print(mlflow.__version__)"
 
       - name: Test installation from wheel
         run: |
-          pip install --force-reinstall ${{ steps.build-wheel.outputs.wheel-path }}
+          pip install --force-reinstall ${{ steps.build-dist.outputs.wheel-path }}
           python -c "import mlflow; print(mlflow.__version__)"
 
       # Anyone with read access can download the uploaded wheel on GitHub.
@@ -79,14 +79,14 @@ jobs:
         uses: actions/upload-artifact@v2
         if: github.event_name == 'push'
         with:
-          name: ${{ steps.build-wheel.outputs.wheel-name }}
-          path: ${{ steps.build-wheel.outputs.wheel-path }}
+          name: ${{ steps.build-dist.outputs.wheel-name }}
+          path: ${{ steps.build-dist.outputs.wheel-path }}
 
       - name: Remove old wheels
         uses: actions/github-script@v3
         if: github.event_name == 'push'
         env:
-          WHEEL_SIZE: ${{ steps.build-wheel.outputs.wheel-size }}
+          WHEEL_SIZE: ${{ steps.build-dist.outputs.wheel-size }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/test-package-build.yml
+++ b/.github/workflows/test-package-build.yml
@@ -36,13 +36,14 @@ jobs:
         run: |
           pip install wheel twine
 
+      - name: Set environment variable for skinny client build
+        if: ${{ matrix.type == 'skinny' }}
+        run: |
+          echo "MLFLOW_SKINNY=true" >> $GITHUB_ENV
+
       - name: Build distribution files
         id: build-wheel
         run: |
-          if [ "${{ matrix.type }}" = "skinny" ]; then
-            export MLFLOW_SKINNY="true"
-          fi
-
           # Build distribution files
           python setup.py sdist bdist_wheel
 
@@ -50,9 +51,11 @@ jobs:
           ls -lh dist
 
           # Set step outputs
+          sdist_path=$(find dist -type f -name "*.tar.gz")
           wheel_path=$(find dist -type f -name "*.whl")
           wheel_name=$(basename $wheel_path)
           wheel_size=$(stat -c %s $wheel_path)
+          echo "::set-output name=sdist-path::${sdist_path}"
           echo "::set-output name=wheel-path::${wheel_path}"
           echo "::set-output name=wheel-name::${wheel_name}"
           echo "::set-output name=wheel-size::${wheel_size}"
@@ -61,7 +64,12 @@ jobs:
         run: |
           twine check --strict ${{ steps.build-wheel.outputs.wheel-path }}
 
-      - name: Test installation
+      - name: Test installation from tarball
+        run: |
+          pip install ${{ steps.build-wheel.outputs.sdist-path }}
+          python -c "import mlflow; print(mlflow.__version__)"
+
+      - name: Test installation from wheel
         run: |
           pip install ${{ steps.build-wheel.outputs.wheel-path }}
           python -c "import mlflow; print(mlflow.__version__)"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
+# Note that README.rst is included in a source distribution by default:
+# https://packaging.python.org/guides/using-manifest-in/#how-files-are-included-in-an-sdist
 include README_SKINNY.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include README_skinny.rst
+include README_SKINNY.rst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README_skinny.rst


### PR DESCRIPTION
## What changes are proposed in this pull request?

This includes the `README_skinny.rst` file in the `sdist`. This enables to install the `mlflow-skinny` package from source tarballs.

Currently we need to manually add this file in the build process of the `mlflow` packages on conda-forge: https://github.com/conda-forge/mlflow-feedstock/pull/59

## How is this patch tested?

I have built an `mlflow` sdist tarball and verified that the `README_skinny.rst` was included in it.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
