### PR TITLE
Add argument type annotations

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -326,6 +326,7 @@ nitpick_ignore = [
     ("py:class", "numpy.ndarray"),
     ("py:class", "pandas.core.series.Series"),
     ("py:class", "pandas.core.frame.DataFrame"),
+    ("py:class", "pandas.DataFrame"),
     ("py:class", "pyspark.sql.dataframe.DataFrame"),
     ("py:class", "matplotlib.figure.Figure"),
     ("py:class", "plotly.graph_objects.Figure"),

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -321,12 +321,15 @@ nitpick_ignore = [
     ("py:class", "enum.Enum"),
     ("py:class", "bytes"),
     ("py:class", "bytearray"),
-    # Suppress warnings that stem from type annotations for model signature
+    # Suppress warnings for missing references in type annotations
     ("py:class", "numpy.dtype"),
     ("py:class", "numpy.ndarray"),
     ("py:class", "pandas.core.series.Series"),
     ("py:class", "pandas.core.frame.DataFrame"),
     ("py:class", "pyspark.sql.dataframe.DataFrame"),
+    ("py:class", "matplotlib.figure.Figure"),
+    ("py:class", "plotly.graph_objects.Figure"),
+    ("py:class", "PIL.Image.Image"),
     ("py:class", "mlflow.types.schema.DataType"),
     ("py:class", "mlflow.types.schema.ColSpec"),
     ("py:class", "mlflow.types.schema.TensorSpec"),

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -33,7 +33,7 @@ from mlflow.utils.databricks_utils import get_databricks_host_creds
 _registry_uri = None
 
 
-def set_registry_uri(uri) -> None:
+def set_registry_uri(uri: str) -> None:
     """
     Set the registry server URI. This method is especially useful if you have a registry server
     that's different from the tracking server.

--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -38,7 +38,7 @@ def is_tracking_uri_set():
     return False
 
 
-def set_tracking_uri(uri) -> None:
+def set_tracking_uri(uri: str) -> None:
     """
     Set the tracking server URI. This does not affect the
     currently active run (if one exists), but takes effect for successive runs.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -11,7 +11,7 @@ import posixpath
 import sys
 import tempfile
 import yaml
-from typing import Any, Dict, Sequence, List, Optional, Union
+from typing import Any, Dict, Sequence, List, Optional, Union, TYPE_CHECKING
 
 from mlflow.entities import Experiment, Run, RunInfo, Param, Metric, RunTag, FileInfo, ViewType
 from mlflow.store.entities.paged_list import PagedList
@@ -38,6 +38,14 @@ from mlflow.utils.databricks_utils import (
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.uri import is_databricks_uri, construct_run_url
 from mlflow.utils.annotations import experimental
+
+if TYPE_CHECKING:
+    try:
+        import matplotlib
+        import plotly
+    except ImportError:
+        pass
+
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -11,9 +11,9 @@ import posixpath
 import sys
 import tempfile
 import yaml
-from typing import List, Optional
+from typing import Any, Dict, Sequence, List, Optional, Union
 
-from mlflow.entities import Experiment, Run, RunInfo, Metric, FileInfo, ViewType
+from mlflow.entities import Experiment, Run, RunInfo, Param, Metric, RunTag, FileInfo, ViewType
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.entities.model_registry import RegisteredModel, ModelVersion
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
@@ -50,7 +50,7 @@ class MlflowClient(object):
     can keep the implementation of the tracking and registry clients independent from each other.
     """
 
-    def __init__(self, tracking_uri=None, registry_uri=None):
+    def __init__(self, tracking_uri: Optional[str] = None, registry_uri: Optional[str] = None):
         """
         :param tracking_uri: Address of local or remote tracking server. If not provided, defaults
                              to the service set by ``mlflow.tracking.set_tracking_uri``. See
@@ -104,7 +104,7 @@ class MlflowClient(object):
 
     # Tracking API
 
-    def get_run(self, run_id) -> Run:
+    def get_run(self, run_id: str) -> Run:
         """
         Fetch the run from backend store. The resulting :py:class:`Run <mlflow.entities.Run>`
         contains a collection of run metadata -- :py:class:`RunInfo <mlflow.entities.RunInfo>`,
@@ -144,7 +144,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.get_run(run_id)
 
-    def get_metric_history(self, run_id, key) -> List[Metric]:
+    def get_metric_history(self, run_id: str, key: str) -> List[Metric]:
         """
         Return a list of metric objects corresponding to all values logged for a given metric.
 
@@ -211,7 +211,12 @@ class MlflowClient(object):
         """
         return self._tracking_client.get_metric_history(run_id, key)
 
-    def create_run(self, experiment_id, start_time=None, tags=None) -> Run:
+    def create_run(
+        self,
+        experiment_id: str,
+        start_time: Optional[int] = None,
+        tags: Optional[Dict[str, Any]] = None,
+    ) -> Run:
         """
         Create a :py:class:`mlflow.entities.Run` object that can be associated with
         metrics, parameters, artifacts, etc.
@@ -256,11 +261,11 @@ class MlflowClient(object):
 
     def list_run_infos(
         self,
-        experiment_id,
-        run_view_type=ViewType.ACTIVE_ONLY,
-        max_results=SEARCH_MAX_RESULTS_DEFAULT,
-        order_by=None,
-        page_token=None,
+        experiment_id: str,
+        run_view_type: str = ViewType.ACTIVE_ONLY,
+        max_results: int = SEARCH_MAX_RESULTS_DEFAULT,
+        order_by: Optional[List[str]] = None,
+        page_token: Optional[bytes] = None,
     ) -> PagedList[RunInfo]:
         """:return: List of :py:class:`mlflow.entities.RunInfo`
 
@@ -312,7 +317,7 @@ class MlflowClient(object):
             experiment_id, run_view_type, max_results, order_by, page_token
         )
 
-    def list_experiments(self, view_type=None) -> List[Experiment]:
+    def list_experiments(self, view_type: Optional[str] = None) -> List[Experiment]:
         """
         :return: List of :py:class:`mlflow.entities.Experiment`
 
@@ -357,7 +362,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.list_experiments(view_type)
 
-    def get_experiment(self, experiment_id) -> Experiment:
+    def get_experiment(self, experiment_id: str) -> Experiment:
         """
         Retrieve an experiment by experiment_id from the backend store
 
@@ -389,7 +394,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.get_experiment(experiment_id)
 
-    def get_experiment_by_name(self, name) -> Optional[Experiment]:
+    def get_experiment_by_name(self, name: str) -> Optional[Experiment]:
         """
         Retrieve an experiment by experiment name from the backend store
 
@@ -422,7 +427,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.get_experiment_by_name(name)
 
-    def create_experiment(self, name, artifact_location=None) -> str:
+    def create_experiment(self, name: str, artifact_location: Optional[str] = None) -> str:
         """Create an experiment.
 
         :param name: The experiment name. Must be unique.
@@ -459,7 +464,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.create_experiment(name, artifact_location)
 
-    def delete_experiment(self, experiment_id) -> None:
+    def delete_experiment(self, experiment_id: str) -> None:
         """
         Delete an experiment from the backend store.
 
@@ -490,7 +495,7 @@ class MlflowClient(object):
         """
         self._tracking_client.delete_experiment(experiment_id)
 
-    def restore_experiment(self, experiment_id) -> None:
+    def restore_experiment(self, experiment_id: str) -> None:
         """
         Restore a deleted experiment unless permanently deleted.
 
@@ -534,7 +539,7 @@ class MlflowClient(object):
         """
         self._tracking_client.restore_experiment(experiment_id)
 
-    def rename_experiment(self, experiment_id, new_name) -> None:
+    def rename_experiment(self, experiment_id: str, new_name: str) -> None:
         """
         Update an experiment's name. The new name must be unique.
 
@@ -577,7 +582,14 @@ class MlflowClient(object):
         """
         self._tracking_client.rename_experiment(experiment_id, new_name)
 
-    def log_metric(self, run_id, key, value, timestamp=None, step=None) -> None:
+    def log_metric(
+        self,
+        run_id: str,
+        key: str,
+        value: float,
+        timestamp: Optional[int] = None,
+        step: Optional[int] = None,
+    ) -> None:
         """
         Log a metric against the run ID.
 
@@ -630,7 +642,7 @@ class MlflowClient(object):
         """
         self._tracking_client.log_metric(run_id, key, value, timestamp, step)
 
-    def log_param(self, run_id, key, value) -> None:
+    def log_param(self, run_id: str, key: str, value: Any) -> None:
         """
         Log a parameter against the run ID.
 
@@ -677,7 +689,7 @@ class MlflowClient(object):
         """
         self._tracking_client.log_param(run_id, key, value)
 
-    def set_experiment_tag(self, experiment_id, key, value) -> None:
+    def set_experiment_tag(self, experiment_id: str, key: str, value: Any) -> None:
         """
         Set a tag on the experiment with the specified ID. Value is converted to a string.
 
@@ -708,7 +720,7 @@ class MlflowClient(object):
         """
         self._tracking_client.set_experiment_tag(experiment_id, key, value)
 
-    def set_tag(self, run_id, key, value) -> None:
+    def set_tag(self, run_id: str, key: str, value: Any) -> None:
         """
         Set a tag on the run with the specified ID. Value is converted to a string.
 
@@ -748,7 +760,7 @@ class MlflowClient(object):
         """
         self._tracking_client.set_tag(run_id, key, value)
 
-    def delete_tag(self, run_id, key) -> None:
+    def delete_tag(self, run_id: str, key: str) -> None:
         """
         Delete a tag from a run. This is irreversible.
 
@@ -788,7 +800,13 @@ class MlflowClient(object):
         """
         self._tracking_client.delete_tag(run_id, key)
 
-    def log_batch(self, run_id, metrics=(), params=(), tags=()) -> None:
+    def log_batch(
+        self,
+        run_id: str,
+        metrics: Sequence[Metric] = (),
+        params: Sequence[Param] = (),
+        tags: Sequence[RunTag] = (),
+    ) -> None:
         """
         Log multiple metrics, params, and/or tags.
 
@@ -878,7 +896,9 @@ class MlflowClient(object):
         """
         self._tracking_client.log_artifact(run_id, local_path, artifact_path)
 
-    def log_artifacts(self, run_id, local_dir, artifact_path=None) -> None:
+    def log_artifacts(
+        self, run_id: str, local_dir: str, artifact_path: Optional[str] = None
+    ) -> None:
         """
         Write a directory of files to the remote ``artifact_uri``.
 
@@ -941,7 +961,7 @@ class MlflowClient(object):
             yield tmp_path
             self.log_artifact(run_id, tmp_path, artifact_dir)
 
-    def log_text(self, run_id, text, artifact_file) -> None:
+    def log_text(self, run_id: str, text: str, artifact_file: str) -> None:
         """
         Log text as an artifact.
 
@@ -972,7 +992,7 @@ class MlflowClient(object):
                 f.write(text)
 
     @experimental
-    def log_dict(self, run_id, dictionary, artifact_file) -> None:
+    def log_dict(self, run_id: str, dictionary: Dict, artifact_file: str) -> None:
         """
         Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
         inferred from the extension of `artifact_file`. If the file extension doesn't exist or
@@ -1016,7 +1036,12 @@ class MlflowClient(object):
                     json.dump(dictionary, f, indent=2)
 
     @experimental
-    def log_figure(self, run_id, figure, artifact_file) -> None:
+    def log_figure(
+        self,
+        run_id: str,
+        figure: Union["matplotlib.figure.Figure", "plotly.graph_objects.Figure"],
+        artifact_file: str,
+    ) -> None:
         """
         Log a figure as an artifact. The following figure objects are supported:
 
@@ -1080,7 +1105,9 @@ class MlflowClient(object):
                 raise TypeError("Unsupported figure object type: '{}'".format(type(figure)))
 
     @experimental
-    def log_image(self, run_id, image, artifact_file) -> None:
+    def log_image(
+        self, run_id: str, image: Union["np.ndarray", "PIL.Image.Image"], artifact_file: str
+    ) -> None:
         """
         Log an image as an artifact. The following image objects are supported:
 
@@ -1232,7 +1259,7 @@ class MlflowClient(object):
         """
         self._tracking_client._record_logged_model(run_id, mlflow_model)
 
-    def list_artifacts(self, run_id, path=None) -> List[FileInfo]:
+    def list_artifacts(self, run_id: str, path=None) -> List[FileInfo]:
         """
         List the artifacts for a run.
 
@@ -1283,7 +1310,7 @@ class MlflowClient(object):
         """
         return self._tracking_client.list_artifacts(run_id, path)
 
-    def download_artifacts(self, run_id, path, dst_path=None) -> str:
+    def download_artifacts(self, run_id: str, path: str, dst_path: Optional[str] = None) -> str:
         """
         Download an artifact file or directory from a run to a local directory if applicable,
         and return a local path for it.
@@ -1329,7 +1356,9 @@ class MlflowClient(object):
         """
         return self._tracking_client.download_artifacts(run_id, path, dst_path)
 
-    def set_terminated(self, run_id, status=None, end_time=None) -> None:
+    def set_terminated(
+        self, run_id: str, status: Optional[str] = None, end_time: Optional[int] = None
+    ) -> None:
         """Set a run's status to terminated.
 
         :param status: A string value of :py:class:`mlflow.entities.RunStatus`.
@@ -1372,7 +1401,7 @@ class MlflowClient(object):
         """
         self._tracking_client.set_terminated(run_id, status, end_time)
 
-    def delete_run(self, run_id) -> None:
+    def delete_run(self, run_id: str) -> None:
         """Deletes a run with the given ID.
 
         :param run_id: The unique run id to delete.
@@ -1401,7 +1430,7 @@ class MlflowClient(object):
         """
         self._tracking_client.delete_run(run_id)
 
-    def restore_run(self, run_id) -> None:
+    def restore_run(self, run_id: str) -> None:
         """
         Restores a deleted run with the given ID.
 
@@ -1436,12 +1465,12 @@ class MlflowClient(object):
 
     def search_runs(
         self,
-        experiment_ids,
-        filter_string="",
-        run_view_type=ViewType.ACTIVE_ONLY,
-        max_results=SEARCH_MAX_RESULTS_DEFAULT,
-        order_by=None,
-        page_token=None,
+        experiment_ids: List[str],
+        filter_string: str = "",
+        run_view_type: str = ViewType.ACTIVE_ONLY,
+        max_results: int = SEARCH_MAX_RESULTS_DEFAULT,
+        order_by: Optional[List[str]] = None,
+        page_token: Optional[bytes] = None,
     ) -> PagedList[Run]:
         """
         Search experiments that fit the search criteria.
@@ -1529,7 +1558,9 @@ class MlflowClient(object):
 
     # Registered Model Methods
 
-    def create_registered_model(self, name, tags=None, description=None) -> RegisteredModel:
+    def create_registered_model(
+        self, name: str, tags: Optional[Dict[str, Any]] = None, description: Optional[str] = None
+    ) -> RegisteredModel:
         """
         Create a new registered model in backend store.
 
@@ -1569,7 +1600,7 @@ class MlflowClient(object):
         """
         return self._get_registry_client().create_registered_model(name, tags, description)
 
-    def rename_registered_model(self, name, new_name) -> RegisteredModel:
+    def rename_registered_model(self, name: str, new_name: str) -> RegisteredModel:
         """
         Update registered model name.
 
@@ -1618,7 +1649,9 @@ class MlflowClient(object):
         """
         self._get_registry_client().rename_registered_model(name, new_name)
 
-    def update_registered_model(self, name, description=None) -> RegisteredModel:
+    def update_registered_model(
+        self, name: str, description: Optional[str] = None
+    ) -> RegisteredModel:
         """
         Updates metadata for RegisteredModel entity. Input field ``description`` should be non-None.
         Backend raises exception if a registered model with given name does not exist.
@@ -1668,7 +1701,7 @@ class MlflowClient(object):
             name=name, description=description
         )
 
-    def delete_registered_model(self, name):
+    def delete_registered_model(self, name: str):
         """
         Delete registered model.
         Backend raises exception if a registered model with given name does not exist.
@@ -1721,7 +1754,9 @@ class MlflowClient(object):
         self._get_registry_client().delete_registered_model(name)
 
     def list_registered_models(
-        self, max_results=SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT, page_token=None
+        self,
+        max_results: int = SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
+        page_token: Optional[bytes] = None,
     ) -> PagedList[RegisteredModel]:
         """
         List of all registered models
@@ -1773,10 +1808,10 @@ class MlflowClient(object):
 
     def search_registered_models(
         self,
-        filter_string=None,
-        max_results=SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
-        order_by=None,
-        page_token=None,
+        filter_string: Optional[str] = None,
+        max_results: int = SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
+        order_by: Optional[List[str]] = None,
+        page_token: Optional[bytes] = None,
     ) -> PagedList[RegisteredModel]:
         """
         Search for registered models in backend that satisfy the filter criteria.
@@ -1850,7 +1885,7 @@ class MlflowClient(object):
             filter_string, max_results, order_by, page_token
         )
 
-    def get_registered_model(self, name) -> RegisteredModel:
+    def get_registered_model(self, name: str) -> RegisteredModel:
         """
         :param name: Name of the registered model to update.
         :return: A single :py:class:`mlflow.entities.model_registry.RegisteredModel` object.
@@ -1888,7 +1923,7 @@ class MlflowClient(object):
         """
         return self._get_registry_client().get_registered_model(name)
 
-    def get_latest_versions(self, name, stages=None) -> ModelVersion:
+    def get_latest_versions(self, name: str, stages: List[str] = None) -> ModelVersion:
         """
         Latest version models for each requests stage. If no ``stages`` provided, returns the
         latest version for each stage.
@@ -2002,7 +2037,7 @@ class MlflowClient(object):
         """
         self._get_registry_client().set_registered_model_tag(name, key, value)
 
-    def delete_registered_model_tag(self, name, key) -> None:
+    def delete_registered_model_tag(self, name: str, key: str) -> None:
         """
         Delete a tag associated with the registered model.
 
@@ -2056,13 +2091,13 @@ class MlflowClient(object):
 
     def create_model_version(
         self,
-        name,
-        source,
-        run_id=None,
-        tags=None,
-        run_link=None,
-        description=None,
-        await_creation_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
+        name: str,
+        source: str,
+        run_id: Optional[str] = None,
+        tags: Optional[Dict[str, Any]] = None,
+        run_link: Optional[str] = None,
+        description: Optional[str] = None,
+        await_creation_for: int = DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
     ) -> ModelVersion:
         """
         Create a new model version from given source (artifact URI).
@@ -2183,7 +2218,9 @@ class MlflowClient(object):
         if workspace_host and run_id and experiment_id:
             return construct_run_url(workspace_host, experiment_id, run_id, workspace_id)
 
-    def update_model_version(self, name, version, description=None) -> ModelVersion:
+    def update_model_version(
+        self, name: str, version: str, description: Optional[str] = None
+    ) -> ModelVersion:
         """
         Update metadata associated with a model version in backend.
 
@@ -2249,7 +2286,7 @@ class MlflowClient(object):
         )
 
     def transition_model_version_stage(
-        self, name, version, stage, archive_existing_versions=False
+        self, name: str, version: str, stage: str, archive_existing_versions: bool = False
     ) -> ModelVersion:
         """
         Update model version stage.
@@ -2318,7 +2355,7 @@ class MlflowClient(object):
             name, version, stage, archive_existing_versions
         )
 
-    def delete_model_version(self, name, version) -> None:
+    def delete_model_version(self, name: str, version: str) -> None:
         """
         Delete model version in backend.
 
@@ -2397,7 +2434,7 @@ class MlflowClient(object):
         """
         self._get_registry_client().delete_model_version(name, version)
 
-    def get_model_version(self, name, version) -> ModelVersion:
+    def get_model_version(self, name: str, version: str) -> ModelVersion:
         """
         :param name: Name of the containing registered model.
         :param version: Version number as an integer of the model version.
@@ -2450,7 +2487,7 @@ class MlflowClient(object):
         """
         return self._get_registry_client().get_model_version(name, version)
 
-    def get_model_version_download_uri(self, name, version) -> str:
+    def get_model_version_download_uri(self, name: str, version: str) -> str:
         """
         Get the download location in Model Registry for this model version.
 
@@ -2492,7 +2529,7 @@ class MlflowClient(object):
         """
         return self._get_registry_client().get_model_version_download_uri(name, version)
 
-    def search_model_versions(self, filter_string) -> PagedList[ModelVersion]:
+    def search_model_versions(self, filter_string: str) -> PagedList[ModelVersion]:
         """
         Search for model versions in backend that satisfy the filter criteria.
 
@@ -2537,7 +2574,7 @@ class MlflowClient(object):
         return self._get_registry_client().search_model_versions(filter_string)
 
     def get_model_version_stages(
-        self, name, version  # pylint: disable=unused-argument
+        self, name: str, version: str  # pylint: disable=unused-argument
     ) -> List[str]:
         """
         :return: A list of valid stages.
@@ -2577,7 +2614,7 @@ class MlflowClient(object):
         """
         return ALL_STAGES
 
-    def set_model_version_tag(self, name, version, key, value) -> None:
+    def set_model_version_tag(self, name: str, version: str, key: str, value: Any) -> None:
         """
         Set a tag for the model version.
 
@@ -2636,7 +2673,7 @@ class MlflowClient(object):
         """
         self._get_registry_client().set_model_version_tag(name, version, key, value)
 
-    def delete_model_version_tag(self, name, version, key) -> None:
+    def delete_model_version_tag(self, name: str, version: str, key: str) -> None:
         """
         Delete a tag associated with the model version.
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1106,7 +1106,7 @@ class MlflowClient(object):
 
     @experimental
     def log_image(
-        self, run_id: str, image: Union["np.ndarray", "PIL.Image.Image"], artifact_file: str
+        self, run_id: str, image: Union["numpy.ndarray", "PIL.Image.Image"], artifact_file: str
     ) -> None:
         """
         Log an image as an artifact. The following image objects are supported:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -992,11 +992,12 @@ class MlflowClient(object):
                 f.write(text)
 
     @experimental
-    def log_dict(self, run_id: str, dictionary: Dict, artifact_file: str) -> None:
+    def log_dict(self, run_id: str, dictionary: Any, artifact_file: str) -> None:
         """
-        Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
-        inferred from the extension of `artifact_file`. If the file extension doesn't exist or
-        match any of [".json", ".yml", ".yaml"], JSON format is used.
+        Log a JSON/YAML-serializable object (e.g. `dict`) as an artifact. The serialization
+        format (JSON or YAML) is automatically inferred from the extension of `artifact_file`.
+        If the file extension doesn't exist or match any of [".json", ".yml", ".yaml"],
+        JSON format is used.
 
         :param run_id: String ID of the run.
         :param dictionary: Dictionary to log.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -265,7 +265,7 @@ class MlflowClient(object):
         run_view_type: int = ViewType.ACTIVE_ONLY,
         max_results: int = SEARCH_MAX_RESULTS_DEFAULT,
         order_by: Optional[List[str]] = None,
-        page_token: Optional[bytes] = None,
+        page_token: Optional[str] = None,
     ) -> PagedList[RunInfo]:
         """:return: List of :py:class:`mlflow.entities.RunInfo`
 
@@ -1471,7 +1471,7 @@ class MlflowClient(object):
         run_view_type: int = ViewType.ACTIVE_ONLY,
         max_results: int = SEARCH_MAX_RESULTS_DEFAULT,
         order_by: Optional[List[str]] = None,
-        page_token: Optional[bytes] = None,
+        page_token: Optional[str] = None,
     ) -> PagedList[Run]:
         """
         Search experiments that fit the search criteria.
@@ -1757,7 +1757,7 @@ class MlflowClient(object):
     def list_registered_models(
         self,
         max_results: int = SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
-        page_token: Optional[bytes] = None,
+        page_token: Optional[str] = None,
     ) -> PagedList[RegisteredModel]:
         """
         List of all registered models
@@ -1812,7 +1812,7 @@ class MlflowClient(object):
         filter_string: Optional[str] = None,
         max_results: int = SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
         order_by: Optional[List[str]] = None,
-        page_token: Optional[bytes] = None,
+        page_token: Optional[str] = None,
     ) -> PagedList[RegisteredModel]:
         """
         Search for registered models in backend that satisfy the filter criteria.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -42,8 +42,8 @@ from mlflow.utils.annotations import experimental
 if TYPE_CHECKING:
     import matplotlib  # pylint: disable=unused-import
     import plotly  # pylint: disable=unused-import
-    import PIL  # pylint: disable=unused-import
     import numpy  # pylint: disable=unused-import
+    import PIL  # pylint: disable=unused-import
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -40,12 +40,10 @@ from mlflow.utils.uri import is_databricks_uri, construct_run_url
 from mlflow.utils.annotations import experimental
 
 if TYPE_CHECKING:
-    try:
-        import matplotlib
-        import plotly
-    except ImportError:
-        pass
-
+    import matplotlib  # pylint: disable=unused-import
+    import plotly  # pylint: disable=unused-import
+    import PIL  # pylint: disable=unused-import
+    import numpy  # pylint: disable=unused-import
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -262,7 +262,7 @@ class MlflowClient(object):
     def list_run_infos(
         self,
         experiment_id: str,
-        run_view_type: str = ViewType.ACTIVE_ONLY,
+        run_view_type: int = ViewType.ACTIVE_ONLY,
         max_results: int = SEARCH_MAX_RESULTS_DEFAULT,
         order_by: Optional[List[str]] = None,
         page_token: Optional[bytes] = None,
@@ -1467,7 +1467,7 @@ class MlflowClient(object):
         self,
         experiment_ids: List[str],
         filter_string: str = "",
-        run_view_type: str = ViewType.ACTIVE_ONLY,
+        run_view_type: int = ViewType.ACTIVE_ONLY,
         max_results: int = SEARCH_MAX_RESULTS_DEFAULT,
         order_by: Optional[List[str]] = None,
         page_token: Optional[bytes] = None,

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -31,11 +31,11 @@ from mlflow.utils.validation import _validate_run_id
 from mlflow.utils.annotations import experimental
 
 if TYPE_CHECKING:
+    import pandas  # pylint: disable=unused-import
     import matplotlib  # pylint: disable=unused-import
     import plotly  # pylint: disable=unused-import
-    import PIL  # pylint: disable=unused-import
     import numpy  # pylint: disable=unused-import
-    import pandas  # pylint: disable=unused-import
+    import PIL  # pylint: disable=unused-import
 
 
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -1238,13 +1238,13 @@ def _get_experiment_id():
 
 @autologging_integration("mlflow")
 def autolog(
-    log_input_examples=False,
-    log_model_signatures=True,
-    log_models=True,
-    disable=False,
-    exclusive=False,
-    disable_for_unsupported_versions=False,
-    silent=False,
+    log_input_examples: bool = False,
+    log_model_signatures: bool = True,
+    log_models: bool = True,
+    disable: bool = False,
+    exclusive: bool = False,
+    disable_for_unsupported_versions: bool = False,
+    silent: bool = False,
     # pylint: disable=unused-argument
 ) -> None:
     """

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -8,7 +8,7 @@ import atexit
 import time
 import logging
 import inspect
-from typing import List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from mlflow.entities import Experiment, Run, RunInfo, RunStatus, Param, RunTag, Metric, ViewType
 from mlflow.entities.lifecycle_stage import LifecycleStage
@@ -49,7 +49,7 @@ NUM_RUNS_PER_PAGE_PANDAS = 10000
 _logger = logging.getLogger(__name__)
 
 
-def set_experiment(experiment_name) -> None:
+def set_experiment(experiment_name: str) -> None:
     """
     Set given experiment as active experiment. If experiment does not exist, create an experiment
     with provided name.
@@ -110,7 +110,13 @@ class ActiveRun(Run):  # pylint: disable=W0223
         return exc_type is None
 
 
-def start_run(run_id=None, experiment_id=None, run_name=None, nested=False, tags=None) -> ActiveRun:
+def start_run(
+    run_id: str = None,
+    experiment_id: Optional[str] = None,
+    run_name: Optional[str] = None,
+    nested: bool = False,
+    tags: Optional[Dict[str, Any]] = None,
+) -> ActiveRun:
     """
     Start a new MLflow run, setting it as the active run under which metrics and parameters
     will be logged. The return value can be used as a context manager within a ``with`` block;
@@ -239,7 +245,7 @@ def start_run(run_id=None, experiment_id=None, run_name=None, nested=False, tags
     return _active_run_stack[-1]
 
 
-def end_run(status=RunStatus.to_string(RunStatus.FINISHED)) -> None:
+def end_run(status: str = RunStatus.to_string(RunStatus.FINISHED)) -> None:
     """End an active MLflow run (if there is one).
 
     .. code-block:: python
@@ -305,7 +311,7 @@ def active_run() -> Optional[ActiveRun]:
     return _active_run_stack[-1] if len(_active_run_stack) > 0 else None
 
 
-def get_run(run_id) -> Run:
+def get_run(run_id: str) -> Run:
     """
     Fetch the run from backend store. The resulting :py:class:`Run <mlflow.entities.Run>`
     contains a collection of run metadata -- :py:class:`RunInfo <mlflow.entities.RunInfo>`,
@@ -339,7 +345,7 @@ def get_run(run_id) -> Run:
     return MlflowClient().get_run(run_id)
 
 
-def log_param(key, value) -> None:
+def log_param(key: str, value: Any) -> None:
     """
     Log a parameter under the current run. If no run is active, this method will create
     a new active run.
@@ -359,7 +365,7 @@ def log_param(key, value) -> None:
     MlflowClient().log_param(run_id, key, value)
 
 
-def set_tag(key, value) -> None:
+def set_tag(key: str, value: Any) -> None:
     """
     Set a tag under the current run. If no run is active, this method will create a
     new active run.
@@ -379,7 +385,7 @@ def set_tag(key, value) -> None:
     MlflowClient().set_tag(run_id, key, value)
 
 
-def delete_tag(key) -> None:
+def delete_tag(key: str) -> None:
     """
     Delete a tag from a run. This is irreversible. If no run is active, this method
     will create a new active run.
@@ -404,7 +410,7 @@ def delete_tag(key) -> None:
     MlflowClient().delete_tag(run_id, key)
 
 
-def log_metric(key, value, step=None) -> None:
+def log_metric(key: str, value: float, step: Optional[int] = None) -> None:
     """
     Log a metric under the current run. If no run is active, this method will create
     a new active run.
@@ -427,7 +433,7 @@ def log_metric(key, value, step=None) -> None:
     MlflowClient().log_metric(run_id, key, value, int(time.time() * 1000), step or 0)
 
 
-def log_metrics(metrics, step=None) -> None:
+def log_metrics(metrics: Dict[str, float], step: Optional[int] = None) -> None:
     """
     Log multiple metrics for the current run. If no run is active, this method will create a new
     active run.
@@ -458,7 +464,7 @@ def log_metrics(metrics, step=None) -> None:
     MlflowClient().log_batch(run_id=run_id, metrics=metrics_arr, params=[], tags=[])
 
 
-def log_params(params) -> None:
+def log_params(params: Dict[str, Any]) -> None:
     """
     Log a batch of params for the current run. If no run is active, this method will create a
     new active run.
@@ -483,7 +489,7 @@ def log_params(params) -> None:
     MlflowClient().log_batch(run_id=run_id, metrics=[], params=params_arr, tags=[])
 
 
-def set_tags(tags) -> None:
+def set_tags(tags: Dict[str, Any]) -> None:
     """
     Log a batch of tags for the current run. If no run is active, this method will create a
     new active run.
@@ -510,7 +516,7 @@ def set_tags(tags) -> None:
     MlflowClient().log_batch(run_id=run_id, metrics=[], params=[], tags=tags_arr)
 
 
-def log_artifact(local_path, artifact_path=None) -> None:
+def log_artifact(local_path: str, artifact_path: Optional[str] = None) -> None:
     """
     Log a local file or directory as an artifact of the currently active run. If no run is
     active, this method will create a new active run.
@@ -537,7 +543,7 @@ def log_artifact(local_path, artifact_path=None) -> None:
     MlflowClient().log_artifact(run_id, local_path, artifact_path)
 
 
-def log_artifacts(local_dir, artifact_path=None) -> None:
+def log_artifacts(local_dir: str, artifact_path: Optional[str] = None) -> None:
     """
     Log all the contents of a local directory as artifacts of the run. If no run is active,
     this method will create a new active run.
@@ -570,7 +576,7 @@ def log_artifacts(local_dir, artifact_path=None) -> None:
     MlflowClient().log_artifacts(run_id, local_dir, artifact_path)
 
 
-def log_text(text, artifact_file) -> None:
+def log_text(text: str, artifact_file: str) -> None:
     """
     Log text as an artifact.
 
@@ -598,7 +604,7 @@ def log_text(text, artifact_file) -> None:
 
 
 @experimental
-def log_dict(dictionary, artifact_file) -> None:
+def log_dict(dictionary: Dict, artifact_file: str) -> None:
     """
     Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
     inferred from the extension of `artifact_file`. If the file extension doesn't exist or match
@@ -632,7 +638,9 @@ def log_dict(dictionary, artifact_file) -> None:
 
 
 @experimental
-def log_figure(figure, artifact_file) -> None:
+def log_figure(
+    figure: Union["matplotlib.figure.Figure", "plotly.graph_objects.Figure"], artifact_file: str
+) -> None:
     """
     Log a figure as an artifact. The following figure objects are supported:
 
@@ -677,7 +685,7 @@ def log_figure(figure, artifact_file) -> None:
 
 
 @experimental
-def log_image(image, artifact_file) -> None:
+def log_image(image: Union["np.ndarray", "PIL.Image.Image"], artifact_file: str) -> None:
     """
     Log an image as an artifact. The following image objects are supported:
 
@@ -745,7 +753,7 @@ def _record_logged_model(mlflow_model):
     MlflowClient()._record_logged_model(run_id, mlflow_model)
 
 
-def get_experiment(experiment_id) -> Experiment:
+def get_experiment(experiment_id: str) -> Experiment:
     """
     Retrieve an experiment by experiment_id from the backend store
 
@@ -774,7 +782,7 @@ def get_experiment(experiment_id) -> Experiment:
     return MlflowClient().get_experiment(experiment_id)
 
 
-def get_experiment_by_name(name) -> Optional[Experiment]:
+def get_experiment_by_name(name: str) -> Optional[Experiment]:
     """
     Retrieve an experiment by experiment name from the backend store
 
@@ -805,7 +813,7 @@ def get_experiment_by_name(name) -> Optional[Experiment]:
     return MlflowClient().get_experiment_by_name(name)
 
 
-def create_experiment(name, artifact_location=None) -> str:
+def create_experiment(name: str, artifact_location: Optional[str] = None) -> str:
     """
     Create an experiment.
 
@@ -840,7 +848,7 @@ def create_experiment(name, artifact_location=None) -> str:
     return MlflowClient().create_experiment(name, artifact_location)
 
 
-def delete_experiment(experiment_id) -> None:
+def delete_experiment(experiment_id: str) -> None:
     """
     Delete an experiment from the backend store.
 
@@ -870,7 +878,7 @@ def delete_experiment(experiment_id) -> None:
     MlflowClient().delete_experiment(experiment_id)
 
 
-def delete_run(run_id) -> None:
+def delete_run(run_id: str) -> None:
     """
     Deletes a run with the given ID.
 
@@ -898,7 +906,7 @@ def delete_run(run_id) -> None:
     MlflowClient().delete_run(run_id)
 
 
-def get_artifact_uri(artifact_path=None) -> str:
+def get_artifact_uri(artifact_path: Optional[str] = None) -> str:
     """
     Get the absolute URI of the specified artifact in the currently active run.
     If `path` is not specified, the artifact root URI of the currently active
@@ -950,12 +958,12 @@ def get_artifact_uri(artifact_path=None) -> str:
 
 
 def search_runs(
-    experiment_ids=None,
-    filter_string="",
-    run_view_type=ViewType.ACTIVE_ONLY,
-    max_results=SEARCH_MAX_RESULTS_PANDAS,
-    order_by=None,
-    output_format="pandas",
+    experiment_ids: Optional[List[str]] = None,
+    filter_string: str = "",
+    run_view_type: str = ViewType.ACTIVE_ONLY,
+    max_results: int = SEARCH_MAX_RESULTS_PANDAS,
+    order_by: Optional[List[str]] = None,
+    output_format: str = "pandas",
 ) -> SearchRunsReturnType:
     """
     Get a pandas DataFrame of runs that fit the search criteria.
@@ -1104,10 +1112,10 @@ def search_runs(
 
 
 def list_run_infos(
-    experiment_id,
-    run_view_type=ViewType.ACTIVE_ONLY,
-    max_results=SEARCH_MAX_RESULTS_DEFAULT,
-    order_by=None,
+    experiment_id: str,
+    run_view_type: str = ViewType.ACTIVE_ONLY,
+    max_results: int = SEARCH_MAX_RESULTS_DEFAULT,
+    order_by: Optional[List[str]] = None,
 ) -> List[RunInfo]:
     """
     Return run information for runs which belong to the experiment_id.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -8,7 +8,7 @@ import atexit
 import time
 import logging
 import inspect
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, TYPE_CHECKING
 
 from mlflow.entities import Experiment, Run, RunInfo, RunStatus, Param, RunTag, Metric, ViewType
 from mlflow.entities.lifecycle_stage import LifecycleStage
@@ -30,12 +30,14 @@ from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID, MLFLOW_RUN_NAME
 from mlflow.utils.validation import _validate_run_id
 from mlflow.utils.annotations import experimental
 
-try:
-    import pandas as pd
+if TYPE_CHECKING:
+    try:
+        import matplotlib
+        import plotly
+        import pandas as pd
+    except ImportError:
+        pass
 
-    SearchRunsReturnType = Union[pd.DataFrame, List[Run]]
-except ImportError:
-    SearchRunsReturnType = List[Run]
 
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"
 _EXPERIMENT_NAME_ENV_VAR = "MLFLOW_EXPERIMENT_NAME"
@@ -965,7 +967,7 @@ def search_runs(
     max_results: int = SEARCH_MAX_RESULTS_PANDAS,
     order_by: Optional[List[str]] = None,
     output_format: str = "pandas",
-) -> SearchRunsReturnType:
+) -> Union[List[Run], "pd.DataFrame"]:
     """
     Get a pandas DataFrame of runs that fit the search criteria.
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -960,7 +960,7 @@ def get_artifact_uri(artifact_path: Optional[str] = None) -> str:
 def search_runs(
     experiment_ids: Optional[List[str]] = None,
     filter_string: str = "",
-    run_view_type: str = ViewType.ACTIVE_ONLY,
+    run_view_type: int = ViewType.ACTIVE_ONLY,
     max_results: int = SEARCH_MAX_RESULTS_PANDAS,
     order_by: Optional[List[str]] = None,
     output_format: str = "pandas",
@@ -1113,7 +1113,7 @@ def search_runs(
 
 def list_run_infos(
     experiment_id: str,
-    run_view_type: str = ViewType.ACTIVE_ONLY,
+    run_view_type: int = ViewType.ACTIVE_ONLY,
     max_results: int = SEARCH_MAX_RESULTS_DEFAULT,
     order_by: Optional[List[str]] = None,
 ) -> List[RunInfo]:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -31,12 +31,11 @@ from mlflow.utils.validation import _validate_run_id
 from mlflow.utils.annotations import experimental
 
 if TYPE_CHECKING:
-    try:
-        import matplotlib
-        import plotly
-        import pandas as pd
-    except ImportError:
-        pass
+    import matplotlib  # pylint: disable=unused-import
+    import plotly  # pylint: disable=unused-import
+    import PIL  # pylint: disable=unused-import
+    import numpy  # pylint: disable=unused-import
+    import pandas  # pylint: disable=unused-import
 
 
 _EXPERIMENT_ID_ENV_VAR = "MLFLOW_EXPERIMENT_ID"
@@ -967,7 +966,7 @@ def search_runs(
     max_results: int = SEARCH_MAX_RESULTS_PANDAS,
     order_by: Optional[List[str]] = None,
     output_format: str = "pandas",
-) -> Union[List[Run], "pd.DataFrame"]:
+) -> Union[List[Run], "pandas.DataFrame"]:
     """
     Get a pandas DataFrame of runs that fit the search criteria.
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -604,15 +604,16 @@ def log_text(text: str, artifact_file: str) -> None:
 
 
 @experimental
-def log_dict(dictionary: Dict, artifact_file: str) -> None:
+def log_dict(dictionary: Any, artifact_file: str) -> None:
     """
-    Log a dictionary as an artifact. The serialization format (JSON or YAML) is automatically
-    inferred from the extension of `artifact_file`. If the file extension doesn't exist or match
-    any of [".json", ".yml", ".yaml"], JSON format is used.
+    Log a JSON/YAML-serializable object (e.g. `dict`) as an artifact. The serialization
+    format (JSON or YAML) is automatically inferred from the extension of `artifact_file`.
+    If the file extension doesn't exist or match any of [".json", ".yml", ".yaml"],
+    JSON format is used.
 
     :param dictionary: Dictionary to log.
     :param artifact_file: The run-relative artifact file path in posixpath format to which
-                            the dictionary is saved (e.g. "dir/data.json").
+                          the dictionary is saved (e.g. "dir/data.json").
 
     .. code-block:: python
         :caption: Example

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -685,7 +685,7 @@ def log_figure(
 
 
 @experimental
-def log_image(image: Union["np.ndarray", "PIL.Image.Image"], artifact_file: str) -> None:
+def log_image(image: Union["numpy.ndarray", "PIL.Image.Image"], artifact_file: str) -> None:
     """
     Log an image as an artifact. The following image objects are supported:
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- Follow-up for #4242 
- Add argument type annotations

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
