### PR TITLE
log_text to append text as lines

### DIFF
--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -964,8 +964,8 @@ class MlflowClient(object):
             client.log_text(run.info.run_id, "<h1>header</h1>", "index.html")
         """
         with self._log_artifact_helper(run_id, artifact_file) as tmp_path:
-            with open(tmp_path, "w") as f:
-                f.write(text)
+            with open(tmp_path, "a") as f:
+                f.write(text  + "\n")
 
     @experimental
     def log_dict(self, run_id, dictionary, artifact_file):

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -513,7 +513,7 @@ def test_log_text(subdir):
 
         filepath = os.path.join(run_artifact_dir, filename)
         with open(filepath) as f:
-            assert f.read() == text
+            assert f.read()[:-1] == text
 
 
 @pytest.mark.parametrize("subdir", [None, ".", "dir", "dir1/dir2", "dir/.."])


### PR DESCRIPTION
Currently `log_text` simply overwrites current file with whatever user logs. This PR will append the text instead and a new line is added to end of file.