### PR TITLE
Add back alembic files to avoid KeyError "formatters"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,9 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     package_data={"mlflow": js_files + models_container_server_files + alembic_files + extra_files}
     if not _is_mlflow_skinny
-    else {"mlflow": alembic_files + extra_files},  # alembic files are needed to avoid config error
+    # include alembic files to enable usage of the skinny client with SQL databases
+    # if users install sqlalchemy, alembic, and sqlparse independently
+    else {"mlflow": alembic_files + extra_files},
     install_requires=CORE_REQUIREMENTS if not _is_mlflow_skinny else SKINNY_REQUIREMENTS,
     extras_require={
         "extras": [

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ setup(
     packages=find_packages(exclude=["tests", "tests.*"]),
     package_data={"mlflow": js_files + models_container_server_files + alembic_files + extra_files}
     if not _is_mlflow_skinny
-    else {"mlflow": extra_files},
+    else {"mlflow": alembic_files + extra_files},  # alembic files are needed to avoid config error
     install_requires=CORE_REQUIREMENTS if not _is_mlflow_skinny else SKINNY_REQUIREMENTS,
     extras_require={
         "extras": [

--- a/tests/test_use_alembic_logger.py
+++ b/tests/test_use_alembic_logger.py
@@ -5,7 +5,7 @@ import pytest
 import mlflow
 from mlflow.pyfunc import PythonModel
 
-def test_repro_missing_alembic_config():
+def test_verify_alembic_runs():
     from mlflow.pyfunc import PythonModel
 
     mlflow.set_tracking_uri('sqlite:///mlflowtest.db')

--- a/tests/test_use_alembic_logger.py
+++ b/tests/test_use_alembic_logger.py
@@ -1,0 +1,12 @@
+import uuid
+
+import pytest
+
+import mlflow
+from mlflow.pyfunc import PythonModel
+
+def test_repro_missing_alembic_config():
+    from mlflow.pyfunc import PythonModel
+
+    mlflow.set_tracking_uri('sqlite:///mlflowtest.db')
+    mlflow.set_experiment("exp_name_example")

--- a/tests/test_use_alembic_logger.py
+++ b/tests/test_use_alembic_logger.py
@@ -1,12 +1,6 @@
-import uuid
-
-import pytest
-
 import mlflow
-from mlflow.pyfunc import PythonModel
 
-def test_verify_alembic_runs():
-    from mlflow.pyfunc import PythonModel
 
-    mlflow.set_tracking_uri('sqlite:///mlflowtest.db')
+def test_verify_alembic_runs(tracking_uri_mock):
+    mlflow.set_tracking_uri(tracking_uri_mock)
     mlflow.set_experiment("exp_name_example")

--- a/tests/test_use_alembic_logger.py
+++ b/tests/test_use_alembic_logger.py
@@ -1,6 +1,0 @@
-import mlflow
-
-
-def test_verify_alembic_runs(tracking_uri_mock):
-    mlflow.set_tracking_uri(tracking_uri_mock)
-    mlflow.set_experiment("exp_name_example")


### PR DESCRIPTION
Add alembic_files in skinny to avoid an error in configparser for alembic usage in SqlAlchemy store


```
   File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\mlflow\tracking\fluent.py", line 73, in set_experiment
    client = MlflowClient()
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\mlflow\tracking\client.py", line 62, in __init__
    self._tracking_client = TrackingServiceClient(final_tracking_uri)
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\mlflow\tracking\_tracking_service\client.py", line 37, in __init__
    self.store = utils._get_store(self.tracking_uri)
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\mlflow\tracking\_tracking_service\utils.py", line 155, in _get_store
    return _tracking_store_registry.get_store(store_uri, artifact_uri)
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\mlflow\tracking\_tracking_service\registry.py", line 38, in get_store
    return builder(store_uri=store_uri, artifact_uri=artifact_uri)
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\mlflow\tracking\_tracking_service\utils.py", line 117, in _get_sqlalchemy_store
    return SqlAlchemyStore(store_uri, artifact_uri)
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\mlflow\store\tracking\sqlalchemy_store.py", line 117, in __init__
    mlflow.store.db.utils._initialize_tables(self.engine)
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\mlflow\store\db\utils.py", line 33, in _initialize_tables
    _upgrade_db(engine)
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\mlflow\store\db\utils.py", line 146, in _upgrade_db
    command.upgrade(config, "heads")
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\alembic\command.py", line 298, in upgrade
    script.run_env()
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\alembic\script\base.py", line 489, in run_env
    util.load_python_file(self.dir, "env.py")
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\alembic\util\pyfiles.py", line 98, in load_python_file
    module = load_module_py(module_id, path)
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\alembic\util\compat.py", line 184, in load_module_py
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\site-packages\mlflow\store\db_migrations\env.py", line 14, in <module>
    fileConfig(config.config_file_name, disable_existing_loggers=False)
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\logging\config.py", line 76, in fileConfig
    formatters = _create_formatters(cp)
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\logging\config.py", line 109, in _create_formatters
    flist = cp["formatters"]["keys"]
  File "c:\mnt\c\users\eddeleon\home\miniconda3\envs\mlflow_skinny_pr\lib\configparser.py", line 959, in __getitem__
    raise KeyError(key)
KeyError: 'formatters'
```

## What changes are proposed in this pull request?

Add alembic files in mlflow_skinny

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Resolve a bug in sqlite store when using mlflow_skinny where config files are missing and a subsequent alembic error is thrown.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
