### PR TITLE
Add spark model export tests in cross version tests

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -345,4 +345,12 @@ jobs:
           pip install -e .[extras]
       - name: Run tests
         run: |
+          SAGEMAKER_OUT=$(mktemp)
+          if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
+            echo "Sagemaker container build succeeded.";
+            # output the last few lines for the timing information (defaults to 10 lines)
+          else
+            echo "Sagemaker container build failed, output:";
+            cat $SAGEMAKER_OUT;
+          fi
           pytest --verbose --ignore-flavors --ignore=tests/projects tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -345,12 +345,4 @@ jobs:
           pip install -e .[extras]
       - name: Run tests
         run: |
-          SAGEMAKER_OUT=$(mktemp)
-          if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
-            echo "Sagemaker container build succeeded.";
-            # output the last few lines for the timing information (defaults to 10 lines)
-          else
-            echo "Sagemaker container build failed, output:";
-            cat $SAGEMAKER_OUT;
-          fi
           pytest --verbose --ignore-flavors --ignore=tests/projects tests

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -283,11 +283,11 @@ spark:
     requirements: ["boto3", "scikit-learn", "pyarrow"]
     run: |
       SAGEMAKER_OUT=$(mktemp)
-        if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
-          echo "Sagemaker container build succeeded.";
-          # output the last few lines for the timing information (defaults to 10 lines)
-        else
-          echo "Sagemaker container build failed, output:";
-          cat $SAGEMAKER_OUT;
+      if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
+        echo "Sagemaker container build succeeded.";
+        # output the last few lines for the timing information (defaults to 10 lines)
+      else
+        echo "Sagemaker container build failed, output:";
+        cat $SAGEMAKER_OUT;
       fi
       pytest --verbose tests/spark --large --ignore tests/spark/test_mleap_model_export.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -272,3 +272,14 @@ statsmodels:
     maximum: "0.12.2"
     run: |
       pytest tests/statsmodels/test_statsmodels_autolog.py --large
+
+spark:
+  package_info:
+    pip_release: "pyspark"
+
+  models:
+    minimum: "2.4.7"
+    maximum: "3.1.1"
+    requirements: ["boto3"]
+    run: |
+      pytest --verbose tests/spark --large  --ignore tests/spark/test_mleap_model_export.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -285,7 +285,6 @@ spark:
       SAGEMAKER_OUT=$(mktemp)
       if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
         echo "Sagemaker container build succeeded.";
-        # output the last few lines for the timing information (defaults to 10 lines)
       else
         echo "Sagemaker container build failed, output:";
         cat $SAGEMAKER_OUT;

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -280,6 +280,6 @@ spark:
   models:
     minimum: "2.4.7"
     maximum: "3.1.1"
-    requirements: ["boto3"]
+    requirements: ["boto3", "scikit-learn"]
     run: |
       pytest --verbose tests/spark --large  --ignore tests/spark/test_mleap_model_export.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -282,4 +282,4 @@ spark:
     maximum: "3.1.1"
     requirements: ["boto3", "scikit-learn", "pyarrow"]
     run: |
-      pytest --verbose tests/spark --large  --ignore tests/spark/test_mleap_model_export.py
+      pytest --verbose tests/spark --large --ignore tests/spark/test_mleap_model_export.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -278,8 +278,16 @@ spark:
     pip_release: "pyspark"
 
   models:
-    minimum: "2.4.7"
+    minimum: "3.0.0"
     maximum: "3.1.1"
     requirements: ["boto3", "scikit-learn", "pyarrow"]
     run: |
+      SAGEMAKER_OUT=$(mktemp)
+        if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
+          echo "Sagemaker container build succeeded.";
+          # output the last few lines for the timing information (defaults to 10 lines)
+        else
+          echo "Sagemaker container build failed, output:";
+          cat $SAGEMAKER_OUT;
+      fi
       pytest --verbose tests/spark --large --ignore tests/spark/test_mleap_model_export.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -288,5 +288,6 @@ spark:
       else
         echo "Sagemaker container build failed, output:";
         cat $SAGEMAKER_OUT;
+        exit 1
       fi
       pytest --verbose tests/spark --large --ignore tests/spark/test_mleap_model_export.py

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -280,6 +280,6 @@ spark:
   models:
     minimum: "2.4.7"
     maximum: "3.1.1"
-    requirements: ["boto3", "scikit-learn"]
+    requirements: ["boto3", "scikit-learn", "pyarrow"]
     run: |
       pytest --verbose tests/spark --large  --ignore tests/spark/test_mleap_model_export.py


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Add cross version tests for the spark model serialization APIs

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
