### PR TITLE
Separate MLeap tests and unpin pyspark

### DIFF
--- a/dev/extra-ml-requirements.txt
+++ b/dev/extra-ml-requirements.txt
@@ -40,7 +40,7 @@ onnxruntime
 # mleap format via ``mlflow.spark.log_model``, ``mlflow.spark.save_model``
 mleap
 # Required by mlflow.spark
-pyspark==2.4.0
+pyspark
 # Required by mlflow.shap
 shap
 # Remove `ipython` once this issue: https://github.com/slundberg/shap/pull/1749 has been addressed

--- a/dev/run-python-sagemaker-tests.sh
+++ b/dev/run-python-sagemaker-tests.sh
@@ -20,7 +20,10 @@ pytest --verbose tests/sagemaker/mock --large
 
 # Added here due to dependency on sagemaker
 # TODO: split out sagemaker tests and move other spark tests to run-python-flavor-tests.sh
+pytest --verbose tests/spark --large  --ignore tests/spark/test_mleap_model_export.py
+
+# MLeap doesn't support spark 3.x (https://github.com/combust/mleap#mleapspark-version)
 pip install pyspark==2.4.5
-pytest --verbose tests/spark --large
+pytest --verbose tests/spark/test_mleap_model_export.py --large
 
 test $err = 0

--- a/dev/run-python-sagemaker-tests.sh
+++ b/dev/run-python-sagemaker-tests.sh
@@ -20,6 +20,7 @@ pytest --verbose tests/sagemaker/mock --large
 
 # Added here due to dependency on sagemaker
 # TODO: split out sagemaker tests and move other spark tests to run-python-flavor-tests.sh
+pip install pyspark==2.4.5
 pytest --verbose tests/spark --large
 
 test $err = 0

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -54,11 +54,6 @@ def configure_environment():
 
 
 def get_spark_session(conf):
-    # setting this env variable is needed when using Spark with Arrow >= 0.15.0
-    # because of a change in Arrow IPC format
-    # https://spark.apache.org/docs/latest/sql-pyspark-pandas-with-arrow.html# \
-    # compatibiliy-setting-for-pyarrow--0150-and-spark-23x-24x
-    os.environ["ARROW_PRE_0_15_IPC_FORMAT"] = "1"
     conf.set(key="spark_session.python.worker.reuse", value=True)
     return (
         pyspark.sql.SparkSession.builder.config(conf=conf)

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 import pytest
 import pyspark
-from py4j.protocol import Py4JJavaError
 from pyspark.sql.types import ArrayType, DoubleType, LongType, StringType, FloatType, IntegerType
 
 import mlflow

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -135,7 +135,7 @@ def test_spark_udf_autofills_column_names_with_schema(spark):
                 columns=["a", "b", "c", "d"], data={"a": [1], "b": [2], "c": [3], "d": [4]}
             )
         )
-        with pytest.raises(Py4JJavaError):
+        with pytest.raises(pyspark.sql.utils.PythonException):
             res = data.withColumn("res1", udf("a", "b")).select("res1").toPandas()
 
         res = data.withColumn("res2", udf("a", "b", "c")).select("res2").toPandas()

--- a/tests/spark/test_mleap_model_export.py
+++ b/tests/spark/test_mleap_model_export.py
@@ -1,0 +1,74 @@
+import os
+
+from pyspark.ml.pipeline import Pipeline
+from pyspark.ml.wrapper import JavaModel
+import pytest
+
+import mlflow
+import mlflow.tracking
+import mlflow.mleap
+from mlflow.models import Model
+from mlflow.utils.file_utils import TempDir
+
+from tests.spark.test_spark_model_export import (
+    spark_model_iris,
+    model_path,
+)  # pylint: disable=unused-import
+
+
+@pytest.mark.large
+def test_mleap_module_model_save_with_relative_path_and_valid_sample_input_produces_mleap_flavor(
+    spark_model_iris,
+):
+    with TempDir(chdr=True) as tmp:
+        model_path = os.path.basename(tmp.path("model"))
+        mlflow_model = Model()
+        mlflow.mleap.save_model(
+            spark_model=spark_model_iris.model,
+            path=model_path,
+            sample_input=spark_model_iris.spark_df,
+            mlflow_model=mlflow_model,
+        )
+        assert mlflow.mleap.FLAVOR_NAME in mlflow_model.flavors
+
+        config_path = os.path.join(model_path, "MLmodel")
+        assert os.path.exists(config_path)
+        config = Model.load(config_path)
+        assert mlflow.mleap.FLAVOR_NAME in config.flavors
+
+
+@pytest.mark.large
+def test_mleap_module_model_save_with_absolute_path_and_valid_sample_input_produces_mleap_flavor(
+    spark_model_iris, model_path
+):
+    model_path = os.path.abspath(model_path)
+    mlflow_model = Model()
+    mlflow.mleap.save_model(
+        spark_model=spark_model_iris.model,
+        path=model_path,
+        sample_input=spark_model_iris.spark_df,
+        mlflow_model=mlflow_model,
+    )
+    assert mlflow.mleap.FLAVOR_NAME in mlflow_model.flavors
+
+    config_path = os.path.join(model_path, "MLmodel")
+    assert os.path.exists(config_path)
+    config = Model.load(config_path)
+    assert mlflow.mleap.FLAVOR_NAME in config.flavors
+
+
+@pytest.mark.large
+def test_mleap_module_model_save_with_unsupported_transformer_raises_serialization_exception(
+    spark_model_iris, model_path
+):
+    class CustomTransformer(JavaModel):
+        def _transform(self, dataset):
+            return dataset
+
+    unsupported_pipeline = Pipeline(stages=[CustomTransformer()])
+    unsupported_model = unsupported_pipeline.fit(spark_model_iris.spark_df)
+
+    with pytest.raises(mlflow.mleap.MLeapSerializationException):
+        mlflow.mleap.save_model(
+            spark_model=unsupported_model, path=model_path, sample_input=spark_model_iris.spark_df
+        )

--- a/tests/spark/test_mleap_model_export.py
+++ b/tests/spark/test_mleap_model_export.py
@@ -1,4 +1,5 @@
 import os
+from unittest import mock
 
 from pyspark.ml.pipeline import Pipeline
 from pyspark.ml.wrapper import JavaModel

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -592,31 +592,6 @@ def test_default_conda_env_strips_dev_suffix_from_pyspark_version(spark_model_ir
 
 
 @pytest.mark.large
-def test_mleap_model_log(spark_model_iris):
-    artifact_path = "model"
-    register_model_patch = mock.patch("mlflow.register_model")
-    with mlflow.start_run(), register_model_patch:
-        sparkm.log_model(
-            spark_model=spark_model_iris.model,
-            sample_input=spark_model_iris.spark_df,
-            artifact_path=artifact_path,
-            registered_model_name="Model1",
-        )
-        model_uri = "runs:/{run_id}/{artifact_path}".format(
-            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
-        )
-        mlflow.register_model.assert_called_once_with(
-            model_uri, "Model1", await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS
-        )
-
-    model_path = _download_artifact_from_uri(artifact_uri=model_uri)
-    config_path = os.path.join(model_path, "MLmodel")
-    mlflow_model = Model.load(config_path)
-    assert sparkm.FLAVOR_NAME in mlflow_model.flavors
-    assert mleap.FLAVOR_NAME in mlflow_model.flavors
-
-
-@pytest.mark.large
 def test_spark_module_model_save_with_mleap_and_unsupported_transformer_raises_exception(
     spark_model_iris, model_path
 ):
@@ -631,27 +606,6 @@ def test_spark_module_model_save_with_mleap_and_unsupported_transformer_raises_e
         sparkm.save_model(
             spark_model=unsupported_model, path=model_path, sample_input=spark_model_iris.spark_df
         )
-
-
-@pytest.mark.large
-def test_spark_module_model_save_with_relative_path_and_valid_sample_input_produces_mleap_flavor(
-    spark_model_iris,
-):
-    with TempDir(chdr=True) as tmp:
-        model_path = os.path.basename(tmp.path("model"))
-        mlflow_model = Model()
-        sparkm.save_model(
-            spark_model=spark_model_iris.model,
-            path=model_path,
-            sample_input=spark_model_iris.spark_df,
-            mlflow_model=mlflow_model,
-        )
-        assert mleap.FLAVOR_NAME in mlflow_model.flavors
-
-        config_path = os.path.join(model_path, "MLmodel")
-        assert os.path.exists(config_path)
-        config = Model.load(config_path)
-        assert mleap.FLAVOR_NAME in config.flavors
 
 
 @pytest.mark.large

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -269,33 +269,18 @@ def test_transformer_model_export(spark_model_transformer, model_path, spark_cus
 @pytest.mark.large
 def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
     sparkm.save_model(
-        spark_model_iris.model,
-        path=model_path,
-        conda_env=spark_custom_env,
-        # Test both spark ml and mleap
-        sample_input=spark_model_iris.spark_df,
+        spark_model_iris.model, path=model_path, conda_env=spark_custom_env,
     )
-
-    # 1. score and compare pyfunc deployed in Sagemaker docker container
-    scoring_response_1 = score_model_in_sagemaker_docker_container(
+    scoring_response = score_model_in_sagemaker_docker_container(
         model_uri=model_path,
         data=spark_model_iris.pandas_df,
         content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
         flavor=mlflow.pyfunc.FLAVOR_NAME,
     )
     np.testing.assert_array_almost_equal(
-        spark_model_iris.predictions, np.array(json.loads(scoring_response_1.content)), decimal=4
+        spark_model_iris.predictions, np.array(json.loads(scoring_response.content)), decimal=4
     )
-    # 2. score and compare mleap deployed in Sagemaker docker container
-    scoring_response_2 = score_model_in_sagemaker_docker_container(
-        model_uri=model_path,
-        data=spark_model_iris.pandas_df.to_json(orient="split"),
-        content_type=pyfunc_scoring_server.CONTENT_TYPE_JSON,
-        flavor=mlflow.mleap.FLAVOR_NAME,
-    )
-    np.testing.assert_array_almost_equal(
-        spark_model_iris.predictions, np.array(json.loads(scoring_response_2.content)), decimal=4
-    )
+
 
 
 @pytest.mark.large

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -282,7 +282,6 @@ def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
     )
 
 
-
 @pytest.mark.large
 def test_sagemaker_docker_model_scoring_with_default_conda_env(spark_model_iris, model_path):
     sparkm.save_model(spark_model_iris.model, path=model_path, conda_env=None)

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -655,47 +655,6 @@ def test_spark_module_model_save_with_relative_path_and_valid_sample_input_produ
 
 
 @pytest.mark.large
-def test_mleap_module_model_save_with_relative_path_and_valid_sample_input_produces_mleap_flavor(
-    spark_model_iris,
-):
-    with TempDir(chdr=True) as tmp:
-        model_path = os.path.basename(tmp.path("model"))
-        mlflow_model = Model()
-        mleap.save_model(
-            spark_model=spark_model_iris.model,
-            path=model_path,
-            sample_input=spark_model_iris.spark_df,
-            mlflow_model=mlflow_model,
-        )
-        assert mleap.FLAVOR_NAME in mlflow_model.flavors
-
-        config_path = os.path.join(model_path, "MLmodel")
-        assert os.path.exists(config_path)
-        config = Model.load(config_path)
-        assert mleap.FLAVOR_NAME in config.flavors
-
-
-@pytest.mark.large
-def test_mleap_module_model_save_with_absolute_path_and_valid_sample_input_produces_mleap_flavor(
-    spark_model_iris, model_path
-):
-    model_path = os.path.abspath(model_path)
-    mlflow_model = Model()
-    mleap.save_model(
-        spark_model=spark_model_iris.model,
-        path=model_path,
-        sample_input=spark_model_iris.spark_df,
-        mlflow_model=mlflow_model,
-    )
-    assert mleap.FLAVOR_NAME in mlflow_model.flavors
-
-    config_path = os.path.join(model_path, "MLmodel")
-    assert os.path.exists(config_path)
-    config = Model.load(config_path)
-    assert mleap.FLAVOR_NAME in config.flavors
-
-
-@pytest.mark.large
 def test_mleap_module_model_save_with_invalid_sample_input_type_raises_exception(
     spark_model_iris, model_path
 ):
@@ -703,23 +662,6 @@ def test_mleap_module_model_save_with_invalid_sample_input_type_raises_exception
         invalid_input = pd.DataFrame()
         sparkm.save_model(
             spark_model=spark_model_iris.model, path=model_path, sample_input=invalid_input
-        )
-
-
-@pytest.mark.large
-def test_mleap_module_model_save_with_unsupported_transformer_raises_serialization_exception(
-    spark_model_iris, model_path
-):
-    class CustomTransformer(JavaModel):
-        def _transform(self, dataset):
-            return dataset
-
-    unsupported_pipeline = Pipeline(stages=[CustomTransformer()])
-    unsupported_model = unsupported_pipeline.fit(spark_model_iris.spark_df)
-
-    with pytest.raises(mleap.MLeapSerializationException):
-        mleap.save_model(
-            spark_model=unsupported_model, path=model_path, sample_input=spark_model_iris.spark_df
         )
 
 

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -19,7 +19,7 @@ import yaml
 import mlflow
 import mlflow.pyfunc.scoring_server as pyfunc_scoring_server
 import mlflow.tracking
-from mlflow import pyfunc, mleap
+from mlflow import pyfunc
 from mlflow import spark as sparkm
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, infer_signature


### PR DESCRIPTION
## What changes are proposed in this pull request?

Separate MLeap tests and unpin pyspark to use the latest version

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
