### PR TITLE
[ML-14300] Add a script that updates `ml-package-versions.yml`

### DIFF
--- a/dev/update_ml_package_versions.py
+++ b/dev/update_ml_package_versions.py
@@ -1,0 +1,148 @@
+"""
+A script to update the maximum package versions in 'mlflow/ml-package-versions.yml'.
+
+# Prerequisites:
+$ pip install packaging pyyaml
+
+# How to run (make sure you're in the repository root):
+$ python dev/update_ml_package_versions.py
+"""
+import argparse
+import json
+from packaging.version import Version
+import re
+import sys
+import urllib.request
+import yaml
+
+
+def read_file(path):
+    with open(path) as f:
+        return f.read()
+
+
+def save_file(src, path):
+    with open(path, "w") as f:
+        f.write(src)
+
+
+def get_package_versions(package_name):
+    url = "https://pypi.python.org/pypi/{}/json".format(package_name)
+    with urllib.request.urlopen(url) as res:
+        data = json.load(res)
+
+    def is_dev_or_pre_release(version_str):
+        v = Version(version_str)
+        return v.is_devrelease or v.is_prerelease
+
+    return [
+        version
+        for version, dist_files in data["releases"].items()
+        if len(dist_files) > 0 and not is_dev_or_pre_release(version)
+    ]
+
+
+def get_latest_version(candidates):
+    return sorted(candidates, key=Version, reverse=True)[0]
+
+
+def update_max_version(src, key, new_max_version, category):
+    """
+    Examples
+    ========
+    >>> src = '''
+    ... sklearn:
+    ...   ...
+    ...   models:
+    ...     minimum: "0.0.0"
+    ...     maximum: "0.0.0"
+    ... xgboost:
+    ...   ...
+    ...   autologging:
+    ...     minimum: "1.1.1"
+    ...     maximum: "1.1.1"
+    ... '''.strip()
+    >>> new_src = update_max_version(src, "sklearn", "0.1.0", "models")
+    >>> new_src = update_max_version(new_src, "xgboost", "1.2.1", "autologging")
+    >>> print(new_src)
+    sklearn:
+      ...
+      models:
+        minimum: "0.0.0"
+        maximum: "0.1.0"
+    xgboost:
+      ...
+      autologging:
+        minimum: "1.1.1"
+        maximum: "1.2.1"
+    """
+    pattern = r"({key}:.+?{category}:.+?maximum: )\".+?\"".format(
+        key=re.escape(key), category=category
+    )
+    # Matches the following pattern:
+    #
+    # <key>:
+    #   ...
+    #   <category>:
+    #     ...
+    #     maximum: "1.2.3"
+    return re.sub(pattern, r'\g<1>"{}"'.format(new_max_version), src, flags=re.DOTALL)
+
+
+def should_ignore_update(src, key, category):
+    pattern = r"{key}:.+?{category}:.+?maximum: \".+?\"(\s+# IGNORE_UPDATE)?".format(
+        key=re.escape(key), category=category
+    )
+    # Matches the following pattern:
+    #
+    # <key>:
+    #   ...
+    #   <category>:
+    #     ...
+    #     maximum: "1.2.3" # IGNORE_UPDATE
+    return re.search(pattern, src, flags=re.DOTALL).group(1) is not None
+
+
+def parse_args(args):
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-p",
+        "--path",
+        help="Path to the ML package versions yaml (default: mlflow/ml-package-versions.yml)",
+        default="mlflow/ml-package-versions.yml",
+        required=False,
+    )
+    return parser.parse_args(args)
+
+
+def main(args):
+    args = parse_args(args)
+
+    yml_path = args.path
+    old_src = read_file(yml_path)
+    new_src = old_src
+    config_dict = yaml.load(old_src, Loader=yaml.SafeLoader)
+
+    for flavor_key, config in config_dict.items():
+        for category in ["autologging", "models"]:
+            if (category not in config) or should_ignore_update(new_src, flavor_key, category):
+                continue
+            print("Processing", flavor_key, category)
+
+            package_name = config["package_info"]["pip_release"]
+            max_ver = config[category]["maximum"]
+            versions = get_package_versions(package_name)
+            unsupported = config[category].get("unsupported", [])
+            versions = set(versions).difference(unsupported)  # exlucde unsupported versions
+            latest_version = get_latest_version(versions)
+
+            if max_ver == latest_version:
+                continue
+
+            new_src = update_max_version(new_src, flavor_key, latest_version, category)
+
+    save_file(new_src, yml_path)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/dev/update_ml_package_versions.py
+++ b/dev/update_ml_package_versions.py
@@ -89,20 +89,6 @@ def update_max_version(src, key, new_max_version, category):
     return re.sub(pattern, r'\g<1>"{}"'.format(new_max_version), src, flags=re.DOTALL)
 
 
-def should_ignore_update(src, key, category):
-    pattern = r"{key}:.+?{category}:.+?maximum: \".+?\"(\s+# IGNORE_UPDATE)?".format(
-        key=re.escape(key), category=category
-    )
-    # Matches the following pattern:
-    #
-    # <key>:
-    #   ...
-    #   <category>:
-    #     ...
-    #     maximum: "1.2.3" # IGNORE_UPDATE
-    return re.search(pattern, src, flags=re.DOTALL).group(1) is not None
-
-
 def parse_args(args):
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -125,7 +111,7 @@ def main(args):
 
     for flavor_key, config in config_dict.items():
         for category in ["autologging", "models"]:
-            if (category not in config) or should_ignore_update(new_src, flavor_key, category):
+            if (category not in config) or config[category].get("freeze", False):
                 continue
             print("Processing", flavor_key, category)
 

--- a/dev/update_ml_package_versions.py
+++ b/dev/update_ml_package_versions.py
@@ -111,7 +111,7 @@ def main(args):
 
     for flavor_key, config in config_dict.items():
         for category in ["autologging", "models"]:
-            if (category not in config) or config[category].get("freeze", False):
+            if (category not in config) or config[category].get("freeze_maximum", False):
                 continue
             print("Processing", flavor_key, category)
 

--- a/dev/update_ml_package_versions.py
+++ b/dev/update_ml_package_versions.py
@@ -111,7 +111,7 @@ def main(args):
 
     for flavor_key, config in config_dict.items():
         for category in ["autologging", "models"]:
-            if (category not in config) or config[category].get("freeze_maximum", False):
+            if (category not in config) or config[category].get("pin_maximum", False):
                 continue
             print("Processing", flavor_key, category)
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -211,7 +211,7 @@ fastai-1.x:
 
   models:
     # Avoid updating the maximum version to 2.x which isn't supported yet
-    freeze: True
+    freeze_maximum: True
     minimum: "1.0.60"
     maximum: "1.0.61"
     requirements: ["scikit-learn"]
@@ -219,7 +219,7 @@ fastai-1.x:
       pytest tests/fastai/test_fastai_model_export.py --large
 
   autologging:
-    freeze: True
+    freeze_maximum: True
     minimum: "1.0.60"
     maximum: "1.0.61"
     requirements: ["scikit-learn"]

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -211,7 +211,7 @@ fastai-1.x:
 
   models:
     # Avoid updating the maximum version to 2.x which isn't supported yet
-    freeze_maximum: True
+    pin_maximum: True
     minimum: "1.0.60"
     maximum: "1.0.61"
     requirements: ["scikit-learn"]
@@ -219,7 +219,7 @@ fastai-1.x:
       pytest tests/fastai/test_fastai_model_export.py --large
 
   autologging:
-    freeze_maximum: True
+    pin_maximum: True
     minimum: "1.0.60"
     maximum: "1.0.61"
     requirements: ["scikit-learn"]

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -211,14 +211,14 @@ fastai-1.x:
 
   models:
     minimum: "1.0.60"
-    maximum: "1.0.61"
+    maximum: "1.0.61" # IGNORE_UPDATE: 2.x is not supported yet
     requirements: ["scikit-learn"]
     run: |
       pytest tests/fastai/test_fastai_model_export.py --large
 
   autologging:
     minimum: "1.0.60"
-    maximum: "1.0.61"
+    maximum: "1.0.61" # IGNORE_UPDATE: 2.x is not supported yet
     requirements: ["scikit-learn"]
     run: |
       pytest tests/fastai/test_fastai_autolog.py --large

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -210,15 +210,18 @@ fastai-1.x:
     pip_release: "fastai"
 
   models:
+    # Avoid updating the maximum version to 2.x which isn't supported yet
+    freeze: True
     minimum: "1.0.60"
-    maximum: "1.0.61" # IGNORE_UPDATE: 2.x is not supported yet
+    maximum: "1.0.61"
     requirements: ["scikit-learn"]
     run: |
       pytest tests/fastai/test_fastai_model_export.py --large
 
   autologging:
+    freeze: True
     minimum: "1.0.60"
-    maximum: "1.0.61" # IGNORE_UPDATE: 2.x is not supported yet
+    maximum: "1.0.61"
     requirements: ["scikit-learn"]
     run: |
       pytest tests/fastai/test_fastai_autolog.py --large

--- a/tests/dev/test_update_ml_package_versions.py
+++ b/tests/dev/test_update_ml_package_versions.py
@@ -1,0 +1,168 @@
+import json
+import os
+import re
+from unittest import mock
+import tempfile
+
+from dev import update_ml_package_versions
+
+
+class MockResponse:
+    def __init__(self, body):
+        self.body = json.dumps(body).encode("utf-8")
+
+    def read(self):
+        return self.body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+    @classmethod
+    def from_versios(cls, versions):
+        return cls({"releases": {v: [v + ".whl"] for v in versions}})
+
+
+def run_test(src, src_expected, mock_responses):
+    def patch_urlopen(url):
+        package_name = re.search(r"https://pypi.python.org/pypi/(.+)/json", url).group(1)
+        return mock_responses[package_name]
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = os.path.join(tmpdir, "versions.yml")
+        with open(tmp_path, "w") as f:
+            f.write(src)
+
+        with mock.patch("urllib.request.urlopen", new=patch_urlopen):
+            update_ml_package_versions.main(["--path", tmp_path])
+
+        with open(tmp_path) as f:
+            assert f.read() == src_expected
+
+
+def test_multiple_flavors_are_correctly_updated():
+    src = """
+sklearn:
+  package_info:
+    pip_release: sklearn
+  autologging:
+    maximum: "0.0.1"
+xgboost:
+  package_info:
+    pip_release: xgboost
+  autologging:
+    maximum: "0.1.1"
+"""
+    mock_responses = {
+        "sklearn": MockResponse.from_versios(["0.0.2"]),
+        "xgboost": MockResponse.from_versios(["0.1.2"]),
+    }
+    src_expected = """
+sklearn:
+  package_info:
+    pip_release: sklearn
+  autologging:
+    maximum: "0.0.2"
+xgboost:
+  package_info:
+    pip_release: xgboost
+  autologging:
+    maximum: "0.1.2"
+"""
+    run_test(src, src_expected, mock_responses)
+
+
+def test_both_models_and_autologging_are_updated():
+    src = """
+sklearn:
+  package_info:
+    pip_release: sklearn
+  models:
+    maximum: "0.0.1"
+  autologging:
+    maximum: "0.0.1"
+"""
+    mock_responses = {
+        "sklearn": MockResponse.from_versios(["0.0.2"]),
+    }
+    src_expected = """
+sklearn:
+  package_info:
+    pip_release: sklearn
+  models:
+    maximum: "0.0.2"
+  autologging:
+    maximum: "0.0.2"
+"""
+    run_test(src, src_expected, mock_responses)
+
+
+def test_pre_and_dev_versions_are_ignored():
+    src = """
+sklearn:
+  package_info:
+    pip_release: sklearn
+  autologging:
+    maximum: "0.0.1"
+"""
+    mock_responses = {
+        "sklearn": MockResponse.from_versios(
+            [
+                # pre-release and dev-release should be filtered out
+                "0.0.3.rc1",  # pre-release
+                "0.0.3.dev1",  # dev-release
+                "0.0.2.post",  # post-release
+                "0.0.2",  # final release
+            ]
+        ),
+    }
+    src_expected = """
+sklearn:
+  package_info:
+    pip_release: sklearn
+  autologging:
+    maximum: "0.0.2.post"
+"""
+    run_test(src, src_expected, mock_responses)
+
+
+def test_unsupported_versions_are_ignored():
+    src = """
+sklearn:
+  package_info:
+    pip_release: sklearn
+  autologging:
+    unsupported: ["0.0.3"]
+    maximum: "0.0.1"
+"""
+    mock_responses = {"sklearn": MockResponse.from_versios(["0.0.2", "0.0.3"])}
+    src_expected = """
+sklearn:
+  package_info:
+    pip_release: sklearn
+  autologging:
+    unsupported: ["0.0.3"]
+    maximum: "0.0.2"
+"""
+    run_test(src, src_expected, mock_responses)
+
+
+def test_ignore_update_comment_prevents_update():
+    src = """
+sklearn:
+  package_info:
+    pip_release: sklearn
+  autologging:
+    maximum: "0.0.1" # IGNORE_UPDATE: > 0.0.1 is not supported yet
+"""
+    mock_responses = {"sklearn": MockResponse.from_versios(["0.0.2"])}
+    src_expected = """
+sklearn:
+  package_info:
+    pip_release: sklearn
+  autologging:
+    maximum: "0.0.1" # IGNORE_UPDATE: > 0.0.1 is not supported yet
+"""
+    run_test(src, src_expected, mock_responses)

--- a/tests/dev/test_update_ml_package_versions.py
+++ b/tests/dev/test_update_ml_package_versions.py
@@ -149,13 +149,14 @@ sklearn:
     run_test(src, src_expected, mock_responses)
 
 
-def test_ignore_update_comment_prevents_update():
+def test_freeze_field_prevents_updating_maximum_version():
     src = """
 sklearn:
   package_info:
     pip_release: sklearn
   autologging:
-    maximum: "0.0.1" # IGNORE_UPDATE: > 0.0.1 is not supported yet
+    freeze: True
+    maximum: "0.0.1"
 """
     mock_responses = {"sklearn": MockResponse.from_versios(["0.0.2"])}
     src_expected = """
@@ -163,6 +164,7 @@ sklearn:
   package_info:
     pip_release: sklearn
   autologging:
-    maximum: "0.0.1" # IGNORE_UPDATE: > 0.0.1 is not supported yet
+    freeze: True
+    maximum: "0.0.1"
 """
     run_test(src, src_expected, mock_responses)

--- a/tests/dev/test_update_ml_package_versions.py
+++ b/tests/dev/test_update_ml_package_versions.py
@@ -155,7 +155,7 @@ sklearn:
   package_info:
     pip_release: sklearn
   autologging:
-    freeze: True
+    freeze_maximum: True
     maximum: "0.0.1"
 """
     mock_responses = {"sklearn": MockResponse.from_versions(["0.0.2"])}
@@ -164,7 +164,7 @@ sklearn:
   package_info:
     pip_release: sklearn
   autologging:
-    freeze: True
+    freeze_maximum: True
     maximum: "0.0.1"
 """
     run_test(src, src_expected, mock_responses)

--- a/tests/dev/test_update_ml_package_versions.py
+++ b/tests/dev/test_update_ml_package_versions.py
@@ -21,7 +21,7 @@ class MockResponse:
         pass
 
     @classmethod
-    def from_versios(cls, versions):
+    def from_versions(cls, versions):
         return cls({"releases": {v: [v + ".whl"] for v in versions}})
 
 
@@ -56,8 +56,8 @@ xgboost:
     maximum: "0.1.1"
 """
     mock_responses = {
-        "sklearn": MockResponse.from_versios(["0.0.2"]),
-        "xgboost": MockResponse.from_versios(["0.1.2"]),
+        "sklearn": MockResponse.from_versions(["0.0.2"]),
+        "xgboost": MockResponse.from_versions(["0.1.2"]),
     }
     src_expected = """
 sklearn:
@@ -85,7 +85,7 @@ sklearn:
     maximum: "0.0.1"
 """
     mock_responses = {
-        "sklearn": MockResponse.from_versios(["0.0.2"]),
+        "sklearn": MockResponse.from_versions(["0.0.2"]),
     }
     src_expected = """
 sklearn:
@@ -108,7 +108,7 @@ sklearn:
     maximum: "0.0.1"
 """
     mock_responses = {
-        "sklearn": MockResponse.from_versios(
+        "sklearn": MockResponse.from_versions(
             [
                 # pre-release and dev-release should be filtered out
                 "0.0.3.rc1",  # pre-release
@@ -137,7 +137,7 @@ sklearn:
     unsupported: ["0.0.3"]
     maximum: "0.0.1"
 """
-    mock_responses = {"sklearn": MockResponse.from_versios(["0.0.2", "0.0.3"])}
+    mock_responses = {"sklearn": MockResponse.from_versions(["0.0.2", "0.0.3"])}
     src_expected = """
 sklearn:
   package_info:
@@ -158,7 +158,7 @@ sklearn:
     freeze: True
     maximum: "0.0.1"
 """
-    mock_responses = {"sklearn": MockResponse.from_versios(["0.0.2"])}
+    mock_responses = {"sklearn": MockResponse.from_versions(["0.0.2"])}
     src_expected = """
 sklearn:
   package_info:

--- a/tests/dev/test_update_ml_package_versions.py
+++ b/tests/dev/test_update_ml_package_versions.py
@@ -155,7 +155,7 @@ sklearn:
   package_info:
     pip_release: sklearn
   autologging:
-    freeze_maximum: True
+    pin_maximum: True
     maximum: "0.0.1"
 """
     mock_responses = {"sklearn": MockResponse.from_versions(["0.0.2"])}
@@ -164,7 +164,7 @@ sklearn:
   package_info:
     pip_release: sklearn
   autologging:
-    freeze_maximum: True
+    pin_maximum: True
     maximum: "0.0.1"
 """
     run_test(src, src_expected, mock_responses)


### PR DESCRIPTION
## What changes are proposed in this pull request?

Adds a script that update `mlflow/ml-package-versions.yml`.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
