### PR TITLE
Diagnose test flakiness

### DIFF
--- a/dev/run-python-flavor-tests.sh
+++ b/dev/run-python-flavor-tests.sh
@@ -8,24 +8,24 @@ export MLFLOW_HOME=$(pwd)
 
 # Run ML framework tests in their own Python processes to avoid OOM issues due to per-framework
 # overhead
-pytest --verbose tests/pytorch --large
-pytest --verbose tests/h2o --large
-pytest --verbose tests/onnx --large
-pytest --verbose tests/pyfunc --large
-pytest --verbose tests/sklearn --large
-pytest --verbose tests/azureml --large
-pytest --verbose tests/models --large
-pytest --verbose tests/xgboost --large
-pytest --verbose tests/lightgbm --large
-pytest --verbose tests/catboost --large
-pytest --verbose tests/statsmodels --large
-pytest --verbose tests/gluon --large
-pytest --verbose tests/gluon_autolog --large
-pytest --verbose tests/spacy --large
-pytest --verbose tests/fastai --large
-pytest --verbose tests/shap --large
-pytest --verbose tests/utils/test_model_utils.py --large
-pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large
+# pytest --verbose tests/pytorch --large
+# pytest --verbose tests/h2o --large
+# pytest --verbose tests/onnx --large
+# pytest --verbose tests/pyfunc --large
+# pytest --verbose tests/sklearn --large
+# pytest --verbose tests/azureml --large
+# pytest --verbose tests/models --large
+# pytest --verbose tests/xgboost --large
+# pytest --verbose tests/lightgbm --large
+# pytest --verbose tests/catboost --large
+# pytest --verbose tests/statsmodels --large
+# pytest --verbose tests/gluon --large
+# pytest --verbose tests/gluon_autolog --large
+# pytest --verbose tests/spacy --large
+# pytest --verbose tests/fastai --large
+# pytest --verbose tests/shap --large
+# pytest --verbose tests/utils/test_model_utils.py --large
+# pytest --verbose tests/tracking/fluent/test_fluent_autolog.py --large
 pytest --verbose tests/autologging --large
 find tests/spark_autologging/ml -name 'test*.py' | xargs -L 1 pytest --large
 

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -67,22 +67,6 @@ def test_autologging_integration():
     return integration_name
 
 
-@pytest.fixture(autouse=True)
-def clean_up_leaked_runs():
-    """
-    Certain test cases validate safety API behavior when runs are leaked. Leaked runs that
-    are not cleaned up between test cases may result in cascading failures that are hard to
-    debug. Accordingly, this fixture attempts to end any active runs it encounters and
-    throws an exception (which reported as an additional error in the pytest execution output).
-    """
-    try:
-        yield
-        assert not mlflow.active_run(), "test case unexpectedly leaked a run!"
-    finally:
-        while mlflow.active_run():
-            mlflow.end_run()
-
-
 class MockEventLogger(AutologgingEventLogger):
 
     LoggerCall = namedtuple(

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1485,6 +1485,3 @@ def test_patch_runs_if_patch_should_be_applied():
     autolog(exclusive=True)
     patch_obj.new_fn()
     assert patch_impl_call_count == 3
-
-def test_fail():
-    mlflow.start_run()

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1485,3 +1485,6 @@ def test_patch_runs_if_patch_should_be_applied():
     autolog(exclusive=True)
     patch_obj.new_fn()
     assert patch_impl_call_count == 3
+
+def test_fail():
+    mlflow.start_run()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,3 +45,19 @@ def enable_test_mode_by_default_for_autologging_integrations():
     for :py:func:`mlflow.utils.autologging_utils._is_testing()`.
     """
     yield from test_mode_on()
+
+
+@pytest.fixture(autouse=True)
+def clean_up_leaked_runs():
+    """
+    Certain test cases validate safety API behavior when runs are leaked. Leaked runs that
+    are not cleaned up between test cases may result in cascading failures that are hard to
+    debug. Accordingly, this fixture attempts to end any active runs it encounters and
+    throws an exception (which reported as an additional error in the pytest execution output).
+    """
+    try:
+        yield
+        assert not mlflow.active_run(), "test case unexpectedly leaked a run!"
+    finally:
+        while mlflow.active_run():
+            mlflow.end_run()


### PR DESCRIPTION
## What changes are proposed in this pull request?

(Please fill in changes proposed in this fix)

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
