### PR TITLE
Fix version mismatch between h2o client and cluster in R

### DIFF
--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -12,7 +12,6 @@ keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(
 reticulate::conda_install("'h5py<3.0.0'", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
-# Pin h2o to prevent version-mismatch between python and R
 reticulate::conda_install("h2o", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 
 # The default timeout value (60 seconds) can be insufficient for `spark_install` to complete

--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -13,7 +13,7 @@ reticulate::conda_install("'h5py<3.0.0'", envname = mlflow:::mlflow_conda_env_na
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
 # Pin h2o to prevent version-mismatch between python and R
-reticulate::conda_install("h2o==3.30.1.3", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
+reticulate::conda_install("h2o", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 
 # The default timeout value (60 seconds) can be insufficient for `spark_install` to complete
 options(timeout=60 * 60)

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -19,8 +19,6 @@ for (pkg in pkgs) {
 }
 install.packages("h2o")
 
-h2o::h2o.init()
-
 model <- h2o::h2o.randomForest(
   x = predictors, y = prediction, training_frame = h2o::as.h2o(train)
 )

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -22,7 +22,7 @@ model <- h2o::h2o.randomForest(
 testthat_model_dir <- tempfile("model_")
 
 teardown({
-  h2o::h2o.shutdown(prompt = FALSE)
+  h2o::h2o.shutdown(prompt = TRUE)
   mlflow_clear_test_dir(testthat_model_dir)
 })
 

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -17,7 +17,6 @@ pkgs <- c("RCurl","jsonlite")
 for (pkg in pkgs) {
   if (! (pkg %in% rownames(installed.packages()))) { install.packages(pkg) }
 }
-# Pin h2o to prevent version-mismatch between python and R
 install.packages("h2o")
 
 h2o::h2o.init()

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -18,7 +18,7 @@ for (pkg in pkgs) {
   if (! (pkg %in% rownames(installed.packages()))) { install.packages(pkg) }
 }
 # Pin h2o to prevent version-mismatch between python and R
-install.packages("https://cran.r-project.org/src/contrib/Archive/h2o/h2o_3.30.1.3.tar.gz", repos=NULL, type="source")
+install.packages("h2o")
 
 h2o::h2o.init()
 

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -1,5 +1,8 @@
 context("Model h2o")
 
+setup({
+  h2o::h2o.init()
+})
 
 idx <- withr::with_seed(3809, sample(nrow(iris)))
 prediction <- "Species"

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -1,8 +1,5 @@
 context("Model h2o")
 
-setup({
-  h2o::h2o.init(port = httpuv::randomPort())
-})
 
 idx <- withr::with_seed(3809, sample(nrow(iris)))
 prediction <- "Species"


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

The r check started failing with the following error:

https://github.com/mlflow/mlflow/pull/4371/checks?check_run_id=2616213879#step:14:200

(key lines are colored green)

```diff
R is connected to the H2O cluster: 
    H2O cluster uptime:         1 seconds 714 milliseconds 
    H2O cluster timezone:       UTC 
    H2O data parsing timezone:  UTC 
+    H2O cluster version:        3.30.1.3 
    H2O cluster version age:    7 months and 20 days !!! 
    H2O cluster name:           H2O_started_from_R_runner_zip376 
    H2O cluster total nodes:    1 
    H2O cluster total memory:   1.51 GB 
    H2O cluster total cores:    2 
    H2O cluster allowed cores:  2 
    H2O cluster healthy:        TRUE 
    H2O Connection ip:          localhost 
    H2O Connection port:        54321 
    H2O Connection proxy:       NA 
    H2O Internal Security:      FALSE 
    H2O API Extensions:         Amazon S3, XGBoost, Algos, AutoML, Core V3, TargetEncoder, Core V4 
    R Version:                  R version 4.1.0 (2021-05-18) 

ERROR: Unexpected HTTP Status code: 412 Precondition Failed (url = http://localhost:54321/3/ParseSetup)

water.exceptions.H2OIllegalArgumentException
+ [1] "water.exceptions.H2OIllegalArgumentException: Unknown parameter: escapechar"                                 
 [2] "    water.api.Schema.fillFromParms(Schema.java:304)"                                                         
 [3] "    water.api.Schema.fillFromParms(Schema.java:249)"                                                         
 [4] "    water.api.Handler.handle(Handler.java:46)"                                                               
 [5] "    water.api.RequestServer.serve(RequestServer.java:470)"                                                   
 [6] "    water.api.RequestServer.doGeneric(RequestServer.java:301)"                                               
 [7] "    water.api.RequestServer.doPost(RequestServer.java:227)"                                                  
 [8] "    javax.servlet.http.HttpServlet.service(HttpServlet.java:707)"                                            
 [9] "    javax.servlet.http.HttpServlet.service(HttpServlet.java:790)"                                            
[10] "    org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:865)"                                  
[11] "    org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:535)"                              
[12] "    org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:255)"                       
[13] "    org.eclipse.jetty.server.handler.ContextHandler.doHandle(ContextHandler.java:1317)"                      
[14] "    org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:203)"                        
[15] "    org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:473)"                               
[16] "    org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:201)"                        
[17] "    org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1219)"                       
[18] "    org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:144)"                           
[19] "    org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)"                   
[20] "    org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)"                         
[21] "    water.webserver.jetty9.Jetty9ServerAdapter$LoginHandler.handle(Jetty9ServerAdapter.java:130)"            
[22] "    org.eclipse.jetty.server.handler.HandlerCollection.handle(HandlerCollection.java:126)"                   
[23] "    org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:132)"                         
[24] "    org.eclipse.jetty.server.Server.handle(Server.java:531)"                                                 
[25] "    org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:352)"                                       
[26] "    org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:260)"                             
[27] "    org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:281)"             
[28] "    org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:102)"                                       
[29] "    org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:118)"                                    
[30] "    org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)"                  
[31] "    org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)"                
[32] "    org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)"               
[33] "    org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126)"                      
[34] "    org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:366)"
[35] "    org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:762)"                        
[36] "    org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:680)"                         
[37] "    java.lang.Thread.run(Thread.java:748)"
```

It looks like the h2o cluster version is old (`3.30.1.3`) and it doesn't support `escapechar` which was added by https://github.com/h2oai/h2o-3/pull/5425.

## How is this patch tested?

(Details)

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
