### PR TITLE
Replace `add_javascript` with `add_js_file` in Sphinx configuration script

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -196,7 +196,7 @@ html_show_sourcelink = False
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 html_show_sphinx = False
 
-html_add_permalinks = " "
+html_permalinks = " "
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 # html_show_copyright = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -196,7 +196,7 @@ html_show_sourcelink = False
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 html_show_sphinx = False
 
-html_permalinks = True
+html_permalinks_icon = " "
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 # html_show_copyright = True

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -196,7 +196,7 @@ html_show_sourcelink = False
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 html_show_sphinx = False
 
-html_permalinks = " "
+html_permalinks = True
 
 # If true, "(C) Copyright ..." is shown in the HTML footer. Default is True.
 # html_show_copyright = True

--- a/docs/source/languagesections/__init__.py
+++ b/docs/source/languagesections/__init__.py
@@ -37,7 +37,7 @@ class PlainSectionDirective(Directive):
 
 
 def add_assets(app):
-    app.add_javascript(JS_FILE)
+    app.add_js_file(JS_FILE)
 
 
 def copy_assets(app, exception):


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

The current sphinx configuration script contains function or variables that no longer exist in the latest version of Sphinx (4.0.1). This PR replace them with valid ones.

```
#!/bin/bash -eo pipefail
make rsthtml
make javadocs

sphinx-build -b html -d build/doctrees  -W --keep-going source build/html
Running Sphinx v4.0.1
making output directory... done
WARNING: html_add_permalinks has been deprecated since v3.5.0. Please use html_permalinks and html_permalinks_icon instead.
WARNING: The config value `html_add_permalinks' has type `str', defaults to `_stable_repr_object'.

Extension error (languagesections):
Handler <function add_assets at 0x7efeadbe8ea0> for event 'builder-inited' threw an exception (exception: 'Sphinx' object has no attribute 'add_javascript')
make: *** [Makefile:70: rsthtml] Error 2

Exited with code exit status 2
CircleCI received exit code 2
```

https://app.circleci.com/pipelines/github/mlflow/mlflow/5602/workflows/f99cdd2b-109a-41a3-b43f-80d09af3ee97/jobs/7502

## How is this patch tested?

Ensure the doc build successfully completes

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
