### PR TITLE
Add pipeline example for pyspark ML autologging

### DIFF
--- a/examples/pyspark_ml_autologging/pipeline.py
+++ b/examples/pyspark_ml_autologging/pipeline.py
@@ -20,17 +20,16 @@ lor = LogisticRegression(maxIter=5, featuresCol=scaler.getOutputCol())
 # Non-neseted pipeline
 pipeline = Pipeline(stages=[assembler, scaler, lor])
 with mlflow.start_run():
-    pipelineModel = pipeline.fit(train)
+    pipeline_model = pipeline.fit(train)
 
-pred = pipelineModel.transform(test)
-pred.select(pipeline.getStages()[-1].getPredictionCol()).show(10)
+columns = ["features", "prediction"]
+pipeline_model.transform(test).select(columns).show()
 
 # Nested pipeline
-nestedPipeline = Pipeline(stages=[Pipeline(stages=[assembler, scaler]), lor])
+nested_pipeline = Pipeline(stages=[Pipeline(stages=[assembler, scaler]), lor])
 with mlflow.start_run():
-    nestedPipelineModel = nestedPipeline.fit(train)
+    nested_pipeline_model = nested_pipeline.fit(train)
 
-pred = nestedPipelineModel.transform(test)
-pred.select(nestedPipeline.getStages()[-1].getPredictionCol()).show(10)
+nested_pipeline_model.transform(test).select(columns).show()
 
 spark.stop()

--- a/examples/pyspark_ml_autologging/pipeline.py
+++ b/examples/pyspark_ml_autologging/pipeline.py
@@ -22,13 +22,15 @@ pipeline = Pipeline(stages=[assembler, scaler, lor])
 with mlflow.start_run():
     pipelineModel = pipeline.fit(train)
 
-pipelineModel.transform(test).select(pipeline.stages[-1].getPredictionCol()).show(10)
+pred = pipelineModel.transform(test)
+pred.select(pipeline.getStages()[-1].getPredictionCol()).show(10)
 
 # Nested pipeline
 nestedPipeline = Pipeline(stages=[Pipeline(stages=[assembler, scaler]), lor])
 with mlflow.start_run():
     nestedPipelineModel = nestedPipeline.fit(train)
 
-nestedPipelineModel.transform(test).select(nestedPipeline.stages[-1].getPredictionCol()).show(10)
+pred = nestedPipelineModel.transform(test)
+pred.select(nestedPipeline.getStages()[-1].getPredictionCol()).show(10)
 
 spark.stop()

--- a/examples/pyspark_ml_autologging/pipeline.py
+++ b/examples/pyspark_ml_autologging/pipeline.py
@@ -1,0 +1,34 @@
+from pyspark.ml.classification import LogisticRegression
+from pyspark.ml.feature import VectorAssembler, StandardScaler
+from pyspark.ml import Pipeline
+from pyspark.sql import SparkSession
+from sklearn.datasets import load_iris
+
+import mlflow
+
+spark = SparkSession.builder.getOrCreate()
+mlflow.pyspark.ml.autolog()
+
+df = load_iris(as_frame=True).frame.rename(columns={"target": "label"})
+df = spark.createDataFrame(df)
+train, test = df.randomSplit([0.8, 0.2])
+
+assembler = VectorAssembler(inputCols=df.columns[:-1], outputCol="features")
+scaler = StandardScaler(inputCol=assembler.getOutputCol(), outputCol="scaledFeatures")
+lor = LogisticRegression(maxIter=5, featuresCol=scaler.getOutputCol())
+
+# Non-neseted pipeline
+pipeline = Pipeline(stages=[assembler, scaler, lor])
+with mlflow.start_run():
+    pipelineModel = pipeline.fit(train)
+
+pipelineModel.transform(test).select(pipeline.stages[-1].getPredictionCol()).show(10)
+
+# Nested pipeline
+nestedPipeline = Pipeline(stages=[Pipeline(stages=[assembler, scaler]), lor])
+with mlflow.start_run():
+    nestedPipelineModel = nestedPipeline.fit(train)
+
+nestedPipelineModel.transform(test).select(nestedPipeline.stages[-1].getPredictionCol()).show(10)
+
+spark.stop()

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -174,6 +174,7 @@ def test_mlflow_run_example(directory, params, tmpdir):
         ("sklearn_autolog", ["python", "grid_search_cv.py"]),
         ("pyspark_ml_autologging", ["python", "logistic_regression.py"]),
         ("pyspark_ml_autologging", ["python", "one_vs_rest.py"]),
+        ("pyspark_ml_autologging", ["python", "pipeline.py"]),
         ("shap", ["python", "regression.py"]),
         ("shap", ["python", "binary_classification.py"]),
         ("shap", ["python", "multiclass_classification.py"]),


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Add a pipeline example for pyspark ML autologging.

## How is this patch tested?

Unit tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
