### PR TITLE
Fix issues in handling flexible numpy datatypes in TensorSpec

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -225,6 +225,7 @@ from mlflow.pyfunc.model import PythonModel, PythonModelContext  # pylint: disab
 from mlflow.pyfunc.model import get_default_conda_env
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType, Schema, TensorSpec
+from mlflow.types.utils import clean_tensor_type
 from mlflow.utils import PYTHON_VERSION, get_major_minor_py_version
 from mlflow.utils.annotations import deprecated
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree
@@ -399,7 +400,7 @@ def _enforce_tensor_spec(values: np.ndarray, tensor_spec: TensorSpec):
                     actual_shape, expected_shape
                 )
             )
-    if values.dtype != tensor_spec.type:
+    if clean_tensor_type(values.dtype) != tensor_spec.type:
         raise MlflowException(
             "dtype of input {0} does not match expected dtype {1}".format(
                 values.dtype, tensor_spec.type

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -139,7 +139,7 @@ class TensorInfo(object):
             raise MlflowException(
                 "MLflow does not support size information in flexible numpy data types. Try"
                 " converting input datatype `{0}` to `{1}`".format(
-                    dtype, np.dtype(dtype.name.rstrip(string.digits))
+                    dtype, dtype.name.rstrip(string.digits)
                 )
             )
 

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 import numpy as np
 import pandas as pd
+import string
 from typing import Dict, Any, List, Union, Optional
 
 from mlflow.exceptions import MlflowException
@@ -133,10 +134,19 @@ class TensorInfo(object):
                     np.dtype, type.__class__
                 )
             )
+        # Throw if size information exists flexible numpy data types
+        if dtype.char in ["U", "S"] and not dtype.name.isalpha():
+            raise MlflowException(
+                "MLflow does not support size information in flexible numpy data types. Try"
+                " converting input datatype `{0}` to `{1}`".format(
+                    dtype, np.dtype(dtype.name.rstrip(string.digits))
+                )
+            )
+
         if not isinstance(shape, (tuple, list)):
             raise TypeError(
-                "Expected `shape` to be instance of `{0}`, received `{1}`".format(
-                    tuple, shape.__class__
+                "Expected `shape` to be instance of `{0}` or `{1}`, received `{2}`".format(
+                    tuple, list, shape.__class__
                 )
             )
         self._dtype = dtype

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -137,10 +137,8 @@ class TensorInfo(object):
         # Throw if size information exists flexible numpy data types
         if dtype.char in ["U", "S"] and not dtype.name.isalpha():
             raise MlflowException(
-                "MLflow does not support size information in flexible numpy data types. Try"
-                " converting input datatype `{0}` to `{1}`".format(
-                    dtype, dtype.name.rstrip(string.digits)
-                )
+                "MLflow does not support size information in flexible numpy data types. Use"
+                ' np.dtype("{0}") instead'.format(dtype.name.rstrip(string.digits))
             )
 
         if not isinstance(shape, (tuple, list)):

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -64,13 +64,10 @@ def clean_tensor_type(dtype: np.dtype):
         )
 
     # Special casing for np.str_ and np.bytes_
-    if dtype.char in ["U", "S"]:
-        warnings.warn(
-            "MLflow does not support handling the size of flexible datatypes such as np.str_"
-            " and np.bytes_. Stripping the size information from input tensor dtype.",
-            stacklevel=2,
-        )
-        dtype = np.dtype(dtype.str.rstrip(string.digits))
+    if dtype.char == "U":
+        return np.dtype("str")
+    elif dtype.char == "S":
+        return np.dtype("bytes")
     return dtype
 
 

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -3,6 +3,7 @@ import warnings
 
 import numpy as np
 import pandas as pd
+import string
 from typing import Optional
 
 from mlflow.exceptions import MlflowException
@@ -47,6 +48,32 @@ def _get_tensor_shape(data: np.ndarray, variable_dimension: Optional[int] = 0) -
     return tuple(variable_input_data_shape)
 
 
+def clean_tensor_type(dtype: np.dtype):
+    """
+    This method strips away the size information stored in flexible datatypes such as np.str_ and
+    np.bytes_. Other numpy dtypes are returned unchanged.
+
+    :param dtype: Numpy dtype of a tensor
+    :return: dtype: Cleaned numpy dtype
+    """
+    if not isinstance(dtype, np.dtype):
+        raise TypeError(
+            "Expected `type` to be instance of `{0}`, received `{1}`".format(
+                np.dtype, type.__class__
+            )
+        )
+
+    # Special casing for np.str_ and np.bytes_
+    if dtype.char in ["U", "S"]:
+        warnings.warn(
+            "MLflow does not support handling the size of flexible datatypes such as np.str_"
+            " and np.bytes_. Stripping the size information from input tensor dtype.",
+            stacklevel=2,
+        )
+        dtype = np.dtype(dtype.str.rstrip(string.digits))
+    return dtype
+
+
 def _infer_schema(data: Any) -> Schema:
     """
     Infer an MLflow schema from a dataset.
@@ -81,7 +108,13 @@ def _infer_schema(data: Any) -> Schema:
             ndarray = data[name]
             if not isinstance(ndarray, np.ndarray):
                 raise TypeError("Data in the dictionary must be of type numpy.ndarray")
-            res.append(TensorSpec(type=ndarray.dtype, shape=_get_tensor_shape(ndarray), name=name))
+            res.append(
+                TensorSpec(
+                    type=clean_tensor_type(ndarray.dtype),
+                    shape=_get_tensor_shape(ndarray),
+                    name=name,
+                )
+            )
         schema = Schema(res)
     elif isinstance(data, pd.Series):
         schema = Schema([ColSpec(type=_infer_pandas_column(data))])
@@ -90,7 +123,9 @@ def _infer_schema(data: Any) -> Schema:
             [ColSpec(type=_infer_pandas_column(data[col]), name=col) for col in data.columns]
         )
     elif isinstance(data, np.ndarray):
-        schema = Schema([TensorSpec(type=data.dtype, shape=_get_tensor_shape(data))])
+        schema = Schema(
+            [TensorSpec(type=clean_tensor_type(data.dtype), shape=_get_tensor_shape(data))]
+        )
     elif _is_spark_df(data):
         schema = Schema(
             [

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -3,7 +3,6 @@ import warnings
 
 import numpy as np
 import pandas as pd
-import string
 from typing import Optional
 
 from mlflow.exceptions import MlflowException

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -349,8 +349,8 @@ def test_all_numpy_dtypes():
     for dtype in bytes_:
         test_dtype(np.array([bytes([1, 255, 12, 34])], dtype=dtype), dtype)
         # Explicitly giving size information for flexible dtype bytes
-    test_dtype(np.array([bytes([1, 255, 12, 34])], dtype='S10'), 'S')
-    test_dtype(np.array([bytes([1, 255, 12, 34])], dtype='S10'), 'bytes')
+    test_dtype(np.array([bytes([1, 255, 12, 34])], dtype="S10"), "S")
+    test_dtype(np.array([bytes([1, 255, 12, 34])], dtype="S10"), "bytes")
 
     # str_
     for dtype in str_:

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -293,7 +293,7 @@ def test_all_numpy_dtypes():
         "ulonglong",
     ]
     floating = ["half", "float16", "single", "float32", "double", "float_", "float64"]
-    complex = [
+    complex_ = [
         "csingle",
         "singlecomplex",
         "complex64",
@@ -301,14 +301,16 @@ def test_all_numpy_dtypes():
         "cfloat",
         "complex_",
         "complex128",
-        "clongdouble",
-        "clongfloat",
-        "longcomplex",
-        "complex256",
     ]
     bytes_ = ["bytes_", "string_"]
     str_ = ["str_", "unicode_"]
     platform_dependent = [
+        # Complex
+        "clongdouble",
+        "clongfloat",
+        "longcomplex",
+        "complex256",
+        # Float
         "longdouble",
         "longfloat",
         "float128",
@@ -340,18 +342,24 @@ def test_all_numpy_dtypes():
         test_dtype(np.array([1.1, -2.2, 3.3, 5.12], dtype=dtype), dtype)
 
     # test complex
-    for dtype in complex:
+    for dtype in complex_:
         test_dtype(np.array([1 + 2j, -2.2 - 3.6j], dtype=dtype), dtype)
 
     # test bytes_
     for dtype in bytes_:
         test_dtype(np.array([bytes([1, 255, 12, 34])], dtype=dtype), dtype)
+        # Explicitly giving size information for flexible dtype bytes
+    test_dtype(np.array([bytes([1, 255, 12, 34])], dtype='S10'), 'S')
+    test_dtype(np.array([bytes([1, 255, 12, 34])], dtype='S10'), 'bytes')
 
     # str_
     for dtype in str_:
         test_dtype(np.array(["m", "l", "f", "l", "o", "w"], dtype=dtype), dtype)
         test_dtype(np.array(["mlflow"], dtype=dtype), dtype)
         test_dtype(np.array(["mlflow is the best"], dtype=dtype), dtype)
+    # Explicitly giving size information for flexible dtype str_
+    test_dtype(np.array(["a", "bc", "def"], dtype="U16"), "str")
+    test_dtype(np.array(["a", "bc", "def"], dtype="U16"), "U")
 
     # platform_dependent
     for dtype in platform_dependent:

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -348,7 +348,7 @@ def test_all_numpy_dtypes():
     # test bytes_
     for dtype in bytes_:
         test_dtype(np.array([bytes([1, 255, 12, 34])], dtype=dtype), dtype)
-        # Explicitly giving size information for flexible dtype bytes
+    # Explicitly giving size information for flexible dtype bytes
     test_dtype(np.array([bytes([1, 255, 12, 34])], dtype="S10"), "S")
     test_dtype(np.array([bytes([1, 255, 12, 34])], dtype="S10"), "bytes")
 

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from mlflow.exceptions import MlflowException
+from mlflow.pyfunc import _enforce_tensor_spec
 from mlflow.types import DataType
 from mlflow.types.schema import ColSpec, Schema, TensorSpec
 from mlflow.types.utils import _infer_schema, _get_tensor_shape
@@ -257,6 +258,7 @@ def test_schema_inference_on_basic_numpy(pandas_df_with_all_types):
         assert schema == Schema([TensorSpec(type=data.dtype, shape=(-1,))])
 
 
+# Todo: arjundc : Remove _enforce_tensor_spec and move to its own test file.
 def test_all_numpy_dtypes():
     def test_dtype(nparray, dtype):
         schema = _infer_schema(nparray)
@@ -264,6 +266,8 @@ def test_all_numpy_dtypes():
         spec = schema.inputs[0]
         recreated_spec = TensorSpec.from_json_dict(**spec.to_dict())
         assert spec == recreated_spec
+        enforced_array = _enforce_tensor_spec(nparray, spec)
+        assert isinstance(enforced_array, np.ndarray)
 
     bool_ = ["bool", "bool_", "bool8"]
     object_ = ["object"]


### PR DESCRIPTION
Signed-off-by: Arjun DCunha <arjun.dcunha@databricks.com>

## What changes are proposed in this pull request?

The serialization and deserialization of flexible numpy data types was failing due to numpy adding the size dynamically to the dtype. 
The PR strips the flexible numpy dtypes of all size based information before creating the tensorSpec.

## How is this patch tested?

Unit tests.

## Release Notes

### Is this a user-facing change?

- [ x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
