### PR TITLE
Cache pyspark wheel bulilt from source

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -64,7 +64,11 @@ jobs:
         id: get-cache-key
         run: |
           date=$(/bin/date -u "+%Y%m%d")
-          hash=$(echo -n "${{ matrix.install }}" | sha256sum)
+          install=$(cat << EOF
+          ${{ matrix.install }}
+          EOF
+          )
+          hash=$(echo -n "$install" | sha256sum)
           echo "::set-output name=key::$date-$hash"
       - uses: actions/cache@v2
         if: ${{ matrix.job_name == 'spark / dev / autologging' }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -69,7 +69,7 @@ jobs:
           hash=$(echo -n "$INSTALL_COMMAND" | sha256sum)
           echo "::set-output name=key::$date-$hash"
       - uses: actions/cache@v2
-        if: ${{ matrix.job_name == 'spark / dev / autologging' }}
+        if: ${{ matrix.package == 'pyspark' && matrix.version == 'dev' }}
         with:
           path: /home/runner/.cache/wheels
           key: ${{ runner.os }}-wheels-${{ steps.get-cache-key.outputs.key }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -67,14 +67,14 @@ jobs:
         run: |
           date=$(date -u "+%Y%m%d")
           hash=$(echo -n "$INSTALL_COMMAND" | sha256sum)
-          echo "::set-output name=key::$date-$hash"
+          echo "::set-output name=key::$ImageOS-$ImageVersion-wheels-$date-$hash"
       - uses: actions/cache@v2
         if: ${{ matrix.package == 'pyspark' && matrix.version == 'dev' }}
         with:
           path: /home/runner/.cache/wheels
-          key: ${{ runner.os }}-wheels-${{ steps.get-cache-key.outputs.key }}
+          key: ${{ steps.get-cache-key.outputs.key }}
           restore-keys: |
-            ${{ runner.os }}-wheels-${{ steps.get-cache-key.outputs.key }}
+            ${{ steps.get-cache-key.outputs.key }}
       - name: Install dependencies
         env:
           CACHE_DIR: /home/runner/.cache/wheels

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -75,6 +75,8 @@ jobs:
           key: ${{ runner.os }}-wheels-${{ steps.get-cache-key.outputs.key }}
           restore-keys: |
             ${{ runner.os }}-wheels-${{ steps.get-cache-key.outputs.key }}
+      - run: |
+          ls ~/.cache/wheels
       - name: Install dependencies
         run: |
           set -x

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -75,8 +75,6 @@ jobs:
           key: ${{ runner.os }}-wheels-${{ steps.get-cache-key.outputs.key }}
           restore-keys: |
             ${{ runner.os }}-wheels-${{ steps.get-cache-key.outputs.key }}
-      - run: |
-          ls ~/.cache/wheels
       - name: Install dependencies
         run: |
           set -x

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -60,6 +60,17 @@ jobs:
         run: |
           conda install python=3.6
           python --version
+      - name: Get date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      - uses: actions/cache@v2
+        if: ${{ matrix.job_name == 'pyspark / dev / autologging' }}
+        with:
+          path: ~/.cache/wheels
+          key: ${{ runner.os }}-wheels-${{ steps.get-date.outputs.date }}
+          restore-keys: |
+            ${{ runner.os }}-wheels-
       - name: Install dependencies
         run: |
           pip install -e .

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -71,11 +71,13 @@ jobs:
       - uses: actions/cache@v2
         if: ${{ matrix.job_name == 'spark / dev / autologging' }}
         with:
-          path: ~/.cache/wheels
+          path: /home/runner/.cache/wheels
           key: ${{ runner.os }}-wheels-${{ steps.get-cache-key.outputs.key }}
           restore-keys: |
             ${{ runner.os }}-wheels-${{ steps.get-cache-key.outputs.key }}
       - name: Install dependencies
+        env:
+          CACHE_DIR: /home/runner/.cache/wheels
         run: |
           set -x
           pip install -e .

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -61,11 +61,12 @@ jobs:
           conda install python=3.6
           python --version
       - name: Get cache key
+        env:
+          INSTALL_COMMAND: ${{ matrix.install }}
         id: get-cache-key
         run: |
           date=$(/bin/date -u "+%Y%m%d")
-          install='${{ matrix.install }}'
-          hash=$(echo -n "$install" | sha256sum)
+          hash=$(echo -n "$INSTALL_COMMAND" | sha256sum)
           echo "::set-output name=key::$date-$hash"
       - uses: actions/cache@v2
         if: ${{ matrix.job_name == 'spark / dev / autologging' }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -64,10 +64,7 @@ jobs:
         id: get-cache-key
         run: |
           date=$(/bin/date -u "+%Y%m%d")
-          install=$(cat << EOF
-          ${{ matrix.install }}
-          EOF
-          )
+          install='${{ matrix.install }}'
           hash=$(echo -n "$install" | sha256sum)
           echo "::set-output name=key::$date-$hash"
       - uses: actions/cache@v2

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -65,7 +65,7 @@ jobs:
         run: |
           echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
       - uses: actions/cache@v2
-        if: ${{ matrix.job_name == 'pyspark / dev / autologging' }}
+        if: ${{ matrix.job_name == 'spark / dev / autologging' }}
         with:
           path: ~/.cache/wheels
           key: ${{ runner.os }}-wheels-${{ steps.get-date.outputs.date }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -74,7 +74,7 @@ jobs:
           path: ~/.cache/wheels
           key: ${{ runner.os }}-wheels-${{ steps.get-cache-key.outputs.key }}
           restore-keys: |
-            ${{ runner.os }}-wheels-
+            ${{ runner.os }}-wheels-${{ steps.get-cache-key.outputs.key }}
       - name: Install dependencies
         run: |
           set -x

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -65,7 +65,7 @@ jobs:
           INSTALL_COMMAND: ${{ matrix.install }}
         id: get-cache-key
         run: |
-          date=$(/bin/date -u "+%Y%m%d")
+          date=$(date -u "+%Y%m%d")
           hash=$(echo -n "$INSTALL_COMMAND" | sha256sum)
           echo "::set-output name=key::$date-$hash"
       - uses: actions/cache@v2

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -60,19 +60,22 @@ jobs:
         run: |
           conda install python=3.6
           python --version
-      - name: Get date
-        id: get-date
+      - name: Get cache key
+        id: get-cache-key
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+          date=$(/bin/date -u "+%Y%m%d")
+          hash=$(echo -n "${{ matrix.install }}" | sha256sum)
+          echo "::set-output name=key::$date-$hash"
       - uses: actions/cache@v2
         if: ${{ matrix.job_name == 'spark / dev / autologging' }}
         with:
           path: ~/.cache/wheels
-          key: ${{ runner.os }}-wheels-${{ steps.get-date.outputs.date }}
+          key: ${{ runner.os }}-wheels-${{ steps.get-cache-key.outputs.key }}
           restore-keys: |
             ${{ runner.os }}-wheels-
       - name: Install dependencies
         run: |
+          set -x
           pip install -e .
           pip install -r dev/small-requirements.txt
           ${{ matrix.install }}

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -438,7 +438,7 @@ def expand_config(config):
                         install=install,
                         run=run,
                         package=pip_release,
-                        version=ver,
+                        version=DEV_VERSION,
                     )
                 )
     return matrix

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -276,7 +276,7 @@ spark:
   package_info:
     pip_release: "pyspark"
     install_dev: |
-      CACHE_DIR="$HOME/.cache/wheels"
+      # The cross-version-tests workflow runs this command with the environment variable `CACHE_DIR`
       if [ -d "$CACHE_DIR" ] && [ ! -z $(find $CACHE_DIR -type f -name "pyspark-*.whl") ]; then
         pip install $(find $CACHE_DIR -type f -name "pyspark-*.whl")
       else

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -278,14 +278,28 @@ spark:
     install_dev: |
       # TODO: Consider using cache because it takes long (20 ~ 30 min) to build spark from source
       # on GitHub Actions environment.
-      temp_dir=$(mktemp -d)
-      git clone --depth 1 https://github.com/apache/spark $temp_dir
-      cd $temp_dir
-      export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g"
-      ./build/mvn -DskipTests --no-transfer-progress clean package
-      cd python
-      python setup.py bdist_wheel
-      pip install dist/*.whl
+
+      CACHE_DIR="~/.cache/wheels"
+      if [ -d "$CACHE_DIR" ] && [ find $CACHE_DIR -type f -name "pyspark-*.whl" ]; then
+        pip install "$CACHE_DIR/pyspark-*.whl"
+      else
+        # Build wheel from source
+        temp_dir=$(mktemp -d)
+        git clone --depth 1 https://github.com/apache/spark $temp_dir
+        cd $temp_dir
+        export MAVEN_OPTS="-Xmx2g -XX:ReservedCodeCacheSize=1g"
+        ./build/mvn -DskipTests --no-transfer-progress clean package
+        cd python
+        python setup.py bdist_wheel
+
+        # Move wheel in cache directory
+        wheel_path=$(find dist -type f -name "*.whl")
+        mkdir -p $CACHE_DIR
+        cp $wheel_path $CACHE_DIR
+
+        # Install wheel
+        pip install $wheel_path
+      fi
 
   models:
     minimum: "3.0.0"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -279,7 +279,7 @@ spark:
       # TODO: Consider using cache because it takes long (20 ~ 30 min) to build spark from source
       # on GitHub Actions environment.
 
-      CACHE_DIR="~/.cache/wheels"
+      CACHE_DIR="$HOME/.cache/wheels"
       if [ -d "$CACHE_DIR" ] && [ ! -z $(find $CACHE_DIR -type f -name "pyspark-*.whl") ]; then
         pip install $CACHE_DIR/pyspark-*.whl
       else
@@ -295,7 +295,7 @@ spark:
         # Move wheel in cache directory
         wheel_path=$(find dist -type f -name "*.whl")
         echo $wheel_path
-        mkdir -p $CACHE_DIR
+        mkdir -p $HOME
         cp $wheel_path $CACHE_DIR
         ls $CACHE_DIR
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -291,10 +291,8 @@ spark:
 
         # Copy wheel in cache directory
         wheel_path=$(find dist -type f -name "*.whl")
-        echo $wheel_path
         mkdir -p $CACHE_DIR
         cp $wheel_path $CACHE_DIR
-        ls $CACHE_DIR
 
         # Install wheel
         pip install $wheel_path

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -276,9 +276,6 @@ spark:
   package_info:
     pip_release: "pyspark"
     install_dev: |
-      # TODO: Consider using cache because it takes long (20 ~ 30 min) to build spark from source
-      # on GitHub Actions environment.
-
       CACHE_DIR="$HOME/.cache/wheels"
       if [ -d "$CACHE_DIR" ] && [ ! -z $(find $CACHE_DIR -type f -name "pyspark-*.whl") ]; then
         pip install $CACHE_DIR/pyspark-*.whl
@@ -292,7 +289,7 @@ spark:
         cd python
         python setup.py bdist_wheel
 
-        # Move wheel in cache directory
+        # Copy wheel in cache directory
         wheel_path=$(find dist -type f -name "*.whl")
         echo $wheel_path
         mkdir -p $HOME

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -294,8 +294,10 @@ spark:
 
         # Move wheel in cache directory
         wheel_path=$(find dist -type f -name "*.whl")
+        echo $wheel_path
         mkdir -p $CACHE_DIR
         cp $wheel_path $CACHE_DIR
+        ls $CACHE_DIR
 
         # Install wheel
         pip install $wheel_path

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -278,7 +278,7 @@ spark:
     install_dev: |
       CACHE_DIR="$HOME/.cache/wheels"
       if [ -d "$CACHE_DIR" ] && [ ! -z $(find $CACHE_DIR -type f -name "pyspark-*.whl") ]; then
-        pip install $CACHE_DIR/pyspark-*.whl
+        pip install $(find $CACHE_DIR -type f -name "pyspark-*.whl")
       else
         # Build wheel from source
         temp_dir=$(mktemp -d)

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -280,8 +280,8 @@ spark:
       # on GitHub Actions environment.
 
       CACHE_DIR="~/.cache/wheels"
-      if [ -d "$CACHE_DIR" ] && [ find $CACHE_DIR -type f -name "pyspark-*.whl" ]; then
-        pip install "$CACHE_DIR/pyspark-*.whl"
+      if [ -d "$CACHE_DIR" ] && [ ! -z $(find $CACHE_DIR -type f -name "pyspark-*.whl") ]; then
+        pip install $CACHE_DIR/pyspark-*.whl
       else
         # Build wheel from source
         temp_dir=$(mktemp -d)

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -292,7 +292,7 @@ spark:
         # Copy wheel in cache directory
         wheel_path=$(find dist -type f -name "*.whl")
         echo $wheel_path
-        mkdir -p $HOME
+        mkdir -p $CACHE_DIR
         cp $wheel_path $CACHE_DIR
         ls $CACHE_DIR
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

- Cache pyspark wheel bulilt from source.
- Depends on #4284 

# Results

- with cache, it takes about 1 min.
- without cache, it takes about 20 ~ 30 min.

## How is this patch tested?

- Existing unit tests
- Manually verified the dev version pyspark is properly built & installed from the source.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
