### PR TITLE
Fix `mlflow models serve` failure in Windows

### DIFF
--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -96,7 +96,7 @@ class PyFuncBackend(FlavorBackend):
             if os.name != "nt":
                 subprocess.Popen(["bash", "-c", command], env=command_env).wait()
             else:
-                subprocess.Popen([command.split(" ")], env=command_env).wait()
+                subprocess.Popen(command, env=command_env).wait()
 
     def can_score_model(self):
         if self._no_conda:

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -223,8 +223,15 @@ class RestEndpoint:
         if self._proc.poll() is None:
             # Terminate the process group containing the scoring process.
             # This will terminate all child processes of the scoring process
-            pgrp = os.getpgid(self._proc.pid)
-            os.killpg(pgrp, signal.SIGTERM)
+            if os.name != "nt":
+                pgrp = os.getpgid(self._proc.pid)
+                os.killpg(pgrp, signal.SIGTERM)
+            else:
+                # https://stackoverflow.com/questions/47016723/windows-equivalent-for-spawning-and-killing-separate-process-group-in-python-3  # noqa
+                import signal
+
+                self._proc.send_signal(signal.CTRL_BREAK_EVENT)
+                self._proc.kill()
 
     def invoke(self, data, content_type):
         if type(data) == pd.DataFrame:

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -228,8 +228,6 @@ class RestEndpoint:
                 os.killpg(pgrp, signal.SIGTERM)
             else:
                 # https://stackoverflow.com/questions/47016723/windows-equivalent-for-spawning-and-killing-separate-process-group-in-python-3  # noqa
-                import signal
-
                 self._proc.send_signal(signal.CTRL_BREAK_EVENT)
                 self._proc.kill()
 

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -7,7 +7,7 @@ import string
 import time
 import signal
 import socket
-from subprocess import Popen, CREATE_NEW_PROCESS_GROUP
+import subprocess
 import uuid
 import sys
 
@@ -79,7 +79,7 @@ def pyfunc_build_image(model_uri, extra_args=None):
     cmd = ["mlflow", "models", "build-docker", "-m", model_uri, "-n", name]
     if extra_args:
         cmd += extra_args
-    p = Popen(cmd,)
+    p = subprocess.Popen(cmd,)
     assert p.wait() == 0, "Failed to build docker image to serve model from %s" % model_uri
     return name
 
@@ -173,7 +173,7 @@ def _get_mlflow_home():
 
 def _start_scoring_proc(cmd, env, stdout=sys.stdout, stderr=sys.stderr):
     if os.name != "nt":
-        return Popen(
+        return subprocess.Popen(
             cmd,
             stdout=stdout,
             stderr=stderr,
@@ -185,14 +185,14 @@ def _start_scoring_proc(cmd, env, stdout=sys.stdout, stderr=sys.stderr):
             preexec_fn=os.setsid,
         )
     else:
-        return Popen(
+        return subprocess.Popen(
             cmd,
             stdout=stdout,
             stderr=stderr,
             universal_newlines=True,
             env=env,
             # On Windows, `os.setsid` and `preexec_fn` are unavailable
-            creationflags=CREATE_NEW_PROCESS_GROUP,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
         )
 
 

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -65,9 +65,6 @@ def sk_model(iris_data):
 
 
 def test_mlflow_models_serve():
-    import numpy as np
-    import pandas as pd
-
     class MyModel(pyfunc.PythonModel):
         def predict(self, context, model_input):  # pylint: disable=unused-variable
             return np.array([1, 2, 3])

--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -64,30 +64,6 @@ def sk_model(iris_data):
     return knn_model
 
 
-def test_mlflow_models_serve():
-    class MyModel(pyfunc.PythonModel):
-        def predict(self, context, model_input):  # pylint: disable=unused-variable
-            return np.array([1, 2, 3])
-
-    model = MyModel()
-
-    with mlflow.start_run():
-        mlflow.pyfunc.log_model(artifact_path="model", python_model=model)
-        model_uri = mlflow.get_artifact_uri("model")
-
-    data = pd.DataFrame({"a": [0]})
-
-    scoring_response = pyfunc_serve_and_score_model(
-        model_uri=model_uri,
-        data=data,
-        content_type=pyfunc.scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
-        extra_args=["--no-conda"],
-    )
-    assert scoring_response.status_code == 200
-    served_model_preds = np.array(json.loads(scoring_response.content))
-    np.testing.assert_array_equal(served_model_preds, model.predict(data, None))
-
-
 @pytest.mark.large
 def test_predict_with_old_mlflow_in_conda_and_with_orient_records(iris_data):
     if no_conda:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from click.testing import CliRunner
 from unittest import mock
+import json
 import os
 import pytest
 import shutil
@@ -9,13 +10,19 @@ import subprocess
 
 from urllib.request import url2pathname
 from urllib.parse import urlparse, unquote
+import numpy as np
+import pandas as pd
 
+import mlflow
 from mlflow.cli import server, ui
+from mlflow import pyfunc
 from mlflow.server import handlers
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.store.tracking.file_store import FileStore
 from mlflow.exceptions import MlflowException
 from mlflow.entities import ViewType
+
+from tests import pyfunc_serve_and_score_model
 
 
 def test_server_static_prefix_validation():
@@ -162,3 +169,27 @@ def test_mlflow_gc_not_deleted_run(file_store):
         )
     runs = store.search_runs(experiment_ids=["0"], filter_string="", run_view_type=ViewType.ALL)
     assert len(runs) == 1
+
+
+def test_mlflow_models_serve():
+    class MyModel(pyfunc.PythonModel):
+        def predict(self, context, model_input):  # pylint: disable=unused-variable
+            return np.array([1, 2, 3])
+
+    model = MyModel()
+
+    with mlflow.start_run():
+        mlflow.pyfunc.log_model(artifact_path="model", python_model=model)
+        model_uri = mlflow.get_artifact_uri("model")
+
+    data = pd.DataFrame({"a": [0]})
+
+    scoring_response = pyfunc_serve_and_score_model(
+        model_uri=model_uri,
+        data=data,
+        content_type=pyfunc.scoring_server.CONTENT_TYPE_JSON_SPLIT_ORIENTED,
+        extra_args=["--no-conda"],
+    )
+    assert scoring_response.status_code == 200
+    served_model_preds = np.array(json.loads(scoring_response.content))
+    np.testing.assert_array_equal(served_model_preds, model.predict(data, None))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ from mlflow.store.tracking.file_store import FileStore
 from mlflow.exceptions import MlflowException
 from mlflow.entities import ViewType
 
-from tests import pyfunc_serve_and_score_model
+from tests.helper_functions import pyfunc_serve_and_score_model
 
 
 def test_server_static_prefix_validation():


### PR DESCRIPTION
Fixing issue 3332 by not splitting the command-string in pyfunc/backend.py anymore. This didn't work on windows 10.

## What changes are proposed in this pull request?

The subprocess.Popen in pyfunc/backend.py is now called with the command as a single string, instead of the command splitted into a list of strings. This is necessary to fix issue #3332.

## How is this patch tested?

It was tested on Windows 10 with Python 3.9.5 and Python 3.8.0. @mpbrigham, the reporter of issue #3332 who first proposed this as a workaround also tested it on Python 3.5, 3.6, 3.7, and 3.8 under Anaconda Prompt and Anaconda Powershell Prompt, and it worked for two other people on the issue.

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [x] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
