### PR TITLE
MLflow Java client: Retry on 500s

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
@@ -50,8 +50,8 @@ class MlflowHttpCaller {
   /**
    * Construct a new MlflowHttpCaller.
    *
-   * @param maxRateLimitIntervalSeconds The maximum number of seconds to retry a single request
-   *                                    in respone to rate limiting (error code 429).
+   * @param maxRateLimitIntervalMs The maximum amount of time, in milliseconds, to spend retrying a
+   *                               single request in response to rate limiting (error code 429).
    * @param rateLimitRetrySleepInitMs The initial backoff delay, in milliseconds, when retrying a
    *                                  request in response to rate limiting (error code 429). The
    *                                  delay is increased exponentially after each rate limiting
@@ -61,23 +61,23 @@ class MlflowHttpCaller {
    *                         retries.
    */
   MlflowHttpCaller(MlflowHostCredsProvider hostCredsProvider,
-                   int maxRateLimitIntervalSeconds,
+                   int maxRateLimitIntervalMs,
                    int rateLimitRetrySleepInitMs,
                    int maxRetryAttempts) {
     this.hostCredsProvider = hostCredsProvider;
-    this.maxRateLimitIntervalMillis = maxRateLimitIntervalSeconds;
+    this.maxRateLimitIntervalMillis = maxRateLimitIntervalMs;
     this.rateLimitRetrySleepInitMillis = rateLimitRetrySleepInitMs;
     this.maxRetryAttempts = maxRetryAttempts;
   }
 
   @VisibleForTesting
   MlflowHttpCaller(MlflowHostCredsProvider hostCredsProvider,
-                   int maxRateLimitIntervalSeconds,
+                   int maxRateLimitIntervalMs,
                    int rateLimitRetrySleepInitMs,
                    int maxRetryAttempts,
                    HttpClient client) {
     this(
-      hostCredsProvider, maxRateLimitIntervalSeconds, rateLimitRetrySleepInitMs, maxRetryAttempts);
+      hostCredsProvider, maxRateLimitIntervalMs, rateLimitRetrySleepInitMs, maxRetryAttempts);
     this.httpClient = client;
   }
 

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
@@ -115,8 +115,11 @@ class MlflowHttpCaller {
         break;
       } catch (MlflowHttpException e) {
         if (attemptsRemaining > 0) {
-          logger.warn("Request returned with status code {} (Rate limit exceeded). Retrying."
-                      + "Attempts remaining: {}.", e.getStatusCode(), attemptsRemaining);
+          logger.warn("Request returned with status code {} (Rate limit exceeded)."
+                      + " Retrying up to {} more times. Response body: {}",
+                      e.getStatusCode(),
+                      attemptsRemaining,
+                      e.getBodyMessage());
           continue;
         } else {
           throw e;

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
@@ -51,12 +51,12 @@ class MlflowHttpCaller {
    * Construct a new MlflowHttpCaller.
    *
    * @param maxRateLimitIntervalSeconds The maximum number of seconds to retry a single request
-   *                                    for rate limiting responses with error code 429.
-   * @param rateLimitRetrySleepInitMs The initial backoff delay when retrying a request for rate
-   *                                  limiting responses with error code 429. The delay is increased
-   *                                  exponentially after each 429 response until the total delay
-   *                                  incurred across all retries for the request exceeds the
-   *                                  specified maxRateLimitIntervalSeconds.
+   *                                    in respone to rate limiting (error code 429).
+   * @param rateLimitRetrySleepInitMs The initial backoff delay, in milliseconds, when retrying a
+   *                                  request in response to rate limiting (error code 429). The
+   *                                  delay is increased exponentially after each rate limiting
+   *                                  response until the total delay incurred across all retries for
+   *                                  the request exceeds the specified maxRateLimitIntervalSeconds.
    * @param maxRetryAttempts The maximum number of times to retry a request, excluding rate limit
    *                         retries.
    */

--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowHttpCaller.java
@@ -114,7 +114,7 @@ class MlflowHttpCaller {
         response = executeRequestWithRateLimitRetries(request);
         break;
       } catch (MlflowHttpException e) {
-        if (attemptsRemaining > 0) {
+        if (attemptsRemaining > 0 && e.getStatusCode() != 429) {
           logger.warn("Request returned with status code {} (Rate limit exceeded)."
                       + " Retrying up to {} more times. Response body: {}",
                       e.getStatusCode(),

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/HttpCallerTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/HttpCallerTest.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.mockito.Mockito.*;
-import org.mockito.MockitoAnnotations;
 
 public class HttpCallerTest {
 

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/HttpCallerTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/HttpCallerTest.java
@@ -17,20 +17,24 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import static org.mockito.Mockito.*;
+import org.mockito.MockitoAnnotations;
 
 public class HttpCallerTest {
 
   static CloseableHttpClient client = mock(CloseableHttpClient.class);
 
-  static CloseableHttpResponse response429 = mock(CloseableHttpResponse.class);
   static CloseableHttpResponse response200 = mock(CloseableHttpResponse.class);
-  static StatusLine statusLine200 = mock(StatusLine.class);
+  static CloseableHttpResponse response429 = mock(CloseableHttpResponse.class);
+  static CloseableHttpResponse response500 = mock(CloseableHttpResponse.class);
   static HttpEntity entity200 = mock(HttpEntity.class);
   static HttpEntity entity429 = mock(HttpEntity.class);
-  static String expectedResponseText = "expected response text.";
+  static HttpEntity entity500 = mock(HttpEntity.class);
+  static StatusLine statusLine200 = mock(StatusLine.class);
   static StatusLine statusLine429 = mock(StatusLine.class);
+  static StatusLine statusLine500 = mock(StatusLine.class);
+  static String expectedResponseText = "expected response text.";
 
-  MlflowHttpCaller caller = new MlflowHttpCaller(new MlflowHostCredsProvider() {
+  MlflowHostCredsProvider hostCredsProvider = new MlflowHostCredsProvider() {
     @Override
     public MlflowHostCreds getHostCreds() {
       return new BasicMlflowHostCreds("http://some/host");
@@ -40,28 +44,34 @@ public class HttpCallerTest {
     public void refresh() {
       // pass
     }
-  }, 4, 1, client);
+  };
 
   @BeforeSuite
   public void beforeAll() throws IOException {
     when(statusLine200.getStatusCode()).thenReturn(200);
-    when(statusLine429.getStatusCode()).thenReturn(429);
     when(response200.getStatusLine()).thenReturn(statusLine200);
-    when(entity200.getContent())
-            .thenReturn(
-                    new ByteArrayInputStream(expectedResponseText.getBytes(StandardCharsets.UTF_8)))
-            .thenReturn(new ByteArrayInputStream(expectedResponseText.getBytes(StandardCharsets.UTF_8)));
-    when(entity429.getContent())
-            .thenReturn(
-                    new ByteArrayInputStream(expectedResponseText.getBytes(StandardCharsets.UTF_8)))
-            .thenReturn(new ByteArrayInputStream(expectedResponseText.getBytes(StandardCharsets.UTF_8)));
+    when(entity200.getContent()).thenAnswer(
+      i -> new ByteArrayInputStream(expectedResponseText.getBytes(StandardCharsets.UTF_8))
+    );
     when(response200.getEntity()).thenReturn(entity200);
+    when(statusLine429.getStatusCode()).thenReturn(429);
     when(response429.getStatusLine()).thenReturn(statusLine429);
+    when(entity429.getContent()).thenAnswer(
+      i -> new ByteArrayInputStream(expectedResponseText.getBytes(StandardCharsets.UTF_8))
+    );
     when(response429.getEntity()).thenReturn(entity429);
+    when(statusLine500.getStatusCode()).thenReturn(500);
+    when(response500.getStatusLine()).thenReturn(statusLine500);
+    when(entity500.getContent()).thenAnswer(
+      i -> new ByteArrayInputStream(expectedResponseText.getBytes(StandardCharsets.UTF_8))
+    );
+    when(response500.getEntity()).thenReturn(entity500);
   }
 
   @Test
-  public void testMultipleRetries() throws IOException {
+  public void testRequestsAreRetriedFor429s() throws IOException {
+    MlflowHttpCaller caller = new MlflowHttpCaller(hostCredsProvider, 4, 1, 1, client);
+
     when(client.execute(any(HttpUriRequest.class)))
             .thenReturn(response429) // sleep for 1 ms
             .thenReturn(response429) // sleep for 2 ms
@@ -78,7 +88,9 @@ public class HttpCallerTest {
   }
 
   @Test
-  public void testMaxRetryIntervalFor429s() throws IOException {
+  public void testMaxRetryIntervalIsRespectedFor429s() throws IOException {
+    MlflowHttpCaller caller = new MlflowHttpCaller(hostCredsProvider, 4, 1, 1, client);
+
     when(client.execute(any(HttpUriRequest.class)))
             .thenReturn(response429) // sleep for 1 ms
             .thenReturn(response429) // sleep for 2 ms
@@ -88,6 +100,7 @@ public class HttpCallerTest {
     MlflowHttpException ex = Assert.expectThrows(MlflowHttpException.class,
             () -> caller.get("some/path"));
     Assert.assertEquals(429, ex.getStatusCode());
+
     when(client.execute(any(HttpUriRequest.class)))
             .thenReturn(response429) // sleep for 1 ms
             .thenReturn(response429) // sleep for 2 ms
@@ -97,5 +110,53 @@ public class HttpCallerTest {
     ex = Assert.expectThrows(MlflowHttpException.class,
             () -> caller.post("some/path", "{\"attr\":\"val\"}"));
     Assert.assertEquals(429, ex.getStatusCode());
+  }
+
+  @Test
+  public void testRequestsAreRetriedFor500s() throws IOException {
+    MlflowHttpCaller caller = new MlflowHttpCaller(hostCredsProvider, 4, 1, 3, client);
+
+    when(client.execute(any(HttpUriRequest.class)))
+            .thenReturn(response500)
+            .thenReturn(response429)
+            .thenReturn(response429)
+            .thenReturn(response500)
+            .thenReturn(response429)
+            .thenReturn(response429)
+            .thenReturn(response200);
+    Assert.assertEquals(expectedResponseText, caller.get("some/path"));
+
+    when(client.execute(any(HttpUriRequest.class)))
+            .thenReturn(response500)
+            .thenReturn(response429)
+            .thenReturn(response429)
+            .thenReturn(response500)
+            .thenReturn(response429)
+            .thenReturn(response429)
+            .thenReturn(response200);
+    Assert.assertEquals(expectedResponseText, caller.post("some/path", "{\"attr\":\"val\"}"));
+  }
+
+  @Test
+  public void testMaxRetryAttemptsIsRespectedFor500s() throws IOException {
+    MlflowHttpCaller caller = new MlflowHttpCaller(hostCredsProvider, 4, 1, 3, client);
+
+    when(client.execute(any(HttpUriRequest.class)))
+            .thenReturn(response500)
+            .thenReturn(response500)
+            .thenReturn(response500) // last response before timing out
+            .thenReturn(response200);// should never be returned;
+    MlflowHttpException ex = Assert.expectThrows(MlflowHttpException.class,
+            () -> caller.get("some/path"));
+    Assert.assertEquals(500, ex.getStatusCode());
+
+    when(client.execute(any(HttpUriRequest.class)))
+            .thenReturn(response500)
+            .thenReturn(response500)
+            .thenReturn(response500) // last response before timing out
+            .thenReturn(response200);// should never be returned;
+    ex = Assert.expectThrows(MlflowHttpException.class,
+            () -> caller.post("some/path", "{\"attr\":\"val\"}"));
+    Assert.assertEquals(500, ex.getStatusCode());
   }
 }

--- a/mlflow/java/client/src/test/java/org/mlflow/tracking/HttpCallerTest.java
+++ b/mlflow/java/client/src/test/java/org/mlflow/tracking/HttpCallerTest.java
@@ -34,7 +34,7 @@ public class HttpCallerTest {
   static StatusLine statusLine500 = mock(StatusLine.class);
   static String expectedResponseText = "expected response text.";
 
-  MlflowHostCredsProvider hostCredsProvider = new MlflowHostCredsProvider() {
+  MlflowHttpCaller caller = new MlflowHttpCaller(new MlflowHostCredsProvider() {
     @Override
     public MlflowHostCreds getHostCreds() {
       return new BasicMlflowHostCreds("http://some/host");
@@ -44,7 +44,7 @@ public class HttpCallerTest {
     public void refresh() {
       // pass
     }
-  };
+  }, 4, 1, 3, client);
 
   @BeforeSuite
   public void beforeAll() throws IOException {
@@ -70,8 +70,6 @@ public class HttpCallerTest {
 
   @Test
   public void testRequestsAreRetriedFor429s() throws IOException {
-    MlflowHttpCaller caller = new MlflowHttpCaller(hostCredsProvider, 4, 1, 1, client);
-
     when(client.execute(any(HttpUriRequest.class)))
             .thenReturn(response429) // sleep for 1 ms
             .thenReturn(response429) // sleep for 2 ms
@@ -89,8 +87,6 @@ public class HttpCallerTest {
 
   @Test
   public void testMaxRetryIntervalIsRespectedFor429s() throws IOException {
-    MlflowHttpCaller caller = new MlflowHttpCaller(hostCredsProvider, 4, 1, 1, client);
-
     when(client.execute(any(HttpUriRequest.class)))
             .thenReturn(response429) // sleep for 1 ms
             .thenReturn(response429) // sleep for 2 ms
@@ -114,8 +110,6 @@ public class HttpCallerTest {
 
   @Test
   public void testRequestsAreRetriedFor500s() throws IOException {
-    MlflowHttpCaller caller = new MlflowHttpCaller(hostCredsProvider, 4, 1, 3, client);
-
     when(client.execute(any(HttpUriRequest.class)))
             .thenReturn(response500)
             .thenReturn(response429)
@@ -139,8 +133,6 @@ public class HttpCallerTest {
 
   @Test
   public void testMaxRetryAttemptsIsRespectedFor500s() throws IOException {
-    MlflowHttpCaller caller = new MlflowHttpCaller(hostCredsProvider, 4, 1, 3, client);
-
     when(client.execute(any(HttpUriRequest.class)))
             .thenReturn(response500)
             .thenReturn(response500)


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

The MLflow Python client retries 3 times on 500x errors, but the Java client does not. This PR adds 500x retries to the Java client for parity. For reference, see https://github.com/mlflow/mlflow/blob/5b3e18e8fa6b9797885417814b24f9451a2c62a7/mlflow/utils/rest_utils.py#L81-L96

## How is this patch tested?

Unit tests included

## Release Notes

Added more robust request retry policy for unexpected errors to the MLflow Java client.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [X] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
