### PR TITLE
Remove h2o version mismatch between python and R

### DIFF
--- a/mlflow/R/mlflow/.create-test-env.R
+++ b/mlflow/R/mlflow/.create-test-env.R
@@ -12,7 +12,7 @@ keras::install_keras(method = "conda", envname = mlflow:::mlflow_conda_env_name(
 reticulate::conda_install("'h5py<3.0.0'", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install(Sys.getenv("MLFLOW_HOME", "../../../../."), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 reticulate::conda_install("xgboost", envname = mlflow:::mlflow_conda_env_name())
-reticulate::conda_install("h2o", envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
+reticulate::conda_install(paste0("h2o==", packageVersion("h2o")), envname = mlflow:::mlflow_conda_env_name(), pip = TRUE)
 
 # The default timeout value (60 seconds) can be insufficient for `spark_install` to complete
 options(timeout=60 * 60)

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -11,13 +11,13 @@ train <- iris[idx[1:100], ]
 test <- iris[idx[101:nrow(iris)], ]
 
 # Installing most recent h2o package, see https://docs.h2o.ai/h2o/latest-stable/h2o-docs/downloading.html#install-in-r
-if ("package:h2o" %in% search()) { detach("package:h2o", unload=TRUE) }
-if ("h2o" %in% rownames(installed.packages())) { remove.packages("h2o") }
-pkgs <- c("RCurl","jsonlite")
-for (pkg in pkgs) {
-  if (! (pkg %in% rownames(installed.packages()))) { install.packages(pkg) }
-}
-install.packages("h2o")
+# if ("package:h2o" %in% search()) { detach("package:h2o", unload=TRUE) }
+# if ("h2o" %in% rownames(installed.packages())) { remove.packages("h2o") }
+# pkgs <- c("RCurl","jsonlite")
+# for (pkg in pkgs) {
+#   if (! (pkg %in% rownames(installed.packages()))) { install.packages(pkg) }
+# }
+# install.packages("h2o")
 
 model <- h2o::h2o.randomForest(
   x = predictors, y = prediction, training_frame = h2o::as.h2o(train)
@@ -49,7 +49,6 @@ test_that("can print model correctly after it is loaded", {
 })
 
 test_that("can load and predict with python pyfunct and h2o backend", {
-  h2o::h2o.shutdown(prompt = FALSE)
   pyfunc <- import("mlflow.pyfunc")
   py_model <- pyfunc$load_model(testthat_model_dir)
 
@@ -73,7 +72,6 @@ test_that("can load and predict with python pyfunct and h2o backend", {
 })
 
 test_that("Can predict with cli backend", {
-  h2o::h2o.shutdown(prompt = FALSE)
   expected <- as.data.frame(h2o::h2o.predict(model, h2o::as.h2o(test)))
 
   # # Test that we can score this model with pyfunc backend

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -25,7 +25,7 @@ model <- h2o::h2o.randomForest(
 testthat_model_dir <- tempfile("model_")
 
 teardown({
-  h2o::h2o.shutdown(prompt = TRUE)
+  h2o::h2o.shutdown(prompt = FALSE)
   mlflow_clear_test_dir(testthat_model_dir)
 })
 
@@ -49,7 +49,7 @@ test_that("can print model correctly after it is loaded", {
 })
 
 test_that("can load and predict with python pyfunct and h2o backend", {
-  h2o::h2o.shutdown(prompt = TRUE)
+  h2o::h2o.shutdown(prompt = FALSE)
   pyfunc <- import("mlflow.pyfunc")
   py_model <- pyfunc$load_model(testthat_model_dir)
 
@@ -73,7 +73,7 @@ test_that("can load and predict with python pyfunct and h2o backend", {
 })
 
 test_that("Can predict with cli backend", {
-  h2o::h2o.shutdown(prompt = TRUE)
+  h2o::h2o.shutdown(prompt = FALSE)
   expected <- as.data.frame(h2o::h2o.predict(model, h2o::as.h2o(test)))
 
   # # Test that we can score this model with pyfunc backend

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -10,15 +10,6 @@ predictors <- setdiff(colnames(iris), prediction)
 train <- iris[idx[1:100], ]
 test <- iris[idx[101:nrow(iris)], ]
 
-# Installing most recent h2o package, see https://docs.h2o.ai/h2o/latest-stable/h2o-docs/downloading.html#install-in-r
-# if ("package:h2o" %in% search()) { detach("package:h2o", unload=TRUE) }
-# if ("h2o" %in% rownames(installed.packages())) { remove.packages("h2o") }
-# pkgs <- c("RCurl","jsonlite")
-# for (pkg in pkgs) {
-#   if (! (pkg %in% rownames(installed.packages()))) { install.packages(pkg) }
-# }
-# install.packages("h2o")
-
 model <- h2o::h2o.randomForest(
   x = predictors, y = prediction, training_frame = h2o::as.h2o(train)
 )

--- a/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model-h2o.R
@@ -49,6 +49,7 @@ test_that("can print model correctly after it is loaded", {
 })
 
 test_that("can load and predict with python pyfunct and h2o backend", {
+  h2o::h2o.shutdown(prompt = TRUE)
   pyfunc <- import("mlflow.pyfunc")
   py_model <- pyfunc$load_model(testthat_model_dir)
 
@@ -72,6 +73,7 @@ test_that("can load and predict with python pyfunct and h2o backend", {
 })
 
 test_that("Can predict with cli backend", {
+  h2o::h2o.shutdown(prompt = TRUE)
   expected <- as.data.frame(h2o::h2o.predict(model, h2o::as.h2o(test)))
 
   # # Test that we can score this model with pyfunc backend


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Remove `h2o` version mismatch between python and R.

## How is this patch tested?

Existing tests

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
