### PR TITLE
Fix flaky test

### DIFF
--- a/tests/autologging/test_autologging_behaviors_integration.py
+++ b/tests/autologging/test_autologging_behaviors_integration.py
@@ -234,9 +234,11 @@ def test_autolog_respects_silent_mode(tmpdir):
 
     mlflow.sklearn.autolog(silent=False, log_input_examples=True)
 
+    executions = []
     with ThreadPoolExecutor(max_workers=50) as executor:
         for _ in range(100):
-            executor.submit(train_model)
+            e = executor.submit(train_model)
+            executions.append(e)
 
     assert all([e.result() is True for e in executions])
     assert stream.getvalue()

--- a/tests/autologging/test_autologging_behaviors_integration.py
+++ b/tests/autologging/test_autologging_behaviors_integration.py
@@ -238,6 +238,7 @@ def test_autolog_respects_silent_mode(tmpdir):
         for _ in range(100):
             executor.submit(train_model)
 
+    assert all([e.result() is True for e in executions])
     assert stream.getvalue()
     # Verify that `warnings.showwarning` was restored to its original value after training
     # and that MLflow event logs are enabled

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -67,22 +67,6 @@ def test_autologging_integration():
     return integration_name
 
 
-@pytest.fixture(autouse=True)
-def clean_up_leaked_runs():
-    """
-    Certain test cases validate safety API behavior when runs are leaked. Leaked runs that
-    are not cleaned up between test cases may result in cascading failures that are hard to
-    debug. Accordingly, this fixture attempts to end any active runs it encounters and
-    throws an exception (which reported as an additional error in the pytest execution output).
-    """
-    try:
-        yield
-        assert not mlflow.active_run(), "test case unexpectedly leaked a run!"
-    finally:
-        while mlflow.active_run():
-            mlflow.end_run()
-
-
 class MockEventLogger(AutologgingEventLogger):
 
     LoggerCall = namedtuple(

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1485,6 +1485,3 @@ def test_patch_runs_if_patch_should_be_applied():
     autolog(exclusive=True)
     patch_obj.new_fn()
     assert patch_impl_call_count == 3
-
-def test_fail():
-    mlflow.start_run()

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1485,3 +1485,6 @@ def test_patch_runs_if_patch_should_be_applied():
     autolog(exclusive=True)
     patch_obj.new_fn()
     assert patch_impl_call_count == 3
+
+def test_fail():
+    mlflow.start_run()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,3 +45,19 @@ def enable_test_mode_by_default_for_autologging_integrations():
     for :py:func:`mlflow.utils.autologging_utils._is_testing()`.
     """
     yield from test_mode_on()
+
+
+@pytest.fixture(autouse=True)
+def clean_up_leaked_runs():
+    """
+    Certain test cases validate safety API behavior when runs are leaked. Leaked runs that
+    are not cleaned up between test cases may result in cascading failures that are hard to
+    debug. Accordingly, this fixture attempts to end any active runs it encounters and
+    throws an exception (which reported as an additional error in the pytest execution output).
+    """
+    try:
+        yield
+        assert not mlflow.active_run(), "test case unexpectedly leaked a run!"
+    finally:
+        while mlflow.active_run():
+            mlflow.end_run()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import os
 import pytest
 
 import mlflow
-from mlflow.tracking.client import MlflowClient
 from mlflow.utils.file_utils import path_to_local_sqlite_uri
 
 from tests.autologging.fixtures import test_mode_on

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,8 +58,10 @@ def clean_up_leaked_runs():
     """
     try:
         yield
-        assert not mlflow.active_run(), "test case unexpectedly leaked a run: {}".format(
-            MlflowClient().get_run(mlflow.active_run().info.run_id)
+        assert (
+            not mlflow.active_run()
+        ), "test case unexpectedly leaked a run. Run info: {}. Run data: {}".format(
+            mlflow.active_run().info, mlflow.active_run().data
         )
     finally:
         while mlflow.active_run():


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR fixes flakiness in the evaluation of the `clean_up_leaked_runs` test fixture caused by a failure to block on futures launched during `test_autologging_behaviors_integration#test_autolog_respects_silent_mode`. It also augments `clean_up_leaked_runs` to print the leaked run for future failure diagnostics.

## How is this patch tested?

- CI tests
- Verification that `clean_up_leaked_runs` successfully prints the leaked  when a test case is introduced that deliberately leaks a run:

Test case code:

```
@pytest.mark.large
def test_fail():
    mlflow.start_run()
```

Error log:

```
AssertionError: test case unexpectedly leaked a run. Run info: <RunInfo: artifact_uri='./mlruns/0/50b65f3bd36e4ec6bbbb2d3805b961c4/artifacts', end_time=None, experiment_id='0', lifecycle_stage='active', run_id='50b65f3bd36e4ec6bbbb2d3805b961c4', run_uuid='50b65f3bd36e4ec6bbbb2d3805b961c4', start_time=1619059579053, status='RUNNING', user_id='corey.zumar'>. Run data: <RunData: metrics={}, params={}, tags={'mlflow.source.name': '/Users/corey.zumar/opt/anaconda3/bin/pytest',
E              'mlflow.source.type': 'LOCAL',
E              'mlflow.user': 'corey.zumar'}>
E           assert not <ActiveRun: >
E            +  where <ActiveRun: > = <function active_run at 0x7fe8b0800790>()
E            +    where <function active_run at 0x7fe8b0800790> = mlflow.active_run
```

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
