### PR TITLE
Fix prepare_data issue in dev version of pytorch-lightning

### DIFF
--- a/examples/pytorch/AxHyperOptimizationPTL/ax_hpo_mnist.py
+++ b/examples/pytorch/AxHyperOptimizationPTL/ax_hpo_mnist.py
@@ -9,7 +9,6 @@ import pytorch_lightning as pl
 def train_evaluate(params, max_epochs=100):
     model = IrisClassification(**params)
     dm = IrisDataModule()
-    dm.prepare_data()
     dm.setup(stage="fit")
     trainer = pl.Trainer(max_epochs=max_epochs)
     mlflow.pytorch.autolog()

--- a/examples/pytorch/AxHyperOptimizationPTL/iris_data_module.py
+++ b/examples/pytorch/AxHyperOptimizationPTL/iris_data_module.py
@@ -14,9 +14,6 @@ class IrisDataModule(pl.LightningDataModule):
         super().__init__()
         self.columns = None
 
-    def prepare_data(self):
-        pass
-
     def _get_iris_as_tensor_dataset(self):
         iris = load_iris()
         df = iris.data

--- a/examples/pytorch/AxHyperOptimizationPTL/iris_data_module.py
+++ b/examples/pytorch/AxHyperOptimizationPTL/iris_data_module.py
@@ -15,6 +15,9 @@ class IrisDataModule(pl.LightningDataModule):
         self.columns = None
 
     def prepare_data(self):
+        pass
+
+    def _get_iris_as_tensor_dataset(self):
         iris = load_iris()
         df = iris.data
         self.columns = iris.feature_names
@@ -28,7 +31,7 @@ class IrisDataModule(pl.LightningDataModule):
 
         # Assign train/val datasets for use in dataloaders
         if stage == "fit" or stage is None:
-            iris_full = self.prepare_data()
+            iris_full = self._get_iris_as_tensor_dataset()
             self.train_set, self.val_set = random_split(iris_full, [130, 20])
 
         # Assign test dataset for use in dataloader(s)

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -117,6 +117,7 @@ class BertDataModule(pl.LightningDataModule):
         """
         Implementation of abstract class
         """
+        pass
 
     def setup(self, stage=None):
         """

--- a/examples/pytorch/BertNewsClassification/bert_classification.py
+++ b/examples/pytorch/BertNewsClassification/bert_classification.py
@@ -113,12 +113,6 @@ class BertDataModule(pl.LightningDataModule):
         self.tokenizer = None
         self.args = kwargs
 
-    def prepare_data(self):
-        """
-        Implementation of abstract class
-        """
-        pass
-
     def setup(self, stage=None):
         """
         Downloads the data, parse it and split the data into train, test, validation data
@@ -401,7 +395,6 @@ if __name__ == "__main__":
             dict_args["accelerator"] = None
 
     dm = BertDataModule(**dict_args)
-    dm.prepare_data()
     dm.setup(stage="fit")
 
     model = BertNewsClassifier(**dict_args)

--- a/examples/pytorch/IterativePruning/iterative_prune_mnist.py
+++ b/examples/pytorch/IterativePruning/iterative_prune_mnist.py
@@ -33,7 +33,6 @@ class IterativePrune:
             mlflow.start_run(run_name="BaseModel")
         mlflow.pytorch.autolog()
         dm = MNISTDataModule(**parser_dict)
-        dm.prepare_data()
         dm.setup(stage="fit")
 
         model = LightningMNISTClassifier(**parser_dict)

--- a/examples/pytorch/IterativePruning/mnist.py
+++ b/examples/pytorch/IterativePruning/mnist.py
@@ -230,7 +230,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         """
         Prepares the data for training and prediction
         """
-        return {}
+        pass
 
     def configure_optimizers(self):
         """

--- a/examples/pytorch/IterativePruning/mnist.py
+++ b/examples/pytorch/IterativePruning/mnist.py
@@ -37,12 +37,6 @@ class MNISTDataModule(pl.LightningDataModule):
             [transforms.ToTensor(), transforms.Normalize((0.1307,), (0.3081,))]
         )
 
-    def prepare_data(self):
-        """
-        Implementation of abstract class
-        """
-        pass
-
     def setup(self, stage=None):
         """
         Downloads the data, parse it and split the data into train, test, validation data
@@ -226,12 +220,6 @@ class LightningMNISTClassifier(pl.LightningModule):
         avg_test_acc = torch.stack([x["test_acc"] for x in outputs]).mean()
         self.log("avg_test_acc", avg_test_acc)
 
-    def prepare_data(self):
-        """
-        Prepares the data for training and prediction
-        """
-        pass
-
     def configure_optimizers(self):
         """
         Initializes the optimizer and learning rate scheduler
@@ -264,7 +252,6 @@ if __name__ == "__main__":
             dict_args["accelerator"] = None
 
     dm = MNISTDataModule(**dict_args)
-    dm.prepare_data()
     dm.setup(stage="fit")
 
     model = LightningMNISTClassifier(**dict_args)

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -224,12 +224,6 @@ class LightningMNISTClassifier(pl.LightningModule):
         avg_test_acc = torch.stack([x["test_acc"] for x in outputs]).mean()
         self.log("avg_test_acc", avg_test_acc)
 
-    def prepare_data(self):
-        """
-        Prepares the data for training and prediction
-        """
-        pass
-
     def configure_optimizers(self):
         """
         Initializes the optimizer and learning rate scheduler
@@ -279,7 +273,6 @@ if __name__ == "__main__":
     model = LightningMNISTClassifier(**dict_args)
 
     dm = MNISTDataModule(**dict_args)
-    dm.prepare_data()
     dm.setup(stage="fit")
 
     early_stopping = EarlyStopping(

--- a/examples/pytorch/MNIST/mnist_autolog_example.py
+++ b/examples/pytorch/MNIST/mnist_autolog_example.py
@@ -228,7 +228,7 @@ class LightningMNISTClassifier(pl.LightningModule):
         """
         Prepares the data for training and prediction
         """
-        return {}
+        pass
 
     def configure_optimizers(self):
         """

--- a/tests/pytorch/iris_data_module.py
+++ b/tests/pytorch/iris_data_module.py
@@ -15,6 +15,9 @@ class IrisDataModuleBase(pl.LightningDataModule):
         self.columns = None
 
     def prepare_data(self):
+        pass
+
+    def _get_iris_as_tensor_dataset(self):
         iris = load_iris()
         df = iris.data
         self.columns = iris.feature_names
@@ -28,7 +31,7 @@ class IrisDataModuleBase(pl.LightningDataModule):
 
         # Assign train/val datasets for use in dataloaders
         if stage == "fit" or stage is None:
-            iris_full = self.prepare_data()
+            iris_full = self._get_iris_as_tensor_dataset()
             self.train_set, self.val_set = random_split(iris_full, [130, 20])
 
         # Assign test dataset for use in dataloader(s)

--- a/tests/pytorch/iris_data_module.py
+++ b/tests/pytorch/iris_data_module.py
@@ -14,9 +14,6 @@ class IrisDataModuleBase(pl.LightningDataModule):
         super().__init__()
         self.columns = None
 
-    def prepare_data(self):
-        pass
-
     def _get_iris_as_tensor_dataset(self):
         iris = load_iris()
         df = iris.data

--- a/tests/pytorch/test_pytorch_autolog.py
+++ b/tests/pytorch/test_pytorch_autolog.py
@@ -21,7 +21,6 @@ def pytorch_model():
     mlflow.pytorch.autolog()
     model = IrisClassification()
     dm = IrisDataModule()
-    dm.prepare_data()
     dm.setup(stage="fit")
     trainer = pl.Trainer(max_epochs=NUM_EPOCHS)
     trainer.fit(model, dm)
@@ -35,7 +34,6 @@ def pytorch_model_without_validation():
     mlflow.pytorch.autolog()
     model = IrisClassificationWithoutValidation()
     dm = IrisDataModuleWithoutValidation()
-    dm.prepare_data()
     dm.setup(stage="fit")
     trainer = pl.Trainer(max_epochs=NUM_EPOCHS)
     trainer.fit(model, dm)
@@ -50,7 +48,6 @@ def test_pytorch_autolog_log_models_configuration(log_models):
     mlflow.pytorch.autolog(log_models=log_models)
     model = IrisClassification()
     dm = IrisDataModule()
-    dm.prepare_data()
     dm.setup(stage="fit")
     trainer = pl.Trainer(max_epochs=NUM_EPOCHS)
     trainer.fit(model, dm)
@@ -111,7 +108,6 @@ def test_pytorch_autolog_persists_manually_created_run():
         mlflow.pytorch.autolog()
         model = IrisClassification()
         dm = IrisDataModule()
-        dm.prepare_data()
         dm.setup(stage="fit")
         trainer = pl.Trainer(max_epochs=NUM_EPOCHS)
         trainer.fit(model, dm)
@@ -129,7 +125,6 @@ def pytorch_model_with_callback(patience):
     mlflow.pytorch.autolog()
     model = IrisClassification()
     dm = IrisDataModule()
-    dm.prepare_data()
     dm.setup(stage="fit")
     early_stopping = EarlyStopping(
         monitor="val_loss",
@@ -185,7 +180,6 @@ def test_pytorch_with_early_stopping_autolog_log_models_configuration_with(log_m
     mlflow.pytorch.autolog(log_models=log_models)
     model = IrisClassification()
     dm = IrisDataModule()
-    dm.prepare_data()
     dm.setup(stage="fit")
     early_stopping = EarlyStopping(monitor="val_loss", mode="min", patience=patience, verbose=True)
 
@@ -265,7 +259,6 @@ def pytorch_model_tests():
     mlflow.pytorch.autolog()
     model = IrisClassification()
     dm = IrisDataModule()
-    dm.prepare_data()
     dm.setup(stage="fit")
     trainer = pl.Trainer(max_epochs=NUM_EPOCHS)
     with mlflow.start_run() as run:


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix the following error that occured in the cross version tests:

https://github.com/mlflow/mlflow/runs/2564549833?check_suite_focus=true#step:11:999

```python
tests/pytorch/test_pytorch_autolog.py:133: in pytorch_model_with_callback
    dm.setup(stage="fit")
/usr/share/miniconda/lib/python3.6/site-packages/pytorch_lightning/core/datamodule.py:385: in wrapped_fn
    return fn(*args, **kwargs)
tests/pytorch/iris_data_module.py:32: in setup
    self.train_set, self.val_set = random_split(iris_full, [130, 20])
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

dataset = None, lengths = [130, 20]
generator = <torch._C.Generator object at 0x7fdb65fc76d8>

    def random_split(dataset: Dataset[T], lengths: Sequence[int],
                     generator: Optional[Generator] = default_generator) -> List[Subset[T]]:
        r"""
        Randomly split a dataset into non-overlapping new datasets of given lengths.
        Optionally fix the generator for reproducible results, e.g.:
    
        >>> random_split(range(10), [3, 7], generator=torch.Generator().manual_seed(42))
    
        Args:
            dataset (Dataset): Dataset to be split
            lengths (sequence): lengths of splits to be produced
            generator (Generator): Generator used for the random permutation.
        """
        # Cannot verify that dataset is Sized
>       if sum(lengths) != len(dataset):  # type: ignore
E       TypeError: object of type 'NoneType' has no len()
```

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
