### PR TITLE
Implementation: pyspark ML autologging for pipeline

### DIFF
--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -243,7 +243,7 @@ def autolog(
         param_map = _get_instance_param_map(estimator)
         if isinstance(estimator, Pipeline):
             pipeline_hyerarchy, stages_param_maps = _get_pipeline_stage_hierarchy_and_params(
-                estimator)
+                estimator.getStages())
             param_map.update(stages_param_maps)
             try_mlflow_log(mlflow.log_dict, pipeline_hyerarchy,
                            artifact_file='pipeline_hyerarchy.json')

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -138,6 +138,10 @@ def _get_instance_param_map(instance):
     for k, v in param_map.items():
         if is_pipeline and k == "stages":
             expanded_param_map[k] = _get_pipeline_stage_hierarchy(instance)[instance.uid]
+            for stage in instance.getStages():
+                stage_param_map = _get_instance_param_map(stage)
+                for ik, iv in stage_param_map.items():
+                    expanded_param_map[f"{stage.uid}.{ik}"] = iv
         elif isinstance(v, Params):
             # handle the case param value type inherits `pyspark.ml.param.Params`
             # e.g. param like `OneVsRest.classifier`/`CrossValidator.estimator`

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -79,11 +79,15 @@ def _get_warning_msg_for_skip_log_model(model):
 
 
 def _should_log_model(spark_model):
+    from pyspark.ml.base import Model
     # TODO: Handle PipelineModel/CrossValidatorModel/TrainValidationSplitModel
     class_name = _get_fully_qualified_class_name(spark_model)
     if class_name in _log_model_allowlist:
         if class_name == "pyspark.ml.classification.OneVsRestModel":
             return _should_log_model(spark_model.models[0])
+        elif class_name == 'pyspark.ml.pipeline.PipelineModel':
+            return all(_should_log_model(stage) for stage in spark_model.stages
+                       if isinstance(stage, Model))
         else:
             return True
     else:

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -143,8 +143,9 @@ def _get_instance_param_map_recursively(instance, level):
             logged_param_name = f"{instance.uid}.{param_name}"
 
         if is_pipeline and param_name == "stages":
-            expanded_param_map[logged_param_name] = \
-                _get_pipeline_stage_hierarchy(instance)[instance.uid]
+            expanded_param_map[logged_param_name] = _get_pipeline_stage_hierarchy(instance)[
+                instance.uid
+            ]
             for stage in instance.getStages():
                 stage_param_map = _get_instance_param_map_recursively(stage, level + 1)
                 expanded_param_map.update(stage_param_map)

--- a/mlflow/pyspark/ml/log_model_allowlist.txt
+++ b/mlflow/pyspark/ml/log_model_allowlist.txt
@@ -39,3 +39,6 @@ pyspark.ml.feature.UnivariateFeatureSelectorModel
 
 # composite model
 pyspark.ml.classification.OneVsRestModel
+
+# pipeline model
+pyspark.ml.pipeline.PipelineModel

--- a/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
@@ -21,11 +21,14 @@ from pyspark.ml.classification import (
     MultilayerPerceptronClassifier,
     OneVsRest,
 )
+from pyspark.ml.feature import HashingTF, Tokenizer
+from pyspark.ml import Pipeline
 from mlflow.pyspark.ml import (
     _should_log_model,
     _get_instance_param_map,
     _get_warning_msg_for_skip_log_model,
     _get_warning_msg_for_fit_call_with_a_list_of_params,
+    _get_pipeline_stage_hierarchy
 )
 
 pytestmark = pytest.mark.large
@@ -55,6 +58,16 @@ def dataset_multinomial(spark_session):
         * 100,
         ["label", "features"],
     )
+
+
+@pytest.fixture(scope="module")
+def dataset_text(spark_session):
+    return spark_session.createDataFrame([
+        (0, "a b c d e spark", 1.0),
+        (1, "b d", 0.0),
+        (2, "spark f g h", 1.0),
+        (3, "hadoop mapreduce", 0.0)
+    ], ["id", "text", "label"])
 
 
 def truncate_param_dict(d):
@@ -202,7 +215,7 @@ def test_fit_with_a_list_of_params(dataset_binomial):
             mock_set_tags.assert_not_called()
 
 
-def test_should_log_model(dataset_binomial, dataset_multinomial):
+def test_should_log_model(dataset_binomial, dataset_multinomial, dataset_text):
     mlflow.pyspark.ml.autolog(log_models=True)
     lor = LogisticRegression()
 
@@ -213,9 +226,22 @@ def test_should_log_model(dataset_binomial, dataset_multinomial):
     ova1_model = ova1.fit(dataset_multinomial)
     assert _should_log_model(ova1_model)
 
+    tokenizer = Tokenizer(inputCol="text", outputCol="words")
+    hashingTF = HashingTF(inputCol=tokenizer.getOutputCol(), outputCol="features")
+    lr = LogisticRegression(maxIter=2)
+    pipeline = Pipeline(stages=[tokenizer, hashingTF, lr])
+    pipeline_model = pipeline.fit(dataset_text)
+    assert _should_log_model(pipeline_model)
+
+    nested_pipeline = Pipeline(stages=[tokenizer, Pipeline(stages=[hashingTF, lr])])
+    nested_pipeline_model = nested_pipeline.fit(dataset_text)
+    assert _should_log_model(nested_pipeline_model)
+
     with mock.patch(
         "mlflow.pyspark.ml._log_model_allowlist",
-        {"pyspark.ml.regression.LinearRegressionModel", "pyspark.ml.classification.OneVsRestModel"},
+        {"pyspark.ml.regression.LinearRegressionModel",
+         "pyspark.ml.classification.OneVsRestModel",
+         "pyspark.ml.pipeline.PipelineModel"},
     ), mock.patch("mlflow.pyspark.ml._logger.warning") as mock_warning:
         lr = LinearRegression()
         lr_model = lr.fit(dataset_binomial)
@@ -224,6 +250,8 @@ def test_should_log_model(dataset_binomial, dataset_multinomial):
         assert not _should_log_model(lor_model)
         mock_warning.called_once_with(_get_warning_msg_for_skip_log_model(lor_model))
         assert not _should_log_model(ova1_model)
+        assert not _should_log_model(pipeline_model)
+        assert not _should_log_model(nested_pipeline_model)
 
 
 def test_param_map_captures_wrapped_params(dataset_binomial):
@@ -245,3 +273,34 @@ def test_param_map_captures_wrapped_params(dataset_binomial):
     assert run_data.params == truncate_param_dict(
         stringify_dict_values(_get_instance_param_map(ova))
     )
+
+
+def test_pipeline(dataset_text):
+    mlflow.pyspark.ml.autolog()
+
+    tokenizer = Tokenizer(inputCol="text", outputCol="words")
+    hashingTF = HashingTF(inputCol=tokenizer.getOutputCol(), outputCol="features")
+    lr = LogisticRegression(maxIter=2, regParam=0.001)
+    pipeline = Pipeline(stages=[tokenizer, hashingTF, lr])
+    inner_pipeline = Pipeline(stages=[hashingTF, lr])
+    nested_pipeline = Pipeline(stages=[tokenizer, inner_pipeline])
+
+    assert _get_pipeline_stage_hierarchy(pipeline) == \
+           {pipeline.uid: [tokenizer.uid, hashingTF.uid, lr.uid]}
+    assert _get_pipeline_stage_hierarchy(nested_pipeline) == \
+           {nested_pipeline.uid: [tokenizer.uid, {inner_pipeline.uid: [hashingTF.uid, lr.uid]}]}
+
+    for estimator in [pipeline, nested_pipeline]:
+        with mlflow.start_run() as run:
+            model = estimator.fit(dataset_text)
+
+        run_id = run.info.run_id
+        run_data = get_run_data(run_id)
+        assert run_data.params == truncate_param_dict(
+            stringify_dict_values(_get_instance_param_map(estimator))
+        )
+        assert run_data.tags == get_expected_class_tags(estimator)
+        assert MODEL_DIR in run_data.artifacts
+        loaded_model = load_model_by_run_id(run_id)
+        assert loaded_model.uid == model.uid
+        assert run_data.artifacts == ['model', 'pipeline_hierarchy.json']

--- a/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark_autologging/ml/test_pyspark_ml_autologging.py
@@ -313,7 +313,7 @@ def test_pipeline(dataset_text):
         assert run_data.artifacts == ["model", "pipeline_hierarchy.json"]
 
 
-def test_get_instance_param_map(spark_session):
+def test_get_instance_param_map(spark_session):  # pylint: disable=unused-argument
     lor = LogisticRegression(maxIter=3, standardization=False)
     lor_params = _get_instance_param_map(lor)
     assert (


### PR DESCRIPTION
## What changes are proposed in this pull request?

Implementation: pyspark ML autologging for pipeline

## How is this patch tested?

Unit tests.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
