### PR TITLE
Set tags only when it's not none in `create_managed_run`

### DIFF
--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -805,7 +805,8 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
 
     def create_managed_run():
         managed_run = mlflow.start_run()
-        try_mlflow_log(mlflow.set_tags, tags)
+        if tags:
+            try_mlflow_log(mlflow.set_tags, tags)
         _logger.info(
             "Created MLflow autologging run with ID '%s', which will track hyperparameters,"
             " performance metrics, model artifacts, and lineage information for the"


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

In `create_managed_run`, we call `mlflow.set_tags` even when the passed-in `tags` is None. This PR fixes it.

https://github.com/mlflow/mlflow/runs/1962908298#step:5:1133

Note we turn off the autologging testing mode by default in `test_autologging_safety_unit.py`.

```
tests/autologging/test_autologging_safety_unit.py::test_with_managed_run_with_non_throwing_function_exhibits_expected_behavior
  /home/runner/work/mlflow/mlflow/mlflow/utils/autologging_utils.py:808: UserWarning: Logging to MLflow failed: 'NoneType' object has no attribute 'items'
    try_mlflow_log(mlflow.set_tags, tags)

tests/autologging/test_autologging_safety_unit.py::test_with_managed_run_with_throwing_function_exhibits_expected_behavior
  /home/runner/work/mlflow/mlflow/mlflow/utils/autologging_utils.py:808: UserWarning: Logging to MLflow failed: 'NoneType' object has no attribute 'items'
    try_mlflow_log(mlflow.set_tags, tags)

tests/autologging/test_autologging_safety_unit.py::test_with_managed_run_with_non_throwing_class_exhibits_expected_behavior
  /home/runner/work/mlflow/mlflow/mlflow/utils/autologging_utils.py:808: UserWarning: Logging to MLflow failed: 'NoneType' object has no attribute 'items'
    try_mlflow_log(mlflow.set_tags, tags)

tests/autologging/test_autologging_safety_unit.py::test_with_managed_run_with_throwing_class_exhibits_expected_behavior
  /home/runner/work/mlflow/mlflow/mlflow/utils/autologging_utils.py:808: UserWarning: Logging to MLflow failed: 'NoneType' object has no attribute 'items'
    try_mlflow_log(mlflow.set_tags, tags)
```

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
