### PR TITLE
Skip logging during sanity check in pytorch autologging

### DIFF
--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -89,6 +89,11 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
                 self.early_stopping = False
 
             def _log_metrics(self, trainer, pl_module):
+                # pytorch-lightning runs a few steps of validation in the beginning of training
+                # as a sanity check. During this phase, we should avoid logging metrics.
+                if trainer.running_sanity_check:
+                    return
+
                 if (pl_module.current_epoch + 1) % every_n_epoch == 0:
                     # `trainer.callback_metrics` contains both training and validation metrics
                     cur_metrics = trainer.callback_metrics

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -90,7 +90,9 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
 
             def _log_metrics(self, trainer, pl_module):
                 # pytorch-lightning runs a few steps of validation in the beginning of training
-                # as a sanity check. During this phase, we should skip logging metrics.
+                # as a sanity check to catch bugs without having to wait for the training routine
+                # to complete. During this check, we should skip logging metrics.
+                # https://pytorch-lightning.readthedocs.io/en/stable/common/trainer.html#num-sanity-val-steps # noqa
                 if trainer.running_sanity_check:
                     return
 

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -90,7 +90,7 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
 
             def _log_metrics(self, trainer, pl_module):
                 # pytorch-lightning runs a few steps of validation in the beginning of training
-                # as a sanity check. During this phase, we should avoid logging metrics.
+                # as a sanity check. During this phase, we should skip logging metrics.
                 if trainer.running_sanity_check:
                     return
 

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -256,7 +256,7 @@ def test_pytorch_autolog_non_early_stop_callback_does_not_log(pytorch_model):
     val_loss_metric_history = client.get_metric_history(run.info.run_id, "val_loss")
     assert trainer.max_epochs == NUM_EPOCHS
     assert len(loss_metric_history) == NUM_EPOCHS
-    assert len(val_metric_history) == NUM_EPOCHS
+    assert len(val_loss_metric_history) == NUM_EPOCHS
 
 
 @pytest.fixture

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -77,8 +77,10 @@ def test_pytorch_autolog_logs_expected_data(pytorch_model):
     data = run.data
 
     # Checking if metrics are logged
-    assert "loss" in data.metrics
-    assert "val_loss" in data.metrics
+    for metric_key in ["loss", "train_acc", "val_loss", "val_acc"]:
+        assert metric_key in run.data.metrics
+        metric_history = client.get_metric_history(run.info.run_id, metric_key)
+        assert len(metric_history) == NUM_EPOCHS
 
     # Testing optimizer parameters are logged
     assert "optimizer_name" in data.params

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -77,6 +77,7 @@ def test_pytorch_autolog_logs_expected_data(pytorch_model):
     data = run.data
 
     # Checking if metrics are logged
+    client = mlflow.tracking.MlflowClient()
     for metric_key in ["loss", "train_acc", "val_loss", "val_acc"]:
         assert metric_key in run.data.metrics
         metric_history = client.get_metric_history(run.info.run_id, metric_key)

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -250,9 +250,11 @@ def test_pytorch_autolog_batch_metrics_logger_logs_expected_metrics(patience):
 def test_pytorch_autolog_non_early_stop_callback_does_not_log(pytorch_model):
     trainer, run = pytorch_model
     client = mlflow.tracking.MlflowClient()
-    metric_history = client.get_metric_history(run.info.run_id, "loss")
+    loss_metric_history = client.get_metric_history(run.info.run_id, "loss")
+    val_loss_metric_history = client.get_metric_history(run.info.run_id, "val_loss")
     assert trainer.max_epochs == NUM_EPOCHS
-    assert len(metric_history) == NUM_EPOCHS
+    assert len(loss_metric_history) == NUM_EPOCHS
+    assert len(val_metric_history) == NUM_EPOCHS
 
 
 @pytest.fixture


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

As @etiennedub pointed out in https://github.com/mlflow/mlflow/pull/4118#issuecomment-786687408, we should skip logging during the validation sanity check.

## How is this patch tested?

Updated test to make sure logging is skipped during the sanity check

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
