### PR TITLE
Add GPG sign for pom.xml and update pom distributionManagement

### DIFF
--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -17,14 +17,6 @@
     <mlflow.shade.packageName>org.mlflow_project</mlflow.shade.packageName>
   </properties>
 
-  <distributionManagement>
-    <repository>
-      <id>bintray</id>
-      <name>mlflow</name>
-      <url>https://api.bintray.com/maven/mlflow/mlflow/mlflow-client/;publish=1</url>
-    </repository>
-  </distributionManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -162,4 +154,9 @@
       </plugin>
       </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>do-sign</id>
+    </profile>
+  </profiles>
 </project>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -47,11 +47,25 @@
     <developerConnection>scm:git:ssh://github.com:mlflow/mlflow.git</developerConnection>
     <url>http://github.com/mlflow/mlflow/tree/master</url>
   </scm>
+  <!--
   <distributionManagement>
     <repository>
       <id>bintray</id>
       <name>mlflow</name>
       <url>https://api.bintray.com/maven/mlflow/mlflow/mlflow-parent/;publish=1</url>
+    </repository>
+  </distributionManagement>
+  -->
+  <distributionManagement>
+    <snapshotRepository>
+      <id>bintray-mlflowdev-mlflowdev-snapshot</id>
+      <name>mlflowdev-mlflowdev</name>
+      <url>https://api.bintray.com/maven/mlflowdev/mlflowdev/mlflow-java/;publish=1</url>
+    </snapshotRepository>
+    <repository>
+      <id>bintray-mlflowdev-mlflowdev</id>
+      <name>mlflowdev-mlflowdev</name>
+      <url>https://api.bintray.com/maven/mlflowdev/mlflowdev/mlflow-java/;publish=1</url>
     </repository>
   </distributionManagement>
 
@@ -266,7 +280,35 @@
           <artifactId>scala-maven-plugin</artifactId>
           <version>4.2.0</version>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-gpg-plugin</artifactId>
+          <version>1.6</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
+  <profiles>
+    <profile>
+      <id>do-sign</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -293,6 +293,14 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
+                <configuration>
+                  <!-- Prevent gpg from using pinentry programs. Fixes: gpg: signing
+                      failed: Inappropriate ioctl for device -->
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -298,6 +298,7 @@
                   <passphraseServerId>${gpg.keyname}</passphraseServerId>
                   <gpgArguments>
                     <arg>-v</arg>
+                    <arg>--batch</arg>
                     <arg>--pinentry-mode</arg>
                     <arg>loopback</arg>
                   </gpgArguments>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -298,9 +298,6 @@
                   <passphraseServerId>${gpg.keyname}</passphraseServerId>
                   <gpgArguments>
                     <arg>--batch</arg>
-                    <arg>--allow-loopback-pinentry</arg>
-                    <arg>--pinentry-mode</arg>
-                    <arg>loopback</arg>
                   </gpgArguments>
                   <executable>gpg2</executable>
                 </configuration>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -293,10 +293,10 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
-                <configuration>
-                  <!-- Prevent gpg from using pinentry programs. Fixes: gpg: signing
-                      failed: Inappropriate ioctl for device -->
-                  <gpgArguments>
+		<configuration>
+                  <keyname>${gpg.keyname}</keyname>
+		  <passphraseServerId>${gpg.keyname}</passphraseServerId>
+		  <gpgArguments>
                     <arg>--pinentry-mode</arg>
                     <arg>loopback</arg>
                   </gpgArguments>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -297,8 +297,7 @@
                   <keyname>${gpg.keyname}</keyname>
                   <passphraseServerId>${gpg.keyname}</passphraseServerId>
                   <gpgArguments>
-                    <arg>--batch</arg>
-                    <arg>--allow-loopback-pinentry</arg>
+                    <arg>-v</arg>
                     <arg>--pinentry-mode</arg>
                     <arg>loopback</arg>
                   </gpgArguments>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -293,13 +293,14 @@
                 <goals>
                   <goal>sign</goal>
                 </goals>
-		<configuration>
+                <configuration>
                   <keyname>${gpg.keyname}</keyname>
-		  <passphraseServerId>${gpg.keyname}</passphraseServerId>
-		  <gpgArguments>
+                  <passphraseServerId>${gpg.keyname}</passphraseServerId>
+                  <gpgArguments>
                     <arg>--pinentry-mode</arg>
                     <arg>loopback</arg>
                   </gpgArguments>
+                  <executable>gpg2</executable>
                 </configuration>
               </execution>
             </executions>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -298,6 +298,9 @@
                   <passphraseServerId>${gpg.keyname}</passphraseServerId>
                   <gpgArguments>
                     <arg>--batch</arg>
+                    <arg>--allow-loopback-pinentry</arg>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
                   </gpgArguments>
                   <executable>gpg2</executable>
                 </configuration>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -297,6 +297,8 @@
                   <keyname>${gpg.keyname}</keyname>
                   <passphraseServerId>${gpg.keyname}</passphraseServerId>
                   <gpgArguments>
+                    <arg>--batch</arg>
+                    <arg>--allow-loopback-pinentry</arg>
                     <arg>--pinentry-mode</arg>
                     <arg>loopback</arg>
                   </gpgArguments>

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -47,25 +47,14 @@
     <developerConnection>scm:git:ssh://github.com:mlflow/mlflow.git</developerConnection>
     <url>http://github.com/mlflow/mlflow/tree/master</url>
   </scm>
-  <!--
-  <distributionManagement>
-    <repository>
-      <id>bintray</id>
-      <name>mlflow</name>
-      <url>https://api.bintray.com/maven/mlflow/mlflow/mlflow-parent/;publish=1</url>
-    </repository>
-  </distributionManagement>
-  -->
   <distributionManagement>
     <snapshotRepository>
-      <id>bintray-mlflowdev-mlflowdev-snapshot</id>
-      <name>mlflowdev-mlflowdev</name>
-      <url>https://api.bintray.com/maven/mlflowdev/mlflowdev/mlflow-java/;publish=1</url>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
     <repository>
-      <id>bintray-mlflowdev-mlflowdev</id>
-      <name>mlflowdev-mlflowdev</name>
-      <url>https://api.bintray.com/maven/mlflowdev/mlflowdev/mlflow-java/;publish=1</url>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
     </repository>
   </distributionManagement>
 

--- a/mlflow/java/scoring/pom.xml
+++ b/mlflow/java/scoring/pom.xml
@@ -9,14 +9,6 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <distributionManagement>
-    <repository>
-      <id>bintray</id>
-      <name>mlflow</name>
-      <url>https://api.bintray.com/maven/mlflow/mlflow/mlflow-scoring/;publish=1</url>
-    </repository>
-  </distributionManagement>
-
   <artifactId>mlflow-scoring</artifactId>
   <packaging>jar</packaging>
   <name>MLflow scoring server</name>
@@ -140,4 +132,9 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>do-sign</id>
+    </profile>
+  </profiles>
 </project>

--- a/mlflow/java/spark/pom.xml
+++ b/mlflow/java/spark/pom.xml
@@ -12,14 +12,6 @@
     <spec2.version>4.2.0</spec2.version>
   </properties>
 
-    <distributionManagement>
-        <repository>
-            <id>bintray</id>
-            <name>mlflow</name>
-            <url>https://api.bintray.com/maven/mlflow/mlflow/mlflow-spark/;publish=1</url>
-        </repository>
-    </distributionManagement>
-
   <parent>
     <groupId>org.mlflow</groupId>
     <artifactId>mlflow-parent</artifactId>
@@ -145,4 +137,9 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>do-sign</id>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add GPG sign for pom.xml

This make it easy to publish to maven central

The steps is:
1) generate gpg key pair
2) Create a `tmp-settings.xml` file including content:
```
<settings>
  <servers>
    <server>
      <id>ossrh</id>
      <username>{Sonatype account username}</username>
      <password>{Sonatype account password}</password>
    </server>
    <server>
      <id>{your gpg key name}</id>
      <passphrase>{your gpg key phrase}</passphrase>
    </server>
  </servers>
  <profiles>
    <profile>
      <activation>
        <activeByDefault>true</activeByDefault>
      </activation>
      <properties>
	      <gpg.keyname>{your gpg key name}</gpg.keyname>
      </properties>
    </profile>
  </profiles>  
</settings>
```
3) Run command:
```
mvn --settings path/to/tmp-settings.xml -Pdo-sign  -DskipTests clean deploy -X
```
Then it will be published to maven central:
if snapshot version, publish to:
 https://oss.sonatype.org/content/repositories/snapshots
if release version, publish to:
 https://oss.sonatype.org/service/local/staging/deploy/maven2

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
