### PR TITLE
(do not merge) struct error

### DIFF
--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 import pyspark
 from py4j.protocol import Py4JJavaError
+from pyspark.sql.functions import struct
 from pyspark.sql.types import ArrayType, DoubleType, LongType, StringType, FloatType, IntegerType
 
 import mlflow
@@ -143,9 +144,9 @@ def test_spark_udf_autofills_column_names_with_schema(spark):
         with pytest.raises(Py4JJavaError):
             res = data.withColumn("res1", udf("a", "b")).select("res1").toPandas()
 
-        res = data.withColumn("res2", udf("a", "b", "c")).select("res2").toPandas()
+        res = data.withColumn("res2", udf(struct("a", "b", "c"))).select("res2").toPandas()
         assert res["res2"][0] == ["a", "b", "c"]
-        res = data.withColumn("res4", udf("a", "b", "c", "d")).select("res4").toPandas()
+        res = data.withColumn("res4", udf(struct("a", "b", "c", "d"))).select("res4").toPandas()
         assert res["res4"][0] == ["a", "b", "c"]
 
 


### PR DESCRIPTION
```
========================================================= test session starts ==========================================================
platform linux -- Python 3.6.13, pytest-3.2.1, py-1.10.0, pluggy-0.4.0
rootdir: /home/andyzhang/mlflow, inifile: pytest.ini
plugins: localserver-0.5.0, cov-2.6.0
collected 3 items

tests/pyfunc/test_spark.py F

======================================================= slowest 5 test durations =======================================================
11.20s call     tests/pyfunc/test_spark.py::test_spark_udf_autofills_column_names_with_schema
2.72s setup    tests/pyfunc/test_spark.py::test_spark_udf_autofills_column_names_with_schema
0.00s teardown tests/pyfunc/test_spark.py::test_spark_udf_autofills_column_names_with_schema
=============================================================== FAILURES ===============================================================
__________________________________________ test_spark_udf_autofills_column_names_with_schema ___________________________________________

spark = <pyspark.sql.session.SparkSession object at 0x7f8deb27f978>

    def test_spark_udf_autofills_column_names_with_schema(spark):
        class TestModel(PythonModel):
            def predict(self, context, model_input):
                return [model_input.columns] * len(model_input)

        signature = ModelSignature(
            inputs=Schema([ColSpec("long", "a"), ColSpec("long", "b"), ColSpec("long", "c")]),
            outputs=Schema([ColSpec("integer")]),
        )
        with mlflow.start_run() as run:
            mlflow.pyfunc.log_model("model", python_model=TestModel(), signature=signature)
            udf = mlflow.pyfunc.spark_udf(
                spark, "runs:/{}/model".format(run.info.run_id), result_type=ArrayType(StringType())
            )
            data = spark.createDataFrame(
                pd.DataFrame(
                    columns=["a", "b", "c", "d"], data={"a": [1], "b": [2], "c": [3], "d": [4]}
                )
            )
            with pytest.raises(Py4JJavaError):
                res = data.withColumn("res1", udf("a", "b")).select("res1").toPandas()

>           res = data.withColumn("res2", udf(struct("a", "b", "c"))).select("res2").toPandas()

TestModel  = <class 'tests.pyfunc.test_spark.test_spark_udf_autofills_column_names_with_schema.<locals>.TestModel'>
data       = DataFrame[a: bigint, b: bigint, c: bigint, d: bigint]
run        = <ActiveRun: >
signature  = inputs:
  ['a': long, 'b': long, 'c': long]
outputs:
  [integer]

spark      = <pyspark.sql.session.SparkSession object at 0x7f8deb27f978>
udf        = <function spark_udf.<locals>.predict at 0x7f8e6a1d62f0>

tests/pyfunc/test_spark.py:147:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/sql/dataframe.py:2142: in toPandas
    pdf = pd.DataFrame.from_records(self.collect(), columns=self.columns)
../anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/sql/dataframe.py:533: in collect
    sock_info = self._jdf.collectToPython()
../anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/py4j/java_gateway.py:1257: in __call__
    answer, self.gateway_client, self.target_id, self.name)
../anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/sql/utils.py:63: in deco
    return f(*a, **kw)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

answer = 'xro167', gateway_client = <py4j.java_gateway.GatewayClient object at 0x7f8deb2795f8>, target_id = 'o160'
name = 'collectToPython'

    def get_return_value(answer, gateway_client, target_id=None, name=None):
        """Converts an answer received from the Java gateway into a Python object.

        For example, string representation of integers are converted to Python
        integer, string representation of objects are converted to JavaObject
        instances, etc.

        :param answer: the string returned by the Java gateway
        :param gateway_client: the gateway client used to communicate with the Java
            Gateway. Only necessary if the answer is a reference (e.g., object,
            list, map)
        :param target_id: the name of the object from which the answer comes from
            (e.g., *object1* in `object1.hello()`). Optional.
        :param name: the name of the member from which the answer comes from
            (e.g., *hello* in `object1.hello()`). Optional.
        """
        if is_error(answer)[0]:
            if len(answer) > 1:
                type = answer[1]
                value = OUTPUT_CONVERTER[type](answer[2:], gateway_client)
                if answer[1] == REFERENCE_TYPE:
                    raise Py4JJavaError(
                        "An error occurred while calling {0}{1}{2}.\n".
>                       format(target_id, ".", name), value)
E                   py4j.protocol.Py4JJavaError: An error occurred while calling o160.collectToPython.
E                   : org.apache.spark.SparkException: Job aborted due to stage failure: Task 1 in stage 1.0 failed 4 times, most recent failure: Lost task 1.3 in stage 1.0 (TID 9, 10.20.6.147, executor 1): org.apache.spark.api.python.PythonException: Traceback (most recent call last):
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 372, in main
E                       process()
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 367, in process
E                       serializer.dump_stream(func(split_index, iterator), outfile)
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/serializers.py", line 283, in dump_stream
E                       for series in iterator:
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/serializers.py", line 301, in load_stream
E                       yield [self.arrow_to_pandas(c) for c in pa.Table.from_batches([batch]).itercolumns()]
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/serializers.py", line 301, in <listcomp>
E                       yield [self.arrow_to_pandas(c) for c in pa.Table.from_batches([batch]).itercolumns()]
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/serializers.py", line 271, in arrow_to_pandas
E                       s = _check_series_convert_date(s, from_arrow_type(arrow_column.type))
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/sql/types.py", line 1672, in from_arrow_type
E                       raise TypeError("Unsupported type in conversion from Arrow: " + str(at))
E                   TypeError: Unsupported type in conversion from Arrow: struct<a: int64, b: int64, c: int64>
E
E                   	at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.handlePythonException(PythonRunner.scala:452)
E                   	at org.apache.spark.sql.execution.python.ArrowPythonRunner$$anon$1.read(ArrowPythonRunner.scala:172)
E                   	at org.apache.spark.sql.execution.python.ArrowPythonRunner$$anon$1.read(ArrowPythonRunner.scala:122)
E                   	at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.hasNext(PythonRunner.scala:406)
E                   	at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
E                   	at org.apache.spark.sql.execution.python.ArrowEvalPythonExec$$anon$2.<init>(ArrowEvalPythonExec.scala:98)
E                   	at org.apache.spark.sql.execution.python.ArrowEvalPythonExec.evaluate(ArrowEvalPythonExec.scala:96)
E                   	at org.apache.spark.sql.execution.python.EvalPythonExec$$anonfun$doExecute$1.apply(EvalPythonExec.scala:127)
E                   	at org.apache.spark.sql.execution.python.EvalPythonExec$$anonfun$doExecute$1.apply(EvalPythonExec.scala:89)
E                   	at org.apache.spark.rdd.RDD$$anonfun$mapPartitions$1$$anonfun$apply$23.apply(RDD.scala:801)
E                   	at org.apache.spark.rdd.RDD$$anonfun$mapPartitions$1$$anonfun$apply$23.apply(RDD.scala:801)
E                   	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
E                   	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
E                   	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
E                   	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
E                   	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
E                   	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
E                   	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
E                   	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
E                   	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
E                   	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
E                   	at org.apache.spark.scheduler.Task.run(Task.scala:121)
E                   	at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:402)
E                   	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
E                   	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:408)
E                   	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
E                   	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
E                   	at java.lang.Thread.run(Thread.java:748)
E
E                   Driver stacktrace:
E                   	at org.apache.spark.scheduler.DAGScheduler.org$apache$spark$scheduler$DAGScheduler$$failJobAndIndependentStages(DAGScheduler.scala:1887)
E                   	at org.apache.spark.scheduler.DAGScheduler$$anonfun$abortStage$1.apply(DAGScheduler.scala:1875)
E                   	at org.apache.spark.scheduler.DAGScheduler$$anonfun$abortStage$1.apply(DAGScheduler.scala:1874)
E                   	at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
E                   	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
E                   	at org.apache.spark.scheduler.DAGScheduler.abortStage(DAGScheduler.scala:1874)
E                   	at org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskSetFailed$1.apply(DAGScheduler.scala:926)
E                   	at org.apache.spark.scheduler.DAGScheduler$$anonfun$handleTaskSetFailed$1.apply(DAGScheduler.scala:926)
E                   	at scala.Option.foreach(Option.scala:257)
E                   	at org.apache.spark.scheduler.DAGScheduler.handleTaskSetFailed(DAGScheduler.scala:926)
E                   	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:2108)
E                   	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2057)
E                   	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:2046)
E                   	at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:49)
E                   	at org.apache.spark.scheduler.DAGScheduler.runJob(DAGScheduler.scala:737)
E                   	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2061)
E                   	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2082)
E                   	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2101)
E                   	at org.apache.spark.SparkContext.runJob(SparkContext.scala:2126)
E                   	at org.apache.spark.rdd.RDD$$anonfun$collect$1.apply(RDD.scala:945)
E                   	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:151)
E                   	at org.apache.spark.rdd.RDDOperationScope$.withScope(RDDOperationScope.scala:112)
E                   	at org.apache.spark.rdd.RDD.withScope(RDD.scala:363)
E                   	at org.apache.spark.rdd.RDD.collect(RDD.scala:944)
E                   	at org.apache.spark.sql.execution.SparkPlan.executeCollect(SparkPlan.scala:299)
E                   	at org.apache.spark.sql.Dataset$$anonfun$collectToPython$1.apply(Dataset.scala:3258)
E                   	at org.apache.spark.sql.Dataset$$anonfun$collectToPython$1.apply(Dataset.scala:3255)
E                   	at org.apache.spark.sql.Dataset$$anonfun$53.apply(Dataset.scala:3365)
E                   	at org.apache.spark.sql.execution.SQLExecution$$anonfun$withNewExecutionId$1.apply(SQLExecution.scala:78)
E                   	at org.apache.spark.sql.execution.SQLExecution$.withSQLConfPropagated(SQLExecution.scala:125)
E                   	at org.apache.spark.sql.execution.SQLExecution$.withNewExecutionId(SQLExecution.scala:73)
E                   	at org.apache.spark.sql.Dataset.withAction(Dataset.scala:3364)
E                   	at org.apache.spark.sql.Dataset.collectToPython(Dataset.scala:3255)
E                   	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
E                   	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
E                   	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
E                   	at java.lang.reflect.Method.invoke(Method.java:498)
E                   	at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
E                   	at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:357)
E                   	at py4j.Gateway.invoke(Gateway.java:282)
E                   	at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
E                   	at py4j.commands.CallCommand.execute(CallCommand.java:79)
E                   	at py4j.GatewayConnection.run(GatewayConnection.java:238)
E                   	at java.lang.Thread.run(Thread.java:748)
E                   Caused by: org.apache.spark.api.python.PythonException: Traceback (most recent call last):
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 372, in main
E                       process()
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 367, in process
E                       serializer.dump_stream(func(split_index, iterator), outfile)
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/serializers.py", line 283, in dump_stream
E                       for series in iterator:
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/serializers.py", line 301, in load_stream
E                       yield [self.arrow_to_pandas(c) for c in pa.Table.from_batches([batch]).itercolumns()]
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/serializers.py", line 301, in <listcomp>
E                       yield [self.arrow_to_pandas(c) for c in pa.Table.from_batches([batch]).itercolumns()]
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/serializers.py", line 271, in arrow_to_pandas
E                       s = _check_series_convert_date(s, from_arrow_type(arrow_column.type))
E                     File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/sql/types.py", line 1672, in from_arrow_type
E                       raise TypeError("Unsupported type in conversion from Arrow: " + str(at))
E                   TypeError: Unsupported type in conversion from Arrow: struct<a: int64, b: int64, c: int64>
E
E                   	at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.handlePythonException(PythonRunner.scala:452)
E                   	at org.apache.spark.sql.execution.python.ArrowPythonRunner$$anon$1.read(ArrowPythonRunner.scala:172)
E                   	at org.apache.spark.sql.execution.python.ArrowPythonRunner$$anon$1.read(ArrowPythonRunner.scala:122)
E                   	at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.hasNext(PythonRunner.scala:406)
E                   	at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
E                   	at org.apache.spark.sql.execution.python.ArrowEvalPythonExec$$anon$2.<init>(ArrowEvalPythonExec.scala:98)
E                   	at org.apache.spark.sql.execution.python.ArrowEvalPythonExec.evaluate(ArrowEvalPythonExec.scala:96)
E                   	at org.apache.spark.sql.execution.python.EvalPythonExec$$anonfun$doExecute$1.apply(EvalPythonExec.scala:127)
E                   	at org.apache.spark.sql.execution.python.EvalPythonExec$$anonfun$doExecute$1.apply(EvalPythonExec.scala:89)
E                   	at org.apache.spark.rdd.RDD$$anonfun$mapPartitions$1$$anonfun$apply$23.apply(RDD.scala:801)
E                   	at org.apache.spark.rdd.RDD$$anonfun$mapPartitions$1$$anonfun$apply$23.apply(RDD.scala:801)
E                   	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
E                   	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
E                   	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
E                   	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
E                   	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
E                   	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
E                   	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
E                   	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
E                   	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
E                   	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
E                   	at org.apache.spark.scheduler.Task.run(Task.scala:121)
E                   	at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:402)
E                   	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
E                   	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:408)
E                   	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
E                   	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
E                   	... 1 more

answer     = 'xro167'
gateway_client = <py4j.java_gateway.GatewayClient object at 0x7f8deb2795f8>
name       = 'collectToPython'
target_id  = 'o160'
type       = 'r'
value      = JavaObject id=o167

../anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/py4j/protocol.py:328: Py4JJavaError
-------------------------------------------------------- Captured stdout setup ---------------------------------------------------------
2021-04-13 04:40:33 WARN  NativeCodeLoader:62 - Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
-------------------------------------------------------- Captured stderr setup ---------------------------------------------------------
Warning: Ignoring non-spark config property: spark_session.python.worker.reuse=True
Setting default log level to "WARN".
To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
--------------------------------------------------------- Captured stdout call ---------------------------------------------------------
2021-04-13 04:40:40 WARN  TaskSetManager:66 - Lost task 1.0 in stage 0.0 (TID 1, 10.20.6.147, executor 1): org.apache.spark.api.python.PythonException: Traceback (most recent call last):
  File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 372, in main
    process()
  File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 367, in process
    serializer.dump_stream(func(split_index, iterator), outfile)
  File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/serializers.py", line 283, in dump_stream
    for series in iterator:
  File "<string>", line 1, in <lambda>
  File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 96, in <lambda>
    return lambda *a: (verify_result_length(*a), arrow_return_type)
  File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 87, in verify_result_length
    result = f(*a)
  File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/util.py", line 99, in wrapper
    return f(*args, **kwargs)
  File "/home/andyzhang/mlflow/mlflow/pyfunc/__init__.py", line 810, in predict
    " the order specified by the schema).".format(len(names), names, len(args))
mlflow.exceptions.MlflowException: Model input is missing columns. Expected 3 input columns ['a', 'b', 'c'], but the model received only 2 unnamed input columns (Since the columns were passed unnamed they are expected to be in the order specified by the schema).

	at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.handlePythonException(PythonRunner.scala:452)
	at org.apache.spark.sql.execution.python.ArrowPythonRunner$$anon$1.read(ArrowPythonRunner.scala:172)
	at org.apache.spark.sql.execution.python.ArrowPythonRunner$$anon$1.read(ArrowPythonRunner.scala:122)
	at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.hasNext(PythonRunner.scala:406)
	at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
	at org.apache.spark.sql.execution.python.ArrowEvalPythonExec$$anon$2.<init>(ArrowEvalPythonExec.scala:98)
	at org.apache.spark.sql.execution.python.ArrowEvalPythonExec.evaluate(ArrowEvalPythonExec.scala:96)
	at org.apache.spark.sql.execution.python.EvalPythonExec$$anonfun$doExecute$1.apply(EvalPythonExec.scala:127)
	at org.apache.spark.sql.execution.python.EvalPythonExec$$anonfun$doExecute$1.apply(EvalPythonExec.scala:89)
	at org.apache.spark.rdd.RDD$$anonfun$mapPartitions$1$$anonfun$apply$23.apply(RDD.scala:801)
	at org.apache.spark.rdd.RDD$$anonfun$mapPartitions$1$$anonfun$apply$23.apply(RDD.scala:801)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:121)
	at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:402)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:408)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

2021-04-13 04:40:43 ERROR TaskSetManager:70 - Task 1 in stage 0.0 failed 4 times; aborting job
2021-04-13 04:40:44 WARN  TaskSetManager:66 - Lost task 1.0 in stage 1.0 (TID 6, 10.20.6.147, executor 0): org.apache.spark.api.python.PythonException: Traceback (most recent call last):
  File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 372, in main
    process()
  File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/worker.py", line 367, in process
    serializer.dump_stream(func(split_index, iterator), outfile)
  File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/serializers.py", line 283, in dump_stream
    for series in iterator:
  File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/serializers.py", line 301, in load_stream
    yield [self.arrow_to_pandas(c) for c in pa.Table.from_batches([batch]).itercolumns()]
  File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/serializers.py", line 301, in <listcomp>
    yield [self.arrow_to_pandas(c) for c in pa.Table.from_batches([batch]).itercolumns()]
  File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/serializers.py", line 271, in arrow_to_pandas
    s = _check_series_convert_date(s, from_arrow_type(arrow_column.type))
  File "/home/andyzhang/anaconda/envs/mlflow-dev-env/lib/python3.6/site-packages/pyspark/python/lib/pyspark.zip/pyspark/sql/types.py", line 1672, in from_arrow_type
    raise TypeError("Unsupported type in conversion from Arrow: " + str(at))
TypeError: Unsupported type in conversion from Arrow: struct<a: int64, b: int64, c: int64>

	at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.handlePythonException(PythonRunner.scala:452)
	at org.apache.spark.sql.execution.python.ArrowPythonRunner$$anon$1.read(ArrowPythonRunner.scala:172)
	at org.apache.spark.sql.execution.python.ArrowPythonRunner$$anon$1.read(ArrowPythonRunner.scala:122)
	at org.apache.spark.api.python.BasePythonRunner$ReaderIterator.hasNext(PythonRunner.scala:406)
	at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
	at org.apache.spark.sql.execution.python.ArrowEvalPythonExec$$anon$2.<init>(ArrowEvalPythonExec.scala:98)
	at org.apache.spark.sql.execution.python.ArrowEvalPythonExec.evaluate(ArrowEvalPythonExec.scala:96)
	at org.apache.spark.sql.execution.python.EvalPythonExec$$anonfun$doExecute$1.apply(EvalPythonExec.scala:127)
	at org.apache.spark.sql.execution.python.EvalPythonExec$$anonfun$doExecute$1.apply(EvalPythonExec.scala:89)
	at org.apache.spark.rdd.RDD$$anonfun$mapPartitions$1$$anonfun$apply$23.apply(RDD.scala:801)
	at org.apache.spark.rdd.RDD$$anonfun$mapPartitions$1$$anonfun$apply$23.apply(RDD.scala:801)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.rdd.MapPartitionsRDD.compute(MapPartitionsRDD.scala:52)
	at org.apache.spark.rdd.RDD.computeOrReadCheckpoint(RDD.scala:324)
	at org.apache.spark.rdd.RDD.iterator(RDD.scala:288)
	at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
	at org.apache.spark.scheduler.Task.run(Task.scala:121)
	at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:402)
	at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
	at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:408)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

2021-04-13 04:40:46 ERROR TaskSetManager:70 - Task 1 in stage 1.0 failed 4 times; aborting job
--------------------------------------------------------- Captured stderr call ---------------------------------------------------------
2021/04/13 04:40:35 INFO mlflow.store.db.utils: Creating initial MLflow database tables...
2021/04/13 04:40:35 INFO mlflow.store.db.utils: Updating database tables
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade  -> 451aebb31d03, add metric step
INFO  [alembic.runtime.migration] Running upgrade 451aebb31d03 -> 90e64c465722, migrate user column to tags
INFO  [alembic.runtime.migration] Running upgrade 90e64c465722 -> 181f10493468, allow nulls for metric values
INFO  [alembic.runtime.migration] Running upgrade 181f10493468 -> df50e92ffc5e, Add Experiment Tags Table
INFO  [alembic.runtime.migration] Running upgrade df50e92ffc5e -> 7ac759974ad8, Update run tags with larger limit
INFO  [alembic.runtime.migration] Running upgrade 7ac759974ad8 -> 89d4b8295536, create latest metrics table
INFO  [89d4b8295536_create_latest_metrics_table_py] Migration complete!
INFO  [alembic.runtime.migration] Running upgrade 89d4b8295536 -> 2b4d017a5e9b, add model registry tables to db
INFO  [2b4d017a5e9b_add_model_registry_tables_to_db_py] Adding registered_models and model_versions tables to database.
INFO  [2b4d017a5e9b_add_model_registry_tables_to_db_py] Migration complete!
INFO  [alembic.runtime.migration] Running upgrade 2b4d017a5e9b -> cfd24bdc0731, Update run status constraint with killed
INFO  [alembic.runtime.migration] Running upgrade cfd24bdc0731 -> 0a8213491aaa, drop_duplicate_killed_constraint
WARNI [0a8213491aaa_drop_duplicate_killed_constraint_py] Failed to drop check constraint. Dropping check constraints may not be supported by your SQL database. Exception content: No support for ALTER of constraints in SQLite dialectPlease refer to the batch mode feature which allows for SQLite migrations using a copy-and-move strategy.
INFO  [alembic.runtime.migration] Running upgrade 0a8213491aaa -> 728d730b5ebd, add registered model tags table
INFO  [alembic.runtime.migration] Running upgrade 728d730b5ebd -> 27a6a02d2cf1, add model version tags table
INFO  [alembic.runtime.migration] Running upgrade 27a6a02d2cf1 -> 84291f40a231, add run_link to model_version
INFO  [alembic.runtime.migration] Running upgrade 84291f40a231 -> a8c4a736bde6, allow nulls for run_id
INFO  [alembic.runtime.migration] Running upgrade a8c4a736bde6 -> 39d1c3be5f05, add_is_nan_constraint_for_metrics_tables_if_necessary
INFO  [alembic.runtime.migration] Running upgrade 39d1c3be5f05 -> c48cb773bb87, reset_default_value_for_is_nan_in_metrics_table_for_mysql
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
[Stage 1:=============================>                             (1 + 1) / 2]INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
========================================================== 2 tests deselected ==========================================================
=============================================== 1 failed, 2 deselected in 14.21 seconds ================================================
```