### PR TITLE
Fix forced default experiment creation

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -125,7 +125,7 @@ class SqlAlchemyStore(AbstractStore):
         if is_local_uri(default_artifact_root):
             mkdir(local_file_uri_to_path(default_artifact_root))
 
-        if len(self.list_experiments()) == 0:
+        if len(self.list_experiments(view_type=ViewType.ALL)) == 0:
             with self.ManagedSessionMaker() as session:
                 self._create_default_experiment(session)
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -1852,6 +1852,14 @@ def test_sqlalchemy_store_behaves_as_expected_with_inmemory_sqlite_db():
     assert param.key in fetched_run.data.params
 
 
+def test_sqlalchemy_store_can_be_initialized_when_default_experiment_has_been_deleted(tmpdir):
+    db_uri = "sqlite:///{}/mlflow.db".format(tmpdir.strpath)
+    store = SqlAlchemyStore(db_uri, ARTIFACT_URI)
+    store.delete_experiment("0")
+    assert store.get_experiment("0").lifecycle_stage == entities.LifecycleStage.DELETED
+    SqlAlchemyStore(db_uri, ARTIFACT_URI)
+
+
 class TestSqlAlchemyStoreSqliteMigratedDB(TestSqlAlchemyStoreSqlite):
     """
     Test case where user has an existing DB with schema generated before MLflow 1.0,


### PR DESCRIPTION
## What changes are proposed in this pull request?
 
Fixes #4351 
## How is this patch tested?

Just followed CONTRIBUTING.rst to setup a local dev server, and confirmed that after the fix,
mlflow works, while before the fix mlflow doesn't work..

## Release Notes

### Is this a user-facing change?

- [ X ] No. You can skip the rest of this section.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ X ] `area/server-infra`: MLflow server, JavaScript dev server
- [ X ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ X ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ X ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:
- [ X ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
