### PR TITLE
End autologged runs when execution is interrupted (sigint)

### DIFF
--- a/mlflow/utils/autologging/__init__.py
+++ b/mlflow/utils/autologging/__init__.py
@@ -618,7 +618,7 @@ class PatchFunction:
     def __call__(self, original, *args, **kwargs):
         try:
             return self._patch_implementation(original, *args, **kwargs)
-        except Exception as e:
+        except (Exception, KeyboardInterrupt) as e:
             try:
                 self._on_exception(e)
             finally:
@@ -954,7 +954,7 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
 
             try:
                 result = patch_function(original, *args, **kwargs)
-            except:
+            except (Exception, KeyboardInterrupt):
                 if managed_run:
                     try_mlflow_log(mlflow.end_run, RunStatus.to_string(RunStatus.FAILED))
                 raise

--- a/mlflow/utils/autologging/__init__.py
+++ b/mlflow/utils/autologging/__init__.py
@@ -619,6 +619,9 @@ class PatchFunction:
         try:
             return self._patch_implementation(original, *args, **kwargs)
         except (Exception, KeyboardInterrupt) as e:
+            # Handle keyboard interrupts, in addition to standard Python exceptions, to ensure
+            # that runs are terminated if a user prematurely interrupts training execution
+            # (e.g. via sigint / ctrl-c)
             try:
                 self._on_exception(e)
             finally:
@@ -955,6 +958,9 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
             try:
                 result = patch_function(original, *args, **kwargs)
             except (Exception, KeyboardInterrupt):
+                # Handle keyboard interrupts, in addition to standard Python exceptions, to ensure
+                # that runs are terminated if a user prematurely interrupts training execution
+                # (e.g. via sigint / ctrl-c)
                 if managed_run:
                     try_mlflow_log(mlflow.end_run, RunStatus.to_string(RunStatus.FAILED))
                 raise

--- a/mlflow/utils/autologging/__init__.py
+++ b/mlflow/utils/autologging/__init__.py
@@ -604,8 +604,9 @@ class PatchFunction:
     @abstractmethod
     def _on_exception(self, exception):
         """
-        Called when an unhandled exception prematurely terminates the execution
-        of `_patch_implementation`.
+        Called when an unhandled standard Python exception (i.e. an exception inheriting from
+        `Exception`) or a `KeyboardInterrupt` prematurely terminates the execution of
+        `_patch_implementation`.
 
         :param exception: The unhandled exception thrown by `_patch_implementation`.
         """
@@ -618,7 +619,7 @@ class PatchFunction:
     def __call__(self, original, *args, **kwargs):
         try:
             return self._patch_implementation(original, *args, **kwargs)
-        except Exception as e:
+        except (Exception, KeyboardInterrupt) as e:
             try:
                 self._on_exception(e)
             finally:
@@ -954,7 +955,10 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
 
             try:
                 result = patch_function(original, *args, **kwargs)
-            except:
+            except (Exception, KeyboardInterrupt):
+                # In addition to standard Python exceptions, handle keyboard interrupts to ensure
+                # that runs are terminated if a user prematurely interrupts training execution
+                # (e.g. via sigint / ctrl-c)
                 if managed_run:
                     try_mlflow_log(mlflow.end_run, RunStatus.to_string(RunStatus.FAILED))
                 raise

--- a/mlflow/utils/autologging/__init__.py
+++ b/mlflow/utils/autologging/__init__.py
@@ -604,9 +604,8 @@ class PatchFunction:
     @abstractmethod
     def _on_exception(self, exception):
         """
-        Called when an unhandled standard Python exception (i.e. an exception inheriting from
-        `Exception`) or a `KeyboardInterrupt` prematurely terminates the execution of
-        `_patch_implementation`.
+        Called when an unhandled exception prematurely terminates the execution
+        of `_patch_implementation`.
 
         :param exception: The unhandled exception thrown by `_patch_implementation`.
         """
@@ -619,7 +618,7 @@ class PatchFunction:
     def __call__(self, original, *args, **kwargs):
         try:
             return self._patch_implementation(original, *args, **kwargs)
-        except (Exception, KeyboardInterrupt) as e:
+        except Exception as e:
             try:
                 self._on_exception(e)
             finally:
@@ -955,10 +954,7 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
 
             try:
                 result = patch_function(original, *args, **kwargs)
-            except (Exception, KeyboardInterrupt):
-                # In addition to standard Python exceptions, handle keyboard interrupts to ensure
-                # that runs are terminated if a user prematurely interrupts training execution
-                # (e.g. via sigint / ctrl-c)
+            except:
                 if managed_run:
                     try_mlflow_log(mlflow.end_run, RunStatus.to_string(RunStatus.FAILED))
                 raise

--- a/mlflow/utils/autologging/__init__.py
+++ b/mlflow/utils/autologging/__init__.py
@@ -619,7 +619,7 @@ class PatchFunction:
         try:
             return self._patch_implementation(original, *args, **kwargs)
         except (Exception, KeyboardInterrupt) as e:
-            # Handle keyboard interrupts, in addition to standard Python exceptions, to ensure
+            # In addition to standard Python exceptions, handle keyboard interrupts to ensure
             # that runs are terminated if a user prematurely interrupts training execution
             # (e.g. via sigint / ctrl-c)
             try:
@@ -958,7 +958,7 @@ def with_managed_run(autologging_integration, patch_function, tags=None):
             try:
                 result = patch_function(original, *args, **kwargs)
             except (Exception, KeyboardInterrupt):
-                # Handle keyboard interrupts, in addition to standard Python exceptions, to ensure
+                # In addition to standard Python exceptions, handle keyboard interrupts to ensure
                 # that runs are terminated if a user prematurely interrupts training execution
                 # (e.g. via sigint / ctrl-c)
                 if managed_run:

--- a/mlflow/utils/autologging/__init__.py
+++ b/mlflow/utils/autologging/__init__.py
@@ -604,8 +604,9 @@ class PatchFunction:
     @abstractmethod
     def _on_exception(self, exception):
         """
-        Called when an unhandled exception prematurely terminates the execution
-        of `_patch_implementation`.
+        Called when an unhandled standard Python exception (i.e. an exception inheriting from
+        `Exception`) or a `KeyboardInterrupt` prematurely terminates the execution of
+        `_patch_implementation`.
 
         :param exception: The unhandled exception thrown by `_patch_implementation`.
         """
@@ -619,9 +620,6 @@ class PatchFunction:
         try:
             return self._patch_implementation(original, *args, **kwargs)
         except (Exception, KeyboardInterrupt) as e:
-            # In addition to standard Python exceptions, handle keyboard interrupts to ensure
-            # that runs are terminated if a user prematurely interrupts training execution
-            # (e.g. via sigint / ctrl-c)
             try:
                 self._on_exception(e)
             finally:

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -989,13 +989,14 @@ def test_patch_function_class_call_invokes_implementation_and_returns_result():
     assert TestPatchFunction.call("foo", lambda: "foo") == 10
 
 
-def test_patch_function_class_call_handles_exceptions_properly():
+@pytest.mark.parametrize("exception_class", [Exception, KeyboardInterrupt])
+def test_patch_function_class_call_handles_exceptions_properly(exception_class):
 
     called_on_exception = False
 
     class TestPatchFunction(PatchFunction):
         def _patch_implementation(self, original, *args, **kwargs):
-            raise Exception("implementation exception")
+            raise exception_class("implementation exception")
 
         def _on_exception(self, exception):
             nonlocal called_on_exception
@@ -1004,7 +1005,7 @@ def test_patch_function_class_call_handles_exceptions_properly():
 
     # Even if an exception is thrown from `_on_exception`, we expect the original
     # exception from the implementation to be surfaced to the caller
-    with pytest.raises(Exception, match="implementation exception"):
+    with pytest.raises(exception_class, match="implementation exception"):
         TestPatchFunction.call("foo", lambda: "foo")
 
     assert called_on_exception


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Autologging creates a fluent MLflow run on behalf of a user if a run does not already exist when a training session begins. However, if the training session is interrupted via a SIGINT (for example, if the the user presses `ctrl-c` on a Mac), this automatically-created run is not ended in certain cases. Specifically, if run was created by an autologging integration that makes use of [PatchFunction](https://github.com/mlflow/mlflow/blob/b57f95498ac11d70d3d153ce5e0895a7ab4ab7e9/mlflow/utils/autologging/__init__.py#L582) (`mlflow.tensorflow.autolog()`, for example: https://github.com/mlflow/mlflow/blob/b57f95498ac11d70d3d153ce5e0895a7ab4ab7e9/mlflow/tensorflow.py#L1043).

This PR fixes that issue, ensuring that runs created on behalf of a user during MLflow autologging are terminated in the event of a user interrupt.

## How is this patch tested?

- Unit tests
- Manual test: I ran the following TensorFlow training code in a Databricks notebook cell, hit "stop execution", and confirmed that there was no active run (i.e. `assert not mlflow.active_run()`) in a subsequent cell after execution was stopped. In contrast, an active run was left behind when the example was run using MLflow 1.14.1.

```
import tensorflow as tf
from tensorflow.keras.wrappers.scikit_learn import KerasClassifier
from tensorflow.keras import layers, regularizers, metrics
from tensorflow.keras.models import Sequential 
from tensorflow.keras.layers import Dense
from tensorflow.keras.optimizers import Adam
from tensorflow.python.keras.metrics import AUC, Precision, Recall

from sklearn.model_selection import GridSearchCV, RandomizedSearchCV
from sklearn.preprocessing import LabelEncoder, OneHotEncoder

import mlflow 
import mlflow.tensorflow

import warnings
warnings.filterwarnings("ignore")

def load_data():
  import pandas as pd
  X = pd.read_csv("x.csv").drop("Unnamed: 0", axis=1)
  y = pd.read_csv("y.csv")["bad_loan"]
  return X, y

def encode_inputs(X):
  ohe = OneHotEncoder()
  ohe.fit(X)
  X = ohe.transform(X)
  return X

def encode_labels(y): 
  enc = LabelEncoder()
  enc.fit(y)
  return enc.transform(y)

def build_model(optimizer='rmsprop', init='glorot_uniform'):
  model = Sequential()
  model.add(Dense(17, input_dim=24064, kernel_initializer=init, 
                  kernel_regularizer=regularizers.l2(1e-2), activation='relu'))
  model.add(Dense(1, activation='sigmoid'))
  
  model.compile(optimizer=optimizer,
                loss='binary_crossentropy',
                metrics=['accuracy'])
  
  return model

X, y = load_data()
X_enc = encode_inputs(X)
y_enc = encode_labels(y)

mlflow.tensorflow.autolog(every_n_iter=1)

model = KerasClassifier(build_fn=build_model, verbose=2)

model.fit(X_enc, y_enc, epochs=100)
```

Please ask @dbczumar for a copy of `x.csv` and `y.csv` if you want to try this particular code snippet yourself. Any tf.keras model that trains for more than 5-10 seconds is sufficient.

## Release Notes

Runs created by autologging are now terminated correctly in the event of sigints / keyboard interrupts.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
