### PR TITLE
Cherry-pick the tensor-info bug fix into branch 1.14

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -225,6 +225,7 @@ from mlflow.pyfunc.model import PythonModel, PythonModelContext  # pylint: disab
 from mlflow.pyfunc.model import get_default_conda_env
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import DataType, Schema, TensorSpec
+from mlflow.types.utils import clean_tensor_type
 from mlflow.utils import PYTHON_VERSION, get_major_minor_py_version
 from mlflow.utils.annotations import deprecated
 from mlflow.utils.file_utils import TempDir, _copy_file_or_tree
@@ -399,7 +400,7 @@ def _enforce_tensor_spec(values: np.ndarray, tensor_spec: TensorSpec):
                     actual_shape, expected_shape
                 )
             )
-    if values.dtype != tensor_spec.type:
+    if clean_tensor_type(values.dtype) != tensor_spec.type:
         raise MlflowException(
             "dtype of input {0} does not match expected dtype {1}".format(
                 values.dtype, tensor_spec.type

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -3,6 +3,7 @@ from enum import Enum
 
 import numpy as np
 import pandas as pd
+import string
 from typing import Dict, Any, List, Union, Optional
 
 from mlflow.exceptions import MlflowException
@@ -133,10 +134,17 @@ class TensorInfo(object):
                     np.dtype, type.__class__
                 )
             )
+        # Throw if size information exists flexible numpy data types
+        if dtype.char in ["U", "S"] and not dtype.name.isalpha():
+            raise MlflowException(
+                "MLflow does not support size information in flexible numpy data types. Use"
+                ' np.dtype("{0}") instead'.format(dtype.name.rstrip(string.digits))
+            )
+
         if not isinstance(shape, (tuple, list)):
             raise TypeError(
-                "Expected `shape` to be instance of `{0}`, received `{1}`".format(
-                    tuple, shape.__class__
+                "Expected `shape` to be instance of `{0}` or `{1}`, received `{2}`".format(
+                    tuple, list, shape.__class__
                 )
             )
         self._dtype = dtype

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 
 from mlflow.exceptions import MlflowException
+from mlflow.pyfunc import _enforce_tensor_spec
 from mlflow.types import DataType
 from mlflow.types.schema import ColSpec, Schema, TensorSpec
 from mlflow.types.utils import _infer_schema, _get_tensor_shape
@@ -46,6 +47,9 @@ def test_tensor_spec():
     with pytest.raises(TypeError) as ex2:
         TensorSpec(np.dtype("float64"), np.array([-1, 2, 3]), "b")
     assert "Expected `shape` to be instance" in str(ex2.value)
+    with pytest.raises(MlflowException) as ex3:
+        TensorSpec(np.dtype("<U10"), (-1,), "b")
+    assert "MLflow does not support size information in flexible numpy data types" in str(ex3.value)
 
     a5 = TensorSpec.from_json_dict(**a1.to_dict())
     assert a5 == a1
@@ -247,33 +251,124 @@ def test_schema_inference_on_dictionary(dict_of_ndarrays):
         _infer_schema({"x": [1]})
 
 
-def test_schema_inference_on_numpy_array(pandas_df_with_all_types):
+def test_schema_inference_on_basic_numpy(pandas_df_with_all_types):
     for col in pandas_df_with_all_types:
         data = pandas_df_with_all_types[col].to_numpy()
         schema = _infer_schema(data)
         assert schema == Schema([TensorSpec(type=data.dtype, shape=(-1,))])
 
+
+# Todo: arjundc : Remove _enforce_tensor_spec and move to its own test file.
+def test_all_numpy_dtypes():
+    def test_dtype(nparray, dtype):
+        schema = _infer_schema(nparray)
+        assert schema == Schema([TensorSpec(np.dtype(dtype), (-1,))])
+        spec = schema.inputs[0]
+        recreated_spec = TensorSpec.from_json_dict(**spec.to_dict())
+        assert spec == recreated_spec
+        enforced_array = _enforce_tensor_spec(nparray, spec)
+        assert isinstance(enforced_array, np.ndarray)
+
+    bool_ = ["bool", "bool_", "bool8"]
+    object_ = ["object"]
+    signed_int = [
+        "byte",
+        "int8",
+        "short",
+        "int16",
+        "intc",
+        "int32",
+        "int_",
+        "int",
+        "intp",
+        "int64",
+        "longlong",
+    ]
+    unsigned_int = [
+        "ubyte",
+        "uint8",
+        "ushort",
+        "uint16",
+        "uintc",
+        "uint32",
+        "uint",
+        "uintp",
+        "uint64",
+        "ulonglong",
+    ]
+    floating = ["half", "float16", "single", "float32", "double", "float_", "float64"]
+    complex_ = [
+        "csingle",
+        "singlecomplex",
+        "complex64",
+        "cdouble",
+        "cfloat",
+        "complex_",
+        "complex128",
+    ]
+    bytes_ = ["bytes_", "string_"]
+    str_ = ["str_", "unicode_"]
+    platform_dependent = [
+        # Complex
+        "clongdouble",
+        "clongfloat",
+        "longcomplex",
+        "complex256",
+        # Float
+        "longdouble",
+        "longfloat",
+        "float128",
+    ]
+
     # test boolean
-    schema = _infer_schema(np.array([True, False, True], dtype=np.bool_))
-    assert schema == Schema([TensorSpec(np.dtype(np.bool_), (-1,))])
+    for dtype in bool_:
+        test_dtype(np.array([True, False, True], dtype=dtype), dtype)
+        test_dtype(np.array([123, 0, -123], dtype=dtype), dtype)
 
-    # test bytes
-    schema = _infer_schema(np.array([bytes([1])], dtype=np.bytes_))
-    assert schema == Schema([TensorSpec(np.dtype("S1"), (-1,))])
+    # test object
+    for dtype in object_:
+        test_dtype(np.array([True, False, True], dtype=dtype), dtype)
+        test_dtype(np.array([123, 0, -123.544], dtype=dtype), dtype)
+        test_dtype(np.array(["test", "this", "type"], dtype=dtype), dtype)
+        test_dtype(np.array(["test", 123, "type"], dtype=dtype), dtype)
+        test_dtype(np.array(["test", 123, 234 + 543j], dtype=dtype), dtype)
 
-    # test (u)ints
-    for t in [np.uint8, np.int8, np.uint16, np.int16, np.uint32, np.int32, np.uint64, np.int64]:
-        schema = _infer_schema(np.array([1, 2, 3], dtype=t))
-        assert schema == Schema([TensorSpec(np.dtype(t), (-1,))])
+    # test signedInt_
+    for dtype in signed_int:
+        test_dtype(np.array([1, 2, 3, -5], dtype=dtype), dtype)
 
-    # test floats
-    for t in [np.float16, np.float32, np.float64]:
-        schema = _infer_schema(np.array([1.1, 2.2, 3.3], dtype=t))
-        assert schema == Schema([TensorSpec(np.dtype(t), (-1,))])
+    # test unsignedInt_
+    for dtype in unsigned_int:
+        test_dtype(np.array([1, 2, 3, 5], dtype=dtype), dtype)
 
-    if hasattr(np, "float128"):
-        schema = _infer_schema(np.array([1.1, 2.2, 3.3], dtype=np.float128))
-        assert schema == Schema([TensorSpec(np.dtype(np.float128), (-1,))])
+    # test floating
+    for dtype in floating:
+        test_dtype(np.array([1.1, -2.2, 3.3, 5.12], dtype=dtype), dtype)
+
+    # test complex
+    for dtype in complex_:
+        test_dtype(np.array([1 + 2j, -2.2 - 3.6j], dtype=dtype), dtype)
+
+    # test bytes_
+    for dtype in bytes_:
+        test_dtype(np.array([bytes([1, 255, 12, 34])], dtype=dtype), dtype)
+    # Explicitly giving size information for flexible dtype bytes
+    test_dtype(np.array([bytes([1, 255, 12, 34])], dtype="S10"), "S")
+    test_dtype(np.array([bytes([1, 255, 12, 34])], dtype="S10"), "bytes")
+
+    # str_
+    for dtype in str_:
+        test_dtype(np.array(["m", "l", "f", "l", "o", "w"], dtype=dtype), dtype)
+        test_dtype(np.array(["mlflow"], dtype=dtype), dtype)
+        test_dtype(np.array(["mlflow is the best"], dtype=dtype), dtype)
+    # Explicitly giving size information for flexible dtype str_
+    test_dtype(np.array(["a", "bc", "def"], dtype="U16"), "str")
+    test_dtype(np.array(["a", "bc", "def"], dtype="U16"), "U")
+
+    # platform_dependent
+    for dtype in platform_dependent:
+        if hasattr(np, dtype):
+            test_dtype(np.array([1.1, -2.2, 3.3, 5.12], dtype=dtype), dtype)
 
 
 @pytest.mark.large


### PR DESCRIPTION
## What changes are proposed in this pull request?

Cherry-picks https://github.com/mlflow/mlflow/pull/4147 into `branch-1.14`

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
