### PR TITLE
Fix 1.15 migration error

### DIFF
--- a/mlflow/store/db_migrations/versions/39d1c3be5f05_add_is_nan_constraint_for_metrics_tables_if_necessary.py
+++ b/mlflow/store/db_migrations/versions/39d1c3be5f05_add_is_nan_constraint_for_metrics_tables_if_necessary.py
@@ -26,20 +26,14 @@ def upgrade():
     # to `True`
     with op.batch_alter_table("latest_metrics") as batch_op:
         batch_op.alter_column(
-            "is_nan",
-            type_=sa.types.Boolean(create_constraint=True),
-            nullable=False,
-            server_default=False,
+            "is_nan", type_=sa.types.Boolean(create_constraint=True), nullable=False
         )
 
     # Introduce a check constraint on the `is_nan` column from the `metrics` table, which was
     # missing prior to this migration
     with op.batch_alter_table("metrics") as batch_op:
         batch_op.alter_column(
-            "is_nan",
-            type_=sa.types.Boolean(create_constraint=True),
-            nullable=False,
-            server_default=False,
+            "is_nan", type_=sa.types.Boolean(create_constraint=True), nullable=False
         )
 
 

--- a/mlflow/store/db_migrations/versions/39d1c3be5f05_add_is_nan_constraint_for_metrics_tables_if_necessary.py
+++ b/mlflow/store/db_migrations/versions/39d1c3be5f05_add_is_nan_constraint_for_metrics_tables_if_necessary.py
@@ -26,14 +26,20 @@ def upgrade():
     # to `True`
     with op.batch_alter_table("latest_metrics") as batch_op:
         batch_op.alter_column(
-            "is_nan", type_=sa.types.Boolean(create_constraint=True), nullable=False, default=False
+            "is_nan",
+            type_=sa.types.Boolean(create_constraint=True),
+            nullable=False,
+            server_default=False,
         )
 
     # Introduce a check constraint on the `is_nan` column from the `metrics` table, which was
     # missing prior to this migration
     with op.batch_alter_table("metrics") as batch_op:
         batch_op.alter_column(
-            "is_nan", type_=sa.types.Boolean(create_constraint=True), nullable=False, default=False
+            "is_nan",
+            type_=sa.types.Boolean(create_constraint=True),
+            nullable=False,
+            server_default=False,
         )
 
 

--- a/mlflow/store/db_migrations/versions/c48cb773bb87_reset_default_value_for_is_nan_in_metrics_table_for_mysql.py
+++ b/mlflow/store/db_migrations/versions/c48cb773bb87_reset_default_value_for_is_nan_in_metrics_table_for_mysql.py
@@ -1,4 +1,4 @@
-"""reset_server_default_for_isnan_in_metrics_table
+"""reset_default_value_for_is_nan_in_metrics_table_for_mysql
 
 Revision ID: c48cb773bb87
 Revises: 39d1c3be5f05
@@ -25,7 +25,7 @@ def upgrade():
     #
     # https://alembic.sqlalchemy.org/en/latest/ops.html#alembic.operations.Operations.alter_column
     #
-    # This migration reverts this change by setting the default column value to "0".
+    # To revert this change, set the default column value to "0" by specifying `server_default`
     with op.batch_alter_table("metrics") as batch_op:
         batch_op.alter_column(
             "is_nan",

--- a/mlflow/store/db_migrations/versions/c48cb773bb87_reset_default_value_for_is_nan_in_metrics_table_for_mysql.py
+++ b/mlflow/store/db_migrations/versions/c48cb773bb87_reset_default_value_for_is_nan_in_metrics_table_for_mysql.py
@@ -17,7 +17,7 @@ depends_on = None
 
 
 def upgrade():
-    # This part of the migration is only relevent for MySQL.
+    # This part of the migration is only relevant for MySQL.
     # In 39d1c3be5f05_add_is_nan_constraint_for_metrics_tables_if_necessary.py
     # (added in MLflow 1.15.0), `alter_column` is called on the `is_nan` column in the `metrics`
     # table without specifying `existing_server_default`. This alters the column default value to

--- a/mlflow/store/db_migrations/versions/c48cb773bb87_reset_server_default_for_isnan_in_metrics_table.py
+++ b/mlflow/store/db_migrations/versions/c48cb773bb87_reset_server_default_for_isnan_in_metrics_table.py
@@ -1,0 +1,38 @@
+"""reset_server_default_for_isnan_in_metrics_table
+
+Revision ID: c48cb773bb87
+Revises: 39d1c3be5f05
+Create Date: 2021-04-02 15:43:28.466043
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "c48cb773bb87"
+down_revision = "39d1c3be5f05"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # In 39d1c3be5f05_add_is_nan_constraint_for_metrics_tables_if_necessary.py
+    # (added in MLflow 1.15.0), `alter_column` is called on the `is_nan` column in the `metrics`
+    # table without specifying `existing_server_default`. This alters the column default value to
+    # NULL in MySQL (see the doc below).
+    #
+    # https://alembic.sqlalchemy.org/en/latest/ops.html#alembic.operations.Operations.alter_column
+    #
+    # This migration reverts this change by setting the default column value to "0".
+    with op.batch_alter_table("metrics") as batch_op:
+        batch_op.alter_column(
+            "is_nan",
+            type_=sa.types.Boolean(create_constraint=True),
+            nullable=False,
+            server_default="0",
+        )
+
+
+def downgrade():
+    pass

--- a/mlflow/store/db_migrations/versions/c48cb773bb87_reset_server_default_for_isnan_in_metrics_table.py
+++ b/mlflow/store/db_migrations/versions/c48cb773bb87_reset_server_default_for_isnan_in_metrics_table.py
@@ -17,6 +17,7 @@ depends_on = None
 
 
 def upgrade():
+    # This part of the migration is only relevent for MySQL.
     # In 39d1c3be5f05_add_is_nan_constraint_for_metrics_tables_if_necessary.py
     # (added in MLflow 1.15.0), `alter_column` is called on the `is_nan` column in the `metrics`
     # table without specifying `existing_server_default`. This alters the column default value to


### PR DESCRIPTION
## What changes are proposed in this pull request?

Fix for https://github.com/mlflow/mlflow/issues/4208

## How is this patch tested?

I've changes this line on my MLflow instance and migrations have been passed successfully.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

While upgrading from 1.13.1 to 1.15.0 I faced this error:
```
INFO  [alembic.runtime.migration] Running upgrade a8c4a736bde6 -> 39d1c3be5f05, add_is_nan_constraint_for_metrics_tables_if_necessary
Traceback (most recent call last):
  File "/usr/local/bin/mlflow", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/mlflow/db.py", line 28, in upgrade
    mlflow.store.db.utils._upgrade_db(engine)
  File "/usr/local/lib/python3.7/site-packages/mlflow/store/db/utils.py", line 146, in _upgrade_db
    command.upgrade(config, "heads")
  File "/usr/local/lib/python3.7/site-packages/alembic/command.py", line 298, in upgrade
    script.run_env()
  File "/usr/local/lib/python3.7/site-packages/alembic/script/base.py", line 489, in run_env
    util.load_python_file(self.dir, "env.py")
  File "/usr/local/lib/python3.7/site-packages/alembic/util/pyfiles.py", line 98, in load_python_file
    module = load_module_py(module_id, path)
  File "/usr/local/lib/python3.7/site-packages/alembic/util/compat.py", line 184, in load_module_py
    spec.loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/usr/local/lib/python3.7/site-packages/mlflow/store/db_migrations/env.py", line 84, in <module>
    run_migrations_online()
  File "/usr/local/lib/python3.7/site-packages/mlflow/store/db_migrations/env.py", line 78, in run_migrations_online
    context.run_migrations()
  File "<string>", line 8, in run_migrations
  File "/usr/local/lib/python3.7/site-packages/alembic/runtime/environment.py", line 846, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/usr/local/lib/python3.7/site-packages/alembic/runtime/migration.py", line 518, in run_migrations
    step.migration_fn(**kw)
  File "/usr/local/lib/python3.7/site-packages/mlflow/store/db_migrations/versions/39d1c3be5f05_add_is_nan_constraint_for_metrics_tables_if_necessary.py", line 29, in upgrade
    "is_nan", type_=sa.types.Boolean(create_constraint=True), nullable=False, default=False
  File "/usr/local/lib/python3.7/contextlib.py", line 119, in __exit__
    next(self.gen)
  File "/usr/local/lib/python3.7/site-packages/alembic/operations/base.py", line 354, in batch_alter_table
    impl.flush()
  File "/usr/local/lib/python3.7/site-packages/alembic/operations/batch.py", line 83, in flush
    fn(*arg, **kw)
  File "/usr/local/lib/python3.7/site-packages/alembic/ddl/postgresql.py", line 144, in alter_column
    **kw
TypeError: alter_column() got an unexpected keyword argument 'default'
```
This is caused by changes from https://github.com/mlflow/mlflow/pull/4191 (https://github.com/mlflow/mlflow/pull/4180). There is no such keyword argument `default` for alembic function `alter_column`, but there is `server_default` instead.
It looks like PR author used latest alembic version instead of `alembic<=1.4.1` mentioned in the setup.py file.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [x] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [x] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
