### PR TITLE
Add statsmodels cross version test in CI

### DIFF
--- a/ml-package-versions.yml
+++ b/ml-package-versions.yml
@@ -246,3 +246,22 @@ spacy:
     requirements: ["scikit-learn"]
     run: |
       pytest tests/spacy/test_spacy_model_export.py --large
+
+statsmodels:
+  package_info:
+    pip_release: "statsmodels"
+
+  install_dev: |
+    pip install git+https://github.com/statsmodels/statsmodels
+
+  models:
+    minimum: "0.11.1"
+    maximum: "0.12.2"
+  run: |
+      pytest tests/statsmodels/test_statsmodels_model_export.py --large
+
+  autologging:
+    minimum: "0.11.1"
+    maximum: "0.12.2"
+    run: |
+      pytest tests/statsmodels/test_statsmodels_autolog.py --large

--- a/ml-package-versions.yml
+++ b/ml-package-versions.yml
@@ -250,9 +250,8 @@ spacy:
 statsmodels:
   package_info:
     pip_release: "statsmodels"
-
-  install_dev: |
-    pip install git+https://github.com/statsmodels/statsmodels
+    install_dev: |
+      pip install git+https://github.com/statsmodels/statsmodels
 
   models:
     minimum: "0.11.1"

--- a/ml-package-versions.yml
+++ b/ml-package-versions.yml
@@ -256,8 +256,8 @@ statsmodels:
   models:
     minimum: "0.11.1"
     maximum: "0.12.2"
-  run: |
-      pytest tests/statsmodels/test_statsmodels_model_export.py --large
+    run: |
+        pytest tests/statsmodels/test_statsmodels_model_export.py --large
 
   autologging:
     minimum: "0.11.1"


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add statsmodels cross version test in CI

## How is this patch tested?

CI

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
