### PR TITLE
Sklearn autologging bug fix: Don't compute metrics when labels are missing

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -756,7 +756,7 @@ def autolog(
         (X, y_true, sample_weight) = _get_args_for_metrics(estimator.fit, args, kwargs)
 
         # log common metrics and artifacts for estimators (classifier, regressor)
-        _log_estimator_content(
+        logged_metrics = _log_estimator_content(
             estimator=estimator,
             prefix=_TRAINING_PREFIX,
             run_id=mlflow.active_run().info.run_id,
@@ -764,6 +764,12 @@ def autolog(
             y_true=y_true,
             sample_weight=sample_weight,
         )
+        if y_true is None and not logged_metrics:
+            _logger.warning(
+                "Training metrics will not be recorded because training labels were not specified."
+                " To automatically record training metrics, provide training labels as inputs to"
+                " the model training function."
+            )
 
         def get_input_example():
             # Fetch an input example using the first several rows of the array-like

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -479,7 +479,8 @@ def _log_specialized_estimator_content(
 def _log_estimator_content(estimator, run_id, prefix, X, y_true=None, sample_weight=None):
     """
     Logs content for the given estimator, which includes metrics and artifacts that might be
-    tailored to the estimator's type (e.g., regression vs classification).
+    tailored to the estimator's type (e.g., regression vs classification). Training labels
+    are required for metric computation; metrics will be omitted if labels are not available.
 
     :param estimator: The estimator used to compute metrics and artifacts.
     :param run_id: The run under which the content is logged.

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -73,7 +73,9 @@ def _get_args_for_metrics(fit_func, fit_args, fit_kwargs):
     :param fit_args: Positional arguments given to fit_func.
     :param fit_kwargs: Keyword arguments given to fit_func.
 
-    :returns: A tuple of either (X, y, sample_weight) or (X, y).
+    :returns: A tuple of either (X, y, sample_weight), where `y` and `sample_weight` may be
+              `None` if the specified `fit_args` and `fit_kwargs` do not specify labels or
+              a sample weighting.
     """
     def _get_Xy(args, kwargs, X_var_name, y_var_name):
         # corresponds to: model.fit(X, y)

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -77,6 +77,7 @@ def _get_args_for_metrics(fit_func, fit_args, fit_kwargs):
               `None` if the specified `fit_args` and `fit_kwargs` do not specify labels or
               a sample weighting.
     """
+
     def _get_Xy(args, kwargs, X_var_name, y_var_name):
         # corresponds to: model.fit(X, y)
         if len(args) >= 2:
@@ -420,7 +421,9 @@ def _log_specialized_estimator_content(
     if y_true is not None:
         try:
             if sklearn.base.is_classifier(fitted_estimator):
-                metrics = _get_classifier_metrics(fitted_estimator, prefix, X, y_true, sample_weight)
+                metrics = _get_classifier_metrics(
+                    fitted_estimator, prefix, X, y_true, sample_weight
+                )
             elif sklearn.base.is_regressor(fitted_estimator):
                 metrics = _get_regressor_metrics(fitted_estimator, prefix, X, y_true, sample_weight)
         except Exception as err:

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -75,7 +75,6 @@ def _get_args_for_metrics(fit_func, fit_args, fit_kwargs):
 
     :returns: A tuple of either (X, y, sample_weight) or (X, y).
     """
-
     def _get_Xy(args, kwargs, X_var_name, y_var_name):
         # corresponds to: model.fit(X, y)
         if len(args) >= 2:
@@ -83,10 +82,10 @@ def _get_args_for_metrics(fit_func, fit_args, fit_kwargs):
 
         # corresponds to: model.fit(X, <y_var_name>=y)
         if len(args) == 1:
-            return args[0], kwargs[y_var_name]
+            return args[0], kwargs.get(y_var_name)
 
         # corresponds to: model.fit(<X_var_name>=X, <y_var_name>=y)
-        return kwargs[X_var_name], kwargs[y_var_name]
+        return kwargs[X_var_name], kwargs.get(y_var_name)
 
     def _get_sample_weight(arg_names, args, kwargs):
         sample_weight_index = arg_names.index(_SAMPLE_WEIGHT)
@@ -409,35 +408,37 @@ def _log_warning_for_artifacts(func_name, func_call, err):
 
 
 def _log_specialized_estimator_content(
-    fitted_estimator, run_id, prefix, X, y_true, sample_weight=None
+    fitted_estimator, run_id, prefix, X, y_true=None, sample_weight=None
 ):
     import sklearn
 
     mlflow_client = MlflowClient()
     metrics = dict()
-    try:
-        if sklearn.base.is_classifier(fitted_estimator):
-            metrics = _get_classifier_metrics(fitted_estimator, prefix, X, y_true, sample_weight)
-        elif sklearn.base.is_regressor(fitted_estimator):
-            metrics = _get_regressor_metrics(fitted_estimator, prefix, X, y_true, sample_weight)
-    except Exception as err:
-        msg = (
-            "Failed to autolog metrics for "
-            + fitted_estimator.__class__.__name__
-            + ". Logging error: "
-            + str(err)
-        )
-        _logger.warning(msg)
-    else:
-        # batch log all metrics
-        try_mlflow_log(
-            mlflow_client.log_batch,
-            run_id,
-            metrics=[
-                Metric(key=str(key), value=value, timestamp=int(time.time() * 1000), step=0)
-                for key, value in metrics.items()
-            ],
-        )
+
+    if y_true is not None:
+        try:
+            if sklearn.base.is_classifier(fitted_estimator):
+                metrics = _get_classifier_metrics(fitted_estimator, prefix, X, y_true, sample_weight)
+            elif sklearn.base.is_regressor(fitted_estimator):
+                metrics = _get_regressor_metrics(fitted_estimator, prefix, X, y_true, sample_weight)
+        except Exception as err:
+            msg = (
+                "Failed to autolog metrics for "
+                + fitted_estimator.__class__.__name__
+                + ". Logging error: "
+                + str(err)
+            )
+            _logger.warning(msg)
+        else:
+            # batch log all metrics
+            try_mlflow_log(
+                mlflow_client.log_batch,
+                run_id,
+                metrics=[
+                    Metric(key=str(key), value=value, timestamp=int(time.time() * 1000), step=0)
+                    for key, value in metrics.items()
+                ],
+            )
 
     if sklearn.base.is_classifier(fitted_estimator):
         try:
@@ -473,7 +474,7 @@ def _log_specialized_estimator_content(
     return metrics
 
 
-def _log_estimator_content(estimator, run_id, prefix, X, y_true, sample_weight):
+def _log_estimator_content(estimator, run_id, prefix, X, y_true=None, sample_weight=None):
     """
     Logs content for the given estimator, which includes metrics and artifacts that might be
     tailored to the estimator's type (e.g., regression vs classification).
@@ -496,7 +497,7 @@ def _log_estimator_content(estimator, run_id, prefix, X, y_true, sample_weight):
         sample_weight=sample_weight,
     )
 
-    if hasattr(estimator, "score"):
+    if hasattr(estimator, "score") and y_true is not None:
         try:
             # Use the sample weight only if it is present in the score args
             score_arg_names = _get_arg_names(estimator.score)

--- a/tests/autologging/test_autologging_behaviors_unit.py
+++ b/tests/autologging/test_autologging_behaviors_unit.py
@@ -223,19 +223,14 @@ def test_silent_mode_restores_warning_and_event_logging_behavior_correctly_if_er
         # execution states across autologging sessions)
         time.sleep(np.random.random())
         patch_destination.fn()
-        return True
 
     with pytest.raises(Exception):
         test_autolog(silent=True)
 
-    executions = []
     with pytest.warns(None):
         with ThreadPoolExecutor(max_workers=50) as executor:
             for _ in range(100):
-                executions.append(executor.submit(parallel_fn))
                 executor.submit(parallel_fn)
-
-    assert all([e.result() is True for e in executions])
 
     assert warnings.showwarning == og_showwarning
     logger.info("verify that event logs are enabled")

--- a/tests/autologging/test_autologging_behaviors_unit.py
+++ b/tests/autologging/test_autologging_behaviors_unit.py
@@ -223,14 +223,19 @@ def test_silent_mode_restores_warning_and_event_logging_behavior_correctly_if_er
         # execution states across autologging sessions)
         time.sleep(np.random.random())
         patch_destination.fn()
+        return True
 
     with pytest.raises(Exception):
         test_autolog(silent=True)
 
+    executions = []
     with pytest.warns(None):
         with ThreadPoolExecutor(max_workers=50) as executor:
             for _ in range(100):
+                executions.append(executor.submit(parallel_fn))
                 executor.submit(parallel_fn)
+
+    assert all([e.result() is True for e in executions])
 
     assert warnings.showwarning == og_showwarning
     logger.info("verify that event logs are enabled")

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1472,3 +1472,25 @@ def test_eval_and_log_metrics_throws_with_invalid_args():
         mlflow.sklearn.eval_and_log_metrics(
             model=SpectralClustering(), X=X, y_true=y_true, prefix="val_"
         )
+
+
+def test_metric_computation_handles_absent_labels():
+    """
+    Verifies that autologging metric computation does not fail For models that do not require
+    labels as inputs to training, such as clustering models and other unsupervised techniques
+    """
+    mlflow.sklearn.autolog()
+
+    model = sklearn.cluster.KMeans()
+
+    with mlflow.start_run() as run:
+        # Train a clustering model solely on samples, without specifying labels
+        model.fit(X=get_iris()[0])
+
+    params, metrics, tags, artifacts = get_run_data(run.info.run_id)
+    assert params == truncate_dict(stringify_dict_values(model.get_params(deep=True)))
+    # We expect metrics to be absent because labels are required to compute autologging metrics
+    # for sklearn models
+    assert not metrics
+    assert tags == get_expected_class_tags(model)
+    assert MODEL_DIR in artifacts

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -1477,7 +1477,7 @@ def test_eval_and_log_metrics_throws_with_invalid_args():
 def test_metric_computation_handles_absent_labels():
     """
     Verifies that autologging metric computation does not fail For models that do not require
-    labels as inputs to training, such as clustering models and other unsupervised techniques
+    labels as inputs to training, such as clustering models and other unsupervised techniques.
     """
     mlflow.sklearn.autolog()
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

All of the metrics that are currently computed as part of sklearn autologging require labels to be specified during training (i.e. they require a `y` argument to be passed to `fit()`. Many unsupervised algorithms don't require `y`. For these algorithms, metric computation currently fails and prints an "unexpected error" warning message:

```
import mlflow
mlflow.sklearn.autolog()

import sklearn.datasets
import sklearn.cluster

def get_iris():
    iris = sklearn.datasets.load_iris()
    X = iris.data[:, :2]
    y = iris.target
    return X, y

X, y = get_iris()
sklearn.cluster.KMeans().fit(X=X)
```

```
2021/05/06 17:50:58 INFO mlflow.utils.autologging_utils: Created MLflow autologging run with ID '51267604cc9c4159b54f0b540bf0b66a', which will track hyperparameters, performance metrics, model artifacts, and lineage information for the current sklearn workflow
2021/05/06 17:50:58 WARNING mlflow.utils.autologging_utils: Encountered unexpected error during sklearn autologging: 'y'
```

This PR fixes the issue by handling the case where `y` is not specified.

## How is this patch tested?

Unit tests

## Release Notes

Fix a bug where an "unexpected error" warning message was printed during unsupervised model training with scikit-learn autologging enabled.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
