### PR TITLE
Set SPARK_LOCAL_IP to fix flaky spark session creation

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -174,6 +174,7 @@ jobs:
       env:
         INSTALL_LARGE_PYTHON_DEPS: true
         INSTALL_SMALL_PYTHON_DEPS: true
+        SPARK_LOCAL_IP: 127.0.0.1
       run: |
         source ./dev/install-common-deps.sh
     - name: Run tests
@@ -198,6 +199,9 @@ jobs:
       run: |
         source ./dev/install-common-deps.sh
     - name: Run tests
+      env:
+        # Fix for https://github.com/mlflow/mlflow/issues/4229
+        SPARK_LOCAL_IP: 127.0.0.1
       run: |
         export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
@@ -253,6 +257,7 @@ jobs:
         env:
           INSTALL_LARGE_PYTHON_DEPS: true
           INSTALL_SMALL_PYTHON_DEPS: true
+          SPARK_LOCAL_IP: 127.0.0.1
         run: |
           source ./dev/install-common-deps.sh
       - name: Run tests
@@ -292,6 +297,7 @@ jobs:
         env:
           INSTALL_LARGE_PYTHON_DEPS: true
           INSTALL_SMALL_PYTHON_DEPS: true
+          SPARK_LOCAL_IP: 127.0.0.1
         run: |
           source ./dev/install-common-deps.sh
       - name: Run tests
@@ -311,6 +317,7 @@ jobs:
         env:
           INSTALL_LARGE_PYTHON_DEPS: true
           INSTALL_SMALL_PYTHON_DEPS: true
+          SPARK_LOCAL_IP: 127.0.0.1
         run: |
           source ./dev/install-common-deps.sh
       - name: Run tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -174,6 +174,7 @@ jobs:
       env:
         INSTALL_LARGE_PYTHON_DEPS: true
         INSTALL_SMALL_PYTHON_DEPS: true
+        # Fix for https://github.com/mlflow/mlflow/issues/4229
         SPARK_LOCAL_IP: 127.0.0.1
       run: |
         source ./dev/install-common-deps.sh
@@ -200,7 +201,6 @@ jobs:
         source ./dev/install-common-deps.sh
     - name: Run tests
       env:
-        # Fix for https://github.com/mlflow/mlflow/issues/4229
         SPARK_LOCAL_IP: 127.0.0.1
       run: |
         export PATH="$CONDA_DIR/bin:$PATH"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -175,6 +175,7 @@ jobs:
         INSTALL_LARGE_PYTHON_DEPS: true
         INSTALL_SMALL_PYTHON_DEPS: true
         # Fix for https://github.com/mlflow/mlflow/issues/4229
+        HIVE_SERVER2_THRIFT_BIND_HOST: 127.0.0.1
         SPARK_LOCAL_IP: 127.0.0.1
       run: |
         source ./dev/install-common-deps.sh
@@ -201,6 +202,7 @@ jobs:
         source ./dev/install-common-deps.sh
     - name: Run tests
       env:
+        HIVE_SERVER2_THRIFT_BIND_HOST: 127.0.0.1
         SPARK_LOCAL_IP: 127.0.0.1
       run: |
         export PATH="$CONDA_DIR/bin:$PATH"
@@ -257,6 +259,7 @@ jobs:
         env:
           INSTALL_LARGE_PYTHON_DEPS: true
           INSTALL_SMALL_PYTHON_DEPS: true
+          HIVE_SERVER2_THRIFT_BIND_HOST: 127.0.0.1
           SPARK_LOCAL_IP: 127.0.0.1
         run: |
           source ./dev/install-common-deps.sh
@@ -297,6 +300,7 @@ jobs:
         env:
           INSTALL_LARGE_PYTHON_DEPS: true
           INSTALL_SMALL_PYTHON_DEPS: true
+          HIVE_SERVER2_THRIFT_BIND_HOST: 127.0.0.1
           SPARK_LOCAL_IP: 127.0.0.1
         run: |
           source ./dev/install-common-deps.sh
@@ -317,6 +321,7 @@ jobs:
         env:
           INSTALL_LARGE_PYTHON_DEPS: true
           INSTALL_SMALL_PYTHON_DEPS: true
+          HIVE_SERVER2_THRIFT_BIND_HOST: 127.0.0.1
           SPARK_LOCAL_IP: 127.0.0.1
         run: |
           source ./dev/install-common-deps.sh

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -174,12 +174,12 @@ jobs:
       env:
         INSTALL_LARGE_PYTHON_DEPS: true
         INSTALL_SMALL_PYTHON_DEPS: true
-        # Fix for https://github.com/mlflow/mlflow/issues/4229
-        HIVE_SERVER2_THRIFT_BIND_HOST: 127.0.0.1
-        SPARK_LOCAL_IP: 127.0.0.1
       run: |
         source ./dev/install-common-deps.sh
     - name: Run tests
+      env:
+        # Fix for https://github.com/mlflow/mlflow/issues/4229
+        SPARK_LOCAL_IP: 127.0.0.1
       run: |
         export PATH="$CONDA_DIR/bin:$PATH"
         source activate test-environment
@@ -202,7 +202,6 @@ jobs:
         source ./dev/install-common-deps.sh
     - name: Run tests
       env:
-        HIVE_SERVER2_THRIFT_BIND_HOST: 127.0.0.1
         SPARK_LOCAL_IP: 127.0.0.1
       run: |
         export PATH="$CONDA_DIR/bin:$PATH"
@@ -259,11 +258,11 @@ jobs:
         env:
           INSTALL_LARGE_PYTHON_DEPS: true
           INSTALL_SMALL_PYTHON_DEPS: true
-          HIVE_SERVER2_THRIFT_BIND_HOST: 127.0.0.1
-          SPARK_LOCAL_IP: 127.0.0.1
         run: |
           source ./dev/install-common-deps.sh
       - name: Run tests
+        env:
+          SPARK_LOCAL_IP: 127.0.0.1
         run: |
           export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
@@ -300,11 +299,11 @@ jobs:
         env:
           INSTALL_LARGE_PYTHON_DEPS: true
           INSTALL_SMALL_PYTHON_DEPS: true
-          HIVE_SERVER2_THRIFT_BIND_HOST: 127.0.0.1
-          SPARK_LOCAL_IP: 127.0.0.1
         run: |
           source ./dev/install-common-deps.sh
       - name: Run tests
+        env:
+          SPARK_LOCAL_IP: 127.0.0.1
         run: |
           export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment
@@ -321,11 +320,11 @@ jobs:
         env:
           INSTALL_LARGE_PYTHON_DEPS: true
           INSTALL_SMALL_PYTHON_DEPS: true
-          HIVE_SERVER2_THRIFT_BIND_HOST: 127.0.0.1
-          SPARK_LOCAL_IP: 127.0.0.1
         run: |
           source ./dev/install-common-deps.sh
       - name: Run tests
+        env:
+          SPARK_LOCAL_IP: 127.0.0.1
         run: |
           export PATH="$CONDA_DIR/bin:$PATH"
           source activate test-environment

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -60,7 +60,11 @@ def get_spark_session(conf):
     # compatibiliy-setting-for-pyarrow--0150-and-spark-23x-24x
     os.environ["ARROW_PRE_0_15_IPC_FORMAT"] = "1"
     conf.set(key="spark_session.python.worker.reuse", value=True)
-    return pyspark.sql.SparkSession.builder.config(conf=conf).master("local[*]").getOrCreate()
+    return (
+        pyspark.sql.SparkSession.builder.config(conf=conf)
+        .master("local-cluster[2, 1, 1024]")
+        .getOrCreate()
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -60,11 +60,7 @@ def get_spark_session(conf):
     # compatibiliy-setting-for-pyarrow--0150-and-spark-23x-24x
     os.environ["ARROW_PRE_0_15_IPC_FORMAT"] = "1"
     conf.set(key="spark_session.python.worker.reuse", value=True)
-    return (
-        pyspark.sql.SparkSession.builder.config(conf=conf)
-        .master("local-cluster[2, 1, 1024]")
-        .getOrCreate()
-    )
+    return pyspark.sql.SparkSession.builder.config(conf=conf).master("local[*]").getOrCreate()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Apply https://github.com/databricks/koalas/pull/2144 to fix flaky spark session creation.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
