### PR TITLE
Run cross version tests when we update maximum versions

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -167,7 +167,7 @@ def filter_versions(versions, min_ver, max_ver, excludes=None):
 
     # Prevent specifying non-existent versions
     assert min_ver in versions
-    # assert max_ver in versions
+    assert max_ver in versions
     assert all(v in versions for v in excludes)
 
     versions = {Version(v): t for v, t in versions.items() if v not in excludes}

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -419,7 +419,7 @@ def expand_config(config):
                         run=run,
                         package=pip_release,
                         version=ver,
-                        newer_than_max=Version(ver) > Version(max_ver),
+                        supported=Version(ver) <= Version(max_ver),
                     )
                 )
 

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -440,7 +440,7 @@ def expand_config(config):
                         run=run,
                         package=pip_release,
                         version=DEV_VERSION,
-                        newer_than_max=True,
+                        supported=False,
                     )
                 )
     return matrix

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -394,14 +394,14 @@ def expand_config(config):
         for key, cfg in cfgs.items():
             print("Processing", flavor_key, key)
             # Released versions
-            versions = filter_versions(
-                all_versions, cfg["minimum"], cfg["maximum"], cfg.get("unsupported"),
-            )
+            min_ver = cfg["minimum"]
+            max_ver = cfg["maximum"]
+            versions = filter_versions(all_versions, min_ver, max_ver, cfg.get("unsupported"),)
             versions = select_latest_micro_versions(versions)
 
             # Explicitly include the minimum supported version
-            if cfg["minimum"] not in versions:
-                versions.append(cfg["minimum"])
+            if min_ver not in versions:
+                versions.append(min_ver)
 
             pip_release = package_info["pip_release"]
             for ver in versions:
@@ -419,6 +419,7 @@ def expand_config(config):
                         run=run,
                         package=pip_release,
                         version=ver,
+                        newer_than_max=Version(ver) > Version(max_ver),
                     )
                 )
 
@@ -439,6 +440,7 @@ def expand_config(config):
                         run=run,
                         package=pip_release,
                         version=DEV_VERSION,
+                        newer_than_max=True,
                     )
                 )
     return matrix
@@ -473,7 +475,10 @@ def main():
     diff_flavor = set(filter(lambda x: x["flavor"] in changed_flavors, matrix))
 
     # If this file contains changes, re-run all the tests, otherwise re-run the affected tests.
-    include = matrix if (__file__ in changed_files) else diff_config.union(diff_flavor)
+    # I'LL REVERT THIS CHANGE BEFORE MERGE
+    # include = matrix if (__file__ in changed_files) else diff_config.union(diff_flavor)
+    include = diff_config.union(diff_flavor)
+    # I'LL REVERT THIS CHANGE BEFORE MERGE
     include = sorted(include, key=lambda x: x["job_name"])
     job_names = [x["job_name"] for x in include]
 

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -167,7 +167,7 @@ def filter_versions(versions, min_ver, max_ver, excludes=None):
 
     # Prevent specifying non-existent versions
     assert min_ver in versions
-    assert max_ver in versions
+    # assert max_ver in versions
     assert all(v in versions for v in excludes)
 
     versions = {Version(v): t for v, t in versions.items() if v not in excludes}

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -475,10 +475,7 @@ def main():
     diff_flavor = set(filter(lambda x: x["flavor"] in changed_flavors, matrix))
 
     # If this file contains changes, re-run all the tests, otherwise re-run the affected tests.
-    # I'LL REVERT THIS CHANGE BEFORE MERGE
-    # include = matrix if (__file__ in changed_files) else diff_config.union(diff_flavor)
-    include = diff_config.union(diff_flavor)
-    # I'LL REVERT THIS CHANGE BEFORE MERGE
+    include = matrix if (__file__ in changed_files) else diff_config.union(diff_flavor)
     include = sorted(include, key=lambda x: x["job_name"])
     job_names = [x["job_name"] for x in include]
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -12,7 +12,7 @@ sklearn:
 
   autologging:
     minimum: "0.20.3"
-    maximum: "0.24.3"
+    maximum: "0.24.2"
     requirements: ["matplotlib"]
     run: |
       pytest tests/sklearn/test_sklearn_autolog.py --large
@@ -226,9 +226,9 @@ fastai-1.x:
       pytest tests/fastai/test_fastai_model_export.py --large
 
   autologging:
-    pin_maximum: True
+    # pin_maximum: True
     minimum: "1.0.60"
-    maximum: "1.0.61"
+    maximum: "2.0.0"
     requirements: ["scikit-learn"]
     run: |
       pytest tests/fastai/test_fastai_autolog.py --large

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -39,7 +39,7 @@ pytorch-lightning:
 
   autologging:
     minimum: "1.0.5"
-    maximum: "1.3.4"
+    maximum: "1.3.0"
     requirements: ["torchvision", "scikit-learn"]
     run: |
       pytest tests/pytorch/test_pytorch_autolog.py --large

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -12,7 +12,7 @@ sklearn:
 
   autologging:
     minimum: "0.20.3"
-    maximum: "0.24.3"
+    maximum: "0.24.2"
     requirements: ["matplotlib"]
     run: |
       pytest tests/sklearn/test_sklearn_autolog.py --large

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -39,7 +39,7 @@ pytorch-lightning:
 
   autologging:
     minimum: "1.0.5"
-    maximum: "1.3.0"
+    maximum: "1.3.4"
     requirements: ["torchvision", "scikit-learn"]
     run: |
       pytest tests/pytorch/test_pytorch_autolog.py --large
@@ -226,9 +226,9 @@ fastai-1.x:
       pytest tests/fastai/test_fastai_model_export.py --large
 
   autologging:
-    # pin_maximum: True
+    pin_maximum: True
     minimum: "1.0.60"
-    maximum: "2.0.0"
+    maximum: "1.0.61"
     requirements: ["scikit-learn"]
     run: |
       pytest tests/fastai/test_fastai_autolog.py --large

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -12,7 +12,7 @@ sklearn:
 
   autologging:
     minimum: "0.20.3"
-    maximum: "0.24.2"
+    maximum: "0.24.3"
     requirements: ["matplotlib"]
     run: |
       pytest tests/sklearn/test_sklearn_autolog.py --large


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

When we update maximum versions for making a new release, run tests for udpated packages.

## How is this patch tested?

Existing check

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
