### PR TITLE
Cache catboost wheel for dev version

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -69,7 +69,8 @@ jobs:
           hash=$(echo -n "$INSTALL_COMMAND" | sha256sum)
           echo "::set-output name=key::$ImageOS-$ImageVersion-wheels-$date-$hash"
       - uses: actions/cache@v2
-        if: ${{ matrix.package == 'pyspark' && matrix.version == 'dev' }}
+        # We only cache wheels that take long to build
+        if: ${{ contains('pyspark, catboost', matrix.package) && matrix.version == 'dev' }}
         with:
           path: /home/runner/.cache/wheels
           key: ${{ steps.get-cache-key.outputs.key }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -69,7 +69,7 @@ jobs:
           hash=$(echo -n "$INSTALL_COMMAND" | sha256sum)
           echo "::set-output name=key::$ImageOS-$ImageVersion-wheels-$date-$hash"
       - uses: actions/cache@v2
-        # We only cache wheels that take long to build
+        # We only cache wheels that take long (> 20 min) to build
         if: ${{ contains('pyspark, catboost', matrix.package) && matrix.version == 'dev' }}
         with:
           path: /home/runner/.cache/wheels

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -76,12 +76,12 @@ jobs:
           key: ${{ steps.get-cache-key.outputs.key }}
           restore-keys: |
             ${{ steps.get-cache-key.outputs.key }}
-      - name: Install MLflow & test dependencies
+      - name: Install mlflow & test dependencies
         run: |
           set -x
           pip install -e .
           pip install -r dev/small-requirements.txt
-      - name: Install ML package
+      - name: Install ${{ matrix.package }} ${{ matrix.version }}
         env:
           CACHE_DIR: /home/runner/.cache/wheels
         run: |

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -76,13 +76,16 @@ jobs:
           key: ${{ steps.get-cache-key.outputs.key }}
           restore-keys: |
             ${{ steps.get-cache-key.outputs.key }}
-      - name: Install dependencies
-        env:
-          CACHE_DIR: /home/runner/.cache/wheels
+      - name: Install MLflow & test dependencies
         run: |
           set -x
           pip install -e .
           pip install -r dev/small-requirements.txt
+      - name: Install ML package
+        env:
+          CACHE_DIR: /home/runner/.cache/wheels
+        run: |
+          set -x
           ${{ matrix.install }}
       - name: Check package versions
         run: |

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -176,8 +176,24 @@ catboost:
   package_info:
     pip_release: "catboost"
     install_dev: |
-      pip install git+https://github.com/catboost/catboost.git#subdirectory=catboost/python-package
-      pip cache list catboost --format=abspath
+      # The cross-version-tests workflow runs this command with the environment variable `CACHE_DIR`
+      if [ -d "$CACHE_DIR" ] && [ ! -z $(find $CACHE_DIR -type f -name "catboost-*.whl") ]; then
+        pip install $(find $CACHE_DIR -type f -name "catboost-*.whl")
+      else
+        # Build wheel from source
+        temp_dir=$(mktemp -d)
+        git clone --depth 1 https://github.com/catboost/catboost $temp_dir
+        cd $temp_dir/python_package
+        python setup.py bdist_wheel
+
+        # Copy wheel in cache directory
+        wheel_path=$(find dist -type f -name "*.whl")
+        mkdir -p $CACHE_DIR
+        cp $wheel_path $CACHE_DIR
+
+        # Install wheel
+        pip install $wheel_path
+      fi
 
   models:
     minimum: "0.23.1"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -183,7 +183,7 @@ catboost:
         # Build wheel from source
         temp_dir=$(mktemp -d)
         git clone --depth 1 https://github.com/catboost/catboost $temp_dir
-        cd $temp_dir/python_package
+        cd $temp_dir/catboost/python_package
         python setup.py bdist_wheel
 
         # Copy wheel in cache directory

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -183,7 +183,7 @@ catboost:
         # Build wheel from source
         temp_dir=$(mktemp -d)
         git clone --depth 1 https://github.com/catboost/catboost $temp_dir
-        cd $temp_dir/catboost/python_package
+        cd $temp_dir/catboost/python-package
         python setup.py bdist_wheel
 
         # Copy wheel in cache directory

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -177,6 +177,7 @@ catboost:
     pip_release: "catboost"
     install_dev: |
       pip install git+https://github.com/catboost/catboost.git#subdirectory=catboost/python-package
+      pip cache list catboost --format=abspath
 
   models:
     minimum: "0.23.1"


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Cache catboost wheel for dev version since it takes long (20 ~ 30 min.) to build it to save github actions usage + run tests faster.

## How is this patch tested?

Exisiting tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
