### PR TITLE
[bug-fix] Fix KubernetesSubmittedRun.get_status() (#3962)

### DIFF
--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -119,9 +119,7 @@ class KubernetesSubmittedRun(SubmittedRun):
 
         return self._status == RunStatus.FINISHED
 
-    def _update_status(self, kube_api=None):
-        if not kube_api:
-            kube_api = kubernetes.client.BatchV1Api()
+    def _update_status(self, kube_api):
         api_response = kube_api.read_namespaced_job_status(
             name=self._job_name, namespace=self._job_namespace, pretty=True
         )
@@ -147,7 +145,8 @@ class KubernetesSubmittedRun(SubmittedRun):
 
     def get_status(self):
         status = self._status
-        return status if RunStatus.is_terminated(status) else self._update_status()
+        kube_api = kubernetes.client.BatchV1Api()
+        return status if RunStatus.is_terminated(status) else self._update_status(kube_api)
 
     def cancel(self):
         with self._status_lock:

--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -114,7 +114,7 @@ class KubernetesSubmittedRun(SubmittedRun):
         return self._mlflow_run_id
 
     def wait(self):
-        while not RunStatus.is_terminated(self._update_status(self._kube_api)):
+        while not RunStatus.is_terminated(self._update_status()):
             time.sleep(self.POLL_STATUS_INTERVAL)
 
         return self._status == RunStatus.FINISHED

--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -119,7 +119,9 @@ class KubernetesSubmittedRun(SubmittedRun):
 
         return self._status == RunStatus.FINISHED
 
-    def _update_status(self, kube_api=kubernetes.client.BatchV1Api()):
+    def _update_status(self, kube_api=None):
+        if not kube_api:
+            kube_api = kubernetes.client.BatchV1Api()
         api_response = kube_api.read_namespaced_job_status(
             name=self._job_name, namespace=self._job_namespace, pretty=True
         )

--- a/mlflow/projects/kubernetes.py
+++ b/mlflow/projects/kubernetes.py
@@ -107,20 +107,20 @@ class KubernetesSubmittedRun(SubmittedRun):
         self._job_namespace = job_namespace
         self._status = RunStatus.SCHEDULED
         self._status_lock = RLock()
+        self._kube_api = kubernetes.client.BatchV1Api()
 
     @property
     def run_id(self):
         return self._mlflow_run_id
 
     def wait(self):
-        kube_api = kubernetes.client.BatchV1Api()
-        while not RunStatus.is_terminated(self._update_status(kube_api)):
+        while not RunStatus.is_terminated(self._update_status(self._kube_api)):
             time.sleep(self.POLL_STATUS_INTERVAL)
 
         return self._status == RunStatus.FINISHED
 
-    def _update_status(self, kube_api):
-        api_response = kube_api.read_namespaced_job_status(
+    def _update_status(self):
+        api_response = self._kube_api.read_namespaced_job_status(
             name=self._job_name, namespace=self._job_namespace, pretty=True
         )
         status = api_response.status
@@ -145,15 +145,13 @@ class KubernetesSubmittedRun(SubmittedRun):
 
     def get_status(self):
         status = self._status
-        kube_api = kubernetes.client.BatchV1Api()
-        return status if RunStatus.is_terminated(status) else self._update_status(kube_api)
+        return status if RunStatus.is_terminated(status) else self._update_status()
 
     def cancel(self):
         with self._status_lock:
             if not RunStatus.is_terminated(self._status):
                 _logger.info("Cancelling job.")
-                kube_api = kubernetes.client.BatchV1Api()
-                kube_api.delete_namespaced_job(
+                self._kube_api.delete_namespaced_job(
                     name=self._job_name,
                     namespace=self._job_namespace,
                     body=kubernetes.client.V1DeleteOptions(),


### PR DESCRIPTION
Signed-off-by: Juan Casse <jcasse@gmail.com>

## What changes are proposed in this pull request?

When submitting an MLflow run to a Kubernetes cluster whose URL hots name is something other than 'localhost', `KubernetesSubmittedRun.get_status()` raises the following exception
`urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='localhost', port=80)`.
The `KubernetesSubmittedRun` class has a bug that does not allow it to use the proper Kubernetes host name. Notice in the exception that `host=localhost`. The code only uses 'localhost' as the host for Kubernetes when calling `get_status()`.

Change
```
def _update_status(self, kube_api=kubernetes.client.BatchV1Api()):
```
to
```
def _update_status(self, kube_api=None):
    if not kube_api:
        kube_api = kubernetes.client.BatchV1Api()
```
## How is this patch tested?

Set up Kubernetes or minikube with a URL host that is NOT 'localhost'. Submit an MLflow run to it using
`mlflow_submitted_run = mlflow.projects.run()`.
Once the function returns, get run status
`status = mlflow_submitted_run.get_status()`.
If the run status is returned, then it works. Otherwise, the exception described above is raised.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes the following bug: When submitting an MLflow run to a Kubernetes cluster whose URL hots name is something other than 'localhost', `KubernetesSubmittedRun.get_status()` raises the following exception
`urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='localhost', port=80)`.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages
- [x] `language/Python`: Python APIs and clients

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations
- [x] `integrations/kubernetes`: Kubernetes integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
