### PR TITLE
Update documentation on preserving spark_udf column names

### DIFF
--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -1169,8 +1169,10 @@ Spark cluster and used to score the model.
 
 .. code-block:: py
 
+    from pyspark.sql.functions import struct
+
     pyfunc_udf = mlflow.pyfunc.spark_udf(<path-to-model>)
-    df = spark_df.withColumn("prediction", pyfunc_udf(<features>))
+    df = spark_df.withColumn("prediction", pyfunc_udf(struct(<feature-names>)))
 
 The resulting UDF is based on Spark's Pandas UDF and is currently limited to producing either a single
 value or an array of values of the same type per observation. By default, we return the first
@@ -1204,9 +1206,11 @@ argument. The following values are supported:
 .. code-block:: py
 
     from pyspark.sql.types import ArrayType, FloatType
-    pyfunc_udf = mlflow.pyfunc.spark_udf(<path-to-model>, result_type=ArrayType(FloatType()))
+    from pyspark.sql.functions import struct
+
+    pyfunc_udf = mlflow.pyfunc.spark_udf("path/to/model", result_type=ArrayType(FloatType()))
     # The prediction column will contain all the numeric columns returned by the model as floats
-    df = spark_df.withColumn("prediction", pyfunc_udf(<features>))
+    df = spark_df.withColumn("prediction", pyfunc_udf(struct("name", "age")))
 
 
 .. _deployment_plugin:

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -686,10 +686,10 @@ def spark_udf(spark, model_uri, result_type="double"):
     A Spark UDF that can be used to invoke the Python function formatted model.
 
     Parameters passed to the UDF are forwarded to the model as a DataFrame where the column names
-    are ordinals (0, 1, ...). On some versions of Spark (3.0 and above), it is also possible to wrap the input in a
-    struct. In that case, the data will be passed as a DataFrame with column names given by the
-    struct definition (e.g. when invoked as my_udf(struct('x', 'y')), the model will get the data as a
-    pandas DataFrame with 2 columns 'x' and 'y').
+    are ordinals (0, 1, ...). On some versions of Spark (3.0 and above), it is also possible to
+    wrap the input in a struct. In that case, the data will be passed as a DataFrame with column
+    names given by the struct definition (e.g. when invoked as my_udf(struct('x', 'y')), the model
+    will get the data as a pandas DataFrame with 2 columns 'x' and 'y').
 
     The predictions are filtered to contain only the columns that can be represented as the
     ``result_type``. If the ``result_type`` is string or array of strings, all predictions are

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -686,9 +686,9 @@ def spark_udf(spark, model_uri, result_type="double"):
     A Spark UDF that can be used to invoke the Python function formatted model.
 
     Parameters passed to the UDF are forwarded to the model as a DataFrame where the column names
-    are ordinals (0, 1, ...). On some versions of Spark, it is also possible to wrap the input in a
+    are ordinals (0, 1, ...). On some versions of Spark (3.0 and above), it is also possible to wrap the input in a
     struct. In that case, the data will be passed as a DataFrame with column names given by the
-    struct definition (e.g. when invoked as my_udf(struct('x', 'y'), the model will ge the data as a
+    struct definition (e.g. when invoked as my_udf(struct('x', 'y')), the model will get the data as a
     pandas DataFrame with 2 columns 'x' and 'y').
 
     The predictions are filtered to contain only the columns that can be represented as the
@@ -699,8 +699,10 @@ def spark_udf(spark, model_uri, result_type="double"):
     .. code-block:: python
         :caption: Example
 
+        from pyspark.sql.functions import struct
+
         predict = mlflow.pyfunc.spark_udf(spark, "/my/local/model")
-        df.withColumn("prediction", predict("name", "age")).show()
+        df.withColumn("prediction", predict(struct("name", "age"))).show()
 
     :param spark: A SparkSession object.
     :param model_uri: The location, in URI format, of the MLflow model with the


### PR DESCRIPTION
## What changes are proposed in this pull request?
Update documentation on preserving spark_udf column names

## How is this patch tested?
Built the docs html and ensured changes rendered as expected

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
