### PR TITLE
Added temporary service unavailable (503) to exp backoff logic

### DIFF
--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -195,24 +195,52 @@ def test_429_retries(request):
             self.text = "mocked text"
 
     request.side_effect = [MockedResponse(x) for x in (429, 200)]
-    assert http_request(host_only, "/my/endpoint", max_rate_limit_interval=0).status_code == 429
+    assert (
+        http_request(
+            host_only, "/my/endpoint", max_backoff_limit=0, backoff_error_codes=(429,)
+        ).status_code
+        == 429
+    )
     request.side_effect = [MockedResponse(x) for x in (429, 200)]
-    assert http_request(host_only, "/my/endpoint", max_rate_limit_interval=1).status_code == 200
+    assert (
+        http_request(
+            host_only, "/my/endpoint", max_backoff_limit=1, backoff_error_codes=(429,)
+        ).status_code
+        == 200
+    )
     request.side_effect = [MockedResponse(x) for x in (429, 429, 200)]
-    assert http_request(host_only, "/my/endpoint", max_rate_limit_interval=1).status_code == 429
+    assert (
+        http_request(
+            host_only, "/my/endpoint", max_backoff_limit=1, backoff_error_codes=(429,)
+        ).status_code
+        == 429
+    )
     request.side_effect = [MockedResponse(x) for x in (429, 429, 200)]
-    assert http_request(host_only, "/my/endpoint", max_rate_limit_interval=2).status_code == 200
+    assert (
+        http_request(
+            host_only, "/my/endpoint", max_backoff_limit=2, backoff_error_codes=(429,)
+        ).status_code
+        == 200
+    )
     request.side_effect = [MockedResponse(x) for x in (429, 429, 200)]
-    assert http_request(host_only, "/my/endpoint", max_rate_limit_interval=3).status_code == 200
+    assert (
+        http_request(
+            host_only, "/my/endpoint", max_backoff_limit=3, backoff_error_codes=(429,)
+        ).status_code
+        == 200
+    )
     # Test that any non 429 code is returned
     request.side_effect = [MockedResponse(x) for x in (429, 404, 429, 200)]
-    assert http_request(host_only, "/my/endpoint").status_code == 404
+    assert http_request(host_only, "/my/endpoint", backoff_error_codes=(429,)).status_code == 404
     # Test that retries work as expected
     request.side_effect = [MockedResponse(x) for x in (429, 503, 429, 200)]
     with pytest.raises(MlflowException, match="failed to return code 200"):
-        http_request(host_only, "/my/endpoint", retries=1)
+        http_request(host_only, "/my/endpoint", retries=1, backoff_error_codes=(429,))
     request.side_effect = [MockedResponse(x) for x in (429, 503, 429, 200)]
-    assert http_request(host_only, "/my/endpoint", retries=2).status_code == 200
+    assert (
+        http_request(host_only, "/my/endpoint", retries=2, backoff_error_codes=(429,)).status_code
+        == 200
+    )
 
 
 @mock.patch("requests.request")


### PR DESCRIPTION
Signed-off-by: jinzhang21 <jin.zhang@databricks.com>

## What changes are proposed in this pull request?

In MLFlow HTTP request function, right now only rate limited error (429) will incur an exponential backoff retry. This PR extend such logic to include temporary service unavailable error (503) as well.

## How is this patch tested?

(TODO) unit test.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
