### PR TITLE
Move to new SHAP Serialization API

### DIFF
--- a/mlflow/shap.py
+++ b/mlflow/shap.py
@@ -415,13 +415,14 @@ def save_explainer(
 
     underlying_model_flavor = None
     underlying_model_path = None
+    model_saver = None
 
     # saving the underlying model if required
     if serialize_model_using_mlflow:
         underlying_model_flavor = get_underlying_model_flavor(explainer.model)
 
         if underlying_model_flavor != _UNKNOWN_MODEL_FLAVOR:
-            explainer.model.save = None  # this prevents SHAP from serializing the underlying model
+            model_saver = False  # this prevents SHAP from serializing the underlying model
             underlying_model_path = os.path.join(path, _UNDERLYING_MODEL_SUBPATH)
 
         if underlying_model_flavor == mlflow.sklearn.FLAVOR_NAME:
@@ -433,7 +434,7 @@ def save_explainer(
     explainer_data_subpath = "explainer.shap"
     explainer_output_path = os.path.join(path, explainer_data_subpath)
     with open(explainer_output_path, "wb") as explainer_output_file_handle:
-        explainer.save(explainer_output_file_handle)
+        explainer.save(explainer_output_file_handle, model_saver=model_saver)
 
     conda_env_subpath = "conda.yaml"
     if conda_env is None:
@@ -574,7 +575,6 @@ def _load_explainer(explainer_file, model=None):
     import shap
 
     def inject_model_loader(in_file):
-        pickle.load(in_file)  # No-Op to move file pointer forward
         return model
 
     with open(explainer_file, "rb") as explainer:

--- a/mlflow/shap.py
+++ b/mlflow/shap.py
@@ -571,10 +571,9 @@ def _load_explainer(explainer_file, model=None):
     :param explainer_file: Local filesystem path to the MLflow Model saved with the ``shap`` flavor
     :param model: model to override underlying explainer model.
     """
-    import pickle
     import shap
 
-    def inject_model_loader(in_file):
+    def inject_model_loader(_in_file):
         return model
 
     with open(explainer_file, "rb") as explainer:

--- a/mlflow/shap.py
+++ b/mlflow/shap.py
@@ -42,8 +42,8 @@ def get_underlying_model_flavor(model):
 
     # checking if underlying model is wrapped
 
-    if hasattr(model, "model"):
-        unwrapped_model = model.model
+    if hasattr(model, "inner_model"):
+        unwrapped_model = model.inner_model
 
         # check if passed model is a method of object
         if isinstance(unwrapped_model, types.MethodType):
@@ -426,9 +426,9 @@ def save_explainer(
             underlying_model_path = os.path.join(path, _UNDERLYING_MODEL_SUBPATH)
 
         if underlying_model_flavor == mlflow.sklearn.FLAVOR_NAME:
-            mlflow.sklearn.save_model(explainer.model.model.__self__, underlying_model_path)
+            mlflow.sklearn.save_model(explainer.model.inner_model.__self__, underlying_model_path)
         elif underlying_model_flavor == mlflow.pytorch.FLAVOR_NAME:
-            mlflow.pytorch.save_model(explainer.model.model, underlying_model_path)
+            mlflow.pytorch.save_model(explainer.model.inner_model, underlying_model_path)
 
     # saving the explainer object
     explainer_data_subpath = "explainer.shap"
@@ -577,8 +577,10 @@ def _load_explainer(explainer_file, model=None):
         return model
 
     with open(explainer_file, "rb") as explainer:
-        model_loader = None if model is None else inject_model_loader
-        explainer = shap.Explainer.load(explainer, model_loader=model_loader)
+        if model is None:
+            explainer = shap.Explainer.load(explainer)
+        else:
+            explainer = shap.Explainer.load(explainer, model_loader=inject_model_loader)
         return explainer
 
 


### PR DESCRIPTION
Signed-off-by: Vivek Chettiar <vivekrchettiar@gmail.com>

## What changes are proposed in this pull request?

Expected Change to the SHAP serialization API, Making changes to use the new API in mlflow.

## How is this patch tested?

Ran exsisting SHAP logging tests

## Release Notes

Internal change to SHAP serialization API Change

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

There is minor change to the SHAP serialization API call expected to be released soon (0.38.2). 

Details:
To indicate that SHAP shouldn't serialize model itself

**Old API:**
    explainer.model.save = None
    explainer.save()

**New API:**
    explainer.save(model_saver = False)

Since, mlflow makes use of this call it needs to be updated.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
