### PR TITLE
Adding functionality to move logged runs

### DIFF
--- a/docs/source/rest-api.rst
+++ b/docs/source/rest-api.rst
@@ -487,6 +487,7 @@ Request Structure
 | dest_experiment_id | ``STRING`` | ID of the experiment to move the run to. |
 |                    |            | This field is required.                  |
 +--------------------+------------+------------------------------------------+
+
 ===========================
 
 

--- a/docs/source/rest-api.rst
+++ b/docs/source/rest-api.rst
@@ -448,6 +448,49 @@ Response Structure
 
 
 
+.. _mlflowMlflowServicemoveRun:
+
+Move Run
+==========
+
+
++----------------------------+-------------+
+|          Endpoint          | HTTP Method |
++============================+=============+
+| ``2.0/mlflow/runs/move``   | ``POST``    |
++----------------------------+-------------+
+
+Move a run to a different experiment.
+
+
+
+
+.. _mlflowMoveRun:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++--------------------+------------+------------------------------------------+
+| Field Name         | Type       | Description                              |
++====================+============+==========================================+
+| run_id             | ``STRING`` | ID of the run to move.                   |
+|                    |            | This field is required.                  |
++--------------------+------------+------------------------------------------+
+| src_experiment_id  | ``STRING`` | ID of the experiment containing the run. |
+|                    |            | This field is required.                  |
++--------------------+------------+------------------------------------------+
+| dest_experiment_id | ``STRING`` | ID of the experiment to move the run to. |
+|                    |            | This field is required.                  |
++--------------------+------------+------------------------------------------+
+===========================
+
+
+
 .. _mlflowMlflowServicedeleteRun:
 
 Delete Run

--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Service.java
@@ -21277,6 +21277,1475 @@ public final class Service {
 
   }
 
+  public interface MoveRunOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:mlflow.MoveRun)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <pre>
+     * ID of the run to move.
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     */
+    boolean hasRunId();
+    /**
+     * <pre>
+     * ID of the run to move.
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     */
+    java.lang.String getRunId();
+    /**
+     * <pre>
+     * ID of the run to move.
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     */
+    com.google.protobuf.ByteString
+        getRunIdBytes();
+
+    /**
+     * <pre>
+     * ID of the source experiment.
+     * </pre>
+     *
+     * <code>optional string src_experiment_id = 2;</code>
+     */
+    boolean hasSrcExperimentId();
+    /**
+     * <pre>
+     * ID of the source experiment.
+     * </pre>
+     *
+     * <code>optional string src_experiment_id = 2;</code>
+     */
+    java.lang.String getSrcExperimentId();
+    /**
+     * <pre>
+     * ID of the source experiment.
+     * </pre>
+     *
+     * <code>optional string src_experiment_id = 2;</code>
+     */
+    com.google.protobuf.ByteString
+        getSrcExperimentIdBytes();
+
+    /**
+     * <pre>
+     * ID of the destination experiment.
+     * </pre>
+     *
+     * <code>optional string dest_experiment_id = 3;</code>
+     */
+    boolean hasDestExperimentId();
+    /**
+     * <pre>
+     * ID of the destination experiment.
+     * </pre>
+     *
+     * <code>optional string dest_experiment_id = 3;</code>
+     */
+    java.lang.String getDestExperimentId();
+    /**
+     * <pre>
+     * ID of the destination experiment.
+     * </pre>
+     *
+     * <code>optional string dest_experiment_id = 3;</code>
+     */
+    com.google.protobuf.ByteString
+        getDestExperimentIdBytes();
+  }
+  /**
+   * Protobuf type {@code mlflow.MoveRun}
+   */
+  public  static final class MoveRun extends
+      com.google.protobuf.GeneratedMessageV3 implements
+      // @@protoc_insertion_point(message_implements:mlflow.MoveRun)
+      MoveRunOrBuilder {
+  private static final long serialVersionUID = 0L;
+    // Use MoveRun.newBuilder() to construct.
+    private MoveRun(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+      super(builder);
+    }
+    private MoveRun() {
+      runId_ = "";
+      srcExperimentId_ = "";
+      destExperimentId_ = "";
+    }
+
+    @java.lang.Override
+    public final com.google.protobuf.UnknownFieldSet
+    getUnknownFields() {
+      return this.unknownFields;
+    }
+    private MoveRun(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      this();
+      if (extensionRegistry == null) {
+        throw new java.lang.NullPointerException();
+      }
+      int mutable_bitField0_ = 0;
+      com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+          com.google.protobuf.UnknownFieldSet.newBuilder();
+      try {
+        boolean done = false;
+        while (!done) {
+          int tag = input.readTag();
+          switch (tag) {
+            case 0:
+              done = true;
+              break;
+            case 10: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000001;
+              runId_ = bs;
+              break;
+            }
+            case 18: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000002;
+              srcExperimentId_ = bs;
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000004;
+              destExperimentId_ = bs;
+              break;
+            }
+            default: {
+              if (!parseUnknownField(
+                  input, unknownFields, extensionRegistry, tag)) {
+                done = true;
+              }
+              break;
+            }
+          }
+        }
+      } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+        throw e.setUnfinishedMessage(this);
+      } catch (java.io.IOException e) {
+        throw new com.google.protobuf.InvalidProtocolBufferException(
+            e).setUnfinishedMessage(this);
+      } finally {
+        this.unknownFields = unknownFields.build();
+        makeExtensionsImmutable();
+      }
+    }
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRun_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRun_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              org.mlflow.api.proto.Service.MoveRun.class, org.mlflow.api.proto.Service.MoveRun.Builder.class);
+    }
+
+    public interface ResponseOrBuilder extends
+        // @@protoc_insertion_point(interface_extends:mlflow.MoveRun.Response)
+        com.google.protobuf.MessageOrBuilder {
+    }
+    /**
+     * Protobuf type {@code mlflow.MoveRun.Response}
+     */
+    public  static final class Response extends
+        com.google.protobuf.GeneratedMessageV3 implements
+        // @@protoc_insertion_point(message_implements:mlflow.MoveRun.Response)
+        ResponseOrBuilder {
+    private static final long serialVersionUID = 0L;
+      // Use Response.newBuilder() to construct.
+      private Response(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
+        super(builder);
+      }
+      private Response() {
+      }
+
+      @java.lang.Override
+      public final com.google.protobuf.UnknownFieldSet
+      getUnknownFields() {
+        return this.unknownFields;
+      }
+      private Response(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        this();
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        com.google.protobuf.UnknownFieldSet.Builder unknownFields =
+            com.google.protobuf.UnknownFieldSet.newBuilder();
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!parseUnknownField(
+                    input, unknownFields, extensionRegistry, tag)) {
+                  done = true;
+                }
+                break;
+              }
+            }
+          }
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(this);
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(
+              e).setUnfinishedMessage(this);
+        } finally {
+          this.unknownFields = unknownFields.build();
+          makeExtensionsImmutable();
+        }
+      }
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRun_Response_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRun_Response_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.Service.MoveRun.Response.class, org.mlflow.api.proto.Service.MoveRun.Response.Builder.class);
+      }
+
+      private byte memoizedIsInitialized = -1;
+      @java.lang.Override
+      public final boolean isInitialized() {
+        byte isInitialized = memoizedIsInitialized;
+        if (isInitialized == 1) return true;
+        if (isInitialized == 0) return false;
+
+        memoizedIsInitialized = 1;
+        return true;
+      }
+
+      @java.lang.Override
+      public void writeTo(com.google.protobuf.CodedOutputStream output)
+                          throws java.io.IOException {
+        unknownFields.writeTo(output);
+      }
+
+      @java.lang.Override
+      public int getSerializedSize() {
+        int size = memoizedSize;
+        if (size != -1) return size;
+
+        size = 0;
+        size += unknownFields.getSerializedSize();
+        memoizedSize = size;
+        return size;
+      }
+
+      @java.lang.Override
+      public boolean equals(final java.lang.Object obj) {
+        if (obj == this) {
+         return true;
+        }
+        if (!(obj instanceof org.mlflow.api.proto.Service.MoveRun.Response)) {
+          return super.equals(obj);
+        }
+        org.mlflow.api.proto.Service.MoveRun.Response other = (org.mlflow.api.proto.Service.MoveRun.Response) obj;
+
+        boolean result = true;
+        result = result && unknownFields.equals(other.unknownFields);
+        return result;
+      }
+
+      @java.lang.Override
+      public int hashCode() {
+        if (memoizedHashCode != 0) {
+          return memoizedHashCode;
+        }
+        int hash = 41;
+        hash = (19 * hash) + getDescriptor().hashCode();
+        hash = (29 * hash) + unknownFields.hashCode();
+        memoizedHashCode = hash;
+        return hash;
+      }
+
+      public static org.mlflow.api.proto.Service.MoveRun.Response parseFrom(
+          java.nio.ByteBuffer data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.Service.MoveRun.Response parseFrom(
+          java.nio.ByteBuffer data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.MoveRun.Response parseFrom(
+          com.google.protobuf.ByteString data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.Service.MoveRun.Response parseFrom(
+          com.google.protobuf.ByteString data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.MoveRun.Response parseFrom(byte[] data)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data);
+      }
+      public static org.mlflow.api.proto.Service.MoveRun.Response parseFrom(
+          byte[] data,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return PARSER.parseFrom(data, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.MoveRun.Response parseFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.Service.MoveRun.Response parseFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.MoveRun.Response parseDelimitedFrom(java.io.InputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.Service.MoveRun.Response parseDelimitedFrom(
+          java.io.InputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+      }
+      public static org.mlflow.api.proto.Service.MoveRun.Response parseFrom(
+          com.google.protobuf.CodedInputStream input)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input);
+      }
+      public static org.mlflow.api.proto.Service.MoveRun.Response parseFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        return com.google.protobuf.GeneratedMessageV3
+            .parseWithIOException(PARSER, input, extensionRegistry);
+      }
+
+      @java.lang.Override
+      public Builder newBuilderForType() { return newBuilder(); }
+      public static Builder newBuilder() {
+        return DEFAULT_INSTANCE.toBuilder();
+      }
+      public static Builder newBuilder(org.mlflow.api.proto.Service.MoveRun.Response prototype) {
+        return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+      }
+      @java.lang.Override
+      public Builder toBuilder() {
+        return this == DEFAULT_INSTANCE
+            ? new Builder() : new Builder().mergeFrom(this);
+      }
+
+      @java.lang.Override
+      protected Builder newBuilderForType(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        Builder builder = new Builder(parent);
+        return builder;
+      }
+      /**
+       * Protobuf type {@code mlflow.MoveRun.Response}
+       */
+      public static final class Builder extends
+          com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+          // @@protoc_insertion_point(builder_implements:mlflow.MoveRun.Response)
+          org.mlflow.api.proto.Service.MoveRun.ResponseOrBuilder {
+        public static final com.google.protobuf.Descriptors.Descriptor
+            getDescriptor() {
+          return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRun_Response_descriptor;
+        }
+
+        @java.lang.Override
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internalGetFieldAccessorTable() {
+          return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRun_Response_fieldAccessorTable
+              .ensureFieldAccessorsInitialized(
+                  org.mlflow.api.proto.Service.MoveRun.Response.class, org.mlflow.api.proto.Service.MoveRun.Response.Builder.class);
+        }
+
+        // Construct using org.mlflow.api.proto.Service.MoveRun.Response.newBuilder()
+        private Builder() {
+          maybeForceBuilderInitialization();
+        }
+
+        private Builder(
+            com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+          super(parent);
+          maybeForceBuilderInitialization();
+        }
+        private void maybeForceBuilderInitialization() {
+          if (com.google.protobuf.GeneratedMessageV3
+                  .alwaysUseFieldBuilders) {
+          }
+        }
+        @java.lang.Override
+        public Builder clear() {
+          super.clear();
+          return this;
+        }
+
+        @java.lang.Override
+        public com.google.protobuf.Descriptors.Descriptor
+            getDescriptorForType() {
+          return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRun_Response_descriptor;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.Service.MoveRun.Response getDefaultInstanceForType() {
+          return org.mlflow.api.proto.Service.MoveRun.Response.getDefaultInstance();
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.Service.MoveRun.Response build() {
+          org.mlflow.api.proto.Service.MoveRun.Response result = buildPartial();
+          if (!result.isInitialized()) {
+            throw newUninitializedMessageException(result);
+          }
+          return result;
+        }
+
+        @java.lang.Override
+        public org.mlflow.api.proto.Service.MoveRun.Response buildPartial() {
+          org.mlflow.api.proto.Service.MoveRun.Response result = new org.mlflow.api.proto.Service.MoveRun.Response(this);
+          onBuilt();
+          return result;
+        }
+
+        @java.lang.Override
+        public Builder clone() {
+          return (Builder) super.clone();
+        }
+        @java.lang.Override
+        public Builder setField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return (Builder) super.setField(field, value);
+        }
+        @java.lang.Override
+        public Builder clearField(
+            com.google.protobuf.Descriptors.FieldDescriptor field) {
+          return (Builder) super.clearField(field);
+        }
+        @java.lang.Override
+        public Builder clearOneof(
+            com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+          return (Builder) super.clearOneof(oneof);
+        }
+        @java.lang.Override
+        public Builder setRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            int index, java.lang.Object value) {
+          return (Builder) super.setRepeatedField(field, index, value);
+        }
+        @java.lang.Override
+        public Builder addRepeatedField(
+            com.google.protobuf.Descriptors.FieldDescriptor field,
+            java.lang.Object value) {
+          return (Builder) super.addRepeatedField(field, value);
+        }
+        @java.lang.Override
+        public Builder mergeFrom(com.google.protobuf.Message other) {
+          if (other instanceof org.mlflow.api.proto.Service.MoveRun.Response) {
+            return mergeFrom((org.mlflow.api.proto.Service.MoveRun.Response)other);
+          } else {
+            super.mergeFrom(other);
+            return this;
+          }
+        }
+
+        public Builder mergeFrom(org.mlflow.api.proto.Service.MoveRun.Response other) {
+          if (other == org.mlflow.api.proto.Service.MoveRun.Response.getDefaultInstance()) return this;
+          this.mergeUnknownFields(other.unknownFields);
+          onChanged();
+          return this;
+        }
+
+        @java.lang.Override
+        public final boolean isInitialized() {
+          return true;
+        }
+
+        @java.lang.Override
+        public Builder mergeFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws java.io.IOException {
+          org.mlflow.api.proto.Service.MoveRun.Response parsedMessage = null;
+          try {
+            parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+          } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+            parsedMessage = (org.mlflow.api.proto.Service.MoveRun.Response) e.getUnfinishedMessage();
+            throw e.unwrapIOException();
+          } finally {
+            if (parsedMessage != null) {
+              mergeFrom(parsedMessage);
+            }
+          }
+          return this;
+        }
+        @java.lang.Override
+        public final Builder setUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.setUnknownFields(unknownFields);
+        }
+
+        @java.lang.Override
+        public final Builder mergeUnknownFields(
+            final com.google.protobuf.UnknownFieldSet unknownFields) {
+          return super.mergeUnknownFields(unknownFields);
+        }
+
+
+        // @@protoc_insertion_point(builder_scope:mlflow.MoveRun.Response)
+      }
+
+      // @@protoc_insertion_point(class_scope:mlflow.MoveRun.Response)
+      private static final org.mlflow.api.proto.Service.MoveRun.Response DEFAULT_INSTANCE;
+      static {
+        DEFAULT_INSTANCE = new org.mlflow.api.proto.Service.MoveRun.Response();
+      }
+
+      public static org.mlflow.api.proto.Service.MoveRun.Response getDefaultInstance() {
+        return DEFAULT_INSTANCE;
+      }
+
+      @java.lang.Deprecated public static final com.google.protobuf.Parser<Response>
+          PARSER = new com.google.protobuf.AbstractParser<Response>() {
+        @java.lang.Override
+        public Response parsePartialFrom(
+            com.google.protobuf.CodedInputStream input,
+            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+            throws com.google.protobuf.InvalidProtocolBufferException {
+          return new Response(input, extensionRegistry);
+        }
+      };
+
+      public static com.google.protobuf.Parser<Response> parser() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Parser<Response> getParserForType() {
+        return PARSER;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.MoveRun.Response getDefaultInstanceForType() {
+        return DEFAULT_INSTANCE;
+      }
+
+    }
+
+    private int bitField0_;
+    public static final int RUN_ID_FIELD_NUMBER = 1;
+    private volatile java.lang.Object runId_;
+    /**
+     * <pre>
+     * ID of the run to move.
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     */
+    public boolean hasRunId() {
+      return ((bitField0_ & 0x00000001) == 0x00000001);
+    }
+    /**
+     * <pre>
+     * ID of the run to move.
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     */
+    public java.lang.String getRunId() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          runId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * ID of the run to move.
+     * </pre>
+     *
+     * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+     */
+    public com.google.protobuf.ByteString
+        getRunIdBytes() {
+      java.lang.Object ref = runId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        runId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int SRC_EXPERIMENT_ID_FIELD_NUMBER = 2;
+    private volatile java.lang.Object srcExperimentId_;
+    /**
+     * <pre>
+     * ID of the source experiment.
+     * </pre>
+     *
+     * <code>optional string src_experiment_id = 2;</code>
+     */
+    public boolean hasSrcExperimentId() {
+      return ((bitField0_ & 0x00000002) == 0x00000002);
+    }
+    /**
+     * <pre>
+     * ID of the source experiment.
+     * </pre>
+     *
+     * <code>optional string src_experiment_id = 2;</code>
+     */
+    public java.lang.String getSrcExperimentId() {
+      java.lang.Object ref = srcExperimentId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          srcExperimentId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * ID of the source experiment.
+     * </pre>
+     *
+     * <code>optional string src_experiment_id = 2;</code>
+     */
+    public com.google.protobuf.ByteString
+        getSrcExperimentIdBytes() {
+      java.lang.Object ref = srcExperimentId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        srcExperimentId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int DEST_EXPERIMENT_ID_FIELD_NUMBER = 3;
+    private volatile java.lang.Object destExperimentId_;
+    /**
+     * <pre>
+     * ID of the destination experiment.
+     * </pre>
+     *
+     * <code>optional string dest_experiment_id = 3;</code>
+     */
+    public boolean hasDestExperimentId() {
+      return ((bitField0_ & 0x00000004) == 0x00000004);
+    }
+    /**
+     * <pre>
+     * ID of the destination experiment.
+     * </pre>
+     *
+     * <code>optional string dest_experiment_id = 3;</code>
+     */
+    public java.lang.String getDestExperimentId() {
+      java.lang.Object ref = destExperimentId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          destExperimentId_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * ID of the destination experiment.
+     * </pre>
+     *
+     * <code>optional string dest_experiment_id = 3;</code>
+     */
+    public com.google.protobuf.ByteString
+        getDestExperimentIdBytes() {
+      java.lang.Object ref = destExperimentId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        destExperimentId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 1, runId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 2, srcExperimentId_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, destExperimentId_);
+      }
+      unknownFields.writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) == 0x00000001)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(1, runId_);
+      }
+      if (((bitField0_ & 0x00000002) == 0x00000002)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, srcExperimentId_);
+      }
+      if (((bitField0_ & 0x00000004) == 0x00000004)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, destExperimentId_);
+      }
+      size += unknownFields.getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof org.mlflow.api.proto.Service.MoveRun)) {
+        return super.equals(obj);
+      }
+      org.mlflow.api.proto.Service.MoveRun other = (org.mlflow.api.proto.Service.MoveRun) obj;
+
+      boolean result = true;
+      result = result && (hasRunId() == other.hasRunId());
+      if (hasRunId()) {
+        result = result && getRunId()
+            .equals(other.getRunId());
+      }
+      result = result && (hasSrcExperimentId() == other.hasSrcExperimentId());
+      if (hasSrcExperimentId()) {
+        result = result && getSrcExperimentId()
+            .equals(other.getSrcExperimentId());
+      }
+      result = result && (hasDestExperimentId() == other.hasDestExperimentId());
+      if (hasDestExperimentId()) {
+        result = result && getDestExperimentId()
+            .equals(other.getDestExperimentId());
+      }
+      result = result && unknownFields.equals(other.unknownFields);
+      return result;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasRunId()) {
+        hash = (37 * hash) + RUN_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getRunId().hashCode();
+      }
+      if (hasSrcExperimentId()) {
+        hash = (37 * hash) + SRC_EXPERIMENT_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getSrcExperimentId().hashCode();
+      }
+      if (hasDestExperimentId()) {
+        hash = (37 * hash) + DEST_EXPERIMENT_ID_FIELD_NUMBER;
+        hash = (53 * hash) + getDestExperimentId().hashCode();
+      }
+      hash = (29 * hash) + unknownFields.hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static org.mlflow.api.proto.Service.MoveRun parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.Service.MoveRun parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.MoveRun parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.Service.MoveRun parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.MoveRun parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static org.mlflow.api.proto.Service.MoveRun parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.MoveRun parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.Service.MoveRun parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.MoveRun parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.Service.MoveRun parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static org.mlflow.api.proto.Service.MoveRun parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input);
+    }
+    public static org.mlflow.api.proto.Service.MoveRun parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessageV3
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(org.mlflow.api.proto.Service.MoveRun prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code mlflow.MoveRun}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessageV3.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:mlflow.MoveRun)
+        org.mlflow.api.proto.Service.MoveRunOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRun_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRun_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                org.mlflow.api.proto.Service.MoveRun.class, org.mlflow.api.proto.Service.MoveRun.Builder.class);
+      }
+
+      // Construct using org.mlflow.api.proto.Service.MoveRun.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessageV3
+                .alwaysUseFieldBuilders) {
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        runId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000001);
+        srcExperimentId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000002);
+        destExperimentId_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return org.mlflow.api.proto.Service.internal_static_mlflow_MoveRun_descriptor;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.MoveRun getDefaultInstanceForType() {
+        return org.mlflow.api.proto.Service.MoveRun.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.MoveRun build() {
+        org.mlflow.api.proto.Service.MoveRun result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public org.mlflow.api.proto.Service.MoveRun buildPartial() {
+        org.mlflow.api.proto.Service.MoveRun result = new org.mlflow.api.proto.Service.MoveRun(this);
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) == 0x00000001)) {
+          to_bitField0_ |= 0x00000001;
+        }
+        result.runId_ = runId_;
+        if (((from_bitField0_ & 0x00000002) == 0x00000002)) {
+          to_bitField0_ |= 0x00000002;
+        }
+        result.srcExperimentId_ = srcExperimentId_;
+        if (((from_bitField0_ & 0x00000004) == 0x00000004)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.destExperimentId_ = destExperimentId_;
+        result.bitField0_ = to_bitField0_;
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder clone() {
+        return (Builder) super.clone();
+      }
+      @java.lang.Override
+      public Builder setField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.setField(field, value);
+      }
+      @java.lang.Override
+      public Builder clearField(
+          com.google.protobuf.Descriptors.FieldDescriptor field) {
+        return (Builder) super.clearField(field);
+      }
+      @java.lang.Override
+      public Builder clearOneof(
+          com.google.protobuf.Descriptors.OneofDescriptor oneof) {
+        return (Builder) super.clearOneof(oneof);
+      }
+      @java.lang.Override
+      public Builder setRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          int index, java.lang.Object value) {
+        return (Builder) super.setRepeatedField(field, index, value);
+      }
+      @java.lang.Override
+      public Builder addRepeatedField(
+          com.google.protobuf.Descriptors.FieldDescriptor field,
+          java.lang.Object value) {
+        return (Builder) super.addRepeatedField(field, value);
+      }
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof org.mlflow.api.proto.Service.MoveRun) {
+          return mergeFrom((org.mlflow.api.proto.Service.MoveRun)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(org.mlflow.api.proto.Service.MoveRun other) {
+        if (other == org.mlflow.api.proto.Service.MoveRun.getDefaultInstance()) return this;
+        if (other.hasRunId()) {
+          bitField0_ |= 0x00000001;
+          runId_ = other.runId_;
+          onChanged();
+        }
+        if (other.hasSrcExperimentId()) {
+          bitField0_ |= 0x00000002;
+          srcExperimentId_ = other.srcExperimentId_;
+          onChanged();
+        }
+        if (other.hasDestExperimentId()) {
+          bitField0_ |= 0x00000004;
+          destExperimentId_ = other.destExperimentId_;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.unknownFields);
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        org.mlflow.api.proto.Service.MoveRun parsedMessage = null;
+        try {
+          parsedMessage = PARSER.parsePartialFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          parsedMessage = (org.mlflow.api.proto.Service.MoveRun) e.getUnfinishedMessage();
+          throw e.unwrapIOException();
+        } finally {
+          if (parsedMessage != null) {
+            mergeFrom(parsedMessage);
+          }
+        }
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object runId_ = "";
+      /**
+       * <pre>
+       * ID of the run to move.
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       */
+      public boolean hasRunId() {
+        return ((bitField0_ & 0x00000001) == 0x00000001);
+      }
+      /**
+       * <pre>
+       * ID of the run to move.
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       */
+      public java.lang.String getRunId() {
+        java.lang.Object ref = runId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            runId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run to move.
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       */
+      public com.google.protobuf.ByteString
+          getRunIdBytes() {
+        java.lang.Object ref = runId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          runId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the run to move.
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       */
+      public Builder setRunId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run to move.
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       */
+      public Builder clearRunId() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        runId_ = getDefaultInstance().getRunId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the run to move.
+       * </pre>
+       *
+       * <code>optional string run_id = 1 [(.mlflow.validate_required) = true];</code>
+       */
+      public Builder setRunIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000001;
+        runId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object srcExperimentId_ = "";
+      /**
+       * <pre>
+       * ID of the source experiment.
+       * </pre>
+       *
+       * <code>optional string src_experiment_id = 2;</code>
+       */
+      public boolean hasSrcExperimentId() {
+        return ((bitField0_ & 0x00000002) == 0x00000002);
+      }
+      /**
+       * <pre>
+       * ID of the source experiment.
+       * </pre>
+       *
+       * <code>optional string src_experiment_id = 2;</code>
+       */
+      public java.lang.String getSrcExperimentId() {
+        java.lang.Object ref = srcExperimentId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            srcExperimentId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the source experiment.
+       * </pre>
+       *
+       * <code>optional string src_experiment_id = 2;</code>
+       */
+      public com.google.protobuf.ByteString
+          getSrcExperimentIdBytes() {
+        java.lang.Object ref = srcExperimentId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          srcExperimentId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the source experiment.
+       * </pre>
+       *
+       * <code>optional string src_experiment_id = 2;</code>
+       */
+      public Builder setSrcExperimentId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        srcExperimentId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the source experiment.
+       * </pre>
+       *
+       * <code>optional string src_experiment_id = 2;</code>
+       */
+      public Builder clearSrcExperimentId() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        srcExperimentId_ = getDefaultInstance().getSrcExperimentId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the source experiment.
+       * </pre>
+       *
+       * <code>optional string src_experiment_id = 2;</code>
+       */
+      public Builder setSrcExperimentIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000002;
+        srcExperimentId_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object destExperimentId_ = "";
+      /**
+       * <pre>
+       * ID of the destination experiment.
+       * </pre>
+       *
+       * <code>optional string dest_experiment_id = 3;</code>
+       */
+      public boolean hasDestExperimentId() {
+        return ((bitField0_ & 0x00000004) == 0x00000004);
+      }
+      /**
+       * <pre>
+       * ID of the destination experiment.
+       * </pre>
+       *
+       * <code>optional string dest_experiment_id = 3;</code>
+       */
+      public java.lang.String getDestExperimentId() {
+        java.lang.Object ref = destExperimentId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            destExperimentId_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the destination experiment.
+       * </pre>
+       *
+       * <code>optional string dest_experiment_id = 3;</code>
+       */
+      public com.google.protobuf.ByteString
+          getDestExperimentIdBytes() {
+        java.lang.Object ref = destExperimentId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          destExperimentId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * ID of the destination experiment.
+       * </pre>
+       *
+       * <code>optional string dest_experiment_id = 3;</code>
+       */
+      public Builder setDestExperimentId(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        destExperimentId_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the destination experiment.
+       * </pre>
+       *
+       * <code>optional string dest_experiment_id = 3;</code>
+       */
+      public Builder clearDestExperimentId() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        destExperimentId_ = getDefaultInstance().getDestExperimentId();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * ID of the destination experiment.
+       * </pre>
+       *
+       * <code>optional string dest_experiment_id = 3;</code>
+       */
+      public Builder setDestExperimentIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        destExperimentId_ = value;
+        onChanged();
+        return this;
+      }
+      @java.lang.Override
+      public final Builder setUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.setUnknownFields(unknownFields);
+      }
+
+      @java.lang.Override
+      public final Builder mergeUnknownFields(
+          final com.google.protobuf.UnknownFieldSet unknownFields) {
+        return super.mergeUnknownFields(unknownFields);
+      }
+
+
+      // @@protoc_insertion_point(builder_scope:mlflow.MoveRun)
+    }
+
+    // @@protoc_insertion_point(class_scope:mlflow.MoveRun)
+    private static final org.mlflow.api.proto.Service.MoveRun DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new org.mlflow.api.proto.Service.MoveRun();
+    }
+
+    public static org.mlflow.api.proto.Service.MoveRun getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    @java.lang.Deprecated public static final com.google.protobuf.Parser<MoveRun>
+        PARSER = new com.google.protobuf.AbstractParser<MoveRun>() {
+      @java.lang.Override
+      public MoveRun parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        return new MoveRun(input, extensionRegistry);
+      }
+    };
+
+    public static com.google.protobuf.Parser<MoveRun> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<MoveRun> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public org.mlflow.api.proto.Service.MoveRun getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface UpdateRunOrBuilder extends
       // @@protoc_insertion_point(interface_extends:mlflow.UpdateRun)
       com.google.protobuf.MessageOrBuilder {
@@ -48140,6 +49609,16 @@ public final class Service {
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
       internal_static_mlflow_CreateRun_Response_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_MoveRun_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_MoveRun_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_mlflow_MoveRun_Response_descriptor;
+  private static final 
+    com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+      internal_static_mlflow_MoveRun_Response_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_mlflow_UpdateRun_descriptor;
   private static final 
     com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
@@ -48348,172 +49827,179 @@ public final class Service {
       " \001(\t\022\017\n\007user_id\030\002 \001(\t\022\022\n\nstart_time\030\007 \001(" +
       "\003\022\034\n\004tags\030\t \003(\0132\016.mlflow.RunTag\032$\n\010Respo" +
       "nse\022\030\n\003run\030\001 \001(\0132\013.mlflow.Run:+\342?(\n&com." +
-      "databricks.rpc.RPC[$this.Response]\"\276\001\n\tU" +
-      "pdateRun\022\016\n\006run_id\030\004 \001(\t\022\020\n\010run_uuid\030\001 \001" +
-      "(\t\022!\n\006status\030\002 \001(\0162\021.mlflow.RunStatus\022\020\n" +
-      "\010end_time\030\003 \001(\003\032-\n\010Response\022!\n\010run_info\030" +
-      "\001 \001(\0132\017.mlflow.RunInfo:+\342?(\n&com.databri" +
-      "cks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun" +
-      "\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n" +
-      "&com.databricks.rpc.RPC[$this.Response]\"" +
-      "[\n\nRestoreRun\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\032\n\n\010R" +
-      "esponse:+\342?(\n&com.databricks.rpc.RPC[$th" +
-      "is.Response]\"\270\001\n\tLogMetric\022\016\n\006run_id\030\006 \001" +
-      "(\t\022\020\n\010run_uuid\030\001 \001(\t\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\022" +
-      "\023\n\005value\030\003 \001(\001B\004\370\206\031\001\022\027\n\ttimestamp\030\004 \001(\003B" +
-      "\004\370\206\031\001\022\017\n\004step\030\005 \001(\003:\0010\032\n\n\010Response:+\342?(\n" +
-      "&com.databricks.rpc.RPC[$this.Response]\"" +
-      "\215\001\n\010LogParam\022\016\n\006run_id\030\004 \001(\t\022\020\n\010run_uuid" +
-      "\030\001 \001(\t\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\022\023\n\005value\030\003 \001(\t" +
-      "B\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.databricks." +
-      "rpc.RPC[$this.Response]\"\220\001\n\020SetExperimen" +
-      "tTag\022\033\n\rexperiment_id\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key" +
-      "\030\002 \001(\tB\004\370\206\031\001\022\023\n\005value\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Res" +
-      "ponse:+\342?(\n&com.databricks.rpc.RPC[$this" +
-      ".Response]\"\213\001\n\006SetTag\022\016\n\006run_id\030\004 \001(\t\022\020\n" +
-      "\010run_uuid\030\001 \001(\t\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\022\023\n\005va" +
-      "lue\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.da" +
-      "tabricks.rpc.RPC[$this.Response]\"m\n\tDele" +
-      "teTag\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\t" +
-      "B\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.databricks." +
-      "rpc.RPC[$this.Response]\"}\n\006GetRun\022\016\n\006run" +
-      "_id\030\002 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\032$\n\010Response\022" +
-      "\030\n\003run\030\001 \001(\0132\013.mlflow.Run:+\342?(\n&com.data" +
-      "bricks.rpc.RPC[$this.Response]\"\230\002\n\nSearc" +
-      "hRuns\022\026\n\016experiment_ids\030\001 \003(\t\022\016\n\006filter\030" +
-      "\004 \001(\t\0224\n\rrun_view_type\030\003 \001(\0162\020.mlflow.Vi" +
-      "ewType:\013ACTIVE_ONLY\022\031\n\013max_results\030\005 \001(\005" +
-      ":\0041000\022\020\n\010order_by\030\006 \003(\t\022\022\n\npage_token\030\007" +
-      " \001(\t\032>\n\010Response\022\031\n\004runs\030\001 \003(\0132\013.mlflow." +
-      "Run\022\027\n\017next_page_token\030\002 \001(\t:+\342?(\n&com.d" +
-      "atabricks.rpc.RPC[$this.Response]\"\330\001\n\rLi" +
-      "stArtifacts\022\016\n\006run_id\030\003 \001(\t\022\020\n\010run_uuid\030" +
-      "\001 \001(\t\022\014\n\004path\030\002 \001(\t\022\022\n\npage_token\030\004 \001(\t\032" +
-      "V\n\010Response\022\020\n\010root_uri\030\001 \001(\t\022\037\n\005files\030\002" +
-      " \003(\0132\020.mlflow.FileInfo\022\027\n\017next_page_toke" +
-      "n\030\003 \001(\t:+\342?(\n&com.databricks.rpc.RPC[$th" +
-      "is.Response]\";\n\010FileInfo\022\014\n\004path\030\001 \001(\t\022\016" +
-      "\n\006is_dir\030\002 \001(\010\022\021\n\tfile_size\030\003 \001(\003\"\250\001\n\020Ge" +
-      "tMetricHistory\022\016\n\006run_id\030\003 \001(\t\022\020\n\010run_uu" +
-      "id\030\001 \001(\t\022\030\n\nmetric_key\030\002 \001(\tB\004\370\206\031\001\032+\n\010Re" +
-      "sponse\022\037\n\007metrics\030\001 \003(\0132\016.mlflow.Metric:" +
-      "+\342?(\n&com.databricks.rpc.RPC[$this.Respo" +
-      "nse]\"\261\001\n\010LogBatch\022\016\n\006run_id\030\001 \001(\t\022\037\n\007met" +
-      "rics\030\002 \003(\0132\016.mlflow.Metric\022\035\n\006params\030\003 \003" +
-      "(\0132\r.mlflow.Param\022\034\n\004tags\030\004 \003(\0132\016.mlflow" +
-      ".RunTag\032\n\n\010Response:+\342?(\n&com.databricks" +
-      ".rpc.RPC[$this.Response]\"g\n\010LogModel\022\016\n\006" +
-      "run_id\030\001 \001(\t\022\022\n\nmodel_json\030\002 \001(\t\032\n\n\010Resp" +
+      "databricks.rpc.RPC[$this.Response]\"\217\001\n\007M" +
+      "oveRun\022\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\022\031\n\021src_expe" +
+      "riment_id\030\002 \001(\t\022\032\n\022dest_experiment_id\030\003 " +
+      "\001(\t\032\n\n\010Response:+\342?(\n&com.databricks.rpc" +
+      ".RPC[$this.Response]\"\276\001\n\tUpdateRun\022\016\n\006ru" +
+      "n_id\030\004 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022!\n\006status\030\002" +
+      " \001(\0162\021.mlflow.RunStatus\022\020\n\010end_time\030\003 \001(" +
+      "\003\032-\n\010Response\022!\n\010run_info\030\001 \001(\0132\017.mlflow" +
+      ".RunInfo:+\342?(\n&com.databricks.rpc.RPC[$t" +
+      "his.Response]\"Z\n\tDeleteRun\022\024\n\006run_id\030\001 \001" +
+      "(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&com.databrick" +
+      "s.rpc.RPC[$this.Response]\"[\n\nRestoreRun\022" +
+      "\024\n\006run_id\030\001 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&" +
+      "com.databricks.rpc.RPC[$this.Response]\"\270" +
+      "\001\n\tLogMetric\022\016\n\006run_id\030\006 \001(\t\022\020\n\010run_uuid" +
+      "\030\001 \001(\t\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\022\023\n\005value\030\003 \001(\001" +
+      "B\004\370\206\031\001\022\027\n\ttimestamp\030\004 \001(\003B\004\370\206\031\001\022\017\n\004step\030" +
+      "\005 \001(\003:\0010\032\n\n\010Response:+\342?(\n&com.databrick" +
+      "s.rpc.RPC[$this.Response]\"\215\001\n\010LogParam\022\016" +
+      "\n\006run_id\030\004 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022\021\n\003key\030" +
+      "\002 \001(\tB\004\370\206\031\001\022\023\n\005value\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Resp" +
       "onse:+\342?(\n&com.databricks.rpc.RPC[$this." +
-      "Response]\"\225\001\n\023GetExperimentByName\022\035\n\017exp" +
-      "eriment_name\030\001 \001(\tB\004\370\206\031\001\0322\n\010Response\022&\n\n" +
-      "experiment\030\001 \001(\0132\022.mlflow.Experiment:+\342?" +
-      "(\n&com.databricks.rpc.RPC[$this.Response" +
-      "]*6\n\010ViewType\022\017\n\013ACTIVE_ONLY\020\001\022\020\n\014DELETE" +
-      "D_ONLY\020\002\022\007\n\003ALL\020\003*I\n\nSourceType\022\014\n\010NOTEB" +
-      "OOK\020\001\022\007\n\003JOB\020\002\022\013\n\007PROJECT\020\003\022\t\n\005LOCAL\020\004\022\014" +
-      "\n\007UNKNOWN\020\350\007*M\n\tRunStatus\022\013\n\007RUNNING\020\001\022\r" +
-      "\n\tSCHEDULED\020\002\022\014\n\010FINISHED\020\003\022\n\n\006FAILED\020\004\022" +
-      "\n\n\006KILLED\020\0052\341\036\n\rMlflowService\022\246\001\n\023getExp" +
-      "erimentByName\022\033.mlflow.GetExperimentByNa" +
-      "me\032$.mlflow.GetExperimentByName.Response" +
-      "\"L\362\206\031H\n,\n\003GET\022\037/mlflow/experiments/get-b" +
-      "y-name\032\004\010\002\020\000\020\001*\026Get Experiment By Name\022\306" +
-      "\001\n\020createExperiment\022\030.mlflow.CreateExper" +
-      "iment\032!.mlflow.CreateExperiment.Response" +
-      "\"u\362\206\031q\n(\n\004POST\022\032/mlflow/experiments/crea" +
-      "te\032\004\010\002\020\000\n0\n\004POST\022\"/preview/mlflow/experi" +
-      "ments/create\032\004\010\002\020\000\020\001*\021Create Experiment\022" +
-      "\274\001\n\017listExperiments\022\027.mlflow.ListExperim" +
-      "ents\032 .mlflow.ListExperiments.Response\"n" +
-      "\362\206\031j\n%\n\003GET\022\030/mlflow/experiments/list\032\004\010" +
-      "\002\020\000\n-\n\003GET\022 /preview/mlflow/experiments/" +
-      "list\032\004\010\002\020\000\020\001*\020List Experiments\022\262\001\n\rgetEx" +
-      "periment\022\025.mlflow.GetExperiment\032\036.mlflow" +
-      ".GetExperiment.Response\"j\362\206\031f\n$\n\003GET\022\027/m" +
-      "lflow/experiments/get\032\004\010\002\020\000\n,\n\003GET\022\037/pre" +
-      "view/mlflow/experiments/get\032\004\010\002\020\000\020\001*\016Get" +
-      " Experiment\022\306\001\n\020deleteExperiment\022\030.mlflo" +
-      "w.DeleteExperiment\032!.mlflow.DeleteExperi" +
-      "ment.Response\"u\362\206\031q\n(\n\004POST\022\032/mlflow/exp" +
-      "eriments/delete\032\004\010\002\020\000\n0\n\004POST\022\"/preview/" +
-      "mlflow/experiments/delete\032\004\010\002\020\000\020\001*\021Delet" +
-      "e Experiment\022\314\001\n\021restoreExperiment\022\031.mlf" +
-      "low.RestoreExperiment\032\".mlflow.RestoreEx" +
-      "periment.Response\"x\362\206\031t\n)\n\004POST\022\033/mlflow" +
-      "/experiments/restore\032\004\010\002\020\000\n1\n\004POST\022#/pre" +
-      "view/mlflow/experiments/restore\032\004\010\002\020\000\020\001*" +
-      "\022Restore Experiment\022\306\001\n\020updateExperiment" +
-      "\022\030.mlflow.UpdateExperiment\032!.mlflow.Upda" +
-      "teExperiment.Response\"u\362\206\031q\n(\n\004POST\022\032/ml" +
-      "flow/experiments/update\032\004\010\002\020\000\n0\n\004POST\022\"/" +
-      "preview/mlflow/experiments/update\032\004\010\002\020\000\020" +
-      "\001*\021Update Experiment\022\234\001\n\tcreateRun\022\021.mlf" +
-      "low.CreateRun\032\032.mlflow.CreateRun.Respons" +
-      "e\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/create\032\004\010\002" +
-      "\020\000\n)\n\004POST\022\033/preview/mlflow/runs/create\032" +
-      "\004\010\002\020\000\020\001*\nCreate Run\022\234\001\n\tupdateRun\022\021.mlfl" +
-      "ow.UpdateRun\032\032.mlflow.UpdateRun.Response" +
-      "\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/update\032\004\010\002\020" +
-      "\000\n)\n\004POST\022\033/preview/mlflow/runs/update\032\004" +
-      "\010\002\020\000\020\001*\nUpdate Run\022\234\001\n\tdeleteRun\022\021.mlflo" +
-      "w.DeleteRun\032\032.mlflow.DeleteRun.Response\"" +
-      "`\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/delete\032\004\010\002\020\000" +
-      "\n)\n\004POST\022\033/preview/mlflow/runs/delete\032\004\010" +
-      "\002\020\000\020\001*\nDelete Run\022\242\001\n\nrestoreRun\022\022.mlflo" +
-      "w.RestoreRun\032\033.mlflow.RestoreRun.Respons" +
-      "e\"c\362\206\031_\n\"\n\004POST\022\024/mlflow/runs/restore\032\004\010" +
-      "\002\020\000\n*\n\004POST\022\034/preview/mlflow/runs/restor" +
-      "e\032\004\010\002\020\000\020\001*\013Restore Run\022\244\001\n\tlogMetric\022\021.m" +
-      "lflow.LogMetric\032\032.mlflow.LogMetric.Respo" +
-      "nse\"h\362\206\031d\n%\n\004POST\022\027/mlflow/runs/log-metr" +
-      "ic\032\004\010\002\020\000\n-\n\004POST\022\037/preview/mlflow/runs/l" +
-      "og-metric\032\004\010\002\020\000\020\001*\nLog Metric\022\246\001\n\010logPar" +
-      "am\022\020.mlflow.LogParam\032\031.mlflow.LogParam.R" +
-      "esponse\"m\362\206\031i\n(\n\004POST\022\032/mlflow/runs/log-" +
-      "parameter\032\004\010\002\020\000\n0\n\004POST\022\"/preview/mlflow" +
-      "/runs/log-parameter\032\004\010\002\020\000\020\001*\tLog Param\022\341" +
-      "\001\n\020setExperimentTag\022\030.mlflow.SetExperime" +
-      "ntTag\032!.mlflow.SetExperimentTag.Response" +
-      "\"\217\001\362\206\031\212\001\n4\n\004POST\022&/mlflow/experiments/se" +
-      "t-experiment-tag\032\004\010\002\020\000\n<\n\004POST\022./preview" +
-      "/mlflow/experiments/set-experiment-tag\032\004" +
-      "\010\002\020\000\020\001*\022Set Experiment Tag\022\222\001\n\006setTag\022\016." +
-      "mlflow.SetTag\032\027.mlflow.SetTag.Response\"_" +
-      "\362\206\031[\n\"\n\004POST\022\024/mlflow/runs/set-tag\032\004\010\002\020\000" +
-      "\n*\n\004POST\022\034/preview/mlflow/runs/set-tag\032\004" +
-      "\010\002\020\000\020\001*\007Set Tag\022\244\001\n\tdeleteTag\022\021.mlflow.D" +
-      "eleteTag\032\032.mlflow.DeleteTag.Response\"h\362\206" +
-      "\031d\n%\n\004POST\022\027/mlflow/runs/delete-tag\032\004\010\002\020" +
-      "\000\n-\n\004POST\022\037/preview/mlflow/runs/delete-t" +
-      "ag\032\004\010\002\020\000\020\001*\nDelete Tag\022\210\001\n\006getRun\022\016.mlfl" +
-      "ow.GetRun\032\027.mlflow.GetRun.Response\"U\362\206\031Q" +
-      "\n\035\n\003GET\022\020/mlflow/runs/get\032\004\010\002\020\000\n%\n\003GET\022\030" +
-      "/preview/mlflow/runs/get\032\004\010\002\020\000\020\001*\007Get Ru" +
-      "n\022\314\001\n\nsearchRuns\022\022.mlflow.SearchRuns\032\033.m" +
-      "lflow.SearchRuns.Response\"\214\001\362\206\031\207\001\n!\n\004POS" +
-      "T\022\023/mlflow/runs/search\032\004\010\002\020\000\n)\n\004POST\022\033/p" +
-      "review/mlflow/runs/search\032\004\010\002\020\000\n(\n\003GET\022\033" +
-      "/preview/mlflow/runs/search\032\004\010\002\020\000\020\001*\013Sea" +
-      "rch Runs\022\260\001\n\rlistArtifacts\022\025.mlflow.List" +
-      "Artifacts\032\036.mlflow.ListArtifacts.Respons" +
-      "e\"h\362\206\031d\n#\n\003GET\022\026/mlflow/artifacts/list\032\004" +
-      "\010\002\020\000\n+\n\003GET\022\036/preview/mlflow/artifacts/l" +
-      "ist\032\004\010\002\020\000\020\001*\016List Artifacts\022\307\001\n\020getMetri" +
-      "cHistory\022\030.mlflow.GetMetricHistory\032!.mlf" +
-      "low.GetMetricHistory.Response\"v\362\206\031r\n(\n\003G" +
-      "ET\022\033/mlflow/metrics/get-history\032\004\010\002\020\000\n0\n" +
-      "\003GET\022#/preview/mlflow/metrics/get-histor" +
-      "y\032\004\010\002\020\000\020\001*\022Get Metric History\022\236\001\n\010logBat" +
-      "ch\022\020.mlflow.LogBatch\032\031.mlflow.LogBatch.R" +
-      "esponse\"e\362\206\031a\n$\n\004POST\022\026/mlflow/runs/log-" +
-      "batch\032\004\010\002\020\000\n,\n\004POST\022\036/preview/mlflow/run" +
-      "s/log-batch\032\004\010\002\020\000\020\001*\tLog Batch\022\236\001\n\010logMo" +
-      "del\022\020.mlflow.LogModel\032\031.mlflow.LogModel." +
-      "Response\"e\362\206\031a\n$\n\004POST\022\026/mlflow/runs/log" +
-      "-model\032\004\010\002\020\000\n,\n\004POST\022\036/preview/mlflow/ru" +
-      "ns/log-model\032\004\010\002\020\000\020\001*\tLog ModelB\036\n\024org.m" +
-      "lflow.api.proto\220\001\001\342?\002\020\001"
+      "Response]\"\220\001\n\020SetExperimentTag\022\033\n\rexperi" +
+      "ment_id\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\022\023" +
+      "\n\005value\030\003 \001(\tB\004\370\206\031\001\032\n\n\010Response:+\342?(\n&co" +
+      "m.databricks.rpc.RPC[$this.Response]\"\213\001\n" +
+      "\006SetTag\022\016\n\006run_id\030\004 \001(\t\022\020\n\010run_uuid\030\001 \001(" +
+      "\t\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\022\023\n\005value\030\003 \001(\tB\004\370\206\031" +
+      "\001\032\n\n\010Response:+\342?(\n&com.databricks.rpc.R" +
+      "PC[$this.Response]\"m\n\tDeleteTag\022\024\n\006run_i" +
+      "d\030\001 \001(\tB\004\370\206\031\001\022\021\n\003key\030\002 \001(\tB\004\370\206\031\001\032\n\n\010Resp" +
+      "onse:+\342?(\n&com.databricks.rpc.RPC[$this." +
+      "Response]\"}\n\006GetRun\022\016\n\006run_id\030\002 \001(\t\022\020\n\010r" +
+      "un_uuid\030\001 \001(\t\032$\n\010Response\022\030\n\003run\030\001 \001(\0132\013" +
+      ".mlflow.Run:+\342?(\n&com.databricks.rpc.RPC" +
+      "[$this.Response]\"\230\002\n\nSearchRuns\022\026\n\016exper" +
+      "iment_ids\030\001 \003(\t\022\016\n\006filter\030\004 \001(\t\0224\n\rrun_v" +
+      "iew_type\030\003 \001(\0162\020.mlflow.ViewType:\013ACTIVE" +
+      "_ONLY\022\031\n\013max_results\030\005 \001(\005:\0041000\022\020\n\010orde" +
+      "r_by\030\006 \003(\t\022\022\n\npage_token\030\007 \001(\t\032>\n\010Respon" +
+      "se\022\031\n\004runs\030\001 \003(\0132\013.mlflow.Run\022\027\n\017next_pa" +
+      "ge_token\030\002 \001(\t:+\342?(\n&com.databricks.rpc." +
+      "RPC[$this.Response]\"\330\001\n\rListArtifacts\022\016\n" +
+      "\006run_id\030\003 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022\014\n\004path\030" +
+      "\002 \001(\t\022\022\n\npage_token\030\004 \001(\t\032V\n\010Response\022\020\n" +
+      "\010root_uri\030\001 \001(\t\022\037\n\005files\030\002 \003(\0132\020.mlflow." +
+      "FileInfo\022\027\n\017next_page_token\030\003 \001(\t:+\342?(\n&" +
+      "com.databricks.rpc.RPC[$this.Response]\";" +
+      "\n\010FileInfo\022\014\n\004path\030\001 \001(\t\022\016\n\006is_dir\030\002 \001(\010" +
+      "\022\021\n\tfile_size\030\003 \001(\003\"\250\001\n\020GetMetricHistory" +
+      "\022\016\n\006run_id\030\003 \001(\t\022\020\n\010run_uuid\030\001 \001(\t\022\030\n\nme" +
+      "tric_key\030\002 \001(\tB\004\370\206\031\001\032+\n\010Response\022\037\n\007metr" +
+      "ics\030\001 \003(\0132\016.mlflow.Metric:+\342?(\n&com.data" +
+      "bricks.rpc.RPC[$this.Response]\"\261\001\n\010LogBa" +
+      "tch\022\016\n\006run_id\030\001 \001(\t\022\037\n\007metrics\030\002 \003(\0132\016.m" +
+      "lflow.Metric\022\035\n\006params\030\003 \003(\0132\r.mlflow.Pa" +
+      "ram\022\034\n\004tags\030\004 \003(\0132\016.mlflow.RunTag\032\n\n\010Res" +
+      "ponse:+\342?(\n&com.databricks.rpc.RPC[$this" +
+      ".Response]\"g\n\010LogModel\022\016\n\006run_id\030\001 \001(\t\022\022" +
+      "\n\nmodel_json\030\002 \001(\t\032\n\n\010Response:+\342?(\n&com" +
+      ".databricks.rpc.RPC[$this.Response]\"\225\001\n\023" +
+      "GetExperimentByName\022\035\n\017experiment_name\030\001" +
+      " \001(\tB\004\370\206\031\001\0322\n\010Response\022&\n\nexperiment\030\001 \001" +
+      "(\0132\022.mlflow.Experiment:+\342?(\n&com.databri" +
+      "cks.rpc.RPC[$this.Response]*6\n\010ViewType\022" +
+      "\017\n\013ACTIVE_ONLY\020\001\022\020\n\014DELETED_ONLY\020\002\022\007\n\003AL" +
+      "L\020\003*I\n\nSourceType\022\014\n\010NOTEBOOK\020\001\022\007\n\003JOB\020\002" +
+      "\022\013\n\007PROJECT\020\003\022\t\n\005LOCAL\020\004\022\014\n\007UNKNOWN\020\350\007*M" +
+      "\n\tRunStatus\022\013\n\007RUNNING\020\001\022\r\n\tSCHEDULED\020\002\022" +
+      "\014\n\010FINISHED\020\003\022\n\n\006FAILED\020\004\022\n\n\006KILLED\020\0052\364\037" +
+      "\n\rMlflowService\022\246\001\n\023getExperimentByName\022" +
+      "\033.mlflow.GetExperimentByName\032$.mlflow.Ge" +
+      "tExperimentByName.Response\"L\362\206\031H\n,\n\003GET\022" +
+      "\037/mlflow/experiments/get-by-name\032\004\010\002\020\000\020\001" +
+      "*\026Get Experiment By Name\022\306\001\n\020createExper" +
+      "iment\022\030.mlflow.CreateExperiment\032!.mlflow" +
+      ".CreateExperiment.Response\"u\362\206\031q\n(\n\004POST" +
+      "\022\032/mlflow/experiments/create\032\004\010\002\020\000\n0\n\004PO" +
+      "ST\022\"/preview/mlflow/experiments/create\032\004" +
+      "\010\002\020\000\020\001*\021Create Experiment\022\274\001\n\017listExperi" +
+      "ments\022\027.mlflow.ListExperiments\032 .mlflow." +
+      "ListExperiments.Response\"n\362\206\031j\n%\n\003GET\022\030/" +
+      "mlflow/experiments/list\032\004\010\002\020\000\n-\n\003GET\022 /p" +
+      "review/mlflow/experiments/list\032\004\010\002\020\000\020\001*\020" +
+      "List Experiments\022\262\001\n\rgetExperiment\022\025.mlf" +
+      "low.GetExperiment\032\036.mlflow.GetExperiment" +
+      ".Response\"j\362\206\031f\n$\n\003GET\022\027/mlflow/experime" +
+      "nts/get\032\004\010\002\020\000\n,\n\003GET\022\037/preview/mlflow/ex" +
+      "periments/get\032\004\010\002\020\000\020\001*\016Get Experiment\022\306\001" +
+      "\n\020deleteExperiment\022\030.mlflow.DeleteExperi" +
+      "ment\032!.mlflow.DeleteExperiment.Response\"" +
+      "u\362\206\031q\n(\n\004POST\022\032/mlflow/experiments/delet" +
+      "e\032\004\010\002\020\000\n0\n\004POST\022\"/preview/mlflow/experim" +
+      "ents/delete\032\004\010\002\020\000\020\001*\021Delete Experiment\022\314" +
+      "\001\n\021restoreExperiment\022\031.mlflow.RestoreExp" +
+      "eriment\032\".mlflow.RestoreExperiment.Respo" +
+      "nse\"x\362\206\031t\n)\n\004POST\022\033/mlflow/experiments/r" +
+      "estore\032\004\010\002\020\000\n1\n\004POST\022#/preview/mlflow/ex" +
+      "periments/restore\032\004\010\002\020\000\020\001*\022Restore Exper" +
+      "iment\022\306\001\n\020updateExperiment\022\030.mlflow.Upda" +
+      "teExperiment\032!.mlflow.UpdateExperiment.R" +
+      "esponse\"u\362\206\031q\n(\n\004POST\022\032/mlflow/experimen" +
+      "ts/update\032\004\010\002\020\000\n0\n\004POST\022\"/preview/mlflow" +
+      "/experiments/update\032\004\010\002\020\000\020\001*\021Update Expe" +
+      "riment\022\234\001\n\tcreateRun\022\021.mlflow.CreateRun\032" +
+      "\032.mlflow.CreateRun.Response\"`\362\206\031\\\n!\n\004POS" +
+      "T\022\023/mlflow/runs/create\032\004\010\002\020\000\n)\n\004POST\022\033/p" +
+      "review/mlflow/runs/create\032\004\010\002\020\000\020\001*\nCreat" +
+      "e Run\022\220\001\n\007moveRun\022\017.mlflow.MoveRun\032\030.mlf" +
+      "low.MoveRun.Response\"Z\362\206\031V\n\037\n\004POST\022\021/mlf" +
+      "low/runs/move\032\004\010\002\020\000\n\'\n\004POST\022\031/preview/ml" +
+      "flow/runs/move\032\004\010\002\020\000\020\001*\010Move Run\022\234\001\n\tupd" +
+      "ateRun\022\021.mlflow.UpdateRun\032\032.mlflow.Updat" +
+      "eRun.Response\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/run" +
+      "s/update\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/" +
+      "runs/update\032\004\010\002\020\000\020\001*\nUpdate Run\022\234\001\n\tdele" +
+      "teRun\022\021.mlflow.DeleteRun\032\032.mlflow.Delete" +
+      "Run.Response\"`\362\206\031\\\n!\n\004POST\022\023/mlflow/runs" +
+      "/delete\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/r" +
+      "uns/delete\032\004\010\002\020\000\020\001*\nDelete Run\022\242\001\n\nresto" +
+      "reRun\022\022.mlflow.RestoreRun\032\033.mlflow.Resto" +
+      "reRun.Response\"c\362\206\031_\n\"\n\004POST\022\024/mlflow/ru" +
+      "ns/restore\032\004\010\002\020\000\n*\n\004POST\022\034/preview/mlflo" +
+      "w/runs/restore\032\004\010\002\020\000\020\001*\013Restore Run\022\244\001\n\t" +
+      "logMetric\022\021.mlflow.LogMetric\032\032.mlflow.Lo" +
+      "gMetric.Response\"h\362\206\031d\n%\n\004POST\022\027/mlflow/" +
+      "runs/log-metric\032\004\010\002\020\000\n-\n\004POST\022\037/preview/" +
+      "mlflow/runs/log-metric\032\004\010\002\020\000\020\001*\nLog Metr" +
+      "ic\022\246\001\n\010logParam\022\020.mlflow.LogParam\032\031.mlfl" +
+      "ow.LogParam.Response\"m\362\206\031i\n(\n\004POST\022\032/mlf" +
+      "low/runs/log-parameter\032\004\010\002\020\000\n0\n\004POST\022\"/p" +
+      "review/mlflow/runs/log-parameter\032\004\010\002\020\000\020\001" +
+      "*\tLog Param\022\341\001\n\020setExperimentTag\022\030.mlflo" +
+      "w.SetExperimentTag\032!.mlflow.SetExperimen" +
+      "tTag.Response\"\217\001\362\206\031\212\001\n4\n\004POST\022&/mlflow/e" +
+      "xperiments/set-experiment-tag\032\004\010\002\020\000\n<\n\004P" +
+      "OST\022./preview/mlflow/experiments/set-exp" +
+      "eriment-tag\032\004\010\002\020\000\020\001*\022Set Experiment Tag\022" +
+      "\222\001\n\006setTag\022\016.mlflow.SetTag\032\027.mlflow.SetT" +
+      "ag.Response\"_\362\206\031[\n\"\n\004POST\022\024/mlflow/runs/" +
+      "set-tag\032\004\010\002\020\000\n*\n\004POST\022\034/preview/mlflow/r" +
+      "uns/set-tag\032\004\010\002\020\000\020\001*\007Set Tag\022\244\001\n\tdeleteT" +
+      "ag\022\021.mlflow.DeleteTag\032\032.mlflow.DeleteTag" +
+      ".Response\"h\362\206\031d\n%\n\004POST\022\027/mlflow/runs/de" +
+      "lete-tag\032\004\010\002\020\000\n-\n\004POST\022\037/preview/mlflow/" +
+      "runs/delete-tag\032\004\010\002\020\000\020\001*\nDelete Tag\022\210\001\n\006" +
+      "getRun\022\016.mlflow.GetRun\032\027.mlflow.GetRun.R" +
+      "esponse\"U\362\206\031Q\n\035\n\003GET\022\020/mlflow/runs/get\032\004" +
+      "\010\002\020\000\n%\n\003GET\022\030/preview/mlflow/runs/get\032\004\010" +
+      "\002\020\000\020\001*\007Get Run\022\314\001\n\nsearchRuns\022\022.mlflow.S" +
+      "earchRuns\032\033.mlflow.SearchRuns.Response\"\214" +
+      "\001\362\206\031\207\001\n!\n\004POST\022\023/mlflow/runs/search\032\004\010\002\020" +
+      "\000\n)\n\004POST\022\033/preview/mlflow/runs/search\032\004" +
+      "\010\002\020\000\n(\n\003GET\022\033/preview/mlflow/runs/search" +
+      "\032\004\010\002\020\000\020\001*\013Search Runs\022\260\001\n\rlistArtifacts\022" +
+      "\025.mlflow.ListArtifacts\032\036.mlflow.ListArti" +
+      "facts.Response\"h\362\206\031d\n#\n\003GET\022\026/mlflow/art" +
+      "ifacts/list\032\004\010\002\020\000\n+\n\003GET\022\036/preview/mlflo" +
+      "w/artifacts/list\032\004\010\002\020\000\020\001*\016List Artifacts" +
+      "\022\307\001\n\020getMetricHistory\022\030.mlflow.GetMetric" +
+      "History\032!.mlflow.GetMetricHistory.Respon" +
+      "se\"v\362\206\031r\n(\n\003GET\022\033/mlflow/metrics/get-his" +
+      "tory\032\004\010\002\020\000\n0\n\003GET\022#/preview/mlflow/metri" +
+      "cs/get-history\032\004\010\002\020\000\020\001*\022Get Metric Histo" +
+      "ry\022\236\001\n\010logBatch\022\020.mlflow.LogBatch\032\031.mlfl" +
+      "ow.LogBatch.Response\"e\362\206\031a\n$\n\004POST\022\026/mlf" +
+      "low/runs/log-batch\032\004\010\002\020\000\n,\n\004POST\022\036/previ" +
+      "ew/mlflow/runs/log-batch\032\004\010\002\020\000\020\001*\tLog Ba" +
+      "tch\022\236\001\n\010logModel\022\020.mlflow.LogModel\032\031.mlf" +
+      "low.LogModel.Response\"e\362\206\031a\n$\n\004POST\022\026/ml" +
+      "flow/runs/log-model\032\004\010\002\020\000\n,\n\004POST\022\036/prev" +
+      "iew/mlflow/runs/log-model\032\004\010\002\020\000\020\001*\tLog M" +
+      "odelB\036\n\024org.mlflow.api.proto\220\001\001\342?\002\020\001"
     };
     com.google.protobuf.Descriptors.FileDescriptor.InternalDescriptorAssigner assigner =
         new com.google.protobuf.Descriptors.FileDescriptor.    InternalDescriptorAssigner() {
@@ -48661,8 +50147,20 @@ public final class Service {
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_CreateRun_Response_descriptor,
         new java.lang.String[] { "Run", });
-    internal_static_mlflow_UpdateRun_descriptor =
+    internal_static_mlflow_MoveRun_descriptor =
       getDescriptor().getMessageTypes().get(15);
+    internal_static_mlflow_MoveRun_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_MoveRun_descriptor,
+        new java.lang.String[] { "RunId", "SrcExperimentId", "DestExperimentId", });
+    internal_static_mlflow_MoveRun_Response_descriptor =
+      internal_static_mlflow_MoveRun_descriptor.getNestedTypes().get(0);
+    internal_static_mlflow_MoveRun_Response_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+        internal_static_mlflow_MoveRun_Response_descriptor,
+        new java.lang.String[] { });
+    internal_static_mlflow_UpdateRun_descriptor =
+      getDescriptor().getMessageTypes().get(16);
     internal_static_mlflow_UpdateRun_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_UpdateRun_descriptor,
@@ -48674,7 +50172,7 @@ public final class Service {
         internal_static_mlflow_UpdateRun_Response_descriptor,
         new java.lang.String[] { "RunInfo", });
     internal_static_mlflow_DeleteRun_descriptor =
-      getDescriptor().getMessageTypes().get(16);
+      getDescriptor().getMessageTypes().get(17);
     internal_static_mlflow_DeleteRun_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_DeleteRun_descriptor,
@@ -48686,7 +50184,7 @@ public final class Service {
         internal_static_mlflow_DeleteRun_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_RestoreRun_descriptor =
-      getDescriptor().getMessageTypes().get(17);
+      getDescriptor().getMessageTypes().get(18);
     internal_static_mlflow_RestoreRun_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_RestoreRun_descriptor,
@@ -48698,7 +50196,7 @@ public final class Service {
         internal_static_mlflow_RestoreRun_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_LogMetric_descriptor =
-      getDescriptor().getMessageTypes().get(18);
+      getDescriptor().getMessageTypes().get(19);
     internal_static_mlflow_LogMetric_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_LogMetric_descriptor,
@@ -48710,7 +50208,7 @@ public final class Service {
         internal_static_mlflow_LogMetric_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_LogParam_descriptor =
-      getDescriptor().getMessageTypes().get(19);
+      getDescriptor().getMessageTypes().get(20);
     internal_static_mlflow_LogParam_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_LogParam_descriptor,
@@ -48722,7 +50220,7 @@ public final class Service {
         internal_static_mlflow_LogParam_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_SetExperimentTag_descriptor =
-      getDescriptor().getMessageTypes().get(20);
+      getDescriptor().getMessageTypes().get(21);
     internal_static_mlflow_SetExperimentTag_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_SetExperimentTag_descriptor,
@@ -48734,7 +50232,7 @@ public final class Service {
         internal_static_mlflow_SetExperimentTag_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_SetTag_descriptor =
-      getDescriptor().getMessageTypes().get(21);
+      getDescriptor().getMessageTypes().get(22);
     internal_static_mlflow_SetTag_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_SetTag_descriptor,
@@ -48746,7 +50244,7 @@ public final class Service {
         internal_static_mlflow_SetTag_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_DeleteTag_descriptor =
-      getDescriptor().getMessageTypes().get(22);
+      getDescriptor().getMessageTypes().get(23);
     internal_static_mlflow_DeleteTag_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_DeleteTag_descriptor,
@@ -48758,7 +50256,7 @@ public final class Service {
         internal_static_mlflow_DeleteTag_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_GetRun_descriptor =
-      getDescriptor().getMessageTypes().get(23);
+      getDescriptor().getMessageTypes().get(24);
     internal_static_mlflow_GetRun_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetRun_descriptor,
@@ -48770,7 +50268,7 @@ public final class Service {
         internal_static_mlflow_GetRun_Response_descriptor,
         new java.lang.String[] { "Run", });
     internal_static_mlflow_SearchRuns_descriptor =
-      getDescriptor().getMessageTypes().get(24);
+      getDescriptor().getMessageTypes().get(25);
     internal_static_mlflow_SearchRuns_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_SearchRuns_descriptor,
@@ -48782,7 +50280,7 @@ public final class Service {
         internal_static_mlflow_SearchRuns_Response_descriptor,
         new java.lang.String[] { "Runs", "NextPageToken", });
     internal_static_mlflow_ListArtifacts_descriptor =
-      getDescriptor().getMessageTypes().get(25);
+      getDescriptor().getMessageTypes().get(26);
     internal_static_mlflow_ListArtifacts_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_ListArtifacts_descriptor,
@@ -48794,13 +50292,13 @@ public final class Service {
         internal_static_mlflow_ListArtifacts_Response_descriptor,
         new java.lang.String[] { "RootUri", "Files", "NextPageToken", });
     internal_static_mlflow_FileInfo_descriptor =
-      getDescriptor().getMessageTypes().get(26);
+      getDescriptor().getMessageTypes().get(27);
     internal_static_mlflow_FileInfo_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_FileInfo_descriptor,
         new java.lang.String[] { "Path", "IsDir", "FileSize", });
     internal_static_mlflow_GetMetricHistory_descriptor =
-      getDescriptor().getMessageTypes().get(27);
+      getDescriptor().getMessageTypes().get(28);
     internal_static_mlflow_GetMetricHistory_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetMetricHistory_descriptor,
@@ -48812,7 +50310,7 @@ public final class Service {
         internal_static_mlflow_GetMetricHistory_Response_descriptor,
         new java.lang.String[] { "Metrics", });
     internal_static_mlflow_LogBatch_descriptor =
-      getDescriptor().getMessageTypes().get(28);
+      getDescriptor().getMessageTypes().get(29);
     internal_static_mlflow_LogBatch_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_LogBatch_descriptor,
@@ -48824,7 +50322,7 @@ public final class Service {
         internal_static_mlflow_LogBatch_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_LogModel_descriptor =
-      getDescriptor().getMessageTypes().get(29);
+      getDescriptor().getMessageTypes().get(30);
     internal_static_mlflow_LogModel_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_LogModel_descriptor,
@@ -48836,7 +50334,7 @@ public final class Service {
         internal_static_mlflow_LogModel_Response_descriptor,
         new java.lang.String[] { });
     internal_static_mlflow_GetExperimentByName_descriptor =
-      getDescriptor().getMessageTypes().get(30);
+      getDescriptor().getMessageTypes().get(31);
     internal_static_mlflow_GetExperimentByName_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_GetExperimentByName_descriptor,

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -305,6 +305,15 @@ public class MlflowClient implements Serializable {
   }
 
   /**
+   * Move a run with the given ID from source experiment to destination experiment
+   */
+  public void moveRun(String runId, String srcExperimentId, String destExperimentId) {
+    String ijson = mapper.makeMoveRun(runId, srcExperimentId, destExperimentId);
+    httpCaller.post("runs/move", ijson);
+  }
+
+
+  /**
    * Delete a run with the given ID.
    */
   public void deleteRun(String runId) {

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowProtobufMapper.java
@@ -109,6 +109,14 @@ class MlflowProtobufMapper {
     return print(builder);
   }
 
+  String makeMoveRun(String runId, String srcExperimentId, String destExperimentId) {
+    MoveRun.Builder builder = MoveRun.newBuilder();
+    builder.setRunId(runId);
+    builder.setSrcExperimentId(srcExperimentId);
+    builder.setDestExperimentId(destExperimentId);
+    return print(builder);
+  }
+
   String makeDeleteRun(String runId) {
     DeleteRun.Builder builder = DeleteRun.newBuilder();
     builder.setRunId(runId);

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -556,9 +556,14 @@ public class MlflowClientTest {
     String expId2 = client.createExperiment(expName2);
 
     RunInfo runCreated = client.createRun(expId1);
+    String runId = runCreated.getRunId();
+    // create tags to generate folder
+    Stack<RunTag> tags = new Stack();
+    tags.push(createTag("t1", "sampletags"));
+    client.logBatch(runId, null, null, tags);
     Assert.assertEquals(runCreated.getExperimentId(), expId1);
     String moveRunId = runCreated.getRunId();
-    client.moveRun(moveRunId);
+    client.moveRun(moveRunId, expId1, expId2);
     Assert.assertEquals(client.getRun(moveRunId).getInfo().getExperimentId(), expId2);
   }
 

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/MlflowClientTest.java
@@ -549,6 +549,20 @@ public class MlflowClientTest {
   }
 
   @Test
+  public void moveRun() {
+    String expName1 = createExperimentName();
+    String expName2 = createExperimentName();
+    String expId1 = client.createExperiment(expName1);
+    String expId2 = client.createExperiment(expName2);
+
+    RunInfo runCreated = client.createRun(expId1);
+    Assert.assertEquals(runCreated.getExperimentId(), expId1);
+    String moveRunId = runCreated.getRunId();
+    client.moveRun(moveRunId);
+    Assert.assertEquals(client.getRun(moveRunId).getInfo().getExperimentId(), expId2);
+  }
+
+  @Test
   public void deleteAndRestoreRun() {
     String expName = createExperimentName();
     String expId = client.createExperiment(expName);

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -172,6 +172,25 @@ service MlflowService {
     };
   }
 
+  // Move run to a different experiment.
+  //
+  rpc moveRun(MoveRun) returns (MoveRun.Response) {
+    option (rpc) = {
+      endpoints: [{
+        method: "POST",
+        path: "/mlflow/runs/move"
+        since { major: 2, minor: 0 },
+      }, {
+        method: "POST",
+        path: "/preview/mlflow/runs/move"
+        since { major: 2, minor: 0 },
+      }],
+
+      visibility: PUBLIC,
+      rpc_doc_title: "Move Run",
+    };
+  }
+
   // Update run metadata.
   //
   rpc updateRun(UpdateRun) returns (UpdateRun.Response) {
@@ -761,6 +780,21 @@ message CreateRun {
     // The newly created run.
     optional Run run = 1;
   }
+}
+
+message MoveRun {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // ID of the run to move.
+  optional string run_id = 1 [(validate_required) = true];
+
+  // ID of the source experiment.
+  optional string src_experiment_id = 2;
+
+  // ID of the destination experiment.
+  optional string dest_experiment_id = 3;
+  
+  message Response {}
 }
 
 message UpdateRun {

--- a/mlflow/protos/service_pb2.py
+++ b/mlflow/protos/service_pb2.py
@@ -24,7 +24,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   package='mlflow',
   syntax='proto2',
   serialized_options=_b('\n\024org.mlflow.api.proto\220\001\001\342?\002\020\001'),
-  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"H\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x04step\x18\x04 \x01(\x03:\x01\x30\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"+\n\rExperimentTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xcb\x01\n\x07RunInfo\x12\x0e\n\x06run_id\x18\x0f \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\xbb\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\x12#\n\x04tags\x18\x07 \x03(\x0b\x32\x15.mlflow.ExperimentTag\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x01\n\x0fListExperiments\x12#\n\tview_type\x18\x01 \x01(\x0e\x32\x10.mlflow.ViewType\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb0\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1aU\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12!\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfoB\x02\x18\x01:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x10UpdateExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xbe\x01\n\tUpdateRun\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tLogMetric\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\xf8\x86\x19\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\xf8\x86\x19\x01\x12\x0f\n\x04step\x18\x05 \x01(\x03:\x01\x30\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8d\x01\n\x08LogParam\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x90\x01\n\x10SetExperimentTag\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8b\x01\n\x06SetTag\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"m\n\tDeleteTag\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"}\n\x06GetRun\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x02\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\t\x12\x0e\n\x06\x66ilter\x18\x04 \x01(\t\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x12\x19\n\x0bmax_results\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12\x10\n\x08order_by\x18\x06 \x03(\t\x12\x12\n\npage_token\x18\x07 \x01(\t\x1a>\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xd8\x01\n\rListArtifacts\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aV\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"\xa8\x01\n\x10GetMetricHistory\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb1\x01\n\x08LogBatch\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x1f\n\x07metrics\x18\x02 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x03 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x04 \x03(\x0b\x32\x0e.mlflow.RunTag\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"g\n\x08LogModel\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x12\n\nmodel_json\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x95\x01\n\x13GetExperimentByName\x12\x1d\n\x0f\x65xperiment_name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x32\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\xe1\x1e\n\rMlflowService\x12\xa6\x01\n\x13getExperimentByName\x12\x1b.mlflow.GetExperimentByName\x1a$.mlflow.GetExperimentByName.Response\"L\xf2\x86\x19H\n,\n\x03GET\x12\x1f/mlflow/experiments/get-by-name\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Get Experiment By Name\x12\xc6\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\xbc\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"n\xf2\x86\x19j\n%\n\x03GET\x12\x18/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\xb2\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"j\xf2\x86\x19\x66\n$\n\x03GET\x12\x17/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\xc6\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\xcc\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"x\xf2\x86\x19t\n)\n\x04POST\x12\x1b/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\n1\n\x04POST\x12#/preview/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12\xc6\x01\n\x10updateExperiment\x12\x18.mlflow.UpdateExperiment\x1a!.mlflow.UpdateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x11Update Experiment\x12\x9c\x01\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12\x9c\x01\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12\x9c\x01\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Run\x12\xa2\x01\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"c\xf2\x86\x19_\n\"\n\x04POST\x12\x14/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bRestore Run\x12\xa4\x01\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"h\xf2\x86\x19\x64\n%\n\x04POST\x12\x17/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12\xa6\x01\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"m\xf2\x86\x19i\n(\n\x04POST\x12\x1a/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12\xe1\x01\n\x10setExperimentTag\x12\x18.mlflow.SetExperimentTag\x1a!.mlflow.SetExperimentTag.Response\"\x8f\x01\xf2\x86\x19\x8a\x01\n4\n\x04POST\x12&/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\n<\n\x04POST\x12./preview/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Set Experiment Tag\x12\x92\x01\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\"_\xf2\x86\x19[\n\"\n\x04POST\x12\x14/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12\xa4\x01\n\tdeleteTag\x12\x11.mlflow.DeleteTag\x1a\x1a.mlflow.DeleteTag.Response\"h\xf2\x86\x19\x64\n%\n\x04POST\x12\x17/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\n-\n\x04POST\x12\x1f/preview/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Tag\x12\x88\x01\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"U\xf2\x86\x19Q\n\x1d\n\x03GET\x12\x10/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12\xcc\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"\x8c\x01\xf2\x86\x19\x87\x01\n!\n\x04POST\x12\x13/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\xb0\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"h\xf2\x86\x19\x64\n#\n\x03GET\x12\x16/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\xc7\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"v\xf2\x86\x19r\n(\n\x03GET\x12\x1b/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric History\x12\x9e\x01\n\x08logBatch\x12\x10.mlflow.LogBatch\x1a\x19.mlflow.LogBatch.Response\"e\xf2\x86\x19\x61\n$\n\x04POST\x12\x16/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\n,\n\x04POST\x12\x1e/preview/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Batch\x12\x9e\x01\n\x08logModel\x12\x10.mlflow.LogModel\x1a\x19.mlflow.LogModel.Response\"e\xf2\x86\x19\x61\n$\n\x04POST\x12\x16/mlflow/runs/log-model\x1a\x04\x08\x02\x10\x00\n,\n\x04POST\x12\x1e/preview/mlflow/runs/log-model\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog ModelB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
+  serialized_pb=_b('\n\rservice.proto\x12\x06mlflow\x1a\x15scalapb/scalapb.proto\x1a\x10\x64\x61tabricks.proto\"H\n\x06Metric\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\x01\x12\x11\n\ttimestamp\x18\x03 \x01(\x03\x12\x0f\n\x04step\x18\x04 \x01(\x03:\x01\x30\"#\n\x05Param\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"C\n\x03Run\x12\x1d\n\x04info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo\x12\x1d\n\x04\x64\x61ta\x18\x02 \x01(\x0b\x32\x0f.mlflow.RunData\"g\n\x07RunData\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x02 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x03 \x03(\x0b\x32\x0e.mlflow.RunTag\"$\n\x06RunTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"+\n\rExperimentTag\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"\xcb\x01\n\x07RunInfo\x12\x0e\n\x06run_id\x18\x0f \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x15\n\rexperiment_id\x18\x02 \x01(\t\x12\x0f\n\x07user_id\x18\x06 \x01(\t\x12!\n\x06status\x18\x07 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x12\n\nstart_time\x18\x08 \x01(\x03\x12\x10\n\x08\x65nd_time\x18\t \x01(\x03\x12\x14\n\x0c\x61rtifact_uri\x18\r \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x0e \x01(\t\"\xbb\x01\n\nExperiment\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0c\n\x04name\x18\x02 \x01(\t\x12\x19\n\x11\x61rtifact_location\x18\x03 \x01(\t\x12\x17\n\x0flifecycle_stage\x18\x04 \x01(\t\x12\x18\n\x10last_update_time\x18\x05 \x01(\x03\x12\x15\n\rcreation_time\x18\x06 \x01(\x03\x12#\n\x04tags\x18\x07 \x03(\x0b\x32\x15.mlflow.ExperimentTag\"\x91\x01\n\x10\x43reateExperiment\x12\x12\n\x04name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x11\x61rtifact_location\x18\x02 \x01(\t\x1a!\n\x08Response\x12\x15\n\rexperiment_id\x18\x01 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x01\n\x0fListExperiments\x12#\n\tview_type\x18\x01 \x01(\x0e\x32\x10.mlflow.ViewType\x1a\x33\n\x08Response\x12\'\n\x0b\x65xperiments\x18\x01 \x03(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb0\x01\n\rGetExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1aU\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment\x12!\n\x04runs\x18\x02 \x03(\x0b\x32\x0f.mlflow.RunInfoB\x02\x18\x01:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"h\n\x10\x44\x65leteExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"i\n\x11RestoreExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"z\n\x10UpdateExperiment\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08new_name\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tCreateRun\x12\x15\n\rexperiment_id\x18\x01 \x01(\t\x12\x0f\n\x07user_id\x18\x02 \x01(\t\x12\x12\n\nstart_time\x18\x07 \x01(\x03\x12\x1c\n\x04tags\x18\t \x03(\x0b\x32\x0e.mlflow.RunTag\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8f\x01\n\x07MoveRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x19\n\x11src_experiment_id\x18\x02 \x01(\t\x12\x1a\n\x12\x64\x65st_experiment_id\x18\x03 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xbe\x01\n\tUpdateRun\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12!\n\x06status\x18\x02 \x01(\x0e\x32\x11.mlflow.RunStatus\x12\x10\n\x08\x65nd_time\x18\x03 \x01(\x03\x1a-\n\x08Response\x12!\n\x08run_info\x18\x01 \x01(\x0b\x32\x0f.mlflow.RunInfo:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"Z\n\tDeleteRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"[\n\nRestoreRun\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb8\x01\n\tLogMetric\x12\x0e\n\x06run_id\x18\x06 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\x01\x42\x04\xf8\x86\x19\x01\x12\x17\n\ttimestamp\x18\x04 \x01(\x03\x42\x04\xf8\x86\x19\x01\x12\x0f\n\x04step\x18\x05 \x01(\x03:\x01\x30\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8d\x01\n\x08LogParam\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x90\x01\n\x10SetExperimentTag\x12\x1b\n\rexperiment_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x8b\x01\n\x06SetTag\x12\x0e\n\x06run_id\x18\x04 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x13\n\x05value\x18\x03 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"m\n\tDeleteTag\x12\x14\n\x06run_id\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x12\x11\n\x03key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"}\n\x06GetRun\x12\x0e\n\x06run_id\x18\x02 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x1a$\n\x08Response\x12\x18\n\x03run\x18\x01 \x01(\x0b\x32\x0b.mlflow.Run:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x98\x02\n\nSearchRuns\x12\x16\n\x0e\x65xperiment_ids\x18\x01 \x03(\t\x12\x0e\n\x06\x66ilter\x18\x04 \x01(\t\x12\x34\n\rrun_view_type\x18\x03 \x01(\x0e\x32\x10.mlflow.ViewType:\x0b\x41\x43TIVE_ONLY\x12\x19\n\x0bmax_results\x18\x05 \x01(\x05:\x04\x31\x30\x30\x30\x12\x10\n\x08order_by\x18\x06 \x03(\t\x12\x12\n\npage_token\x18\x07 \x01(\t\x1a>\n\x08Response\x12\x19\n\x04runs\x18\x01 \x03(\x0b\x32\x0b.mlflow.Run\x12\x17\n\x0fnext_page_token\x18\x02 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xd8\x01\n\rListArtifacts\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12\x12\n\npage_token\x18\x04 \x01(\t\x1aV\n\x08Response\x12\x10\n\x08root_uri\x18\x01 \x01(\t\x12\x1f\n\x05\x66iles\x18\x02 \x03(\x0b\x32\x10.mlflow.FileInfo\x12\x17\n\x0fnext_page_token\x18\x03 \x01(\t:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\";\n\x08\x46ileInfo\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x0e\n\x06is_dir\x18\x02 \x01(\x08\x12\x11\n\tfile_size\x18\x03 \x01(\x03\"\xa8\x01\n\x10GetMetricHistory\x12\x0e\n\x06run_id\x18\x03 \x01(\t\x12\x10\n\x08run_uuid\x18\x01 \x01(\t\x12\x18\n\nmetric_key\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x1a+\n\x08Response\x12\x1f\n\x07metrics\x18\x01 \x03(\x0b\x32\x0e.mlflow.Metric:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\xb1\x01\n\x08LogBatch\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x1f\n\x07metrics\x18\x02 \x03(\x0b\x32\x0e.mlflow.Metric\x12\x1d\n\x06params\x18\x03 \x03(\x0b\x32\r.mlflow.Param\x12\x1c\n\x04tags\x18\x04 \x03(\x0b\x32\x0e.mlflow.RunTag\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"g\n\x08LogModel\x12\x0e\n\x06run_id\x18\x01 \x01(\t\x12\x12\n\nmodel_json\x18\x02 \x01(\t\x1a\n\n\x08Response:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]\"\x95\x01\n\x13GetExperimentByName\x12\x1d\n\x0f\x65xperiment_name\x18\x01 \x01(\tB\x04\xf8\x86\x19\x01\x1a\x32\n\x08Response\x12&\n\nexperiment\x18\x01 \x01(\x0b\x32\x12.mlflow.Experiment:+\xe2?(\n&com.databricks.rpc.RPC[$this.Response]*6\n\x08ViewType\x12\x0f\n\x0b\x41\x43TIVE_ONLY\x10\x01\x12\x10\n\x0c\x44\x45LETED_ONLY\x10\x02\x12\x07\n\x03\x41LL\x10\x03*I\n\nSourceType\x12\x0c\n\x08NOTEBOOK\x10\x01\x12\x07\n\x03JOB\x10\x02\x12\x0b\n\x07PROJECT\x10\x03\x12\t\n\x05LOCAL\x10\x04\x12\x0c\n\x07UNKNOWN\x10\xe8\x07*M\n\tRunStatus\x12\x0b\n\x07RUNNING\x10\x01\x12\r\n\tSCHEDULED\x10\x02\x12\x0c\n\x08\x46INISHED\x10\x03\x12\n\n\x06\x46\x41ILED\x10\x04\x12\n\n\x06KILLED\x10\x05\x32\xf4\x1f\n\rMlflowService\x12\xa6\x01\n\x13getExperimentByName\x12\x1b.mlflow.GetExperimentByName\x1a$.mlflow.GetExperimentByName.Response\"L\xf2\x86\x19H\n,\n\x03GET\x12\x1f/mlflow/experiments/get-by-name\x1a\x04\x08\x02\x10\x00\x10\x01*\x16Get Experiment By Name\x12\xc6\x01\n\x10\x63reateExperiment\x12\x18.mlflow.CreateExperiment\x1a!.mlflow.CreateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/create\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x43reate Experiment\x12\xbc\x01\n\x0flistExperiments\x12\x17.mlflow.ListExperiments\x1a .mlflow.ListExperiments.Response\"n\xf2\x86\x19j\n%\n\x03GET\x12\x18/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\n-\n\x03GET\x12 /preview/mlflow/experiments/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x10List Experiments\x12\xb2\x01\n\rgetExperiment\x12\x15.mlflow.GetExperiment\x1a\x1e.mlflow.GetExperiment.Response\"j\xf2\x86\x19\x66\n$\n\x03GET\x12\x17/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\n,\n\x03GET\x12\x1f/preview/mlflow/experiments/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eGet Experiment\x12\xc6\x01\n\x10\x64\x65leteExperiment\x12\x18.mlflow.DeleteExperiment\x1a!.mlflow.DeleteExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\x11\x44\x65lete Experiment\x12\xcc\x01\n\x11restoreExperiment\x12\x19.mlflow.RestoreExperiment\x1a\".mlflow.RestoreExperiment.Response\"x\xf2\x86\x19t\n)\n\x04POST\x12\x1b/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\n1\n\x04POST\x12#/preview/mlflow/experiments/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Restore Experiment\x12\xc6\x01\n\x10updateExperiment\x12\x18.mlflow.UpdateExperiment\x1a!.mlflow.UpdateExperiment.Response\"u\xf2\x86\x19q\n(\n\x04POST\x12\x1a/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/experiments/update\x1a\x04\x08\x02\x10\x00\x10\x01*\x11Update Experiment\x12\x9c\x01\n\tcreateRun\x12\x11.mlflow.CreateRun\x1a\x1a.mlflow.CreateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/create\x1a\x04\x08\x02\x10\x00\x10\x01*\nCreate Run\x12\x90\x01\n\x07moveRun\x12\x0f.mlflow.MoveRun\x1a\x18.mlflow.MoveRun.Response\"Z\xf2\x86\x19V\n\x1f\n\x04POST\x12\x11/mlflow/runs/move\x1a\x04\x08\x02\x10\x00\n\'\n\x04POST\x12\x19/preview/mlflow/runs/move\x1a\x04\x08\x02\x10\x00\x10\x01*\x08Move Run\x12\x9c\x01\n\tupdateRun\x12\x11.mlflow.UpdateRun\x1a\x1a.mlflow.UpdateRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/update\x1a\x04\x08\x02\x10\x00\x10\x01*\nUpdate Run\x12\x9c\x01\n\tdeleteRun\x12\x11.mlflow.DeleteRun\x1a\x1a.mlflow.DeleteRun.Response\"`\xf2\x86\x19\\\n!\n\x04POST\x12\x13/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/delete\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Run\x12\xa2\x01\n\nrestoreRun\x12\x12.mlflow.RestoreRun\x1a\x1b.mlflow.RestoreRun.Response\"c\xf2\x86\x19_\n\"\n\x04POST\x12\x14/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/restore\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bRestore Run\x12\xa4\x01\n\tlogMetric\x12\x11.mlflow.LogMetric\x1a\x1a.mlflow.LogMetric.Response\"h\xf2\x86\x19\x64\n%\n\x04POST\x12\x17/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\n-\n\x04POST\x12\x1f/preview/mlflow/runs/log-metric\x1a\x04\x08\x02\x10\x00\x10\x01*\nLog Metric\x12\xa6\x01\n\x08logParam\x12\x10.mlflow.LogParam\x1a\x19.mlflow.LogParam.Response\"m\xf2\x86\x19i\n(\n\x04POST\x12\x1a/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\n0\n\x04POST\x12\"/preview/mlflow/runs/log-parameter\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Param\x12\xe1\x01\n\x10setExperimentTag\x12\x18.mlflow.SetExperimentTag\x1a!.mlflow.SetExperimentTag.Response\"\x8f\x01\xf2\x86\x19\x8a\x01\n4\n\x04POST\x12&/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\n<\n\x04POST\x12./preview/mlflow/experiments/set-experiment-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Set Experiment Tag\x12\x92\x01\n\x06setTag\x12\x0e.mlflow.SetTag\x1a\x17.mlflow.SetTag.Response\"_\xf2\x86\x19[\n\"\n\x04POST\x12\x14/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\n*\n\x04POST\x12\x1c/preview/mlflow/runs/set-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Set Tag\x12\xa4\x01\n\tdeleteTag\x12\x11.mlflow.DeleteTag\x1a\x1a.mlflow.DeleteTag.Response\"h\xf2\x86\x19\x64\n%\n\x04POST\x12\x17/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\n-\n\x04POST\x12\x1f/preview/mlflow/runs/delete-tag\x1a\x04\x08\x02\x10\x00\x10\x01*\nDelete Tag\x12\x88\x01\n\x06getRun\x12\x0e.mlflow.GetRun\x1a\x17.mlflow.GetRun.Response\"U\xf2\x86\x19Q\n\x1d\n\x03GET\x12\x10/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\n%\n\x03GET\x12\x18/preview/mlflow/runs/get\x1a\x04\x08\x02\x10\x00\x10\x01*\x07Get Run\x12\xcc\x01\n\nsearchRuns\x12\x12.mlflow.SearchRuns\x1a\x1b.mlflow.SearchRuns.Response\"\x8c\x01\xf2\x86\x19\x87\x01\n!\n\x04POST\x12\x13/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n)\n\x04POST\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\n(\n\x03GET\x12\x1b/preview/mlflow/runs/search\x1a\x04\x08\x02\x10\x00\x10\x01*\x0bSearch Runs\x12\xb0\x01\n\rlistArtifacts\x12\x15.mlflow.ListArtifacts\x1a\x1e.mlflow.ListArtifacts.Response\"h\xf2\x86\x19\x64\n#\n\x03GET\x12\x16/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\n+\n\x03GET\x12\x1e/preview/mlflow/artifacts/list\x1a\x04\x08\x02\x10\x00\x10\x01*\x0eList Artifacts\x12\xc7\x01\n\x10getMetricHistory\x12\x18.mlflow.GetMetricHistory\x1a!.mlflow.GetMetricHistory.Response\"v\xf2\x86\x19r\n(\n\x03GET\x12\x1b/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\n0\n\x03GET\x12#/preview/mlflow/metrics/get-history\x1a\x04\x08\x02\x10\x00\x10\x01*\x12Get Metric History\x12\x9e\x01\n\x08logBatch\x12\x10.mlflow.LogBatch\x1a\x19.mlflow.LogBatch.Response\"e\xf2\x86\x19\x61\n$\n\x04POST\x12\x16/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\n,\n\x04POST\x12\x1e/preview/mlflow/runs/log-batch\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog Batch\x12\x9e\x01\n\x08logModel\x12\x10.mlflow.LogModel\x1a\x19.mlflow.LogModel.Response\"e\xf2\x86\x19\x61\n$\n\x04POST\x12\x16/mlflow/runs/log-model\x1a\x04\x08\x02\x10\x00\n,\n\x04POST\x12\x1e/preview/mlflow/runs/log-model\x1a\x04\x08\x02\x10\x00\x10\x01*\tLog ModelB\x1e\n\x14org.mlflow.api.proto\x90\x01\x01\xe2?\x02\x10\x01')
   ,
   dependencies=[scalapb_dot_scalapb__pb2.DESCRIPTOR,databricks__pb2.DESCRIPTOR,])
 
@@ -49,8 +49,8 @@ _VIEWTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4243,
-  serialized_end=4297,
+  serialized_start=4389,
+  serialized_end=4443,
 )
 _sym_db.RegisterEnumDescriptor(_VIEWTYPE)
 
@@ -84,8 +84,8 @@ _SOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4299,
-  serialized_end=4372,
+  serialized_start=4445,
+  serialized_end=4518,
 )
 _sym_db.RegisterEnumDescriptor(_SOURCETYPE)
 
@@ -119,8 +119,8 @@ _RUNSTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   serialized_options=None,
-  serialized_start=4374,
-  serialized_end=4451,
+  serialized_start=4520,
+  serialized_end=4597,
 )
 _sym_db.RegisterEnumDescriptor(_RUNSTATUS)
 
@@ -998,6 +998,74 @@ _CREATERUN = _descriptor.Descriptor(
 )
 
 
+_MOVERUN_RESPONSE = _descriptor.Descriptor(
+  name='Response',
+  full_name='mlflow.MoveRun.Response',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  serialized_options=None,
+  is_extendable=False,
+  syntax='proto2',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=898,
+  serialized_end=908,
+)
+
+_MOVERUN = _descriptor.Descriptor(
+  name='MoveRun',
+  full_name='mlflow.MoveRun',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='run_id', full_name='mlflow.MoveRun.run_id', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=_b('\370\206\031\001'), file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='src_experiment_id', full_name='mlflow.MoveRun.src_experiment_id', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='dest_experiment_id', full_name='mlflow.MoveRun.dest_experiment_id', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      serialized_options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[_MOVERUN_RESPONSE, ],
+  enum_types=[
+  ],
+  serialized_options=_b('\342?(\n&com.databricks.rpc.RPC[$this.Response]'),
+  is_extendable=False,
+  syntax='proto2',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=1837,
+  serialized_end=1980,
+)
+
+
 _UPDATERUN_RESPONSE = _descriptor.Descriptor(
   name='Response',
   full_name='mlflow.UpdateRun.Response',
@@ -1024,8 +1092,8 @@ _UPDATERUN_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1937,
-  serialized_end=1982,
+  serialized_start=2083,
+  serialized_end=2128,
 )
 
 _UPDATERUN = _descriptor.Descriptor(
@@ -1075,8 +1143,8 @@ _UPDATERUN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=1837,
-  serialized_end=2027,
+  serialized_start=1983,
+  serialized_end=2173,
 )
 
 
@@ -1129,8 +1197,8 @@ _DELETERUN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2029,
-  serialized_end=2119,
+  serialized_start=2175,
+  serialized_end=2265,
 )
 
 
@@ -1183,8 +1251,8 @@ _RESTORERUN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2121,
-  serialized_end=2212,
+  serialized_start=2267,
+  serialized_end=2358,
 )
 
 
@@ -1272,8 +1340,8 @@ _LOGMETRIC = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2215,
-  serialized_end=2399,
+  serialized_start=2361,
+  serialized_end=2545,
 )
 
 
@@ -1347,8 +1415,8 @@ _LOGPARAM = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2402,
-  serialized_end=2543,
+  serialized_start=2548,
+  serialized_end=2689,
 )
 
 
@@ -1415,8 +1483,8 @@ _SETEXPERIMENTTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2546,
-  serialized_end=2690,
+  serialized_start=2692,
+  serialized_end=2836,
 )
 
 
@@ -1490,8 +1558,8 @@ _SETTAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2693,
-  serialized_end=2832,
+  serialized_start=2839,
+  serialized_end=2978,
 )
 
 
@@ -1551,8 +1619,8 @@ _DELETETAG = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2834,
-  serialized_end=2943,
+  serialized_start=2980,
+  serialized_end=3089,
 )
 
 
@@ -1619,8 +1687,8 @@ _GETRUN = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=2945,
-  serialized_end=3070,
+  serialized_start=3091,
+  serialized_end=3216,
 )
 
 
@@ -1657,8 +1725,8 @@ _SEARCHRUNS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3246,
-  serialized_end=3308,
+  serialized_start=3392,
+  serialized_end=3454,
 )
 
 _SEARCHRUNS = _descriptor.Descriptor(
@@ -1722,8 +1790,8 @@ _SEARCHRUNS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3073,
-  serialized_end=3353,
+  serialized_start=3219,
+  serialized_end=3499,
 )
 
 
@@ -1767,8 +1835,8 @@ _LISTARTIFACTS_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3441,
-  serialized_end=3527,
+  serialized_start=3587,
+  serialized_end=3673,
 )
 
 _LISTARTIFACTS = _descriptor.Descriptor(
@@ -1818,8 +1886,8 @@ _LISTARTIFACTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3356,
-  serialized_end=3572,
+  serialized_start=3502,
+  serialized_end=3718,
 )
 
 
@@ -1863,8 +1931,8 @@ _FILEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3574,
-  serialized_end=3633,
+  serialized_start=3720,
+  serialized_end=3779,
 )
 
 
@@ -1894,8 +1962,8 @@ _GETMETRICHISTORY_RESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3716,
-  serialized_end=3759,
+  serialized_start=3862,
+  serialized_end=3905,
 )
 
 _GETMETRICHISTORY = _descriptor.Descriptor(
@@ -1938,8 +2006,8 @@ _GETMETRICHISTORY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3636,
-  serialized_end=3804,
+  serialized_start=3782,
+  serialized_end=3950,
 )
 
 
@@ -2013,8 +2081,8 @@ _LOGBATCH = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3807,
-  serialized_end=3984,
+  serialized_start=3953,
+  serialized_end=4130,
 )
 
 
@@ -2074,8 +2142,8 @@ _LOGMODEL = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3986,
-  serialized_end=4089,
+  serialized_start=4132,
+  serialized_end=4235,
 )
 
 
@@ -2135,8 +2203,8 @@ _GETEXPERIMENTBYNAME = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4092,
-  serialized_end=4241,
+  serialized_start=4238,
+  serialized_end=4387,
 )
 
 _RUN.fields_by_name['info'].message_type = _RUNINFO
@@ -2159,6 +2227,7 @@ _UPDATEEXPERIMENT_RESPONSE.containing_type = _UPDATEEXPERIMENT
 _CREATERUN_RESPONSE.fields_by_name['run'].message_type = _RUN
 _CREATERUN_RESPONSE.containing_type = _CREATERUN
 _CREATERUN.fields_by_name['tags'].message_type = _RUNTAG
+_MOVERUN_RESPONSE.containing_type = _MOVERUN
 _UPDATERUN_RESPONSE.fields_by_name['run_info'].message_type = _RUNINFO
 _UPDATERUN_RESPONSE.containing_type = _UPDATERUN
 _UPDATERUN.fields_by_name['status'].enum_type = _RUNSTATUS
@@ -2200,6 +2269,7 @@ DESCRIPTOR.message_types_by_name['DeleteExperiment'] = _DELETEEXPERIMENT
 DESCRIPTOR.message_types_by_name['RestoreExperiment'] = _RESTOREEXPERIMENT
 DESCRIPTOR.message_types_by_name['UpdateExperiment'] = _UPDATEEXPERIMENT
 DESCRIPTOR.message_types_by_name['CreateRun'] = _CREATERUN
+DESCRIPTOR.message_types_by_name['MoveRun'] = _MOVERUN
 DESCRIPTOR.message_types_by_name['UpdateRun'] = _UPDATERUN
 DESCRIPTOR.message_types_by_name['DeleteRun'] = _DELETERUN
 DESCRIPTOR.message_types_by_name['RestoreRun'] = _RESTORERUN
@@ -2381,6 +2451,21 @@ CreateRun = _reflection.GeneratedProtocolMessageType('CreateRun', (_message.Mess
   ))
 _sym_db.RegisterMessage(CreateRun)
 _sym_db.RegisterMessage(CreateRun.Response)
+
+MoveRun = _reflection.GeneratedProtocolMessageType('MoveRun', (_message.Message,), dict(
+
+  Response = _reflection.GeneratedProtocolMessageType('Response', (_message.Message,), dict(
+    DESCRIPTOR = _MOVERUN_RESPONSE,
+    __module__ = 'service_pb2'
+    # @@protoc_insertion_point(class_scope:mlflow.MoveRun.Response)
+    ))
+  ,
+  DESCRIPTOR = _MOVERUN,
+  __module__ = 'service_pb2'
+  # @@protoc_insertion_point(class_scope:mlflow.MoveRun)
+  ))
+_sym_db.RegisterMessage(MoveRun)
+_sym_db.RegisterMessage(MoveRun.Response)
 
 UpdateRun = _reflection.GeneratedProtocolMessageType('UpdateRun', (_message.Message,), dict(
 
@@ -2629,6 +2714,8 @@ _RESTOREEXPERIMENT._options = None
 _UPDATEEXPERIMENT.fields_by_name['experiment_id']._options = None
 _UPDATEEXPERIMENT._options = None
 _CREATERUN._options = None
+_MOVERUN.fields_by_name['run_id']._options = None
+_MOVERUN._options = None
 _UPDATERUN._options = None
 _DELETERUN.fields_by_name['run_id']._options = None
 _DELETERUN._options = None
@@ -2667,8 +2754,8 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   serialized_options=None,
-  serialized_start=4454,
-  serialized_end=8391,
+  serialized_start=4600,
+  serialized_end=8684,
   methods=[
   _descriptor.MethodDescriptor(
     name='getExperimentByName',
@@ -2743,9 +2830,18 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
     serialized_options=_b('\362\206\031\\\n!\n\004POST\022\023/mlflow/runs/create\032\004\010\002\020\000\n)\n\004POST\022\033/preview/mlflow/runs/create\032\004\010\002\020\000\020\001*\nCreate Run'),
   ),
   _descriptor.MethodDescriptor(
+    name='moveRun',
+    full_name='mlflow.MlflowService.moveRun',
+    index=8,
+    containing_service=None,
+    input_type=_MOVERUN,
+    output_type=_MOVERUN_RESPONSE,
+    serialized_options=_b('\362\206\031V\n\037\n\004POST\022\021/mlflow/runs/move\032\004\010\002\020\000\n\'\n\004POST\022\031/preview/mlflow/runs/move\032\004\010\002\020\000\020\001*\010Move Run'),
+  ),
+  _descriptor.MethodDescriptor(
     name='updateRun',
     full_name='mlflow.MlflowService.updateRun',
-    index=8,
+    index=9,
     containing_service=None,
     input_type=_UPDATERUN,
     output_type=_UPDATERUN_RESPONSE,
@@ -2754,7 +2850,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='deleteRun',
     full_name='mlflow.MlflowService.deleteRun',
-    index=9,
+    index=10,
     containing_service=None,
     input_type=_DELETERUN,
     output_type=_DELETERUN_RESPONSE,
@@ -2763,7 +2859,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='restoreRun',
     full_name='mlflow.MlflowService.restoreRun',
-    index=10,
+    index=11,
     containing_service=None,
     input_type=_RESTORERUN,
     output_type=_RESTORERUN_RESPONSE,
@@ -2772,7 +2868,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='logMetric',
     full_name='mlflow.MlflowService.logMetric',
-    index=11,
+    index=12,
     containing_service=None,
     input_type=_LOGMETRIC,
     output_type=_LOGMETRIC_RESPONSE,
@@ -2781,7 +2877,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='logParam',
     full_name='mlflow.MlflowService.logParam',
-    index=12,
+    index=13,
     containing_service=None,
     input_type=_LOGPARAM,
     output_type=_LOGPARAM_RESPONSE,
@@ -2790,7 +2886,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='setExperimentTag',
     full_name='mlflow.MlflowService.setExperimentTag',
-    index=13,
+    index=14,
     containing_service=None,
     input_type=_SETEXPERIMENTTAG,
     output_type=_SETEXPERIMENTTAG_RESPONSE,
@@ -2799,7 +2895,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='setTag',
     full_name='mlflow.MlflowService.setTag',
-    index=14,
+    index=15,
     containing_service=None,
     input_type=_SETTAG,
     output_type=_SETTAG_RESPONSE,
@@ -2808,7 +2904,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='deleteTag',
     full_name='mlflow.MlflowService.deleteTag',
-    index=15,
+    index=16,
     containing_service=None,
     input_type=_DELETETAG,
     output_type=_DELETETAG_RESPONSE,
@@ -2817,7 +2913,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='getRun',
     full_name='mlflow.MlflowService.getRun',
-    index=16,
+    index=17,
     containing_service=None,
     input_type=_GETRUN,
     output_type=_GETRUN_RESPONSE,
@@ -2826,7 +2922,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='searchRuns',
     full_name='mlflow.MlflowService.searchRuns',
-    index=17,
+    index=18,
     containing_service=None,
     input_type=_SEARCHRUNS,
     output_type=_SEARCHRUNS_RESPONSE,
@@ -2835,7 +2931,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='listArtifacts',
     full_name='mlflow.MlflowService.listArtifacts',
-    index=18,
+    index=19,
     containing_service=None,
     input_type=_LISTARTIFACTS,
     output_type=_LISTARTIFACTS_RESPONSE,
@@ -2844,7 +2940,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='getMetricHistory',
     full_name='mlflow.MlflowService.getMetricHistory',
-    index=19,
+    index=20,
     containing_service=None,
     input_type=_GETMETRICHISTORY,
     output_type=_GETMETRICHISTORY_RESPONSE,
@@ -2853,7 +2949,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='logBatch',
     full_name='mlflow.MlflowService.logBatch',
-    index=20,
+    index=21,
     containing_service=None,
     input_type=_LOGBATCH,
     output_type=_LOGBATCH_RESPONSE,
@@ -2862,7 +2958,7 @@ _MLFLOWSERVICE = _descriptor.ServiceDescriptor(
   _descriptor.MethodDescriptor(
     name='logModel',
     full_name='mlflow.MlflowService.logModel',
-    index=21,
+    index=22,
     containing_service=None,
     input_type=_LOGMODEL,
     output_type=_LOGMODEL_RESPONSE,

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -25,6 +25,7 @@ from mlflow.protos.service_pb2 import (
     ListArtifacts,
     GetMetricHistory,
     CreateRun,
+    MoveRun,
     UpdateRun,
     LogMetric,
     LogParam,
@@ -343,6 +344,21 @@ def _create_run():
 
     response_message = CreateRun.Response()
     response_message.run.MergeFrom(run.to_proto())
+    response = Response(mimetype="application/json")
+    response.set_data(message_to_json(response_message))
+    return response
+
+
+@catch_mlflow_exception
+def _move_run():
+    request_message = _get_request_message(MoveRun())
+    run_id = request_message.run_id or request_message.run_uuid
+    updated_info = _get_tracking_store().move_run(
+        run_id=run_id,
+        src_experiment_id=request_message.src_experiment_id,
+        dest_experiment_id=request_message.dest_experiment_id,
+    )
+    response_message = MoveRun.Response()
     response = Response(mimetype="application/json")
     response.set_data(message_to_json(response_message))
     return response
@@ -844,6 +860,7 @@ HANDLERS = {
     UpdateExperiment: _update_experiment,
     CreateRun: _create_run,
     UpdateRun: _update_run,
+    MoveRun: _move_run,
     DeleteRun: _delete_run,
     RestoreRun: _restore_run,
     LogParam: _log_param,

--- a/mlflow/server/js/src/common/forms/validations.js
+++ b/mlflow/server/js/src/common/forms/validations.js
@@ -33,7 +33,7 @@ export const getExperimentIdValidator = (getCurrentExperimentId, getExistingExpe
       // no need to execute below validations when no value is entered
       // eslint-disable-next-line callback-return
       callback(undefined);
-    } else if (isNaN(value)) {
+    } else if (!(Number(value) === parseInt(value, 10))) {
       callback(`Experiment ID must be an integer`);
     } else if (getCurrentExperimentId() == value) {
       callback(`"${value}" is the current experiment ID`);

--- a/mlflow/server/js/src/common/forms/validations.js
+++ b/mlflow/server/js/src/common/forms/validations.js
@@ -33,8 +33,6 @@ export const getExperimentIdValidator = (getCurrentExperimentId, getExistingExpe
       // no need to execute below validations when no value is entered
       // eslint-disable-next-line callback-return
       callback(undefined);
-    } else if (!(Number(value) === parseInt(value, 10))) {
-      callback(`Experiment ID must be an integer`);
     } else if (getCurrentExperimentId() == value) {
       callback(`"${value}" is the current experiment ID`);
     } else if (!getExistingExperimentIds().includes(value)) {

--- a/mlflow/server/js/src/common/forms/validations.js
+++ b/mlflow/server/js/src/common/forms/validations.js
@@ -27,6 +27,28 @@ export const getExperimentNameValidator = (getExistingExperimentNames) => {
   };
 };
 
+export const getExperimentIdValidator = (getCurrentExperimentId, getExistingExperimentIds) => {
+  return (rule, value, callback) => {
+    console.log('CCCCCCCCCCCCCCCCCCCCCCCCCCC', getCurrentExperimentId(), value);
+    if (value.length === 0) {
+      // no need to execute below validations when no value is entered
+      // eslint-disable-next-line callback-return
+      callback(undefined);
+    } else if (isNaN(value)) {
+      callback(`Experiment ID must be an integer`);
+    } else if (getCurrentExperimentId() == value) {
+      callback(`"${value}" is the current experiment ID`);
+    } else if (!getExistingExperimentIds().includes(value)) {
+      // getExistingExperimentNames returns the names of all active experiments
+      // check whether the passed value is part of the list
+      // eslint-disable-next-line callback-return
+      callback(`Experiment ID "${value}" does not exists.`);
+    } else {
+      callback(undefined); // experiment id exists
+    }
+  };
+};
+
 export const modelNameValidator = (rule, name, callback) => {
   if (name.length === 0) {
     callback(undefined);

--- a/mlflow/server/js/src/common/forms/validations.js
+++ b/mlflow/server/js/src/common/forms/validations.js
@@ -29,7 +29,6 @@ export const getExperimentNameValidator = (getExistingExperimentNames) => {
 
 export const getExperimentIdValidator = (getCurrentExperimentId, getExistingExperimentIds) => {
   return (rule, value, callback) => {
-    console.log('CCCCCCCCCCCCCCCCCCCCCCCCCCC', getCurrentExperimentId(), value);
     if (value.length === 0) {
       // no need to execute below validations when no value is entered
       // eslint-disable-next-line callback-return

--- a/mlflow/server/js/src/experiment-tracking/actions.js
+++ b/mlflow/server/js/src/experiment-tracking/actions.js
@@ -72,6 +72,22 @@ export const getRunApi = (runId, id = getUUID()) => {
   };
 };
 
+export const MOVE_RUN_API = 'MOVE_RUN_API';
+export const moveRunApi = (runUuid, srcExperimentId, destExperimentId, id = getUUID()) => {
+  return (dispatch) => {
+    const deleteResponse = dispatch({
+      type: MOVE_RUN_API,
+      payload: wrapDeferred(MlflowService.moveRun, { 
+        run_id: runUuid,
+        src_experiment_id: srcExperimentId,
+        dest_experiment_id: destExperimentId
+      }),
+      meta: { id: getUUID() },
+    });
+    return deleteResponse.then(() => dispatch(getRunApi(runUuid, id)));
+  };
+};
+
 export const DELETE_RUN_API = 'DELETE_RUN_API';
 export const deleteRunApi = (runUuid, id = getUUID()) => {
   return (dispatch) => {

--- a/mlflow/server/js/src/experiment-tracking/components/modals/ExperimentIdForm.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/ExperimentIdForm.js
@@ -1,0 +1,66 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import { Form, Input } from 'antd';
+
+export const NEW_ID_FIELD = 'experimentId';
+
+/**
+ * Component that renders a form for updating a run's or experiment's name.
+ */
+class ExperimentIdFormComponent extends Component {
+  static propTypes = {
+    form: PropTypes.object.isRequired,
+    // name: PropTypes.string.isRequired,
+    visible: PropTypes.bool.isRequired,
+    validator: PropTypes.func,
+  };
+
+  componentDidUpdate(prevProps) {
+    this.autoFocus(prevProps);
+    this.resetFields(prevProps);
+  }
+
+  autoFocusInputRef = (inputToAutoFocus) => {
+    this.inputToAutoFocus = inputToAutoFocus;
+    inputToAutoFocus.focus();
+    inputToAutoFocus.select();
+  };
+
+  autoFocus = (prevProps) => {
+    if (prevProps.visible === false && this.props.visible === true) {
+      // focus on input field
+      this.inputToAutoFocus && this.inputToAutoFocus.focus();
+      // select text
+      this.inputToAutoFocus && this.inputToAutoFocus.select();
+    }
+  };
+
+  resetFields = (prevProps) => {
+    if (prevProps.name !== this.props.name) {
+      // reset input field to reset displayed initialValue
+      this.props.form.resetFields([NEW_ID_FIELD]);
+    }
+  };
+
+  render() {
+    const { getFieldDecorator } = this.props.form;
+    return (
+      <Form layout='vertical'>
+        <Form.Item label={`Enter experiment ID`}>
+          {getFieldDecorator(NEW_ID_FIELD, {
+            rules: [
+              { required: true, message: `Please enter a experiment ID` },
+              { validator: this.props.validator },
+            ],
+            initialValue: this.props.name,
+          })(
+            <Input placeholder={`Input a experimentID`} ref={this.autoFocusInputRef} />,
+          )}
+        </Form.Item>
+      </Form>
+    );
+  }
+}
+
+export const ExperimentIdForm = Form.create()(ExperimentIdFormComponent);

--- a/mlflow/server/js/src/experiment-tracking/components/modals/ExperimentIdForm.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/ExperimentIdForm.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { ExperimentIdForm } from './ExperimentIdForm';
+
+describe('Render test', () => {
+  const minimalProps = {
+    type: 'run',
+    name: 'Test',
+    visible: true,
+    // eslint-disable-next-line no-unused-vars
+    form: { getFieldDecorator: jest.fn((opts) => (c) => c) },
+  };
+
+  it('should render with minimal props without exploding', () => {
+    const wrapper = shallow(<ExperimentIdForm {...minimalProps} />);
+    expect(wrapper.length).toBe(1);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunModal.js
@@ -30,7 +30,6 @@ export class MoveRunModalImpl extends Component {
     const movePromises = [];
     const newExperimentId = values[NEW_ID_FIELD];
     this.props.selectedRunIds.forEach((runId) => {
-      console.log(runId, this.props.experimentId, newExperimentId);
       movePromises.push(this.props.moveRunApi(
         runId, this.props.experimentId, newExperimentId
       ));

--- a/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunModal.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunModal.js
@@ -1,0 +1,81 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import debounce from 'lodash/debounce';
+
+import { GenericInputModal } from './GenericInputModal';
+import { ExperimentIdForm, NEW_ID_FIELD } from './ExperimentIdForm';
+import { getExperimentIdValidator } from '../../../common/forms/validations';
+
+import { moveRunApi, openErrorModal } from '../../actions';
+import { getExperiments } from '../../reducers/Reducers';
+
+export class MoveRunModalImpl extends Component {
+  // constructor(props) {
+  //   super(props);
+  //   this.handleSubmit = this.handleSubmit.bind(this);
+  // }
+
+  static propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    experimentId: PropTypes.string,
+    experimentName: PropTypes.string,
+    selectedRunIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+    openErrorModal: PropTypes.func.isRequired,
+    moveRunApi: PropTypes.func.isRequired,
+  };
+
+  handleSubmit = (values) => {
+    const movePromises = [];
+    const newExperimentId = values[NEW_ID_FIELD];
+    this.props.selectedRunIds.forEach((runId) => {
+      console.log(runId, this.props.experimentId, newExperimentId);
+      movePromises.push(this.props.moveRunApi(
+        runId, this.props.experimentId, newExperimentId
+      ));
+    });
+    return Promise.all(movePromises).catch((err) => {
+      this.props.openErrorModal('While moving an experiment run, an error occurred.');
+    });
+  };
+
+  debouncedExperimentIdValidator = debounce(
+    getExperimentIdValidator(() => this.props.experimentId, () => this.props.experimentIds),
+    400,
+  );
+
+  render() {
+    const { isOpen, experimentId } = this.props;
+    return (
+      <GenericInputModal
+        title='Move to Experiment'
+        okText='Move'
+        isOpen={isOpen}
+        handleSubmit={this.handleSubmit}
+        onClose={this.props.onClose}
+      >
+        <ExperimentIdForm
+          name='Enter experiment ID'
+          visible={isOpen}
+          validator={this.debouncedExperimentIdValidator}
+        />
+      </GenericInputModal>
+    );
+  }
+}
+
+const mapStateToProps = (state) => {
+  const experiments = getExperiments(state);
+  const experimentIds = experiments.map((e) => e.getExperimentId());
+  return { experimentIds };
+};
+
+const mapDispatchToProps = {
+  moveRunApi,
+  openErrorModal,
+};
+
+export const MoveRunModal = connect(mapStateToProps, mapDispatchToProps)(MoveRunModalImpl);
+
+

--- a/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunModel.test.js
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/MoveRunModel.test.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { MoveRunModalImpl } from './MoveRunModal';
+import { NEW_ID_FIELD } from './ExperimentIdForm';
+
+/**
+ * Return a function that can be used to mock run move API requests, appending moved run IDs
+ * to the provided list.
+ * @param shouldFail: If true, the generated function will return a promise that always reject
+ * @param moveddIdsList List to which to append IDs of moved runs
+ * @returns {function(*=): Promise<any>}
+ */
+const getMockMoveRunApiFn = (shouldFail, movedIdsList) => {
+  return (runId) => {
+    return new Promise((resolve, reject) => {
+      window.setTimeout(() => {
+        if (shouldFail) {
+          reject();
+        } else {
+          movedIdsList.push(runId);
+          resolve();
+        }
+      }, 1000);
+    });
+  };
+};
+
+describe('MyComponent', () => {
+  let wrapper;
+  let instance;
+  let minimalProps;
+
+  beforeEach(() => {
+    minimalProps = {
+      isOpen: false,
+      onClose: jest.fn(),
+      selectedRunIds: ['runId0', 'runId1'],
+      openErrorModal: jest.fn(),
+      moveRunApi: getMockMoveRunApiFn(false, []),
+    };
+    wrapper = shallow(<MoveRunModalImpl {...minimalProps} />);
+  });
+
+  test('should render with minimal props without exploding', () => {
+    expect(wrapper.length).toBe(1);
+  });
+
+  test('should move each selected run on submission', (done) => {
+    const movedRunIds = [];
+    const moveRunApi = getMockMoveRunApiFn(false, movedRunIds);
+    const values = { NEW_ID_FIELD: '2' };
+    wrapper = shallow(<MoveRunModalImpl {...{ ...minimalProps, moveRunApi }} />);
+    instance = wrapper.instance();
+    instance.handleSubmit(values).then(() => {
+      expect(movedRunIds).toEqual(minimalProps.selectedRunIds);
+      done();
+    });
+  });
+
+  test('should show error modal if deletion fails', (done) => {
+    const movedRunIds = [];
+    const moveRunApi = getMockMoveRunApiFn(true, movedRunIds);
+    const values = { NEW_ID_FIELD: '2' };
+    wrapper = shallow(<MoveRunModalImpl {...{ ...minimalProps, moveRunApi }} />);
+    instance = wrapper.instance();
+    instance.handleSubmit(values).then(() => {
+      expect(movedRunIds).toEqual([]);
+      expect(minimalProps.openErrorModal).toBeCalled();
+      done();
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.js
@@ -164,6 +164,23 @@ export class MlflowService {
     });
   }
   /**
+   * @param {MoveRun} data: Immutable Record
+   * @param {function} success
+   * @param {function} error
+   * @return {Promise}
+   */
+   static moveRun({ data, success, error }) {
+    return $.ajax(Utils.getAjaxUrl('ajax-api/2.0/preview/mlflow/runs/move'), {
+      type: 'POST',
+      contentType: 'application/json; charset=utf-8',
+      dataType: 'json',
+      data: JSON.stringify(data),
+      jsonp: false,
+      success: success,
+      error: error,
+    });
+  }
+  /**
    * @param {RestoreRun} data: Immutable Record
    * @param {function} success
    * @param {function} error

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -6,6 +6,7 @@ from mlflow.protos.service_pb2 import (
     MlflowService,
     GetExperiment,
     GetRun,
+    MoveRun,
     SearchRuns,
     ListExperiments,
     GetMetricHistory,
@@ -248,6 +249,13 @@ class RestStore(AbstractStore):
         if response_proto.next_page_token:
             next_page_token = response_proto.next_page_token
         return runs, next_page_token
+
+    def move_run(self, run_id, src_experiment_id, dest_experiment_id):
+        req_body = message_to_json(MoveRun(
+            run_id=run_id,
+            src_experiment_id=src_experiment_id,
+            dest_experiment_id=dest_experiment_id))
+        self._call_endpoint(MoveRun, req_body)
 
     def delete_run(self, run_id):
         req_body = message_to_json(DeleteRun(run_id=run_id))

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -375,6 +375,14 @@ class SqlAlchemyStore(AbstractStore):
 
             return run.to_mlflow_entity()
 
+    def move_run(self, run_id, src_experiment_id, dest_experiment_id):
+        with self.ManagedSessionMaker() as session:
+            run = self._get_run(run_uuid=run_id, session=session)
+            self._check_run_is_active(run)
+            run.experiment_id = dest_experiment_id
+            self._save_to_db(objs=run, session=session)
+            run = run.to_mlflow_entity()
+
     def _get_run(self, session, run_uuid, eager=False):
         """
         :param eager: If ``True``, eagerly loads the run's summary metrics (``latest_metrics``),

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -265,6 +265,10 @@ def mv(target, new_parent):
     shutil.move(target, new_parent)
 
 
+def rmdir(path):
+    shutil.rmtree(path)
+
+
 def write_to(filename, data):
     with codecs.open(filename, mode="w", encoding=ENCODING) as handle:
         handle.write(data)

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -21,6 +21,7 @@ from mlflow.protos.service_pb2 import (
     CreateRun,
     DeleteExperiment,
     DeleteRun,
+    MoveRun,
     LogBatch,
     LogMetric,
     LogParam,
@@ -247,6 +248,15 @@ class TestRestStore(object):
             store.delete_run("u25")
             self._verify_requests(
                 mock_http, creds, "runs/delete", "POST", message_to_json(DeleteRun(run_id="u25"))
+            )
+
+        with mock.patch("mlflow.utils.rest_utils.http_request") as mock_http:
+            store.move_run("u25", "0", "1")
+            self._verify_requests(
+                mock_http, creds, "runs/move", "POST", message_to_json(MoveRun(
+                    run_id="u25",
+                    src_experiment_id="0",
+                    dest_experiment_id="1"))
             )
 
         with mock.patch("mlflow.utils.rest_utils.http_request") as mock_http:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Implemented python API, Java client and tracking UI support for moving logged runs to a different experiment

A `/mlflow/runs/move` POST request is added to the REST API with parameters:
- `run_id`
- `src_experiment_id`: numeric experiment id for the source of the run
- `dest_experiment_id`: numeric experiment id for where the move the run

Links to #4307 

## How is this patch tested?
- Unit test
- Manual test by creating and moving an experiment via both local and db tracking backend

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

UI and REST API functionality added for moving logged runs to a different experiment

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [x] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
