### PR TITLE
FR-2770: add flavor support for Gensim models

### DIFF
--- a/mlflow/gensim.py
+++ b/mlflow/gensim.py
@@ -1,0 +1,219 @@
+"""
+The ``mlflow.gensim`` module provides an API for logging and loading Gensim models.
+This module exports Gensim models with the following flavors:
+
+Python (native) `pickle <https://scikit-learn.org/stable/modules/model_persistence.html>`_ format
+    This is the main flavor that can be loaded back into a gensim model.
+
+:py:mod:`mlflow.pyfunc`
+    Produced for use by generic pyfunc-based deployment tools and batch inference.
+"""
+
+from __future__ import absolute_import
+
+import os
+import pickle
+import yaml
+import logging
+
+import mlflow
+from mlflow import pyfunc
+from mlflow.models import Model, ModelInputExample
+from mlflow.models.signature import ModelSignature
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.utils.environment import _mlflow_conda_env
+from mlflow.utils.model_utils import _get_flavor_configuration
+from mlflow.exceptions import MlflowException
+
+FLAVOR_NAME = "gensim"
+
+_logger = logging.getLogger(__name__)
+
+
+def get_default_conda_env():
+    """
+    :return: The default Conda environment for MLflow Models produced by calls to
+             :func:`save_model()` and :func:`log_model()`.
+    """
+    import gensim
+
+    return _mlflow_conda_env(
+        additional_conda_deps=None,
+        additional_pip_deps=[
+            "gensim=={}".format(gensim.__version__),
+        ],
+        additional_conda_channels=None)
+
+
+def save_model(gen_model, path, conda_env=None, mlflow_model=Model()):
+    """
+    Save an Gensim model to a path on the local file system.
+
+    :param gen_model: Gensim model to be saved.
+    :param path: Local path where the model is to be saved.
+    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
+                      Conda environment yaml file. If provided, this describes the environment
+                      this model should be run in. At minimum, it should specify the dependencies
+                      contained in :func:`get_default_conda_env()`. If ``None``, the default
+                      :func:`get_default_conda_env()` environment is added to the model.
+                      The following is an *example* dictionary representation of a Conda
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0',
+                                'pip': [
+                                    'gensim==3.8.3'
+                                ]
+                            ]
+                        }
+
+    :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
+    """
+    import gensim
+
+    path = os.path.abspath(path)
+    if os.path.exists(path):
+        raise MlflowException("Path '{}' already exists".format(path))
+
+    model_data_subpath = "model.pkl"
+    model_data_path = os.path.join(path, model_data_subpath)
+    os.makedirs(path)
+
+    # Save an Gensim model
+    _save_model(gen_model=gen_model, output_path=model_data_path)
+
+    conda_env_subpath = "conda.yaml"
+    if conda_env is None:
+        conda_env = get_default_conda_env()
+    elif not isinstance(conda_env, dict):
+        with open(conda_env, "r") as f:
+            conda_env = yaml.safe_load(f)
+    with open(os.path.join(path, conda_env_subpath), "w") as f:
+        yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
+
+    pyfunc.add_to_model(mlflow_model, loader_module="mlflow.gensim",
+                        data=model_data_subpath, env=conda_env_subpath)
+
+    mlflow_model.add_flavor(FLAVOR_NAME, genism_version=gensim.__version__, data=model_data_subpath)
+    mlflow_model.save(os.path.join(path, "MLmodel"))
+
+
+def log_model(gen_model, artifact_path, conda_env=None, registered_model_name=None,
+              signature: ModelSignature=None, input_example: ModelInputExample=None):
+    """
+    Log an Gensim model as an MLflow artifact for the current run.
+
+    :param gen_model: gensim model to be saved.
+    :param artifact_path: Run-relative artifact path.
+    :param conda_env: Either a dictionary representation of a Conda environment or the path to a
+                      Conda environment yaml file. If provided, this describes the environment
+                      this model should be run in. At minimum, it should specify the dependencies
+                      contained in :func:`get_default_conda_env()`. If ``None``, the default
+                      :func:`get_default_conda_env()` environment is added to the model.
+                      The following is an *example* dictionary representation of a Conda
+                      environment::
+
+                        {
+                            'name': 'mlflow-env',
+                            'channels': ['defaults'],
+                            'dependencies': [
+                                'python=3.7.0',
+                                'pip': [
+                                    'gensim==3.8.3'
+                                ]
+                            ]
+                        }
+    :param registered_model_name: (Experimental) If given, create a model version under
+                                  ``registered_model_name``, also creating a registered model if one
+                                  with the given name does not exist.
+
+    :param signature: (Experimental) :py:class:`ModelSignature <mlflow.models.ModelSignature>`
+                      describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
+                      The model signature can be :py:func:`inferred <mlflow.models.infer_signature>`
+                      from datasets with valid model input (e.g. the training dataset) and valid
+                      model output (e.g. model predictions generated on the training dataset),
+                      for example:
+
+                      .. code-block:: python
+
+                        from mlflow.models.signature import infer_signature
+                        train = df.drop_column("target_label")
+                        signature = infer_signature(train, model.predict(train))
+    :param input_example: (Experimental) Input example provides one or several instances of valid
+                          model input. The example can be used as a hint of what data to feed the
+                          model. The given example will be converted to a Pandas DataFrame and then
+                          serialized to json using the Pandas split-oriented format. Bytes are
+                          base64-encoded.
+
+    """
+    Model.log(artifact_path=artifact_path, flavor=mlflow.gensim,
+              registered_model_name=registered_model_name,
+              gen_model=gen_model, conda_env=conda_env,
+              signature=signature, input_example=input_example)
+
+
+def _load_model_from_local_file(path):
+    """
+    Load a gensim model saved as an MLflow artifact on the local file system.
+
+    :param path: Local filesystem path to the MLflow Model with the ``gensim`` flavor.
+    """
+    # TODO: we could validate the gensim version here
+    with open(path, "rb") as f:
+        return pickle.load(f)
+
+
+def _load_pyfunc(path):
+    """
+    Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
+
+    :param path: Local filesystem path to the MLflow Model with the ``sklearn`` flavor.
+    """
+    return _load_model_from_local_file(path)
+
+
+def _save_model(gen_model, output_path):
+    """
+    :param gen_model: The gensim model to serialize.
+    :param output_path: The file path to which to write the serialized model.
+    """
+    with open(output_path, "wb") as out:
+        pickle.dump(gen_model, out)
+
+
+def load_model(model_uri):
+    """
+    Load a gensim model from a local file or a run.
+
+    :param model_uri: The location, in URI format, of the MLflow model, for example:
+
+                      - ``/Users/me/path/to/local/model``
+                      - ``relative/path/to/local/model``
+                      - ``s3://my_bucket/path/to/model``
+                      - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
+                      - ``models:/<model_name>/<model_version>``
+                      - ``models:/<model_name>/<stage>``
+
+                      For more information about supported URI schemes, see
+                      `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
+                      artifact-locations>`_.
+
+    :return: A gensim model.
+
+    .. code-block:: python
+        :caption: Example
+
+        import mlflow.gensim
+        doc2vec_model = mlflow.gensim.load_model("path/to/your/model/")
+
+        # define tokens to embbed vector
+        tokens = ...
+        embeddings = doc2vec_model.infer_vector(tokens)
+    """
+    local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
+    gensim_model_artifacts_path = os.path.join(local_model_path, flavor_conf['data'])
+    return _load_model_from_local_file(path=gensim_model_artifacts_path)

--- a/mlflow/gensim.py
+++ b/mlflow/gensim.py
@@ -100,8 +100,7 @@ def save_model(gen_model, path, conda_env=None, mlflow_model=Model()):
     mlflow_model.save(os.path.join(path, "MLmodel"))
 
 
-def log_model(gen_model, artifact_path, conda_env=None, registered_model_name=None,
-              input_example: ModelInputExample = None):
+def log_model(gen_model, artifact_path, conda_env=None, registered_model_name=None):
     """
     Log an Gensim model as an MLflow artifact for the current run.
 
@@ -135,19 +134,13 @@ def log_model(gen_model, artifact_path, conda_env=None, registered_model_name=No
                         from mlflow.models.signature import infer_signature
                         train = df.drop_column("target_label")
                         signature = infer_signature(train, model.predict(train))
-    :param input_example: (Experimental) Input example provides one or several instances of valid
-                          model input. The example can be used as a hint of what data to feed the
-                          model. The given example will be converted to a Pandas DataFrame and then
-                          serialized to json using the Pandas split-oriented format. Bytes are
-                          base64-encoded.
 
     """
     Model.log(artifact_path=artifact_path,
               flavor=mlflow.gensim,
               registered_model_name=registered_model_name,
               gen_model=gen_model,
-              conda_env=conda_env,
-              input_example=input_example)
+              conda_env=conda_env)
 
 
 def _load_model_from_local_file(path):

--- a/mlflow/gensim.py
+++ b/mlflow/gensim.py
@@ -18,7 +18,7 @@ import logging
 
 import mlflow
 from mlflow import pyfunc
-from mlflow.models import Model, ModelInputExample
+from mlflow.models import Model
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration

--- a/mlflow/gensim.py
+++ b/mlflow/gensim.py
@@ -19,7 +19,6 @@ import logging
 import mlflow
 from mlflow import pyfunc
 from mlflow.models import Model, ModelInputExample
-from mlflow.models.signature import ModelSignature
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
@@ -102,7 +101,7 @@ def save_model(gen_model, path, conda_env=None, mlflow_model=Model()):
 
 
 def log_model(gen_model, artifact_path, conda_env=None, registered_model_name=None,
-              signature: ModelSignature=None, input_example: ModelInputExample=None):
+              input_example: ModelInputExample = None):
     """
     Log an Gensim model as an MLflow artifact for the current run.
 
@@ -130,12 +129,6 @@ def log_model(gen_model, artifact_path, conda_env=None, registered_model_name=No
                                   ``registered_model_name``, also creating a registered model if one
                                   with the given name does not exist.
 
-    :param signature: (Experimental) :py:class:`ModelSignature <mlflow.models.ModelSignature>`
-                      describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
-                      The model signature can be :py:func:`inferred <mlflow.models.infer_signature>`
-                      from datasets with valid model input (e.g. the training dataset) and valid
-                      model output (e.g. model predictions generated on the training dataset),
-                      for example:
 
                       .. code-block:: python
 
@@ -149,10 +142,12 @@ def log_model(gen_model, artifact_path, conda_env=None, registered_model_name=No
                           base64-encoded.
 
     """
-    Model.log(artifact_path=artifact_path, flavor=mlflow.gensim,
+    Model.log(artifact_path=artifact_path,
+              flavor=mlflow.gensim,
               registered_model_name=registered_model_name,
-              gen_model=gen_model, conda_env=conda_env,
-              signature=signature, input_example=input_example)
+              gen_model=gen_model,
+              conda_env=conda_env,
+              input_example=input_example)
 
 
 def _load_model_from_local_file(path):

--- a/mlflow/gensim.py
+++ b/mlflow/gensim.py
@@ -1,10 +1,8 @@
 """
 The ``mlflow.gensim`` module provides an API for logging and loading Gensim models.
 This module exports Gensim models with the following flavors:
-
-Python (native) `pickle <https://scikit-learn.org/stable/modules/model_persistence.html>`_ format
-    This is the main flavor that can be loaded back into a gensim model.
-
+Gensim (native) format
+    This is the main flavor that can be loaded back into Gensim.
 :py:mod:`mlflow.pyfunc`
     Produced for use by generic pyfunc-based deployment tools and batch inference.
 """
@@ -12,24 +10,32 @@ Python (native) `pickle <https://scikit-learn.org/stable/modules/model_persisten
 from __future__ import absolute_import
 
 import os
-import pickle
 import yaml
-import logging
+import pickle
+from typing import (
+    Any,
+    Dict,
+    Hashable,
+    List,
+    Optional,
+    Union,
+)
 
 import mlflow
 from mlflow import pyfunc
-from mlflow.models import Model
+from mlflow.models import Model, ModelSignature
+from mlflow.models.utils import ModelInputExample, _save_example
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.model_utils import _get_flavor_configuration
 from mlflow.exceptions import MlflowException
+from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+
 
 FLAVOR_NAME = "gensim"
 
-_logger = logging.getLogger(__name__)
 
-
-def get_default_conda_env():
+def get_default_conda_env() -> Optional[Union[Dict[Hashable, Any], List]]:
     """
     :return: The default Conda environment for MLflow Models produced by calls to
              :func:`save_model()` and :func:`log_model()`.
@@ -38,17 +44,22 @@ def get_default_conda_env():
 
     return _mlflow_conda_env(
         additional_conda_deps=None,
-        additional_pip_deps=[
-            "gensim=={}".format(gensim.__version__),
-        ],
-        additional_conda_channels=None)
+        additional_pip_deps=["gensim=={}".format(gensim.__version__), ],
+        additional_conda_channels=None,
+    )
 
 
-def save_model(gen_model, path, conda_env=None, mlflow_model=Model()):
+def save_model(
+    gensim_model,
+    path: str,
+    conda_env: Optional[Union[Dict, str]] = None,
+    mlflow_model: Model = Model(),
+    signature: Optional[ModelSignature] = None,
+    input_example: Optional[ModelInputExample] = None,
+) -> None:
     """
-    Save an Gensim model to a path on the local file system.
-
-    :param gen_model: Gensim model to be saved.
+    Save a Gensim model to a path on the local file system.
+    :param gensim_model: Gensim model to be saved.
     :param path: Local path where the model is to be saved.
     :param conda_env: Either a dictionary representation of a Conda environment or the path to a
                       Conda environment yaml file. If provided, this describes the environment
@@ -57,32 +68,50 @@ def save_model(gen_model, path, conda_env=None, mlflow_model=Model()):
                       :func:`get_default_conda_env()` environment is added to the model.
                       The following is an *example* dictionary representation of a Conda
                       environment::
-
                         {
                             'name': 'mlflow-env',
                             'channels': ['defaults'],
                             'dependencies': [
                                 'python=3.7.0',
                                 'pip': [
-                                    'gensim==3.8.3'
+                                    'gensim==4.0.1'
                                 ]
                             ]
                         }
-
     :param mlflow_model: :py:mod:`mlflow.models.Model` this flavor is being added to.
+    :param signature: (Experimental) :py:class:`ModelSignature <mlflow.models.ModelSignature>`
+                      describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
+                      The model signature can be :py:func:`inferred <mlflow.models.infer_signature>`
+                      from datasets with valid model input (e.g. the training dataset with target
+                      column omitted) and valid model output (e.g. model predictions generated on
+                      the training dataset), for example:
+                      .. code-block:: python
+                        from mlflow.models.signature import infer_signature
+                        train = df.drop_column("target_label")
+                        predictions = ... # compute model predictions
+                        signature = infer_signature(train, predictions)
+    :param input_example: (Experimental) Input example provides one or several instances of valid
+                          model input. The example can be used as a hint of what data to feed the
+                          model. The given example will be converted to a Pandas DataFrame and then
+                          serialized to json using the Pandas split-oriented format. Bytes are
+                          base64-encoded.
     """
     import gensim
 
     path = os.path.abspath(path)
     if os.path.exists(path):
         raise MlflowException("Path '{}' already exists".format(path))
-
-    model_data_subpath = "model.pkl"
+    model_data_subpath = "model.gensim"
     model_data_path = os.path.join(path, model_data_subpath)
     os.makedirs(path)
 
-    # Save an Gensim model
-    _save_model(gen_model=gen_model, output_path=model_data_path)
+    if signature is not None:
+        mlflow_model.signature = signature
+    if input_example is not None:
+        _save_example(mlflow_model, input_example, path)
+
+    # Save the Gensim model
+    gensim_model.save(model_data_path)
 
     conda_env_subpath = "conda.yaml"
     if conda_env is None:
@@ -93,18 +122,33 @@ def save_model(gen_model, path, conda_env=None, mlflow_model=Model()):
     with open(os.path.join(path, conda_env_subpath), "w") as f:
         yaml.safe_dump(conda_env, stream=f, default_flow_style=False)
 
-    pyfunc.add_to_model(mlflow_model, loader_module="mlflow.gensim",
-                        data=model_data_subpath, env=conda_env_subpath)
+    pyfunc.add_to_model(
+        model=mlflow_model,
+        loader_module="mlflow.gensim",
+        data=model_data_subpath,
+        env=conda_env_subpath,
+    )
 
-    mlflow_model.add_flavor(FLAVOR_NAME, genism_version=gensim.__version__, data=model_data_subpath)
+    mlflow_model.add_flavor(
+        FLAVOR_NAME, gensim_version=gensim.__version__, data=model_data_subpath,
+    )
+
     mlflow_model.save(os.path.join(path, "MLmodel"))
 
 
-def log_model(gen_model, artifact_path, conda_env=None, registered_model_name=None):
+def log_model(
+    gensim_model,
+    artifact_path: str,
+    conda_env: Optional[Union[Dict, str]] = None,
+    registered_model_name: Optional[str] = None,
+    signature: Optional[ModelSignature] = None,
+    input_example: Optional[ModelInputExample] = None,
+    await_registration_for: int = DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
+    **kwargs
+) -> None:
     """
-    Log an Gensim model as an MLflow artifact for the current run.
-
-    :param gen_model: gensim model to be saved.
+    Log a Gensim model as an MLflow artifact for the current run.
+    :param gensim_model: Gensim model to be saved.
     :param artifact_path: Run-relative artifact path.
     :param conda_env: Either a dictionary representation of a Conda environment or the path to a
                       Conda environment yaml file. If provided, this describes the environment
@@ -113,7 +157,6 @@ def log_model(gen_model, artifact_path, conda_env=None, registered_model_name=No
                       :func:`get_default_conda_env()` environment is added to the model.
                       The following is an *example* dictionary representation of a Conda
                       environment::
-
                         {
                             'name': 'mlflow-env',
                             'channels': ['defaults'],
@@ -127,81 +170,92 @@ def log_model(gen_model, artifact_path, conda_env=None, registered_model_name=No
     :param registered_model_name: (Experimental) If given, create a model version under
                                   ``registered_model_name``, also creating a registered model if one
                                   with the given name does not exist.
-
-
                       .. code-block:: python
-
                         from mlflow.models.signature import infer_signature
                         train = df.drop_column("target_label")
                         signature = infer_signature(train, model.predict(train))
-
+    :param signature: (Experimental) :py:class:`ModelSignature <mlflow.models.ModelSignature>`
+                      describes model input and output :py:class:`Schema <mlflow.types.Schema>`.
+                      The model signature can be :py:func:`inferred <mlflow.models.infer_signature>`
+                      from datasets with valid model input (e.g. the training dataset with target
+                      column omitted) and valid model output (e.g. model predictions generated on
+                      the training dataset), for example:
+                      .. code-block:: python
+                        from mlflow.models.signature import infer_signature
+                        train = df.drop_column("target_label")
+                        predictions = ... # compute model predictions
+                        signature = infer_signature(train, predictions)
+    :param input_example: (Experimental) Input example provides one or several instances of valid
+                          model input. The example can be used as a hint of what data to feed the
+                          model. The given example will be converted to a Pandas DataFrame and then
+                          serialized to json using the Pandas split-oriented format. Bytes are
+                          base64-encoded.
+    :param await_registration_for: Number of seconds to wait for the model version to finish
+                            being created and is in ``READY`` status. By default, the function
+                            waits for five minutes. Specify 0 or None to skip waiting.
     """
-    Model.log(artifact_path=artifact_path,
-              flavor=mlflow.gensim,
-              registered_model_name=registered_model_name,
-              gen_model=gen_model,
-              conda_env=conda_env)
+    Model.log(
+        artifact_path=artifact_path,
+        flavor=mlflow.gensim,
+        registered_model_name=registered_model_name,
+        gensim_model=gensim_model,
+        conda_env=conda_env,
+        signature=signature,
+        input_example=input_example,
+        await_registration_for=await_registration_for,
+        **kwargs
+    )
 
 
-def _load_model_from_local_file(path):
+def _load_model_from_local_file(path: str) -> Any:
     """
-    Load a gensim model saved as an MLflow artifact on the local file system.
-
+    Load a Gensim model saved as an MLflow artifact on the local file system.
     :param path: Local filesystem path to the MLflow Model with the ``gensim`` flavor.
     """
-    # TODO: we could validate the gensim version here
     with open(path, "rb") as f:
         return pickle.load(f)
 
 
-def _load_pyfunc(path):
+def _load_pyfunc(path: str) -> Any:
     """
     Load PyFunc implementation. Called by ``pyfunc.load_pyfunc``.
-
     :param path: Local filesystem path to the MLflow Model with the ``sklearn`` flavor.
     """
     return _load_model_from_local_file(path)
 
 
-def _save_model(gen_model, output_path):
+def _save_model(gensim_model, output_path: str) -> None:
     """
-    :param gen_model: The gensim model to serialize.
+    :param gensim_model: The Gensim model to serialize.
     :param output_path: The file path to which to write the serialized model.
     """
     with open(output_path, "wb") as out:
-        pickle.dump(gen_model, out)
+        pickle.dump(gensim_model, out)
 
 
-def load_model(model_uri):
+def load_model(model_uri) -> Any:
     """
-    Load a gensim model from a local file or a run.
-
+    Load a Gensim model from a local file or a run.
     :param model_uri: The location, in URI format, of the MLflow model, for example:
-
                       - ``/Users/me/path/to/local/model``
                       - ``relative/path/to/local/model``
                       - ``s3://my_bucket/path/to/model``
                       - ``runs:/<mlflow_run_id>/run-relative/path/to/model``
                       - ``models:/<model_name>/<model_version>``
                       - ``models:/<model_name>/<stage>``
-
                       For more information about supported URI schemes, see
                       `Referencing Artifacts <https://www.mlflow.org/docs/latest/concepts.html#
                       artifact-locations>`_.
-
-    :return: A gensim model.
-
+    :return: A Gensim model.
     .. code-block:: python
         :caption: Example
-
         import mlflow.gensim
         doc2vec_model = mlflow.gensim.load_model("path/to/your/model/")
-
-        # define tokens to embbed vector
+        # define tokens to embed vector
         tokens = ...
         embeddings = doc2vec_model.infer_vector(tokens)
     """
     local_model_path = _download_artifact_from_uri(artifact_uri=model_uri)
     flavor_conf = _get_flavor_configuration(model_path=local_model_path, flavor_name=FLAVOR_NAME)
-    gensim_model_artifacts_path = os.path.join(local_model_path, flavor_conf['data'])
+    gensim_model_artifacts_path = os.path.join(local_model_path, flavor_conf["data"])
     return _load_model_from_local_file(path=gensim_model_artifacts_path)

--- a/tests/gensim/test_gensim_model_export.py
+++ b/tests/gensim/test_gensim_model_export.py
@@ -22,8 +22,6 @@ from gensim.models.word2vec import Word2Vec
 from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
 from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
 from tests.helper_functions import score_model_in_sagemaker_docker_container
-from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
-
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 

--- a/tests/gensim/test_gensim_model_export.py
+++ b/tests/gensim/test_gensim_model_export.py
@@ -19,6 +19,11 @@ from mlflow.utils.model_utils import _get_flavor_configuration
 import gensim.downloader as api
 from gensim.models.word2vec import Word2Vec
 
+from tests.helper_functions import set_boto_credentials  # pylint: disable=unused-import
+from tests.helper_functions import mock_s3_bucket  # pylint: disable=unused-import
+from tests.helper_functions import score_model_in_sagemaker_docker_container
+from tests.projects.utils import tracking_uri_mock  # pylint: disable=unused-import
+
 
 ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 

--- a/tests/gensim/test_gensim_model_export.py
+++ b/tests/gensim/test_gensim_model_export.py
@@ -1,0 +1,232 @@
+from __future__ import print_function
+
+import mock
+import os
+import pytest
+import yaml
+from collections import namedtuple
+
+import mlflow.gensim
+import mlflow.utils
+from mlflow import pyfunc
+from mlflow.models import Model
+from mlflow.store.artifact.s3_artifact_repo import S3ArtifactRepository
+from mlflow.tracking.artifact_utils import _download_artifact_from_uri
+from mlflow.utils.environment import _mlflow_conda_env
+from mlflow.utils.file_utils import TempDir
+from mlflow.utils.model_utils import _get_flavor_configuration
+
+import gensim.downloader as api
+from gensim.models.word2vec import Word2Vec
+
+
+ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
+
+
+@pytest.fixture(scope="session")
+def gensim_word2vec_model():
+    corpus = api.load('text8')
+    model = Word2Vec(corpus)
+
+    return ModelWithData(model=model, inference_data=corpus)
+
+
+@pytest.fixture
+def model_path(tmpdir):
+    return os.path.join(str(tmpdir), "model")
+
+
+@pytest.fixture
+def gensim_custom_env(tmpdir):
+    conda_env = os.path.join(str(tmpdir), "conda_env.yml")
+    _mlflow_conda_env(
+            conda_env,
+            additional_conda_deps=["gensim", "pytest"])
+    return conda_env
+
+
+@pytest.mark.large
+def test_model_save_load(gensim_word2vec_model, model_path):
+    word2vecmodel = gensim_word2vec_model.model
+
+    mlflow.gensim.save_model(gen_model=word2vecmodel, path=model_path)
+    reloaded_word2vec_model = mlflow.gensim.load_model(model_uri=model_path)
+
+    assert all([a == b for a, b in zip(word2vecmodel.wv.most_similar('tree'),
+                                       reloaded_word2vec_model.wv.most_similar('tree'))])
+
+
+@pytest.mark.large
+def test_model_load_from_remote_uri_succeeds(gensim_word2vec_model, model_path, mock_s3_bucket):
+
+    mlflow.gensim.save_model(gen_model=gensim_word2vec_model.model, path=model_path)
+
+    artifact_root = "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
+    artifact_path = "model"
+    artifact_repo = S3ArtifactRepository(artifact_root)
+    artifact_repo.log_artifacts(model_path, artifact_path=artifact_path)
+
+    model_uri = artifact_root + "/" + artifact_path
+    reloaded_word2vec_model = mlflow.gensim.load_model(model_uri=model_uri)
+
+    assert all([a == b for a, b in zip(gensim_word2vec_model.model.wv.most_similar('tree'),
+                                       reloaded_word2vec_model.wv.most_similar('tree'))])
+
+
+@pytest.mark.large
+def test_model_log(gensim_word2vec_model):
+
+    old_uri = mlflow.get_tracking_uri()
+    with TempDir(chdr=True, remove_on_exit=True) as tmp:
+        for should_start_run in [False, True]:
+            try:
+                mlflow.set_tracking_uri("test")
+                if should_start_run:
+                    mlflow.start_run()
+
+                artifact_path = "embedding"
+                conda_env = os.path.join(tmp.path(), "conda_env.yaml")
+                _mlflow_conda_env(conda_env, additional_pip_deps=["gensim"])
+
+                mlflow.gensim.log_model(
+                        gen_model=gensim_word2vec_model.model,
+                        artifact_path=artifact_path,
+                        conda_env=conda_env)
+                model_uri = "runs:/{run_id}/{artifact_path}".format(
+                    run_id=mlflow.active_run().info.run_id,
+                    artifact_path=artifact_path)
+
+                reloaded_word2vec_model = mlflow.gensim.load_model(model_uri=model_uri)
+                assert all([a == b for a, b in zip(gensim_word2vec_model.model.wv.most_similar('tree'),
+                                                   reloaded_word2vec_model.wv.most_similar('tree'))])
+
+                model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+                model_config = Model.load(os.path.join(model_path, "MLmodel"))
+                assert pyfunc.FLAVOR_NAME in model_config.flavors
+                assert pyfunc.ENV in model_config.flavors[pyfunc.FLAVOR_NAME]
+                env_path = model_config.flavors[pyfunc.FLAVOR_NAME][pyfunc.ENV]
+                assert os.path.exists(os.path.join(model_path, env_path))
+
+            finally:
+                mlflow.end_run()
+                mlflow.set_tracking_uri(old_uri)
+
+
+def test_log_model_calls_register_model(gensim_word2vec_model):
+    artifact_path = "embedding"
+    register_model_patch = mock.patch("mlflow.register_model")
+    with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:
+        conda_env = os.path.join(tmp.path(), "conda_env.yaml")
+        _mlflow_conda_env(conda_env, additional_pip_deps=["gensim"])
+        mlflow.gensim.log_model(gen_model=gensim_word2vec_model.model, artifact_path=artifact_path,
+                                conda_env=conda_env, registered_model_name="AdsModel1")
+
+        model_uri = "runs:/{run_id}/{artifact_path}".format(run_id=mlflow.active_run().info.run_id,
+                                                            artifact_path=artifact_path)
+        mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
+
+
+def test_log_model_no_registered_model_name(gensim_word2vec_model):
+    artifact_path = "model"
+    register_model_patch = mock.patch("mlflow.register_model")
+    with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:
+        conda_env = os.path.join(tmp.path(), "conda_env.yaml")
+        _mlflow_conda_env(conda_env, additional_pip_deps=["gensim"])
+        mlflow.gensim.log_model(gen_model=gensim_word2vec_model.model, artifact_path=artifact_path,
+                                conda_env=conda_env)
+        mlflow.register_model.assert_not_called()
+
+
+@pytest.mark.large
+def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
+        gensim_word2vec_model, model_path, gensim_custom_env):
+
+    mlflow.gensim.save_model(
+            gen_model=gensim_word2vec_model.model, path=model_path, conda_env=gensim_custom_env)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+    assert saved_conda_env_path != gensim_custom_env
+
+    with open(gensim_custom_env, "r") as f:
+        gensim_custom_env_parsed = yaml.safe_load(f)
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == gensim_custom_env_parsed
+
+
+@pytest.mark.large
+def test_model_save_accepts_conda_env_as_dict(gensim_word2vec_model, model_path):
+    conda_env = dict(mlflow.gensim.get_default_conda_env())
+    conda_env["dependencies"].append("pytest")
+    mlflow.gensim.save_model(
+            gen_model=gensim_word2vec_model.model, path=model_path, conda_env=conda_env)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == conda_env
+
+
+@pytest.mark.large
+def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
+        gensim_word2vec_model, gensim_custom_env):
+    artifact_path = "model"
+    with mlflow.start_run():
+        mlflow.gensim.log_model(gen_model=gensim_word2vec_model.model,
+                                artifact_path=artifact_path,
+                                conda_env=gensim_custom_env)
+        model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id,
+            artifact_path=artifact_path)
+
+    model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    assert os.path.exists(saved_conda_env_path)
+    assert saved_conda_env_path != gensim_custom_env
+
+    with open(gensim_custom_env, "r") as f:
+        gensim_custom_env_parsed = yaml.safe_load(f)
+    with open(saved_conda_env_path, "r") as f:
+        saved_conda_env_parsed = yaml.safe_load(f)
+    assert saved_conda_env_parsed == gensim_custom_env_parsed
+
+
+@pytest.mark.large
+def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
+        gensim_word2vec_model, model_path):
+    word2vec_model = gensim_word2vec_model.model
+    mlflow.gensim.save_model(gen_model=word2vec_model, path=model_path, conda_env=None)
+
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    with open(conda_env_path, "r") as f:
+        conda_env = yaml.safe_load(f)
+
+    assert conda_env == mlflow.gensim.get_default_conda_env()
+
+
+@pytest.mark.large
+def test_model_log_without_specified_conda_env_uses_default_env_with_expected_dependencies(
+        gensim_word2vec_model):
+    artifact_path = "model"
+    word2vec_model = gensim_word2vec_model.model
+    with mlflow.start_run():
+        mlflow.gensim.log_model(gen_model=word2vec_model, artifact_path=artifact_path, conda_env=None)
+        model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id,
+            artifact_path=artifact_path)
+
+    model_path = _download_artifact_from_uri(artifact_uri=model_uri)
+    pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
+    conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
+    with open(conda_env_path, "r") as f:
+        conda_env = yaml.safe_load(f)
+
+    assert conda_env == mlflow.gensim.get_default_conda_env()
+

--- a/tests/gensim/test_gensim_model_export.py
+++ b/tests/gensim/test_gensim_model_export.py
@@ -97,8 +97,10 @@ def test_model_log(gensim_word2vec_model):
                     artifact_path=artifact_path)
 
                 reloaded_word2vec_model = mlflow.gensim.load_model(model_uri=model_uri)
-                assert all([a == b for a, b in zip(gensim_word2vec_model.model.wv.most_similar('tree'),
-                                                   reloaded_word2vec_model.wv.most_similar('tree'))])
+                assert all(
+                    [a == b for a, b in zip(gensim_word2vec_model.model.wv.most_similar('tree'),
+                                            reloaded_word2vec_model.wv.most_similar('tree'))]
+                )
 
                 model_path = _download_artifact_from_uri(artifact_uri=model_uri)
                 model_config = Model.load(os.path.join(model_path, "MLmodel"))
@@ -217,7 +219,10 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
     artifact_path = "model"
     word2vec_model = gensim_word2vec_model.model
     with mlflow.start_run():
-        mlflow.gensim.log_model(gen_model=word2vec_model, artifact_path=artifact_path, conda_env=None)
+        mlflow.gensim.log_model(gen_model=word2vec_model,
+                                artifact_path=artifact_path,
+                                conda_env=None)
+
         model_uri = "runs:/{run_id}/{artifact_path}".format(
             run_id=mlflow.active_run().info.run_id,
             artifact_path=artifact_path)
@@ -229,4 +234,3 @@ def test_model_log_without_specified_conda_env_uses_default_env_with_expected_de
         conda_env = yaml.safe_load(f)
 
     assert conda_env == mlflow.gensim.get_default_conda_env()
-

--- a/tests/gensim/test_gensim_model_export.py
+++ b/tests/gensim/test_gensim_model_export.py
@@ -16,6 +16,8 @@ from mlflow.utils.environment import _mlflow_conda_env
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.model_utils import _get_flavor_configuration
 
+from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+
 import gensim.downloader as api
 from gensim.models.word2vec import Word2Vec
 
@@ -28,7 +30,7 @@ ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
 
 @pytest.fixture(scope="session")
 def gensim_word2vec_model():
-    corpus = api.load('text8')
+    corpus = api.load("text8")
     model = Word2Vec(corpus)
 
     return ModelWithData(model=model, inference_data=corpus)
@@ -42,9 +44,7 @@ def model_path(tmpdir):
 @pytest.fixture
 def gensim_custom_env(tmpdir):
     conda_env = os.path.join(str(tmpdir), "conda_env.yml")
-    _mlflow_conda_env(
-            conda_env,
-            additional_conda_deps=["gensim", "pytest"])
+    _mlflow_conda_env(conda_env, additional_conda_deps=["gensim", "pytest"])
     return conda_env
 
 
@@ -52,17 +52,23 @@ def gensim_custom_env(tmpdir):
 def test_model_save_load(gensim_word2vec_model, model_path):
     word2vecmodel = gensim_word2vec_model.model
 
-    mlflow.gensim.save_model(gen_model=word2vecmodel, path=model_path)
+    mlflow.gensim.save_model(gensim_model=word2vecmodel, path=model_path)
     reloaded_word2vec_model = mlflow.gensim.load_model(model_uri=model_path)
 
-    assert all([a == b for a, b in zip(word2vecmodel.wv.most_similar('tree'),
-                                       reloaded_word2vec_model.wv.most_similar('tree'))])
+    assert all(
+        [
+            a == b
+            for a, b in zip(
+                word2vecmodel.wv.most_similar("tree"),
+                reloaded_word2vec_model.wv.most_similar("tree"),
+            )
+        ]
+    )
 
 
 @pytest.mark.large
 def test_model_load_from_remote_uri_succeeds(gensim_word2vec_model, model_path, mock_s3_bucket):
-
-    mlflow.gensim.save_model(gen_model=gensim_word2vec_model.model, path=model_path)
+    mlflow.gensim.save_model(gensim_model=gensim_word2vec_model.model, path=model_path)
 
     artifact_root = "s3://{bucket_name}".format(bucket_name=mock_s3_bucket)
     artifact_path = "model"
@@ -72,8 +78,15 @@ def test_model_load_from_remote_uri_succeeds(gensim_word2vec_model, model_path, 
     model_uri = artifact_root + "/" + artifact_path
     reloaded_word2vec_model = mlflow.gensim.load_model(model_uri=model_uri)
 
-    assert all([a == b for a, b in zip(gensim_word2vec_model.model.wv.most_similar('tree'),
-                                       reloaded_word2vec_model.wv.most_similar('tree'))])
+    assert all(
+        [
+            a == b
+            for a, b in zip(
+                gensim_word2vec_model.model.wv.most_similar("tree"),
+                reloaded_word2vec_model.wv.most_similar("tree"),
+            )
+        ]
+    )
 
 
 @pytest.mark.large
@@ -92,17 +105,23 @@ def test_model_log(gensim_word2vec_model):
                 _mlflow_conda_env(conda_env, additional_pip_deps=["gensim"])
 
                 mlflow.gensim.log_model(
-                        gen_model=gensim_word2vec_model.model,
-                        artifact_path=artifact_path,
-                        conda_env=conda_env)
+                    gensim_model=gensim_word2vec_model.model,
+                    artifact_path=artifact_path,
+                    conda_env=conda_env,
+                )
                 model_uri = "runs:/{run_id}/{artifact_path}".format(
-                    run_id=mlflow.active_run().info.run_id,
-                    artifact_path=artifact_path)
+                    run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
+                )
 
                 reloaded_word2vec_model = mlflow.gensim.load_model(model_uri=model_uri)
                 assert all(
-                    [a == b for a, b in zip(gensim_word2vec_model.model.wv.most_similar('tree'),
-                                            reloaded_word2vec_model.wv.most_similar('tree'))]
+                    [
+                        a == b
+                        for a, b in zip(
+                            gensim_word2vec_model.model.wv.most_similar("tree"),
+                            reloaded_word2vec_model.wv.most_similar("tree"),
+                        )
+                    ]
                 )
 
                 model_path = _download_artifact_from_uri(artifact_uri=model_uri)
@@ -123,12 +142,19 @@ def test_log_model_calls_register_model(gensim_word2vec_model):
     with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:
         conda_env = os.path.join(tmp.path(), "conda_env.yaml")
         _mlflow_conda_env(conda_env, additional_pip_deps=["gensim"])
-        mlflow.gensim.log_model(gen_model=gensim_word2vec_model.model, artifact_path=artifact_path,
-                                conda_env=conda_env, registered_model_name="AdsModel1")
+        mlflow.gensim.log_model(
+            gensim_model=gensim_word2vec_model.model,
+            artifact_path=artifact_path,
+            conda_env=conda_env,
+            registered_model_name="AdsModel1",
+        )
 
-        model_uri = "runs:/{run_id}/{artifact_path}".format(run_id=mlflow.active_run().info.run_id,
-                                                            artifact_path=artifact_path)
-        mlflow.register_model.assert_called_once_with(model_uri, "AdsModel1")
+        model_uri = "runs:/{run_id}/{artifact_path}".format(
+            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
+        )
+        mlflow.register_model.assert_called_once_with(
+            model_uri, "AdsModel1", await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+        )
 
 
 def test_log_model_no_registered_model_name(gensim_word2vec_model):
@@ -137,17 +163,22 @@ def test_log_model_no_registered_model_name(gensim_word2vec_model):
     with mlflow.start_run(), register_model_patch, TempDir(chdr=True, remove_on_exit=True) as tmp:
         conda_env = os.path.join(tmp.path(), "conda_env.yaml")
         _mlflow_conda_env(conda_env, additional_pip_deps=["gensim"])
-        mlflow.gensim.log_model(gen_model=gensim_word2vec_model.model, artifact_path=artifact_path,
-                                conda_env=conda_env)
+        mlflow.gensim.log_model(
+            gensim_model=gensim_word2vec_model.model,
+            artifact_path=artifact_path,
+            conda_env=conda_env,
+        )
         mlflow.register_model.assert_not_called()
 
 
 @pytest.mark.large
 def test_model_save_persists_specified_conda_env_in_mlflow_model_directory(
-        gensim_word2vec_model, model_path, gensim_custom_env):
+    gensim_word2vec_model, model_path, gensim_custom_env
+):
 
     mlflow.gensim.save_model(
-            gen_model=gensim_word2vec_model.model, path=model_path, conda_env=gensim_custom_env)
+        gensim_model=gensim_word2vec_model.model, path=model_path, conda_env=gensim_custom_env
+    )
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -166,7 +197,8 @@ def test_model_save_accepts_conda_env_as_dict(gensim_word2vec_model, model_path)
     conda_env = dict(mlflow.gensim.get_default_conda_env())
     conda_env["dependencies"].append("pytest")
     mlflow.gensim.save_model(
-            gen_model=gensim_word2vec_model.model, path=model_path, conda_env=conda_env)
+        gensim_model=gensim_word2vec_model.model, path=model_path, conda_env=conda_env
+    )
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     saved_conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -179,15 +211,18 @@ def test_model_save_accepts_conda_env_as_dict(gensim_word2vec_model, model_path)
 
 @pytest.mark.large
 def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
-        gensim_word2vec_model, gensim_custom_env):
+    gensim_word2vec_model, gensim_custom_env
+):
     artifact_path = "model"
     with mlflow.start_run():
-        mlflow.gensim.log_model(gen_model=gensim_word2vec_model.model,
-                                artifact_path=artifact_path,
-                                conda_env=gensim_custom_env)
+        mlflow.gensim.log_model(
+            gensim_model=gensim_word2vec_model.model,
+            artifact_path=artifact_path,
+            conda_env=gensim_custom_env,
+        )
         model_uri = "runs:/{run_id}/{artifact_path}".format(
-            run_id=mlflow.active_run().info.run_id,
-            artifact_path=artifact_path)
+            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
+        )
 
     model_path = _download_artifact_from_uri(artifact_uri=model_uri)
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
@@ -204,9 +239,10 @@ def test_model_log_persists_specified_conda_env_in_mlflow_model_directory(
 
 @pytest.mark.large
 def test_model_save_without_specified_conda_env_uses_default_env_with_expected_dependencies(
-        gensim_word2vec_model, model_path):
+    gensim_word2vec_model, model_path
+):
     word2vec_model = gensim_word2vec_model.model
-    mlflow.gensim.save_model(gen_model=word2vec_model, path=model_path, conda_env=None)
+    mlflow.gensim.save_model(gensim_model=word2vec_model, path=model_path, conda_env=None)
 
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)
     conda_env_path = os.path.join(model_path, pyfunc_conf[pyfunc.ENV])
@@ -218,17 +254,18 @@ def test_model_save_without_specified_conda_env_uses_default_env_with_expected_d
 
 @pytest.mark.large
 def test_model_log_without_specified_conda_env_uses_default_env_with_expected_dependencies(
-        gensim_word2vec_model):
+    gensim_word2vec_model,
+):
     artifact_path = "model"
     word2vec_model = gensim_word2vec_model.model
     with mlflow.start_run():
-        mlflow.gensim.log_model(gen_model=word2vec_model,
-                                artifact_path=artifact_path,
-                                conda_env=None)
+        mlflow.gensim.log_model(
+            gensim_model=word2vec_model, artifact_path=artifact_path, conda_env=None
+        )
 
         model_uri = "runs:/{run_id}/{artifact_path}".format(
-            run_id=mlflow.active_run().info.run_id,
-            artifact_path=artifact_path)
+            run_id=mlflow.active_run().info.run_id, artifact_path=artifact_path
+        )
 
     model_path = _download_artifact_from_uri(artifact_uri=model_uri)
     pyfunc_conf = _get_flavor_configuration(model_path=model_path, flavor_name=pyfunc.FLAVOR_NAME)


### PR DESCRIPTION
## What changes are proposed in this pull request?

* In feature request #2770, @persas proposed adding flavor support for Gensim.
* In pull request #2878, @persas attempted to merge their changes, albeit encountered issues.

This pull request attempts to finalize the changes made by @persas. I have done the following:
* cherry-picked the relevant commits from @persas' fork's [branch](https://github.com/persas/mlflow/tree/gensim_flavor)
* updated linting/formatting, added a few new function parameters
* tested locally

I will preempt a code review question posted in #2878:

> Does this pickled object have a predict method that takes a DataFrame as input?

To be honest, I don't know how to implement this. Syntactically, sure, but I don't think `predict` maps cleanly to Gensim's models.

For example, a Gensim Word2Vec model has the following methods (just off the top of my head... I'm sure there are others):

```
# a tiny model trained on a handful of European Union regulations

In[1]:
model.wv.most_similar('bank')

Out[1]: 
[('central', 0.7694460153579712),
 ('gaza', 0.580155611038208),
 ('banking', 0.570080041885376),
 ('saderat', 0.5607864856719971),
 ('intelligence', 0.5576319098472595),
 ('government', 0.5570472478866577),
 ('pyongyang', 0.5333139300346375),
 ('subsidiary', 0.5194635391235352),
 ('credit', 0.5088622570037842),
 ('549300re88ojp9j24z18', 0.497680127620697)]

In[2]:
model.wv.n_similarity(['grain'], ['wheat'])

Out[2]: 
0.47097108

In[3]:
model.wv.relative_cosine_similarity('grain', 'barley')

Out[3]: 
0.11125039338027068

In[4]:
model.wv.similar_by_word('meat')

Out[4]: 
[('offal', 0.6513410806655884),
 ('frozen', 0.6433013677597046),
 ('carcase', 0.6225498914718628),
 ('boned', 0.6214909553527832),
 ('boneless', 0.6209194660186768),
 ('cut', 0.6071479916572571),
 ('sheep', 0.5907434821128845),
 ('poultry', 0.5677666068077087),
 ('bone', 0.5666332840919495),
 ('chilled', 0.5539602041244507)]

```
It is not clear to me what `predict`'s input `dataframe` would contain, and I don't know what the output ought to be.

## How is this patch tested?

1. Unit tests
2. `./dev/run-small-python-tests.sh`, albeit some fail (Hadoop and such?)
3. Manual testing using an existing MLflow instance and PyCharm's console:
```
import gensim
import mlflow

mlflow.set_tracking_uri('https://my.datascience.server/mlflow/')
mlflow.set_experiment('gensim_flavor')
model = gensim.models.word2vec.Word2Vec([['hello', 'world']*5])
with mlflow.start_run(run_name='test_1') as run:
    mlflow.gensim.log_model(model, 'model.gensim', registered_model_name='registered_model_name')
```
I do not expect these changes to pass first tests. Hopefully I will be able to address accordingly.

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

This pull request adds flavor support for Gensim models.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
