### PR TITLE
[DO NOT MREGE] Debug spark datasource logging

### DIFF
--- a/dev/run-python-tf-tests.sh
+++ b/dev/run-python-tf-tests.sh
@@ -6,17 +6,17 @@ err=0
 trap 'err=1' ERR
 export MLFLOW_HOME=$(pwd)
 
-pytest --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
-pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
-pytest --verbose tests/keras --large
-pytest --verbose tests/keras_autolog --large
-# Downgrade TensorFlow and Keras in order to test compatibility with older versions
-pip install 'tensorflow==1.15.4'
-pip install 'keras==2.2.5'
-pytest --verbose tests/keras --large
-pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
-pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
-pytest --verbose tests/keras_autolog --large
+# pytest --verbose tests/tensorflow/test_tensorflow2_model_export.py --large
+# pytest --verbose tests/tensorflow_autolog/test_tensorflow2_autolog.py --large
+# pytest --verbose tests/keras --large
+# pytest --verbose tests/keras_autolog --large
+# # Downgrade TensorFlow and Keras in order to test compatibility with older versions
+# pip install 'tensorflow==1.15.4'
+# pip install 'keras==2.2.5'
+# pytest --verbose tests/keras --large
+# pytest --verbose tests/tensorflow/test_tensorflow_model_export.py --large
+# pytest --verbose tests/tensorflow_autolog/test_tensorflow_autolog.py --large
+# pytest --verbose tests/keras_autolog --large
 
 # Run Spark autologging tests, which rely on tensorflow
 ./dev/test-spark-autologging.sh

--- a/dev/test-spark-autologging.sh
+++ b/dev/test-spark-autologging.sh
@@ -2,7 +2,7 @@
 # Test Spark autologging against the Spark 3.0 preview. This script is temporary and should be
 # removed once Spark 3.0 is released in favor of simply updating all tests to run against Spark 3.0
 # (i.e. updating the pyspark dependency version in dev/large-requirements.txt)
-set -ex
+# set -ex
 
 # Build Java package
 pushd mlflow/java/spark

--- a/dev/test-spark-autologging.sh
+++ b/dev/test-spark-autologging.sh
@@ -9,6 +9,10 @@ pushd mlflow/java/spark
 mvn package -DskipTests -q
 popd
 
+spark-submit --version
+pytest tests/spark_autologging/datasource/test_spark_datasource_autologging.py \
+  -k test_autologging_of_datasources_with_different_formats --large --verbose --capture=no
+
 # Install PySpark 3.0 preview & run tests. For faster local iteration, you can also simply download
 # the .tgz used below (http://mirror.cogentco.com/pub/apache/spark/spark-3.0.0-preview/spark-3.0.0-preview-bin-hadoop2.7.tgz),
 # extract it, and set SPARK_HOME to the path of the extracted folder while invoking pytest as
@@ -21,7 +25,9 @@ pip install -e spark-3.0.0-preview-bin-hadoop2.7/python
 popd
 
 export SPARK_HOME=$TEMPDIR/spark-3.0.0-preview-bin-hadoop2.7
-find tests/spark_autologging -name 'test*.py' | xargs -L 1 pytest --large
+spark-submit --version
+pytest tests/spark_autologging/datasource/test_spark_datasource_autologging.py \
+  -k test_autologging_of_datasources_with_different_formats --large --verbose --capture=no
 
 rm -rf $TEMPDIR
 

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
@@ -48,11 +48,17 @@ private[autologging] trait DatasourceAttributeExtractorBase {
     if (deltaInfoOpt.isDefined) {
       deltaInfoOpt
     } else {
+      logger.warn("x" * 80)
+      logger.warn(leafNode.getClass().getCanonicalName())
       leafNode match {
-        case relation: DataSourceV2Relation =>
+        case relation: DataSourceV2Relation => {
+          logger.warn("Matched DataSourceV2Relation")
           getSparkTableInfoFromTable(relation.table)
-        case other =>
+        }
+        case other => {
+          logger.warn("Matched other")
           None
+        }
       }
     }
   }

--- a/tests/spark_autologging/datasource/test_spark_datasource_autologging.py
+++ b/tests/spark_autologging/datasource/test_spark_datasource_autologging.py
@@ -75,7 +75,10 @@ def test_autologging_of_datasources_with_different_formats(spark_session, format
                 df.collect()
                 time.sleep(1)
             run = mlflow.get_run(run_id)
-            _assert_spark_data_logged(run=run, path=file_path, data_format=data_format)
+            print(data_format, file_path, run)
+            # _assert_spark_data_logged(run=run, path=file_path, data_format=data_format)
+
+    assert False
 
 
 @pytest.mark.large


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

[DO NOT MREGE] Debug spark datasource logging

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
