### PR TITLE
Separate MLeap jars in spark tests

### DIFF
--- a/tests/spark/test_mleap_model_export.py
+++ b/tests/spark/test_mleap_model_export.py
@@ -1,8 +1,10 @@
 import json
+import logging
 import os
 from unittest import mock
 
 import numpy as np
+import pyspark
 from pyspark.ml.pipeline import Pipeline
 from pyspark.ml.wrapper import JavaModel
 import pytest
@@ -14,15 +16,29 @@ from mlflow.utils.file_utils import TempDir
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from tests.helper_functions import score_model_in_sagemaker_docker_container
+from tests.pyfunc.test_spark import get_spark_session
 
 
 from tests.spark.test_spark_model_export import (  # pylint: disable=unused-import
     model_path,
     iris_df,
-    spark_context,
     spark_model_iris,
     spark_custom_env,
 )
+
+_logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def spark_context():
+    conf = pyspark.SparkConf()
+    conf.set(
+        key="spark.jars.packages",
+        value="ml.combust.mleap:mleap-spark-base_2.11:0.12.0,"
+        "ml.combust.mleap:mleap-spark_2.11:0.12.0",
+    )
+    spark_session = get_spark_session(conf)
+    return spark_session.sparkContext
 
 
 @pytest.mark.large

--- a/tests/spark/test_mleap_model_export.py
+++ b/tests/spark/test_mleap_model_export.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 from unittest import mock
 
@@ -25,8 +24,6 @@ from tests.spark.test_spark_model_export import (  # pylint: disable=unused-impo
     spark_model_iris,
     spark_custom_env,
 )
-
-_logger = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/spark/test_mleap_model_export.py
+++ b/tests/spark/test_mleap_model_export.py
@@ -34,8 +34,10 @@ def spark_context():
     conf = pyspark.SparkConf()
     conf.set(
         key="spark.jars.packages",
-        value="ml.combust.mleap:mleap-spark-base_2.11:0.12.0,"
-        "ml.combust.mleap:mleap-spark_2.11:0.12.0",
+        value=(
+            "ml.combust.mleap:mleap-spark-base_2.11:0.12.0,"
+            "ml.combust.mleap:mleap-spark_2.11:0.12.0"
+        ),
     )
     spark_session = get_spark_session(conf)
     return spark_session.sparkContext

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -58,11 +58,6 @@ SparkModelWithData = namedtuple(
 @pytest.fixture(scope="session", autouse=True)
 def spark_context():
     conf = pyspark.SparkConf()
-    conf.set(
-        key="spark.jars.packages",
-        value="ml.combust.mleap:mleap-spark-base_2.11:0.12.0,"
-        "ml.combust.mleap:mleap-spark_2.11:0.12.0",
-    )
     max_tries = 3
     for num_tries in range(max_tries):
         try:


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Separate MLeap jars in spark tests.

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
