### PR TITLE
Bug fix for TensorFlow autologging: do not mutate user-specified callbacks list

### DIFF
--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1061,9 +1061,9 @@ def autolog(
                     args[5] = callbacks
                     args = tuple(args)
                 else:
-                    callbacks = list(kwargs.get("callbacks", []))
                     # Make a shallow copy of the preexisting callbacks and introduce TensorBoard
                     # & tf.keras callbacks if necessary
+                    callbacks = list(kwargs.get("callbacks", []))
                     kwargs["callbacks"], self.log_dir = _setup_callbacks(
                         callbacks, log_models, metrics_logger
                     )

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1046,12 +1046,12 @@ def autolog(
             with batch_metrics_logger(run_id) as metrics_logger:
                 # Check if the 'callback' argument of fit() is set positionally
                 if len(args) >= 6:
-                    # Make a shallow copy of the training function's positional arguments to avoid
-                    # permanently modifying their contents for future training invocations. Convert
-                    # the copied arguments to a list in order to mutate the contents
+                    # Convert the positional training function arguments to a list in order to
+                    # mutate the contents
                     args = list(args)
-                    # Make a shallow copy of the preexisting callbacks and introduce TensorBoard
-                    # & tf.keras callbacks if necessary
+                    # Make a shallow copy of the preexisting callbacks to avoid permanently
+                    # modifying their contents for future training invocations. Introduce
+                    # TensorBoard & tf.keras callbacks if necessary
                     callbacks = list(args[5])
                     callbacks, self.log_dir = _setup_callbacks(
                         callbacks, log_models, metrics_logger
@@ -1061,9 +1061,6 @@ def autolog(
                     args[5] = callbacks
                     args = tuple(args)
                 else:
-                    # Make a shallow copy of the training function's keyword arguments to avoid
-                    # permanently modifying their contents for future training invocations
-                    kwargs = dict(kwargs)
                     callbacks = list(kwargs.get("callbacks", []))
                     # Make a shallow copy of the preexisting callbacks and introduce TensorBoard
                     # & tf.keras callbacks if necessary

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1063,7 +1063,7 @@ def autolog(
                 else:
                     # Make a shallow copy of the preexisting callbacks and introduce TensorBoard
                     # & tf.keras callbacks if necessary
-                    callbacks = list(kwargs.get("callbacks", []))
+                    callbacks = list(kwargs.get("callbacks") or [])
                     kwargs["callbacks"], self.log_dir = _setup_callbacks(
                         callbacks, log_models, metrics_logger
                     )

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1061,9 +1061,9 @@ def autolog(
                     args[5] = callbacks
                     args = tuple(args)
                 else:
+                    callbacks = list(kwargs.get("callbacks", []))
                     # Make a shallow copy of the preexisting callbacks and introduce TensorBoard
                     # & tf.keras callbacks if necessary
-                    callbacks = list(kwargs.get("callbacks", []))
                     kwargs["callbacks"], self.log_dir = _setup_callbacks(
                         callbacks, log_models, metrics_logger
                     )

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1054,7 +1054,7 @@ def autolog(
                     # & tf.keras callbacks if necessary
                     callbacks = list(args[5])
                     callbacks, self.log_dir = _setup_callbacks(
-                        callbacks, log_models, metrics_logger 
+                        callbacks, log_models, metrics_logger
                     )
                     # Replace the callbacks positional entry in the copied arguments and convert
                     # the arguments back to tuple form for usage in the training function
@@ -1073,7 +1073,7 @@ def autolog(
 
                 early_stop_callback = _get_early_stop_callback(callbacks)
                 _log_early_stop_callback_params(early_stop_callback)
-                
+
                 history = original(inst, *args, **kwargs)
 
                 _log_early_stop_callback_metrics(early_stop_callback, history, metrics_logger)

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -975,7 +975,7 @@ def autolog(
         return serialized
 
     @exception_safe_function
-    def _early_stop_check(callbacks):
+    def _get_early_stop_callback(callbacks):
         for callback in callbacks:
             if isinstance(callback, tensorflow.keras.callbacks.EarlyStopping):
                 return callback
@@ -1044,25 +1044,36 @@ def autolog(
 
             run_id = mlflow.active_run().info.run_id
             with batch_metrics_logger(run_id) as metrics_logger:
-                # Checking if the 'callback' argument of fit() is set
+                # Check if the 'callback' argument of fit() is set positionally
                 if len(args) >= 6:
-                    tmp_list = list(args)
-                    early_stop_callback = _early_stop_check(tmp_list[5])
-                    tmp_list[5], self.log_dir = _setup_callbacks(
-                        tmp_list[5], log_models, metrics_logger
+                    # Make a shallow copy of the training function's positional arguments to avoid
+                    # permanently modifying their contents for future training invocations. Convert
+                    # the copied arguments to a list in order to mutate the contents
+                    args = list(args)
+                    # Make a shallow copy of the preexisting callbacks and introduce TensorBoard
+                    # & tf.keras callbacks if necessary
+                    callbacks = list(args[5])
+                    callbacks, self.log_dir = _setup_callbacks(
+                        callbacks, log_models, metrics_logger 
                     )
-                    args = tuple(tmp_list)
-                elif kwargs.get("callbacks"):
-                    early_stop_callback = _early_stop_check(kwargs["callbacks"])
-                    kwargs["callbacks"], self.log_dir = _setup_callbacks(
-                        kwargs["callbacks"], log_models, metrics_logger
-                    )
+                    # Replace the callbacks positional entry in the copied arguments and convert
+                    # the arguments back to tuple form for usage in the training function
+                    args[5] = callbacks
+                    args = tuple(args)
                 else:
+                    # Make a shallow copy of the training function's keyword arguments to avoid
+                    # permanently modifying their contents for future training invocations
+                    kwargs = dict(kwargs)
+                    callbacks = list(kwargs.get("callbacks", []))
+                    # Make a shallow copy of the preexisting callbacks and introduce TensorBoard
+                    # & tf.keras callbacks if necessary
                     kwargs["callbacks"], self.log_dir = _setup_callbacks(
-                        [], log_models, metrics_logger
+                        callbacks, log_models, metrics_logger
                     )
 
+                early_stop_callback = _get_early_stop_callback(callbacks)
                 _log_early_stop_callback_params(early_stop_callback)
+                
                 history = original(inst, *args, **kwargs)
 
                 _log_early_stop_callback_metrics(early_stop_callback, history, metrics_logger)

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -1091,8 +1091,8 @@ def safe_patch(
                             # Verify that the patch function implementation has not mutated the
                             # user-specified arguments during the preamble (i.e.  prior to the
                             # original / underlying function invocation)
-                            assert args == preamble_args_snapshot 
-                            assert kwargs == preamble_kwargs_snapshot 
+                            assert args == preamble_args_snapshot
+                            assert kwargs == preamble_kwargs_snapshot
                             # Verify that the arguments being passed to the original / underlying
                             # function are complete (no user-specified arguments have been omitted)
                             # and exception safe (any additional arguments introduced by MLflow,
@@ -1171,12 +1171,12 @@ def safe_patch(
                     kwargs,
                 )
 
-                if _is_testing(): 
+                if _is_testing():
                     # Verify that the patch function implementation has not mutated the
                     # user-specified arguments during the postamble (i.e. after the original /
                     # underlying function invocation)
-                    assert args == postamble_args_snapshot 
-                    assert kwargs == postamble_kwargs_snapshot 
+                    assert args == postamble_args_snapshot
+                    assert kwargs == postamble_kwargs_snapshot
 
             except Exception as e:
                 # Exceptions thrown during execution of the original function should be propagated

--- a/mlflow/utils/autologging_utils.py
+++ b/mlflow/utils/autologging_utils.py
@@ -1028,8 +1028,6 @@ def safe_patch(
         """
         if _is_testing():
             preexisting_run_for_testing = mlflow.active_run()
-            preamble_args_snapshot, preamble_kwargs_snapshot = args, kwargs
-            postamble_args_snapshot, postamble_kwargs_snapshot = args, kwargs
 
         original = gorilla.get_original_attribute(destination, function_name)
 
@@ -1071,12 +1069,6 @@ def safe_patch(
             try:
 
                 def call_original(*og_args, **og_kwargs):
-                    """
-                    :param og_args: The positional arguments passed by the patch function
-                                    implementation to the original / underlying function
-                    :param og_kwargs: The keyword arguments passed by the patch function
-                                      implementation to the original / underlying function
-                    """
                     try:
                         try_log_autologging_event(
                             AutologgingEventLogger.get_logger().log_original_function_start,
@@ -1088,15 +1080,6 @@ def safe_patch(
                         )
 
                         if _is_testing():
-                            # Verify that the patch function implementation has not mutated the
-                            # user-specified arguments during the preamble (i.e.  prior to the
-                            # original / underlying function invocation)
-                            assert args == preamble_args_snapshot
-                            assert kwargs == preamble_kwargs_snapshot
-                            # Verify that the arguments being passed to the original / underlying
-                            # function are complete (no user-specified arguments have been omitted)
-                            # and exception safe (any additional arguments introduced by MLflow,
-                            # such as callbacks, are resilient to unexpected exceptions)
                             _validate_args(args, kwargs, og_args, og_kwargs)
                             # By the time `original` is called by the patch implementation, we
                             # assume that either: 1. the patch implementation has already
@@ -1122,10 +1105,6 @@ def safe_patch(
                             og_args,
                             og_kwargs,
                         )
-
-                        if _is_testing():
-                            nonlocal postamble_args_snapshot, postamble_kwargs_snapshot
-                            postamble_args_snapshot, postamble_kwargs_snapshot = args, kwargs
 
                         return original_result
                     except Exception as e:
@@ -1170,14 +1149,6 @@ def safe_patch(
                     args,
                     kwargs,
                 )
-
-                if _is_testing():
-                    # Verify that the patch function implementation has not mutated the
-                    # user-specified arguments during the postamble (i.e. after the original /
-                    # underlying function invocation)
-                    assert args == postamble_args_snapshot
-                    assert kwargs == postamble_kwargs_snapshot
-
             except Exception as e:
                 # Exceptions thrown during execution of the original function should be propagated
                 # to the caller. Additionally, exceptions encountered during test mode should be

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -522,6 +522,19 @@ def test_tf_keras_autolog_logs_to_and_deletes_temporary_directory_when_tensorboa
         assert not os.path.exists(mock_log_dir_inst.location)
 
 
+def test_tf_keras_autolog_does_not_mutate_original_callbacks_list(tmpdir, random_train_data, random_one_hot_labels, fit_variant):
+    """
+    TensorFlow autologging passes new callbacks to the `fit()` / `fit_generator()` function. If
+    preexisting user-defined callbacks already exist, these new callbacks are added to the
+    user-specified ones. This test verifies that the new callbacks are added to the without
+    permanently mutating the original list of callbacks.
+    """
+    callbacks = [tf.keras.callbacks.TensorBoard(log_dir=tmpdir)]
+     
+
+    pass
+
+
 def create_tf_estimator_model(directory, export, training_steps=500, use_v1_estimator=False):
     CSV_COLUMN_NAMES = ["SepalLength", "SepalWidth", "PetalLength", "PetalWidth", "Species"]
 

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -459,8 +459,9 @@ def test_tf_keras_autolog_non_early_stop_callback_no_log(tf_keras_random_data_ru
 
 
 @pytest.mark.parametrize("fit_variant", ["fit", "fit_generator"])
+@pytest.mark.parametrize("positional", [True, False])
 def test_tf_keras_autolog_does_not_mutate_original_callbacks_list(
-    tmpdir, random_train_data, random_one_hot_labels, fit_variant
+    tmpdir, random_train_data, random_one_hot_labels, fit_variant, positional
 ):
     """
     TensorFlow autologging passes new callbacks to the `fit()` / `fit_generator()` function. If
@@ -483,9 +484,16 @@ def test_tf_keras_autolog_does_not_mutate_original_callbacks_list(
             while True:
                 yield data, labels
 
-        model.fit_generator(generator(), epochs=10, steps_per_epoch=1, callbacks=callbacks)
+        if positional:
+            model.fit_generator(generator(), 1, 10, 1, callbacks)
+        else:
+            model.fit_generator(generator(), epochs=10, steps_per_epoch=1, callbacks=callbacks)
+
     else:
-        model.fit(data, labels, epochs=10, callbacks=callbacks)
+        if positional:
+            model.fit(data, labels, None, 10, 1, callbacks)
+        else:
+            model.fit(data, labels, epochs=10, callbacks=callbacks)
 
     assert len(callbacks) == 1
     assert callbacks == [tensorboard_callback]


### PR DESCRIPTION
## What changes are proposed in this pull request?

TensorFlow autologging passes new callbacks to the `fit()` / `fit_generator()` function. If preexisting user-defined callbacks already exist, these new callbacks are added to the user-specified ones. Unfortunately, the current implementation mutates the list of user-defined callbacks, rather than creating a copy of the list and modifying it. As a result, when users call `fit()` / `fit_generator()` multiple times, they end up with a list of multiple MLflow-defined tf.keras callbacks for metric logging.

This becomes problematic in hyperopt use cases. In the following example, sklearn's GridSearch API is used with a tf.keras model. Each call to `fit()` in the grid search attaches an MLflow metric logging callback for all preceding `fit()` invocations. Each callback logs metrics to the run corresponding to its initial `fit()` call. As a result, all runs end up with the same metrics (the ones corresponding to the final `fit()` call). Here's some example code:

```
import tensorflow as tf
from tensorflow.keras.wrappers.scikit_learn import KerasClassifier
from tensorflow.keras import layers, regularizers, metrics
from tensorflow.keras.models import Sequential 
from tensorflow.keras.layers import Dense
from tensorflow.keras.optimizers import Adam
from tensorflow.python.keras.metrics import AUC, Precision, Recall

from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
from sklearn.preprocessing import LabelEncoder, OneHotEncoder

import mlflow 
import mlflow.tensorflow

import warnings
warnings.filterwarnings("ignore")

def load_data():
  import pandas as pd
  X = pd.read_csv("x.csv").drop("Unnamed: 0", axis=1)
  y = pd.read_csv("y.csv")["bad_loan"]
  return X, y

def encode_inputs(X):
  ohe = OneHotEncoder()
  ohe.fit(X)
  X = ohe.transform(X)
  return X

def encode_labels(y): 
  enc = LabelEncoder()
  enc.fit(y)
  return enc.transform(y)

def build_model(optimizer='rmsprop', init='glorot_uniform'):
  model = Sequential()
  model.add(Dense(17, input_dim=24064, kernel_initializer=init, 
                  kernel_regularizer=regularizers.l2(1e-2), activation='relu'))
  model.add(Dense(1, activation='sigmoid'))
  
  model.compile(optimizer=optimizer,
                loss='binary_crossentropy',
                metrics=['accuracy'])
  
  return model

X, y = load_data()
X_enc = encode_inputs(X)
y_enc = encode_labels(y)

mlflow.tensorflow.autolog(every_n_iter=1)

model = KerasClassifier(build_fn=build_model, verbose=2)

# Test with small/few parameters
optimizers = ['rmsprop']
inits= ['glorot_uniform', 'normal']
epochs = [3, 5]  

experiment_log_dir = "foobazbiz"
tensorboard_callback = tf.keras.callbacks.TensorBoard(log_dir=experiment_log_dir)

fit_params = dict(callbacks=[tensorboard_callback])
# fit_params = {} 

param_grid = dict(optimizer=optimizers, epochs=epochs, init=inits)
grid = GridSearchCV(estimator=model, param_grid=param_grid, cv=3)

grid_result = grid.fit(X_enc, y_enc, **fit_params)

mlflow.end_run()
```

(please ask me for datasets if you want to run this yourself)

Before this PR, the results are as follows (note that all runs share the same metrics): 

<img width="1240" alt="Screen Shot 2021-03-22 at 11 55 51 AM" src="https://user-images.githubusercontent.com/39497902/112027879-a12b5100-8b05-11eb-9b33-fd1475df958b.png">

After this PR, the results are as follows (note that each run has different metrics, as expected):

<img width="1239" alt="Screen Shot 2021-03-22 at 11 57 33 AM" src="https://user-images.githubusercontent.com/39497902/112028084-cfa92c00-8b05-11eb-99f3-1b2e7637ddee.png">


## How is this patch tested?

New unit tests + manual gridsearch test case described immediately above.

## Release Notes

Fix a bug in TensorFlow autologging causing user-specified callback lists passed to `fit()` / `fit_generator()` to be modified.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
