### PR TITLE
Fix version checking in disable_for_unsupported_versions

### DIFF
--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -21,7 +21,9 @@ FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY = {
 
 
 def _check_version_in_range(ver, min_ver, max_ver):
-    return Version(min_ver) <= Version(ver) <= Version(max_ver)
+    version = Version(ver)
+    return not version.is_devrelease and not version.is_prerelease and \
+        Version(min_ver) <= version <= Version(max_ver)
 
 
 def _load_version_file_as_dict():

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -22,8 +22,11 @@ FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY = {
 
 def _check_version_in_range(ver, min_ver, max_ver):
     version = Version(ver)
-    return not version.is_devrelease and not version.is_prerelease and \
-        Version(min_ver) <= version <= Version(max_ver)
+    return (
+        not version.is_devrelease
+        and not version.is_prerelease
+        and Version(min_ver) <= version <= Version(max_ver)
+    )
 
 
 def _load_version_file_as_dict():

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -29,6 +29,11 @@ def _check_version_in_range(ver, min_ver, max_ver):
     )
 
 
+def _is_pre_or_dev_release(ver):
+    v = Version(ver)
+    return v.is_devrelease or v.is_prerelease
+
+
 def _load_version_file_as_dict():
     version_file_path = resource_filename(__name__, "../../ml-package-versions.yml")
     with open(version_file_path) as f:
@@ -52,5 +57,7 @@ def is_flavor_supported_for_associated_package_versions(flavor_name):
     """
     module_name, module_key = FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY[flavor_name]
     actual_version = importlib.import_module(module_name).__version__
+    if _is_pre_or_dev_release(actual_version):
+        return False
     min_version, max_version, _ = get_min_max_version_and_pip_release(module_key)
     return _check_version_in_range(actual_version, min_version, max_version)

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -21,12 +21,7 @@ FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY = {
 
 
 def _check_version_in_range(ver, min_ver, max_ver):
-    version = Version(ver)
-    return (
-        not version.is_devrelease
-        and not version.is_prerelease
-        and Version(min_ver) <= version <= Version(max_ver)
-    )
+    return Version(min_ver) <= Version(ver) <= Version(max_ver)
 
 
 def _is_pre_or_dev_release(ver):

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -1,7 +1,7 @@
 import importlib
 import yaml
 
-from distutils.version import LooseVersion
+from packaging.version import Version
 from pkg_resources import resource_filename
 
 
@@ -21,7 +21,7 @@ FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY = {
 
 
 def _check_version_in_range(ver, min_ver, max_ver):
-    return LooseVersion(min_ver) <= LooseVersion(ver) <= LooseVersion(max_ver)
+    return Version(min_ver) <= Version(ver) <= Version(max_ver)
 
 
 def _load_version_file_as_dict():

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ SKINNY_REQUIREMENTS = [
     "protobuf>=3.6.0",
     "pytz",
     "requests>=2.17.3",
+    "packaging",
 ]
 
 """

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -680,6 +680,15 @@ def test_check_version_in_range():
     assert not _check_version_in_range("1.1.0", "1.0.1", "1.0.3")
     assert _check_version_in_range("1.0.3", "1.0.1", "1.0.3.post1")
 
+    # test skip prerelease version
+    assert not _check_version_in_range('0.24.0rc1', '0.23', '0.25')
+
+    # test skip prerelease version
+    assert not _check_version_in_range('0.24.0rc1', '0.23', '0.25')
+
+    # test skip devrelease version
+    assert not _check_version_in_range('0.24.0dev1', '0.23', '0.25')
+
 
 _module_version_info_dict_patch = {
     "sklearn": {

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -751,6 +751,8 @@ _module_version_info_dict_patch = {
         ("xgboost", "0.89", False),
         ("sklearn", "0.20.3", True),
         ("sklearn", "0.20.2", False),
+        ("sklearn", "0.23.0rc1", False),
+        ("sklearn", "0.23.0dev0", False),
         ("pytorch", "1.0.5", True),
         ("pytorch", "1.0.4", False),
         ("pyspark.ml", "3.1.0", True),

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -26,6 +26,7 @@ from mlflow.utils.autologging_utils.safety import _wrap_patch, AutologgingSessio
 from mlflow.utils.autologging_utils.versioning import (
     FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY,
     _check_version_in_range,
+    _is_pre_or_dev_release,
     is_flavor_supported_for_associated_package_versions,
 )
 
@@ -680,14 +681,11 @@ def test_check_version_in_range():
     assert not _check_version_in_range("1.1.0", "1.0.1", "1.0.3")
     assert _check_version_in_range("1.0.3", "1.0.1", "1.0.3.post1")
 
-    # test skip prerelease version
-    assert not _check_version_in_range("0.24.0rc1", "0.23", "0.25")
 
-    # test skip prerelease version
-    assert not _check_version_in_range("0.24.0rc1", "0.23", "0.25")
-
-    # test skip devrelease version
-    assert not _check_version_in_range("0.24.0dev1", "0.23", "0.25")
+def test_is_pre_or_dev_release():
+    assert _is_pre_or_dev_release("0.24.0rc1")
+    assert _is_pre_or_dev_release("0.24.0dev1")
+    assert not _is_pre_or_dev_release("0.24.0")
 
 
 _module_version_info_dict_patch = {

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -681,13 +681,13 @@ def test_check_version_in_range():
     assert _check_version_in_range("1.0.3", "1.0.1", "1.0.3.post1")
 
     # test skip prerelease version
-    assert not _check_version_in_range('0.24.0rc1', '0.23', '0.25')
+    assert not _check_version_in_range("0.24.0rc1", "0.23", "0.25")
 
     # test skip prerelease version
-    assert not _check_version_in_range('0.24.0rc1', '0.23', '0.25')
+    assert not _check_version_in_range("0.24.0rc1", "0.23", "0.25")
 
     # test skip devrelease version
-    assert not _check_version_in_range('0.24.0dev1', '0.23', '0.25')
+    assert not _check_version_in_range("0.24.0dev1", "0.23", "0.25")
 
 
 _module_version_info_dict_patch = {


### PR DESCRIPTION
Signed-off-by: Weichen Xu <weichen.xu@databricks.com>

## What changes are proposed in this pull request?

Fix version checking in disable_for_unsupported_versions

The loose version checking will generate wrong result when comparing value like:

0.24.0rc1 > 0.24.0

## How is this patch tested?

Unit tests.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
