### PR TITLE
Update event loggers to reflect stderr changes, add enable / disable capabilities

### DIFF
--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -43,7 +43,7 @@ MLFLOW_LOGGING_STREAM = MlflowLoggingStream()
 def disable_logging():
     """
     Disables the `MlflowLoggingStream` used by event logging APIs throughout MLflow
-    (e.g., `logger.info()`, etc), silencing all subsequent event logs.
+    (`eprint()`, `logger.info()`, etc), silencing all subsequent event logs.
     """
     MLFLOW_LOGGING_STREAM.enabled = False
 
@@ -55,6 +55,15 @@ def enable_logging():
     the effects of `disable_logging()`.
     """
     MLFLOW_LOGGING_STREAM.enabled = True
+
+
+def logging_is_enabled():
+    """
+    :return: `True` of the `MlflowLoggingStream` used by event logging APIs throughout
+             MLflow (`eprint()`, `logger.info()`, etc) is enabled. `False` if the stream
+             is disabled.
+    """
+    return MLFLOW_LOGGING_STREAM.enabled
 
 
 def _configure_mlflow_loggers(root_module_name):

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -51,8 +51,8 @@ def disable_logging():
 def enable_logging():
     """
     Enables the `MlflowLoggingStream` used by event logging APIs throughout MLflow
-    (e.g., `logger.info()`, etc), emitting all subsequent event logs. This reverses
-    the effects of `disable_logging()`.
+    (`eprint()`, `logger.info()`, etc), emitting all subsequent event logs. This
+    reverses the effects of `disable_logging()`.
     """
     MLFLOW_LOGGING_STREAM.enabled = True
 

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -9,6 +9,54 @@ LOGGING_LINE_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
 LOGGING_DATETIME_FORMAT = "%Y/%m/%d %H:%M:%S"
 
 
+class MlflowLoggingStream:
+    """
+    A Python stream for use with event logging APIs throughout MLflow (`eprint()`,
+    `logger.info()`, etc.). This stream wraps `sys.stderr`, forwarding `write()` and
+    `flush()` calls to the stream referred to by `sys.stderr` at the time of the call.
+    It also provides capabilities for disabling the stream to silence event logs.
+    """
+
+    def __init__(self):
+        self._enabled = True
+
+    def write(self, text):
+        if self._enabled:
+            sys.stderr.write(text)
+
+    def flush(self):
+        if self._enabled:
+            sys.stderr.flush()
+
+    @property
+    def enabled(self):
+        return self._enabled
+
+    @enabled.setter
+    def enabled(self, value):
+        self._enabled = value
+
+
+MLFLOW_LOGGING_STREAM = MlflowLoggingStream()
+
+
+def disable_logging():
+    """
+    Disables the `MlflowLoggingStream` used by event logging APIs throughout MLflow
+    (e.g., `logger.info()`, etc), silencing all subsequent event logs.
+    """
+    MLFLOW_LOGGING_STREAM.enabled = False
+
+
+def enable_logging():
+    """
+    Enables the `MlflowLoggingStream` used by event logging APIs throughout MLflow
+    (e.g., `logger.info()`, etc), emitting all subsequent event logs. This reverses
+    the effects of `disable_logging()`.
+    """
+    MLFLOW_LOGGING_STREAM.enabled = True
+
+
 def _configure_mlflow_loggers(root_module_name):
     logging.config.dictConfig(
         {
@@ -25,7 +73,7 @@ def _configure_mlflow_loggers(root_module_name):
                     "level": "INFO",
                     "formatter": "mlflow_formatter",
                     "class": "logging.StreamHandler",
-                    "stream": sys.stderr,
+                    "stream": MLFLOW_LOGGING_STREAM,
                 },
             },
             "loggers": {
@@ -40,4 +88,4 @@ def _configure_mlflow_loggers(root_module_name):
 
 
 def eprint(*args, **kwargs):
-    print(*args, file=sys.stderr, **kwargs)
+    print(*args, file=MLFLOW_LOGGING_STREAM, **kwargs)

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -18,6 +18,16 @@ def reset_stderr():
     sys.stderr = prev_stderr
 
 
+@pytest.fixture(autouse=True)
+def reset_logging_enablement():
+    prev_is_enabled = logging_utils.logging_is_enabled()
+    yield
+    if prev_is_enabled:
+        logging_utils.enable_logging()
+    else:
+        logging_utils.disable_logging()
+
+
 class TestStream:
     def __init__(self):
         self.content = None
@@ -83,3 +93,10 @@ def test_event_logging_stream_flushes_properly():
     eprint("foo", flush=True)
     assert "foo" in stream.content
     assert stream.flush_count > 0
+
+
+def test_logging_is_enabled_accurately_reflects_enablement_state():
+    logging_utils.disable_logging()
+    assert not logging_utils.logging_is_enabled()
+    logging_utils.enable_logging()
+    assert logging_utils.logging_is_enabled()

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -1,0 +1,85 @@
+import logging
+import sys
+import pytest
+
+import mlflow
+import mlflow.utils.logging_utils as logging_utils
+from mlflow.utils.logging_utils import eprint
+
+logger = logging.getLogger(mlflow.__name__)
+
+LOGGING_FNS_TO_TEST = [logger.info, logger.warning, logger.critical, eprint]
+
+
+@pytest.fixture(autouse=True)
+def reset_stderr():
+    prev_stderr = sys.stderr
+    yield
+    sys.stderr = prev_stderr
+
+
+class TestStream:
+    def __init__(self):
+        self.content = None
+        self.flush_count = 0
+
+    def write(self, text):
+        self.content = (self.content or "") + text
+
+    def flush(self):
+        self.flush_count += 1
+
+    def reset(self):
+        self.content = None
+        self.flush_count = 0
+
+
+@pytest.mark.parametrize("logging_fn", LOGGING_FNS_TO_TEST)
+def test_event_logging_apis_respect_stderr_reassignment(logging_fn):
+    stream1 = TestStream()
+    stream2 = TestStream()
+    message_content = "test message"
+
+    sys.stderr = stream1
+    assert stream1.content is None
+    logging_fn(message_content)
+    assert message_content in stream1.content
+    assert stream2.content is None
+    stream1.reset()
+
+    sys.stderr = stream2
+    assert stream2.content is None
+    logging_fn(message_content)
+    assert message_content in stream2.content
+    assert stream1.content is None
+
+
+@pytest.mark.parametrize("logging_fn", LOGGING_FNS_TO_TEST)
+def test_event_logging_apis_respect_stream_disablement_enablement(logging_fn):
+    stream = TestStream()
+    sys.stderr = stream
+    message_content = "test message"
+
+    assert stream.content is None
+    logging_fn(message_content)
+    assert message_content in stream.content
+    stream.reset()
+
+    logging_utils.disable_logging()
+    logging_fn(message_content)
+    assert stream.content is None
+    stream.reset()
+
+    logging_utils.enable_logging()
+    assert stream.content is None
+    logging_fn(message_content)
+    assert message_content in stream.content
+
+
+def test_event_logging_stream_flushes_properly():
+    stream = TestStream()
+    sys.stderr = stream
+
+    eprint("foo", flush=True)
+    assert "foo" in stream.content
+    assert stream.flush_count > 0


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR addresses the following topics:

- If `sys.stderr` is reassigned after MLflow configures its event loggers (e.g. `_logger` instances across various modules) upon import (via `mlflow.utils.logging_utils._configure_mlflow_loggers`), MLflow's event loggers continue to write outputs to the old value of `stderr` (whatever `stderr` referred to at runtime).

- We'd like to add a `silent` mode to MLflow autologging that suppresses event logs, warnings, etc during MLflow autologging. Accordingly, this PR introduces a capability to disable the logging stream referenced by MLflow's event logging APIs (`logger.info`, `logger.warning`, `eprint()`).

## How is this patch tested?

Included unit tests

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging **(Not exactly, but close enough)**

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
