### PR TITLE
Use python 3.7 for dev sklearn testing

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Install mlflow & test dependencies
         run: |
           set -x
+          pip install --upgrade pip
           pip install -e .
           pip install -r dev/small-requirements.txt
       - name: Install ${{ matrix.package }} ${{ matrix.version }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -80,7 +80,6 @@ jobs:
       - name: Install mlflow & test dependencies
         run: |
           set -x
-          pip install --upgrade pip
           pip install -e .
           pip install -r dev/small-requirements.txt
       - name: Install ${{ matrix.package }} ${{ matrix.version }}

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -59,7 +59,12 @@ jobs:
           echo "/usr/share/miniconda/bin" >> $GITHUB_PATH
       - name: Update python
         run: |
-          conda install python=3.6
+          if [[ "${{ matrix.package }}" = "sklearn" && "${{ matrix.version }}" = "dev" ]]; then
+            python_version=3.7
+          else
+            python_version=3.6
+          fi
+          conda install python=$python_version
           python --version
       - name: Get cache key
         env:

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -59,7 +59,7 @@ jobs:
           echo "/usr/share/miniconda/bin" >> $GITHUB_PATH
       - name: Update python
         run: |
-          if [[ "${{ matrix.package }}" = "sklearn" && "${{ matrix.version }}" = "dev" ]]; then
+          if [[ "${{ matrix.package }}" = "scikit-learn" && "${{ matrix.version }}" = "dev" ]]; then
             python_version=3.7
           else
             python_version=3.6

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -5,7 +5,7 @@ sklearn:
       # This installs scikit-learn from the default branch
       # Use `--use-no-pep517` as a workaround for workaround for this issue:
       # https://github.com/scikit-learn/scikit-learn/issues/20115
-      pip install git+https://github.com/scikit-learn/scikit-learn.git --use-no-pep517
+      pip install --use-no-pep517 git+https://github.com/scikit-learn/scikit-learn.git
 
   models:
     minimum: "0.20.3"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -2,6 +2,7 @@ sklearn:
   package_info:
     pip_release: "scikit-learn"
     install_dev: |
+      pip install Cython>=0.28.5 scipy>=1.1.0
       # This installs scikit-learn from the default branch
       # Use `--no-use-pep517` as a workaround for this issue:
       # https://github.com/scikit-learn/scikit-learn/issues/20115

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -2,11 +2,8 @@ sklearn:
   package_info:
     pip_release: "scikit-learn"
     install_dev: |
-      pip install Cython>=0.28.5 scipy>=1.1.0
       # This installs scikit-learn from the default branch
-      # Use `--no-use-pep517` as a workaround for this issue:
-      # https://github.com/scikit-learn/scikit-learn/issues/20115
-      pip install --no-use-pep517 git+https://github.com/scikit-learn/scikit-learn.git
+      pip install git+https://github.com/scikit-learn/scikit-learn.git
 
   models:
     minimum: "0.20.3"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -2,7 +2,7 @@ sklearn:
   package_info:
     pip_release: "scikit-learn"
     install_dev: |
-      # This installs scikit-learn from the default branch
+      # This installs scikit-learn from the default branch 
       pip install git+https://github.com/scikit-learn/scikit-learn.git
 
   models:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -3,9 +3,9 @@ sklearn:
     pip_release: "scikit-learn"
     install_dev: |
       # This installs scikit-learn from the default branch
-      # Use `--use-no-pep517` as a workaround for workaround for this issue:
+      # Use `--no-use-pep517` as a workaround for workaround for this issue:
       # https://github.com/scikit-learn/scikit-learn/issues/20115
-      pip install --use-no-pep517 git+https://github.com/scikit-learn/scikit-learn.git
+      pip install --no-use-pep517 git+https://github.com/scikit-learn/scikit-learn.git
 
   models:
     minimum: "0.20.3"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -3,7 +3,7 @@ sklearn:
     pip_release: "scikit-learn"
     install_dev: |
       # This installs scikit-learn from the default branch
-      # Use `--no-use-pep517` as a workaround for workaround for this issue:
+      # Use `--no-use-pep517` as a workaround for this issue:
       # https://github.com/scikit-learn/scikit-learn/issues/20115
       pip install --no-use-pep517 git+https://github.com/scikit-learn/scikit-learn.git
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -3,7 +3,6 @@ sklearn:
     pip_release: "scikit-learn"
     install_dev: |
       # This installs scikit-learn from the default branch
-      echo "dummy change"
       pip install git+https://github.com/scikit-learn/scikit-learn.git
 
   models:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -2,7 +2,8 @@ sklearn:
   package_info:
     pip_release: "scikit-learn"
     install_dev: |
-      # This installs scikit-learn from the default branch 
+      # This installs scikit-learn from the default branch
+      echo "dummy change"
       pip install git+https://github.com/scikit-learn/scikit-learn.git
 
   models:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -3,7 +3,9 @@ sklearn:
     pip_release: "scikit-learn"
     install_dev: |
       # This installs scikit-learn from the default branch
-      pip install git+https://github.com/scikit-learn/scikit-learn.git
+      # Use `--use-no-pep517` as a workaround for workaround for this issue:
+      # https://github.com/scikit-learn/scikit-learn/issues/20115
+      pip install git+https://github.com/scikit-learn/scikit-learn.git --use-no-pep517
 
   models:
     minimum: "0.20.3"


### PR DESCRIPTION
Signed-off-by: harupy <17039389+harupy@users.noreply.github.com>

## What changes are proposed in this pull request?

Fix a failure in the cross version test for dev sklearn:

https://github.com/mlflow/mlflow/runs/2627560961?check_suite_focus=true#step:9:1

```
+ pip install git+https://github.com/scikit-learn/scikit-learn.git
Collecting git+https://github.com/scikit-learn/scikit-learn.git
  Cloning https://github.com/scikit-learn/scikit-learn.git to /tmp/pip-req-build-ok6ft72n
  Running command git clone -q https://github.com/scikit-learn/scikit-learn.git /tmp/pip-req-build-ok6ft72n
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
    Preparing wheel metadata: started
    Preparing wheel metadata: finished with status 'error'
    ERROR: Command errored out with exit status 1:
     command: /usr/share/miniconda/bin/python /usr/share/miniconda/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpuhur6nzz
         cwd: /tmp/pip-req-build-ok6ft72n
    Complete output (24 lines):
    Partial import of sklearn during the build process.
    Traceback (most recent call last):
      File "/usr/share/miniconda/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 280, in <module>
        main()
      File "/usr/share/miniconda/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 263, in main
        json_out['return_val'] = hook(**hook_input['kwargs'])
      File "/usr/share/miniconda/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py", line 133, in prepare_metadata_for_build_wheel
        return hook(metadata_directory, config_settings)
      File "/tmp/pip-build-env-eiw0x7g9/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 166, in prepare_metadata_for_build_wheel
        self.run_setup()
      File "/tmp/pip-build-env-eiw0x7g9/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 259, in run_setup
        self).run_setup(setup_script=setup_script)
      File "/tmp/pip-build-env-eiw0x7g9/overlay/lib/python3.6/site-packages/setuptools/build_meta.py", line 150, in run_setup
        exec(compile(code, __file__, 'exec'), locals())
      File "setup.py", line 301, in <module>
        setup_package()
      File "setup.py", line 287, in setup_package
        check_package_status('numpy', min_deps.NUMPY_MIN_VERSION)
      File "setup.py", line 223, in check_package_status
        req_str, instructions))
    ImportError: Your installation of numpy 1.13.3 is out-of-date.
    scikit-learn requires numpy >= 1.14.5.
    Installation instructions are available on the scikit-learn website: http://scikit-learn.org/stable/install.html
    
    ----------------------------------------
WARNING: Discarding git+https://github.com/scikit-learn/scikit-learn.git. Command errored out with exit status 1: /usr/share/miniconda/bin/python /usr/share/miniconda/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpuhur6nzz Check the logs for full command output.
ERROR: Command errored out with exit status 1: /usr/share/miniconda/bin/python /usr/share/miniconda/lib/python3.6/site-packages/pip/_vendor/pep517/_in_process.py prepare_metadata_for_build_wheel /tmp/tmpuhur6nzz Check the logs for full command output.
Error: Process completed with exit code 1.
```

As discussed in https://github.com/scikit-learn/scikit-learn/issues/20084, the sklearn team is planning to drop Python 3.6 support in the next major release and started preparing for that. As a part of the preparation, https://github.com/scikit-learn/scikit-learn/pull/20069 bumped the minimum supported version of `numpy` to `1.14.5` and caused the failure above.

## How is this patch tested?

Existing checks

## Release Notes

### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

(Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change.)

### What component(s), interfaces, languages, and integrations does this PR affect?
Components 
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: Local serving, model deployment tools, spark UDFs
- [ ] `area/server-infra`: MLflow server, JavaScript dev server
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface 
- [ ] `area/uiux`: Front-end, user experience, JavaScript, plotting
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language 
- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations
- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->
<a name="release-note-category"></a>
### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
