### PR TITLE
Pytorch - MNIST example - Dataset Download Error - Fix

### DIFF
--- a/examples/pytorch/MNIST/example1/conda.yaml
+++ b/examples/pytorch/MNIST/example1/conda.yaml
@@ -6,9 +6,7 @@ dependencies:
 - python=3.8.2
 - pytorch=1.8.0
 - pytorch-lightning==1.0.2
-- torchvision=0.9.0
 - pip
 - pip:
   - mlflow
-  - cloudpickle==1.6.0
-  - boto3
+  - torchvision==0.9.1

--- a/examples/pytorch/MNIST/example2/conda.yaml
+++ b/examples/pytorch/MNIST/example2/conda.yaml
@@ -6,9 +6,7 @@ dependencies:
 - python=3.8.2
 - pytorch=1.8.0
 - pytorch-lightning==1.0.2
-- torchvision=0.9.0
 - pip
 - pip:
   - mlflow
-  - cloudpickle==1.6.0
-  - boto3
+  - torchvision==0.9.1

--- a/examples/pytorch/conda.yaml
+++ b/examples/pytorch/conda.yaml
@@ -9,6 +9,6 @@ dependencies:
   - pip
   - pip:
     - torch==1.8.0
-    - torchvision==0.9.0
+    - torchvision==0.9.1
     - mlflow>=1.0
     - tensorboardX

--- a/examples/pytorch/conda.yaml
+++ b/examples/pytorch/conda.yaml
@@ -8,7 +8,7 @@ dependencies:
   - python=3.6
   - pip
   - pip:
-    - torch==1.8.0
+    - torch==1.8.1
     - torchvision==0.9.1
     - mlflow>=1.0
     - tensorboardX


### PR DESCRIPTION
…issue

Signed-off-by: Shrinath Suresh <shrinath@ideas2it.com>

## What changes are proposed in this pull request?

MNIST examples are failing while downloading the MNIST dataset using torchvision==0.9.0. 

```
Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz to dataset/MNIST/raw/train-images-idx3-ubyte.gz
Traceback (most recent call last):
  File "mnist_autolog_example1.py", line 283, in <module>
    dm.setup(stage="fit")
  File "/home/ubuntu/anaconda3/envs/mlflow-23896ee5fdcfaa89ebd9ddac74372307da8e30d5/lib/python3.8/site-packages/pytorch_lightning/core/datamodule.py", line 90, in wrapped_fn
    return fn(*args, **kwargs)
  File "mnist_autolog_example1.py", line 51, in setup
    self.df_train = datasets.MNIST(
  File "/home/ubuntu/anaconda3/envs/mlflow-23896ee5fdcfaa89ebd9ddac74372307da8e30d5/lib/python3.8/site-packages/torchvision/datasets/mnist.py", line 79, in __init__
    self.download()
  File "/home/ubuntu/anaconda3/envs/mlflow-23896ee5fdcfaa89ebd9ddac74372307da8e30d5/lib/python3.8/site-packages/torchvision/datasets/mnist.py", line 146, in download
    download_and_extract_archive(url, download_root=self.raw_folder, filename=filename, md5=md5)
  File "/home/ubuntu/anaconda3/envs/mlflow-23896ee5fdcfaa89ebd9ddac74372307da8e30d5/lib/python3.8/site-packages/torchvision/datasets/utils.py", line 314, in download_and_extract_archive
    download_url(url, download_root, filename, md5)
  File "/home/ubuntu/anaconda3/envs/mlflow-23896ee5fdcfaa89ebd9ddac74372307da8e30d5/lib/python3.8/site-packages/torchvision/datasets/utils.py", line 140, in download_url
    raise e
  File "/home/ubuntu/anaconda3/envs/mlflow-23896ee5fdcfaa89ebd9ddac74372307da8e30d5/lib/python3.8/site-packages/torchvision/datasets/utils.py", line 132, in download_url
    _urlretrieve(url, fpath)
  File "/home/ubuntu/anaconda3/envs/mlflow-23896ee5fdcfaa89ebd9ddac74372307da8e30d5/lib/python3.8/site-packages/torchvision/datasets/utils.py", line 29, in _urlretrieve
    with urllib.request.urlopen(urllib.request.Request(url, headers={"User-Agent": USER_AGENT})) as response:
  File "/home/ubuntu/anaconda3/envs/mlflow-23896ee5fdcfaa89ebd9ddac74372307da8e30d5/lib/python3.8/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)
  File "/home/ubuntu/anaconda3/envs/mlflow-23896ee5fdcfaa89ebd9ddac74372307da8e30d5/lib/python3.8/urllib/request.py", line 531, in open
    response = meth(req, response)
  File "/home/ubuntu/anaconda3/envs/mlflow-23896ee5fdcfaa89ebd9ddac74372307da8e30d5/lib/python3.8/urllib/request.py", line 640, in http_response
    response = self.parent.error(
  File "/home/ubuntu/anaconda3/envs/mlflow-23896ee5fdcfaa89ebd9ddac74372307da8e30d5/lib/python3.8/urllib/request.py", line 569, in error
    return self._call_chain(*args)
  File "/home/ubuntu/anaconda3/envs/mlflow-23896ee5fdcfaa89ebd9ddac74372307da8e30d5/lib/python3.8/urllib/request.py", line 502, in _call_chain
    result = func(*args)
  File "/home/ubuntu/anaconda3/envs/mlflow-23896ee5fdcfaa89ebd9ddac74372307da8e30d5/lib/python3.8/urllib/request.py", line 649, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 503: Service Unavailable
```

In torchvision==0.9.1, an alternate URL is added for the same and the example is working as expected.

```
Downloading http://yann.lecun.com/exdb/mnist/train-images-idx3-ubyte.gz
Failed to download (trying next):
HTTP Error 503: Service Unavailable

Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-images-idx3-ubyte.gz to dataset/MNIST/raw/train-images-idx3-ubyte.gz
9913344it [00:00, 57901808.78it/s]                                                                                                                                                                          
Extracting dataset/MNIST/raw/train-images-idx3-ubyte.gz to dataset/MNIST/raw

Downloading http://yann.lecun.com/exdb/mnist/train-labels-idx1-ubyte.gz
Failed to download (trying next):
HTTP Error 503: Service Unavailable

Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/train-labels-idx1-ubyte.gz to dataset/MNIST/raw/train-labels-idx1-ubyte.gz
29696it [00:00, 2411454.79it/s]                                                                                                                                                                             
Extracting dataset/MNIST/raw/train-labels-idx1-ubyte.gz to dataset/MNIST/raw

Downloading http://yann.lecun.com/exdb/mnist/t10k-images-idx3-ubyte.gz
Failed to download (trying next):
HTTP Error 503: Service Unavailable

Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz
Downloading https://ossci-datasets.s3.amazonaws.com/mnist/t10k-images-idx3-ubyte.gz to dataset/MNIST/raw/t10k-images-idx3-ubyte.gz
1649664it [00:00, 15201603.64it/s]                                                                                                                                                                          
Extracting dataset/MNIST/raw/t10k-images-idx3-ubyte.gz to dataset/MNIST/raw

Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz
Downloading http://yann.lecun.com/exdb/mnist/t10k-labels-idx1-ubyte.gz to dataset/MNIST/raw/t10k-labels-idx1-ubyte.gz
5120it [00:00, 34918433.30it/s]                                                                                                                                                                             
Extracting dataset/MNIST/raw/t10k-labels-idx1-ubyte.gz to dataset/MNIST/raw
```

I have updated the `conda.yaml` to install `torchvision==0.9.1`

## How is this patch tested?

Tested the examples locally. Please find the logs as below
[mnist_success_torchvision0.9.1.log](https://github.com/mlflow/mlflow/files/6213579/mnist_success_torchvision0.9.1.log)
[mnist_error_torchvision0.9.log](https://github.com/mlflow/mlflow/files/6213580/mnist_error_torchvision0.9.log)

Existing Unit Tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
