### PR TITLE
Fix: When top level call autologging failed, nested calls autologging are still enabled

### DIFF
--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -545,12 +545,12 @@ def safe_patch(
 # Represents an active autologging session using two fields:
 # - integration: the name of the autologging integration corresponding to the session
 # - id: a unique session identifier (e.g., a UUID)
-# - state: init/succeeded/failed
+# - state: the state of AutologgingSession, will be one of running/succeeded/failed
 class AutologgingSession:
     def __init__(self, integration, id_):
         self.integration = integration
         self.id = id_
-        self.state = "init"
+        self.state = "running"
 
 
 class _AutologgingSessionManager:

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -370,9 +370,10 @@ def safe_patch(
                 mlflow.active_run() and not _AutologgingSessionManager.active_session()
             )
 
-            if autologging_integration in _AUTOLOGGING_INTEGRATIONS_TEMP_DISABLED_SET or \
-                    autologging_is_disabled(autologging_integration) or (
-                    user_created_fluent_run_is_active and exclusive
+            if (
+                autologging_integration in _AUTOLOGGING_INTEGRATIONS_TEMP_DISABLED_SET
+                or autologging_is_disabled(autologging_integration)
+                or (user_created_fluent_run_is_active and exclusive)
             ):
                 # If the autologging integration associated with this patch is disabled,
                 # or if the current autologging integration is in exclusive mode and a user-created

--- a/tests/autologging/fixtures.py
+++ b/tests/autologging/fixtures.py
@@ -16,10 +16,18 @@ def patch_destination():
     class PatchObj:
         def __init__(self):
             self.fn_call_count = 0
+            self.recurse_fn_call_count = 0
 
         def fn(self, *args, **kwargs):  # pylint: disable=unused-argument
             self.fn_call_count += 1
             return PATCH_DESTINATION_FN_DEFAULT_RESULT
+
+        def recursive_fn(self, level, max_depth):
+            self.recurse_fn_call_count += 1
+            if level == max_depth:
+                return PATCH_DESTINATION_FN_DEFAULT_RESULT
+            else:
+                return self.recursive_fn(level + 1, max_depth)
 
     return PatchObj()
 

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1485,3 +1485,38 @@ def test_patch_runs_if_patch_should_be_applied():
     autolog(exclusive=True)
     patch_obj.new_fn()
     assert patch_impl_call_count == 3
+
+
+def test_nested_call_autologging_disabled_when_top_level_call_autologging_failed(patch_destination):
+    patch_impl_call_count = 0
+
+    @autologging_integration(
+        "test_nested_call_autologging_disabled_when_top_level_call_autologging_failed"
+    )
+    def autolog(disable=False, exclusive=False, silent=False):
+        def patch_impl(original, *args, **kwargs):
+            nonlocal patch_impl_call_count
+            patch_impl_call_count += 1
+
+            level = kwargs["level"]
+
+            if level == 0:
+                raise RuntimeError("analog top level call autologging failure.")
+
+            return original(*args, **kwargs)
+
+        safe_patch(
+            "test_nested_call_autologging_disabled_when_top_level_call_autologging_failed",
+            patch_destination,
+            "recursive_fn",
+            patch_impl,
+        )
+
+    autolog()
+    for max_depth in [1, 2, 3]:
+        patch_impl_call_count = 0
+        patch_destination.recurse_fn_call_count = 0
+        with mlflow.start_run():
+            patch_destination.recursive_fn(level=0, max_depth=max_depth)
+        assert patch_impl_call_count == 1
+        assert patch_destination.recurse_fn_call_count == max_depth + 1


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Fix: If _log_pretraining_metadata raise exception, the original patched fit will be called and then all nested fit will be autologged.

## How is this patch tested?

Unit test.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
