### PR TITLE
Document the valid characters and maximum string length for log_param, log_metric and set_tag

### DIFF
--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -168,7 +168,8 @@ class TrackingServiceClient(object):
         Log a metric against the run ID.
 
         :param run_id: The run id to which the metric should be logged.
-        :param key: Metric name.
+        :param key: Metric name (string). This string may only contain alphanumerics, underscores (_),
+                    dashes (-), periods (.), spaces ( ), and slashes (/).
         :param value: Metric value (float). Note that some special values such
                       as +/- Infinity may be replaced by other values depending on the store. For
                       example, the SQLAlchemy store replaces +/- Inf with max / min float values.
@@ -206,8 +207,11 @@ class TrackingServiceClient(object):
         Set a tag on the run with the specified ID. Value is converted to a string.
 
         :param run_id: String ID of the run.
-        :param key: Name of the tag.
-        :param value: Tag value (converted to a string)
+        :param key: Tag name (string). This string may only contain alphanumerics, underscores (_), dashes (-),
+                    periods (.), spaces ( ), and slashes (/).
+                    Maximum length: 250 characters.
+        :param value: Tag value (string, but will be string-ified if not).
+                      Maximum length: 5000 characters.
         """
         _validate_tag_name(key)
         tag = RunTag(key, str(value))

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -600,7 +600,8 @@ class MlflowClient(object):
         Log a metric against the run ID.
 
         :param run_id: The run id to which the metric should be logged.
-        :param key: Metric name.
+        :param key: Metric name (string). This string may only contain alphanumerics, underscores (_),
+                    dashes (-), periods (.), spaces ( ), and slashes (/).
         :param value: Metric value (float). Note that some special values such
                       as +/- Infinity may be replaced by other values depending on the store. For
                       example, the SQLAlchemy store replaces +/- Inf with max / min float values.
@@ -653,7 +654,11 @@ class MlflowClient(object):
         Log a parameter against the run ID.
 
         :param run_id: The run id to which the param should be logged.
-        :param value: Value is converted to a string.
+        :param key: Parameter name (string). This string may only contain alphanumerics, underscores (_), dashes (-),
+                    periods (.), spaces ( ), and slashes (/).
+                    Maximum length: 250 characters.
+        :param value: Parameter value (string, but will be string-ified if not).
+                      Maximum length: 250 characters.
 
         .. code-block:: python
             :caption: Example
@@ -731,8 +736,11 @@ class MlflowClient(object):
         Set a tag on the run with the specified ID. Value is converted to a string.
 
         :param run_id: String ID of the run.
-        :param key: Name of the tag.
-        :param value: Tag value (converted to a string)
+        :param key: Tag name (string).
+                    This string may only contain alphanumerics, underscores (_), dashes (-), periods (.), spaces ( ), and slashes (/).
+                    Maximum length: 250 characters.
+        :param value: Tag value (string, but will be string-ified if not).
+                      Maximum length: 5000 characters.
 
         .. code-block:: python
             :caption: Example

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -351,8 +351,11 @@ def log_param(key: str, value: Any) -> None:
     Log a parameter under the current run. If no run is active, this method will create
     a new active run.
 
-    :param key: Parameter name (string)
-    :param value: Parameter value (string, but will be string-ified if not)
+    :param key: Parameter name (string). This string may only contain alphanumerics, underscores (_), dashes (-),
+                periods (.), spaces ( ), and slashes (/).
+                Maximum length: 250 characters.
+    :param value: Parameter value (string, but will be string-ified if not).
+                  Maximum length: 250 characters.
 
     .. code-block:: python
         :caption: Example
@@ -371,8 +374,11 @@ def set_tag(key: str, value: Any) -> None:
     Set a tag under the current run. If no run is active, this method will create a
     new active run.
 
-    :param key: Tag name (string)
-    :param value: Tag value (string, but will be string-ified if not)
+    :param key: Tag name (string). This string may only contain alphanumerics, underscores (_), dashes (-),
+                periods (.), spaces ( ), and slashes (/).
+                Maximum length: 250 characters.
+    :param value: Tag value (string, but will be string-ified if not).
+                  Maximum length: 5000 characters.
 
     .. code-block:: python
         :caption: Example
@@ -416,7 +422,8 @@ def log_metric(key: str, value: float, step: Optional[int] = None) -> None:
     Log a metric under the current run. If no run is active, this method will create
     a new active run.
 
-    :param key: Metric name (string).
+    :param key: Metric name (string). This string may only contain alphanumerics, underscores (_),
+                dashes (-), periods (.), spaces ( ), and slashes (/).
     :param value: Metric value (float). Note that some special values such as +/- Infinity may be
                   replaced by other values depending on the store. For example, the
                   SQLAlchemy store replaces +/- Infinity with max / min float values.


### PR DESCRIPTION
#4202 

Signed-off-by: James Tran <tmnhat2001@gmail.com>

## What changes are proposed in this pull request?

Document the valid characters and maximum string length for log_param, log_metric and set_tag.

The documentation is based on the description in #4202 and the following rules:
- Validate metric name: https://github.com/mlflow/mlflow/blob/af54bbd253d5ed0e6850f49573e92ebb8f2cc7b0/mlflow/utils/validation.py#L52
- Validate param: https://github.com/mlflow/mlflow/blob/af54bbd253d5ed0e6850f49573e92ebb8f2cc7b0/mlflow/utils/validation.py#L105
- Validate tag: https://github.com/mlflow/mlflow/blob/af54bbd253d5ed0e6850f49573e92ebb8f2cc7b0/mlflow/utils/validation.py#L115

## How is this patch tested?

This is tested manually by building and checking the documentation.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)
Document the valid characters and maximum string length for log_param, log_metric and set_tag.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
