### PR TITLE
Fix PyTorch Lightning callback hook args

### DIFF
--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -115,7 +115,9 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
             # in pytorch-lightning >= 1.2.0.
             if LooseVersion(pl.__version__) >= LooseVersion("1.2.0"):
 
-                def on_train_epoch_end(self, trainer, pl_module, _):
+                def on_train_epoch_end(
+                    self, trainer, pl_module, *args, **kwargs
+                ):  # pylint: disable=arguments-differ
                     """
                     Log loss and other metrics values after each train epoch
 

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -115,9 +115,14 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
             # in pytorch-lightning >= 1.2.0.
             if LooseVersion(pl.__version__) >= LooseVersion("1.2.0"):
 
+                # NB: Override `on_train_epoch_end` with an additional `*args` parameter for
+                # compatibility with versions of pytorch-lightning <= 1.2.0, which required an
+                # `outputs` argument that was not used and is no longer defined in
+                # pytorch-lightning >= 1.3.0
+
                 def on_train_epoch_end(
-                    self, trainer, pl_module, *args, **kwargs
-                ):  # pylint: disable=signature-differs,unused-argument
+                    self, trainer, pl_module, *args
+                ):  # pylint: disable=signature-differs,arguments-differ,unused-argument
                     """
                     Log loss and other metrics values after each train epoch
 

--- a/mlflow/pytorch/_pytorch_autolog.py
+++ b/mlflow/pytorch/_pytorch_autolog.py
@@ -117,7 +117,7 @@ def _create_patch_fit(log_every_n_epoch=1, log_models=True):
 
                 def on_train_epoch_end(
                     self, trainer, pl_module, *args, **kwargs
-                ):  # pylint: disable=arguments-differ
+                ):  # pylint: disable=signature-differs,unused-argument
                     """
                     Log loss and other metrics values after each train epoch
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

PyTorch Lightning 1.3.0 removed the `outputs` argument from the `on_train_epoch_end` training callback hook, breaking our implementation of this hook.

This PR converts the representation of `outputs` from a specific "unnamed" argument (`_`) to a member of the set of generic positional arguments (`*args`).

## How is this patch tested?

Existing unit tests

## Release Notes

Implemented a training callback hook fix for compatibility with PyTorch Lightning 1.3.0

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
