### PR TITLE
Fix run deletion message on GDPR-enabled platforms

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteExperimentModal.js
@@ -58,9 +58,8 @@ export class DeleteExperimentModalImpl extends Component {
             </p>
             {process.env.SHOW_GDPR_PURGING_MESSAGES === 'true' ? (
               <p>
-                Deleted experiments are restorable for 30 days, after which they are purged.
-                <br />
-                Artifacts are not automatically purged and must be manually deleted.
+                Deleted experiments are restorable for 30 days, after which they are purged along
+                with their associated runs, including metrics, params, tags, and artifacts.
               </p>
             ) : (
               ''

--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.js
@@ -47,9 +47,7 @@ export class DeleteRunModalImpl extends Component {
             {process.env.SHOW_GDPR_PURGING_MESSAGES === 'true' ? (
               <p>
                 Deleted runs are restorable for 30 days, after which they are purged along with
-                associated metrics, params and tags.
-                <br />
-                Artifacts are not automatically purged and must be manually deleted.
+                associated metrics, params, tags, and artifacts.
               </p>
             ) : (
               ''


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Fix run deletion message on GDPR-enabled platforms

## How is this patch tested?

Existing unit tests

## Release Notes

### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
