### PR TITLE
Make mlflow compatible with protobuf 3.6.1

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -46,8 +46,8 @@ if Version(google.protobuf.__version__) <= Version("3.6.1"):
 
 del google, Version
 
-# noqa: E402
-from mlflow.version import VERSION as __version__  # pylint: disable=unused-import
+# pylint: disable=unused-import
+from mlflow.version import VERSION as __version__  # noqa: E402
 from mlflow.utils.logging_utils import _configure_mlflow_loggers  # noqa: E402
 import mlflow.tracking._model_registry.fluent  # noqa: E402
 import mlflow.tracking.fluent  # noqa: E402
@@ -55,7 +55,7 @@ import mlflow.tracking.fluent  # noqa: E402
 # Filter annoying Cython warnings that serve no good purpose, and so before
 # importing other modules.
 # See: https://github.com/numpy/numpy/pull/432/commits/170ed4e33d6196d7
-import warnings
+import warnings  # noqa: E402
 
 warnings.filterwarnings("ignore", message="numpy.dtype size changed")  # noqa: E402
 warnings.filterwarnings("ignore", message="numpy.ufunc size changed")  # noqa: E402

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -35,14 +35,13 @@ if Version(google.protobuf.__version__) <= Version("3.6.1"):
 
     # For version less than 3.6.1, Add EnumTypeWrapper.__getattr__ to access values
     # see https://github.com/protocolbuffers/protobuf/pull/5234
-    class NewEnumTypeWrapper(enum_type_wrapper.EnumTypeWrapper):
-        def __getattr__(self, name):
-            """Returns the value coresponding to the given enum name."""
-            if name in self._enum_type.values_by_name:
-                return self._enum_type.values_by_name[name].number
-            raise AttributeError
+    def patched_EnumTypeWrapper__getattr__(self, name):
+        """Returns the value coresponding to the given enum name."""
+        if name in self._enum_type.values_by_name:
+            return self._enum_type.values_by_name[name].number
+        raise AttributeError
 
-    enum_type_wrapper.EnumTypeWrapper = NewEnumTypeWrapper
+    enum_type_wrapper.EnumTypeWrapper.__getattr__ = patched_EnumTypeWrapper__getattr__
 
 from mlflow.version import VERSION as __version__  # pylint: disable=unused-import
 from mlflow.utils.logging_utils import _configure_mlflow_loggers

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -43,10 +43,10 @@ if Version(google.protobuf.__version__) <= Version("3.6.1"):
 
     enum_type_wrapper.EnumTypeWrapper.__getattr__ = patched_EnumTypeWrapper__getattr__
 
-from mlflow.version import VERSION as __version__  # pylint: disable=unused-import
-from mlflow.utils.logging_utils import _configure_mlflow_loggers
-import mlflow.tracking._model_registry.fluent
-import mlflow.tracking.fluent
+from mlflow.version import VERSION as __version__  # pylint: disable=unused-import # noqa: E402
+from mlflow.utils.logging_utils import _configure_mlflow_loggers  # noqa: E402
+import mlflow.tracking._model_registry.fluent  # noqa: E402
+import mlflow.tracking.fluent  # noqa: E402
 
 # Filter annoying Cython warnings that serve no good purpose, and so before
 # importing other modules.

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -30,6 +30,7 @@ For a lower level API, see the :py:mod:`mlflow.tracking` module.
 import google.protobuf
 from packaging.version import Version
 
+# This is a patch for protobuf <= 3.6.1, to make mlflow compatible with protobuf <= 3.6.1
 if Version(google.protobuf.__version__) <= Version("3.6.1"):
     from google.protobuf.internal import enum_type_wrapper
 
@@ -43,7 +44,10 @@ if Version(google.protobuf.__version__) <= Version("3.6.1"):
 
     enum_type_wrapper.EnumTypeWrapper.__getattr__ = patched_EnumTypeWrapper__getattr__
 
-from mlflow.version import VERSION as __version__  # pylint: disable=unused-import # noqa: E402
+del google, Version
+
+# noqa: E402
+from mlflow.version import VERSION as __version__  # pylint: disable=unused-import
 from mlflow.utils.logging_utils import _configure_mlflow_loggers  # noqa: E402
 import mlflow.tracking._model_registry.fluent  # noqa: E402
 import mlflow.tracking.fluent  # noqa: E402


### PR DESCRIPTION
## What changes are proposed in this pull request?

Make mlflow compatible with protobuf 3.6.1:
for protobuf ==3.6.1
Add EnumTypeWrapper.__getattr__ to access values

## How is this patch tested?

N/A

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
