### PR TITLE
Handle package versions that violate PEP 440

### DIFF
--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -27,6 +27,7 @@ from mlflow.utils.autologging_utils.versioning import (
     FLAVOR_TO_MODULE_NAME_AND_VERSION_INFO_KEY,
     _check_version_in_range,
     _is_pre_or_dev_release,
+    _violates_pep_440,
     is_flavor_supported_for_associated_package_versions,
 )
 
@@ -688,6 +689,13 @@ def test_is_pre_or_dev_release():
     assert not _is_pre_or_dev_release("0.24.0")
 
 
+def test_violates_pep_440():
+    assert _violates_pep_440("0.24.0-SNAPSHOT")
+    assert not _violates_pep_440("0.24.0rc1")
+    assert not _violates_pep_440("0.24.0dev1")
+    assert not _violates_pep_440("0.24.0")
+
+
 _module_version_info_dict_patch = {
     "sklearn": {
         "package_info": {"pip_release": "scikit-learn"},
@@ -753,6 +761,7 @@ _module_version_info_dict_patch = {
         ("sklearn", "0.20.2", False),
         ("sklearn", "0.23.0rc1", False),
         ("sklearn", "0.23.0dev0", False),
+        ("sklearn", "0.23.0-SNAPSHOT", False),
         ("pytorch", "1.0.5", True),
         ("pytorch", "1.0.4", False),
         ("pyspark.ml", "3.1.0", True),


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix for https://github.com/mlflow/mlflow/runs/2564551888?check_suite_focus=true#step:11:1456:

```
self = <[AttributeError("'Version' object has no attribute '_version'") raised in repr()] Version object at 0x7f9552a95e80>
version = '1.5.0-SNAPSHOT'

    def __init__(self, version):
        # type: (str) -> None
    
        # Validate the version and parse it into pieces
        match = self._regex.search(version)
        if not match:
>           raise InvalidVersion("Invalid version: '{0}'".format(version))
E           packaging.version.InvalidVersion: Invalid version: '1.5.0-SNAPSHOT'
```

`packaging.version.Version` throws when the given version violates PEP440.

## How is this patch tested?

Existing tests + new tests

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
