### PR TITLE
test: fix flaky spark session creation

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -14,293 +14,7 @@ env:
   CONDA_DIR: /usr/share/miniconda
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      env:
-        INSTALL_LARGE_PYTHON_DEPS: true
-        INSTALL_SMALL_PYTHON_DEPS: true
-      run: |
-        source ./dev/install-common-deps.sh
-        pip install -r ./dev/lint-requirements.txt
-    - name: Run tests
-      run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        ./lint.sh
-  r:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Uninstall default-jdk and adoptopenjdk-11-hotspot if present
-      run: |
-        # deleting other version(s) of JDK because they are not needed and they might interfere with JNI linker configuration in the 'setup-r' step
-        sudo apt-get -y remove --purge default-jdk adoptopenjdk-11-hotspot || :
-    - uses: actions/checkout@master
-    - uses: actions/setup-java@v1
-      with:
-        # GitHub Actions' Ubuntu 20.04 image uses Java 11 (which is incompatible with Spark 2.4.x) by default:
-        # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#java
-        java-version: 8
-    - name: Re-configure dynamic linker run-time bindings for adoptopenjdk-8-hotspot-amd64
-      run: |
-        sudo mkdir -p /etc/ld.so.conf.d
-        sudo bash -c "cat > /etc/ld.so.conf.d/jre.conf <<< '/usr/lib/jvm/adoptopenjdk-8-hotspot-amd64/jre/lib/amd64/server'"
-        sudo ldconfig -v
-    - uses: r-lib/actions/setup-r@v1
-    # This step dumps the current set of R dependencies and R version into files to be used
-    # as a cache key when caching/restoring R dependencies.
-    - name: Query dependencies
-      run: |
-        print(R.version)
-        install.packages('remotes')
-        saveRDS(remotes::dev_package_deps("mlflow/R/mlflow", dependencies = TRUE), ".github/depends.Rds", version = 2)
-        writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
-      shell: Rscript {0}
-
-    - name: Get OS name
-      id: os-name
-      run: |
-        # `os_name` will be like "Ubuntu-20.04.1-LTS"
-        os_name=$(lsb_release -ds | sed 's/\s/-/g')
-        echo "::set-output name=os-name::$os_name"
-    - name: Cache R packages
-      if: runner.os != 'Windows'
-      uses: actions/cache@v2
-      with:
-        path: ${{ env.R_LIBS_USER }}
-        # We cache R dependencies based on a tuple of the current OS, the R version, and the list of
-        # R dependencies
-        key: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
-        restore-keys: ${{ steps.os-name.outputs.os-name }}-${{ hashFiles('.github/R-version') }}-1-
-    # Cache spark archive downloaded in `mlflow/R/mlflow/.create-test-env.R`
-    - name: Cache spark archive
-      uses: actions/cache@v2
-      with:
-        path: ~/spark/spark-2.4.5-bin-hadoop2.7
-        key: ${{ hashFiles('mlflow/R/mlflow/.spark-version') }}
-    - name: Install system dependencies
-      run: |
-        sudo apt-get install -y libcurl4-openssl-dev
-        sudo R CMD javareconf
-    - name: Install dependencies
-      run: |
-        install.packages("devtools")
-        remotes::install_deps('mlflow/R/mlflow', dependencies = TRUE, upgrade = FALSE)
-      shell: Rscript {0}
-    - name: Create test environment
-      run: |
-        source ./dev/install-common-deps.sh
-        cd mlflow/R/mlflow
-        R CMD build .
-        cd tests
-        Rscript ../.create-test-env.R
-    - name: Run tests
-      run: |
-        export LINTR_COMMENT_BOT=false
-        cd mlflow/R/mlflow/tests
-        Rscript ../.run-tests.R
-    - name: Calculate code coverage
-      if: ${{ success() }}
-      run: |
-        export MLFLOW_HOME=$(pwd)
-        cd mlflow/R/mlflow/tests
-        Rscript -e 'covr::codecov()' || :
-      env:
-        COVR_RUNNING: true
-    - name: Show 00check.log on failure
-      if: ${{ failure() }}
-      run: |
-        LOG_FILE="${HOME}/build/mlflow/mlflow/mlflow/R/mlflow/mlflow.Rcheck/00check.log"
-        [ -r "${LOG_FILE}" ] && cat "${LOG_FILE}"
-        cp "${LOG_FILE}" /tmp
-    - uses: actions/upload-artifact@v1
-      if: failure()
-      with:
-        name: 00check.log
-        path: /tmp/00check.log
-
-  # python-skinny tests cover a subset of mlflow functionality
-  # that is meant to be supported with a smaller dependency footprint.
-  # The python skinny tests cover the subset of mlflow functionality
-  # while also verifying certain dependencies are omitted.
-  python-skinny:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      env:
-        INSTALL_SKINNY_PYTHON_DEPS: true
-        MLFLOW_SKINNY: true
-      run: |
-        source ./dev/install-common-deps.sh
-    - name: Run tests
-      run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        ./dev/run-python-skinny-tests.sh
-
-  python-small:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      env:
-        INSTALL_SMALL_PYTHON_DEPS: true
-      run: |
-        source ./dev/install-common-deps.sh
-    - name: Run tests
-      run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        ./dev/run-small-python-tests.sh
-
-  python-large:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Increase available disk space
-      run: |
-        # Increase available disk space by removing unnecessary tool chains:
-        # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
-        rm -rf "$AGENT_TOOLSDIRECTORY"
-    - uses: actions/setup-java@v1
-      with:
-        # GitHub Actions' Ubuntu 20.04 image uses Java 11 (which is incompatible with Spark 2.4.x) by default:
-        # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md#java
-        java-version: 8
-    - name: Install dependencies
-      env:
-        INSTALL_LARGE_PYTHON_DEPS: true
-        INSTALL_SMALL_PYTHON_DEPS: true
-      run: |
-        source ./dev/install-common-deps.sh
-    - name: Run tests
-      run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        ./dev/run-large-python-tests.sh
-    - name: Run anaconda compatibility tests
-      run: |
-        ./dev/test-anaconda-compatibility.sh "anaconda3:2020.11"
-        ./dev/test-anaconda-compatibility.sh "anaconda3:2019.03"
-
-  java:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Java
-      uses: actions/setup-java@v1
-      with:
-        java-version: 8
-    - name: Install dependencies
-      run: |
-        source ./dev/install-common-deps.sh
-    - name: Run tests
-      run: |
-        export PATH="$CONDA_DIR/bin:$PATH"
-        source activate test-environment
-        cd mlflow/java
-        mvn clean package -q
-
-  js:
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: mlflow/server/js
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: 10.x
-    - name: Install dependencies
-      run: |
-        npm i
-    - name: Run lint
-      run: |
-        npm run lint
-    - name: Run tests
-      run: |
-        npm run test
-
-  protos:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: |
-        wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip -O $HOME/protoc.zip
-        sudo unzip $HOME/protoc.zip -d /usr
-    - name: Run tests
-      run: |
-        ./test-generate-protos.sh
-
-  flavors:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Increase available disk space
-        run: |
-          # Increase available disk space by removing unnecessary tool chains:
-          # https://github.com/actions/virtual-environments/issues/709#issuecomment-612569242
-          rm -rf "$AGENT_TOOLSDIRECTORY"
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - name: Install dependencies
-        env:
-          INSTALL_LARGE_PYTHON_DEPS: true
-          INSTALL_SMALL_PYTHON_DEPS: true
-        run: |
-          source ./dev/install-common-deps.sh
-      - name: Run tests
-        run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
-          source activate test-environment
-          ./dev/run-python-flavor-tests.sh;
-
-  import:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.6'
-      - name: Install mlflow
-        run: |
-          pip install -e .
-      - name: Verify mlflow can be imported without errors
-        run: |
-          python -c "import mlflow"
-
-          # Just importing mlflow should not create `mlruns` directory
-          # See: https://github.com/mlflow/mlflow/issues/3400
-          if [ -d "./mlruns" ]; then
-            exit 1
-          fi
-
-  tensorflow:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
-        with:
-          java-version: 8
-      - name: Install dependencies
-        env:
-          INSTALL_LARGE_PYTHON_DEPS: true
-          INSTALL_SMALL_PYTHON_DEPS: true
-        run: |
-          source ./dev/install-common-deps.sh
-      - name: Run tests
-        run: |
-          export PATH="$CONDA_DIR/bin:$PATH"
-          source activate test-environment
-          ./dev/run-python-tf-tests.sh;
-
-  sagemaker:
+  sagemaker1:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -319,19 +33,97 @@ jobs:
           source activate test-environment
           ./dev/run-python-sagemaker-tests.sh;
 
-  windows:
-    runs-on: windows-latest
+  sagemaker2:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-java@v1
         with:
-          python-version: 3.7
-      - name: Install dependecies
+          java-version: 8
+      - name: Install dependencies
+        env:
+          INSTALL_LARGE_PYTHON_DEPS: true
+          INSTALL_SMALL_PYTHON_DEPS: true
         run: |
-          pip install -r dev-requirements.txt
-          pip install -r dev/small-requirements.txt
-          pip install --no-dependencies tests/resources/mlflow-test-plugin
-          pip install -e .[extras]
+          source ./dev/install-common-deps.sh
       - name: Run tests
         run: |
-          pytest --verbose --ignore-flavors --ignore=tests/projects tests
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          ./dev/run-python-sagemaker-tests.sh;
+
+  sagemaker3:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Install dependencies
+        env:
+          INSTALL_LARGE_PYTHON_DEPS: true
+          INSTALL_SMALL_PYTHON_DEPS: true
+        run: |
+          source ./dev/install-common-deps.sh
+      - name: Run tests
+        run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          ./dev/run-python-sagemaker-tests.sh;
+
+  sagemaker4:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Install dependencies
+        env:
+          INSTALL_LARGE_PYTHON_DEPS: true
+          INSTALL_SMALL_PYTHON_DEPS: true
+        run: |
+          source ./dev/install-common-deps.sh
+      - name: Run tests
+        run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          ./dev/run-python-sagemaker-tests.sh;
+
+  sagemaker5:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Install dependencies
+        env:
+          INSTALL_LARGE_PYTHON_DEPS: true
+          INSTALL_SMALL_PYTHON_DEPS: true
+        run: |
+          source ./dev/install-common-deps.sh
+      - name: Run tests
+        run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          ./dev/run-python-sagemaker-tests.sh;
+
+  sagemaker6:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Install dependencies
+        env:
+          INSTALL_LARGE_PYTHON_DEPS: true
+          INSTALL_SMALL_PYTHON_DEPS: true
+        run: |
+          source ./dev/install-common-deps.sh
+      - name: Run tests
+        run: |
+          export PATH="$CONDA_DIR/bin:$PATH"
+          source activate test-environment
+          ./dev/run-python-sagemaker-tests.sh;

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -40,7 +40,7 @@ from tests.helper_functions import pyfunc_serve_and_score_model
 from tests.helper_functions import score_model_in_sagemaker_docker_container
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
-from tests.pyfunc.test_spark import score_model_as_udf
+from tests.pyfunc.test_spark import score_model_as_udf, spark
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
 
@@ -230,7 +230,7 @@ def test_that_keras_module_arg_works(model_path):
     [(model, None), (tf_keras_model, None), (tf_keras_model, "h5"), (tf_keras_model, "tf")],
 )
 @pytest.mark.large
-def test_model_save_load(build_model, save_format, model_path, data):
+def test_model_save_load(spark, build_model, save_format, model_path, data):
     x, _ = data
     keras_model = build_model(data)
     if build_model == tf_keras_model:
@@ -267,6 +267,7 @@ def test_model_save_load(build_model, save_format, model_path, data):
 
     # test spark udf
     spark_udf_preds = score_model_as_udf(
+        spark,
         model_uri=os.path.abspath(model_path), pandas_df=pd.DataFrame(x), result_type="float"
     )
     np.allclose(np.array(spark_udf_preds), expected.reshape(len(spark_udf_preds)))
@@ -320,6 +321,7 @@ def test_custom_model_save_load(custom_model, custom_layer, data, custom_predict
     assert all(pyfunc_loaded.predict(x).values == custom_predicted)
     # test spark udf
     spark_udf_preds = score_model_as_udf(
+        spark,
         model_uri=os.path.abspath(model_path), pandas_df=pd.DataFrame(x), result_type="float"
     )
     np.allclose(np.array(spark_udf_preds), custom_predicted.reshape(len(spark_udf_preds)))

--- a/tests/keras/test_keras_model_export.py
+++ b/tests/keras/test_keras_model_export.py
@@ -230,7 +230,7 @@ def test_that_keras_module_arg_works(model_path):
     [(model, None), (tf_keras_model, None), (tf_keras_model, "h5"), (tf_keras_model, "tf")],
 )
 @pytest.mark.large
-def test_model_save_load(spark, build_model, save_format, model_path, data):
+def test_model_save_load(build_model, save_format, model_path, data, request):
     x, _ = data
     keras_model = build_model(data)
     if build_model == tf_keras_model:

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -22,8 +22,7 @@ prediction = [int(1), int(2), "class1", float(0.1), 0.2]
 types = [np.int32, np.int, np.str, np.float32, np.double]
 
 
-def score_model_as_udf(model_uri, pandas_df, result_type="double"):
-    spark = get_spark_session(pyspark.SparkConf())
+def score_model_as_udf(spark, model_uri, pandas_df, result_type="double"):
     spark_df = spark.createDataFrame(pandas_df)
     pyfunc_udf = spark_udf(spark=spark, model_uri=model_uri, result_type=result_type)
     new_df = spark_df.withColumn("prediction", pyfunc_udf(*pandas_df.columns))
@@ -70,7 +69,9 @@ def get_spark_session(conf):
 @pytest.fixture(scope="session")
 def spark():
     conf = pyspark.SparkConf()
-    return get_spark_session(conf)
+    session = get_spark_session(conf)
+    yield session
+    session.stop()
 
 
 @pytest.fixture

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -69,6 +69,7 @@ def get_spark_session(conf):
 @pytest.fixture(scope="session")
 def spark():
     conf = pyspark.SparkConf()
+    conf.set("spark.driver.bindAddress", "127.0.0.1")
     session = get_spark_session(conf)
     yield session
     session.stop()

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -63,6 +63,7 @@ def spark_context():
         value="ml.combust.mleap:mleap-spark-base_2.11:0.12.0,"
         "ml.combust.mleap:mleap-spark_2.11:0.12.0",
     )
+    conf.set("spark.driver.bindAddress", "127.0.0.1")
     max_tries = 3
     spark_session = None
     for num_tries in range(max_tries):


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
