### PR TITLE
Fix for TensorFlow 2.5 compatibility

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -49,9 +49,7 @@ tensorflow:
   package_info:
     pip_release: "tensorflow"
     install_dev: |
-      # Unpin `tf-nightly` once the following issue is addressed:
-      # https://github.com/tensorflow/tensorflow/issues/46429
-      pip install 'tf-nightly==2.5.0.dev20210112'
+      pip install tf-nightly
 
   models:
     minimum: "1.15.4"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -94,10 +94,6 @@ tensorflow:
 keras:
   package_info:
     pip_release: "keras"
-    install_dev: |
-      # In keras >= 2.4.0, `keras` simply redirects to `tensorflow.keras`:
-      # https://github.com/keras-team/keras#multi-backend-keras-and-tfkeras
-      pip install tf-nightly 'keras>=2.4.0'
 
   models:
     minimum: "2.2.4"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -97,9 +97,7 @@ keras:
     install_dev: |
       # In keras >= 2.4.0, `keras` simply redirects to `tensorflow.keras`:
       # https://github.com/keras-team/keras#multi-backend-keras-and-tfkeras
-      # Unpin `tf-nightly` once the following issue is addressed:
-      # https://github.com/tensorflow/tensorflow/issues/46429
-      pip install 'tf-nightly==2.5.0.dev20210112' 'keras>=2.4.0'
+      pip install tf-nightly 'keras>=2.4.0'
 
   models:
     minimum: "2.2.4"

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1015,7 +1015,7 @@ def autolog(
         except Exception:  # pylint: disable=W0703
             return None
 
-    def _log_early_stop_callback_metrics(callback, history, metrics_logger, initial_epoch):
+    def _log_early_stop_callback_metrics(callback, history, expected_last_epoch, metrics_logger):
         if callback:
             callback_attrs = _get_early_stop_callback_attrs(callback)
             if callback_attrs is None:
@@ -1023,8 +1023,11 @@ def autolog(
             stopped_epoch, restore_best_weights, patience = callback_attrs
             metrics_logger.record_metrics({"stopped_epoch": stopped_epoch})
 
-            # Weights are restored only if early stopping occurs
-            if stopped_epoch != initial_epoch and restore_best_weights:
+            # Only log restored model metrics if early stopping occurs, as determined by the
+            # the value of `stopped_epoch`. `stopped_epoch` is non-zero if early stopping has
+            # occurred, except in the case where training was early stopped after the first epoch
+            # due to a configured patience value of zero
+            if ((stopped_epoch > 0) or (patience == 0 and expected_last_epoch > 0)) and restore_best_weights:
                 restored_epoch = stopped_epoch - patience
                 metrics_logger.record_metrics({"restored_epoch": restored_epoch})
                 restored_index = history.epoch.index(restored_epoch)
@@ -1087,8 +1090,13 @@ def autolog(
 
                 history = original(inst, *args, **kwargs)
 
-                initial_epoch = args[11] if len(args) >= 12 else kwargs.get("initial_epoch")
-                _log_early_stop_callback_metrics(early_stop_callback, history, metrics_logger, initial_epoch)
+                epochs = args[3] if len(args) >= 4 else kwargs.get("epochs", 0) 
+                _log_early_stop_callback_metrics(
+                    callback=early_stop_callback,
+                    history=history,
+                    expected_last_epoch=epochs,
+                    metrics_logger=metrics_logger
+                )
 
             _flush_queue()
             _log_artifacts_with_warning(

--- a/mlflow/tensorflow.py
+++ b/mlflow/tensorflow.py
@@ -1027,7 +1027,9 @@ def autolog(
             # the value of `stopped_epoch`. `stopped_epoch` is non-zero if early stopping has
             # occurred, except in the case where training was early stopped after the first epoch
             # due to a configured patience value of zero
-            if ((stopped_epoch > 0) or (patience == 0 and expected_last_epoch > 0)) and restore_best_weights:
+            if (
+                (stopped_epoch > 0) or (patience == 0 and expected_last_epoch > 0)
+            ) and restore_best_weights:
                 restored_epoch = stopped_epoch - patience
                 metrics_logger.record_metrics({"restored_epoch": restored_epoch})
                 restored_index = history.epoch.index(restored_epoch)
@@ -1090,12 +1092,12 @@ def autolog(
 
                 history = original(inst, *args, **kwargs)
 
-                epochs = args[3] if len(args) >= 4 else kwargs.get("epochs", 0) 
+                epochs = args[3] if len(args) >= 4 else kwargs.get("epochs", 0)
                 _log_early_stop_callback_metrics(
                     callback=early_stop_callback,
                     history=history,
                     expected_last_epoch=epochs,
-                    metrics_logger=metrics_logger
+                    metrics_logger=metrics_logger,
                 )
 
             _flush_queue()

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -331,7 +331,7 @@ def tf_keras_random_data_run_with_callback(
 @pytest.mark.large
 @pytest.mark.parametrize("restore_weights", [True])
 @pytest.mark.parametrize("callback", ["early"])
-@pytest.mark.parametrize("patience", [0, 1, 5])
+@pytest.mark.parametrize("patience", [1, 5])
 @pytest.mark.parametrize("initial_epoch", [0, 10])
 def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback):
     run, history, callback = tf_keras_random_data_run_with_callback
@@ -346,7 +346,7 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     assert "stopped_epoch" in metrics
     assert "restored_epoch" in metrics
     restored_epoch = int(metrics["restored_epoch"])
-    assert int(metrics["stopped_epoch"]) - max(1, callback.patience) == restored_epoch
+    assert int(metrics["stopped_epoch"]) - callback.patience == restored_epoch
     assert "loss" in history.history
     num_of_epochs = len(history.history["loss"])
     client = mlflow.tracking.MlflowClient()

--- a/tests/tensorflow_autolog/test_tensorflow2_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow2_autolog.py
@@ -359,7 +359,7 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
 @pytest.mark.large
 @pytest.mark.parametrize("restore_weights", [True])
 @pytest.mark.parametrize("callback", ["early"])
-@pytest.mark.parametrize("patience", [1, 5])
+@pytest.mark.parametrize("patience", [0, 1, 5])
 @pytest.mark.parametrize("initial_epoch", [0, 10])
 def test_tf_keras_autolog_batch_metrics_logger_logs_expected_metrics(
     callback, restore_weights, patience, initial_epoch

--- a/tests/tensorflow_autolog/test_tensorflow_autolog.py
+++ b/tests/tensorflow_autolog/test_tensorflow_autolog.py
@@ -257,16 +257,13 @@ def test_tf_keras_autolog_early_stop_logs(tf_keras_random_data_run_with_callback
     assert "restored_epoch" in metrics
     assert "epoch_loss" in metrics
     restored_epoch = int(metrics["restored_epoch"])
-    assert int(metrics["stopped_epoch"]) - max(1, callback.patience) == restored_epoch
+    assert int(metrics["stopped_epoch"]) - callback.patience == restored_epoch
     assert "loss" in history.history
-    num_of_epochs = len(history.history["loss"])
     client = mlflow.tracking.MlflowClient()
     # TF 1.X TB callback logs loss as `epoch_loss`
     metric_history = client.get_metric_history(run.info.run_id, "epoch_loss")
-    # Check the test epoch numbers are correct
-    assert num_of_epochs == max(1, callback.patience) + 1
-    # Check that MLflow has logged the metrics of the "best" model
-    assert len(metric_history) == num_of_epochs + 1
+    # Check that MLflow has logged the metrics of the "best" model, in addition to per-epoch metrics
+    assert len(metric_history) == len(history.history["loss"]) + 1
     # Check that MLflow has logged the correct data
     assert history.history["loss"][history.epoch.index(restored_epoch)] == metric_history[-1].value
 


### PR DESCRIPTION
Signed-off-by: dbczumar <corey.zumar@databricks.com>

## What changes are proposed in this pull request?

Fix early stopping behavior incompatibilities with TensorFlow 2.5.x in TensorFlow autologgiing.

## How is this patch tested?

Unit tests

## Release Notes

TensorFlow autologging early stopping metrics are now correctly logged for TensorFlow 2.5.x.

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
