### PR TITLE
Make datetime.date objects JSON serializable

### DIFF
--- a/mlflow/utils/proto_json_utils.py
+++ b/mlflow/utils/proto_json_utils.py
@@ -1,4 +1,5 @@
 import base64
+import datetime
 
 from json import JSONEncoder
 
@@ -75,7 +76,7 @@ class NumpyEncoder(JSONEncoder):
             return encode_binary(o), True
         if isinstance(o, np.datetime64):
             return np.datetime_as_string(o), True
-        if isinstance(o, pd.Timestamp):
+        if isinstance(o, (pd.Timestamp, datetime.date)):
             return o.isoformat(), True
         return o, False
 

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -1,11 +1,14 @@
 import os
+from datetime import date
 
 import mlflow
-from mlflow.models.utils import _save_example
+import pandas as pd
+import numpy as np
 
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.models import Model
 from mlflow.models.signature import ModelSignature
+from mlflow.models.utils import _save_example
 from mlflow.types.schema import Schema, ColSpec
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.proto_json_utils import _dataframe_from_json
@@ -88,3 +91,37 @@ def test_model_log():
         path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
         x = _dataframe_from_json(path)
         assert x.to_dict(orient="records")[0] == input_example
+
+def test_model_log_with_input_example_succeeds():
+    with TempDir(chdr=True) as tmp:
+        experiment_id = mlflow.create_experiment("test")
+        sig = ModelSignature(
+            inputs=Schema([
+                ColSpec("integer", "a"),
+                ColSpec("string", "b"),
+                ColSpec("boolean", "c"),
+                ColSpec("string", "d"),
+                ColSpec("datetime", "e")
+            ]),
+            outputs=Schema([ColSpec(name=None, type="double")]),
+        )
+        input_example = pd.DataFrame({
+            "a": np.int32(1),
+            "b": "test string",
+            "c": True,
+            "d": date.today(),
+            "e": np.datetime64("2020-01-01T00:00:00")
+        }, index=[0])
+        with mlflow.start_run(experiment_id=experiment_id) as r:
+            Model.log("some/path", TestFlavor, signature=sig, input_example=input_example)
+
+        local_path = _download_artifact_from_uri(
+            "runs:/{}/some/path".format(r.info.run_id), output_path=tmp.path("")
+        )
+        loaded_model = Model.load(os.path.join(local_path, "MLmodel"))
+        path = os.path.join(local_path, loaded_model.saved_input_example_info["artifact_path"])
+        x = _dataframe_from_json(path, schema=sig.inputs)
+
+        # date column will get deserialized into string
+        input_example["d"] = input_example["d"].apply(lambda x: x.isoformat())
+        assert x.equals(input_example)

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -92,26 +92,32 @@ def test_model_log():
         x = _dataframe_from_json(path)
         assert x.to_dict(orient="records")[0] == input_example
 
+
 def test_model_log_with_input_example_succeeds():
     with TempDir(chdr=True) as tmp:
         experiment_id = mlflow.create_experiment("test")
         sig = ModelSignature(
-            inputs=Schema([
-                ColSpec("integer", "a"),
-                ColSpec("string", "b"),
-                ColSpec("boolean", "c"),
-                ColSpec("string", "d"),
-                ColSpec("datetime", "e")
-            ]),
+            inputs=Schema(
+                [
+                    ColSpec("integer", "a"),
+                    ColSpec("string", "b"),
+                    ColSpec("boolean", "c"),
+                    ColSpec("string", "d"),
+                    ColSpec("datetime", "e"),
+                ]
+            ),
             outputs=Schema([ColSpec(name=None, type="double")]),
         )
-        input_example = pd.DataFrame({
-            "a": np.int32(1),
-            "b": "test string",
-            "c": True,
-            "d": date.today(),
-            "e": np.datetime64("2020-01-01T00:00:00")
-        }, index=[0])
+        input_example = pd.DataFrame(
+            {
+                "a": np.int32(1),
+                "b": "test string",
+                "c": True,
+                "d": date.today(),
+                "e": np.datetime64("2020-01-01T00:00:00"),
+            },
+            index=[0],
+        )
         with mlflow.start_run(experiment_id=experiment_id) as r:
             Model.log("some/path", TestFlavor, signature=sig, input_example=input_example)
 


### PR DESCRIPTION
Signed-off-by: Viswesh Periyasamy <viswesh.periyasamy@databricks.com>

## What changes are proposed in this pull request?

Adding support for Python's `datetime.date` objects to be serializable. When pyspark dataframes get converted to pandas, they are converted to type `object`. When logging input examples, these objects are converted to dictionaries, which converts the date columns to Python `datetime.date`. We can make these serialize to ISO format the same way we do for timestamp and datetime columns in general so the input examples can be logged.

## How is this patch tested?

Added unit test

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Models can now be logged with input examples that have `datetime.date` objects.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
