### PR TITLE
Add return type annotations to key MLflow APIs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -345,7 +345,7 @@ def _get_reference_map():
     """
     Gets a dict that maps an invalid reference to a valid one.
     """
-    res = {
+    ref_map = {
         "mlflow.tracking.fluent.ActiveRun": "mlflow.ActiveRun",
         "mlflow.store.entities.paged_list.PagedList": "mlflow.store.entities.PagedList",
     }
@@ -354,7 +354,7 @@ def _get_reference_map():
     for entity_name in mlflow.entities.__all__:
         invalid_ref = "mlflow.entities.{}.{}".format(_camel_to_snake(entity_name), entity_name)
         valid_ref = "mlflow.entities.{}".format(entity_name)
-        res[invalid_ref] = valid_ref
+        ref_map[invalid_ref] = valid_ref
 
     # Model registry entities
     for entity_name in mlflow.entities.model_registry.__all__:
@@ -362,9 +362,9 @@ def _get_reference_map():
             _camel_to_snake(entity_name), entity_name
         )
         valid_ref = "mlflow.entities.model_registry.{}".format(entity_name)
-        res[invalid_ref] = valid_ref
+        ref_map[invalid_ref] = valid_ref
 
-    return res
+    return ref_map
 
 
 reference_map = _get_reference_map()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -337,10 +337,6 @@ nitpick_ignore = [
 ]
 
 
-def _camel_to_snake(x):
-    return re.sub(r"(?<!^)(?=[A-Z])", "_", x).lower()
-
-
 def _get_reference_map():
     """
     Gets a dict that maps an invalid reference to a valid one.
@@ -352,15 +348,15 @@ def _get_reference_map():
 
     # Tracking entities
     for entity_name in mlflow.entities.__all__:
-        invalid_ref = "mlflow.entities.{}.{}".format(_camel_to_snake(entity_name), entity_name)
+        entity_cls = getattr(mlflow.entities, entity_name)
+        invalid_ref = entity_cls.__module__ + "." + entity_name
         valid_ref = "mlflow.entities.{}".format(entity_name)
         ref_map[invalid_ref] = valid_ref
 
     # Model registry entities
     for entity_name in mlflow.entities.model_registry.__all__:
-        invalid_ref = "mlflow.entities.model_registry.{}.{}".format(
-            _camel_to_snake(entity_name), entity_name
-        )
+        entity_cls = getattr(mlflow.entities.model_registry, entity_name)
+        invalid_ref = entity_cls.__module__ + "." + entity_name
         valid_ref = "mlflow.entities.model_registry.{}".format(entity_name)
         ref_map[invalid_ref] = valid_ref
 
@@ -368,6 +364,8 @@ def _get_reference_map():
 
 
 reference_map = _get_reference_map()
+
+print(reference_map)
 
 
 def resolve_missing_references(app, doctree):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,6 @@
 
 import sys
 import os
-import re
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -353,8 +353,7 @@ def _get_reference_map():
     `mlflow.tracking.fluent.ActiveRun` as a reference target, but the module
     `mlflow.tracking.fluent` is undocumented, so Sphinx raises this warning:
     `WARNING: py:class reference target not found: mlflow.tracking.fluent.ActiveRun`.
-    We can avoid this warning by mapping `mlflow.tracking.fluent.ActiveRun` to `mlflow.ActiveRun`
-    (note the module `mlflow` is documented).
+    As a workaround, replace `mlflow.tracking.fluent.ActiveRun` with `mlflow.ActiveRun`.
     """
     ref_map = {
         # < Invalid reference >: < valid reference >

--- a/docs/source/python_api/mlflow.entities.rst
+++ b/docs/source/python_api/mlflow.entities.rst
@@ -8,3 +8,7 @@ mlflow.entities
 .. automodule:: mlflow.entities.model_registry
     :members:
     :undoc-members:
+
+.. automodule:: mlflow.store.entities
+    :members:
+    :undoc-members:

--- a/mlflow/store/entities/__init__.py
+++ b/mlflow/store/entities/__init__.py
@@ -1,0 +1,3 @@
+from mlflow.store.entities.paged_list import PagedList
+
+__all__ = ["PagedList"]

--- a/mlflow/store/entities/paged_list.py
+++ b/mlflow/store/entities/paged_list.py
@@ -4,6 +4,12 @@ T = TypeVar("T")
 
 
 class PagedList(List[T]):
+    """
+    Wrapper class around the base Python `List` type. Contains an additional `token`  string
+    attribute that can be passed to the pagination API that returned this list to fetch additional
+    elements, if any are available
+    """
+
     def __init__(self, items: List[T], token):
         super().__init__(items)
         self.token = token

--- a/mlflow/store/entities/paged_list.py
+++ b/mlflow/store/entities/paged_list.py
@@ -1,4 +1,9 @@
-class PagedList(list):
-    def __init__(self, items, token):
+from typing import TypeVar, List
+
+T = TypeVar("T")
+
+
+class PagedList(List[T]):
+    def __init__(self, items: List[T], token):
         super().__init__(items)
         self.token = token

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -1,5 +1,5 @@
 from mlflow.exceptions import MlflowException
-from mlflow.entiries.model_registry import ModelVersion
+from mlflow.entities.model_registry import ModelVersion
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, ErrorCode
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.tracking import MlflowClient

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -1,4 +1,5 @@
 from mlflow.exceptions import MlflowException
+from mlflow.entiries.model_registry import ModelVersion
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, ErrorCode
 from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.tracking import MlflowClient
@@ -6,7 +7,9 @@ from mlflow.utils.logging_utils import eprint
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 
 
-def register_model(model_uri, name, await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS):
+def register_model(
+    model_uri, name, await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+) -> ModelVersion:
     """
     Create a new model version in model registry for the model files specified by ``model_uri``.
     Note that this method assumes the model registry backend URI is the same as that of the

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -33,7 +33,7 @@ from mlflow.utils.databricks_utils import get_databricks_host_creds
 _registry_uri = None
 
 
-def set_registry_uri(uri):
+def set_registry_uri(uri) -> None:
     """
     Set the registry server URI. This method is especially useful if you have a registry server
     that's different from the tracking server.
@@ -80,7 +80,7 @@ def _get_registry_uri_from_context():
     return _registry_uri
 
 
-def get_registry_uri():
+def get_registry_uri() -> str:
     """
     Get the current registry URI. If none has been specified, defaults to the tracking URI.
 

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -38,7 +38,7 @@ def is_tracking_uri_set():
     return False
 
 
-def set_tracking_uri(uri):
+def set_tracking_uri(uri) -> None:
     """
     Set the tracking server URI. This does not affect the
     currently active run (if one exists), but takes effect for successive runs.
@@ -75,7 +75,7 @@ def _resolve_tracking_uri(tracking_uri=None):
     return tracking_uri or get_tracking_uri()
 
 
-def get_tracking_uri():
+def get_tracking_uri() -> str:
     """
     Get the current tracking URI. This may not correspond to the tracking URI of
     the currently active run, since the tracking URI can be updated via ``set_tracking_uri``.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -11,7 +11,7 @@ import posixpath
 import sys
 import tempfile
 import yaml
-from typing import List
+from typing import List, Optional
 
 from mlflow.entities import Experiment, Run, RunInfo, Metric, FileInfo, ViewType
 from mlflow.store.entities.paged_list import PagedList
@@ -389,7 +389,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.get_experiment(experiment_id)
 
-    def get_experiment_by_name(self, name) -> Experiment:
+    def get_experiment_by_name(self, name) -> Optional[Experiment]:
         """
         Retrieve an experiment by experiment name from the backend store
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -394,7 +394,8 @@ class MlflowClient(object):
         Retrieve an experiment by experiment name from the backend store
 
         :param name: The experiment name, which is case sensitive.
-        :return: :py:class:`mlflow.entities.Experiment`
+        :return: An instance of :py:class:`mlflow.entities.Experiment`
+                 if an experiment with the specified name exists, otherwise None.
 
         .. code-block:: python
             :caption: Example

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -11,8 +11,11 @@ import posixpath
 import sys
 import tempfile
 import yaml
+from typing import List
 
-from mlflow.entities import ViewType
+from mlflow.entities import Experiment, Run, RunInfo, Metric, FileInfo, ViewType
+from mlflow.store.entities.paged_list import PagedList
+from mlflow.entities.model_registry import RegisteredModel, ModelVersion
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import FEATURE_DISABLED
@@ -101,7 +104,7 @@ class MlflowClient(object):
 
     # Tracking API
 
-    def get_run(self, run_id):
+    def get_run(self, run_id) -> Run:
         """
         Fetch the run from backend store. The resulting :py:class:`Run <mlflow.entities.Run>`
         contains a collection of run metadata -- :py:class:`RunInfo <mlflow.entities.RunInfo>`,
@@ -141,7 +144,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.get_run(run_id)
 
-    def get_metric_history(self, run_id, key):
+    def get_metric_history(self, run_id, key) -> List[Metric]:
         """
         Return a list of metric objects corresponding to all values logged for a given metric.
 
@@ -208,7 +211,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.get_metric_history(run_id, key)
 
-    def create_run(self, experiment_id, start_time=None, tags=None):
+    def create_run(self, experiment_id, start_time=None, tags=None) -> Run:
         """
         Create a :py:class:`mlflow.entities.Run` object that can be associated with
         metrics, parameters, artifacts, etc.
@@ -258,7 +261,7 @@ class MlflowClient(object):
         max_results=SEARCH_MAX_RESULTS_DEFAULT,
         order_by=None,
         page_token=None,
-    ):
+    ) -> PagedList[RunInfo]:
         """:return: List of :py:class:`mlflow.entities.RunInfo`
 
         .. code-block:: python
@@ -354,7 +357,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.list_experiments(view_type)
 
-    def get_experiment(self, experiment_id):
+    def get_experiment(self, experiment_id) -> Experiment:
         """
         Retrieve an experiment by experiment_id from the backend store
 
@@ -386,7 +389,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.get_experiment(experiment_id)
 
-    def get_experiment_by_name(self, name):
+    def get_experiment_by_name(self, name) -> Experiment:
         """
         Retrieve an experiment by experiment name from the backend store
 
@@ -418,7 +421,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.get_experiment_by_name(name)
 
-    def create_experiment(self, name, artifact_location=None):
+    def create_experiment(self, name, artifact_location=None) -> str:
         """Create an experiment.
 
         :param name: The experiment name. Must be unique.
@@ -1228,7 +1231,7 @@ class MlflowClient(object):
         """
         self._tracking_client._record_logged_model(run_id, mlflow_model)
 
-    def list_artifacts(self, run_id, path=None):
+    def list_artifacts(self, run_id, path=None) -> List[FileInfo]:
         """
         List the artifacts for a run.
 
@@ -1279,7 +1282,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.list_artifacts(run_id, path)
 
-    def download_artifacts(self, run_id, path, dst_path=None):
+    def download_artifacts(self, run_id, path, dst_path=None) -> str:
         """
         Download an artifact file or directory from a run to a local directory if applicable,
         and return a local path for it.
@@ -1438,7 +1441,7 @@ class MlflowClient(object):
         max_results=SEARCH_MAX_RESULTS_DEFAULT,
         order_by=None,
         page_token=None,
-    ):
+    ) -> PagedList[Run]:
         """
         Search experiments that fit the search criteria.
 
@@ -1525,7 +1528,7 @@ class MlflowClient(object):
 
     # Registered Model Methods
 
-    def create_registered_model(self, name, tags=None, description=None):
+    def create_registered_model(self, name, tags=None, description=None) -> RegisteredModel:
         """
         Create a new registered model in backend store.
 
@@ -1565,7 +1568,7 @@ class MlflowClient(object):
         """
         return self._get_registry_client().create_registered_model(name, tags, description)
 
-    def rename_registered_model(self, name, new_name):
+    def rename_registered_model(self, name, new_name) -> RegisteredModel:
         """
         Update registered model name.
 
@@ -1614,7 +1617,7 @@ class MlflowClient(object):
         """
         self._get_registry_client().rename_registered_model(name, new_name)
 
-    def update_registered_model(self, name, description=None):
+    def update_registered_model(self, name, description=None) -> RegisteredModel:
         """
         Updates metadata for RegisteredModel entity. Input field ``description`` should be non-None.
         Backend raises exception if a registered model with given name does not exist.
@@ -1718,7 +1721,7 @@ class MlflowClient(object):
 
     def list_registered_models(
         self, max_results=SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT, page_token=None
-    ):
+    ) -> PagedList[RegisteredModel]:
         """
         List of all registered models
 
@@ -1773,7 +1776,7 @@ class MlflowClient(object):
         max_results=SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
         order_by=None,
         page_token=None,
-    ):
+    ) -> PagedList[RegisteredModel]:
         """
         Search for registered models in backend that satisfy the filter criteria.
 
@@ -1846,7 +1849,7 @@ class MlflowClient(object):
             filter_string, max_results, order_by, page_token
         )
 
-    def get_registered_model(self, name):
+    def get_registered_model(self, name) -> RegisteredModel:
         """
         :param name: Name of the registered model to update.
         :return: A single :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
@@ -1884,7 +1887,7 @@ class MlflowClient(object):
         """
         return self._get_registry_client().get_registered_model(name)
 
-    def get_latest_versions(self, name, stages=None):
+    def get_latest_versions(self, name, stages=None) -> ModelVersion:
         """
         Latest version models for each requests stage. If no ``stages`` provided, returns the
         latest version for each stage.
@@ -2059,7 +2062,7 @@ class MlflowClient(object):
         run_link=None,
         description=None,
         await_creation_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
-    ):
+    ) -> ModelVersion:
         """
         Create a new model version from given source (artifact URI).
 
@@ -2179,7 +2182,7 @@ class MlflowClient(object):
         if workspace_host and run_id and experiment_id:
             return construct_run_url(workspace_host, experiment_id, run_id, workspace_id)
 
-    def update_model_version(self, name, version, description=None):
+    def update_model_version(self, name, version, description=None) -> ModelVersion:
         """
         Update metadata associated with a model version in backend.
 
@@ -2244,7 +2247,9 @@ class MlflowClient(object):
             name=name, version=version, description=description
         )
 
-    def transition_model_version_stage(self, name, version, stage, archive_existing_versions=False):
+    def transition_model_version_stage(
+        self, name, version, stage, archive_existing_versions=False
+    ) -> ModelVersion:
         """
         Update model version stage.
 
@@ -2444,7 +2449,7 @@ class MlflowClient(object):
         """
         return self._get_registry_client().get_model_version(name, version)
 
-    def get_model_version_download_uri(self, name, version):
+    def get_model_version_download_uri(self, name, version) -> str:
         """
         Get the download location in Model Registry for this model version.
 
@@ -2486,7 +2491,7 @@ class MlflowClient(object):
         """
         return self._get_registry_client().get_model_version_download_uri(name, version)
 
-    def search_model_versions(self, filter_string):
+    def search_model_versions(self, filter_string) -> PagedList[ModelVersion]:
         """
         Search for model versions in backend that satisfy the filter criteria.
 
@@ -2530,7 +2535,9 @@ class MlflowClient(object):
         """
         return self._get_registry_client().search_model_versions(filter_string)
 
-    def get_model_version_stages(self, name, version):  # pylint: disable=unused-argument
+    def get_model_version_stages(
+        self, name, version
+    ) -> List[str]:  # pylint: disable=unused-argument
         """
         :return: A list of valid stages.
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -312,7 +312,7 @@ class MlflowClient(object):
             experiment_id, run_view_type, max_results, order_by, page_token
         )
 
-    def list_experiments(self, view_type=None):
+    def list_experiments(self, view_type=None) -> List[Experiment]:
         """
         :return: List of :py:class:`mlflow.entities.Experiment`
 
@@ -458,7 +458,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.create_experiment(name, artifact_location)
 
-    def delete_experiment(self, experiment_id):
+    def delete_experiment(self, experiment_id) -> None:
         """
         Delete an experiment from the backend store.
 
@@ -489,7 +489,7 @@ class MlflowClient(object):
         """
         self._tracking_client.delete_experiment(experiment_id)
 
-    def restore_experiment(self, experiment_id):
+    def restore_experiment(self, experiment_id) -> None:
         """
         Restore a deleted experiment unless permanently deleted.
 
@@ -533,7 +533,7 @@ class MlflowClient(object):
         """
         self._tracking_client.restore_experiment(experiment_id)
 
-    def rename_experiment(self, experiment_id, new_name):
+    def rename_experiment(self, experiment_id, new_name) -> None:
         """
         Update an experiment's name. The new name must be unique.
 
@@ -576,7 +576,7 @@ class MlflowClient(object):
         """
         self._tracking_client.rename_experiment(experiment_id, new_name)
 
-    def log_metric(self, run_id, key, value, timestamp=None, step=None):
+    def log_metric(self, run_id, key, value, timestamp=None, step=None) -> None:
         """
         Log a metric against the run ID.
 
@@ -629,7 +629,7 @@ class MlflowClient(object):
         """
         self._tracking_client.log_metric(run_id, key, value, timestamp, step)
 
-    def log_param(self, run_id, key, value):
+    def log_param(self, run_id, key, value) -> None:
         """
         Log a parameter against the run ID.
 
@@ -676,7 +676,7 @@ class MlflowClient(object):
         """
         self._tracking_client.log_param(run_id, key, value)
 
-    def set_experiment_tag(self, experiment_id, key, value):
+    def set_experiment_tag(self, experiment_id, key, value) -> None:
         """
         Set a tag on the experiment with the specified ID. Value is converted to a string.
 
@@ -707,7 +707,7 @@ class MlflowClient(object):
         """
         self._tracking_client.set_experiment_tag(experiment_id, key, value)
 
-    def set_tag(self, run_id, key, value):
+    def set_tag(self, run_id, key, value) -> None:
         """
         Set a tag on the run with the specified ID. Value is converted to a string.
 
@@ -747,7 +747,7 @@ class MlflowClient(object):
         """
         self._tracking_client.set_tag(run_id, key, value)
 
-    def delete_tag(self, run_id, key):
+    def delete_tag(self, run_id, key) -> None:
         """
         Delete a tag from a run. This is irreversible.
 
@@ -787,7 +787,7 @@ class MlflowClient(object):
         """
         self._tracking_client.delete_tag(run_id, key)
 
-    def log_batch(self, run_id, metrics=(), params=(), tags=()):
+    def log_batch(self, run_id, metrics=(), params=(), tags=()) -> None:
         """
         Log multiple metrics, params, and/or tags.
 
@@ -840,7 +840,7 @@ class MlflowClient(object):
         """
         self._tracking_client.log_batch(run_id, metrics, params, tags)
 
-    def log_artifact(self, run_id, local_path, artifact_path=None):
+    def log_artifact(self, run_id, local_path, artifact_path=None) -> None:
         """
         Write a local file or directory to the remote ``artifact_uri``.
 
@@ -877,7 +877,7 @@ class MlflowClient(object):
         """
         self._tracking_client.log_artifact(run_id, local_path, artifact_path)
 
-    def log_artifacts(self, run_id, local_dir, artifact_path=None):
+    def log_artifacts(self, run_id, local_dir, artifact_path=None) -> None:
         """
         Write a directory of files to the remote ``artifact_uri``.
 
@@ -940,7 +940,7 @@ class MlflowClient(object):
             yield tmp_path
             self.log_artifact(run_id, tmp_path, artifact_dir)
 
-    def log_text(self, run_id, text, artifact_file):
+    def log_text(self, run_id, text, artifact_file) -> None:
         """
         Log text as an artifact.
 
@@ -971,7 +971,7 @@ class MlflowClient(object):
                 f.write(text)
 
     @experimental
-    def log_dict(self, run_id, dictionary, artifact_file):
+    def log_dict(self, run_id, dictionary, artifact_file) -> None:
         """
         Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
         inferred from the extension of `artifact_file`. If the file extension doesn't exist or
@@ -1015,7 +1015,7 @@ class MlflowClient(object):
                     json.dump(dictionary, f, indent=2)
 
     @experimental
-    def log_figure(self, run_id, figure, artifact_file):
+    def log_figure(self, run_id, figure, artifact_file) -> None:
         """
         Log a figure as an artifact. The following figure objects are supported:
 
@@ -1079,7 +1079,7 @@ class MlflowClient(object):
                 raise TypeError("Unsupported figure object type: '{}'".format(type(figure)))
 
     @experimental
-    def log_image(self, run_id, image, artifact_file):
+    def log_image(self, run_id, image, artifact_file) -> None:
         """
         Log an image as an artifact. The following image objects are supported:
 
@@ -1328,7 +1328,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.download_artifacts(run_id, path, dst_path)
 
-    def set_terminated(self, run_id, status=None, end_time=None):
+    def set_terminated(self, run_id, status=None, end_time=None) -> None:
         """Set a run's status to terminated.
 
         :param status: A string value of :py:class:`mlflow.entities.RunStatus`.
@@ -1371,7 +1371,7 @@ class MlflowClient(object):
         """
         self._tracking_client.set_terminated(run_id, status, end_time)
 
-    def delete_run(self, run_id):
+    def delete_run(self, run_id) -> None:
         """Deletes a run with the given ID.
 
         :param run_id: The unique run id to delete.
@@ -1400,7 +1400,7 @@ class MlflowClient(object):
         """
         self._tracking_client.delete_run(run_id)
 
-    def restore_run(self, run_id):
+    def restore_run(self, run_id) -> None:
         """
         Restores a deleted run with the given ID.
 
@@ -1954,7 +1954,7 @@ class MlflowClient(object):
         """
         return self._get_registry_client().get_latest_versions(name, stages)
 
-    def set_registered_model_tag(self, name, key, value):
+    def set_registered_model_tag(self, name, key, value) -> None:
         """
         Set a tag for the registered model.
 
@@ -2001,7 +2001,7 @@ class MlflowClient(object):
         """
         self._get_registry_client().set_registered_model_tag(name, key, value)
 
-    def delete_registered_model_tag(self, name, key):
+    def delete_registered_model_tag(self, name, key) -> None:
         """
         Delete a tag associated with the registered model.
 
@@ -2317,7 +2317,7 @@ class MlflowClient(object):
             name, version, stage, archive_existing_versions
         )
 
-    def delete_model_version(self, name, version):
+    def delete_model_version(self, name, version) -> None:
         """
         Delete model version in backend.
 
@@ -2396,7 +2396,7 @@ class MlflowClient(object):
         """
         self._get_registry_client().delete_model_version(name, version)
 
-    def get_model_version(self, name, version):
+    def get_model_version(self, name, version) -> ModelVersion:
         """
         :param name: Name of the containing registered model.
         :param version: Version number as an integer of the model version.
@@ -2576,7 +2576,7 @@ class MlflowClient(object):
         """
         return ALL_STAGES
 
-    def set_model_version_tag(self, name, version, key, value):
+    def set_model_version_tag(self, name, version, key, value) -> None:
         """
         Set a tag for the model version.
 
@@ -2635,7 +2635,7 @@ class MlflowClient(object):
         """
         self._get_registry_client().set_model_version_tag(name, version, key, value)
 
-    def delete_model_version_tag(self, name, version, key):
+    def delete_model_version_tag(self, name, version, key) -> None:
         """
         Delete a tag associated with the model version.
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -2536,8 +2536,8 @@ class MlflowClient(object):
         return self._get_registry_client().search_model_versions(filter_string)
 
     def get_model_version_stages(
-        self, name, version
-    ) -> List[str]:  # pylint: disable=unused-argument
+        self, name, version  # pylint: disable=unused-argument
+    ) -> List[str]:
         """
         :return: A list of valid stages.
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -774,7 +774,7 @@ def get_experiment(experiment_id) -> Experiment:
     return MlflowClient().get_experiment(experiment_id)
 
 
-def get_experiment_by_name(name) -> Experiment:
+def get_experiment_by_name(name) -> Optional[Experiment]:
     """
     Retrieve an experiment by experiment name from the backend store
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1236,8 +1236,8 @@ def autolog(
     disable=False,
     exclusive=False,
     disable_for_unsupported_versions=False,
-    silent=False,
-):  # pylint: disable=unused-argument
+    silent=False,  # pylint: disable=unused-argument
+) -> None:
     """
     Enables (or disables) and configures autologging for all supported integrations.
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -33,9 +33,9 @@ from mlflow.utils.annotations import experimental
 try:
     import pandas as pd
 
-    SearchRunsReturyType = Union[pd.DataFrame, List[Run]]
+    SearchRunsReturnType = Union[pd.DataFrame, List[Run]]
 except ImportError:
-    SearchRunsReturyType = List[Run]
+    SearchRunsReturnType = List[Run]
 
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"
 _EXPERIMENT_NAME_ENV_VAR = "MLFLOW_EXPERIMENT_NAME"
@@ -955,7 +955,7 @@ def search_runs(
     max_results=SEARCH_MAX_RESULTS_PANDAS,
     order_by=None,
     output_format="pandas",
-) -> SearchRunsReturyType:
+) -> SearchRunsReturnType:
     """
     Get a pandas DataFrame of runs that fit the search criteria.
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -280,7 +280,7 @@ def end_run(status=RunStatus.to_string(RunStatus.FINISHED)):
 atexit.register(end_run)
 
 
-def active_run() -> Optinal[ActiveRun]:
+def active_run() -> Optional[ActiveRun]:
     """Get the currently active ``Run``, or None if no such run exists.
 
     **Note**: You cannot access currently-active run attributes

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -49,7 +49,7 @@ NUM_RUNS_PER_PAGE_PANDAS = 10000
 _logger = logging.getLogger(__name__)
 
 
-def set_experiment(experiment_name):
+def set_experiment(experiment_name) -> None:
     """
     Set given experiment as active experiment. If experiment does not exist, create an experiment
     with provided name.
@@ -239,7 +239,7 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False, tags
     return _active_run_stack[-1]
 
 
-def end_run(status=RunStatus.to_string(RunStatus.FINISHED)):
+def end_run(status=RunStatus.to_string(RunStatus.FINISHED)) -> None:
     """End an active MLflow run (if there is one).
 
     .. code-block:: python
@@ -339,7 +339,7 @@ def get_run(run_id) -> Run:
     return MlflowClient().get_run(run_id)
 
 
-def log_param(key, value):
+def log_param(key, value) -> None:
     """
     Log a parameter under the current run. If no run is active, this method will create
     a new active run.
@@ -359,7 +359,7 @@ def log_param(key, value):
     MlflowClient().log_param(run_id, key, value)
 
 
-def set_tag(key, value):
+def set_tag(key, value) -> None:
     """
     Set a tag under the current run. If no run is active, this method will create a
     new active run.
@@ -379,7 +379,7 @@ def set_tag(key, value):
     MlflowClient().set_tag(run_id, key, value)
 
 
-def delete_tag(key):
+def delete_tag(key) -> None:
     """
     Delete a tag from a run. This is irreversible. If no run is active, this method
     will create a new active run.
@@ -404,7 +404,7 @@ def delete_tag(key):
     MlflowClient().delete_tag(run_id, key)
 
 
-def log_metric(key, value, step=None):
+def log_metric(key, value, step=None) -> None:
     """
     Log a metric under the current run. If no run is active, this method will create
     a new active run.
@@ -427,7 +427,7 @@ def log_metric(key, value, step=None):
     MlflowClient().log_metric(run_id, key, value, int(time.time() * 1000), step or 0)
 
 
-def log_metrics(metrics, step=None):
+def log_metrics(metrics, step=None) -> None:
     """
     Log multiple metrics for the current run. If no run is active, this method will create a new
     active run.
@@ -458,7 +458,7 @@ def log_metrics(metrics, step=None):
     MlflowClient().log_batch(run_id=run_id, metrics=metrics_arr, params=[], tags=[])
 
 
-def log_params(params):
+def log_params(params) -> None:
     """
     Log a batch of params for the current run. If no run is active, this method will create a
     new active run.
@@ -483,7 +483,7 @@ def log_params(params):
     MlflowClient().log_batch(run_id=run_id, metrics=[], params=params_arr, tags=[])
 
 
-def set_tags(tags):
+def set_tags(tags) -> None:
     """
     Log a batch of tags for the current run. If no run is active, this method will create a
     new active run.
@@ -510,7 +510,7 @@ def set_tags(tags):
     MlflowClient().log_batch(run_id=run_id, metrics=[], params=[], tags=tags_arr)
 
 
-def log_artifact(local_path, artifact_path=None):
+def log_artifact(local_path, artifact_path=None) -> None:
     """
     Log a local file or directory as an artifact of the currently active run. If no run is
     active, this method will create a new active run.
@@ -537,7 +537,7 @@ def log_artifact(local_path, artifact_path=None):
     MlflowClient().log_artifact(run_id, local_path, artifact_path)
 
 
-def log_artifacts(local_dir, artifact_path=None):
+def log_artifacts(local_dir, artifact_path=None) -> None:
     """
     Log all the contents of a local directory as artifacts of the run. If no run is active,
     this method will create a new active run.
@@ -570,7 +570,7 @@ def log_artifacts(local_dir, artifact_path=None):
     MlflowClient().log_artifacts(run_id, local_dir, artifact_path)
 
 
-def log_text(text, artifact_file):
+def log_text(text, artifact_file) -> None:
     """
     Log text as an artifact.
 
@@ -598,7 +598,7 @@ def log_text(text, artifact_file):
 
 
 @experimental
-def log_dict(dictionary, artifact_file):
+def log_dict(dictionary, artifact_file) -> None:
     """
     Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
     inferred from the extension of `artifact_file`. If the file extension doesn't exist or match
@@ -632,7 +632,7 @@ def log_dict(dictionary, artifact_file):
 
 
 @experimental
-def log_figure(figure, artifact_file):
+def log_figure(figure, artifact_file) -> None:
     """
     Log a figure as an artifact. The following figure objects are supported:
 
@@ -677,7 +677,7 @@ def log_figure(figure, artifact_file):
 
 
 @experimental
-def log_image(image, artifact_file):
+def log_image(image, artifact_file) -> None:
     """
     Log an image as an artifact. The following image objects are supported:
 
@@ -839,7 +839,7 @@ def create_experiment(name, artifact_location=None) -> str:
     return MlflowClient().create_experiment(name, artifact_location)
 
 
-def delete_experiment(experiment_id):
+def delete_experiment(experiment_id) -> None:
     """
     Delete an experiment from the backend store.
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1237,7 +1237,8 @@ def autolog(
     exclusive=False,
     disable_for_unsupported_versions=False,
     silent=False,
-) -> None:  # pylint: disable=unused-argument
+    # pylint: disable=unused-argument
+) -> None:
     """
     Enables (or disables) and configures autologging for all supported integrations.
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1236,8 +1236,8 @@ def autolog(
     disable=False,
     exclusive=False,
     disable_for_unsupported_versions=False,
-    silent=False,  # pylint: disable=unused-argument
-) -> None:
+    silent=False,
+) -> None:  # pylint: disable=unused-argument
     """
     Enables (or disables) and configures autologging for all supported integrations.
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -779,7 +779,8 @@ def get_experiment_by_name(name) -> Optional[Experiment]:
     Retrieve an experiment by experiment name from the backend store
 
     :param name: The case senstive experiment name.
-    :return: :py:class:`mlflow.entities.Experiment`
+    :return: An instance of :py:class:`mlflow.entities.Experiment`
+             if an experiment with the specified name exists, otherwise None.
 
     .. code-block:: python
         :caption: Example


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Put type annotations on key MLflow APIs.

#### Which API should be annotated?

- Fluent APIs (e.g. `mlflow.start_run`)
- Client APIs  (e.g. `mlflow.tracking.MlflowClient.get_run`)

## How is this patch tested?

Manual testing

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
