### PR TITLE
Use `callbacks` instead of `checkpoint_callback` which will be removed in pytorch-lightning 1.3

### DIFF
--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -143,9 +143,7 @@ def pytorch_model_with_callback(patience):
         )
 
         trainer = pl.Trainer(
-            max_epochs=NUM_EPOCHS * 2,
-            callbacks=[early_stopping],
-            checkpoint_callback=checkpoint_callback,
+            max_epochs=NUM_EPOCHS * 2, callbacks=[early_stopping, checkpoint_callback],
         )
         trainer.fit(model, dm)
 
@@ -195,9 +193,7 @@ def test_pytorch_with_early_stopping_autolog_log_models_configuration_with(log_m
         )
 
         trainer = pl.Trainer(
-            max_epochs=NUM_EPOCHS * 2,
-            callbacks=[early_stopping],
-            checkpoint_callback=checkpoint_callback,
+            max_epochs=NUM_EPOCHS * 2, callbacks=[early_stopping, checkpoint_callback],
         )
         trainer.fit(model, dm)
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

In pytorch-lightning 1.3, `ModelCheckpoint` must be passed via `callbacks` argument instead of `callback_argument`:

https://github.com/PyTorchLightning/pytorch-lightning/pull/6166

This change break the pytorch autologging tests.

https://github.com/mlflow/mlflow/pull/4119/checks?check_run_id=1984192483#step:8:3133

```
>           if self.early_stopping and trainer.checkpoint_callback.best_model_path:
E           AttributeError: 'NoneType' object has no attribute 'best_model_path'
```

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
