### PR TITLE
Use latest version of torchvision to fix MNIST download issue

### DIFF
--- a/examples/pytorch/MNIST/example1/conda.yaml
+++ b/examples/pytorch/MNIST/example1/conda.yaml
@@ -4,9 +4,9 @@ channels:
 - pytorch
 dependencies:
 - python=3.8.2
-- pytorch=1.6.0
+- pytorch=1.8.0
 - pytorch-lightning==1.0.2
-- torchvision=0.7.0
+- torchvision=0.9.0
 - pip
 - pip:
   - mlflow

--- a/examples/pytorch/MNIST/example2/conda.yaml
+++ b/examples/pytorch/MNIST/example2/conda.yaml
@@ -4,9 +4,9 @@ channels:
 - pytorch
 dependencies:
 - python=3.8.2
-- pytorch=1.6.0
+- pytorch=1.8.0
 - pytorch-lightning==1.0.2
-- torchvision=0.7.0
+- torchvision=0.9.0
 - pip
 - pip:
   - mlflow

--- a/examples/pytorch/conda.yaml
+++ b/examples/pytorch/conda.yaml
@@ -8,7 +8,7 @@ dependencies:
   - python=3.6
   - pip
   - pip:
-    - torch==1.6.0
-    - torchvision==0.7.0
+    - torch==1.8.0
+    - torchvision==0.9.0
     - mlflow>=1.0
     - tensorboardX


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix the following error by using the latest version of `torchvision` (which contains a [patch](https://github.com/pytorch/vision/pull/3499) for the error):

https://github.com/mlflow/mlflow/runs/2049471684?check_suite_focus=true#step:7:952

```
  File "/usr/share/miniconda/envs/mlflow-6ab8f5b66c87573e5d699b6d54d4000661bc3749/lib/python3.8/site-packages/torchvision/datasets/mnist.py", line 70, in __init__
    self.download()
  File "/usr/share/miniconda/envs/mlflow-6ab8f5b66c87573e5d699b6d54d4000661bc3749/lib/python3.8/site-packages/torchvision/datasets/mnist.py", line 137, in download
    download_and_extract_archive(url, download_root=self.raw_folder, filename=filename, md5=md5)
  File "/usr/share/miniconda/envs/mlflow-6ab8f5b66c87573e5d699b6d54d4000661bc3749/lib/python3.8/site-packages/torchvision/datasets/utils.py", line 235, in download_and_extract_archive
    download_url(url, download_root, filename, md5)
  File "/usr/share/miniconda/envs/mlflow-6ab8f5b66c87573e5d699b6d54d4000661bc3749/lib/python3.8/site-packages/torchvision/datasets/utils.py", line 83, in download_url
    raise e
  File "/usr/share/miniconda/envs/mlflow-6ab8f5b66c87573e5d699b6d54d4000661bc3749/lib/python3.8/site-packages/torchvision/datasets/utils.py", line 69, in download_url
    urllib.request.urlretrieve(
  File "/usr/share/miniconda/envs/mlflow-6ab8f5b66c87573e5d699b6d54d4000661bc3749/lib/python3.8/urllib/request.py", line 247, in urlretrieve
    with contextlib.closing(urlopen(url, data)) as fp:
  File "/usr/share/miniconda/envs/mlflow-6ab8f5b66c87573e5d699b6d54d4000661bc3749/lib/python3.8/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/usr/share/miniconda/envs/mlflow-6ab8f5b66c87573e5d699b6d54d4000661bc3749/lib/python3.8/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/usr/share/miniconda/envs/mlflow-6ab8f5b66c87573e5d699b6d54d4000661bc3749/lib/python3.8/urllib/request.py", line 640, in http_response
    response = self.parent.error(
  File "/usr/share/miniconda/envs/mlflow-6ab8f5b66c87573e5d699b6d54d4000661bc3749/lib/python3.8/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/usr/share/miniconda/envs/mlflow-6ab8f5b66c87573e5d699b6d54d4000661bc3749/lib/python3.8/urllib/request.py", line 502, in _call_chain
    result = func(*args)
  File "/usr/share/miniconda/envs/mlflow-6ab8f5b66c87573e5d699b6d54d4000661bc3749/lib/python3.8/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 403: Forbidden
```

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
