### PR TITLE
Fix #2551

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -897,9 +897,7 @@ def _get_orderby_clauses(order_by_list, session):
                 )
             else:  # other entities do not have an 'is_nan' field
                 clauses.append(
-                    sql.case([(order_value.is_(None), 1)], else_=0).label(
-                        "clause_%s" % clause_id
-                    )
+                    sql.case([(order_value.is_(None), 1)], else_=0).label("clause_%s" % clause_id)
                 )
 
             if (key_type, key) in observed_order_by_clauses:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -884,9 +884,11 @@ def _get_orderby_clauses(order_by_list, session):
                 clauses.append(
                     sql.case(
                         [
-                            # Ideally the use of "IS" is preferred here but owing to sqlalchemy translation in MSSQL we are forced to use "=" instead.
-                            # These 2 options are functionally identical / unchanged because the column (is_nan) is not nullable.
-                            # However it could become an issue if this precondition changes in the future.
+                            # Ideally the use of "IS" is preferred here but owing to sqlalchemy
+                            # translation in MSSQL we are forced to use "=" instead.
+                            # These 2 options are functionally identical / unchanged because
+                            # the column (is_nan) is not nullable. However it could become an issue
+                            # if this precondition changes in the future.
                             (subquery.c.is_nan == sqlalchemy.true(), 1),
                             (order_value.is_(None), 1),
                         ],

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -883,12 +883,18 @@ def _get_orderby_clauses(order_by_list, session):
             if SearchUtils.is_metric(key_type, "="):
                 clauses.append(
                     sql.case(
-                        [(subquery.c.is_nan.is_(True), 1), (order_value.is_(None), 1)], else_=0
+                        [
+                            (subquery.c.is_nan == sqlalchemy.true(), 1),
+                            (order_value == sqlalchemy.null(), 1),
+                        ],
+                        else_=0,
                     ).label("clause_%s" % clause_id)
                 )
             else:  # other entities do not have an 'is_nan' field
                 clauses.append(
-                    sql.case([(order_value.is_(None), 1)], else_=0).label("clause_%s" % clause_id)
+                    sql.case([(order_value == sqlalchemy.null(), 1)], else_=0).label(
+                        "clause_%s" % clause_id
+                    )
                 )
 
             if (key_type, key) in observed_order_by_clauses:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -884,15 +884,18 @@ def _get_orderby_clauses(order_by_list, session):
                 clauses.append(
                     sql.case(
                         [
+                            # Ideally the use of "IS" is preferred here but owing to sqlalchemy translation in MSSQL we are forced to use "=" instead.
+                            # These 2 options are functionally identical / unchanged because the column (is_nan) is not nullable.
+                            # However it could become an issue if this precondition changes in the future.
                             (subquery.c.is_nan == sqlalchemy.true(), 1),
-                            (order_value == sqlalchemy.null(), 1),
+                            (order_value.is_(None), 1),
                         ],
                         else_=0,
                     ).label("clause_%s" % clause_id)
                 )
             else:  # other entities do not have an 'is_nan' field
                 clauses.append(
-                    sql.case([(order_value == sqlalchemy.null(), 1)], else_=0).label(
+                    sql.case([(order_value.is_(None), 1)], else_=0).label(
                         "clause_%s" % clause_id
                     )
                 )

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1989,9 +1989,10 @@ def test_get_orderby_clauses():
         with pytest.raises(MlflowException, match=match):
             _get_orderby_clauses(["tag.t", "tag.t"], session)
 
+        # test that an exception is NOT raised when key types are different
+        _get_orderby_clauses(["param.a", "metric.a", "tag.a"], session)
+
         # test that "=" is used rather than "is" when comparing to True
         parsed = [str(x) for x in _get_orderby_clauses(["metric.a"], session)[0]]
         assert "is_nan = true" in parsed[0]
-
-        # test that an exception is NOT raised when key types are different
-        _get_orderby_clauses(["param.a", "metric.a", "tag.a"], session)
+        assert "value IS NULL" in parsed[0]

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1989,5 +1989,9 @@ def test_get_orderby_clauses():
         with pytest.raises(MlflowException, match=match):
             _get_orderby_clauses(["tag.t", "tag.t"], session)
 
+        # test that "=" is used rather than "is" when comparing to True
+        parsed = [str(x) for x in _get_orderby_clauses(["metric.a"], session)[0]]
+        assert "is_nan = true" in parsed[0]
+
         # test that an exception is NOT raised when key types are different
         _get_orderby_clauses(["param.a", "metric.a", "tag.a"], session)


### PR DESCRIPTION
Signed-off-by: Naor Volkovich <naor2013@icloud.com>

## What changes are proposed in this pull request?

The bug #2551 is caused by doing "is true" in the relevant SQL which translates in mssql to "is 1" which fails.
This pull request changes this SQL to be "= true" which works and fixes the bug.

## How is this patch tested?

I ran the small tests.

## Release Notes

### Is this a user-facing change?

- [x ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
