### PR TITLE
allow mvn to configure proxy

### DIFF
--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -49,6 +49,11 @@ def _get_mlflow_install_step(dockerfile_context_dir, mlflow_home):
     Get docker build commands for installing MLflow given a Docker context dir and optional source
     directory
     """
+    MLFLOW_MVN_HTTP_PROXY_HOST = os.environ.get("MLFLOW_MVN_HTTP_PROXY_HOST", "")
+    MLFLOW_MVN_HTTP_PROXY_PORT = os.environ.get("MLFLOW_MVN_HTTP_PROXY_PORT", "")
+    MLFLOW_MVN_HTTPS_PROXY_HOST = os.environ.get("MLFLOW_MVN_HTTPS_PROXY_HOST", "")
+    MLFLOW_MVN_HTTPS_PROXY_PORT = os.environ.get("MLFLOW_MVN_HTTPS_PROXY_PORT", "")
+    MLFLOW_MVN_NO_PROXY_HOSTS = os.environ.get("MLFLOW_MVN_NO_PROXY_HOSTS", "")
     if mlflow_home:
         mlflow_dir = _copy_project(src_path=mlflow_home, dst_path=dockerfile_context_dir)
         return (
@@ -66,15 +71,34 @@ def _get_mlflow_install_step(dockerfile_context_dir, mlflow_home):
             "RUN mvn "
             " --batch-mode dependency:copy"
             " -Dartifact=org.mlflow:mlflow-scoring:{version}:pom"
+            " -Dhttp.proxyHost={MLFLOW_MVN_HTTP_PROXY_HOST}"
+            " -Dhttp.proxyPort={MLFLOW_MVN_HTTP_PROXY_PORT}"
+            " -Dhttps.proxyHost={MLFLOW_MVN_HTTPS_PROXY_HOST}"
+            " -Dhttps.proxyPort={MLFLOW_MVN_HTTPS_PROXY_PORT}"
+            " -Dhttps.nonProxyHosts={MLFLOW_MVN_NO_PROXY_HOSTS}"
+            " -Dhttp.nonProxyHosts={MLFLOW_MVN_NO_PROXY_HOSTS}"
             " -DoutputDirectory=/opt/java\n"
             "RUN mvn "
             " --batch-mode dependency:copy"
             " -Dartifact=org.mlflow:mlflow-scoring:{version}:jar"
+            " -Dhttp.proxyHost={MLFLOW_MVN_HTTP_PROXY_HOST}"
+            " -Dhttp.proxyPort={MLFLOW_MVN_HTTP_PROXY_PORT}"
+            " -Dhttps.proxyHost={MLFLOW_MVN_HTTPS_PROXY_HOST}"
+            " -Dhttps.proxyPort={MLFLOW_MVN_HTTPS_PROXY_PORT}"
+            " -Dhttps.nonProxyHosts={MLFLOW_MVN_NO_PROXY_HOSTS}"
+            " -Dhttp.nonProxyHosts={MLFLOW_MVN_NO_PROXY_HOSTS}"
             " -DoutputDirectory=/opt/java/jars\n"
             "RUN cp /opt/java/mlflow-scoring-{version}.pom /opt/java/pom.xml\n"
             "RUN cd /opt/java && mvn "
-            "--batch-mode dependency:copy-dependencies -DoutputDirectory=/opt/java/jars\n"
-        ).format(version=mlflow.version.VERSION)
+            "--batch-mode dependency:copy-dependencies -Dhttp.proxyHost={MLFLOW_MVN_HTTP_PROXY_HOST} -Dhttp.proxyPort={MLFLOW_MVN_HTTP_PROXY_PORT} -Dhttps.proxyHost={MLFLOW_MVN_HTTPS_PROXY_HOST} -Dhttps.proxyPort={MLFLOW_MVN_HTTPS_PROXY_PORT} -Dhttps.nonProxyHosts={MLFLOW_MVN_NO_PROXY_HOSTS} -Dhttp.nonProxyHosts={MLFLOW_MVN_NO_PROXY_HOSTS} -DoutputDirectory=/opt/java/jars\n"
+        ).format(
+            version=mlflow.version.VERSION, 
+            MLFLOW_MVN_HTTP_PROXY_HOST=MLFLOW_MVN_HTTP_PROXY_HOST,
+            MLFLOW_MVN_HTTP_PROXY_PORT=MLFLOW_MVN_HTTP_PROXY_PORT,
+            MLFLOW_MVN_HTTPS_PROXY_HOST=MLFLOW_MVN_HTTPS_PROXY_HOST,
+            MLFLOW_MVN_HTTPS_PROXY_PORT=MLFLOW_MVN_HTTPS_PROXY_PORT,
+            MLFLOW_MVN_NO_PROXY_HOSTS=MLFLOW_MVN_NO_PROXY_HOSTS
+        )
 
 
 def _build_image(image_name, entrypoint, mlflow_home=None, custom_setup_steps_hook=None):


### PR DESCRIPTION
Signed-off-by: Tianchen Wu <wu.tianchhen.business@gmail.com>

## What changes are proposed in this pull request?

allow user to build prediction server docker image behind enterprise proxy (implementation details: allow mvn in dockerfile from pull to accept proxy setting through command line)

The following environment variables can be configured:

* MLFLOW_MVN_HTTP_PROXY_HOST
* MLFLOW_MVN_HTTP_PROXY_PORT
* MLFLOW_MVN_HTTPS_PROXY_HOST
* MLFLOW_MVN_HTTPS_PROXY_PORT
* MLFLOW_MVN_NO_PROXY_HOSTS

## How is this patch tested?

tested with command mlflow models build-docker within enterprise proxy setting

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

This is a new feature for user. Now they can configure mvn proxy when mlflow models build-docker

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [x] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
