### PR TITLE
Fix a leaked run error in `test_pytorch_test_metrics_logged`

### DIFF
--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -262,15 +262,17 @@ def test_pytorch_autolog_non_early_stop_callback_does_not_log(pytorch_model):
 
 @pytest.fixture
 def pytorch_model_tests():
+    mlflow.pytorch.autolog()
     model = IrisClassification()
     dm = IrisDataModule()
     dm.prepare_data()
     dm.setup(stage="fit")
     trainer = pl.Trainer(max_epochs=NUM_EPOCHS)
-    trainer.fit(model, dm)
-    trainer.test()
+    with mlflow.start_run() as run:
+        trainer.fit(model, dm)
+        trainer.test()
     client = mlflow.tracking.MlflowClient()
-    run = client.get_run(client.list_run_infos(experiment_id="0")[0].run_id)
+    run = client.get_run(run.info.run_id)
     return trainer, run
 
 


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix a leaked run error in `test_pytorch_test_metrics_logged`.

https://github.com/mlflow/mlflow/runs/2464693969?check_suite_focus=true#step:10:23

```
==================================== ERRORS ====================================
____________ ERROR at teardown of test_pytorch_test_metrics_logged _____________

    @pytest.fixture(autouse=True)
    def clean_up_leaked_runs():
        """
        Certain test cases validate safety API behavior when runs are leaked. Leaked runs that
        are not cleaned up between test cases may result in cascading failures that are hard to
        debug. Accordingly, this fixture attempts to end any active runs it encounters and
        throws an exception (which reported as an additional error in the pytest execution output).
        """
        try:
            yield
>           assert (
                not mlflow.active_run()
            ), "test case unexpectedly leaked a run. Run info: {}. Run data: {}".format(
                mlflow.active_run().info, mlflow.active_run().data
            )
E           AssertionError: test case unexpectedly leaked a run. Run info: <RunInfo: artifact_uri='./mlruns/0/2a9d070e8c4b4d4b8e27cf0754d2190e/artifacts', end_time=None, experiment_id='0', lifecycle_stage='active', run_id='2a9d070e8c4b4d4b8e27cf0754d2190e', run_uuid='2a9d070e8c4b4d4b8e27cf0754d2190e', start_time=1619683570521, status='RUNNING', user_id='runner'>. Run data: <RunData: metrics={}, params={}, tags={'mlflow.source.name': '/usr/share/miniconda/bin/pytest',
E              'mlflow.source.type': 'LOCAL',
E              'mlflow.user': 'runner'}>
E           assert not <ActiveRun: >
E            +  where <ActiveRun: > = <function active_run at 0x7fabc1ac96a8>()
E            +    where <function active_run at 0x7fabc1ac96a8> = mlflow.active_run
```

## How is this patch tested?

Fixed test

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
